### PR TITLE
Improve CI experience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
       run: bundle exec fastlane build_for_testing
     - name: Run all tests
       run: bundle exec fastlane test_without_building
-    - name: Post Codecov report
-      run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }}
+    # - name: Post Codecov report
+    #   run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }}
     - name: Run Danger - Code conventions & linting
       run: bundle exec danger
       env:

--- a/Dangerfile
+++ b/Dangerfile
@@ -37,12 +37,6 @@ if !has_changelog_escape && !git.modified_files.include?("CHANGELOG.md") && has_
     fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/GetStream/stream-chat-swift/blob/master/CHANGELOG.md).")
 end
 
-## Finally, let's combine them and put extra condition 
-## for changed number of lines of code
-if has_app_changes && !has_test_changes && git.lines_of_code > 20
-    warn("Tests were not updated", sticky: false)
-end
-
 swiftlint.config_file = '.swiftlint.yml'
 swiftlint.directory = 'Sources'
 swiftlint.lint_files inline_mode: true


### PR DESCRIPTION
- Temporarily disable code coverage reports on PRs.
- Remove Danger's warning that tests were not updated: 
  - This warning is not relevant. For many (all?) internal changes we don't want tests to be updated! As long as tests compile and are green we should be good.