### PR TITLE
Update Dangerfile to not warn for CHANGELOG when meta tag is used

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -27,7 +27,10 @@ has_app_changes = !git.modified_files.grep(/Sources/).empty?
 ## Then, we should check if tests are updated
 has_test_changes = !git.modified_files.grep(/StreamChatCoreTests/).empty?
 
-has_changelog_escape = github.pr_body.include? "#no_changelog"
+has_meta_label = github.pr_labels.any? { |label| label.include? "meta" }
+has_no_changelog_tag = github.pr_body.include? "#no_changelog"
+has_skip_changelog_tag = github.pr_body.include? "#skip_changelog"
+has_changelog_escape = has_meta_label || has_no_changelog_tag || has_skip_changelog_tag
 
 # Add a CHANGELOG entry for app changes
 if !has_changelog_escape && !git.modified_files.include?("CHANGELOG.md") && has_app_changes


### PR DESCRIPTION
Doesn't make sense to include changelog entry for meta PRs
