### PR TITLE
WebSocket connection as event

### DIFF
--- a/Example/Sources/LoginViewController.swift
+++ b/Example/Sources/LoginViewController.swift
@@ -135,12 +135,12 @@ final class LoginViewController: ViewController {
             return
         }
         
-        func showNext(_ connection: Connection) {
+        func showNext(_ result: Result<UserConnection, ClientError>) {
             loginButton.isEnabled = true
             
-            if case .disconnected(let error) = connection {
-                show(errorMessage: error?.localizedDescription ?? "Disconnected")
-            } else if case .connected = connection, showNextViewController {
+            if let error = result.error {
+                show(errorMessage: error.localizedDescription)
+            } else if showNextViewController {
                 showRootViewController(animated: animated)
             }
         }

--- a/Example/Sources/Main.storyboard
+++ b/Example/Sources/Main.storyboard
@@ -75,159 +75,69 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="fQM-5J-VyU">
-                                <rect key="frame" x="16" y="64" width="343" height="470"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="fQM-5J-VyU">
+                                <rect key="frame" x="16" y="64" width="343" height="398"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lMz-sX-zDG">
-                                        <rect key="frame" x="0.0" y="0.0" width="128" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="87" height="30"/>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
-                                        <state key="normal" title="Show all channels"/>
+                                        <state key="normal" title="All channels"/>
                                         <connections>
                                             <segue destination="aEe-dp-x44" kind="presentation" modalPresentationStyle="fullScreen" id="seW-P6-fEX"/>
                                         </connections>
                                     </button>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NfR-jx-apB">
-                                        <rect key="frame" x="0.0" y="45" width="343" height="1"/>
-                                        <color key="backgroundColor" red="0.83741801979999997" green="0.83743780850000005" blue="0.83742713930000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="1" id="aJG-im-NEt"/>
-                                        </constraints>
-                                    </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Try-iz-4dr">
-                                        <rect key="frame" x="0.0" y="61" width="215" height="30"/>
+                                        <rect key="frame" x="0.0" y="60" width="146" height="30"/>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
-                                        <state key="normal" title="Show my messaging channels"/>
+                                        <state key="normal" title="Messaging channels"/>
                                         <connections>
                                             <segue destination="Jpg-eB-15H" kind="presentation" modalPresentationStyle="fullScreen" id="qta-yE-T30"/>
                                         </connections>
                                     </button>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Is3-cY-vA9">
-                                        <rect key="frame" x="0.0" y="106" width="343" height="1"/>
-                                        <color key="backgroundColor" red="0.83741801979999997" green="0.83743780850000005" blue="0.83742713930000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="1" id="xac-Wl-l6s"/>
-                                        </constraints>
-                                    </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uBn-vP-Vku">
-                                        <rect key="frame" x="0.0" y="122" width="263" height="30"/>
+                                        <rect key="frame" x="0.0" y="120" width="280" height="30"/>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
-                                        <state key="normal" title="Show split view of channels and chat"/>
+                                        <state key="normal" title="Split view of channels and chat for iPad"/>
                                         <connections>
                                             <segue destination="FA6-rb-JLu" kind="presentation" modalPresentationStyle="fullScreen" id="gPS-K7-ckQ"/>
                                         </connections>
                                     </button>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gbU-nu-nAs">
-                                        <rect key="frame" x="0.0" y="167" width="343" height="1"/>
-                                        <color key="backgroundColor" red="0.83741801979999997" green="0.83743780850000005" blue="0.83742713930000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="1" id="W39-gf-ApT"/>
-                                        </constraints>
-                                    </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Of-ZP-Ztv">
-                                        <rect key="frame" x="0.0" y="183" width="142" height="30"/>
+                                        <rect key="frame" x="0.0" y="180" width="200" height="30"/>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
-                                        <state key="normal" title="Show #general chat"/>
+                                        <state key="normal" title="Chat in #messaging:general"/>
                                         <connections>
                                             <segue destination="Z71-Wp-boH" kind="presentation" modalPresentationStyle="fullScreen" id="x9o-K0-tAV"/>
                                         </connections>
                                     </button>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qr4-mI-Aca">
-                                        <rect key="frame" x="0.0" y="228" width="343" height="1"/>
-                                        <color key="backgroundColor" red="0.83741801979999997" green="0.83743780850000005" blue="0.83742713930000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="1" id="w5I-Ww-kht"/>
-                                        </constraints>
-                                    </view>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total Unread Count: &lt;Disabled&gt;" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tp6-sE-CBi">
-                                        <rect key="frame" x="0.0" y="244" width="219.5" height="18"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unread Count: &lt;Disabled&gt;" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r90-MX-Ekn" userLabel="UnreadCount">
+                                        <rect key="frame" x="0.0" y="240" width="172" height="17"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p8S-Fb-tWu">
-                                        <rect key="frame" x="0.0" y="277" width="343" height="1"/>
-                                        <color key="backgroundColor" red="0.83741801979999997" green="0.83743780850000005" blue="0.83742713930000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="1" id="RCM-pe-Xap"/>
-                                        </constraints>
-                                    </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Watcher Count: &lt;Disabled&gt;" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LML-Ms-XJg">
-                                        <rect key="frame" x="0.0" y="293" width="190" height="18"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <rect key="frame" x="0.0" y="287" width="179" height="17"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mr8-ak-oSo">
-                                        <rect key="frame" x="0.0" y="326" width="343" height="1"/>
-                                        <color key="backgroundColor" red="0.83741801979999997" green="0.83743780850000005" blue="0.83742713930000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="1" id="2lJ-fr-F2c"/>
-                                        </constraints>
-                                    </view>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="29t-nH-723">
-                                        <rect key="frame" x="0.0" y="342" width="173" height="30"/>
-                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
-                                        <state key="normal" title="Check if you are banned"/>
-                                        <connections>
-                                            <action selector="checkForBan:" destination="0IT-ko-SLg" eventType="touchUpInside" id="Ebl-YK-JQp"/>
-                                        </connections>
-                                    </button>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pB8-mF-TRX">
-                                        <rect key="frame" x="0.0" y="387" width="343" height="1"/>
-                                        <color key="backgroundColor" red="0.83741801979999997" green="0.83743780850000005" blue="0.83742713930000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="1" id="vnA-K0-oI2"/>
-                                        </constraints>
-                                    </view>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Offline mode:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bRL-1s-rt3" userLabel="Offline:">
-                                        <rect key="frame" x="0.0" y="403" width="93" height="18"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total Unread Count: &lt;Disabled&gt;" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tp6-sE-CBi">
+                                        <rect key="frame" x="0.0" y="334" width="207" height="17"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="88s-xm-EP6">
-                                        <rect key="frame" x="0.0" y="436" width="343" height="1"/>
-                                        <color key="backgroundColor" red="0.83741801979999997" green="0.83743780850000005" blue="0.83742713930000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="1" id="ZYx-GI-2Xg"/>
-                                        </constraints>
-                                    </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Push  notifications:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MVq-bk-kzB">
-                                        <rect key="frame" x="0.0" y="452" width="130.5" height="18"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <rect key="frame" x="0.0" y="381" width="123.5" height="17"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstItem="qr4-mI-Aca" firstAttribute="width" secondItem="fQM-5J-VyU" secondAttribute="width" id="63B-qm-Ywr"/>
-                                    <constraint firstItem="gbU-nu-nAs" firstAttribute="width" secondItem="fQM-5J-VyU" secondAttribute="width" id="FUK-FQ-UjH"/>
-                                    <constraint firstItem="88s-xm-EP6" firstAttribute="width" secondItem="fQM-5J-VyU" secondAttribute="width" id="JAj-7u-7So"/>
-                                    <constraint firstItem="NfR-jx-apB" firstAttribute="width" secondItem="fQM-5J-VyU" secondAttribute="width" id="W57-dd-fAC"/>
-                                    <constraint firstItem="Is3-cY-vA9" firstAttribute="width" secondItem="fQM-5J-VyU" secondAttribute="width" id="XmS-Ge-9cD"/>
-                                    <constraint firstItem="Mr8-ak-oSo" firstAttribute="width" secondItem="fQM-5J-VyU" secondAttribute="width" id="Z3W-3U-xbk"/>
-                                    <constraint firstItem="pB8-mF-TRX" firstAttribute="width" secondItem="fQM-5J-VyU" secondAttribute="width" id="ZOT-mP-dAd"/>
-                                    <constraint firstItem="p8S-Fb-tWu" firstAttribute="width" secondItem="fQM-5J-VyU" secondAttribute="width" id="e2b-zi-XFR"/>
-                                </constraints>
                             </stackView>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="–" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eTn-JY-iPB">
-                                <rect key="frame" x="158" y="249" width="16" height="16"/>
-                                <color key="backgroundColor" name="systemRedColor" catalog="System" colorSpace="catalog"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="16" id="Jsh-lg-vjv"/>
-                                    <constraint firstAttribute="height" constant="16" id="vuK-pc-5Dk"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="9"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <color key="highlightedColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <integer key="value" value="8"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DARK MODE" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="11f-PJ-qcd">
-                                <rect key="frame" x="241" y="132" width="72" height="16"/>
+                                <rect key="frame" x="172" y="131" width="72" height="16"/>
                                 <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="72" id="i8J-3r-nDA"/>
@@ -243,41 +153,41 @@
                                 </userDefinedRuntimeAttributes>
                             </label>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jQp-EN-Voh">
-                                <rect key="frame" x="310" y="246.5" width="51" height="31"/>
+                                <rect key="frame" x="310" y="297" width="51" height="31"/>
                             </switch>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OkG-5O-emD">
-                                <rect key="frame" x="265.5" y="247.5" width="39.5" height="29"/>
-                                <string key="text">unread
-badge</string>
-                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jrn-MT-IQv">
-                                <rect key="frame" x="310" y="350.5" width="51" height="31"/>
+                                <rect key="frame" x="310" y="344" width="51" height="31"/>
                             </switch>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="H0k-lx-tmL">
-                                <rect key="frame" x="310" y="509.5" width="51" height="31"/>
+                                <rect key="frame" x="310" y="438" width="51" height="31"/>
                             </switch>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="1lG-cg-5R8">
-                                <rect key="frame" x="310" y="301.5" width="51" height="31"/>
-                            </switch>
-                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="dR6-bE-we3">
-                                <rect key="frame" x="310" y="460.5" width="51" height="31"/>
+                                <rect key="frame" x="310" y="391" width="51" height="31"/>
                             </switch>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It doesn't hold the state and to disable Push notifications you need to toggle it twice." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B0u-JV-sSq">
-                                <rect key="frame" x="16" y="539" width="283" height="29"/>
+                                <rect key="frame" x="16" y="467" width="283" height="29"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7rg-Xd-yMa">
-                                <rect key="frame" x="0.0" y="583" width="375" height="1"/>
-                                <color key="backgroundColor" red="0.83741801979999997" green="0.83743780850000005" blue="0.83742713930000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="1" id="b5l-qn-iGf"/>
-                                </constraints>
-                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filter: the current user is a member of channels" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ncz-qn-Ssy">
+                                <rect key="frame" x="16" y="154" width="268" height="14.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="In #messaging:general" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KXt-y3-Xl9">
+                                <rect key="frame" x="16" y="368" width="128" height="14.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="In #messaging:general" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wdX-uG-nfO">
+                                <rect key="frame" x="16" y="321" width="128" height="14.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fyw-02-BDi">
                                 <rect key="frame" x="118.5" y="618" width="138.5" height="29"/>
                                 <string key="text">Demo Project
@@ -291,47 +201,42 @@ Stream Swift SDK v.1.0.0</string>
                         <constraints>
                             <constraint firstItem="jrn-MT-IQv" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="LML-Ms-XJg" secondAttribute="trailing" constant="10" id="21z-y7-4iv"/>
                             <constraint firstItem="11f-PJ-qcd" firstAttribute="leading" secondItem="Try-iz-4dr" secondAttribute="trailing" constant="10" id="4ic-pP-d1B"/>
-                            <constraint firstItem="eTn-JY-iPB" firstAttribute="leading" secondItem="5Of-ZP-Ztv" secondAttribute="trailing" id="7eh-gI-RGo"/>
-                            <constraint firstItem="dR6-bE-we3" firstAttribute="centerY" secondItem="bRL-1s-rt3" secondAttribute="centerY" id="BdG-it-ipQ"/>
-                            <constraint firstItem="7rg-Xd-yMa" firstAttribute="leading" secondItem="5vB-qP-Wuo" secondAttribute="leading" id="BrI-Wb-SCz"/>
-                            <constraint firstItem="OkG-5O-emD" firstAttribute="centerY" secondItem="jQp-EN-Voh" secondAttribute="centerY" id="EtX-0u-umn"/>
+                            <constraint firstItem="KXt-y3-Xl9" firstAttribute="leading" secondItem="LML-Ms-XJg" secondAttribute="leading" id="5AX-Ou-M4D"/>
+                            <constraint firstItem="jQp-EN-Voh" firstAttribute="centerY" secondItem="r90-MX-Ekn" secondAttribute="centerY" id="5hn-mW-dvy"/>
+                            <constraint firstItem="wdX-uG-nfO" firstAttribute="leading" secondItem="r90-MX-Ekn" secondAttribute="leading" id="CcP-zs-9BN"/>
+                            <constraint firstItem="wdX-uG-nfO" firstAttribute="top" secondItem="r90-MX-Ekn" secondAttribute="bottom" id="E7V-vb-vDU"/>
                             <constraint firstItem="B0u-JV-sSq" firstAttribute="leading" secondItem="MVq-bk-kzB" secondAttribute="leading" id="G4B-f4-p79"/>
                             <constraint firstItem="1lG-cg-5R8" firstAttribute="centerY" secondItem="tp6-sE-CBi" secondAttribute="centerY" id="I6Y-59-cBo"/>
+                            <constraint firstItem="KXt-y3-Xl9" firstAttribute="top" secondItem="LML-Ms-XJg" secondAttribute="bottom" id="JBZ-nx-a9r"/>
                             <constraint firstItem="jQp-EN-Voh" firstAttribute="trailing" secondItem="fQM-5J-VyU" secondAttribute="trailing" id="JHC-nQ-XuY"/>
-                            <constraint firstItem="eTn-JY-iPB" firstAttribute="centerY" secondItem="5Of-ZP-Ztv" secondAttribute="centerY" constant="-5" id="Jfi-ED-ACl"/>
                             <constraint firstItem="H0k-lx-tmL" firstAttribute="centerY" secondItem="MVq-bk-kzB" secondAttribute="centerY" id="JiW-cq-VUP"/>
-                            <constraint firstItem="7rg-Xd-yMa" firstAttribute="trailing" secondItem="5vB-qP-Wuo" secondAttribute="trailing" id="Nm8-OB-Fkt"/>
                             <constraint firstItem="H0k-lx-tmL" firstAttribute="trailing" secondItem="fQM-5J-VyU" secondAttribute="trailing" id="UPl-Cd-D6W"/>
-                            <constraint firstItem="jQp-EN-Voh" firstAttribute="leading" secondItem="OkG-5O-emD" secondAttribute="trailing" constant="5" id="VBD-P5-eON"/>
                             <constraint firstItem="Fyw-02-BDi" firstAttribute="centerX" secondItem="pUb-7p-fIc" secondAttribute="centerX" id="WfN-1q-yri"/>
                             <constraint firstItem="fQM-5J-VyU" firstAttribute="trailing" secondItem="jrn-MT-IQv" secondAttribute="trailing" id="Y6b-uF-Qxa"/>
                             <constraint firstItem="B0u-JV-sSq" firstAttribute="trailing" secondItem="fQM-5J-VyU" secondAttribute="trailing" constant="-60" id="YXy-7G-fdL"/>
                             <constraint firstItem="fQM-5J-VyU" firstAttribute="leading" secondItem="pUb-7p-fIc" secondAttribute="leading" constant="16" id="Yjs-jQ-l1d"/>
                             <constraint firstItem="pUb-7p-fIc" firstAttribute="trailing" secondItem="fQM-5J-VyU" secondAttribute="trailing" constant="16" id="Ztz-Qr-06v"/>
                             <constraint firstItem="11f-PJ-qcd" firstAttribute="centerY" secondItem="Try-iz-4dr" secondAttribute="centerY" id="aut-4i-Eio"/>
-                            <constraint firstItem="jQp-EN-Voh" firstAttribute="centerY" secondItem="5Of-ZP-Ztv" secondAttribute="centerY" id="bEW-cC-JuG"/>
                             <constraint firstItem="fQM-5J-VyU" firstAttribute="top" secondItem="pUb-7p-fIc" secondAttribute="top" constant="20" id="bmR-kQ-ZPs"/>
                             <constraint firstItem="jrn-MT-IQv" firstAttribute="centerY" secondItem="LML-Ms-XJg" secondAttribute="centerY" id="hcw-6a-JAC"/>
-                            <constraint firstItem="dR6-bE-we3" firstAttribute="trailing" secondItem="fQM-5J-VyU" secondAttribute="trailing" id="lgw-dm-e2K"/>
                             <constraint firstItem="B0u-JV-sSq" firstAttribute="top" secondItem="MVq-bk-kzB" secondAttribute="bottom" constant="5" id="qS7-8L-5W1"/>
+                            <constraint firstItem="Ncz-qn-Ssy" firstAttribute="top" secondItem="Try-iz-4dr" secondAttribute="bottom" id="qTK-US-dZ0"/>
                             <constraint firstItem="1lG-cg-5R8" firstAttribute="trailing" secondItem="fQM-5J-VyU" secondAttribute="trailing" id="qTd-Gz-MV4"/>
+                            <constraint firstItem="Ncz-qn-Ssy" firstAttribute="leading" secondItem="Try-iz-4dr" secondAttribute="leading" id="ttA-na-RZj"/>
                             <constraint firstItem="pUb-7p-fIc" firstAttribute="bottom" secondItem="Fyw-02-BDi" secondAttribute="bottom" constant="20" id="vik-Ho-cFz"/>
-                            <constraint firstItem="7rg-Xd-yMa" firstAttribute="top" secondItem="B0u-JV-sSq" secondAttribute="bottom" constant="15" id="zGc-6l-Vej"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="pUb-7p-fIc"/>
                     </view>
                     <navigationItem key="navigationItem" title="Stream Chat" id="fEj-xA-1Kw"/>
                     <connections>
-                        <outlet property="badgeLabel" destination="eTn-JY-iPB" id="e9E-76-dq3"/>
-                        <outlet property="badgeSwitch" destination="jQp-EN-Voh" id="ICQ-KT-RZ0"/>
                         <outlet property="notificationsSwitch" destination="H0k-lx-tmL" id="MCi-8p-JQM"/>
-                        <outlet property="offlineMode" destination="dR6-bE-we3" id="6B5-gs-PVO"/>
                         <outlet property="onlineSwitch" destination="jrn-MT-IQv" id="cmf-96-hY1"/>
                         <outlet property="onlinelabel" destination="LML-Ms-XJg" id="Lgb-US-mZB"/>
                         <outlet property="splitViewButton" destination="uBn-vP-Vku" id="gHC-eV-Gpl"/>
-                        <outlet property="splitViewSeparator" destination="gbU-nu-nAs" id="9QM-AO-y8F"/>
                         <outlet property="totalUnreadCountLabel" destination="tp6-sE-CBi" id="Kfe-Qa-uQ7"/>
                         <outlet property="totalUnreadCountSwitch" destination="1lG-cg-5R8" id="4Mk-4p-lEG"/>
+                        <outlet property="unreadCountLabel" destination="r90-MX-Ekn" id="yHY-vV-xRg"/>
+                        <outlet property="unreadCountSwitch" destination="jQp-EN-Voh" id="Khx-fY-yIg"/>
                         <outlet property="versionLabel" destination="Fyw-02-BDi" id="n0D-xi-gJO"/>
                     </connections>
                 </viewController>
@@ -426,8 +331,8 @@ Stream Swift SDK v.1.0.0</string>
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="wm7-Ii-BZP" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="KhY-db-khs">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="KhY-db-khs">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -448,55 +353,55 @@ Stream Swift SDK v.1.0.0</string>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="efb-oB-Elc">
-                                <rect key="frame" x="16" y="54" width="343" height="280"/>
+                                <rect key="frame" x="16" y="54" width="343" height="316"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Client API key:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cwF-PR-bJn">
-                                        <rect key="frame" x="0.0" y="0.0" width="343" height="17"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="18"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder=" Stream Chat API key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="b0t-D9-sKI">
-                                        <rect key="frame" x="0.0" y="22" width="343" height="25"/>
+                                        <rect key="frame" x="0.0" y="23" width="343" height="36"/>
                                         <color key="backgroundColor" systemColor="quaternarySystemFillColor" red="0.4549019608" green="0.4549019608" blue="0.50196078430000002" alpha="0.080000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="25" id="XIf-4p-ctT"/>
+                                            <constraint firstAttribute="height" constant="36" id="XIf-4p-ctT"/>
                                         </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" smartDashesType="no" smartInsertDeleteType="no"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="The current user:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Na5-V9-XpN">
-                                        <rect key="frame" x="0.0" y="52" width="343" height="17"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <rect key="frame" x="0.0" y="64" width="343" height="18"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder=" User id" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="sRM-UZ-Fap">
-                                        <rect key="frame" x="0.0" y="74" width="343" height="25"/>
+                                        <rect key="frame" x="0.0" y="87" width="343" height="36"/>
                                         <color key="backgroundColor" systemColor="quaternarySystemFillColor" red="0.4549019608" green="0.4549019608" blue="0.50196078430000002" alpha="0.080000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="25" id="HCA-x1-cHa"/>
+                                            <constraint firstAttribute="height" constant="36" id="HCA-x1-cHa"/>
                                         </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" smartDashesType="no" smartInsertDeleteType="no"/>
                                     </textField>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder=" User name" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tm9-EU-QhU">
-                                        <rect key="frame" x="0.0" y="104" width="343" height="25"/>
+                                        <rect key="frame" x="0.0" y="128" width="343" height="36"/>
                                         <color key="backgroundColor" systemColor="quaternarySystemFillColor" red="0.4549019608" green="0.4549019608" blue="0.50196078430000002" alpha="0.080000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="25" id="tcC-Mt-Pnd"/>
+                                            <constraint firstAttribute="height" constant="36" id="tcC-Mt-Pnd"/>
                                         </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" smartDashesType="no" smartInsertDeleteType="no"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Token:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4vw-If-lcR">
-                                        <rect key="frame" x="0.0" y="134" width="343" height="17"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <rect key="frame" x="0.0" y="169" width="343" height="18"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="No1-11-4jC">
-                                        <rect key="frame" x="0.0" y="156" width="343" height="60"/>
+                                        <rect key="frame" x="0.0" y="192" width="343" height="60"/>
                                         <color key="backgroundColor" systemColor="quaternarySystemFillColor" red="0.4549019608" green="0.4549019608" blue="0.50196078430000002" alpha="0.080000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="60" id="DpA-2I-uKa"/>
@@ -506,14 +411,14 @@ Stream Swift SDK v.1.0.0</string>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                     </textView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C9w-aB-O6T">
-                                        <rect key="frame" x="0.0" y="221" width="343" height="10"/>
+                                        <rect key="frame" x="0.0" y="257" width="343" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="mkK-dl-rld"/>
                                         </constraints>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lj1-9I-86W">
-                                        <rect key="frame" x="0.0" y="236" width="343" height="44"/>
+                                        <rect key="frame" x="0.0" y="272" width="343" height="44"/>
                                         <color key="backgroundColor" systemColor="systemFillColor" red="0.47058823529999999" green="0.47058823529999999" blue="0.50196078430000002" alpha="0.20000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="ewp-N9-BMF"/>
@@ -532,7 +437,7 @@ Stream Swift SDK v.1.0.0</string>
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Wf-hg-MXM">
-                                <rect key="frame" x="280" y="182.5" width="79" height="28"/>
+                                <rect key="frame" x="280" y="218" width="79" height="28"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <state key="normal" title="development"/>
                                 <connections>
@@ -540,7 +445,7 @@ Stream Swift SDK v.1.0.0</string>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OUJ-of-Bfu">
-                                <rect key="frame" x="229" y="182.5" width="35" height="28"/>
+                                <rect key="frame" x="229" y="218" width="35" height="28"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <state key="normal" title="guest"/>
                                 <connections>

--- a/Example/Sources/RootViewController.swift
+++ b/Example/Sources/RootViewController.swift
@@ -108,8 +108,7 @@ final class RootViewController: UIViewController {
     }
     
     @IBAction func checkForBan(_ sender: Any) {
-        Client.shared.rx.connection
-            .filter({ $0.isConnected })
+        Client.shared.rx.connected
             .take(1)
             .subscribe(onNext: { _ in
                 if User.current.isBanned {

--- a/Sources/Client/Client/Client+Events.swift
+++ b/Sources/Client/Client/Client+Events.swift
@@ -152,8 +152,7 @@ extension Client {
             switch event {
             case .userStartWatching(_, let watcherCount, _, _),
                  .userStopWatching(_, let watcherCount, _, _),
-                 .messageNew(_, let watcherCount, _, _),
-                 .notificationMessageNew(_, _, _, let watcherCount, _):
+                 .messageNew(_, let watcherCount, _, _):
                 callback(.success(watcherCount))
             default:
                 break

--- a/Sources/Client/Client/Client+Events.swift
+++ b/Sources/Client/Client/Client+Events.swift
@@ -148,12 +148,7 @@ extension Client {
 
     /// Subscribes to the watcher count for a channel that the user is watching
     func subscribeToWatcherCount(for channel: Channel, _ callback: @escaping Completion<Int>) -> Cancellable {
-        let eventTypes: Set<EventType> = [.userStartWatching,
-                                          .userStopWatching,
-                                          .messageNew,
-                                          .notificationMessageNew]
-
-        return channel.subscribe(forEvents: eventTypes, { event in
+        channel.subscribe(forEvents: [.userStartWatching, .userStopWatching, .messageNew], { event in
             switch event {
             case .userStartWatching(_, let watcherCount, _, _),
                  .userStopWatching(_, let watcherCount, _, _),

--- a/Sources/Client/Client/Client+Events.swift
+++ b/Sources/Client/Client/Client+Events.swift
@@ -32,25 +32,42 @@ struct Subscription: Cancellable {
     }
 }
 
+/// A subscription bag allows you collect multiple subscriptions and cancel them at once.
 public final class SubscriptionBag: Cancellable {
     private var subscriptions = [Cancellable]()
     
+    /// Add a subscription.
+    /// - Parameter subscription: a subscriiption.
     public func add(_ subscription: Cancellable) {
         subscriptions.append(subscription)
     }
     
+    /// Add multiple subscriptions in a chain way.
+    /// - Parameter subscription: a subscription
+    /// - Returns: this subscription bag.
+    @discardableResult
+    public func adding(_ subscription: Cancellable) -> Self {
+        subscriptions.append(subscription)
+        return self
+    }
+    
+    /// Cancel and clear all subscriptions in the bag.
     public func cancel() {
         subscriptions.forEach { $0.cancel() }
+        subscriptions = []
     }
 }
 
 extension Client {
+    
     /// Observe events for the given event types.
     /// - Parameters:
     ///   - eventTypes: A set of event types to be observed. Defaults to all events.
     ///   - callback: Callback closure to be called for each new event.
-    /// - Returns: `Subscription` object to be able to cancel observing. Call `subscription.cancel()` when you want to stop observing.
-    /// - Warning: Subscriptions do not cancel on `deinit` and that can cause crashes / memory leaks, so make sure you handle subscriptions correctly.
+    /// - Returns: `Subscription` object to be able to cancel observing.
+    ///            Call `subscription.cancel()` when you want to stop observing.
+    /// - Warning: Subscriptions do not cancel on `deinit` and that can cause crashes / memory leaks,
+    ///            so make sure you handle subscriptions correctly.
     public func subscribe(forEvents eventTypes: Set<EventType> = Set(EventType.allCases),
                           _ callback: @escaping OnEvent) -> Cancellable {
         subscribe(forEvents: eventTypes, cid: nil, callback)

--- a/Sources/Client/Client/Client+Request.swift
+++ b/Sources/Client/Client/Client+Request.swift
@@ -155,7 +155,7 @@ extension Client {
         
         var queryItems = [URLQueryItem(name: "api_key", value: apiKey)]
         
-        if let connectionId = webSocket.lastConnectionId {
+        if let connectionId = webSocket.connectionId {
             queryItems.append(URLQueryItem(name: "connection_id", value: connectionId))
         } else if endpoint.requiresConnectionId {
             return .failure(.emptyConnectionId)
@@ -234,7 +234,6 @@ extension Client {
         performInCallbackQueue { [unowned self] in
             if !self.isExpiredTokenInProgress {
                 self.waitingRequests = []
-                self.onConnect(.connected)
             }
         }
     }

--- a/Sources/Client/Client/Client+Setup.swift
+++ b/Sources/Client/Client/Client+Setup.swift
@@ -18,12 +18,12 @@ extension Client {
     ///   - user: the current user (see `User`).
     ///   - token: a Stream Chat API token.
     ///   - completion: a connection completion block.
-    public func set(user: User, token: Token, _ completion: Client.OnConnect? = nil) {
+    public func set(user: User, token: Token, _ completion: Client.Completion<UserConnection>? = nil) {
         reset()
         
         if apiKey.isEmpty || token.isEmpty {
             logger?.log("❌ API key or token is empty: \(apiKey), \(token)", level: .error)
-            completion?(.disconnected(ClientError.emptyAPIKey))
+            completion?(.failure(.emptyAPIKey))
             return
         }
         
@@ -38,12 +38,12 @@ extension Client {
     /// - Parameters:
     ///   - user: a guest user.
     ///   - completion: a connection completion block.
-    public func setGuestUser(_ user: User, _ completion: Client.OnConnect? = nil) {
+    public func setGuestUser(_ user: User, _ completion: Client.Completion<UserConnection>? = nil) {
         reset()
         
         if apiKey.isEmpty {
             logger?.log("❌ API key is empty", level: .error)
-            completion?(.disconnected(ClientError.emptyAPIKey))
+            completion?(.failure(.emptyAPIKey))
             return
         }
         
@@ -52,12 +52,11 @@ extension Client {
         logger?.log("Sending a request for a Guest Token...")
         
         request(endpoint: .guestToken(user)) { [unowned self] (result: Result<TokenResponse, ClientError>) in
-            do {
-                let response = try result.get()
+            if let response = result.value {
                 self.set(user: response.user, token: response.token, completion)
-            } catch {
+            } else if let error = result.error {
                 self.logger?.log(error, message: "Guest Token")
-                completion?(.disconnected(error))
+                completion?(.failure(error))
             }
         }
     }
@@ -68,7 +67,7 @@ extension Client {
     /// While you’re anonymous, you can’t do much, but for the livestream channel type,
     /// you’re still allowed to read the chat conversation.
     /// - Parameter completion: a connection completion block.
-    public func setAnonymousUser(_ completion: Client.OnConnect? = nil) {
+    public func setAnonymousUser(_ completion: Client.Completion<UserConnection>? = nil) {
         reset()
         userAtomic.set(.anonymous)
         tokenProvider = nil
@@ -113,12 +112,12 @@ extension Client {
     ///   - user: the current user (see `User`).
     ///   - tokenProvider: a token provider.
     ///   - completion: a connection completion block.
-    public func set(user: User, tokenProvider: @escaping TokenProvider, completion: Client.OnConnect? = nil) {
+    public func set(user: User, tokenProvider: @escaping TokenProvider, completion: Client.Completion<UserConnection>? = nil) {
         reset()
         
         if apiKey.isEmpty {
             logger?.log("❌ API key is empty.", level: .error)
-            completion?(.disconnected(ClientError.emptyAPIKey))
+            completion?(.failure(.emptyAPIKey))
             return
         }
         
@@ -127,7 +126,7 @@ extension Client {
         touchTokenProvider(isExpiredTokenInProgress: false, completion)
     }
     
-    func touchTokenProvider(isExpiredTokenInProgress: Bool, _ completion: Client.OnConnect?) {
+    func touchTokenProvider(isExpiredTokenInProgress: Bool, _ completion: Client.Completion<UserConnection>?) {
         guard let tokenProvider = tokenProvider else {
             return
         }
@@ -142,7 +141,7 @@ extension Client {
         tokenProvider { [unowned self] in self.setup(token: $0, completion) }
     }
     
-    private func setup(token: Token, _ completion: Client.OnConnect?) {
+    private func setup(token: Token, _ completion: Client.Completion<UserConnection>?) {
         if webSocket.isConnected {
             webSocket.disconnect(reason: "Requesting new token")
         }
@@ -153,7 +152,7 @@ extension Client {
             do {
                 token = try developmentToken()
             } catch {
-                completion?(.disconnected(error))
+                completion?(.failure(.encodingFailure(error, object: ["jwt": ["user_id": user.id]])))
                 return
             }
         }
@@ -168,9 +167,12 @@ extension Client {
         
         if let error = checkUserAndToken(token) {
             logger?.log(error)
-            completion?(.disconnected(error))
+            completion?(.failure(error))
             return
         }
+        
+        // Switch completion block to the main thread.
+        let completion = completion == nil ? nil : { result in DispatchQueue.main.async { completion?(result) } }
         
         do {
             let webSocket = try setupWebSocket(user: user, token: token)
@@ -179,20 +181,14 @@ extension Client {
             urlSession = setupURLSession(token: token)
             self.token = token
             
-            var onConnect: OnConnect?
-                
-            if let completion = completion {
-                onConnect = { connection in DispatchQueue.main.async { completion(connection) } }
-            }
-            
             // Observe Internet connection state and handle the Client connection.
             InternetConnection.shared.onStateChanged = { [unowned self] state in
-                self.connect(internetConnectionState: state, onConnect)
+                self.connect(internetConnectionState: state, completion)
             }
             
             // Observe Application state and handle the Client connection.
             Application.shared.onStateChanged = { [unowned self] state in
-                self.connect(appState: state, onConnect)
+                self.connect(appState: state, completion)
             }
             
             // Start observing Internet connection state and get the current state.
@@ -200,7 +196,7 @@ extension Client {
             
         } catch {
             logger?.log(error)
-            completion?(.disconnected(error))
+            completion?(.failure(.unexpectedError(description: error.localizedDescription, error: error)))
         }
     }
     

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -220,6 +220,13 @@ public final class Client {
             self.waitingRequests = []
         }
     }
+    
+    /// Checks if the given channel is watching.
+    /// - Parameter channel: a channel.
+    /// - Returns: returns true if the client is watching for the channel.
+    public func isWatching(channel: Channel) -> Bool {
+        channelsAtomic.get(default: [:])[channel.cid] != nil
+    }
 }
 
 // MARK: - Waiting Request

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -148,6 +148,10 @@ public final class Client {
     }
     
     /// Handle a connection with an application state.
+    /// - Note:
+    ///   - Skip if the Internet is not available.
+    ///   - Skip if it's already connected.
+    ///   - Skip if it's reconnecting.
     ///
     /// Application State:
     /// - `.active`
@@ -175,10 +179,6 @@ public final class Client {
     }
     
     /// Connect to websocket.
-    /// - Note:
-    ///   - Skip if the Internet is not available.
-    ///   - Skip if it's already connected.
-    ///   - Skip if it's reconnecting.
     /// - Parameter completion: a completion block will be call once when the connection will be established.
     func connect(_ completion: Client.Completion<UserConnection>?) {
         if let completion = completion {
@@ -192,7 +192,6 @@ public final class Client {
                     
                     if case .disconnected(let error) = state, let clientError = error {
                         completion(.failure(clientError))
-                        subscription?.cancel()
                     }
                 }
             }

--- a/Sources/Client/Client/ClientError.swift
+++ b/Sources/Client/Client/ClientError.swift
@@ -9,7 +9,8 @@
 import Foundation
 
 /// A client error.
-public enum ClientError: LocalizedError, CustomDebugStringConvertible {
+public enum ClientError: LocalizedError, CustomDebugStringConvertible, Equatable {
+    
     /// An unexpected error.
     case unexpectedError(description: String, error: Error?)
     /// The API Key is empty.
@@ -38,6 +39,8 @@ public enum ClientError: LocalizedError, CustomDebugStringConvertible {
     case requestFailed(Error?)
     /// A response client error.
     case responseError(ClientErrorResponse)
+    /// A websocket disconnect error.
+    case websocketDisconnectError(Swift.Error)
     /// An encoding failed with an error.
     case encodingFailure(Error, object: Encodable)
     /// A decoding failed with an error.
@@ -100,14 +103,23 @@ public enum ClientError: LocalizedError, CustomDebugStringConvertible {
             
             return "A request failed with unknown error"
             
-        case .responseError(let error): return error.localizedDescription
-        case .encodingFailure(let error, _): return "An encoding failed: \(error.localizedDescription)"
-        case .decodingFailure(let error): return "A decoding failed: \(error.localizedDescription)"
-        case .errorMessage(let message): return message.text
-        case .emptyDeviceToken: return "A device token is empty"
+        case .responseError(let error):
+            return error.localizedDescription
+        case .websocketDisconnectError(let error):
+            return error.localizedDescription
+        case .encodingFailure(let error, _):
+            return "An encoding failed: \(error.localizedDescription)"
+        case .decodingFailure(let error):
+            return "A decoding failed: \(error.localizedDescription)"
+        case .errorMessage(let message):
+            return message.text
+        case .emptyDeviceToken:
+            return "A device token is empty"
             
-        case .channelsSearchQueryEmpty: return "A channels search query is empty"
-        case .channelsSearchFilterEmpty: return "Filter can't be an empty for the message search"
+        case .channelsSearchQueryEmpty:
+            return "A channels search query is empty"
+        case .channelsSearchFilterEmpty:
+            return "Filter can't be an empty for the message search"
         }
     }
     
@@ -141,6 +153,8 @@ public enum ClientError: LocalizedError, CustomDebugStringConvertible {
             return "ClientError.requestFailed(\(String(describing: error)))"
         case .responseError(let error):
             return "ClientError.responseError(\(error))"
+        case .websocketDisconnectError(let error):
+            return "ClientError.websocketDisconnectError(\(error)"
         case .encodingFailure(let error, let object):
             return "ClientError.encodingFailure(\(error), \(object))"
         case .decodingFailure(let error):
@@ -154,6 +168,10 @@ public enum ClientError: LocalizedError, CustomDebugStringConvertible {
         case .channelsSearchFilterEmpty:
             return "ClientError.channelsSearchFilterEmpty"
         }
+    }
+    
+    public static func == (lhs: ClientError, rhs: ClientError) -> Bool {
+        lhs.debugDescription == rhs.debugDescription
     }
 }
 

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -217,20 +217,17 @@ extension Channel {
         let validEvents = eventTypes.intersection(EventType.channelEventTypes)
         
         if validEvents.count != eventTypes.count, let logger = Client.shared.logger {
-            var badEvents = eventTypes
-            badEvents.subtract(EventType.channelEventTypes)
-            
-            let message = "⚠️ The events \(badEvents) are not channel events and will never get handled by your completion handler. "
-                + "Please check the documentation on event for more information."
-            
-            logger.log(message, level: .error)
+            let notValidEvents = eventTypes.subtracting(EventType.channelEventTypes)
+            logger.log("⚠️ The events \(notValidEvents) are not channel events "
+                + "and will never get handled by your completion handler. "
+                + "Please check the documentation on event for more information.", level: .error)
         }
         
         guard !validEvents.isEmpty else {
             return Subscription { _ in }
         }
         
-        let subscription = Client.shared.subscribe(forEvents: eventTypes, cid: cid, callback)
+        let subscription = Client.shared.subscribe(forEvents: validEvents, cid: cid, callback)
         subscriptionBag.add(subscription)
         return subscription
     }

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -78,12 +78,8 @@ public final class Channel: Codable {
     public var extraData: ChannelExtraDataCodable?
     /// Check if the channel was deleted.
     public var isDeleted: Bool { deleted != nil }
-    
     /// Checks if read events evalable for the current user.
-    public var readEventsEnabled: Bool {
-        config.readEventsEnabled && members.contains(Member.current)
-    }
-    
+    public var readEventsEnabled: Bool { config.readEventsEnabled && members.contains(Member.current) }
     /// Returns the current unread count.
     public var unreadCount: ChannelUnreadCount { unreadCountAtomic.get(default: .noUnread) }
     
@@ -107,20 +103,15 @@ public final class Channel: Codable {
     public var unreadMessageRead: MessageRead? { unreadMessageReadAtomic.get() }
     /// Checks if the current status of the channel is unread.
     public var isUnread: Bool { unreadCount.messages > 0 }
-    
     /// An option to enable ban users.
     public var banEnabling = BanEnabling.disabled
     var bannedUsers = [User]()
-    
     /// Checks if the channel is direct message type between 2 users.
     public var isDirectMessage: Bool { id.hasPrefix("!members") && members.count == 2 }
-    
     /// An event when the channel was updated.
     public var onUpdate: OnUpdate<Channel>?
-    
     /// Checks if the channel was decoded from a channel response.
     public let didLoad: Bool
-    
     /// Checks if the channel is watching by the client.
     public var isWatching: Bool { Client.shared.isWatching(channel: self) }
     

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -121,6 +121,9 @@ public final class Channel: Codable {
     /// Checks if the channel was decoded from a channel response.
     public let didLoad: Bool
     
+    /// Checks if the channel is watching by the client.
+    public var isWatching: Bool { Client.shared.isWatching(channel: self) }
+    
     private var subscriptionBag = SubscriptionBag()
     
     public init(type: ChannelType,

--- a/Sources/Client/Model/EventType.swift
+++ b/Sources/Client/Model/EventType.swift
@@ -88,11 +88,11 @@ public enum EventType: String, Codable, CaseIterable {
     
     /// Checks if the type is a channel event type.
     public var isChannelCase: Bool {
-        EventType.channelCases.contains(self)
+        EventType.channelEventTypes.contains(self)
     }
     
     /// All channel event types.
-    public static var channelCases: Set<EventType> {
+    public static var channelEventTypes: Set<EventType> {
         [.userBanned,
          .userStartWatching,
          .userStopWatching,

--- a/Sources/Client/Model/EventType.swift
+++ b/Sources/Client/Model/EventType.swift
@@ -87,7 +87,7 @@ public enum EventType: String, Codable, CaseIterable {
     case notificationInviteRejected = "notification.invite_rejected"
     
     /// Checks if the type is a channel event type.
-    public var isChannelCase: Bool {
+    public var isChannelEventType: Bool {
         EventType.channelEventTypes.contains(self)
     }
     

--- a/Sources/Client/Model/EventType.swift
+++ b/Sources/Client/Model/EventType.swift
@@ -1,0 +1,115 @@
+//
+//  EventType.swift
+//  StreamChatClient
+//
+//  Created by Alexey Bukhtin on 08/04/2020.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A web socket event type.
+public enum EventType: String, Codable, CaseIterable {
+    
+    /// When the state of the connection changed.
+    case connectionChanged = "connection.changed"
+    /// Every 30 second to confirm that the client connection is still active.
+    case healthCheck = "health.check"
+    /// A pong event.
+    case pong
+    
+    /// When a user presence changed, e.g. online, offline, away (when subscribed to the user presence).
+    case userPresenceChanged = "user.presence.changed"
+    /// When a user was updated (when subscribed to the user presence).
+    case userUpdated = "user.updated"
+    /// When a user was banned (when subscribed to the user presence).
+    case userBanned = "user.banned"
+    /// When a user starts watching a channel (when watching the channel).
+    case userStartWatching = "user.watching.start"
+    /// When a user stops watching a channel (when watching the channel).
+    case userStopWatching = "user.watching.stop"
+    
+    /// Sent when a user starts typing (when watching the channel).
+    case typingStart = "typing.start"
+    /// Sent when a user stops typing (when watching the channel).
+    case typingStop = "typing.stop"
+    
+    /// When a channel was updated (when watching the channel).
+    case channelUpdated = "channel.updated"
+    /// When a channel was deleted (when watching the channel).
+    case channelDeleted = "channel.deleted"
+    /// When a channel was hidden (when watching the channel).
+    case channelHidden = "channel.hidden"
+    
+    /// When a new message was added on a channel (when watching the channel).
+    case messageNew = "message.new"
+    /// When a message was updated (when watching the channel).
+    case messageUpdated = "message.updated"
+    /// When a message was deleted (when watching the channel).
+    case messageDeleted = "message.deleted"
+    /// When a channel was marked as read (when watching the channel).
+    case messageRead = "message.read"
+    /// ⚠️ When a message reaction was added or deleted (when watching the channel).
+//    case messageReaction = "message.reaction"
+    
+    /// When a member was added to a channel (when watching the channel).
+    case memberAdded = "member.added"
+    /// When a member was updated (when watching the channel).
+    case memberUpdated = "member.updated"
+    /// When a member was removed from a channel (when watching the channel).
+    case memberRemoved = "member.removed"
+    
+    /// When a message reaction was added.
+    case reactionNew = "reaction.new"
+    /// When a message reaction updated.
+    case reactionUpdated = "reaction.updated"
+    /// When a message reaction deleted.
+    case reactionDeleted = "reaction.deleted"
+    
+    /// When a message was added to a channel (when clients that are not currently watching the channel).
+    case notificationMessageNew = "notification.message_new"
+    /// When the total count of unread messages (across all channels the user is a member) changes
+    /// (when clients from the user affected by the change).
+    case notificationMarkRead = "notification.mark_read"
+    /// When the user mutes someone.
+    case notificationMutesUpdated = "notification.mutes_updated"
+    
+    /// When the user accepts an invite (when the user invited).
+    case notificationAddedToChannel = "notification.added_to_channel"
+    /// When a user was removed from a channel (when the user invited).
+    case notificationRemovedFromChannel = "notification.removed_from_channel"
+    
+    /// When the user was invited to join a channel (when the user invited).
+    case notificationInvited = "notification.invited"
+    /// When the user accepts an invite (when the user invited).
+    case notificationInviteAccepted = "notification.invite_accepted"
+    /// When the user reject an invite (when the user invited).
+    case notificationInviteRejected = "notification.invite_rejected"
+    
+    /// Checks if the type is a channel event type.
+    public var isChannelCase: Bool {
+        EventType.channelCases.contains(self)
+    }
+    
+    /// All channel event types.
+    public static var channelCases: Set<EventType> {
+        [.userBanned,
+         .userStartWatching,
+         .userStopWatching,
+         .typingStart,
+         .typingStop,
+         .channelUpdated,
+         .channelDeleted,
+         .channelHidden,
+         .messageNew,
+         .messageUpdated,
+         .messageDeleted,
+         .messageRead,
+         .memberAdded,
+         .memberUpdated,
+         .memberRemoved,
+         .reactionNew,
+         .reactionUpdated,
+         .reactionDeleted]
+    }
+}

--- a/Sources/Client/Model/UserConnection.swift
+++ b/Sources/Client/Model/UserConnection.swift
@@ -1,0 +1,17 @@
+//
+//  UserConnection.swift
+//  StreamChatClient
+//
+//  Created by Alexey Bukhtin on 08/04/2020.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A user connection result.
+public struct UserConnection: Decodable {
+    /// An authorized user.
+    public let user: User
+    /// A websocket connection id.
+    public let connectionId: String
+}

--- a/Sources/Client/WebSocket/ConnectionState.swift
+++ b/Sources/Client/WebSocket/ConnectionState.swift
@@ -9,22 +9,29 @@
 import Foundation
 
 /// A web socket connection state.
-public enum Connection: Equatable {
+public enum ConnectionState: Equatable {
     
     /// The websocket is not connected.
     case notConnected
     /// The websocket was connected, waiting for a `connectionId` for requests.
     case connecting
     /// The websocket was connected.
-    case connected
+    case connected(UserConnection)
     /// The websocket is disconnecting.
     case disconnecting
     /// The websocket was disconnected with an error.
-    case disconnected(Swift.Error?)
+    case disconnected(ClientError?)
     
-    public var isConnected: Bool { self == .connected }
+    /// Checks if the connection state is connected.
+    public var isConnected: Bool {
+        if case .connected = self {
+            return true
+        }
+        
+        return false
+    }
     
-    public static func == (lhs: Connection, rhs: Connection) -> Bool {
+    public static func == (lhs: ConnectionState, rhs: ConnectionState) -> Bool {
         switch (lhs, rhs) {
         case (.notConnected, .notConnected),
              (.connecting, .connecting),

--- a/Sources/Core/Client/Client+RxEvents.swift
+++ b/Sources/Core/Client/Client+RxEvents.swift
@@ -70,7 +70,7 @@ extension Reactive where Base == Client {
                     
                     return nil
                 })
-                .unwrap()
+                .compactMap { $0 }
                 .distinctUntilChanged()
                 .share(replay: 1)
         }

--- a/Sources/Core/Client/Client+RxUnreadCount.swift
+++ b/Sources/Core/Client/Client+RxUnreadCount.swift
@@ -16,7 +16,7 @@ public extension Reactive where Base == Client {
     
     /// Observe an unread count of messages and channels.
     var unreadCount: Observable<UnreadCount> {
-        connection
+        connectionState
             .filter({ $0.isConnected })
             .flatMapLatest({ [unowned base] _ -> Observable<UnreadCount> in
                 Observable<UnreadCount>.create({ observer in

--- a/Sources/Core/Extensions/RxFunctions.swift
+++ b/Sources/Core/Extensions/RxFunctions.swift
@@ -12,12 +12,6 @@ import RxSwift
 import RxCocoa
 
 public extension ObservableType {
-    
-    /// Unwrap an optional event value.
-    func unwrap<T>() -> Observable<T> where Element == T? {
-        filter { $0 != nil }.map { $0! }
-    }
-    
     /// Map an event value to `Void()`.
     func void() -> Observable<Void> {
         map { _ in Void() }

--- a/Sources/Core/Extensions/RxFunctions.swift
+++ b/Sources/Core/Extensions/RxFunctions.swift
@@ -7,17 +7,32 @@
 //
 
 import Foundation
+import StreamChatClient
 import RxSwift
+import RxCocoa
 
 public extension ObservableType {
     
     /// Unwrap an optional event value.
     func unwrap<T>() -> Observable<T> where Element == T? {
-        return filter { $0 != nil }.map { $0! }
+        filter { $0 != nil }.map { $0! }
     }
     
     /// Map an event value to `Void()`.
     func void() -> Observable<Void> {
-        return map { _ in Void() }
+        map { _ in Void() }
+    }
+}
+
+public extension ObservableType where Element == ViewChanges {
+    
+    func asClientDriver() -> Driver<Element> {
+        asDriver(onErrorRecover: { error in
+            if let clientError = error as? ClientError {
+                return Driver.just(Element.error(clientError))
+            }
+            
+            return Driver.just(Element.error(.unexpectedError(description: error.localizedDescription, error: error)))
+        })
     }
 }

--- a/Sources/Core/Presenter/Channel/ChannelPresenter+RxRequests.swift
+++ b/Sources/Core/Presenter/Channel/ChannelPresenter+RxRequests.swift
@@ -92,7 +92,7 @@ extension Reactive where Base == ChannelPresenter {
             .filter { $0 != .none }
             .map { [weak base] in base?.mapWithEphemeralMessage($0) ?? .none }
             .filter { $0 != .none }
-            .asDriver { Driver.just(ViewChanges.error(AnyError($0))) }
+            .asClientDriver()
     }
 }
 
@@ -191,7 +191,7 @@ private extension Reactive where Base == ChannelPresenter {
             .filter { $0 != .none }
             .map { [weak base] in base?.mapWithEphemeralMessage($0) ?? .none }
             .filter { $0 != .none }
-            .asDriver { Driver.just(ViewChanges.error(AnyError($0))) }
+            .asClientDriver()
     }
     
     var ephemeralMessageEvents: Driver<ViewChanges> {
@@ -199,13 +199,13 @@ private extension Reactive where Base == ChannelPresenter {
             .skip(1)
             .map { [weak base] in base?.parseEphemeralMessageEvents($0) ?? .none }
             .filter { $0 != .none }
-            .asDriver { Driver.just(ViewChanges.error(AnyError($0))) }
+            .asClientDriver()
     }
     
     func parsedRepliesResponse(_ repliesResponse: Observable<[Message]>) -> Driver<ViewChanges> {
         repliesResponse
             .map { [weak base] in base?.parse(replies: $0) ?? .none }
             .filter { $0 != .none }
-            .asDriver { Driver.just(ViewChanges.error(AnyError($0))) }
+            .asClientDriver()
     }
 }

--- a/Sources/Core/Presenter/Channels/ChannelsPresenter+Rx.swift
+++ b/Sources/Core/Presenter/Channels/ChannelsPresenter+Rx.swift
@@ -51,7 +51,7 @@ private extension Reactive where Base == ChannelsPresenter {
         channelResponses
             .map { [weak base] in base?.parseChannels($0) ?? .none }
             .filter { $0 != .none }
-            .asDriver { Driver.just(ViewChanges.error(AnyError($0))) }
+            .asClientDriver()
     }
     
     var channelsRequest: Observable<[ChannelResponse]> {
@@ -71,7 +71,7 @@ private extension Reactive where Base == ChannelsPresenter {
             })
             .map { [weak base] in base?.parse(event: $0) ?? .none }
             .filter { $0 != .none }
-            .asDriver { Driver.just(ViewChanges.error(AnyError($0))) }
+            .asClientDriver()
     }
     
     func channelsQuery(pagination: Pagination) -> ChannelsQuery {

--- a/Sources/Core/Presenter/Presenter+Rx.swift
+++ b/Sources/Core/Presenter/Presenter+Rx.swift
@@ -32,7 +32,7 @@ extension Reactive  where Base: Presenter {
                     
                     return nil
                 })
-                .unwrap()
+                .compactMap { $0 }
                 .asDriver(onErrorJustReturn: .none)
         }
     }

--- a/Sources/Core/Presenter/Presenter+Rx.swift
+++ b/Sources/Core/Presenter/Presenter+Rx.swift
@@ -20,10 +20,10 @@ extension Reactive  where Base: Presenter {
     /// Observe connection errors as `ViewChanges`.
     public var connectionErrors: Driver<ViewChanges> {
         associated(to: base, key: &Presenter.rxConnectionErrorsKey) {
-            Client.shared.rx.connection
+            Client.shared.rx.connectionState
                 .map({ connection -> ViewChanges? in
-                    if case .disconnected(let error) = connection, let errorResponse = error as? ClientErrorResponse {
-                        return .error(AnyError(errorResponse))
+                    if case .disconnected(let error) = connection, let disconnectError = error {
+                        return .error(disconnectError)
                     }
                     
                     if case .notConnected = connection {
@@ -47,7 +47,7 @@ public extension Reactive  where Base: Presenter {
     /// - Parameter pagination: an initial page size (see `Pagination`).
     /// - Returns: an observable pagination for a request.
     func prepareRequest(startPaginationWith pagination: Pagination = []) -> Observable<Pagination> {
-        let connectionObservable = Client.shared.rx.connection
+        let connectionObservable = Client.shared.rx.connectionState
             .do(onNext: { [weak base] connection in
                 if !connection.isConnected,
                     let base = base,

--- a/Sources/Core/Presenter/ViewChanges.swift
+++ b/Sources/Core/Presenter/ViewChanges.swift
@@ -31,7 +31,7 @@ public enum ViewChanges: Equatable, Decodable {
     /// Disconnected deliberately.
     case disconnected
     /// Error message.
-    case error(AnyError)
+    case error(ClientError)
     
     public init(from decoder: Decoder) throws {
         self = .none

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
@@ -116,7 +116,7 @@ extension ChatViewController {
                 .disposed(by: disposeBag)
         }
         
-        let textViewEvents = composerView.textView.rx.text.skip(1).unwrap().share()
+        let textViewEvents = composerView.textView.rx.text.skip(1).compactMap({ $0 }).share()
         
         // Dispatch commands from text view.
         textViewEvents.subscribe(onNext: { [weak self] in self?.dispatchCommands(in: $0) }).disposed(by: disposeBag)

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -160,7 +160,7 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
         
         keyboard.notification.bind(to: rx.keyboard).disposed(by: self.disposeBag)
         
-        Client.shared.rx.connection
+        Client.shared.rx.connectionState
             .observeOn(MainScheduler.instance)
             .subscribe(onNext: { [weak self] in self?.update(for: $0) })
             .disposed(by: disposeBag)
@@ -247,14 +247,14 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
         nil
     }
     
-    /// Updates for `FooterView` and `ComposerView` with the client connection.
-    open func update(for connection: Connection) {
+    /// Updates for `FooterView` and `ComposerView` with the client connectionState.
+    open func update(for connectionState: ConnectionState) {
         // Update footer.
         updateFooterView()
         
         // Update composer view.
         if composerView.superview != nil {
-            if connection == .connected {
+            if connectionState.isConnected {
                 if composerView.styleState == .disabled {
                     composerView.styleState = .normal
                 }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -42,7 +42,9 @@
 		8A5069B923CE131B009F127A /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EDC122E9BAC5005CFAC9 /* Starscream.framework */; };
 		8A5211D5238EE7DC004BED65 /* Attachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5211D4238EE7DC004BED65 /* Attachment.swift */; };
 		8A559D26230D937C00E66096 /* StreamChatCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EC9F22E9B355005CFAC9 /* StreamChatCore.framework */; };
+		8A65559D243DF2D00023046C /* UserConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A65559C243DF2D00023046C /* UserConnection.swift */; };
 		8A6F69D2230ECCD300B8CC1F /* User+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6F69D1230ECCD300B8CC1F /* User+Tests.swift */; };
+		8A7C58EE243DE9740062487E /* EventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7C58ED243DE9740062487E /* EventType.swift */; };
 		8A831C8624294083003F0DB4 /* InternetConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACC7C3C241924B5000750E4 /* InternetConnection.swift */; };
 		8A831C8724294356003F0DB4 /* Reachability.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EDC322E9BAC5005CFAC9 /* Reachability.framework */; };
 		8A8BB2A52384573400C2F9DE /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8BB2A32384573400C2F9DE /* Realm.framework */; };
@@ -60,7 +62,7 @@
 		8AC0D94F23D4BA7D0080B8BC /* FilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC0D94E23D4BA7D0080B8BC /* FilterTests.swift */; };
 		8ACB0E9E23EB13CE0066343A /* StreamChatClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A50694F23CDEA31009F127A /* StreamChatClient.framework */; };
 		8ACC2B62242B8B8600EF509D /* Chat.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8ACC2B61242B8B8600EF509D /* Chat.xcassets */; };
-		8ACC7BFB241924AD000750E4 /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACC7BB2241924AD000750E4 /* Connection.swift */; };
+		8ACC7BFB241924AD000750E4 /* ConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACC7BB2241924AD000750E4 /* ConnectionState.swift */; };
 		8ACC7BFC241924AD000750E4 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACC7BB3241924AD000750E4 /* WebSocket.swift */; };
 		8ACC7BFE241924AD000750E4 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACC7BB6241924AD000750E4 /* Environment.swift */; };
 		8ACC7BFF241924AD000750E4 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACC7BB7241924AD000750E4 /* Atomic.swift */; };
@@ -315,7 +317,9 @@
 		8A50696A23CDEDA4009F127A /* StreamChatCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StreamChatCore.h; sourceTree = "<group>"; };
 		8A5211D4238EE7DC004BED65 /* Attachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Attachment.swift; sourceTree = "<group>"; };
 		8A559D21230D937B00E66096 /* StreamChatCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A65559C243DF2D00023046C /* UserConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserConnection.swift; sourceTree = "<group>"; };
 		8A6F69D1230ECCD300B8CC1F /* User+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+Tests.swift"; sourceTree = "<group>"; };
+		8A7C58ED243DE9740062487E /* EventType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventType.swift; sourceTree = "<group>"; };
 		8A8BB295238452B600C2F9DE /* StreamChatRealm.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatRealm.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A8BB2A2238456A200C2F9DE /* StreamChatRealm.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = StreamChatRealm.podspec; sourceTree = "<group>"; };
 		8A8BB2A32384573400C2F9DE /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = Carthage/Build/iOS/Realm.framework; sourceTree = "<group>"; };
@@ -328,7 +332,7 @@
 		8AC0D94B23D4ABC50080B8BC /* ClientTests02+Users.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClientTests02+Users.swift"; sourceTree = "<group>"; };
 		8AC0D94E23D4BA7D0080B8BC /* FilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTests.swift; sourceTree = "<group>"; };
 		8ACC2B61242B8B8600EF509D /* Chat.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Chat.xcassets; sourceTree = "<group>"; };
-		8ACC7BB2241924AD000750E4 /* Connection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Connection.swift; sourceTree = "<group>"; };
+		8ACC7BB2241924AD000750E4 /* ConnectionState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConnectionState.swift; sourceTree = "<group>"; };
 		8ACC7BB3241924AD000750E4 /* WebSocket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSocket.swift; sourceTree = "<group>"; };
 		8ACC7BB6241924AD000750E4 /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		8ACC7BB7241924AD000750E4 /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
@@ -685,7 +689,7 @@
 			isa = PBXGroup;
 			children = (
 				8ACC7BB3241924AD000750E4 /* WebSocket.swift */,
-				8ACC7BB2241924AD000750E4 /* Connection.swift */,
+				8ACC7BB2241924AD000750E4 /* ConnectionState.swift */,
 			);
 			path = WebSocket;
 			sourceTree = "<group>";
@@ -722,13 +726,15 @@
 		8ACC7BC3241924AD000750E4 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				8ACC7BC4241924AD000750E4 /* UnreadCount.swift */,
+				8A7C58ED243DE9740062487E /* EventType.swift */,
 				8ACC7BC5241924AD000750E4 /* Event.swift */,
+				8A65559C243DF2D00023046C /* UserConnection.swift */,
 				8ACC7BC7241924AD000750E4 /* Message */,
 				8ACC7BD2241924AD000750E4 /* Sorting.swift */,
 				8ACC7BD3241924AD000750E4 /* User */,
 				8ACC7BD9241924AD000750E4 /* QueryOptions.swift */,
 				8ACC7BDA241924AD000750E4 /* Channel */,
+				8ACC7BC4241924AD000750E4 /* UnreadCount.swift */,
 				8ACC7BE4241924AD000750E4 /* Pagination.swift */,
 				8ACC7BE5241924AD000750E4 /* Filter.swift */,
 				8ACC7BE6241924AD000750E4 /* SearchQuery.swift */,
@@ -778,14 +784,14 @@
 		8ACC7BDA241924AD000750E4 /* Channel */ = {
 			isa = PBXGroup;
 			children = (
+				8ACC7BE1241924AD000750E4 /* ChannelType.swift */,
+				8ACC7BDF241924AD000750E4 /* ChannelId.swift */,
 				8ACC7BDE241924AD000750E4 /* Channel.swift */,
 				8ACC7BDB241924AD000750E4 /* Channel+Requests.swift */,
 				8AB2A02A2423C1B500CE54F6 /* ChannelExtraData.swift */,
 				8ACC7BDC241924AD000750E4 /* ChannelQuery.swift */,
 				8ACC7BDD241924AD000750E4 /* ChannelsQuery.swift */,
-				8ACC7BDF241924AD000750E4 /* ChannelId.swift */,
 				8ACC7BE0241924AD000750E4 /* Channel+UnreadCount.swift */,
-				8ACC7BE1241924AD000750E4 /* ChannelType.swift */,
 				8ACC7BE2241924AD000750E4 /* ChannelResponse.swift */,
 				8ACC7BE3241924AD000750E4 /* Channel+WatcherCount.swift */,
 			);
@@ -1531,12 +1537,13 @@
 				8ACC7C09241924AD000750E4 /* Database.swift in Sources */,
 				8AA8F13D241FD2BD008FD89C /* Reaction.swift in Sources */,
 				8ACC7C1D241924AD000750E4 /* Channel+Requests.swift in Sources */,
+				8A7C58EE243DE9740062487E /* EventType.swift in Sources */,
 				8ACC7C18241924AD000750E4 /* User+Requests.swift in Sources */,
 				79D50C7724321BDA0052BA03 /* Client+Events.swift in Sources */,
 				8ACC7C27241924AD000750E4 /* Filter.swift in Sources */,
 				8ACC7C0A241924AD000750E4 /* UnreadCount.swift in Sources */,
 				8ACC7C10241924AD000750E4 /* AttachmentFile.swift in Sources */,
-				8ACC7BFB241924AD000750E4 /* Connection.swift in Sources */,
+				8ACC7BFB241924AD000750E4 /* ConnectionState.swift in Sources */,
 				8ACC7C2B241924AD000750E4 /* Token.swift in Sources */,
 				8ACC7C25241924AD000750E4 /* Channel+WatcherCount.swift in Sources */,
 				8A9ECEF7242A57B900206E7D /* AssociatedValue.swift in Sources */,
@@ -1575,6 +1582,7 @@
 				8ACC7C13241924AD000750E4 /* MessageAction.swift in Sources */,
 				8ACC7C24241924AD000750E4 /* ChannelResponse.swift in Sources */,
 				8AB2A02D242534EA00CE54F6 /* UserExtraData.swift in Sources */,
+				8A65559D243DF2D00023046C /* UserConnection.swift in Sources */,
 				8ACC7C1E241924AD000750E4 /* ChannelQuery.swift in Sources */,
 				8ACC7C2F241924AD000750E4 /* Client+Message.swift in Sources */,
 				8ACC7C01241924AD000750E4 /* RepeatingTimer.swift in Sources */,

--- a/Tests/Client/Integration Tests/ClientTests00.swift
+++ b/Tests/Client/Integration Tests/ClientTests00.swift
@@ -13,31 +13,33 @@ final class ClientTests00: TestCase {
     
     func test01WebSocketConnection() {
         expect("WebSocket connected") { expectation in
-            Client.shared.onConnect = { connection in
-                if case .connected = connection {
+            TestCase.setupClientUser()
+            
+            var subscription: Cancellable?
+            subscription = Client.shared.subscribe(forEvents: [.connectionChanged]) {
+                if case .connectionChanged(let connectionState) = $0, connectionState.isConnected {
                     XCTAssertTrue(Client.shared.isConnected)
                     Client.shared.disconnect()
                     XCTAssertFalse(Client.shared.isConnected)
-                    Client.shared.onConnect = { _ in }
+                    subscription?.cancel()
                     expectation.fulfill()
                 }
             }
-            
-            TestCase.setupClientUser()
         }
     }
     
     func test02AnonymousUser() {
         expect("WebSocket connected") { expectation in
-            Client.shared.onConnect = { connection in
-                if case .connected = connection {
+            Client.shared.setAnonymousUser()
+            
+            var subscription: Cancellable?
+            subscription = Client.shared.subscribe(forEvents: [.connectionChanged]) {
+                if case .connectionChanged(let connectionState) = $0, connectionState.isConnected {
                     XCTAssertTrue(Client.shared.isConnected)
-                    Client.shared.onConnect = { _ in }
+                    subscription?.cancel()
                     expectation.fulfill()
                 }
             }
-            
-            Client.shared.setAnonymousUser()
         }
         
         expect("create a channel for anonymous") { expectation in

--- a/Tests/Client/Unit Tests/QueryEncodingTests.swift
+++ b/Tests/Client/Unit Tests/QueryEncodingTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import StreamChatClient
 
 final class QueryEncodingTests: XCTestCase {
-    private let channel = Client.shared.channel(type: .messaging, id: "general")
+    private let channel = Client(apiKey: "test").channel(type: .messaging, id: "general")
     private let encoder = JSONEncoder()
     
     private let simpleFilter: Filter = .equal("id", to: 42)

--- a/releasing.md
+++ b/releasing.md
@@ -24,7 +24,7 @@
 8. Commit updated docs to the repo.
 9. Add release notes: https://github.com/GetStream/stream-chat-swift/releases
 10. Push the release to the Cocoapods: 
-  - `pod trunk push StreamChatColient.podspec`
+  - `pod trunk push StreamChatClient.podspec`
   - `pod trunk push StreamChatCore.podspec`
   - `pod trunk push StreamChat.podspec`
 


### PR DESCRIPTION
- added `set(user:)` with a completion block with a result of `UserConnection`.
- `WebSocket` connection now is publishing as events.
- `Token` event observing was removed because connection management moved to LLC.
- check if channel subscription for channel events only (show a warning in logs)
- Example app UI was simplified
- added a priority to the client for WebSocket events to avoid late update for the user and watching channels.