### PR TITLE
Add debugDescription to all errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ✅ Added
 
 ### 🐞 Fixed
+- Error description of failed request is now human-readable [#104](https://github.com/GetStream/stream-chat-swift/issues/104)
 
 # [1.5.7](https://github.com/GetStream/stream-chat-swift/releases/tag/1.5.7)
 _♥️ February 14, 2020 ♥️_

--- a/Sources/Core/Client/Client+Request.swift
+++ b/Sources/Core/Client/Client+Request.swift
@@ -145,7 +145,7 @@ extension Client {
         } catch let error as ClientError {
             completion(.failure(error))
         } catch {
-            completion(.failure(.unexpectedError(description: "\(error)")))
+            completion(.failure(.unexpectedError(description: error.localizedDescription, error: error)))
         }
         
         return URLSessionDataTask()
@@ -260,7 +260,8 @@ extension Client {
              .sendFile(let fileName, let mimeType, let data, _):
             multipartFormData = MultipartFormData(data, fileName: fileName, mimeType: mimeType)
         default:
-            return .failure(.unexpectedError(description: "Encoding unexpected endpoint \(endpoint) for a file uploading."))
+            let errorDescription = "Encoding unexpected endpoint \(endpoint) for a file uploading."
+            return .failure(.unexpectedError(description: errorDescription, error: nil))
         }
         
         let data = multipartFormData.multipartFormData
@@ -296,7 +297,7 @@ extension Client {
         guard let httpResponse = response as? HTTPURLResponse else {
             logger?.log(response, data: data, forceToShowData: true)
             let errorDescription = "Expecting HTTPURLResponse, but got \(response?.description ?? "nil")"
-            performInCallbackQueue { completion(.failure(.unexpectedError(description: errorDescription))) }
+            performInCallbackQueue { completion(.failure(.unexpectedError(description: errorDescription, error: nil))) }
             return
         }
 

--- a/Sources/Core/Client/ClientError.swift
+++ b/Sources/Core/Client/ClientError.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A client error.
-public enum ClientError: LocalizedError {
+public enum ClientError: LocalizedError, CustomDebugStringConvertible {
     /// An unexpected error.
     case unexpectedError(description: String)
     /// The API Key is empty.
@@ -74,25 +74,56 @@ public enum ClientError: LocalizedError {
             
         case .requestFailed(let error):
             if let error = error {
-                return "A request failed: \(error)"
+                return "A request failed: \(error.localizedDescription)"
             }
             
             return "A request failed with unknown error"
             
         case .responseError(let error):
-            return "A response failed: \(error)"
-        case .encodingFailure(let error, let object):
-            return "A encoding failed: \(error) for object: \(object)"
+            return error.localizedDescription
+        case .encodingFailure(let error, _):
+            return "An encoding failed: \(error.localizedDescription)"
         case .decodingFailure(let error):
-            return "A decoding failed: \(error)"
+            return "A decoding failed: \(error.localizedDescription)"
         case .errorMessage(let message):
             return message.text
+        }
+    }
+
+    public var debugDescription: String {
+        switch self {
+        case .unexpectedError(let description):
+            return "ClientError.unexpectedError(\(description))"
+        case .emptyAPIKey:
+            return "ClientError.emptyAPIKey"
+        case .emptyToken:
+            return "ClientError.emptyToken"
+        case .tokenInvalid(let description):
+            return "ClientError.tokenInvalid(\(description))"
+        case .emptyUser:
+            return "ClientError.emptyUser"
+        case .emptyConnectionId:
+            return "ClientError.emptyConnectionId"
+        case .emptyBody(let description):
+            return "ClientError.emptyBody(\(description))"
+        case .invalidURL(let url):
+            return "ClientError.invalidURL(\(url ?? "<unknown>"))"
+        case .requestFailed(let error):
+            return "ClientError.requestFailed(\(String(describing: error)))"
+        case .responseError(let error):
+            return "ClientError.responseError(\(error))"
+        case .encodingFailure(let error, let object):
+            return "ClientError.encodingFailure(\(error), \(object))"
+        case .decodingFailure(let error):
+            return "ClientError.decodingFailure(\(error))"
+        case .errorMessage(let message):
+            return "ClientError.errorMessage(\(message.text))"
         }
     }
 }
 
 /// A parsed server response error.
-public struct ClientErrorResponse: LocalizedError, Decodable {
+public struct ClientErrorResponse: LocalizedError, Decodable, CustomDebugStringConvertible {
     static let tokenExpiredErrorCode = 40
     
     private enum CodingKeys: String, CodingKey {
@@ -109,12 +140,16 @@ public struct ClientErrorResponse: LocalizedError, Decodable {
     public let statusCode: Int
     
     public var errorDescription: String? {
-        return "Client JSON Error \(code): \(message) (Status code: \(statusCode))."
+        return "Error #\(code): \(message)"
+    }
+
+    public var debugDescription: String {
+        return "ClientErrorResponse(code: \(code), message: \"\(message)\", statusCode: \(statusCode)))."
     }
 }
 
 /// A wrapper for any Error.
-public struct AnyError: Error, Equatable {
+public struct AnyError: Error, Equatable, CustomDebugStringConvertible {
     /// Some error.
     public let error: Error
     
@@ -122,13 +157,31 @@ public struct AnyError: Error, Equatable {
         return error.localizedDescription
     }
     
+    public var debugDescription: String {
+        return "AnyError(error: \(error))"
+    }
+
     public static func == (lhs: AnyError, rhs: AnyError) -> Bool {
         return lhs.error.localizedDescription == rhs.error.localizedDescription
     }
 }
 
 /// An encoding error
-public enum EncodingError: Error {
-    /// Field with this value can't be encoded
-    case valueUnsupported
+public enum EncodingError: Error, LocalizedError, CustomDebugStringConvertible {
+    /// Attachment's type not supported
+    case attachmentUnsupported
+
+    public var errorDescription: String? {
+        switch self {
+        case .attachmentUnsupported:
+            return "This attachment type is not supported"
+        }
+    }
+
+    public var debugDescription: String {
+        switch self {
+        case .attachmentUnsupported:
+            return "EncodingError.attachmentUnsupported"
+        }
+    }
 }

--- a/Sources/Core/Client/ClientError.swift
+++ b/Sources/Core/Client/ClientError.swift
@@ -11,7 +11,7 @@ import Foundation
 /// A client error.
 public enum ClientError: LocalizedError, CustomDebugStringConvertible {
     /// An unexpected error.
-    case unexpectedError(description: String)
+    case unexpectedError(description: String, error: Error?)
     /// The API Key is empty.
     case emptyAPIKey
     /// A token is empty.
@@ -55,7 +55,7 @@ public enum ClientError: LocalizedError, CustomDebugStringConvertible {
     
     public var errorDescription: String? {
         switch self {
-        case .unexpectedError(let description):
+        case .unexpectedError(let description, _):
             return "Unexpected error: \(description)"
         case .emptyAPIKey:
             return "The Client API Key is empty"
@@ -92,8 +92,8 @@ public enum ClientError: LocalizedError, CustomDebugStringConvertible {
 
     public var debugDescription: String {
         switch self {
-        case .unexpectedError(let description):
-            return "ClientError.unexpectedError(\(description))"
+        case .unexpectedError(let description, let error):
+            return "ClientError.unexpectedError(description: \(description), error: \(String(describing: error)))"
         case .emptyAPIKey:
             return "ClientError.emptyAPIKey"
         case .emptyToken:

--- a/Sources/Core/Model/Attachment.swift
+++ b/Sources/Core/Model/Attachment.swift
@@ -301,7 +301,7 @@ public enum AttachmentType: RawRepresentable, Codable, Equatable {
 
     public func encode(to encoder: Encoder) throws {
         guard self != .unknown else {
-            throw ClientError.encodingFailure(EncodingError.valueUnsupported, object: self)
+            throw EncodingError.attachmentUnsupported
         }
         var container = encoder.singleValueContainer()
         try container.encode(rawValue)

--- a/Sources/UI/Banners/Banners.swift
+++ b/Sources/UI/Banners/Banners.swift
@@ -135,25 +135,6 @@ public extension Banners {
     ///
     /// - Parameter error: an error.
     func show(error: Error) {
-        var error = error
-        var message = "\(error)"
-        
-        if let anyError = (error as? AnyError)?.error {
-            error = anyError
-        }
-        
-        if let clientError = error as? ClientError {
-            message = clientError.errorDescription ?? message
-            
-            if let internalError = clientError.error {
-                error = internalError
-            }
-        }
-        
-        if let clientErrorResponse = error as? ClientErrorResponse {
-            message = "Error #\(clientErrorResponse.code): \(clientErrorResponse.message)"
-        }
-        
-        show(errorMessage: message)
+        show(errorMessage: error.localizedDescription)
     }
 }


### PR DESCRIPTION
# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

That's another take on issue #104 .
I modified errors so they conform to `CustomDebugStringConvertible`. This way `print(error.localizedDescription)` will always produce human-readable error and `print(error)` will produce more detailed debug information. 

`localizedDescription` is suitable for displaying error to the user while `String(describing: error)` or `\(error)` should be used when displaying error in the logs.

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-27 at 11 29 37](https://user-images.githubusercontent.com/7826664/75436378-bd85aa00-5954-11ea-8912-7e82a911b339.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-27 at 11 29 14](https://user-images.githubusercontent.com/7826664/75436384-bfe80400-5954-11ea-9e7e-de09aca25796.png)
