### PR TITLE
CIS 120 Add possibility to assert a network request was made

### DIFF
--- a/Sources/Client/Client/Client+Request.swift
+++ b/Sources/Client/Client/Client+Request.swift
@@ -16,7 +16,7 @@ extension Client {
     func setupURLSession(token: Token = "") -> URLSession {
         let headers = authHeaders(token: token)
         logger?.log(headers: headers)
-        let config = URLSessionConfiguration.default
+        let config = defaultURLSessionConfiguration
         config.waitsForConnectivity = true
         config.httpAdditionalHeaders = headers
         return URLSession(configuration: config, delegate: urlSessionTaskDelegate, delegateQueue: nil)

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -106,8 +106,10 @@ public final class Client: Uploader {
     /// Check if API key and token are valid and the web socket is connected.
     public var isConnected: Bool { !apiKey.isEmpty && webSocket.isConnected }
     var needsToRecoverConnection = false
-    
-    lazy var urlSession = URLSession(configuration: .default)
+
+    let defaultURLSessionConfiguration: URLSessionConfiguration
+    lazy var urlSession = URLSession(configuration: self.defaultURLSessionConfiguration)
+
     lazy var urlSessionTaskDelegate = ClientURLSessionTaskDelegate() // swiftlint:disable:this weak_delegate
     let callbackQueue: DispatchQueue?
     
@@ -144,8 +146,11 @@ public final class Client: Uploader {
     
     /// Creates a new instance of the network client.
     ///
-    /// - Parameter config: The configuration object with details of how the new instance should be set up.
-    init(config: Client.Config) {
+    /// - Parameters:
+    ///   - config: The configuration object with details of how the new instance should be set up.
+    ///   - defaultURLSessionConfiguration: The base URLSession configuration `Client` uses for its
+    ///     URL sessions. `Client` is allowed to override the configuration with its own settings.
+    init(config: Client.Config, defaultURLSessionConfiguration: URLSessionConfiguration = .default) {
         self.apiKey = config.apiKey
         self.baseURL = config.baseURL
         self.callbackQueue = config.callbackQueue ?? .global(qos: .userInitiated)
@@ -153,6 +158,8 @@ public final class Client: Uploader {
         self.database = config.database
         self.logOptions = config.logOptions
         logger = logOptions.logger(icon: "🐴", for: [.requestsError, .requests, .requestsInfo])
+
+        self.defaultURLSessionConfiguration = defaultURLSessionConfiguration
 
         if !apiKey.isEmpty, logOptions.isEnabled {
             ClientLogger.logger("💬", "", "Stream Chat v.\(Environment.version)")

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		7900717F2440850700E5246F /* QueryEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900717D244084E200E5246F /* QueryEncodingTests.swift */; };
 		791664DD245AC78B0020710B /* RequestRecorderURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */; };
+		791664DF245AC89E0020710B /* Client+DevicesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664DE245AC89E0020710B /* Client+DevicesTests.swift */; };
 		791664E2245AF8AF0020710B /* AssertNetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664E1245AF8AF0020710B /* AssertNetworkRequest.swift */; };
 		791664E3245AF90A0020710B /* RequestRecorderURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */; };
 		791664E4245AF90A0020710B /* RequestRecorderURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */; };
@@ -300,6 +301,7 @@
 		465D64C1231808A2006BAE42 /* AttachmentTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentTypeTests.swift; sourceTree = "<group>"; };
 		7900717D244084E200E5246F /* QueryEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryEncodingTests.swift; sourceTree = "<group>"; };
 		791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestRecorderURLProtocol.swift; sourceTree = "<group>"; };
+		791664DE245AC89E0020710B /* Client+DevicesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Client+DevicesTests.swift"; sourceTree = "<group>"; };
 		791664E1245AF8AF0020710B /* AssertNetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertNetworkRequest.swift; sourceTree = "<group>"; };
 		7920E84E2449C6EF00CCBFBF /* fastlane */ = {isa = PBXFileReference; lastKnownFileType = folder; path = fastlane; sourceTree = "<group>"; };
 		794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestableCodingKey.swift; sourceTree = "<group>"; };
@@ -704,6 +706,7 @@
 				465D64C1231808A2006BAE42 /* AttachmentTypeTests.swift */,
 				8A30D07A237D81C20082B951 /* StringExtensionsTests.swift */,
 				7900717D244084E200E5246F /* QueryEncodingTests.swift */,
+				791664DE245AC89E0020710B /* Client+DevicesTests.swift */,
 			);
 			path = "Unit Tests";
 			sourceTree = "<group>";
