### PR TITLE
Setup ExtraData types

### DIFF
--- a/Sources/Client/Client/Client+Config.swift
+++ b/Sources/Client/Client/Client+Config.swift
@@ -19,8 +19,6 @@ extension Client {
         public let baseURL: BaseURL
         /// A request callback queue, default nil (some background thread).
         public let callbackQueue: DispatchQueue?
-        /// A list of extra data types.
-        public let extraDataTypes: [ExtraData.TypeKey: Codable.Type]
         /// When the app will go to the background, start a background task to stay connected for 5 min.
         public let stayConnectedInBackground: Bool
         /// A local database.
@@ -32,7 +30,6 @@ extension Client {
         /// - Parameters:
         ///     - apiKey: a Stream Chat API key.
         ///     - baseURL: a base URL (see `BaseURL`).
-        ///     - extraDataTypes: custom extra data types for decoding data in your custom types.
         ///     - stayConnectedInBackground: when the app will go to the background,
         ///                                  start a background task to stay connected for 5 min.
         ///     - database: a database manager.
@@ -40,14 +37,12 @@ extension Client {
         ///     - logOptions: enable logs (see `ClientLogger.Options`), e.g. `.all`
         public init(apiKey: String,
                     baseURL: BaseURL = .usEast,
-                    extraDataTypes: [ExtraData.TypeKey: Codable.Type] = [:],
                     stayConnectedInBackground: Bool = true,
                     database: Database? = nil,
                     callbackQueue: DispatchQueue? = nil,
                     logOptions: ClientLogger.Options = []) {
             self.apiKey = apiKey
             self.baseURL = baseURL
-            self.extraDataTypes = extraDataTypes
             self.stayConnectedInBackground = stayConnectedInBackground
             self.database = database
             self.callbackQueue = callbackQueue
@@ -59,7 +54,6 @@ extension Client {
         /// - Parameters:
         ///     - apiKey: a Stream Chat API key.
         ///     - baseURL: a base URL.
-        ///     - extraDataTypes: custom extra data types for decoding data in your custom types.
         ///     - stayConnectedInBackground: when the app will go to the background,
         ///                                  start a background task to stay connected for 5 min
         ///     - database: a database manager.
@@ -67,14 +61,12 @@ extension Client {
         ///     - logOptions: enable logs (see `ClientLogger.Options`), e.g. `.all`
         public init(apiKey: String,
                     baseURL: URL,
-                    extraDataTypes: [ExtraData.TypeKey: Codable.Type] = [:],
                     stayConnectedInBackground: Bool = true,
                     database: Database? = nil,
                     callbackQueue: DispatchQueue? = nil,
                     logOptions: ClientLogger.Options = []) {
             self.init(apiKey: apiKey,
                       baseURL: .init(url: baseURL),
-                      extraDataTypes: extraDataTypes,
                       stayConnectedInBackground: stayConnectedInBackground,
                       database: database,
                       callbackQueue: callbackQueue,
@@ -86,7 +78,6 @@ extension Client {
         /// - Parameters:
         ///     - apiKey: a Stream Chat API key.
         ///     - baseURL: a base URL string.
-        ///     - extraDataTypes: custom extra data types for decoding data in your custom types.
         ///     - stayConnectedInBackground: when the app will go to the background,
         ///                                  start a background task to stay connected for 5 min
         ///     - database: a database manager.
@@ -94,7 +85,6 @@ extension Client {
         ///     - logOptions: enable logs (see `ClientLogger.Options`), e.g. `.all`
         public init?(apiKey: String,
                      baseURL: String,
-                     extraDataTypes: [ExtraData.TypeKey: Codable.Type] = [:],
                      stayConnectedInBackground: Bool = true,
                      database: Database? = nil,
                      callbackQueue: DispatchQueue? = nil,
@@ -103,7 +93,6 @@ extension Client {
             
             self.init(apiKey: apiKey,
                       baseURL: .init(url: url),
-                      extraDataTypes: extraDataTypes,
                       stayConnectedInBackground: stayConnectedInBackground,
                       database: database,
                       callbackQueue: callbackQueue,

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -36,11 +36,9 @@ public final class Client {
         }
     }
     
+    /// A base URL.
     public let baseURL: BaseURL
     let stayConnectedInBackground: Bool
-    
-    /// A list of extra data types.
-    public let extraDataTypes: [ExtraData.TypeKey: Codable.Type]
     /// A database for an offline mode.
     public internal(set) var database: Database?
     
@@ -109,7 +107,6 @@ public final class Client {
     ///     - logOptions: enable logs (see `ClientLogger.Options`), e.g. `.all`
     init(apiKey: String = Client.config.apiKey,
          baseURL: BaseURL = Client.config.baseURL,
-         extraDataTypes: [ExtraData.TypeKey: Codable.Type] = Client.config.extraDataTypes,
          stayConnectedInBackground: Bool = Client.config.stayConnectedInBackground,
          database: Database? = Client.config.database,
          callbackQueue: DispatchQueue? = Client.config.callbackQueue,
@@ -127,7 +124,6 @@ public final class Client {
         self.apiKey = apiKey
         self.baseURL = baseURL
         self.callbackQueue = callbackQueue ?? .global(qos: .userInitiated)
-        self.extraDataTypes = extraDataTypes
         self.stayConnectedInBackground = stayConnectedInBackground
         self.database = database
         self.logOptions = logOptions

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -46,6 +46,10 @@ public final class Channel: Codable {
         case invites
     }
     
+    /// A custom extra data type for channels.
+    /// - Note: Use this variable to setup your own extra data type for decoding channels custom fields from JSON data.
+    public static var extraDataType: Codable.Type?
+    
     /// A channel id.
     public let id: String
     /// A channel type + id.
@@ -195,7 +199,7 @@ public final class Channel: Codable {
         self.name = (name ?? "").isEmpty ? members.channelName(default: id) : (name ?? "")
         imageURL = try? container.decodeIfPresent(URL.self, forKey: .imageURL)
         invitedMembers = Set<Member>()
-        extraData = try? ExtraData(from: decoder, forKey: .channel)
+        extraData = try? ExtraData(from: decoder, forType: Self.extraDataType)
         let config = try container.decode(Config.self, forKey: .config)
         self.config = config
         created = try container.decodeIfPresent(Date.self, forKey: .created) ?? config.created

--- a/Sources/Client/Model/ExtraData.swift
+++ b/Sources/Client/Model/ExtraData.swift
@@ -10,10 +10,6 @@ import Foundation
 
 /// An extra data container.
 public struct ExtraData: Codable {
-    /// A custom extra data decodable type key.
-    public enum TypeKey: String {
-        case user, channel, message, attachment, reaction
-    }
     
     /// An extra data.
     public let object: Codable
@@ -46,8 +42,12 @@ public struct ExtraData: Codable {
     /// - Parameters:
     ///   - decoder: the decoder to read data from.
     ///   - key: a decodable type key.
-    public init?(from decoder: Decoder, forKey key: TypeKey) throws {
-        self.init(try (Client.shared.extraDataTypes[key])?.init(from: decoder))
+    public init?(from decoder: Decoder, forType type: Codable.Type?) throws {
+        guard let codableType = type else {
+            return nil
+        }
+        
+        self.init(try codableType.init(from: decoder))
     }
 }
 
@@ -77,7 +77,7 @@ public extension ExtraData {
     final class UserWrapper: Wrapper {
         required init(from decoder: Decoder) throws {
             try super.init(from: decoder)
-            object = try? ExtraData(from: decoder, forKey: .user)?.object
+            object = try? ExtraData(from: decoder, forType: User.extraDataType)?.object
         }
     }
     
@@ -85,7 +85,7 @@ public extension ExtraData {
     final class ChannelWrapper: Wrapper {
         required init(from decoder: Decoder) throws {
             try super.init(from: decoder)
-            object = try? ExtraData(from: decoder, forKey: .channel)?.object
+            object = try? ExtraData(from: decoder, forType: Channel.extraDataType)?.object
         }
     }
     
@@ -93,7 +93,7 @@ public extension ExtraData {
     final class MessageWrapper: Wrapper {
         required init(from decoder: Decoder) throws {
             try super.init(from: decoder)
-            object = try? ExtraData(from: decoder, forKey: .message)?.object
+            object = try? ExtraData(from: decoder, forType: Message.extraDataType)?.object
         }
     }
     
@@ -101,7 +101,7 @@ public extension ExtraData {
     final class AttachmentWrapper: Wrapper {
         required init(from decoder: Decoder) throws {
             try super.init(from: decoder)
-            object = try? ExtraData(from: decoder, forKey: .attachment)?.object
+            object = try? ExtraData(from: decoder, forType: Attachment.extraDataType)?.object
         }
     }
     
@@ -109,7 +109,7 @@ public extension ExtraData {
     final class ReactionWrapper: Wrapper {
         required init(from decoder: Decoder) throws {
             try super.init(from: decoder)
-            object = try? ExtraData(from: decoder, forKey: .reaction)?.object
+            object = try? ExtraData(from: decoder, forType: Reaction.extraDataType)?.object
         }
     }
 }

--- a/Sources/Client/Model/Message/Attachment/Attachment.swift
+++ b/Sources/Client/Model/Message/Attachment/Attachment.swift
@@ -27,6 +27,10 @@ public struct Attachment: Codable {
         case actions
     }
     
+    /// A custom extra data type for attachments.
+    /// - Note: Use this variable to setup your own extra data type for decoding attachments custom fields from JSON data.
+    public static var extraDataType: Codable.Type?
+    
     /// A title.
     public let title: String
     /// An author.
@@ -125,7 +129,7 @@ public struct Attachment: Codable {
         self.text = text
         file = (type == .file || type == .video) ? try AttachmentFile(from: decoder) : nil
         actions = try container.decodeIfPresent([Action].self, forKey: .actions) ?? []
-        extraData = try? ExtraData(from: decoder, forKey: .attachment)
+        extraData = try? ExtraData(from: decoder, forType: Self.extraDataType)
     }
     
     /// Image upload:

--- a/Sources/Client/Model/Message/Message.swift
+++ b/Sources/Client/Model/Message/Message.swift
@@ -30,6 +30,10 @@ public struct Message: Codable {
         case reactionScores = "reaction_scores"
     }
     
+    /// A custom extra data type for messages.
+    /// - Note: Use this variable to setup your own extra data type for decoding messages custom fields from JSON data.
+    public static var extraDataType: Codable.Type?
+    
     static var flaggedIds = Set<String>()
     
     /// A message id.
@@ -184,8 +188,8 @@ public struct Message: Codable {
         replyCount = try container.decode(Int.self, forKey: .replyCount)
         latestReactions = (try? container.decode([Reaction].self, forKey: .latestReactions)) ?? []
         ownReactions = (try? container.decode([Reaction].self, forKey: .ownReactions)) ?? []
-        extraData = try? ExtraData(from: decoder, forKey: .message)
         reactionScores = try container.decodeIfPresent([String: Int].self, forKey: .reactionScores) ?? [:]
+        extraData = try? ExtraData(from: decoder, forType: Self.extraDataType)
     }
     
     private func checkIfTextAsAttachmentURL(_ text: String) -> Bool {

--- a/Sources/Client/Model/Message/Reaction.swift
+++ b/Sources/Client/Model/Message/Reaction.swift
@@ -18,6 +18,10 @@ public struct Reaction: Codable {
         case created = "created_at"
     }
     
+    /// A custom extra data type for reactions.
+    /// - Note: Use this variable to setup your own extra data type for decoding reactions custom fields from JSON data.
+    public static var extraDataType: Codable.Type?
+    
     /// A reaction type.
     public let type: String
     /// A score.
@@ -63,7 +67,7 @@ public struct Reaction: Codable {
         messageId = try container.decode(String.self, forKey: .messageId)
         user = try container.decodeIfPresent(User.self, forKey: .user)
         created = try container.decode(Date.self, forKey: .created)
-        extraData = try? ExtraData(from: decoder, forKey: .reaction)
+        extraData = try? ExtraData(from: decoder, forType: Self.extraDataType)
     }
     
     public func encode(to encoder: Encoder) throws {

--- a/Sources/Client/Model/User/User.swift
+++ b/Sources/Client/Model/User/User.swift
@@ -28,6 +28,10 @@ public struct User: Codable {
         case isAnonymous = "anon"
     }
     
+    /// A custom extra data type for users.
+    /// - Note: Use this variable to setup your own extra data type for decoding users custom fields from JSON data.
+    public static var extraDataType: Codable.Type?
+    
     /// An unkown user.
     public static let unknown: User = {
         let id = UUID().uuidString
@@ -158,7 +162,7 @@ public struct User: Codable {
         isBanned = try container.decodeIfPresent(Bool.self, forKey: .isBanned) ?? false
         devices = try container.decodeIfPresent([Device].self, forKey: .devices) ?? []
         mutedUsers = try container.decodeIfPresent([MutedUser].self, forKey: .mutedUsers) ?? []
-        extraData = try? ExtraData(from: decoder, forKey: .user)
+        extraData = try? ExtraData(from: decoder, forType: Self.extraDataType)
         
         if let name = try? container.decodeIfPresent(String.self, forKey: .name) {
             self.name = name

--- a/Sources/Core/Client/Subscription.swift
+++ b/Sources/Core/Client/Subscription.swift
@@ -9,8 +9,8 @@
 import StreamChatClient
 import RxSwift
 
-/// A subscription for an async request.
-/// You have to keep as an instance variable until you need results in a completion block.
+/// A subscription for events.
+/// You have to keep subscription variable until you need events.
 ///
 /// For example:
 /// ```
@@ -20,20 +20,28 @@ import RxSwift
 ///     open override func viewWillAppear() {
 ///         super.viewWillAppear(animated)
 ///
-///         subscription = Client.shared.onEvent() { event
-///             print(event)
+///         // Subscribe for client events.
+///         subscription = Client.shared.onEvent() { result in
+///             print(result)
 ///         }
 ///     }
 ///
 ///     open override func viewWillDisappear() {
 ///         super.viewWillDisappear()
-///         subscription = nil
+///
+///         // Unsubscribe from client events.
+///         subscription?.cancel()
 ///     }
 /// }
 /// ```
 public final class Subscription {
     fileprivate static let shared = Subscription()
-    let disposeBag = DisposeBag()
+    private(set) var disposeBag = DisposeBag()
+    
+    /// Cancel the subscription.
+    public func cancel() {
+        disposeBag = DisposeBag()
+    }
 }
 
 // MARK: Client Completion Binding

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -302,8 +302,6 @@
 		8A466E62241A3A7D003C21BA /* Client+WebSocket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Client+WebSocket.swift"; sourceTree = "<group>"; };
 		8A466E64241A3AAA003C21BA /* Client+Setup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Client+Setup.swift"; sourceTree = "<group>"; };
 		8A466E66241A3AB6003C21BA /* BaseURL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseURL.swift; sourceTree = "<group>"; };
-		8A4AB32324102196000A23DD /* ReactionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionType.swift; sourceTree = "<group>"; };
-		8A4AB325241021C4000A23DD /* ReactionScores.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionScores.swift; sourceTree = "<group>"; };
 		8A50694F23CDEA31009F127A /* StreamChatClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A50695723CDEA31009F127A /* StreamChatClientTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatClientTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A50696723CDEDA3009F127A /* StreamChat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StreamChat.h; sourceTree = "<group>"; };
@@ -664,15 +662,6 @@
 				8A30D07A237D81C20082B951 /* StringExtensionsTests.swift */,
 			);
 			path = "Unit Tests";
-			sourceTree = "<group>";
-		};
-		8ACC7BAF24192477000750E4 /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-				8A4AB32324102196000A23DD /* ReactionType.swift */,
-				8A4AB325241021C4000A23DD /* ReactionScores.swift */,
-			);
-			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		8ACC7BB0241924AD000750E4 /* Client */ = {
@@ -1193,7 +1182,6 @@
 				8AD5EDD922E9C7BC005CFAC9 /* StreamChat.podspec */,
 				8A8BB2A2238456A200C2F9DE /* StreamChatRealm.podspec */,
 				8AD5EDDA22E9C7BC005CFAC9 /* Cartfile */,
-				8ACC7BAF24192477000750E4 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};

--- a/Tests/Client/Integration Tests/ClientTests01+Channels.swift
+++ b/Tests/Client/Integration Tests/ClientTests01+Channels.swift
@@ -38,7 +38,7 @@ final class ClientTests01_Channels: TestCase {
     static let messageText = "Text \(UUID().uuidString)"
     
     let member2 = User.user2.asMember
-    let loveReactionType = ReactionType.regular("love", emoji: "❤️")
+    let loveReactionType = "love"
     
     let unreadCounts: [UnreadCount] = [.init(channels: 0, messages: 0),
                                        .init(channels: 1, messages: 1),
@@ -51,8 +51,8 @@ final class ClientTests01_Channels: TestCase {
     func test01BigFlow() {
         let client1 = Client(apiKey: TestCase.apiKey,
                              baseURL: TestCase.baseURL,
-                             callbackQueue: .main,
                              stayConnectedInBackground: false,
+                             callbackQueue: .main,
                              logOptions: [])
         
         Client.shared.set(user: .user2, token: .token2)

--- a/Tests/Client/Integration Tests/ClientTests10+ClientLogger.swift
+++ b/Tests/Client/Integration Tests/ClientTests10+ClientLogger.swift
@@ -43,7 +43,7 @@ final class ClientTests10_ClientLogger: XCTestCase {
         
         let testMembers = Set([User.user1.asMember])
         let testMessage = Message(id: "test", type: .reply, text: "test")
-        let testReaction = Reaction(type: .regular("angry", emoji: "😠"), messageId: testMessage.id)
+        let testReaction = Reaction(type: "angry", messageId: testMessage.id)
         
         allEndpoints = [.guestToken(User.user1),
                         .addDevice(deviceId: "test", User.user1),

--- a/Tests/Client/TestCase.swift
+++ b/Tests/Client/TestCase.swift
@@ -30,8 +30,8 @@ class TestCase: XCTestCase {
         
         Client.config = .init(apiKey: Self.apiKey,
                               baseURL: Self.baseURL,
-                              callbackQueue: .main,
                               stayConnectedInBackground: false,
+                              callbackQueue: .main,
                               logOptions: [])
     }
     


### PR DESCRIPTION
Create a custom extra data type with any complexity, but `Codable`:
```swift
struct ProductChannel: Codable {
    let info: String
    let product: Product
}
```

Set this custom type at any time (this is good for tutorials) to the related our model type:
```swift
Channel.extraDataType = ProductChannel.self
```

Use extra data in place:
```swift
if let productChannel = channelPresenter.channel.extraData?.object as? ProductChannel {
    cell.nameLabel.text = productChannel.product.name
    cell.detailTextLabel.text = productChannel.info
}
```