### PR TITLE
Show human-readable error's description when request fails...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ✅ Added
 
 ### 🐞 Fixed
+- Error description of failed request is now human-readable [#104](https://github.com/GetStream/stream-chat-swift/issues/104)
 
 # [1.5.7](https://github.com/GetStream/stream-chat-swift/releases/tag/1.5.7)
 _♥️ February 14, 2020 ♥️_

--- a/Sources/Core/Client/ClientError.swift
+++ b/Sources/Core/Client/ClientError.swift
@@ -74,13 +74,13 @@ public enum ClientError: LocalizedError {
             
         case .requestFailed(let error):
             if let error = error {
-                return "A request failed: \(error)"
+                return "A request failed: \(error.localizedDescription)"
             }
             
             return "A request failed with unknown error"
             
         case .responseError(let error):
-            return "A response failed: \(error)"
+            return "A response failed: \(error.localizedDescription)"
         case .encodingFailure(let error, let object):
             return "A encoding failed: \(error) for object: \(object)"
         case .decodingFailure(let error):

--- a/Sources/Core/Client/ClientError.swift
+++ b/Sources/Core/Client/ClientError.swift
@@ -82,9 +82,9 @@ public enum ClientError: LocalizedError {
         case .responseError(let error):
             return "A response failed: \(error.localizedDescription)"
         case .encodingFailure(let error, let object):
-            return "A encoding failed: \(error) for object: \(object)"
+            return "A encoding failed: \(error.localizedDescription) for object: \(object)"
         case .decodingFailure(let error):
-            return "A decoding failed: \(error)"
+            return "A decoding failed: \(error.localizedDescription)"
         case .errorMessage(let message):
             return message.text
         }


### PR DESCRIPTION
… because of connectivity issue

# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [ ] Code changes are tested - this area was not tested before so I didn't add tests :(

## Description of the pull request
Fixes #104 
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-26 at 11 56 31](https://user-images.githubusercontent.com/7826664/75339043-0aec1380-5890-11ea-91d5-3f2363d27af5.png)