@@ -1695,6 +1698,7 @@
 				8AE6206E23CF658700AB3426 /* User+Tests.swift in Sources */,
 				791664E2245AF8AF0020710B /* AssertNetworkRequest.swift in Sources */,
 				8AC0D94F23D4BA7D0080B8BC /* FilterTests.swift in Sources */,
+				791664DF245AC89E0020710B /* Client+DevicesTests.swift in Sources */,
 				791664DD245AC78B0020710B /* RequestRecorderURLProtocol.swift in Sources */,
 				7900717F2440850700E5246F /* QueryEncodingTests.swift in Sources */,
 				8AB33A5E240EA19A00777682 /* AttachmentTypeTests.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		7900717F2440850700E5246F /* QueryEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900717D244084E200E5246F /* QueryEncodingTests.swift */; };
 		791664DD245AC78B0020710B /* RequestRecorderURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */; };
+		791664E2245AF8AF0020710B /* AssertNetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664E1245AF8AF0020710B /* AssertNetworkRequest.swift */; };
 		791664E3245AF90A0020710B /* RequestRecorderURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */; };
 		791664E4245AF90A0020710B /* RequestRecorderURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */; };
 		794BDE4A2434BD7400BFBA1F /* NestableCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */; };
@@ -299,6 +300,7 @@
 		465D64C1231808A2006BAE42 /* AttachmentTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentTypeTests.swift; sourceTree = "<group>"; };
 		7900717D244084E200E5246F /* QueryEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryEncodingTests.swift; sourceTree = "<group>"; };
 		791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestRecorderURLProtocol.swift; sourceTree = "<group>"; };
+		791664E1245AF8AF0020710B /* AssertNetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertNetworkRequest.swift; sourceTree = "<group>"; };
 		7920E84E2449C6EF00CCBFBF /* fastlane */ = {isa = PBXFileReference; lastKnownFileType = folder; path = fastlane; sourceTree = "<group>"; };
 		794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestableCodingKey.swift; sourceTree = "<group>"; };
 		795FCD1B23EB155000990F15 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -627,6 +629,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		791664E0245AF8960020710B /* Custom Assertions */ = {
+			isa = PBXGroup;
+			children = (
+				791664E1245AF8AF0020710B /* AssertNetworkRequest.swift */,
+			);
+			path = "Custom Assertions";
+			sourceTree = "<group>";
+		};
 		8A5069C023CE23FC009F127A /* Headers */ = {
 			isa = PBXGroup;
 			children = (
@@ -1283,6 +1293,7 @@
 			children = (
 				8AC0D94D23D4BA640080B8BC /* Unit Tests */,
 				8AE6206B23CF640E00AB3426 /* Integration Tests */,
+				791664E0245AF8960020710B /* Custom Assertions */,
 				791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */,
 			);
 			path = Client;
@@ -1682,6 +1693,7 @@
 			files = (
 				8AFA57292418EC1700FD07EC /* StringExtensionsTests.swift in Sources */,
 				8AE6206E23CF658700AB3426 /* User+Tests.swift in Sources */,
+				791664E2245AF8AF0020710B /* AssertNetworkRequest.swift in Sources */,
 				8AC0D94F23D4BA7D0080B8BC /* FilterTests.swift in Sources */,
 				791664DD245AC78B0020710B /* RequestRecorderURLProtocol.swift in Sources */,
 				7900717F2440850700E5246F /* QueryEncodingTests.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		7900717F2440850700E5246F /* QueryEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900717D244084E200E5246F /* QueryEncodingTests.swift */; };
+		791664DD245AC78B0020710B /* RequestRecorderURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */; };
+		791664E3245AF90A0020710B /* RequestRecorderURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */; };
+		791664E4245AF90A0020710B /* RequestRecorderURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */; };
 		794BDE4A2434BD7400BFBA1F /* NestableCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */; };
 		79A9E4F72449D3AF00599B95 /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */; };
 		79A9E4F92449DF2D00599B95 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F82449DF2D00599B95 /* Reachability.swift */; };
