### PR TITLE
[Minor]: Typo in Source files Path

### DIFF
--- a/StreamChatRealm.podspec
+++ b/StreamChatRealm.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.source = { :git => "https://github.com/GetStream/stream-chat-swift.git", :tag => "#{spec.version}" }
   spec.requires_arc = true
 
-  spec.source_files  = "Sources/Databse/Realm/**/*.swift"
+  spec.source_files  = "Sources/Database/Realm/**/*.swift"
 
   spec.framework = "Foundation"
 


### PR DESCRIPTION
Typo for database folder.

The StreamChatRealm podspec had a typo in the source files path which was not allowing the pod to install any files.

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
