### PR TITLE
Improve Carthage setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         restore-keys: ${{ runner.os }}-gem-
     - name: Install Carthage dependencies
       if: steps.carthage-cache.outputs.cache-hit != 'true'
-      run: echo 'BUILD_LIBRARY_FOR_DISTRIBUTION=YES'>/tmp/config.xcconfig; XCODE_XCCONFIG_FILE=/tmp/config.xcconfig carthage update --platform iOS --new-resolver --no-use-binaries --cache-builds; rm /tmp/config.xcconfig
+      run: echo 'BUILD_LIBRARY_FOR_DISTRIBUTION=YES'>/tmp/config.xcconfig; XCODE_XCCONFIG_FILE=/tmp/config.xcconfig carthage bootstrap --platform iOS --new-resolver --no-use-binaries --cache-builds; rm /tmp/config.xcconfig
     - name: Install RubyGems
       if: steps.rubygem-cache.outputs.cache-hit != 'true'
       run: bundle install

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "ReactiveX/RxSwift" "5.1.1"
-github "RxSwiftCommunity/RxGesture" "3.0.2"
+github "RxSwiftCommunity/RxGesture" "3.0.3"
 github "SnapKit/SnapKit" "5.0.1"
 github "daltoniam/Starscream" "3.1.1"
 github "kean/Nuke" "8.4.1"


### PR DESCRIPTION
- We shouldn't be using `carthage update` for installing the dependencies. This can result in dependencies updating to without us knowing about it.
- `carthage bootstrap` resolves the dependency tree based on the info from `Cartfile.resolved` and never updates the dependencies.
