### PR TITLE
Refactor CI/Beta workflows

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,4 +1,4 @@
-name: Nightly
+name: Beta
     
 on:
   push:
@@ -15,9 +15,7 @@ jobs:
       id: carthage-cache
       with:
         path: Carthage
-        key: ${{ runner.os }}-carthage-stable-${{ hashFiles('**/Cartfile.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-carthage-stable-
+        key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
     - name: Cache RubyGems
       uses: actions/cache@v1
       id: rubygem-cache
@@ -26,7 +24,6 @@ jobs:
         key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: ${{ runner.os }}-gem-
     - name: Install Carthage dependencies
-      if: steps.carthage-cache.outputs.cache-hit != 'true'
       run: echo 'BUILD_LIBRARY_FOR_DISTRIBUTION=YES'>/tmp/config.xcconfig; XCODE_XCCONFIG_FILE=/tmp/config.xcconfig carthage update --platform iOS --new-resolver --no-use-binaries --cache-builds; rm /tmp/config.xcconfig
     - name: Install RubyGems
       if: steps.rubygem-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,7 @@ jobs:
       id: carthage-cache
       with:
         path: Carthage
-        key: ${{ runner.os }}-carthage-stable-${{ hashFiles('**/Cartfile.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-carthage-stable-
+        key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
     - name: Cache RubyGems
       uses: actions/cache@v1
       id: rubygem-cache
@@ -32,13 +30,12 @@ jobs:
         key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: ${{ runner.os }}-gem-
     - name: Install Carthage dependencies
-      if: steps.carthage-cache.outputs.cache-hit != 'true'
       run: echo 'BUILD_LIBRARY_FOR_DISTRIBUTION=YES'>/tmp/config.xcconfig; XCODE_XCCONFIG_FILE=/tmp/config.xcconfig carthage bootstrap --platform iOS --new-resolver --no-use-binaries --cache-builds; rm /tmp/config.xcconfig
     - name: Install RubyGems
       if: steps.rubygem-cache.outputs.cache-hit != 'true'
       run: bundle install
     - name: Clean and build the StreamChat scheme
-      run: xcodebuild clean test -project StreamChat.xcodeproj -scheme StreamChatCore -destination "platform=iOS Simulator,name=iPhone 11 Pro"
+      run: bundle exec fastlane test
     - name: Post Codecov report
       run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }}
     - name: Run Danger - Code conventions & linting

--- a/Tests/Client/TestCase.swift
+++ b/Tests/Client/TestCase.swift
@@ -9,6 +9,8 @@
 import XCTest
 @testable import StreamChatClient
 
+let defaultTimeout = 10
+
 class TestCase: XCTestCase {
     
     static let apiKey = "qk4nn7rpcn75"
@@ -74,7 +76,7 @@ extension TestCase {
     }
     
     func expect(_ description: String,
-                timeout: TimeInterval = TimeInterval(5),
+                timeout: TimeInterval = TimeInterval(defaultTimeout),
                 callback: (_ test: XCTestExpectation) -> Void) {
         let test = expectation(description: "\n💥💀✝️ expecting \(description)")
         callback(test)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -103,3 +103,8 @@ lane :beta do
       release_notes: message
   )
 end
+
+desc "Builds and runs all the tests"
+lane:test do
+  scan(scheme: "StreamChat")
+end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -30,6 +30,11 @@ Installs all Certs and Profiles necessary for development and ad-hoc
 fastlane beta
 ```
 Builds the latest version with ad-hoc and uploads to firebase
+### test
+```
+fastlane test
+```
+Builds and runs all the tests
 
 ----
 

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -1,0 +1,24 @@
+# For more information about this configuration visit
+# https://docs.fastlane.tools/actions/scan/#scanfile
+
+# In general, you can use the options available
+# fastlane scan --help
+
+devices(["iPhone 11"])
+
+# Enable skip_build to skip debug builds for faster test performance
+skip_build(true)
+
+project("StreamChat.xcodeproj")
+
+clean(true)
+
+# Needed for codecov
+code_coverage(true)
+
+# Our integration tests need to run in parallel
+disable_concurrent_testing(true)
+
+configuration("Debug")
+
+result_bundle(true)


### PR DESCRIPTION
Refactor Carthage caching to rebuild deps when cache misses, and makes sure it runs when cache hits too (it'll take a couple of seconds since we use `--cache-builds`. Also renames nightly to Beta since it doesn't run Nightly, and introduces fastlane lane for testing (goodbye xcodebuild)

#skip_changelog
