### PR TITLE
Fix composerView disappearing after sending the bg

### DIFF
--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -185,10 +185,6 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
                                       with coordinator: UIViewControllerTransitionCoordinator) {
         super.willTransition(to: newCollection, with: coordinator)
         
-        if composerView.textView.isFirstResponder {
-            composerView.textView.resignFirstResponder()
-        }
-        
         DispatchQueue.main.async { self.initialSafeAreaBottom = self.calculatedSafeAreaBottom }
     }
     


### PR DESCRIPTION
Fixes #118

Steps to reproduce this bug can be found in #118

After investigating a couple of messajing apps (Whatsapp, Slack, Twitter) I've realized that when those apps are sent to bg when keyboard is visible, they don't `resignFirstResponder` so when reopened, keyboard is correctly visible. I believe the best solution is to follow other messaging apps so our SDK behaves like users expect.

The issue arises from keyboard notification not sent when we `resignFirstResponder` after apps is reopened. Our state machine breaks and calculations are not correct anymore.

One other solution could be to `resignFirstResponder` in `viewWillDisappear`.