### PR TITLE
Bugfix: tokenInvalid error.

### DIFF
--- a/Sources/Core/Client/Client+Setup.swift
+++ b/Sources/Core/Client/Client+Setup.swift
@@ -126,7 +126,7 @@ extension Client {
             return ClientError.tokenInvalid(description: "Token is invalid or Token payload is invalid")
         }
         
-        if payload["user_id"] == user.id {
+        if let userId = payload["user_id"] as? String, userId == user.id {
             return nil
         }
         

--- a/Sources/Core/Client/Token.swift
+++ b/Sources/Core/Client/Token.swift
@@ -25,12 +25,12 @@ extension Token {
         return payload != nil
     }
     
-    var payload: [String: String]? {
+    var payload: [String: Any]? {
         let parts = split(separator: ".")
         
         if parts.count == 3,
             let payloadData = jwtDecodeBase64(String(parts[1])),
-            let json = (try? JSONSerialization.jsonObject(with: payloadData)) as? [String: String] {
+            let json = (try? JSONSerialization.jsonObject(with: payloadData)) as? [String: Any] {
             return json
         }
         


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Change `Token`'s `payload` variable to be a [String: Any] dictionary.

The JWT token on our chat decodes to:
```
{"exp": 00000000, "user_id": "xxxxx"}
```

where `exp` is an Int and `user_id` is a String. Currently, `Token`'s `payload` variable tries to cast the serialized JSON  object as a [String: String] dictionary, which returns a `tokenInvalid` error and a request will never be made. The Stream getting started tutorial only contains the `user_id` key in the JSON, so it succeeds.
