### PR TITLE
Add completion closure to connect function

### DIFF
--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -143,7 +143,22 @@ public final class Client {
     ///   - Skip if the Internet is not available.
     ///   - Skip if it's already connected.
     ///   - Skip if it's reconnecting.
-    public func connect() {
+    /// - Parameter completion: Completion closure called once connection is established. Only called once.
+    public func connect(completion: Client.OnConnect? = nil) {
+        if let completion = completion {
+            let oldOnConnectClosure = onConnect
+            
+            onConnect = { [weak self] connection in
+                if connection.isConnected {
+                    oldOnConnectClosure(connection)
+                    completion(connection)
+                    self?.onConnect = oldOnConnectClosure
+                } else {
+                    oldOnConnectClosure(connection)
+                }
+            }
+        }
+        
         webSocket.connect()
     }
     


### PR DESCRIPTION
I needed this while writing the Push notification test application. I've used this closure:
```swift
Client.shared.onConnect = { connection in
    if connection.isConnected {
        DispatchQueue.main.async {
            self.viewController?.askForNotificationPermissionIfNeeded()
        }
        Client.shared.onConnect = { _ in }
    }
}
Client.shared.connect()
```
but a completion closure (which automatically handles this) would be more clear.