### PR TITLE
Use member avatar as channel image in one-on-one convenience initializer

### DIFF
--- a/Sources/Core/Model/Channel.swift
+++ b/Sources/Core/Model/Channel.swift
@@ -120,7 +120,12 @@ public final class Channel: Codable {
             members.append(currentUser.asMember)
         }
         
-        self.init(type: type, id: "", name: member.user.name, members: members, extraData: extraData)
+        self.init(type: type,
+                  id: "",
+                  name: member.user.name,
+                  imageURL: member.user.avatarURL,
+                  members: members,
+                  extraData: extraData)
     }
     
     /// Init a channel.


### PR DESCRIPTION
# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [X] Code changes are tested (add some information if not applicable)
    - Not sure that tests are needed here

## Description of the pull request

Use member avatar as channel image in one-on-one convenience initializer.

Because the `imageURL` property of a `Channel` object is currently not configurable after initialization, it’s impossible to get the user’s avatar set up using the one-on-one convenience initializer. Using this avatar feels like the correct default to me.
