### PR TITLE
Remove unused RxBlocking import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🐞 Fixed
 - SPM support [#156](https://github.com/GetStream/stream-chat-swift/issues/156).
 - Made `SubscriptionBag.init` public [#172](https://github.com/GetStream/stream-chat-swift/issues/172).
+- Unused `RxBlocking` dependency removed [#177](https://github.com/GetStream/stream-chat-swift/pull/177).
 
 # [2.0.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.0.1)
 _April 3, 2020_

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -238,7 +238,6 @@
 		8AD5EDC822E9BAC5005CFAC9 /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EDC022E9BAC5005CFAC9 /* RxRelay.framework */; };
 		8AD5EDCA22E9BAC5005CFAC9 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EDC222E9BAC5005CFAC9 /* RxSwift.framework */; };
 		8AD5EDCC22E9BAC5005CFAC9 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EDC422E9BAC5005CFAC9 /* RxCocoa.framework */; };
-		8AD5EDCD22E9BAC5005CFAC9 /* RxBlocking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EDC522E9BAC5005CFAC9 /* RxBlocking.framework */; };
 		8AD5EDD322E9BB0C005CFAC9 /* SnapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EDCF22E9BB0C005CFAC9 /* SnapKit.framework */; };
 		8AD5EDD422E9BB0C005CFAC9 /* RxGesture.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EDD022E9BB0C005CFAC9 /* RxGesture.framework */; };
 		8AD5EDD522E9BB0C005CFAC9 /* Nuke.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EDD122E9BB0C005CFAC9 /* Nuke.framework */; };
@@ -593,7 +592,6 @@
 				8AD5EDCA22E9BAC5005CFAC9 /* RxSwift.framework in Frameworks */,
 				8AD5EDCC22E9BAC5005CFAC9 /* RxCocoa.framework in Frameworks */,
 				8ACB0E9E23EB13CE0066343A /* StreamChatClient.framework in Frameworks */,
-				8AD5EDCD22E9BAC5005CFAC9 /* RxBlocking.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
`RxBlocking` was referenced as a linked framework in `StreamChatCore`. The dependency is never used and can be removed.