### PR TITLE
Fix link detection accuracy in messages with markdown

### DIFF
--- a/Sources/UI/Chat/Cells/MessageTextEnrichment.swift
+++ b/Sources/UI/Chat/Cells/MessageTextEnrichment.swift
@@ -68,8 +68,8 @@ final class MessageTextEnrichment {
     func enrich() -> Observable<NSAttributedString> {
         Observable.create({ [weak self] observer -> Disposable in
             if let self = self {
-                self.parseLinks()
                 self.parse()
+                self.parseLinks()
                 
                 if let attributedString = self.attributedString {
                     observer.onNext(attributedString)
@@ -209,6 +209,7 @@ private extension MessageTextEnrichment {
             return
         }
         
+        let text = attributedString?.string ?? self.text
         detectedURLs = DataDetector.shared.matchURLs(text)
         
         if detectedURLs.isEmpty {


### PR DESCRIPTION
Ranges of links were being decided before markdown was parsed, so they were shifted right by the number of characters removed in the markdown parsing.

I just moved the link parsing to after the markdown parsing & made sure the attributedString.string (without markdown symbols) is used instead of the plain text.

| Before | After |
|-|-|
|![2020-04-02 01 46 38](https://user-images.githubusercontent.com/5606812/78212440-1f6e8d80-7486-11ea-9f56-3d588e06566c.gif)|![2020-04-02 02 05 59](https://user-images.githubusercontent.com/5606812/78212697-dff47100-7486-11ea-928d-fd1c8ef9879d.gif)|

Test strings: 
```
Google: https://google.com
Discord: https://discord.com

**Google**: https://google.com
**Discord**: https://discord.com
```