### PR TITLE
Fix keyboard disappearing after every message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix keyboard disappearing after every message [#227](https://github.com/GetStream/stream-chat-swift/issues/227)
 
 # [2.1.0](https://github.com/GetStream/stream-chat-swift/releases/tag/2.1.0)
 _April 29, 2020_

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
@@ -169,6 +169,10 @@ extension ChatViewController {
             composerEditingContainerView.animate(show: false)
         }
         
+        // We don't want users to send the same message multiple times
+        // in case their internet is slow and message isn't sent immediately
+        composerView.sendButton.isEnabled = false
+        
         presenter?.rx.send(text: text)
             .subscribe(
                 onNext: { [weak self] messageResponse in

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
@@ -169,8 +169,6 @@ extension ChatViewController {
             composerEditingContainerView.animate(show: false)
         }
         
-        composerView.styleState = .disabled
-        
         presenter?.rx.send(text: text)
             .subscribe(
                 onNext: { [weak self] messageResponse in


### PR DESCRIPTION
We don't need to disable composer after every message, messages are sent via WS and this is very fast.