@@ -295,6 +298,7 @@
 /* Begin PBXFileReference section */
 		465D64C1231808A2006BAE42 /* AttachmentTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentTypeTests.swift; sourceTree = "<group>"; };
 		7900717D244084E200E5246F /* QueryEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryEncodingTests.swift; sourceTree = "<group>"; };
+		791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestRecorderURLProtocol.swift; sourceTree = "<group>"; };
 		7920E84E2449C6EF00CCBFBF /* fastlane */ = {isa = PBXFileReference; lastKnownFileType = folder; path = fastlane; sourceTree = "<group>"; };
 		794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestableCodingKey.swift; sourceTree = "<group>"; };
 		795FCD1B23EB155000990F15 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -1279,6 +1283,7 @@
 			children = (
 				8AC0D94D23D4BA640080B8BC /* Unit Tests */,
 				8AE6206B23CF640E00AB3426 /* Integration Tests */,
+				791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */,
 			);
 			path = Client;
 			sourceTree = "<group>";
@@ -1577,6 +1582,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				791664E3245AF90A0020710B /* RequestRecorderURLProtocol.swift in Sources */,
 				79EE3942245320610034EBF3 /* ClientTests00.swift in Sources */,
 				79EE39452453206E0034EBF3 /* ClientTests10+ClientLogger.swift in Sources */,
 				79EE3944245320690034EBF3 /* ClientTests02+Users.swift in Sources */,
@@ -1677,6 +1683,7 @@
 				8AFA57292418EC1700FD07EC /* StringExtensionsTests.swift in Sources */,
 				8AE6206E23CF658700AB3426 /* User+Tests.swift in Sources */,
 				8AC0D94F23D4BA7D0080B8BC /* FilterTests.swift in Sources */,
+				791664DD245AC78B0020710B /* RequestRecorderURLProtocol.swift in Sources */,
 				7900717F2440850700E5246F /* QueryEncodingTests.swift in Sources */,
 				8AB33A5E240EA19A00777682 /* AttachmentTypeTests.swift in Sources */,
 			);
