### PR TITLE
Fixes ComposerView going behind keyboard when tabbar is used

### DIFF
--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -51,14 +51,13 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
     
     /// Calculates the bottom inset for the `ComposerView` when the keyboard will appear.
     open var calculatedSafeAreaBottom: CGFloat {
-        var bottom = view.safeAreaInsets.bottom
-        bottom = bottom > 0 ? bottom : (parent?.view.safeAreaInsets.bottom ?? 0)
-        
-        if let tabBar = tabBarController?.tabBar, !tabBar.isTranslucent {
-            bottom += tabBar.frame.height
+        if let tabBar = tabBarController?.tabBar, !tabBar.isTranslucent, !hidesBottomBarWhenPushed {
+            return tabBar.frame.height
+        } else {
+            var bottom = view.safeAreaInsets.bottom
+            bottom = bottom > 0 ? bottom : (parent?.view.safeAreaInsets.bottom ?? 0)
+            return bottom
         }
-        
-        return bottom
     }
     
     /// Attachments file types for thw composer view.


### PR DESCRIPTION
I've tested the fix with iOS11.4, 12.2, 12.4 and 13.3. All work good. I'm opening a PR but I'll be brainstorming a bit on how to write a UI test on this, so this is WiP for now.