### PR TITLE
CIS-114 Make shared Client config more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
+### ✅ Added
+- `logAssert(_:_:)` and `logAssertionFailure(_:)` functions added to `ClientLogger` [#231](https://github.com/GetStream/stream-chat-swift/issues/231).
+
 ### 🔄 Changed
+- Configuring the shared `Client` using the static `Client.config` variable has been deprecated. Please create an instance of the `Client.Config` struct and call `Client.configureShared(_:)` to set up the shared instance of `Client` [#231](https://github.com/GetStream/stream-chat-swift/issues/231).
+  ```swift
+  // Deprecated:
+  Client.config = .init(apiKey: apiKey, baseURL: .usEast, logOptions: .info)
+
+  // Preferred:
+  let config = Client.Config(apiKey: apiKey, baseURL: .usEast, logOptions: .info)
+  Client.configureShared(config)
+  ```
+- `Client.shared` triggers assertion failure when used without configuring [#231](https://github.com/GetStream/stream-chat-swift/issues/231).
+- `Client.Config` triggers assertion failure when created with an empty API key value [#231](https://github.com/GetStream/stream-chat-swift/issues/231).
+- Assigning an empty string to `Client.apiKey` triggers assertion failure [#231](https://github.com/GetStream/stream-chat-swift/issues/231).
 
 # [2.1.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.1.1)
 _May 01, 2020_

--- a/Example/Sources/LoginViewController.swift
+++ b/Example/Sources/LoginViewController.swift
@@ -117,7 +117,9 @@ final class LoginViewController: ViewController {
         loggedInToken = token
         
         if !clientSetupped {
-            Client.config = .init(apiKey: apiKey, baseURL: .usEast, logOptions: .info)
+            let config = Client.Config(apiKey: apiKey, baseURL: .usEast, logOptions: .info)
+            Client.configureShared(config)
+
             Notifications.shared.clearApplicationIconBadgeNumberOnAppActive = true
             store(key: .apiKey, value: apiKey)
             clientSetupped = true

--- a/Sources/.swiftlint.yml
+++ b/Sources/.swiftlint.yml
@@ -43,6 +43,7 @@ function_body_length:
 
 identifier_name:
   excluded: [r, g, b, a, x, y, z, dx, dy, dz, i, j, k, id, op, or, me, at, to, in]
+  allowed_symbols: ["_"]
 
 line_length: 
   warning: 134

--- a/Sources/Client/Client/Client+Config.swift
+++ b/Sources/Client/Client/Client+Config.swift
@@ -37,9 +37,10 @@ extension Client {
 
         /// Creates a new config object.
         ///
-        /// - Parameter apiKey: A StreamChat API key for your app. You can find it in your Dashboard on
+        /// - Parameter apiKey: A StreamChat API key for your app. You can find it in the Dashboard on
         ///   https://getstream.io after logging in.
         public init(apiKey: String) {
+            ClientLogger.logAssert(!apiKey.isEmpty, "Empty string is not a valid apiKey.")
             self.apiKey = apiKey
         }
     }

--- a/Sources/Client/Client/Client+Config.swift
+++ b/Sources/Client/Client/Client+Config.swift
@@ -11,92 +11,115 @@ import Foundation
 // MARK: - Client Configuration
 
 extension Client {
-    /// A config for a shread `Client`.
+
+    /// A configuration object for `Client`.
+    ///
+    /// To create a new `Config` object a non-empty API key string has to be provided. After initializing,
+    /// it's possible to change additional parameters:
+    /// ```
+    ///     var config = Client.Config(apiKey: "<API_KEY>")
+    ///     config.baseURL = .dublin
+    ///     config.logOptions = [.debug]
+    /// ```
     public struct Config {
         /// A Stream Chat API key.
         public let apiKey: String
         /// A base URL (see `BaseURL`).
-        public let baseURL: BaseURL
+        public var baseURL: BaseURL = .usEast
         /// A request callback queue, default nil (some background thread).
-        public let callbackQueue: DispatchQueue?
+        public var callbackQueue: DispatchQueue?
         /// When the app will go to the background, start a background task to stay connected for 5 min.
-        public let stayConnectedInBackground: Bool
+        public var stayConnectedInBackground: Bool = true
         /// A local database.
-        public let database: Database?
+        public var database: Database?
         /// Enable logs (see `ClientLogger.Options`), e.g. `.all`.
-        public let logOptions: ClientLogger.Options
-        
-        /// Init a config for a shread `Client`.
-        /// - Parameters:
-        ///     - apiKey: a Stream Chat API key.
-        ///     - baseURL: a base URL (see `BaseURL`).
-        ///     - stayConnectedInBackground: when the app will go to the background,
-        ///                                  start a background task to stay connected for 5 min.
-        ///     - database: a database manager.
-        ///     - callbackQueue: a request callback queue, default nil (some background thread).
-        ///     - logOptions: enable logs (see `ClientLogger.Options`), e.g. `.all`
-        public init(apiKey: String,
-                    baseURL: BaseURL = .usEast,
-                    stayConnectedInBackground: Bool = true,
-                    database: Database? = nil,
-                    callbackQueue: DispatchQueue? = nil,
-                    logOptions: ClientLogger.Options = []) {
+        public var logOptions: ClientLogger.Options = []
+
+        /// Creates a new config object.
+        ///
+        /// - Parameter apiKey: A StreamChat API key for your app. You can find it in your Dashboard on
+        ///   https://getstream.io after logging in.
+        public init(apiKey: String) {
             self.apiKey = apiKey
-            self.baseURL = baseURL
-            self.stayConnectedInBackground = stayConnectedInBackground
-            self.database = database
-            self.callbackQueue = callbackQueue
-            self.logOptions = logOptions
-        }
-        
-        /// Init a config for the shared `Client`.
-        ///
-        /// - Parameters:
-        ///     - apiKey: a Stream Chat API key.
-        ///     - baseURL: a base URL.
-        ///     - stayConnectedInBackground: when the app will go to the background,
-        ///                                  start a background task to stay connected for 5 min.
-        ///     - database: a database manager.
-        ///     - callbackQueue: a request callback queue, default nil (some background thread).
-        ///     - logOptions: enable logs (see `ClientLogger.Options`), e.g. `.info`
-        public init(apiKey: String,
-                    baseURL: URL,
-                    stayConnectedInBackground: Bool = true,
-                    database: Database? = nil,
-                    callbackQueue: DispatchQueue? = nil,
-                    logOptions: ClientLogger.Options = []) {
-            self.init(apiKey: apiKey,
-                      baseURL: .init(url: baseURL),
-                      stayConnectedInBackground: stayConnectedInBackground,
-                      database: database,
-                      callbackQueue: callbackQueue,
-                      logOptions: logOptions)
-        }
-        
-        /// Init a config for the shared `Client`.
-        ///
-        /// - Parameters:
-        ///     - apiKey: a Stream Chat API key.
-        ///     - baseURL: a base URL string.
-        ///     - stayConnectedInBackground: when the app will go to the background,
-        ///                                  start a background task to stay connected for 5 min
-        ///     - database: a database manager.
-        ///     - callbackQueue: a request callback queue, default nil (some background thread).
-        ///     - logOptions: enable logs (see `ClientLogger.Options`), e.g. `.all`
-        public init?(apiKey: String,
-                     baseURL: String,
-                     stayConnectedInBackground: Bool = true,
-                     database: Database? = nil,
-                     callbackQueue: DispatchQueue? = nil,
-                     logOptions: ClientLogger.Options = []) {
-            guard let url = URL(string: baseURL) else { return nil }
-            
-            self.init(apiKey: apiKey,
-                      baseURL: .init(url: url),
-                      stayConnectedInBackground: stayConnectedInBackground,
-                      database: database,
-                      callbackQueue: callbackQueue,
-                      logOptions: logOptions)
         }
     }
+}
+
+// MARK: - Backward compatibility:
+
+extension Client.Config {
+    /// Init a config for the shared `Client`.
+    /// - Parameters:
+    ///     - apiKey: a Stream Chat API key.
+    ///     - baseURL: a base URL (see `BaseURL`).
+    ///     - stayConnectedInBackground: when the app will go to the background,
+    ///                                  start a background task to stay connected for 5 min.
+    ///     - database: a database manager.
+    ///     - callbackQueue: a request callback queue, default nil (some background thread).
+    ///     - logOptions: enable logs (see `ClientLogger.Options`), e.g. `.all`
+    public init(apiKey: String,
+                baseURL: BaseURL = .usEast,
+                stayConnectedInBackground: Bool = true,
+                database: Database? = nil,
+                callbackQueue: DispatchQueue? = nil,
+                logOptions: ClientLogger.Options = []) {
+
+        self = .init(apiKey: apiKey)
+        self.baseURL = baseURL
+        self.stayConnectedInBackground = stayConnectedInBackground
+        self.database = database
+        self.callbackQueue = callbackQueue
+        self.logOptions = logOptions
+    }
+
+    /// Init a config for the shared `Client`.
+    ///
+    /// - Parameters:
+    ///     - apiKey: a Stream Chat API key.
+    ///     - baseURL: a base URL.
+    ///     - stayConnectedInBackground: when the app will go to the background,
+    ///                                  start a background task to stay connected for 5 min.
+    ///     - database: a database manager.
+    ///     - callbackQueue: a request callback queue, default nil (some background thread).
+    ///     - logOptions: enable logs (see `ClientLogger.Options`), e.g. `.info`
+    public init(apiKey: String,
+                baseURL: URL,
+                stayConnectedInBackground: Bool = true,
+                database: Database? = nil,
+                callbackQueue: DispatchQueue? = nil,
+                logOptions: ClientLogger.Options = []) {
+        self.init(apiKey: apiKey,
+                  baseURL: .init(url: baseURL),
+                  stayConnectedInBackground: stayConnectedInBackground,
+                  database: database,
+                  callbackQueue: callbackQueue,
+                  logOptions: logOptions)
+    }
+
+    /// Init a config for the shared `Client`.
+    ///
+    /// - Parameters:
+    ///     - apiKey: a Stream Chat API key.
+    ///     - baseURL: a base URL string.
+    ///     - stayConnectedInBackground: when the app will go to the background,
+    ///                                  start a background task to stay connected for 5 min
+    ///     - database: a database manager.
+    ///     - callbackQueue: a request callback queue, default nil (some background thread).
+    ///     - logOptions: enable logs (see `ClientLogger.Options`), e.g. `.all`
+    public init?(apiKey: String,
+                 baseURL: String,
+                 stayConnectedInBackground: Bool = true,
+                 database: Database? = nil,
+                 callbackQueue: DispatchQueue? = nil,
+                 logOptions: ClientLogger.Options = []) {
+        guard let url = URL(string: baseURL) else { return nil }
+
+        self.init(apiKey: apiKey,
+                  baseURL: .init(url: url),
+                  stayConnectedInBackground: stayConnectedInBackground,
+                  database: database,
+                  callbackQueue: callbackQueue,
+                  logOptions: logOptions)
+    }
+
 }

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -27,7 +27,7 @@ public final class Client: Uploader {
     ///         You have to setup another user after that.
     public var apiKey: String {
         didSet {
-            checkAPIKey()
+            ClientLogger.logAssert(!apiKey.isEmpty, "Empty string is not a valid apiKey.")
             disconnect()
         }
     }
@@ -129,20 +129,10 @@ public final class Client: Uploader {
         #if DEBUG
         checkLatestVersion()
         #endif
-        checkAPIKey()
     }
     
     deinit {
         subscriptionBag.cancel()
-    }
-    
-    private func checkAPIKey() {
-        if apiKey.isEmpty {
-            ClientLogger.logger("❌❌❌", "", "The Stream Chat Client didn't setup properly. "
-                + "You are trying to use it before setting up the API Key. "
-                + "Please use `Client.config = .init(apiKey:) to setup your api key. "
-                + "You can debug this issue by putting a breakpoint in \(#file)\(#line)")
-        }
     }
     
     /// Handle a connection with an application state.

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -58,6 +58,18 @@ public final class Client: Uploader {
     /// A backing variable for `Client.shared`. We need this to have finer control over its creation.
     private static var backingSharedClient: Client?
 
+    /// Configures the shared instance of `Client`.
+    ///
+    /// - Parameter configuration: The configuration object with details of how the shared instance should be set up.
+    public static func configureShared(_ config: Config) {
+        guard backingSharedClient == nil else {
+            ClientLogger.logAssertionFailure(
+                "`Client.shared` instance was already used. It's not possible to change its configuration."
+            )
+            return
+        }
+        configForSharedClient = config
+    }
     
     /// Stream API key.
     /// - Note: If you will change API key the Client will be disconnected and the current user will be logged out.

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -142,21 +142,18 @@ public final class Client: Uploader {
     /// Weak references to channels by cid.
     let watchingChannelsAtomic = Atomic<[ChannelId: [WeakRef<Channel>]]>([:])
     
-    /// Init a network client.
-    /// - Parameters:
-    ///   - apiKey: a Stream Chat API key.
-    ///   - baseURL: a base URL (see `BaseURL`).
-    ///   - stayConnectedInBackground: when the app will go to the background,
-    ///                                start a background task to stay connected for 5 min.
-    ///   - database: a database manager (in development).
-    ///   - callbackQueue: a request callback queue, default nil (some background thread).
-    ///   - logOptions: enable logs (see `ClientLogger.Options`), e.g. `.info`.
-    init(apiKey: String = Client.config.apiKey,
-         baseURL: BaseURL = Client.config.baseURL,
-         stayConnectedInBackground: Bool = Client.config.stayConnectedInBackground,
-         database: Database? = Client.config.database,
-         callbackQueue: DispatchQueue? = Client.config.callbackQueue,
-         logOptions: ClientLogger.Options = Client.config.logOptions) {
+    /// Creates a new instance of the network client.
+    ///
+    /// - Parameter config: The configuration object with details of how the new instance should be set up.
+    init(config: Client.Config) {
+        self.apiKey = config.apiKey
+        self.baseURL = config.baseURL
+        self.callbackQueue = config.callbackQueue ?? .global(qos: .userInitiated)
+        self.stayConnectedInBackground = config.stayConnectedInBackground
+        self.database = config.database
+        self.logOptions = config.logOptions
+        logger = logOptions.logger(icon: "🐴", for: [.requestsError, .requests, .requestsInfo])
+
         if !apiKey.isEmpty, logOptions.isEnabled {
             ClientLogger.logger("💬", "", "Stream Chat v.\(Environment.version)")
             ClientLogger.logger("🔑", "", apiKey)
@@ -166,15 +163,7 @@ public final class Client: Uploader {
                 ClientLogger.logger("💽", "", "\(database.self)")
             }
         }
-        
-        self.apiKey = apiKey
-        self.baseURL = baseURL
-        self.callbackQueue = callbackQueue ?? .global(qos: .userInitiated)
-        self.stayConnectedInBackground = stayConnectedInBackground
-        self.database = database
-        self.logOptions = logOptions
-        logger = logOptions.logger(icon: "🐴", for: [.requestsError, .requests, .requestsInfo])
-        
+
         #if DEBUG
         checkLatestVersion()
         #endif

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -24,6 +24,14 @@ public final class Client: Uploader {
     """)
     public static var config: Config = .init(apiKey: "_deprecated") {
         didSet {
+            guard backingSharedClient == nil else {
+                ClientLogger.logAssertionFailure(
+                    "`Client.shared` instance was already used. It's not possible to change its configuration."
+                )
+                return
+            }
+
+            configForSharedClient = config
         }
     }
 
@@ -37,8 +45,14 @@ public final class Client: Uploader {
             return client
         }
 
-        _sharedClient = Client(config: configForSharedClient ?? .init(apiKey: "__API_KEY_NOT_CONFIGURED__"))
-        return _sharedClient!
+        ClientLogger.logAssert(
+            configForSharedClient != nil,
+            "The shared instance of the Stream chat client wasn't configured. " +
+            "Create an instance of the `Client.Config` struct and call `Client.configureShared(_:)` to set it up."
+        )
+
+        backingSharedClient = Client(config: configForSharedClient ?? .init(apiKey: "__API_KEY_NOT_CONFIGURED__"))
+        return backingSharedClient!
     }
 
     /// A backing variable for `Client.shared`. We need this to have finer control over its creation.

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -18,9 +18,32 @@ public final class Client: Uploader {
     public typealias OnEvent = (Event) -> Void
     
     /// A client config (see `Config`).
-    public static var config = Config(apiKey: "")
-    /// A shared client.
-    public static let shared = Client()
+    @available(*, deprecated, message: """
+    Configuring the shared Client using the static `Client.config` variable has been deprecated. Please create an instance
+    of the `Client.Config` struct and call `Client.configureShared(_:)` to set up the shared instance of Client.
+    """)
+    public static var config: Config = .init(apiKey: "_deprecated") {
+        didSet {
+        }
+    }
+
+    /// The configuration object used for creating `Client.shared`.
+    private static var configForSharedClient: Config?
+
+    /// The shared client.
+    public static var shared: Client {
+        if let client = backingSharedClient {
+            // Return the existing instance
+            return client
+        }
+
+        _sharedClient = Client(config: configForSharedClient ?? .init(apiKey: "__API_KEY_NOT_CONFIGURED__"))
+        return _sharedClient!
+    }
+
+    /// A backing variable for `Client.shared`. We need this to have finer control over its creation.
+    private static var backingSharedClient: Client?
+
     
     /// Stream API key.
     /// - Note: If you will change API key the Client will be disconnected and the current user will be logged out.

--- a/Sources/Client/Client/ClientLogger.swift
+++ b/Sources/Client/Client/ClientLogger.swift
@@ -299,7 +299,32 @@ public final class ClientLogger {
     public static func log(_ icon: String, dateTime: String = "", _ message: String) {
         ClientLogger.logger(icon, dateTime, message)
     }
-    
+
+    /// Performs `Swift.assert` and stops program execution if `condition` evaluated to false. In RELEASE builds only
+    /// logs the failure.
+    ///
+    /// - Parameters:
+    ///   - condition: The condition to test.
+    ///   - message: A custom message to log if `condition` is evaluated to false.
+    public static func logAssert(_ condition: Bool,
+                                 _ message: @autoclosure () -> String,
+                                 file: StaticString = #file,
+                                 line: UInt = #line) {
+
+        guard condition == false else { return }
+        let evaluatedMessage = message()
+        Swift.assert(condition, evaluatedMessage, file: file, line: line)
+        ClientLogger.logger("", "", "Assertion failure in \(file)[\(line)]: " + evaluatedMessage)
+    }
+
+    /// Triggers `Swift.assertionFailure`. In RELEASE builds only logs the failure.
+    ///
+    /// - Parameter message: A custom message to log.
+    public static func logAssertionFailure(_ message: String, file: StaticString = #file, line: UInt = #line) {
+        Swift.assertionFailure(message, file: file, line: line)
+        ClientLogger.logger("", "", "Assertion failure \(file)[\(line)]: " + message)
+    }
+
     static func showConnectionAlert(_ error: Error, jsonError: ClientErrorResponse?) {
         #if DEBUG
         let jsonError = jsonError ?? ClientErrorResponse(code: 0, message: "<unknown>", statusCode: 0)

--- a/Tests/Client/Integration Tests/ClientTests01+Channels.swift
+++ b/Tests/Client/Integration Tests/ClientTests01+Channels.swift
@@ -51,11 +51,13 @@ final class ClientTests01_Channels: TestCase {
     func test01BigFlow() {
         // MARK: User 1
         
-        let client1 = Client(apiKey: TestCase.apiKey,
-                             baseURL: TestCase.baseURL,
-                             stayConnectedInBackground: false,
-                             callbackQueue: .main,
-                             logOptions: [])
+        let client1 = Client(config: .init(
+            apiKey: TestCase.apiKey,
+            baseURL: TestCase.baseURL,
+            stayConnectedInBackground: false,
+            callbackQueue: .main,
+            logOptions: []
+        ))
         
         StorageHelper.shared.add(client1, key: .client1)
         

--- a/Tests/Client/Integration Tests/TestCase.swift
+++ b/Tests/Client/Integration Tests/TestCase.swift
@@ -30,11 +30,13 @@ class TestCase: XCTestCase {
         isClientReady = true
         ClientLogger.logger = { print($0, $2) }
         
-        Client.config = .init(apiKey: Self.apiKey,
-                              baseURL: Self.baseURL,
-                              stayConnectedInBackground: false,
-                              callbackQueue: .main,
-                              logOptions: [])
+        Client.configureShared(.init(
+            apiKey: Self.apiKey,
+            baseURL: Self.baseURL,
+            stayConnectedInBackground: false,
+            callbackQueue: .main,
+            logOptions: []
+        ))
     }
     
     override static func tearDown() {

--- a/Tests/Client/Unit Tests/QueryEncodingTests.swift
+++ b/Tests/Client/Unit Tests/QueryEncodingTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import StreamChatClient
 
 final class QueryEncodingTests: XCTestCase {
-    private let channel = Client(apiKey: "test").channel(type: .messaging, id: "general")
+    private let channel = Client(config: .init(apiKey: "test")).channel(type: .messaging, id: "general")
     private let encoder = JSONEncoder()
     
     private let simpleFilter: Filter = .equal("id", to: 42)


### PR DESCRIPTION
### In this PR:

- **No breaking changes!**

- Using the static `Client.config` variable is deprecated.

<img width="954" alt="Screen Shot 2020-04-30 at 17 50 31" src="https://user-images.githubusercontent.com/6388510/80788638-fe36b500-8b89-11ea-84c0-38f67c4557f7.png">

- Configuring the shared `Client` has to be done explicitly by calling `Client.configure(_:)`.

```swift
// Deprecated:
Client.config = .init(apiKey: apiKey, logOptions: .info)

// Preferred:
var config = Client.Config(apiKey: apiKey)
config.logOptions = .info
Client.configure(config)
```

- Using `Client.shared` without configuring it triggers an assertion failure in the DEBUG configuration (silently fails in RELEASE):

<img width="599" alt="Screen Shot 2020-05-01 at 13 54 29" src="https://user-images.githubusercontent.com/6388510/80803719-72d21980-8bb3-11ea-80f8-c0c0ceb9df3f.png">

  - Trying to change the configuration of an existing singleton triggers an assertion failure in the DEBUG configuration (silently fails in RELEASE):

<img width="746" alt="Screen Shot 2020-05-01 at 13 50 21" src="https://user-images.githubusercontent.com/6388510/80803489-b5dfbd00-8bb2-11ea-994e-cb91be4f6d5f.png">

  - Using an empty string as the API key triggers an assertion failure in the DEBUG configuration (silently fails in RELEASE):

<img width="756" alt="Screen Shot 2020-05-01 at 13 52 45" src="https://user-images.githubusercontent.com/6388510/80803593-0c4cfb80-8bb3-11ea-9d1e-0b33e886b0f0.png">

---

Happy to hear your suggestions and ideas on how to improve the code design proposed here!