@@ -1687,6 +1694,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A6F69D2230ECCD300B8CC1F /* User+Tests.swift in Sources */,
+				791664E4245AF90A0020710B /* RequestRecorderURLProtocol.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
+++ b/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
@@ -1,0 +1,149 @@
+//
+//  AssertNetworkRequest.swift
+//  StreamChatClientTests
+//
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import XCTest
+@testable import StreamChatClient
+
+
+/// Synchronously waits for a network request to be made and asserts its properties.
+///
+/// The function always uses the latest request `RequestRecorderURLProtocol` records. If no request has
+/// been made within the `timeout` period, this assertion fails with the time-out error.
+///
+/// The values specified in the `headers`, `queryParameters` and `body` represents the mandatory subset of
+/// the values the request must have. A request is valid even when it contains additional parameters than
+/// the ones specified in these values.
+///
+/// - Parameters:
+///   - method: The HTTP method the request.
+///   - path: The `path` part of the request's URL.
+///   - headers: The headers required for the request.
+///   - queryParameters: The query parameters required for the request.
+///   - body: The expected body of the request.
+///   - timeout: The maximum time this function waits for a request to be made.
+///
+func AssertNetworkRequest(method: Endpoint.Method,
+                          path: String,
+                          headers: [String: String]?,
+                          queryParameters: [String: String]?,
+                          body: [String: Any]?,
+                          timeout: TimeInterval = 0.5,
+                          file: StaticString = #file,
+                          line: UInt = #line) {
+
+    guard let request = RequestRecorderURLProtocol.waitForRequest(timeout: timeout) else {
+        XCTFail("Waiting for request timed out. No request was made.", file: file, line: line)
+        return
+    }
+
+    var errorMessage = ""
+    defer {
+        if !errorMessage.isEmpty {
+            XCTFail("AssertNetworkRequest failed:" + errorMessage, file: file, line: line)
+        }
+    }
+
+    // Check method
+    if method.rawValue != request.httpMethod {
+        errorMessage += "\n  - Incorrect method: expected \"\(method.rawValue)\" got \"\(request.httpMethod ?? "_")\""
+    }
+
+    guard let url = request.url, let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+        errorMessage += "\n  - Missing URL"
+        return
+    }
+
+    // Check path
+    if components.path != path {
+        errorMessage += "\n  - Incorrect path: expected \"\(path)\" got \"\(components.path)\""
+    }
+
+    // Check headers
+    let requestHeaders = request.allHTTPHeaderFields ?? [:]
+    headers?.forEach { (key, value) in
+        if let requestHeaderValue = requestHeaders[key] {
+            if value != requestHeaderValue {
+                errorMessage += "\n  - Incorrect header value for \"\(key)\": expected \"\(value)\" got \"\(requestHeaderValue)\""
+            }
+
+        } else {
+            errorMessage += "\n  - Missing header value for \"\(key)\""
+        }
+    }
+
+    // Check query parameters
+    let items = components.queryItems ?? []
+    queryParameters?.forEach { (key, value) in
+        if let requestValue = items[key] {
+            if value != requestValue {
+                errorMessage += "\n  - Incorrect query value for \"\(key)\": expected \"\(value)\" got \"\(requestValue)\""
+            }
+
+        } else {
+            errorMessage += "\n  - Missing query value for \"\(key)\""
+        }
+    }
+
+    // Check the request body
+    var requestBodyData: Data?
+    if let data = request.httpBody {
+        requestBodyData = data
+    }
+    if let stream = request.httpBodyStream {
+        requestBodyData = Data(reading: stream)
+    }
+
+    guard let data = requestBodyData else {
+        if body != nil {
+            errorMessage += "\n  - Missing request body"
+        }
+        return
+    }
+
+    guard let requestBodyJSON = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        errorMessage += "\n  - Request body is not a valid JSON"
+        return
+    }
+
+    body?.forEach { (key, value) in
+        if let requestValue = requestBodyJSON[key] {
+            if String(describing: value) != String(describing: requestValue) {
+                errorMessage += "\n  - Incorrect body value for \"\(key)\": expected \"\(value)\" got \"\(requestValue)\""
+            }
+        } else {
+            errorMessage += "\n  - Missing body value for \"\(key)\""
+        }
+    }
+}
+
+private extension Array where Element == URLQueryItem {
+  /// Returns the value of the URLQueryItem with the given name. Returns `nil`
+  /// if the query item doesn't exist.
+  subscript(_ name: String) -> String? {
+    first(where: { $0.name == name}).flatMap({ $0.value })
+  }
+}
+
+private extension Data {
+    /// Creates a new Data instance from the provided InputStream. It opens and closes the stream during the process.
+    init(reading input: InputStream) {
+        self.init()
+        input.open()
+
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        while input.hasBytesAvailable {
+            let read = input.read(buffer, maxLength: bufferSize)
+            if (read == 0) {
+                break  // added
+            }
+            append(buffer, count: read)
+        }
+        buffer.deallocate()
+        input.close()
+    }
+}

--- a/Tests/Client/RequestRecorderURLProtocol.swift
+++ b/Tests/Client/RequestRecorderURLProtocol.swift
@@ -1,0 +1,59 @@
+//
+//  RequestRecorderURLProtocol.swift
+//  StreamChatClientTests
+//
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+/// This URLProtocol subclass allows to intercept the network communication
+/// and provides the latest network request made.
+class RequestRecorderURLProtocol: URLProtocol {
+
+    private static var latestRequestExpectation: XCTestExpectation?
+    private static var latestRequest: URLRequest?
+
+    /// Returns the latest network request this URLProtocol recorded.
+    ///
+    /// If no request has been made since the last time this function was invoked, it synchronously
+    /// waits for the next request to be made.
+    ///
+    /// - Parameter timeout: Specifies the time the function waits for a new request to be made.
+    static func waitForRequest(timeout: TimeInterval) -> URLRequest? {
+        defer {
+            // Delete the used request
+            latestRequest = nil
+        }
+
+        guard latestRequest == nil else { return latestRequest }
+
+        latestRequestExpectation = .init(description: "Wait for incoming request.")
+        _ = XCTWaiter.wait(for: [latestRequestExpectation!], timeout: timeout)
+        return latestRequest
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        DispatchQueue.main.async {
+            latestRequest = request
+            latestRequestExpectation?.fulfill()
+        }
+        return false
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        // Overriding this function is required by the superclass.
+        return request
+    }
+
+    // MARK: Instance methods
+
+    override func startLoading() {
+        // Required by the superclass.
+    }
+
+    override func stopLoading() {
+        // Required by the superclass.
+    }
+}

--- a/Tests/Client/Unit Tests/Client+DevicesTests.swift
+++ b/Tests/Client/Unit Tests/Client+DevicesTests.swift
@@ -1,0 +1,104 @@
+//
+//  Client+DevicesTests.swift
+//  StreamChatClientTests
+//
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import XCTest
+
+@testable import StreamChatClient
+
+class Client_DevicesTests: XCTestCase {
+
+    var client: Client!
+    var testUser: User!
+
+    override func setUp() {
+        super.setUp()
+        let sessionConfig = URLSessionConfiguration.default
+        sessionConfig.protocolClasses?.insert(RequestRecorderURLProtocol.self, at: 0)
+
+        let clientConfig = Client.Config(apiKey: "test_api_key")
+        // We can create a new `Client` instance unless we use `Client.shared` in tests.
+        client = Client(config: clientConfig, defaultURLSessionConfiguration: sessionConfig)
+
+        testUser = User(id: "test_user_\(UUID())")
+        client.set(user: testUser, token: "test_token")
+    }
+
+    func test_getDevice_createsRequest() {
+        // Action
+        client.devices { _ in }
+
+        // Assert
+        AssertNetworkRequest(
+            method: .get,
+            path: "/devices",
+            headers: ["Content-Type": "application/json"],
+            queryParameters: ["api_key": "test_api_key"],
+            body: nil
+        )
+    }
+
+    func test_addDeviceWithDeviceID_createsRequest() {
+        let testDeviceId = "device_id_\(UUID())"
+
+        // Action
+        client.addDevice(deviceId: testDeviceId)
+
+        // Assert
+        AssertNetworkRequest(
+            method: .post,
+            path: "/devices",
+            headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
+            queryParameters: ["api_key": "test_api_key"],
+            body: [
+                "user_id": testUser.id,
+                "id": testDeviceId,
+                "push_provider": "apn",
+            ]
+        )
+    }
+
+    func test_addDeviceWithDeviceToken_createsRequest() {
+        // Setup
+        let deviceToken = Data([1, 2, 3, 4])
+
+        // Action
+        client.addDevice(deviceToken: deviceToken)
+
+        // Assert
+        AssertNetworkRequest(
+            method: .post,
+            path: "/devices",
+            headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
+            queryParameters: ["api_key": "test_api_key"],
+            body: [
+                "user_id": testUser.id,
+                "id": "01020304", // the hexadecimal representation of the data
+                "push_provider": "apn",
+            ]
+        )
+    }
+
+    func test_removeDevice_createsRequest() {
+        // Setup
+        let testDeviceId = "device_id_\(UUID())"
+
+        // Action
+        client.removeDevice(deviceId: testDeviceId)
+
+        // Assert
+        AssertNetworkRequest(
+            method: .delete,
+            path: "/devices",
+            headers: ["Content-Type": "application/json"],
+            queryParameters: [
+                "api_key": "test_api_key",
+                "id": testDeviceId,
+            ],
+            body: nil
+        )
+    }
+}


### PR DESCRIPTION
### In this PR:
  - I made the default `URLSessionConfiguration` the client uses configurable. I had to do it to make it possible to register a custom `URLProtocol` on `Client`'s `URLSession`.

- I created `RequestRecorderURLProtocol`, a `URLProtocol` implementation which listens to all network requests and stores the last one made. You can call `getLatestRequestSynchronously()` on it to synchronously wait for a future request. This is quite cool but it makes asynchronous tests as simple to write as synchronous.

- To showcase how this can be used I added tests for `Client+Device` API calls.

Please note that this is just the first step. As we will use this more and more we can add more functionality and smooth all rough edges.

#no_changelog

---

@buh @b-onc Since this PR is big, I prepared the commit history in the way such that you can review commit by commit.