### PR TITLE
Update Example apps to not used removed dependencies

### DIFF
--- a/Example/Carthage/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/Carthage/ChatExample.xcodeproj/project.pbxproj
@@ -16,10 +16,7 @@
 		8A08B1872395281300C900EB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08B17F2395281300C900EB /* AppDelegate.swift */; };
 		8A08B1882395281300C900EB /* CustomChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08B1802395281300C900EB /* CustomChatViewController.swift */; };
 		8A08B1892395281300C900EB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8A08B1812395281300C900EB /* LaunchScreen.storyboard */; };
-		8A0A7EB12301AE4E0033E6D9 /* Gzip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A0A7E9B2301AD330033E6D9 /* Gzip.framework */; };
 		8A0A7EB22301AE4E0033E6D9 /* Nuke.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A0A7E9A2301AD330033E6D9 /* Nuke.framework */; };
-		8A0A7EB32301AE4E0033E6D9 /* Reachability.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A0A7E9E2301AD330033E6D9 /* Reachability.framework */; };
-		8A0A7EB52301AE4E0033E6D9 /* RxBlocking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A0A7E9C2301AD330033E6D9 /* RxBlocking.framework */; };
 		8A0A7EB62301AE4E0033E6D9 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A0A7E9D2301AD330033E6D9 /* RxCocoa.framework */; };
 		8A0A7EB72301AE4E0033E6D9 /* RxGesture.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A0A7E9F2301AD330033E6D9 /* RxGesture.framework */; };
 		8A0A7EB82301AE4E0033E6D9 /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A0A7EA02301AD330033E6D9 /* RxRelay.framework */; };
@@ -146,10 +143,7 @@
 			files = (
 				8A7EE010238580BD00BDB18D /* StreamChat.framework in Frameworks */,
 				8A7EE013238580BF00BDB18D /* StreamChatCore.framework in Frameworks */,
-				8A0A7EB12301AE4E0033E6D9 /* Gzip.framework in Frameworks */,
 				8A0A7EB22301AE4E0033E6D9 /* Nuke.framework in Frameworks */,
-				8A0A7EB32301AE4E0033E6D9 /* Reachability.framework in Frameworks */,
-				8A0A7EB52301AE4E0033E6D9 /* RxBlocking.framework in Frameworks */,
 				8A0A7EB62301AE4E0033E6D9 /* RxCocoa.framework in Frameworks */,
 				8A0A7EB72301AE4E0033E6D9 /* RxGesture.framework in Frameworks */,
 				8A0A7EB82301AE4E0033E6D9 /* RxRelay.framework in Frameworks */,
@@ -391,9 +385,6 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/../../Carthage/Build/iOS/RxCocoa.framework",
-				"$(SRCROOT)/../../Carthage/Build/iOS/Gzip.framework",
-				"$(SRCROOT)/../../Carthage/Build/iOS/RxBlocking.framework",
-				"$(SRCROOT)/../../Carthage/Build/iOS/Reachability.framework",
 				"$(SRCROOT)/../../Carthage/Build/iOS/RxRelay.framework",
 				"$(SRCROOT)/../../Carthage/Build/iOS/Starscream.framework",
 				"$(SRCROOT)/../../Carthage/Build/iOS/RxSwift.framework",
@@ -407,9 +398,6 @@
 			);
 			outputPaths = (
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/RxCocoa.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Gzip.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/RxBlocking.framework",
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Reachability.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/RxRelay.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Starscream.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/RxSwift.framework",

--- a/Example/Cocoapods/Podfile.lock
+++ b/Example/Cocoapods/Podfile.lock
@@ -1,7 +1,5 @@
 PODS:
-  - GzipSwift (5.1.1)
   - Nuke (8.4.1)
-  - ReachabilitySwift (5.0.0)
   - RxCocoa (5.1.1):
     - RxRelay (~> 5)
     - RxSwift (~> 5)
@@ -20,8 +18,6 @@ PODS:
     - StreamChatCore
     - SwiftyGif (~> 5.2.0)
   - StreamChatClient (2.0.1):
-    - GzipSwift (~> 5.1)
-    - ReachabilitySwift (~> 5.0)
     - Starscream (~> 3.1)
   - StreamChatCore (2.0.1):
     - RxCocoa (~> 5.1)
@@ -36,9 +32,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - GzipSwift
     - Nuke
-    - ReachabilitySwift
     - RxCocoa
     - RxGesture
     - RxRelay
@@ -56,9 +50,7 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  GzipSwift: 893f3e48e597a1a4f62fafcb6514220fcf8287fa
   Nuke: d780e3507a86b86c589ab3cc5cd302d5456f06fb
-  ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   RxCocoa: 32065309a38d29b5b0db858819b5bf9ef038b601
   RxGesture: d6bd7447ca3a596c7a9702a6a2b6a2bb5d8bae54
   RxRelay: d77f7d771495f43c556cbc43eebd1bb54d01e8e9
@@ -66,7 +58,7 @@ SPEC CHECKSUMS:
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
   StreamChat: b51631f5cf0e85edd313086880136e581f9800d2
-  StreamChatClient: 91b0f585e7dc92ade58e657daffafb16d485b2a6
+  StreamChatClient: a53cc44cbb5bfa0ea42f78ca8dae036033906128
   StreamChatCore: 37ce6d81f92bd893c9e242e4090f3f6a69d1ab00
   SwiftyGif: b85c6b33a9411859d9e1db998b6a8214aea942df
 


### PR DESCRIPTION
- Our Example apps we still using removed dependencies.
- Both Carthage and CocoaPods integration are fixed