### PR TITLE
CIS-71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🔄 Changed
 - `Pagination` doesn't support `+` operator anymore, please use a set of  `PaginationOption`s from now on [#158](https://github.com/GetStream/stream-chat-swift/issues/158)
 - `channel.subscribeToWatcherCount` uses channel events to publish updated counts and does not call `channel.watch` as a side-effect anymore [#161](https://github.com/GetStream/stream-chat-swift/issues/161)
+- Subscriptions for a channel unread count and watcher count [#172](https://github.com/GetStream/stream-chat-swift/issues/172).
+- Changed a returning type for requests as `Cancellable` instead of `URLSessionTask` to make requests and events more consistent [#172](https://github.com/GetStream/stream-chat-swift/issues/172).
+- The example project was updated [#172](https://github.com/GetStream/stream-chat-swift/issues/172).
 
 ### ✅ Added
 - Better errors when developers forget to call `set(user:)` or don't wait for its completion [#160](https://github.com/GetStream/stream-chat-swift/issues/160)
+- Examples for a channel unread count and watcher count in the Example app [#172](https://github.com/GetStream/stream-chat-swift/issues/172).
 
 ### 🐞 Fixed
 - SPM support [#156](https://github.com/GetStream/stream-chat-swift/issues/156).
+- Made `SubscriptionBag.init` public [#172](https://github.com/GetStream/stream-chat-swift/issues/172).
 
 # [2.0.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.0.1)
 _April 3, 2020_

--- a/Example/Sources/Main.storyboard
+++ b/Example/Sources/Main.storyboard
@@ -83,7 +83,7 @@
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                         <state key="normal" title="All channels"/>
                                         <connections>
-                                            <segue destination="aEe-dp-x44" kind="presentation" modalPresentationStyle="fullScreen" id="seW-P6-fEX"/>
+                                            <segue destination="aEe-dp-x44" kind="presentation" identifier="allChannels" modalPresentationStyle="fullScreen" id="seW-P6-fEX"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Try-iz-4dr">
@@ -110,26 +110,26 @@
                                             <segue destination="Z71-Wp-boH" kind="presentation" modalPresentationStyle="fullScreen" id="x9o-K0-tAV"/>
                                         </connections>
                                     </button>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unread Count: &lt;Disabled&gt;" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r90-MX-Ekn" userLabel="UnreadCount">
-                                        <rect key="frame" x="0.0" y="240" width="172" height="17"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unread Count" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r90-MX-Ekn" userLabel="UnreadCount">
+                                        <rect key="frame" x="0.0" y="240" width="90" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Watcher Count: &lt;Disabled&gt;" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LML-Ms-XJg">
-                                        <rect key="frame" x="0.0" y="287" width="179" height="17"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Watcher Count" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LML-Ms-XJg">
+                                        <rect key="frame" x="0.0" y="287" width="97" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total Unread Count: &lt;Disabled&gt;" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tp6-sE-CBi">
-                                        <rect key="frame" x="0.0" y="334" width="207" height="17"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total Unread Count" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tp6-sE-CBi">
+                                        <rect key="frame" x="0.0" y="334" width="125" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Push  notifications:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MVq-bk-kzB">
-                                        <rect key="frame" x="0.0" y="381" width="123.5" height="17"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Push  notifications" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MVq-bk-kzB">
+                                        <rect key="frame" x="0.0" y="381" width="119.5" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -168,6 +168,12 @@
                                 <rect key="frame" x="16" y="467" width="283" height="29"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filter: the current user is a member of channels" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZnC-yl-OYz">
+                                <rect key="frame" x="16" y="94" width="268" height="14.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filter: the current user is a member of channels" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ncz-qn-Ssy">
@@ -211,6 +217,7 @@ Stream Swift SDK v.1.0.0</string>
                             <constraint firstItem="jQp-EN-Voh" firstAttribute="trailing" secondItem="fQM-5J-VyU" secondAttribute="trailing" id="JHC-nQ-XuY"/>
                             <constraint firstItem="H0k-lx-tmL" firstAttribute="centerY" secondItem="MVq-bk-kzB" secondAttribute="centerY" id="JiW-cq-VUP"/>
                             <constraint firstItem="H0k-lx-tmL" firstAttribute="trailing" secondItem="fQM-5J-VyU" secondAttribute="trailing" id="UPl-Cd-D6W"/>
+                            <constraint firstItem="ZnC-yl-OYz" firstAttribute="top" secondItem="lMz-sX-zDG" secondAttribute="bottom" id="VIr-PM-04v"/>
                             <constraint firstItem="Fyw-02-BDi" firstAttribute="centerX" secondItem="pUb-7p-fIc" secondAttribute="centerX" id="WfN-1q-yri"/>
                             <constraint firstItem="fQM-5J-VyU" firstAttribute="trailing" secondItem="jrn-MT-IQv" secondAttribute="trailing" id="Y6b-uF-Qxa"/>
                             <constraint firstItem="B0u-JV-sSq" firstAttribute="trailing" secondItem="fQM-5J-VyU" secondAttribute="trailing" constant="-60" id="YXy-7G-fdL"/>
@@ -224,6 +231,7 @@ Stream Swift SDK v.1.0.0</string>
                             <constraint firstItem="1lG-cg-5R8" firstAttribute="trailing" secondItem="fQM-5J-VyU" secondAttribute="trailing" id="qTd-Gz-MV4"/>
                             <constraint firstItem="Ncz-qn-Ssy" firstAttribute="leading" secondItem="Try-iz-4dr" secondAttribute="leading" id="ttA-na-RZj"/>
                             <constraint firstItem="pUb-7p-fIc" firstAttribute="bottom" secondItem="Fyw-02-BDi" secondAttribute="bottom" constant="20" id="vik-Ho-cFz"/>
+                            <constraint firstItem="ZnC-yl-OYz" firstAttribute="leading" secondItem="lMz-sX-zDG" secondAttribute="leading" id="x6G-C0-mfJ"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="pUb-7p-fIc"/>
                     </view>

--- a/Sources/Client/Client/Client+Channel.swift
+++ b/Sources/Client/Client/Client+Channel.swift
@@ -104,10 +104,10 @@ public extension Client {
         
         var modifiedCompletion = completion
         
-        if query.options.contains(.watch) && (query.options.contains(.state) || query.options.contains(.presence)) {
+        if query.options.contains(.watch), query.options.contains(.state) {
             modifiedCompletion = { [unowned self] result in
                 if let channel = result.value?.channel {
-                    self.refreshWatchingChannels(with: channel, queryOptions: query.options)
+                    self.refreshWatchingChannels(with: channel)
                 }
                 
                 completion(result)

--- a/Sources/Client/Client/Client+Devices.swift
+++ b/Sources/Client/Client/Client+Devices.swift
@@ -17,7 +17,7 @@ public extension Client {
     ///   - deviceToken: a device token.
     ///   - completion: an empty completion block.
     @discardableResult
-    func addDevice(deviceToken: Data, _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> URLSessionTask {
+    func addDevice(deviceToken: Data, _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> Cancellable {
         addDevice(deviceId: deviceToken.deviceToken, completion)
     }
     
@@ -26,7 +26,7 @@ public extension Client {
     ///   - deviceId: a Push Notifications device identifier.
     ///   - completion: an empty completion block.
     @discardableResult
-    func addDevice(deviceId: String, _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> URLSessionTask {
+    func addDevice(deviceId: String, _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> Cancellable {
         let device = Device(deviceId)
         
         let completion = doBefore(completion) { [unowned self] _ in
@@ -41,7 +41,7 @@ public extension Client {
     /// Gets a list of user devices.
     /// - Parameter completion: a completion block wiith `[Device]`.
     @discardableResult
-    func devices(_ completion: @escaping Client.Completion<[Device]>) -> URLSessionTask {
+    func devices(_ completion: @escaping Client.Completion<[Device]>) -> Cancellable {
         let completion = doBefore(completion) { [unowned self] devices in
             self.userAtomic.devices = devices
             self.logger?.log("📱 Devices updated")
@@ -57,7 +57,7 @@ public extension Client {
     ///   - deviceId: a Push Notifications device identifier.
     ///   - completion: an empty completion block.
     @discardableResult
-    func removeDevice(deviceId: String, _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> URLSessionTask {
+    func removeDevice(deviceId: String, _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> Cancellable {
         let completion = doBefore(completion) { [unowned self] devices in
             self.userAtomic.update { oldUser in
                 if let index = self.user.devices.firstIndex(where: { $0.id == deviceId }) {

--- a/Sources/Client/Client/Client+Events.swift
+++ b/Sources/Client/Client/Client+Events.swift
@@ -137,7 +137,7 @@ extension Client {
         }
         
         return subscription
-    }      
+    }
     
     func subscribeToUnreadCount(for channel: Channel, _ callback: @escaping Completion<ChannelUnreadCount>) -> Cancellable {
         let subscription = subscribe(forEvents: [.messageNew, .messageRead], cid: channel.cid) { _ in
@@ -178,7 +178,7 @@ extension Client {
         } else {
             logger?.log("⚠️ You are trying to subscribe to watcher count for the channel: (\(channel.cid)), "
                 + "but you didn't start watching it. Please, make a query with "
-                + "pagination: `[.limit(1)]` and query options: `[.watch, .presence]`")
+                + "pagination: `[.limit(1)]` and query options: `[.watch, .state]`")
         }
 
         return subscription

--- a/Sources/Client/Client/Client+Events.swift
+++ b/Sources/Client/Client/Client+Events.swift
@@ -148,7 +148,8 @@ extension Client {
         guard isWatching(channel: channel) else {
             logger?.log("⚠️ You are trying to subscribe for a channel unread count: (\(channel.cid)), "
                 + "but you didn't start watching it. Please, make a query first with "
-                + "pagination: `[.limit(100)]` and query options: `[.watch, .state]`")
+                + "messages pagination: `[.limit(100)]` and query options: `[.watch, .state]`: "
+                + "`channel.query(messagesPagination: [.limit(100)], options: [.watch, .state])`")
             
             return subscription
         }
@@ -178,7 +179,8 @@ extension Client {
         } else {
             logger?.log("⚠️ You are trying to subscribe to watcher count for the channel: (\(channel.cid)), "
                 + "but you didn't start watching it. Please, make a query with "
-                + "pagination: `[.limit(1)]` and query options: `[.watch, .state]`")
+                + "messages pagination: `[.limit(1)]` and query options: `[.watch, .state]`:"
+                + "`channel.query(messagesPagination: [.limit(1)], options: [.watch, .state])`")
         }
 
         return subscription

--- a/Sources/Client/Client/Client+WebSocket.swift
+++ b/Sources/Client/Client/Client+WebSocket.swift
@@ -47,7 +47,7 @@ extension Client {
         return WebSocket(request, stayConnectedInBackground: stayConnectedInBackground, logger: logger) { [unowned self] event in
             guard case .connectionChanged(let connectionState) = event else {
                 self.updateUserUnreadCount(event: event) // User unread counts should be updated before channels unread counts.
-                self.updateChannelsUnreadCount(event: event)
+                self.updateChannelsForWatcherAndUnreadCount(event: event)
                 return
             }
             

--- a/Sources/Client/Model/Channel/Channel+Config.swift
+++ b/Sources/Client/Model/Channel/Channel+Config.swift
@@ -1,0 +1,145 @@
+//
+//  Channel+Config.swift
+//  StreamChatClient
+//
+//  Created by Alexey Bukhtin on 14/04/2020.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+// MARK: Config
+
+public extension Channel {
+    /// A channel config.
+    struct Config: Decodable {
+        // swiftlint:disable:next nesting
+        private enum CodingKeys: String, CodingKey {
+            case reactionsEnabled = "reactions"
+            case typingEventsEnabled = "typing_events"
+            case readEventsEnabled = "read_events"
+            case connectEventsEnabled = "connect_events"
+            case uploadsEnabled = "uploads"
+            case repliesEnabled = "replies"
+            case searchEnabled = "search"
+            case mutesEnabled = "mutes"
+            case urlEnrichmentEnabled = "url_enrichment"
+            case messageRetention = "message_retention"
+            case maxMessageLength = "max_message_length"
+            case commands
+            case created = "created_at"
+            case updated = "updated_at"
+        }
+        
+        /// If users are allowed to add reactions to messages. Enabled by default.
+        public let reactionsEnabled: Bool
+        /// Controls if typing indicators are shown. Enabled by default.
+        public let typingEventsEnabled: Bool
+        /// Controls whether the chat shows how far you’ve read. Enabled by default.
+        public let readEventsEnabled: Bool
+        /// Determines if events are fired for connecting and disconnecting to a chat. Enabled by default.
+        public let connectEventsEnabled: Bool
+        /// Enables uploads.
+        public let uploadsEnabled: Bool
+        /// Enables message threads and replies. Enabled by default.
+        public let repliesEnabled: Bool
+        /// Controls if messages should be searchable (this is a premium feature). Disabled by default.
+        public let searchEnabled: Bool
+        /// Determines if users are able to mute other users. Enabled by default.
+        public let mutesEnabled: Bool
+        /// Determines if URL enrichment enabled to show they as attachments. Enabled by default.
+        public let urlEnrichmentEnabled: Bool
+        /// Determines if users are able to flag messages. Enabled by default.
+        public let flagsEnabled: Bool
+        /// A number of days or infinite. Infinite by default.
+        public let messageRetention: String
+        /// The max message length. 5000 by default.
+        public let maxMessageLength: Int
+        /// An array of commands, e.g. /giphy.
+        public let commands: [Command]
+        /// A channel created date.
+        public let created: Date
+        /// A channel updated date.
+        public let updated: Date
+        
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            reactionsEnabled = try container.decode(Bool.self, forKey: .reactionsEnabled)
+            typingEventsEnabled = try container.decode(Bool.self, forKey: .typingEventsEnabled)
+            readEventsEnabled = try container.decode(Bool.self, forKey: .readEventsEnabled)
+            connectEventsEnabled = try container.decode(Bool.self, forKey: .connectEventsEnabled)
+            uploadsEnabled = try container.decodeIfPresent(Bool.self, forKey: .uploadsEnabled) ?? false
+            repliesEnabled = try container.decode(Bool.self, forKey: .repliesEnabled)
+            searchEnabled = try container.decode(Bool.self, forKey: .searchEnabled)
+            mutesEnabled = try container.decode(Bool.self, forKey: .mutesEnabled)
+            urlEnrichmentEnabled = try container.decode(Bool.self, forKey: .urlEnrichmentEnabled)
+            messageRetention = try container.decode(String.self, forKey: .messageRetention)
+            maxMessageLength = try container.decode(Int.self, forKey: .maxMessageLength)
+            commands = try container.decodeIfPresent([Command].self, forKey: .commands) ?? []
+            flagsEnabled = commands.first(where: { $0.name.contains("flag") }) != nil
+            created = try container.decode(Date.self, forKey: .created)
+            updated = try container.decode(Date.self, forKey: .updated)
+        }
+        
+        public init(reactionsEnabled: Bool = false,
+                    typingEventsEnabled: Bool = false,
+                    readEventsEnabled: Bool = false,
+                    connectEventsEnabled: Bool = false,
+                    uploadsEnabled: Bool = false,
+                    repliesEnabled: Bool = false,
+                    searchEnabled: Bool = false,
+                    mutesEnabled: Bool = false,
+                    urlEnrichmentEnabled: Bool = false,
+                    flagsEnabled: Bool = false,
+                    messageRetention: String = "",
+                    maxMessageLength: Int = 0,
+                    commands: [Command] = [],
+                    created: Date = .init(),
+                    updated: Date = .init()) {
+            self.reactionsEnabled = reactionsEnabled
+            self.typingEventsEnabled = typingEventsEnabled
+            self.readEventsEnabled = readEventsEnabled
+            self.connectEventsEnabled = connectEventsEnabled
+            self.uploadsEnabled = uploadsEnabled
+            self.repliesEnabled = repliesEnabled
+            self.searchEnabled = searchEnabled
+            self.mutesEnabled = mutesEnabled
+            self.urlEnrichmentEnabled = urlEnrichmentEnabled
+            self.flagsEnabled = flagsEnabled
+            self.messageRetention = messageRetention
+            self.maxMessageLength = maxMessageLength
+            self.commands = commands
+            self.created = created
+            self.updated = updated
+        }
+    }
+    
+    /// A command in a message, e.g. /giphy.
+    struct Command: Decodable, Hashable {
+        /// A command name.
+        public let name: String
+        /// A description.
+        public let description: String
+        public let set: String
+        /// Args for the command.
+        public let args: String
+        
+        public init(name: String = "",
+                    description: String = "",
+                    set: String = "",
+                    args: String = "") {
+            self.name = name
+            self.description = description
+            self.set = set
+            self.args = args
+        }
+        
+        public static func == (lhs: Command, rhs: Command) -> Bool {
+            lhs.name == rhs.name
+        }
+        
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(name)
+        }
+    }
+}

--- a/Sources/Client/Model/Channel/Channel+Requests.swift
+++ b/Sources/Client/Model/Channel/Channel+Requests.swift
@@ -15,7 +15,7 @@ public extension Channel {
     /// Create a channel.
     /// - Parameter completion: a completion block with `ChannelResponse`.
     @discardableResult
-    func create(_ completion: @escaping Client.Completion<ChannelResponse>) -> URLSessionTask {
+    func create(_ completion: @escaping Client.Completion<ChannelResponse>) -> Cancellable {
         Client.shared.create(channel: self, completion)
     }
     
@@ -29,7 +29,7 @@ public extension Channel {
                membersPagination: Pagination = [],
                watchersPagination: Pagination = [],
                options: QueryOptions = [],
-               _ completion: @escaping Client.Completion<ChannelResponse>) -> URLSessionTask {
+               _ completion: @escaping Client.Completion<ChannelResponse>) -> Cancellable {
         Client.shared.queryChannel(self,
                                    messagesPagination: messagesPagination,
                                    membersPagination: membersPagination,
@@ -43,14 +43,14 @@ public extension Channel {
     ///   - options: an additional channel options, e.g. `.presence`
     ///   - completion: a completion block with `ChannelResponse`.
     @discardableResult
-    func watch(options: QueryOptions = [], _ completion: @escaping Client.Completion<ChannelResponse>) -> URLSessionTask {
+    func watch(options: QueryOptions = [], _ completion: @escaping Client.Completion<ChannelResponse>) -> Cancellable {
         Client.shared.watch(channel: self, options: options, completion)
     }
     
     /// Stop watching the channel for a state changes.
     /// - Parameter completion: an empty completion block.
     @discardableResult
-    func stopWatching(_ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> URLSessionTask {
+    func stopWatching(_ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> Cancellable {
         Client.shared.stopWatching(channel: self, completion)
     }
     
@@ -60,7 +60,7 @@ public extension Channel {
     ///   - clearHistory: checks if needs to remove a message history of the channel.
     ///   - completion: an empty completion block.
     @discardableResult
-    func hide(clearHistory: Bool = false, _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> URLSessionTask {
+    func hide(clearHistory: Bool = false, _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> Cancellable {
         Client.shared.hide(channel: self, clearHistory: clearHistory, completion)
     }
     
@@ -69,7 +69,7 @@ public extension Channel {
     ///   - user: the current user.
     ///   - completion: an empty completion block.
     @discardableResult
-    func show(_ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> URLSessionTask {
+    func show(_ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> Cancellable {
         Client.shared.show(channel: self, completion)
     }
     
@@ -83,14 +83,14 @@ public extension Channel {
     func update(name: String? = nil,
                 imageURL: URL? = nil,
                 extraData: ChannelExtraDataCodable? = nil,
-                _ completion: @escaping Client.Completion<ChannelResponse>) -> URLSessionTask {
+                _ completion: @escaping Client.Completion<ChannelResponse>) -> Cancellable {
         Client.shared.update(channel: self, name: name, imageURL: imageURL, extraData: extraData, completion)
     }
     
     /// Delete the channel.
     /// - Parameter completion: a completion block with `Channel`.
     @discardableResult
-    func delete(_ completion: @escaping Client.Completion<Channel>) -> URLSessionTask {
+    func delete(_ completion: @escaping Client.Completion<Channel>) -> Cancellable {
         Client.shared.delete(channel: self, completion)
     }
     
@@ -101,7 +101,7 @@ public extension Channel {
     ///   - message: a message.
     ///   - completion: a completion block with `MessageResponse`.
     @discardableResult
-    func send(message: Message, _ completion: @escaping Client.Completion<MessageResponse>) -> URLSessionTask {
+    func send(message: Message, _ completion: @escaping Client.Completion<MessageResponse>) -> Cancellable {
         Client.shared.send(message: message, to: self, completion)
     }
     
@@ -113,14 +113,14 @@ public extension Channel {
     @discardableResult
     func send(action: Attachment.Action,
               for ephemeralMessage: Message,
-              _ completion: @escaping Client.Completion<MessageResponse>) -> URLSessionTask {
+              _ completion: @escaping Client.Completion<MessageResponse>) -> Cancellable {
         Client.shared.send(action: action, for: ephemeralMessage, to: self, completion)
     }
     
     /// Mark messages in the channel as read.
     /// - Parameter completion: a completion block with `Event`.
     @discardableResult
-    func markRead(_ completion: @escaping Client.Completion<Event>) -> URLSessionTask {
+    func markRead(_ completion: @escaping Client.Completion<Event>) -> Cancellable {
         Client.shared.markRead(channel: self, completion)
     }
     
@@ -129,7 +129,7 @@ public extension Channel {
     ///   - eventType: an event type.
     ///   - completion: a completion block with `Event`.
     @discardableResult
-    func send(eventType: EventType, _ completion: @escaping Client.Completion<Event>) -> URLSessionTask {
+    func send(eventType: EventType, _ completion: @escaping Client.Completion<Event>) -> Cancellable {
         Client.shared.send(eventType: eventType, to: self, completion)
     }
     
@@ -140,7 +140,7 @@ public extension Channel {
     ///   - user: a user.
     ///   - completion: a completion block with `ChannelResponse`.
     @discardableResult
-    func add(user: User, _ completion: @escaping Client.Completion<ChannelResponse>) -> URLSessionTask {
+    func add(user: User, _ completion: @escaping Client.Completion<ChannelResponse>) -> Cancellable {
         Client.shared.add(user: user, to: self, completion)
     }
     
@@ -149,7 +149,7 @@ public extension Channel {
     ///   - users: users.
     ///   - completion: a completion block with `ChannelResponse`.
     @discardableResult
-    func add(users: Set<User>, _ completion: @escaping Client.Completion<ChannelResponse>) -> URLSessionTask {
+    func add(users: Set<User>, _ completion: @escaping Client.Completion<ChannelResponse>) -> Cancellable {
         Client.shared.add(users: users, to: self, completion)
     }
     
@@ -158,7 +158,7 @@ public extension Channel {
     ///   - member: a member.
     ///   - completion: a completion block with `ChannelResponse`.
     @discardableResult
-    func add(member: Member, _ completion: @escaping Client.Completion<ChannelResponse>) -> URLSessionTask {
+    func add(member: Member, _ completion: @escaping Client.Completion<ChannelResponse>) -> Cancellable {
         Client.shared.add(member: member, to: self, completion)
     }
     
@@ -167,7 +167,7 @@ public extension Channel {
     ///   - members: members.
     ///   - completion: a completion block with `ChannelResponse`.
     @discardableResult
-    func add(members: Set<Member>, _ completion: @escaping Client.Completion<ChannelResponse>) -> URLSessionTask {
+    func add(members: Set<Member>, _ completion: @escaping Client.Completion<ChannelResponse>) -> Cancellable {
         Client.shared.add(members: members, to: self, completion)
     }
     
@@ -176,7 +176,7 @@ public extension Channel {
     ///   - user: a user.
     ///   - completion: a completion block with `ChannelResponse`.
     @discardableResult
-    func remove(user: User, _ completion: @escaping Client.Completion<ChannelResponse>) -> URLSessionTask {
+    func remove(user: User, _ completion: @escaping Client.Completion<ChannelResponse>) -> Cancellable {
         Client.shared.remove(user: user, from: self, completion)
     }
     
@@ -185,7 +185,7 @@ public extension Channel {
     ///   - users: users.
     ///   - completion: a completion block with `ChannelResponse`.
     @discardableResult
-    func remove(users: Set<User>, _ completion: @escaping Client.Completion<ChannelResponse>) -> URLSessionTask {
+    func remove(users: Set<User>, _ completion: @escaping Client.Completion<ChannelResponse>) -> Cancellable {
         Client.shared.remove(users: users, from: self, completion)
     }
     
@@ -194,7 +194,7 @@ public extension Channel {
     ///   - member: a member.
     ///   - completion: a completion block with `ChannelResponse`.
     @discardableResult
-    func remove(member: Member, _ completion: @escaping Client.Completion<ChannelResponse>) -> URLSessionTask {
+    func remove(member: Member, _ completion: @escaping Client.Completion<ChannelResponse>) -> Cancellable {
         Client.shared.remove(member: member, from: self, completion)
     }
     
@@ -203,7 +203,7 @@ public extension Channel {
     ///   - members: members.
     ///   - completion: a completion block with `ChannelResponse`.
     @discardableResult
-    func remove(members: Set<Member>, _ completion: @escaping Client.Completion<ChannelResponse>) -> URLSessionTask {
+    func remove(members: Set<Member>, _ completion: @escaping Client.Completion<ChannelResponse>) -> Cancellable {
         Client.shared.remove(members: members, from: self, completion)
     }
     
@@ -218,7 +218,7 @@ public extension Channel {
     func ban(user: User,
              timeoutInMinutes: Int? = nil,
              reason: String? = nil,
-             _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> URLSessionTask {
+             _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> Cancellable {
         Client.shared.ban(user: user, in: self, timeoutInMinutes: timeoutInMinutes, reason: reason, completion)
     }
     
@@ -229,7 +229,7 @@ public extension Channel {
     ///   - member: a member.
     ///   - completion: a completion block with `ChannelResponse`.
     @discardableResult
-    func invite(member: Member, _ completion: @escaping Client.Completion<ChannelResponse>) -> URLSessionTask {
+    func invite(member: Member, _ completion: @escaping Client.Completion<ChannelResponse>) -> Cancellable {
         Client.shared.invite(member: member, to: self, completion)
     }
     
@@ -238,7 +238,7 @@ public extension Channel {
     ///   - members: a list of members.
     ///   - completion: a completion block with `ChannelResponse`.
     @discardableResult
-    func invite(members: Set<Member>, _ completion: @escaping Client.Completion<ChannelResponse>) -> URLSessionTask {
+    func invite(members: Set<Member>, _ completion: @escaping Client.Completion<ChannelResponse>) -> Cancellable {
         Client.shared.invite(members: members, to: self, completion)
     }
     
@@ -249,7 +249,7 @@ public extension Channel {
     ///   - completion: a completion block with `ChannelInviteResponse`.
     @discardableResult
     func acceptInvite(with message: Message? = nil,
-                      _ completion: @escaping Client.Completion<ChannelInviteResponse>) -> URLSessionTask {
+                      _ completion: @escaping Client.Completion<ChannelInviteResponse>) -> Cancellable {
         Client.shared.acceptInvite(for: self, with: message, completion)
     }
     
@@ -259,7 +259,7 @@ public extension Channel {
     ///   - completion: a completion block with `ChannelInviteResponse`.
     @discardableResult
     func rejectInvite(with message: Message? = nil,
-                      _ completion: @escaping Client.Completion<ChannelInviteResponse>) -> URLSessionTask {
+                      _ completion: @escaping Client.Completion<ChannelInviteResponse>) -> Cancellable {
         Client.shared.rejectInvite(for: self, with: message, completion)
     }
     
@@ -275,7 +275,7 @@ public extension Channel {
                    mimeType: String,
                    imageData: Data,
                    _ progress: @escaping Client.Progress,
-                   _ completion: @escaping Client.Completion<URL>) -> URLSessionTask {
+                   _ completion: @escaping Client.Completion<URL>) -> Cancellable {
         Client.shared.sendImage(fileName: fileName, mimeType: mimeType, imageData: imageData, to: self, progress, completion)
     }
     
@@ -289,7 +289,7 @@ public extension Channel {
                   mimeType: String,
                   fileData: Data,
                   _ progress: @escaping Client.Progress,
-                  _ completion: @escaping Client.Completion<URL>) -> URLSessionTask {
+                  _ completion: @escaping Client.Completion<URL>) -> Cancellable {
         Client.shared.sendFile(fileName: fileName, mimeType: mimeType, fileData: fileData, to: self, progress, completion)
     }
     
@@ -298,7 +298,7 @@ public extension Channel {
     ///   - url: an image URL.
     ///   - completion: an empty completion block.
     @discardableResult
-    func deleteImage(url: URL, _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> URLSessionTask {
+    func deleteImage(url: URL, _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> Cancellable {
         Client.shared.deleteImage(url: url, from: self, completion)
     }
     
@@ -307,7 +307,7 @@ public extension Channel {
     ///   - url: a file URL.
     ///   - completion: an empty completion block.
     @discardableResult
-    func deleteFile(url: URL, _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> URLSessionTask {
+    func deleteFile(url: URL, _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> Cancellable {
         Client.shared.deleteFile(url: url, from: self, completion)
     }
 }

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -113,7 +113,7 @@ public final class Channel: Codable {
     /// Checks if the channel was decoded from a channel response.
     public let didLoad: Bool
     /// Checks if the channel is watching by the client.
-    public var isWatching: Bool { Client.shared.isWatching(channel: self) }
+    public var isWatched: Bool { Client.shared.isWatching(channel: self) }
     
     private var subscriptionBag = SubscriptionBag()
     

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -117,6 +117,9 @@ public final class Channel: Codable {
     
     private var subscriptionBag = SubscriptionBag()
     
+    /// Checks for the channel data encoding is empty.
+    var isEmpty: Bool { extraData == nil && members.isEmpty && invitedMembers.isEmpty }
+    
     public init(type: ChannelType,
                 id: String,
                 members: [User],
@@ -169,8 +172,6 @@ public final class Channel: Codable {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: EncodingKeys.self)
-        try container.encode(name, forKey: .name)
-        try container.encodeIfPresent(imageURL, forKey: .imageURL)
         extraData?.encodeSafely(to: encoder, logMessage: "📦 when encoding a channel extra data")
         
         var allMembers = members

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -191,6 +191,12 @@ public final class Channel: Codable {
         unreadMessageReadAtomic.set(messageRead)
         unreadCountAtomic.set(.noUnread)
     }
+    
+    /// Check is the user is banned for the channel.
+    /// - Parameter user: a user.
+    public func isBanned(_ user: User) -> Bool {
+        bannedUsers.contains(user)
+    }
 }
 
 extension Channel: Hashable, CustomStringConvertible {
@@ -246,7 +252,7 @@ extension Channel {
     }
 }
 
-// MARK: ChannelExtraDataCodable
+// MARK: Channel Extra Data Codable
 
 extension Channel {
     
@@ -271,153 +277,6 @@ extension Channel {
             var object: ChannelExtraDataCodable = extraData ?? ChannelExtraData()
             object.imageURL = newValue
             extraData = object
-        }
-    }
-}
-
-// MARK: - Helpers
-
-extension Channel {
-    
-    /// Check is the user is banned for the channel.
-    /// - Parameter user: a user.
-    public func isBanned(_ user: User) -> Bool {
-        bannedUsers.contains(user)
-    }
-}
-
-// MARK: - Config
-
-public extension Channel {
-    /// A channel config.
-    struct Config: Decodable {
-        // swiftlint:disable:next nesting
-        private enum CodingKeys: String, CodingKey {
-            case reactionsEnabled = "reactions"
-            case typingEventsEnabled = "typing_events"
-            case readEventsEnabled = "read_events"
-            case connectEventsEnabled = "connect_events"
-            case uploadsEnabled = "uploads"
-            case repliesEnabled = "replies"
-            case searchEnabled = "search"
-            case mutesEnabled = "mutes"
-            case urlEnrichmentEnabled = "url_enrichment"
-            case messageRetention = "message_retention"
-            case maxMessageLength = "max_message_length"
-            case commands
-            case created = "created_at"
-            case updated = "updated_at"
-        }
-        
-        /// If users are allowed to add reactions to messages. Enabled by default.
-        public let reactionsEnabled: Bool
-        /// Controls if typing indicators are shown. Enabled by default.
-        public let typingEventsEnabled: Bool
-        /// Controls whether the chat shows how far you’ve read. Enabled by default.
-        public let readEventsEnabled: Bool
-        /// Determines if events are fired for connecting and disconnecting to a chat. Enabled by default.
-        public let connectEventsEnabled: Bool
-        /// Enables uploads.
-        public let uploadsEnabled: Bool
-        /// Enables message threads and replies. Enabled by default.
-        public let repliesEnabled: Bool
-        /// Controls if messages should be searchable (this is a premium feature). Disabled by default.
-        public let searchEnabled: Bool
-        /// Determines if users are able to mute other users. Enabled by default.
-        public let mutesEnabled: Bool
-        /// Determines if URL enrichment enabled to show they as attachments. Enabled by default.
-        public let urlEnrichmentEnabled: Bool
-        /// Determines if users are able to flag messages. Enabled by default.
-        public let flagsEnabled: Bool
-        /// A number of days or infinite. Infinite by default.
-        public let messageRetention: String
-        /// The max message length. 5000 by default.
-        public let maxMessageLength: Int
-        /// An array of commands, e.g. /giphy.
-        public let commands: [Command]
-        /// A channel created date.
-        public let created: Date
-        /// A channel updated date.
-        public let updated: Date
-        
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            reactionsEnabled = try container.decode(Bool.self, forKey: .reactionsEnabled)
-            typingEventsEnabled = try container.decode(Bool.self, forKey: .typingEventsEnabled)
-            readEventsEnabled = try container.decode(Bool.self, forKey: .readEventsEnabled)
-            connectEventsEnabled = try container.decode(Bool.self, forKey: .connectEventsEnabled)
-            uploadsEnabled = try container.decodeIfPresent(Bool.self, forKey: .uploadsEnabled) ?? false
-            repliesEnabled = try container.decode(Bool.self, forKey: .repliesEnabled)
-            searchEnabled = try container.decode(Bool.self, forKey: .searchEnabled)
-            mutesEnabled = try container.decode(Bool.self, forKey: .mutesEnabled)
-            urlEnrichmentEnabled = try container.decode(Bool.self, forKey: .urlEnrichmentEnabled)
-            messageRetention = try container.decode(String.self, forKey: .messageRetention)
-            maxMessageLength = try container.decode(Int.self, forKey: .maxMessageLength)
-            commands = try container.decodeIfPresent([Command].self, forKey: .commands) ?? []
-            flagsEnabled = commands.first(where: { $0.name.contains("flag") }) != nil
-            created = try container.decode(Date.self, forKey: .created)
-            updated = try container.decode(Date.self, forKey: .updated)
-        }
-        
-        public init(reactionsEnabled: Bool = false,
-                    typingEventsEnabled: Bool = false,
-                    readEventsEnabled: Bool = false,
-                    connectEventsEnabled: Bool = false,
-                    uploadsEnabled: Bool = false,
-                    repliesEnabled: Bool = false,
-                    searchEnabled: Bool = false,
-                    mutesEnabled: Bool = false,
-                    urlEnrichmentEnabled: Bool = false,
-                    flagsEnabled: Bool = false,
-                    messageRetention: String = "",
-                    maxMessageLength: Int = 0,
-                    commands: [Command] = [],
-                    created: Date = .init(),
-                    updated: Date = .init()) {
-            self.reactionsEnabled = reactionsEnabled
-            self.typingEventsEnabled = typingEventsEnabled
-            self.readEventsEnabled = readEventsEnabled
-            self.connectEventsEnabled = connectEventsEnabled
-            self.uploadsEnabled = uploadsEnabled
-            self.repliesEnabled = repliesEnabled
-            self.searchEnabled = searchEnabled
-            self.mutesEnabled = mutesEnabled
-            self.urlEnrichmentEnabled = urlEnrichmentEnabled
-            self.flagsEnabled = flagsEnabled
-            self.messageRetention = messageRetention
-            self.maxMessageLength = maxMessageLength
-            self.commands = commands
-            self.created = created
-            self.updated = updated
-        }
-    }
-    
-    /// A command in a message, e.g. /giphy.
-    struct Command: Decodable, Hashable {
-        /// A command name.
-        public let name: String
-        /// A description.
-        public let description: String
-        public let set: String
-        /// Args for the command.
-        public let args: String
-        
-        public init(name: String = "",
-                    description: String = "",
-                    set: String = "",
-                    args: String = "") {
-            self.name = name
-            self.description = description
-            self.set = set
-            self.args = args
-        }
-        
-        public static func == (lhs: Command, rhs: Command) -> Bool {
-            lhs.name == rhs.name
-        }
-        
-        public func hash(into hasher: inout Hasher) {
-            hasher.combine(name)
         }
     }
 }

--- a/Sources/Client/Model/Channel/ChannelQuery.swift
+++ b/Sources/Client/Model/Channel/ChannelQuery.swift
@@ -53,7 +53,7 @@ public struct ChannelQuery: Encodable {
         try options.encode(to: encoder)
         
         // The channel data only needs for creating it.
-        if !channel.didLoad {
+        if !channel.didLoad, !channel.isEmpty {
             try container.encode(channel, forKey: .data)
         }
         

--- a/Sources/Client/Model/Message/Message+Requests.swift
+++ b/Sources/Client/Model/Message/Message+Requests.swift
@@ -13,7 +13,7 @@ public extension Message {
     /// Delete the message.
     /// - Parameter completion: a completion block with `MessageResponse`.
     @discardableResult
-    func delete(_ completion: @escaping Client.Completion<MessageResponse>) -> URLSessionTask {
+    func delete(_ completion: @escaping Client.Completion<MessageResponse>) -> Cancellable {
         Client.shared.delete(message: self, completion)
     }
     
@@ -22,7 +22,7 @@ public extension Message {
     ///   - pagination: a pagination (see `Pagination`).
     ///   - completion: a completion block with `[Message]`.
     @discardableResult
-    func replies(pagination: Pagination, _ completion: @escaping Client.Completion<[Message]>) -> URLSessionTask {
+    func replies(pagination: Pagination, _ completion: @escaping Client.Completion<[Message]>) -> Cancellable {
         Client.shared.replies(for: self, pagination: pagination, completion)
     }
     
@@ -36,7 +36,7 @@ public extension Message {
     func addReaction(type: String,
                      score: Int,
                      extraData: Codable? = nil,
-                     _ completion: @escaping Client.Completion<MessageResponse>) -> URLSessionTask {
+                     _ completion: @escaping Client.Completion<MessageResponse>) -> Cancellable {
         Client.shared.addReaction(type: type, score: score, extraData: extraData, to: self, completion)
     }
     
@@ -45,7 +45,7 @@ public extension Message {
     ///   - type: a reaction type, e.g. like.
     ///   - completion: a completion block with `MessageResponse`.
     @discardableResult
-    func deleteReaction(type: String, _ completion: @escaping Client.Completion<MessageResponse>) -> URLSessionTask {
+    func deleteReaction(type: String, _ completion: @escaping Client.Completion<MessageResponse>) -> Cancellable {
         Client.shared.deleteReaction(type: type, from: self, completion)
     }
     
@@ -54,14 +54,14 @@ public extension Message {
     /// Flag a message.
     /// - Parameter completion: a completion block with `FlagMessageResponse`.
     @discardableResult
-    func flag(_ completion: @escaping Client.Completion<FlagMessageResponse>) -> URLSessionTask {
+    func flag(_ completion: @escaping Client.Completion<FlagMessageResponse>) -> Cancellable {
         Client.shared.flag(message: self, completion)
     }
     
     /// Unflag a message.
     /// - Parameter completion: a completion block with `FlagMessageResponse`.
     @discardableResult
-    func unflag(_ completion: @escaping Client.Completion<FlagMessageResponse>) -> URLSessionTask {
+    func unflag(_ completion: @escaping Client.Completion<FlagMessageResponse>) -> Cancellable {
         Client.shared.unflag(message: self, completion)
     }
 }

--- a/Sources/Client/Model/User/User+Requests.swift
+++ b/Sources/Client/Model/User/User+Requests.swift
@@ -13,35 +13,35 @@ public extension User {
     /// Update or create the user.
     /// - Parameter completion: a completion block with `User`.
     @discardableResult
-    func update(_ completion: @escaping Client.Completion<User>) -> URLSessionTask {
+    func update(_ completion: @escaping Client.Completion<User>) -> Cancellable {
         Client.shared.update(user: self, completion)
     }
     
     /// Mute the user.
     /// - Parameter completion: a completion block with `MutedUsersResponse`.
     @discardableResult
-    func mute(_ completion: @escaping Client.Completion<MutedUsersResponse>) -> URLSessionTask {
+    func mute(_ completion: @escaping Client.Completion<MutedUsersResponse>) -> Cancellable {
         Client.shared.mute(user: self, completion)
     }
     
     /// Unmute the user.
     /// - Parameter completion: an empty completion block.
     @discardableResult
-    func unmute(_ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> URLSessionTask {
+    func unmute(_ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> Cancellable {
         Client.shared.unmute(user: self, completion)
     }
     
     /// Flag the user.
     /// - Parameter completion: a completion block with `FlagUserResponse`.
     @discardableResult
-    func flag(user: User, _ completion: @escaping Client.Completion<FlagUserResponse>) -> URLSessionTask {
+    func flag(user: User, _ completion: @escaping Client.Completion<FlagUserResponse>) -> Cancellable {
         Client.shared.flag(user: self, completion)
     }
     
     /// Unflag the user.
     /// - Parameter completion: a completion block with `FlagUserResponse`.
     @discardableResult
-    func unflag(user: User, _ completion: @escaping Client.Completion<FlagUserResponse>) -> URLSessionTask {
+    func unflag(user: User, _ completion: @escaping Client.Completion<FlagUserResponse>) -> Cancellable {
         Client.shared.unflag(user: self, completion)
     }
 }

--- a/Sources/Client/WebSocket/WebSocket.swift
+++ b/Sources/Client/WebSocket/WebSocket.swift
@@ -33,7 +33,7 @@ final class WebSocket {
     
     private lazy var handshakeTimer =
         RepeatingTimer(timeInterval: .seconds(WebSocket.pingTimeInterval), queue: webSocket.callbackQueue) { [weak self] in
-            self?.logger?.log("🏓➡️")
+            self?.logger?.log("🏓➡️", level: .info)
             self?.webSocket.write(ping: .empty)
     }
     
@@ -316,7 +316,7 @@ extension WebSocket: WebSocketDelegate {
             
             // Skip pong events.
             if case .pong = event {
-                logger?.log("⬅️🏓")
+                logger?.log("⬅️🏓", level: .info)
                 return nil
             }
             

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		794BDE4A2434BD7400BFBA1F /* NestableCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */; };
 		79D50C7724321BDA0052BA03 /* Client+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D50C7624321BDA0052BA03 /* Client+Events.swift */; };
 		80B937A52434F5FC003D950E /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B937A42434F5FC003D950E /* Array+Extensions.swift */; };
+		8A0673B42445E0570042CFD3 /* Channel+Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0673B32445E0570042CFD3 /* Channel+Config.swift */; };
 		8A1207CB238ED68000E41790 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1207C9238ED66500E41790 /* Message.swift */; };
 		8A1207CD238EE3C700E41790 /* Reaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1207CC238EE3C700E41790 /* Reaction.swift */; };
 		8A1BC0FE23969079006694A1 /* ChannelsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1BC0FD23969079006694A1 /* ChannelsResponse.swift */; };
@@ -287,6 +288,7 @@
 		795FCD1B23EB155000990F15 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		79D50C7624321BDA0052BA03 /* Client+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Client+Events.swift"; sourceTree = "<group>"; };
 		80B937A42434F5FC003D950E /* Array+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
+		8A0673B32445E0570042CFD3 /* Channel+Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Channel+Config.swift"; sourceTree = "<group>"; };
 		8A1207C9238ED66500E41790 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		8A1207CC238EE3C700E41790 /* Reaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reaction.swift; sourceTree = "<group>"; };
 		8A14347823ABBF30002A45BC /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
@@ -787,6 +789,7 @@
 				8ACC7BE1241924AD000750E4 /* ChannelType.swift */,
 				8ACC7BDF241924AD000750E4 /* ChannelId.swift */,
 				8ACC7BDE241924AD000750E4 /* Channel.swift */,
+				8A0673B32445E0570042CFD3 /* Channel+Config.swift */,
 				8ACC7BDB241924AD000750E4 /* Channel+Requests.swift */,
 				8AB2A02A2423C1B500CE54F6 /* ChannelExtraData.swift */,
 				8ACC7BDC241924AD000750E4 /* ChannelQuery.swift */,
@@ -1532,6 +1535,7 @@
 				8ACC7D5924192529000750E4 /* Client+Config.swift in Sources */,
 				8ACC7C17241924AD000750E4 /* UsersQuery.swift in Sources */,
 				8A466E61241A3A4D003C21BA /* Client+Request.swift in Sources */,
+				8A0673B42445E0570042CFD3 /* Channel+Config.swift in Sources */,
 				8ACC7C2A241924AD000750E4 /* BanEnabling.swift in Sources */,
 				8ACC7C31241924AD000750E4 /* Client+Devices.swift in Sources */,
 				8ACC7C09241924AD000750E4 /* Database.swift in Sources */,

--- a/Tests/Client/Unit Tests/QueryEncodingTests.swift
+++ b/Tests/Client/Unit Tests/QueryEncodingTests.swift
@@ -44,7 +44,7 @@ final class QueryEncodingTests: XCTestCase {
                                    watchersPagination: self.complexPagination(),
                                    options: .watch) }
         
-        let expectedString = #"{"messages":{"limit":10},"data":{"name":null},"watch":true,"watchers":{"id_gt":"42","id_lt":"92","offset":10,"limit":10},"members":{"limit":10,"offset":20}}"#
+        let expectedString = #"{"messages":{"limit":10},"watch":true,"watchers":{"id_gt":"42","id_lt":"92","offset":10,"limit":10},"members":{"limit":10,"offset":20}}"#
         
         nonDeterministicAssertEqual(expectedString, try encode(query()))
     }


### PR DESCRIPTION
- Fixed subscriptions for a channel unread count and watcher count.
- Added examples for a channel unread count and watcher count to the Example app.
- Replaced request response as `Cancellable` instead of `URLSessionTask` to make requests and events consistent.
- `WaitingRequest` confirms `Cancellable`.
- Added refreshing watching channels in the client.
- Fixed `SubscriptionBag.init` for the public usage.
- Fixed `Channel` encoding with empty data.
- Example project updated