### PR TITLE
Removes proxy and staging servers

### DIFF
--- a/Example/Sources/LoginViewController.swift
+++ b/Example/Sources/LoginViewController.swift
@@ -115,7 +115,7 @@ final class LoginViewController: UIViewController {
         
         if !clientSetupped {
             Client.config = .init(apiKey: apiKey,
-                                  baseURL: .init(serverLocation: .proxyEast),
+                                  baseURL: .usEast,
                                   database: Database.instance,
                                   logOptions: [.requests, .webSocketInfo])
             

--- a/Sources/Client/BaseURL.swift
+++ b/Sources/Client/BaseURL.swift
@@ -10,6 +10,9 @@ import Foundation
 
 /// A base URL for the `Client`.
 public struct BaseURL: CustomStringConvertible {
+    public static let usEast = BaseURL(urlString: "https://chat-proxy-us-east.stream-io-api.com/")
+    public static let dublin = BaseURL(urlString: "https://chat-proxy-dublin.stream-io-api.com/")
+    
     static let placeholderURL = URL(string: "https://getstream.io")!
     
     public let baseURL: URL
@@ -17,16 +20,17 @@ public struct BaseURL: CustomStringConvertible {
     
     public var description: String { return baseURL.absoluteString }
     
-    /// Create a base URL.
-    /// - Parameter serverLocation: a Stream Chat server location.
-    public init(serverLocation: ServerLocation = .usEast) {
-        self.init(customURL: URL(string: serverLocation.rawValue)!)
+    /// Create a base URL from an URL string.
+    ///
+    /// - Parameter urlString: a Stream Chat server location url string.
+    init(urlString: String) {
+        self.init(url: URL(string: urlString)!)
     }
     
     /// Init with a custom server URL.
     ///
     /// - Parameter url: an URL
-    public init(customURL url: URL) {
+    init(url: URL) {
         var urlString = url.absoluteString
         
         // Remove a scheme prefix.
@@ -40,19 +44,5 @@ public struct BaseURL: CustomStringConvertible {
         urlString = urlString.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         baseURL = URL(string: "https://\(urlString)/")!
         wsURL = URL(string: "wss://\(urlString)/")!
-    }
-}
-
-// MARK: - Base URL Location
-
-extension BaseURL {
-    /// A server location.
-    public enum ServerLocation: String {
-        /// An US-East.
-        case usEast = "https://chat-us-east-1.stream-io-api.com/"
-        /// A proxy server.
-        case proxyEast = "https://chat-proxy-us-east.stream-io-api.com/"
-        /// A staging server.
-        case staging = "https://chat-us-east-staging.stream-io-api.com/"
     }
 }

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -203,7 +203,7 @@ extension Client {
         /// Enable logs (see `ClientLogger.Options`), e.g. `.all`.
         public let logOptions: ClientLogger.Options
         
-        /// Init a config for a shread `Client`.
+        /// Init a config for the shared `Client`.
         ///
         /// - Parameters:
         ///     - apiKey: a Stream Chat API key.
@@ -213,7 +213,7 @@ extension Client {
         ///                                  start a background task to stay connected for 5 min
         ///     - logOptions: enable logs (see `ClientLogger.Options`), e.g. `.all`
         public init(apiKey: String,
-                    baseURL: BaseURL = BaseURL(),
+                    baseURL: BaseURL = .usEast,
                     callbackQueue: DispatchQueue? = nil,
                     stayConnectedInBackground: Bool = true,
                     database: Database? = nil,
@@ -224,6 +224,53 @@ extension Client {
             self.stayConnectedInBackground = stayConnectedInBackground
             self.database = database
             self.logOptions = logOptions
+        }
+        
+        /// Init a config for the shared `Client`.
+        ///
+        /// - Parameters:
+        ///     - apiKey: a Stream Chat API key.
+        ///     - baseURL: a base URL.
+        ///     - callbackQueue: a request callback queue, default nil (some background thread).
+        ///     - stayConnectedInBackground: when the app will go to the background,
+        ///                                  start a background task to stay connected for 5 min
+        ///     - logOptions: enable logs (see `ClientLogger.Options`), e.g. `.all`
+        public init(apiKey: String,
+                    baseURL: URL,
+                    callbackQueue: DispatchQueue? = nil,
+                    stayConnectedInBackground: Bool = true,
+                    database: Database? = nil,
+                    logOptions: ClientLogger.Options = []) {
+            self.init(apiKey: apiKey,
+                      baseURL: .init(url: baseURL),
+                      callbackQueue: callbackQueue,
+                      stayConnectedInBackground: stayConnectedInBackground,
+                      database: database,
+                      logOptions: logOptions)
+        }
+        
+        /// Init a config for the shared `Client`.
+        ///
+        /// - Parameters:
+        ///     - apiKey: a Stream Chat API key.
+        ///     - baseURL: a base URL string.
+        ///     - callbackQueue: a request callback queue, default nil (some background thread).
+        ///     - stayConnectedInBackground: when the app will go to the background,
+        ///                                  start a background task to stay connected for 5 min
+        ///     - logOptions: enable logs (see `ClientLogger.Options`), e.g. `.all`
+        public init?(apiKey: String,
+                    baseURL: String,
+                    callbackQueue: DispatchQueue? = nil,
+                    stayConnectedInBackground: Bool = true,
+                    database: Database? = nil,
+                    logOptions: ClientLogger.Options = []) {
+            guard let url = URL(string: baseURL) else { return nil }
+            self.init(apiKey: apiKey,
+                      baseURL: .init(url: url),
+                      callbackQueue: callbackQueue,
+                      stayConnectedInBackground: stayConnectedInBackground,
+                      database: database,
+                      logOptions: logOptions)
         }
     }
     


### PR DESCRIPTION
... and adds Config initializer for baseURL param

So users can do:
```swift
if let config = Client.Config(apiKey: apiKey, baseURL: "https://your-awesome-chat-server.com/") {
    Client.config = config
}
```
or
```swift
if let url = URL("https://your-awesome-chat-server.com/") {
    Client.config = .init(apiKey: apiKey, baseURL: url)
}
```
and
```swift
Client.config = .init(apiKey: apiKey, baseURL: .usEast)
```
more!
```swift
Client.config = .init(apiKey: apiKey, baseURL: .dublin)
```
without losing the current functionality
