### PR TITLE
Channel's config: Accept value null in commands

### DIFF
--- a/Sources/Core/Model/Channel.swift
+++ b/Sources/Core/Model/Channel.swift
@@ -213,7 +213,7 @@ public extension Channel {
         /// The max message length. 5000 by default.
         public let maxMessageLength: Int
         /// An array of commands, e.g. /giphy.
-        public let commands: [Command]
+        public let commands: [Command]?
         /// A channel created date.
         public let created: Date
         /// A channel updated date.

--- a/Sources/UI/User Story/Chat/Chat View Controller/ChatViewController+Composer.swift
+++ b/Sources/UI/User Story/Chat/Chat View Controller/ChatViewController+Composer.swift
@@ -181,10 +181,10 @@ extension ChatViewController {
     
     func createComposerCommandsContainerView() -> ComposerHelperContainerView {
         let container = createComposerHelperContainerView(title: "Commands", closeButtonIsHidden: true)
-        container.isEnabled = !(channelPresenter?.channel.config.commands.isEmpty ?? true)
+        container.isEnabled = !(channelPresenter?.channel.config.commands?.isEmpty ?? true)
         
         if container.isEnabled, let channelConfig = channelPresenter?.channel.config {
-            channelConfig.commands.forEach { command in
+            channelConfig.commands?.forEach { command in
                 let view = ComposerCommandView(frame: .zero)
                 view.backgroundColor = container.backgroundColor
                 view.update(command: command.name, args: command.args, description: command.description)


### PR DESCRIPTION
# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

When commands are disabled, API is returning null instead of empty array and parsing fails.