### PR TITLE
Update Cartfile with adding version on RxAppState

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -7,4 +7,4 @@ github "ashleymills/Reachability.swift" ~> 4.3.0
 
 github "ReactiveX/RxSwift" ~> 5.0
 github "RxSwiftCommunity/RxGesture"
-github "pixeldock/RxAppState"
+github "pixeldock/RxAppState" ~> 1.5.3


### PR DESCRIPTION
## Description of the pull request
Without defining a version, apps relying on given functionality can change at will by virtue of Streams dependency updates. For example in the latest version of `RxAppState` `RxApplicationDelegateProxy` no longer exists and apps may rely on that RxApplicationDelegateProxy's presence. Or, other dependency conflicts may arise by inclusion of the Stream SDK's lack of version specification.