### PR TITLE
Remove deprecation warning for UIDocumentMenuViewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Discard messages from muted users [#186](https://github.com/GetStream/stream-chat-swift/pull/186).
 - Fix composerView hiding behind keyboard after launching from bg [#188](https://github.com/GetStream/stream-chat-swift/pull/188).
 - Open `prepareForReuse()` in `ChannelTableViewCell` and `MessageTableViewCell` [#190](https://github.com/GetStream/stream-chat-swift/pull/190).
+- Fix the deprecation warning in the `UI` framework [#201](https://github.com/GetStream/stream-chat-swift/pull/201).
+
 
 # [2.0.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.0.1)
 _April 3, 2020_

--- a/Sources/UI/Web View/WebViewController.swift
+++ b/Sources/UI/Web View/WebViewController.swift
@@ -45,8 +45,15 @@ open class WebViewController: UIViewController, WKNavigationDelegate {
     func setDocumentMenuViewControllerSoureViewsIfNeeded(_ viewControllerToPresent: UIViewController) {
         // Prevent the app from crashing if the WKWebView decides to present a UIDocumentMenuViewController
         // while it self is presented modally.
+        
+        // More info:
+        // - https://github.com/GetStream/stream-chat-swift/issues/66
+        // - https://stackoverflow.com/questions/58164583/wkwebview-with-the-new-ios13-modal-crash-when-a-file-picker-is-invoked
+        
         if #available(iOS 13, *),
-            viewControllerToPresent is UIDocumentMenuViewController,
+            // Using NSClassFromString to remove compiler's deprecation warning for `UIDocumentMenuViewController`.
+            let menuViewControllerClass = NSClassFromString("UIDocumentMenuViewController"),
+            viewControllerToPresent.isKind(of: menuViewControllerClass),
             UIDevice.current.userInterfaceIdiom == .phone {
             viewControllerToPresent.popoverPresentationController?.sourceView = webView
             viewControllerToPresent.popoverPresentationController?.sourceRect =


### PR DESCRIPTION
- This is a part of the work for CIS-89.
- I added additional links with more info about the bug the code causing the warning fixes.
- I used the good old Obj-C style to remove the deprecation warning from the compiler.