### PR TITLE
Add override point to customize error presentation on ChatViewController

### DIFF
--- a/Sources/UI/User Story/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/User Story/Chat/Chat View Controller/ChatViewController.swift
@@ -155,6 +155,14 @@ open class ChatViewController: UIViewController, UITableViewDataSource, UITableV
         return nil
     }
     
+    /// Presents error using Banner. You can override this method in order to change error presentation.
+    ///
+    /// - Parameters:
+    ///   - error: error to be presented.
+    open func presentError(_ error: AnyError) {
+        Banners.shared.show(error: error)
+    }
+
     private func markReadIfPossible() {
         channelPresenter?.markReadIfPossible().subscribe().disposed(by: disposeBag)
     }
@@ -274,7 +282,7 @@ extension ChatViewController {
             }
             
         case .error(let error):
-            Banners.shared.show(error: error)
+            presentError(error)
             
         case .footerUpdated:
             updateFooterView()


### PR DESCRIPTION
# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

This change allows user to customize error presentation on `ChatViewController`