### PR TITLE
CIS-38 Fix container.encode for Pagination encoding array

### DIFF
--- a/Sources/Client/Model/Pagination.swift
+++ b/Sources/Client/Model/Pagination.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public typealias Pagination = Set<PaginationOption>
 
-public extension Set where Element == PaginationOption {
+public extension Pagination {
     var limit: Int? {
         first(where: { $0.limit != nil })?.limit
     }
@@ -26,7 +26,8 @@ public extension Set where Element == PaginationOption {
 
 public extension KeyedEncodingContainer {
     mutating func encode(_ value: Pagination, forKey key: Self.Key) throws {
-        try value.forEach({ try self.encode($0, forKey: key) })
+        let encoder = self.superEncoder(forKey: key)
+        try value.forEach({ try $0.encode(to: encoder) })
     }
 }
 

--- a/Sources/Client/Model/Pagination.swift
+++ b/Sources/Client/Model/Pagination.swift
@@ -24,6 +24,12 @@ public extension Set where Element == PaginationOption {
     }
 }
 
+public extension KeyedEncodingContainer {
+    mutating func encode(_ value: Pagination, forKey key: Self.Key) throws {
+        try value.forEach({ try self.encode($0, forKey: key) })
+    }
+}
+
 /// Pagination options.
 ///
 /// For example:

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7900717F2440850700E5246F /* QueryEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900717D244084E200E5246F /* QueryEncodingTests.swift */; };
 		794BDE4A2434BD7400BFBA1F /* NestableCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */; };
 		79D50C7724321BDA0052BA03 /* Client+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D50C7624321BDA0052BA03 /* Client+Events.swift */; };
 		80B937A52434F5FC003D950E /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B937A42434F5FC003D950E /* Array+Extensions.swift */; };
@@ -279,6 +280,7 @@
 
 /* Begin PBXFileReference section */
 		465D64C1231808A2006BAE42 /* AttachmentTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentTypeTests.swift; sourceTree = "<group>"; };
+		7900717D244084E200E5246F /* QueryEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryEncodingTests.swift; sourceTree = "<group>"; };
 		794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestableCodingKey.swift; sourceTree = "<group>"; };
 		795FCD1B23EB155000990F15 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		79D50C7624321BDA0052BA03 /* Client+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Client+Events.swift"; sourceTree = "<group>"; };
@@ -658,6 +660,7 @@
 				8AC0D94E23D4BA7D0080B8BC /* FilterTests.swift */,
 				465D64C1231808A2006BAE42 /* AttachmentTypeTests.swift */,
 				8A30D07A237D81C20082B951 /* StringExtensionsTests.swift */,
+				7900717D244084E200E5246F /* QueryEncodingTests.swift */,
 			);
 			path = "Unit Tests";
 			sourceTree = "<group>";
@@ -1591,6 +1594,7 @@
 				8A1D042623D0FB560099AA7F /* ClientTests01+Channels.swift in Sources */,
 				8AE6206D23CF642900AB3426 /* TestCase.swift in Sources */,
 				8AC0D94F23D4BA7D0080B8BC /* FilterTests.swift in Sources */,
+				7900717F2440850700E5246F /* QueryEncodingTests.swift in Sources */,
 				8AB33A5E240EA19A00777682 /* AttachmentTypeTests.swift in Sources */,
 				8AC0D94C23D4ABC50080B8BC /* ClientTests02+Users.swift in Sources */,
 			);

