### PR TITLE
Change podspecs to lock all frameworks to same version

### DIFF
--- a/StreamChat.podspec
+++ b/StreamChat.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |spec|
 
   spec.framework = "Foundation", "UIKit"
 
-  spec.dependency "StreamChatCore"
+  spec.dependency "StreamChatCore", "#{spec.version}"
   spec.dependency "Nuke", "~> 8.4"
   spec.dependency "SnapKit", "~> 5.0"
   spec.dependency "SwiftyGif", "~> 5.2.0"

--- a/StreamChatCore.podspec
+++ b/StreamChatCore.podspec
@@ -16,8 +16,8 @@ Pod::Spec.new do |spec|
   spec.source_files  = "Sources/Core/**/*.swift"
 
   spec.framework = "Foundation", "UIKit"
-
-  spec.dependency "StreamChatClient"
+    
+  spec.dependency "StreamChatClient", "#{spec.version}"
   spec.dependency "RxSwift", "~> 5.1"
   spec.dependency "RxCocoa", "~> 5.1"
 end

--- a/StreamChatRealm.podspec
+++ b/StreamChatRealm.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |spec|
 
   spec.framework = "Foundation"
 
-  spec.dependency "StreamChatCore"
+  spec.dependency "StreamChatCore", "#{spec.version}"
   spec.dependency "RealmSwift"
 end


### PR DESCRIPTION
- This PR fixes podspec files to always fetch dependencies with the same version number.