### PR TITLE
Fix typing events are not reliably sent in UI components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### 🐞 Fixed
-
+- (UI Components) Typing events are now reliably sent [#122](https://github.com/GetStream/stream-chat-swift/issues/122)
 
 # [1.6.0](https://github.com/GetStream/stream-chat-swift/releases/tag/1.6.0)
 _March 10, 2020_

--- a/Sources/Core/Client/Client+Request.swift
+++ b/Sources/Core/Client/Client+Request.swift
@@ -62,8 +62,8 @@ extension Client {
             do {
                 let podTrunk = try JSONDecoder().decode(PodTrunk.self, from: data)
                 if let latestVersion = podTrunk.versions.last?.name, latestVersion > Environment.version {
-                    ClientLogger.logger("📢", "", "StreamChat \(latestVersion) is released (you are on \(Environment.version))."
-                        + "It's recommended to update to the latest version")
+                    ClientLogger.logger("📢", "", "StreamChat \(latestVersion) is released (you are on \(Environment.version)). "
+                        + "It's recommended to update to the latest version.")
                 }
             } catch {}
         }

--- a/Sources/Core/Presenter/Channel Presenter/ChannelPresenter.swift
+++ b/Sources/Core/Presenter/Channel Presenter/ChannelPresenter.swift
@@ -265,21 +265,15 @@ extension ChannelPresenter {
 extension ChannelPresenter {
     /// Send a typing event.
     public func sendEvent(isTyping: Bool) -> Observable<Event> {
-        guard parentMessage == nil else {
+        guard parentMessage == nil && isTyping != startedTyping else {
             return .empty()
         }
         
-        if isTyping {
-            if !startedTyping {
-                startedTyping = true
-                return channel.send(eventType: .typingStart).observeOn(MainScheduler.instance)
-            }
-        } else if startedTyping {
-            startedTyping = false
-            return channel.send(eventType: .typingStop).observeOn(MainScheduler.instance)
-        }
+        startedTyping = isTyping
         
-        return .empty()
+        return channel
+            .send(eventType: isTyping ? .typingStart : .typingStop)
+            .observeOn(MainScheduler.instance)
     }
     
     /// Send Read event if the app is active.

--- a/Sources/Core/Presenter/Channel Presenter/ChannelPresenter.swift
+++ b/Sources/Core/Presenter/Channel Presenter/ChannelPresenter.swift
@@ -55,7 +55,6 @@ public final class ChannelPresenter: Presenter<ChatItem> {
     /// Show statuses separators, e.g. Today
     public private(set) var showStatuses = true
     
-    private var startedTyping = false
     let lastMessageAtomic = Atomic<Message>()
     
     /// The last parsed message from WebSocket events.
@@ -263,21 +262,7 @@ extension ChannelPresenter {
 // MARK: - Send Event
 
 extension ChannelPresenter {
-    /// Send a typing event.
-    public func sendEvent(isTyping: Bool) -> Observable<Event> {
-        guard parentMessage == nil && isTyping != startedTyping else {
-            return .empty()
-        }
-        
-        startedTyping = isTyping
-        
-        return channel
-            .send(eventType: isTyping ? .typingStart : .typingStop)
-            .observeOn(MainScheduler.instance)
-    }
-    
     /// Send Read event if the app is active.
-    ///
     /// - Returns: an observable completion.
     public func markReadIfPossible() -> Observable<Void> {
         guard InternetConnection.shared.isAvailable, channel.config.readEventsEnabled else {

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
@@ -118,9 +118,9 @@ extension ChatViewController {
             .unwrap()
             .do(onNext: { [weak self] in self?.dispatchCommands(in: $0) })
             .filter { [weak self] in !$0.isBlank && (self?.channelPresenter?.channel.config.typingEventsEnabled ?? false) }
-            .flatMapLatest { [weak self] _ in self?.channelPresenter?.sendEvent(isTyping: true) ?? .empty() }
-            .debounce(.seconds(3), scheduler: MainScheduler.instance)
-            .flatMapLatest { [weak self] _ in self?.channelPresenter?.sendEvent(isTyping: false) ?? .empty() }
+            .buffer(timeSpan: .seconds(3), count: 1, scheduler: MainScheduler.instance)
+            .flatMapLatest { [weak self] (input) -> Observable<StreamChatCore.Event> in
+                self?.channelPresenter?.sendEvent(isTyping: !input.isEmpty) ?? .empty() }
             .subscribe()
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
Here's a video showing it working: 
https://www.dropbox.com/s/ibrmgcyjwesuu1f/Screen%20Recording%202020-03-18%20at%2011.35.35.mov?dl=0

The idea is:
1. When the user starts typing, send `typingStarted` event, only once.
2. If the user doesn't type for 3 seconds, send `typingStopped` event, only once.

I've tried to simplify as much as possible for this scenario. `bufffer` helps me fire periodical events, which `debounce` does not do. Also, `debounce` and sending `typingStopped` event relied on server response of `typingStarted` event, which didn't work as expected.



