### PR TITLE
Refactor release lane with git checks

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,8 +11,16 @@ desc "Release a new version"
 lane :release do |options|
   UI.user_error!("Please use type parameter with one of the options: type:patch, type:minor, type:major") unless ["patch", "minor", "major"].include?(options[:type])
   
+  ensure_git_status_clean
+  
+  ensure_git_branch # We can only release on master
+  
   version_number = increment_version_number(bump_type: options[:type], xcodeproj: "StreamChat.xcodeproj")
   increment_version_number(version_number: version_number, xcodeproj: "./Example/Carthage/ChatExample.xcodeproj")
+  
+  if git_tag_exists(tag: version_number)
+    UI.user_error!("Tag for version #{version_number} already exists!")
+  end
   
   changes = touch_changelog(release_version: version_number)
   
@@ -41,9 +49,14 @@ lane :release do |options|
                    
   push_to_git_remote(tags: true)
                    
-  pod_push(path: "StreamChatClient.podspec", allow_warnings: true)
-  pod_push(path: "StreamChatCore.podspec", allow_warnings: true)
-  pod_push(path: "StreamChat.podspec", allow_warnings: true)
+  pod_push(path: "StreamChatClient.podspec", allow_warnings: true, skip_import_validation: true)
+  pod_push(path: "StreamChatCore.podspec", allow_warnings: true, skip_import_validation: true)
+  pod_push(path: "StreamChat.podspec", allow_warnings: true, skip_import_validation: true)
+  
+  slack(
+    message: "#{version_number} successfully released!",
+    default_payloads: [:git_author],
+  )
   
   UI.success("Successfully released #{version_number}")
   UI.success("Github release was created as draft, please visit #{github_release["url"]} to publish it")


### PR DESCRIPTION
... and skip pod_push validation since our CI is awesome
#skip_changelog
