### PR TITLE
Add release lane to fastlane

### DIFF
--- a/Example/Carthage/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/Carthage/ChatExample.xcodeproj/project.pbxproj
@@ -575,7 +575,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.ChatExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development io.getstream.ChatExample";
@@ -601,7 +600,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.ChatExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Example/Carthage/ChatExample/Info.plist
+++ b/Example/Carthage/ChatExample/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>205</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>2.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1811,8 +1811,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 2.0.1;
 				DEVELOPMENT_TEAM = "";
-				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatClient;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1823,7 +1823,7 @@
 		8A50696223CDEA31009F127A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				MARKETING_VERSION = 2.0.1;
+				CURRENT_PROJECT_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatClient;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 			};
@@ -2054,8 +2054,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 2.0.1;
 				DEVELOPMENT_TEAM = "";
-				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChat;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2066,7 +2066,7 @@
 		8AD5EC9922E9A3E8005CFAC9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				MARKETING_VERSION = 2.0.1;
+				CURRENT_PROJECT_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChat;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 			};
@@ -2076,8 +2076,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 2.0.1;
 				DEVELOPMENT_TEAM = "";
-				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2088,7 +2088,7 @@
 		8AD5ECA622E9B355005CFAC9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				MARKETING_VERSION = 2.0.1;
+				CURRENT_PROJECT_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 			};

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,6 +7,48 @@ before_all do
   end
 end
 
