### PR TITLE
Fix strikethrough markdown with ~~

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ✅ Added
 
 ### 🐞 Fixed
+- Fixed strikethrough markdown with ~~ correctly applied [#97](https://github.com/GetStream/stream-chat-swift/issues/97)
 
 # [1.5.6](https://github.com/GetStream/stream-chat-swift/releases/tag/1.5.6)
 _February 11, 2020_

--- a/Sources/UI/Chat/Cells/MessageTextEnrichment.swift
+++ b/Sources/UI/Chat/Cells/MessageTextEnrichment.swift
@@ -38,7 +38,8 @@ final class MessageTextEnrichment {
             return nil
         }
         
-        let addMarkdown = style.markdownEnabled && message.text.rangeOfCharacter(from: .markdown) != nil
+        let addMarkdown = style.markdownEnabled
+            && message.text.replacingOccurrences(of: "~~", with: "-").rangeOfCharacter(from: .markdown) != nil
         let mentionedUserNames = message.mentionedUsers.map({ $0.name })
         
         let enrichURLs = enrichURLs && message.text.probablyHasURL


### PR DESCRIPTION
Since `.markdown` CharacterSet did not include "~~" character (and could not include - since it's 2 characters) `addMarkdown` was returning false for strings such as `~~str~~`