### PR TITLE
Fix composerView hiding behind keyboard after sending bg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unnecessary `Reachability` dependency removed [#184](https://github.com/GetStream/stream-chat-swift/pull/184).
 - Flag message/user [#186](https://github.com/GetStream/stream-chat-swift/pull/186).
 - Discard messages from muted users [#186](https://github.com/GetStream/stream-chat-swift/pull/186).
+- Fix composerView hiding behind keyboard after launching from bg [#188](https://github.com/GetStream/stream-chat-swift/pull/188).
 - Open `prepareForReuse()` in `ChannelTableViewCell` and `MessageTableViewCell` [#190](https://github.com/GetStream/stream-chat-swift/pull/190).
 
 # [2.0.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.0.1)

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -62,7 +62,9 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
             return tabBar.frame.height
         }
         
-        return view.safeAreaInsets.bottom > 0 ? view.safeAreaInsets.bottom : (parent?.view.safeAreaInsets.bottom ?? 0)
+        let initialSafeAreaInsetBottom = view.safeAreaInsets.bottom - additionalSafeAreaInsets.bottom
+        
+        return initialSafeAreaInsetBottom > 0 ? initialSafeAreaInsetBottom : (parent?.view.safeAreaInsets.bottom ?? 0)
     }
     
     /// Attachments file types for thw composer view.


### PR DESCRIPTION
Originally #124 should've resolved this, but seems like it didn't. Issue is caused from VC calling `willTransitionTo(traitCollection)` when going into bg. Keyboard is visible at this stage so `initialSafeAreaBottom` is wrongly calculated taking into account the keyboard's size.
Fixes #188