+desc "Release a new version"
+lane :release do |options|
+  UI.user_error!("Please use type parameter with one of the options: type:patch, type:minor, type:major") unless ["patch", "minor", "major"].include?(options[:type])
+  
+  version_number = increment_version_number(bump_type: options[:type], xcodeproj: "StreamChat.xcodeproj")
+  increment_version_number(version_number: version_number, xcodeproj: "./Example/Carthage/ChatExample.xcodeproj")
+  
+  changes = touch_changelog(release_version: version_number)
+  
+  version_bump_podspec(path: "StreamChatClient.podspec", version_number: version_number)
+  version_bump_podspec(path: "StreamChatCore.podspec", version_number: version_number)
+  version_bump_podspec(path: "StreamChat.podspec", version_number: version_number)
+  
+  jazzy_command_start = "bundle exec jazzy --xcodebuild-arguments "
+  jazzy_command_end = "-a GetStream.io -u getstream.io -g https://github.com/GetStream/stream-chat-swift"
+  sh(jazzy_command_start + "\"-project\",\"../StreamChat.xcodeproj\",\"-scheme\",\"StreamChatClient\",\"-sdk\",\"iphonesimulator\" --output \"../docs/client\" " + jazzy_command_end)
+  sh(jazzy_command_start + "\"-project\",\"../StreamChat.xcodeproj\",\"-scheme\",\"StreamChatCore\",\"-sdk\",\"iphonesimulator\" --output \"../docs/core\" " + jazzy_command_end)
+  sh(jazzy_command_start + "\"-project\",\"../StreamChat.xcodeproj\",\"-scheme\",\"StreamChat\",\"-sdk\",\"iphonesimulator\" --output \"../docs/ui\" " + jazzy_command_end)
+  
+  sh("git add -A")
+  sh("git commit -m 'Bump #{version_number}'")
+  sh("git tag #{version_number}")
+  
+  github_release = set_github_release(
+                     repository_name: "GetStream/stream-chat-swift",
+                     api_token: ENV["GITHUB_TOKEN"],
+                     name: version_number,
+                     tag_name: version_number,
+                     description: changes,
+                     is_draft: true
+                   )
+                   
+  push_to_git_remote(tags: true)
+                   
+  pod_push(path: "StreamChatClient.podspec", allow_warnings: true)
+  pod_push(path: "StreamChatCore.podspec", allow_warnings: true)
+  pod_push(path: "StreamChat.podspec", allow_warnings: true)
+  
+  UI.success("Successfully released #{version_number}")
+  UI.success("Github release was created as draft, please visit #{github_release["url"]} to publish it")
+end
+
 desc "Installs all Certs and Profiles necessary for development and ad-hoc"
 lane :match_me do
   match(
@@ -38,7 +80,7 @@ lane :beta do
   
   build_number = increment_build_number(
                    xcodeproj: "./Example/Carthage/ChatExample.xcodeproj",
-                   build_number: ENV["GITHUB_SHA"]
+                   build_number: ENV["GITHUB_SHA"].truncate(7, omission: '')
                  )
 
   gym(

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -15,6 +15,11 @@ Install _fastlane_ using
 or alternatively using `brew cask install fastlane`
 
 # Available Actions
+### release
+```
+fastlane release
+```
+Release a new version
 ### match_me
 ```
 fastlane match_me

--- a/fastlane/actions/touch_changelog.rb
+++ b/fastlane/actions/touch_changelog.rb
@@ -1,0 +1,88 @@
+module Fastlane
+  module Actions
+    class TouchChangelogAction < Action
+      def self.run(params)
+        changelog_path = params[:changelog_path] unless params[:changelog_path].to_s.empty?
+        
+        release_version = params[:release_version] unless params[:release_version].to_s.empty?
+
+        UI.message "Starting to update '#{changelog_path}'"
+        
+        file_data = File.readlines(changelog_path)
+        unchanged_file_data = file_data
+        
+        upcoming_line = -1
+        changes_since_last_release = ""
+        
+        File.open(changelog_path).each.with_index { |line, index|
+            if upcoming_line != -1
+                if line.start_with?("# [")
+                    break
+                else
+                    changes_since_last_release += line
+                end
+            elsif line == "# Upcoming\n"
+                upcoming_line = index
+            end
+        }
+        
+        file_data[upcoming_line] = "# [#{release_version}](https://github.com/GetStream/stream-chat-swift/releases/tag/#{release_version})"
+        
+        today = Time.now.strftime("%B %d, %Y")
+        file_data.insert(upcoming_line + 1, "_#{today}_")
+        
+        file_data.insert(upcoming_line, "# Upcoming")
+        file_data.insert(upcoming_line + 1, "")
+        file_data.insert(upcoming_line + 2, "### 🔄 Changed")
+        file_data.insert(upcoming_line + 3, "")
+
+        # Write updated content to file
+        changelog = File.open(changelog_path, "w")
+        changelog.puts(file_data)
+        changelog.close
+        UI.success("Successfully updated #{changelog_path}")
+        return changes_since_last_release
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Updates CHANGELOG.md file with release"
+      end
+
+      def self.details
+        "Use this action to rename your unrelease section to your release version and add a new unreleased section to your project CHANGELOG.md"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :changelog_path,
+                                       env_name: "FL_CHANGELOG_PATH",
+                                       description: "The path to your project CHANGELOG.md",
+                                       is_string: true,
+                                       default_value: "./CHANGELOG.md",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :release_version,
+                                       env_name: "FL_CHANGELOG_RELEASE_VERSION",
+                                       description: "The release version, according to semantic versioning",
+                                       is_string: true,
+                                       default_value: "",
+                                       optional: false,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Please provide a release version with format MAJOR.MINOR.PATCH") unless !(value =~ /\d+\.\d+\.\d+/).nil?
+                                       end)
+        ]
+      end
+
+      def self.authors
+        ["b-onc"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
For now, we can only run it locally with a correct GITHUB_TOKEN (it asks for one in CLI if it can't find it in ENV)

I've left the `pod_push` actions to the last step since they can fail unnecessarily, in that case we should only run `pod trunk push <podpsec>` in our CLI, all other stuff will be taken care of by fastlane

And yes, I've wrote a custom `touch_changelog` action just for our CHANGELOG format and learnt a lot of ruby from the process......

Closes #77 
#skip_changelog