### PR TITLE
CIS-65 Add verbose error for endpoints requiring connection id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### ✅ Added
-
+- Better errors when developers forget to call `set(user:)` or don't wait for its completion [#160](https://github.com/GetStream/stream-chat-swift/issues/160)
 
 ### 🐞 Fixed
 - SPM support [#156](https://github.com/GetStream/stream-chat-swift/issues/156).

--- a/Sources/Client/Client/Client+Request.swift
+++ b/Sources/Client/Client/Client+Request.swift
@@ -156,7 +156,9 @@ extension Client {
         var queryItems = [URLQueryItem(name: "api_key", value: apiKey)]
         
         if let connectionId = webSocket.lastConnectionId {
-            queryItems.append(URLQueryItem(name: "client_id", value: connectionId))
+            queryItems.append(URLQueryItem(name: "connection_id", value: connectionId))
+        } else if endpoint.requiresConnectionId {
+            return .failure(.emptyConnectionId)
         }
         
         if let endpointQueryItems = endpoint.jsonQueryItems {

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -156,8 +156,9 @@ public final class Client {
     private func checkAPIKey() {
         if apiKey.isEmpty {
             ClientLogger.logger("❌❌❌", "", "The Stream Chat Client didn't setup properly. "
-                + "You are trying to use it before setup the API Key.")
-            Thread.callStackSymbols.forEach { ClientLogger.logger("", "", $0) }
+                + "You are trying to use it before setting up the API Key. "
+                + "Please use `Client.config = .init(apiKey:) to setup your api key. "
+                + "You can debug this issue by putting a breakpoint in \(#file)\(#line)")
         }
     }
     

--- a/Sources/Client/Client/ClientError.swift
+++ b/Sources/Client/Client/ClientError.swift
@@ -70,7 +70,8 @@ public enum ClientError: LocalizedError, CustomDebugStringConvertible {
         case .unexpectedError(let description, _):
             return "Unexpected error: \(description)"
         case .emptyAPIKey:
-            return "The Client API Key is empty"
+            return "Client API Key is empty."
+                + " Please use `Client.config = .init(apiKey:) before using Client to setup your api key correctly."
         case .emptyToken:
             return "A Client Token is empty"
         case .invalidToken(let description):
@@ -80,7 +81,7 @@ public enum ClientError: LocalizedError, CustomDebugStringConvertible {
         case .emptyUser:
             return "The current Client user is empty"
         case .emptyConnectionId:
-            return "A Web Socket connection id is empty. Authorization missed"
+            return "Web Socket connection id is empty. Authorization missed. Please call set(user:) and wait for its completion."
         case .emptyChannelId:
             return "A channel id is empty"
         case .emptyMessageId:

--- a/Sources/Client/Client/Endpoint.swift
+++ b/Sources/Client/Client/Endpoint.swift
@@ -331,6 +331,52 @@ extension Endpoint {
         }
     }
     
+    var requiresConnectionId: Bool {
+        switch self {
+        case .users,
+             .updateUsers,
+             .channels,
+             .channel,
+             .stopWatching:
+            return true
+        case .guestToken,
+             .message,
+             .markAllRead,
+             .deleteChannel,
+             .invite,
+             .addMembers,
+             .removeMembers,
+             .replies,
+             .deleteMessage,
+             .deleteReaction,
+             .sendImage,
+             .sendFile,
+             .deleteImage,
+             .deleteFile,
+             .inviteAnswer,
+             .addDevice,
+             .removeDevice,
+             .devices,
+             .search,
+             .updateChannel,
+             .showChannel,
+             .hideChannel,
+             .sendMessage,
+             .sendMessageAction,
+             .markRead,
+             .addReaction,
+             .sendEvent,
+             .muteUser,
+             .unmuteUser,
+             .flagUser,
+             .unflagUser,
+             .flagMessage,
+             .unflagMessage,
+             .ban:
+            return false
+        }
+    }
+    
     private func path(to channel: Channel, _ subPath: String? = nil) -> String {
         "channels/\(channel.type.rawValue)\(channel.id.isEmpty ? "" : "/\(channel.id)")\(subPath == nil ? "" : "/\(subPath ?? "")")"
     }


### PR DESCRIPTION
I don't think printing the callStack on error is good/expected by developers, so I replaced it with instructions to print callstack (like RxSwift does)

I've followed our REST docs to see which endpoints require connection id, but I'd appreciate a second pair of eyes: https://getstream.io/chat/docs_rest/
