### PR TITLE
Added raw type to unknown AttachmentType

### DIFF
--- a/Sources/Core/Client/ClientError.swift
+++ b/Sources/Core/Client/ClientError.swift
@@ -64,7 +64,7 @@ public enum ClientError: LocalizedError {
         case .emptyBody(let description):
             return "A request or response body data is empty: \(description)"
         case .invalidURL(let url):
-            return "An invalide URL: \(url ?? "<unknown>")"
+            return "An invalid URL: \(url ?? "<unknown>")"
             
         case .requestFailed(let error):
             if let error = error {
@@ -115,4 +115,10 @@ public struct AnyError: Error, Equatable {
     public static func == (lhs: AnyError, rhs: AnyError) -> Bool {
         return lhs.error.localizedDescription == rhs.error.localizedDescription
     }
+}
+
+/// An encoding error
+public enum EncodingError: Error {
+    /// Field with this value can't be encoded
+    case valueUnsupported
 }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		465D64C2231808A2006BAE42 /* AttachmentTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465D64C1231808A2006BAE42 /* AttachmentTypeTests.swift */; };
 		8A04964222E9D71400E94795 /* Chat.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8AD5ECD322E9BA39005CFAC9 /* Chat.xcassets */; };
 		8A04964422E9F52D00E94795 /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD5ED0622E9BA39005CFAC9 /* Presenter.swift */; };
 		8A04964522E9F53200E94795 /* ChannelsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD5ED0922E9BA39005CFAC9 /* ChannelsPresenter.swift */; };
@@ -178,6 +179,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		465D64C1231808A2006BAE42 /* AttachmentTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentTypeTests.swift; sourceTree = "<group>"; };
 		8A04964E22EF1A8900E94795 /* QueryOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryOptions.swift; sourceTree = "<group>"; };
 		8A04965022EF4B2400E94795 /* UsersQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsersQuery.swift; sourceTree = "<group>"; };
 		8A04965222F0910200E94795 /* Message+Requests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+Requests.swift"; sourceTree = "<group>"; };
@@ -386,6 +388,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		46EA815F23196308008ABC04 /* Unit Tests */ = {
+			isa = PBXGroup;
+			children = (
+				465D64C1231808A2006BAE42 /* AttachmentTypeTests.swift */,
+			);
+			path = "Unit Tests";
+			sourceTree = "<group>";
+		};
 		8A04964322E9F51C00E94795 /* Presenter */ = {
 			isa = PBXGroup;
 			children = (
@@ -410,6 +420,7 @@
 		8A559D22230D937C00E66096 /* StreamChatCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				46EA815F23196308008ABC04 /* Unit Tests */,
 				8A6F69CE230EB75300B8CC1F /* Integration Tests */,
 				8A6F69D0230ECCB600B8CC1F /* Extensions */,
 				8A559D25230D937C00E66096 /* Info.plist */,
@@ -1086,6 +1097,7 @@
 				8AD0A9942314252700B8EB97 /* ClientSetupTests.swift in Sources */,
 				8AD0A9962314394200B8EB97 /* ChannelTests.swift in Sources */,
 				8A6F69D2230ECCD300B8CC1F /* User+Tests.swift in Sources */,
+				465D64C2231808A2006BAE42 /* AttachmentTypeTests.swift in Sources */,
 				8A559D24230D937C00E66096 /* ClientRequestsTests.swift in Sources */,
 				8A6F69D4230ECD7300B8CC1F /* TestCase.swift in Sources */,
 			);

--- a/StreamChatCoreTests/Unit Tests/AttachmentTypeTests.swift
+++ b/StreamChatCoreTests/Unit Tests/AttachmentTypeTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import StreamChatCore
+
+class AttachmentTypeTests: XCTestCase {
+    struct MetaType: Codable {
+        let type: AttachmentType
+    }
+
+    func testRawValue() {
+        XCTAssertEqual(AttachmentType.unknown.rawValue, nil)
+        XCTAssertEqual(AttachmentType.custom(type: "type/custom").rawValue, "type/custom")
+        XCTAssertEqual(AttachmentType.image.rawValue, "image")
+        XCTAssertEqual(AttachmentType.imgur.rawValue, "imgur")
+        XCTAssertEqual(AttachmentType.giphy.rawValue, "giphy")
+        XCTAssertEqual(AttachmentType.video.rawValue, "video")
+        XCTAssertEqual(AttachmentType.youtube.rawValue, "youtube")
+        XCTAssertEqual(AttachmentType.product.rawValue, "product")
+        XCTAssertEqual(AttachmentType.file.rawValue, "file")
+        XCTAssertEqual(AttachmentType.link.rawValue, "link")
+    }
+
+    func testCreatingFromRawValue() {
+        XCTAssertEqual(AttachmentType(rawValue: nil), .unknown)
+        XCTAssertEqual(AttachmentType(rawValue: ""), .unknown)
+        XCTAssertEqual(AttachmentType(rawValue: "type/custom"), .custom(type: "type/custom"))
+        XCTAssertEqual(AttachmentType(rawValue: "image"), .image)
+        XCTAssertEqual(AttachmentType(rawValue: "imgur"), .imgur)
+        XCTAssertEqual(AttachmentType(rawValue: "giphy"), .giphy)
+        XCTAssertEqual(AttachmentType(rawValue: "video"), .video)
+        XCTAssertEqual(AttachmentType(rawValue: "youtube"), .youtube)
+        XCTAssertEqual(AttachmentType(rawValue: "product"), .product)
+        XCTAssertEqual(AttachmentType(rawValue: "file"), .file)
+        XCTAssertEqual(AttachmentType(rawValue: "link"), .link)
+    }
+
+    func testDecoding() {
+        let json = "{\"type\":\"image\"}"
+        let data = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let meta = try! decoder.decode(MetaType.self, from: data)
+        XCTAssertEqual(meta.type, .image)
+    }
+
+    func testEncoding() {
+        let meta = MetaType(type: .giphy)
+        let encoder = JSONEncoder()
+        let data = try! encoder.encode(meta)
+        let json = String(data: data, encoding: .utf8)
+        XCTAssertEqual(json, "{\"type\":\"giphy\"}")
+    }
+}


### PR DESCRIPTION
# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [X] Code changes are tested (add some information if not applicable)

## Description of the pull request

There was no information in the application what was the type of the attachment if it wasn't on the list of recognized types. I added parameter to `.unknown` type