--- a/Tests/Client/Unit Tests/QueryEncodingTests.swift
+++ b/Tests/Client/Unit Tests/QueryEncodingTests.swift
@@ -1,0 +1,128 @@
+//
+//  QueryEncodingTests.swift
+//  StreamChatClient
+//
+//  Created by Bahadir Oncel on 10.04.2020.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import XCTest
+@testable import StreamChatClient
+
+final class QueryEncodingTests: XCTestCase {
+    private let channel = Client.shared.channel(type: .messaging, id: "general")
+    private let encoder = JSONEncoder()
+    
+    private let simpleFilter: Filter = .equal("id", to: 42)
+    private let mediumFilter: Filter = .in("members", ["john"]) & .autocomplete("id", with: "ro")
+    private let complexFilter: Filter = .in("members", ["john"])
+        & .equal("unread_count", to: 0)
+        & (.greater("id", than: 42) | (.notEqual("avatar", to: "null") & .autocomplete("name", with: "ro")))
+    
+    private let simplePagination: () -> Pagination = { [.limit(10)] }
+    private let mediumPagination: () -> Pagination = { [.limit(10), .offset(20)] }
+    private let complexPagination: () -> Pagination = { [.limit(10), .offset(10), .greaterThan("42"), .lessThan("92")] }
+    
+    /// NOTE
+    /// Under the hood, `Pagination` is a Set, and Sets are unordered. This causes encodings to have nondeterministic string outputs.
+    /// For example, `complexPagination` can be encoded in any combination of its `PaginationOption`s. So both:
+    /// `{"id_gt":"42","id_lt":"92","offset":10,"limit":10}`
+    /// and
+    /// `{"id_lt":"92","id_gt":"42","offset":10,"limit":10}`
+    /// are valid, although our tests will fail for the latter.
+    /// If we assume the ordering is purely random, we have 1/4! chance of getting the ordering we are searching for.
+    /// For 1 roll, this means 1/24 = 0,041
+    /// For n rolls, our chances of getting the ordering we want _at least once_ is 1-(23/24)^n
+    /// So for 100 rolls, our chance of getting it once is 1-(23/24)^100 = 0,985
+    /// That's why we encode and compare the strings (up to) 100 times, to have a confidence interval of %98,5.
+    /// See `func nonDeterministicAssertEqual`
+    
+    func testChannelQueryEncoding() {
+        let query = { ChannelQuery(channel: self.channel,
+                                   messagesPagination: self.simplePagination(),
+                                   membersPagination: self.mediumPagination(),
+                                   watchersPagination: self.complexPagination(),
+                                   options: .watch) }
+        
+        let expectedString = #"{"messages":{"limit":10},"data":{"name":null},"watch":true,"watchers":{"id_gt":"42","id_lt":"92","offset":10,"limit":10},"members":{"limit":10,"offset":20}}"#
+        
+        nonDeterministicAssertEqual(expectedString, try encode(query()))
+    }
+    
+    func testChannelsQueryEncoding() {
+        let query = { ChannelsQuery(filter: self.simpleFilter,
+                                    sort: [.init("name", isAscending: true)],
+                                    pagination: self.complexPagination(),
+                                    messagesLimit: self.mediumPagination(),
+                                    options: .presence) }
+        
+        let expectedString = #"{"offset":10,"sort":[{"field":"name","direction":1}],"filter_conditions":{"id":42},"message_limit":10,"presence":true,"limit":10,"id_lt":"92","id_gt":"42"}"#
+        
+        nonDeterministicAssertEqual(expectedString, try encode(query()))
+    }
+    
+    func testSearchQueryEncoding() {
+        let query = { SearchQuery(filter: self.mediumFilter,
+                                  query: "hello",
+                                  pagination: self.mediumPagination()) }
+        
+        let expectedString = #"{"limit":10,"query":"hello","offset":20,"filter_conditions":{"$and":[{"members":{"$in":["john"]}},{"id":{"$autocomplete":"ro"}}]}}"#
+        
+        nonDeterministicAssertEqual(expectedString, try encode(query()))
+    }
+    
+    func testUsersQueryEncoding() {
+        let query = { UsersQuery(filter: self.complexFilter,
+                               sort: .init("name", isAscending: true),
+                               options: .all) }
+        
+        let expectedString = #"{"presence":true,"state":true,"watch":true,"sort":{"field":"name","direction":1},"filter_conditions":{"$and":[{"members":{"$in":["john"]}},{"unread_count":0},{"$or":[{"id":{"$gt":42}},{"$and":[{"avatar":{"$ne":"null"}},{"name":{"$autocomplete":"ro"}}]}]}]}}"#
+        
+        nonDeterministicAssertEqual(expectedString, try encode(query()))
+    }
+    
+    private func error(with message: String) -> NSError {
+        NSError(domain: "QueryGenerationTests", code: -1, userInfo: ["message:": message])
+    }
+    
+    /// - Returns: the string representation of the data
+    /// - Throws: Error to fail the test
+    private func encode<T: Encodable>(_ data: T) throws -> String {
+        do {
+            let encoded = try encoder.encode(data)
+            guard let stringRep = String(data: encoded, encoding: .utf8) else {
+                throw error(with: "Failed to get string representation for data")
+            }
+            return stringRep
+        } catch let err {
+            throw error(with: "Error during encoding: \(err)")
+        }
+    }
+    
+    private func nonDeterministicAssertEqual<T>(_ expression1: @autoclosure () throws -> T,
+                                                _ expression2: @autoclosure () throws -> T,
+                                                tryUpTo times: Int = 100) where T : StringProtocol {
+        var equal = false
+        
+        do {
+            let expr1 = try expression1()
+            let expr2 = try expression2()
+            
+            guard expr1.count == expr2.count else {
+                throw error(with: "Representation lenghts don't match")
+            }
+            
+            equal = equal || (expr1 == expr2)
+            
+            for _ in 0..<(times - 1) {
+                if equal { break }
+                try equal = equal || (expression1() == expression2())
+            }
+        } catch {
+            XCTFail("Threw \(error)")
+            return
+        }
+        
+        XCTAssert(equal, "Encoding did not match expected")
+    }
+}


### PR DESCRIPTION
Fixes #165
#skip_changelog

Fixes the block in `ChannelQuery`:
```swift
if !messagesPagination.isEmpty {
    try container.encode(messagesPagination, forKey: .messages)
}

if !membersPagination.isEmpty {
    try container.encode(membersPagination, forKey: .members)
}

if !watchersPagination.isEmpty {
    try container.encode(watchersPagination, forKey: .watchers)
}
```
encoding an array instead of an object.

Also closes CIS-38