### PR TITLE
Update MessageViewStyle to add messageInsetSpacing and update Message…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `MessageViewStyle.pointedCornerRadius` to make pointed corner rounded [#191](https://github.com/GetStream/stream-chat-swift/issues/191). 
 - Added methods for `AvatarView` customization [#203](https://github.com/GetStream/stream-chat-swift/issues/203):
 - Added `messageInsetSpacing` to `MessageViewStyle` to allow control of spacing between message and container
-   [?](tbd):
+   [#216](https://github.com/GetStream/stream-chat-swift/pull/216).
 
 `ChannelsViewController`:
 ```swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ChatViewStyle.dynamic` for iOS 13 to support dynamic colors for dark mode [#191](https://github.com/GetStream/stream-chat-swift/issues/191). 
 - Added `MessageViewStyle.pointedCornerRadius` to make pointed corner rounded [#191](https://github.com/GetStream/stream-chat-swift/issues/191). 
 - Added methods for `AvatarView` customization [#203](https://github.com/GetStream/stream-chat-swift/issues/203):
+- Added `messageInsetSpacing` to `MessageViewStyle` to allow control of spacing between message and container
+   [?](tbd):
 
 `ChannelsViewController`:
 ```swift

--- a/Sources/UI/Chat/Cells/MessageTableViewCell.swift
+++ b/Sources/UI/Chat/Cells/MessageTableViewCell.swift
@@ -249,10 +249,10 @@ open class MessageTableViewCell: UITableViewCell, Reusable {
         messageContainerView.addSubview(messageLabel)
         
         messageLabel.snp.makeConstraints { make in
-            make.left.equalTo(CGFloat.messageHorizontalInset)
-            make.right.equalTo(-CGFloat.messageHorizontalInset)
-            make.top.equalTo(CGFloat.messageVerticalInset).priority(999)
-            make.bottom.equalTo(-CGFloat.messageVerticalInset).priority(999)
+            make.left.equalTo(style.messageInsetSpacing.horizontal)
+            make.right.equalTo(-style.messageInsetSpacing.horizontal)
+            make.top.equalTo(style.messageInsetSpacing.vertical).priority(999)
+            make.bottom.equalTo(-style.messageInsetSpacing.vertical).priority(999)
         }
         
         contentView.addSubview(messageStackView)

--- a/Sources/UI/Style/MessageViewStyle.swift
+++ b/Sources/UI/Style/MessageViewStyle.swift
@@ -83,6 +83,9 @@ public struct MessageViewStyle: Hashable {
     /// A margin.
     public var edgeInsets: UIEdgeInsets
     
+    /// The spacing between the message text and the message container
+    public var messageInsetSpacing: Spacing
+    
     /// A reaction style.
     public var reactionViewStyle: ReactionViewStyle
     
@@ -128,6 +131,7 @@ public struct MessageViewStyle: Hashable {
     ///   - pointedCornerRadius: a pointed corner radius.
     ///   - spacing: spacings between elements.
     ///   - edgeInsets: edge insets.
+    ///   - messageInsetSpacing: spacing between the message and the message container
     ///   - reactionViewStyle: a reaction style.
     ///   - showTimeThreshold: a time threshold between messages to show additional time. To enable it should be more than 60 sec.
     ///   - additionalDateStyle: additional date style will work with showTimeThreshold paramenter.
@@ -153,6 +157,8 @@ public struct MessageViewStyle: Hashable {
                                                  left: .messageEdgePadding,
                                                  bottom: .messageBottomPadding,
                                                  right: .messageEdgePadding),
+                messageInsetSpacing: Spacing = .init(horizontal: .messageHorizontalInset,
+                                                     vertical: .messageVerticalInset),
                 reactionViewStyle: ReactionViewStyle = ReactionViewStyle(),
                 showTimeThreshold: TimeInterval = 0,
                 additionalDateStyle: AdditionalDateStyle = .userNameAndDate,
@@ -175,6 +181,7 @@ public struct MessageViewStyle: Hashable {
         self.pointedCornerRadius = pointedCornerRadius > 1 ? pointedCornerRadius : 0
         self.spacing = spacing
         self.edgeInsets = edgeInsets
+        self.messageInsetSpacing = messageInsetSpacing
         self.reactionViewStyle = reactionViewStyle
         self.showTimeThreshold = showTimeThreshold
         self.additionalDateStyle = additionalDateStyle
@@ -265,6 +272,7 @@ public struct MessageViewStyle: Hashable {
             && lhs.pointedCornerRadius == rhs.pointedCornerRadius
             && lhs.spacing == rhs.spacing
             && lhs.edgeInsets == rhs.edgeInsets
+            && lhs.messageInsetSpacing == rhs.messageInsetSpacing
             && lhs.reactionViewStyle == rhs.reactionViewStyle
             && lhs.showTimeThreshold == rhs.showTimeThreshold
             && lhs.additionalDateStyle == rhs.additionalDateStyle
@@ -293,6 +301,7 @@ public struct MessageViewStyle: Hashable {
         hasher.combine(edgeInsets.bottom)
         hasher.combine(edgeInsets.left)
         hasher.combine(edgeInsets.right)
+        hasher.combine(messageInsetSpacing)
         hasher.combine(reactionViewStyle)
         hasher.combine(showTimeThreshold)
         hasher.combine(additionalDateStyle)


### PR DESCRIPTION
…TableViewCell to use that spacing

# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
This PR updates the `MessageViewStyle` struct with a new property, `messageInsetSpacing` that allows the spacing between the text and the text container in a the `MessageTableViewCell` to be adjusted.  This will allow for greater flexibility for the user to customize the UI provided by StreamChat without having to implement their own. 

The screenshot shows the result of adjusting the new property. 

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-24 at 12 01 06](https://user-images.githubusercontent.com/52974770/80232828-86193e00-8623-11ea-9ff2-fc641b0a460d.png)
