### PR TITLE
CIS-138 Recover the default extra data for User and Channel types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Files over 20MB will correctly show file size warning [#239](https://github.com/GetStream/stream-chat-swift/issues/239)
 
 
+### 🐞 Fixed
+- Show in logs if extra data decoding failed for the `User` or `Channel` [#238](https://github.com/GetStream/stream-chat-swift/issues/238).
+- Recover the default extra data for User and Channel types [#238](https://github.com/GetStream/stream-chat-swift/issues/238).
+
 # [2.1.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.1.1)
 _May 01, 2020_
 

--- a/Sources/Client/Extensions/URL+Extensions.swift
+++ b/Sources/Client/Extensions/URL+Extensions.swift
@@ -1,0 +1,16 @@
+//
+//  URL+Extensions.swift
+//  StreamChatClient
+//
+//  Created by Alexey Bukhtin on 04/05/2020.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension URL {
+    /// Removes a front-end default SVG image. iOS doesn't support SVG by default.
+    func removingRandomSVG() -> URL? {
+        absoluteString.contains("random_svg") ? nil : self
+    }
+}

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -174,7 +174,8 @@ public final class Channel: Codable {
             return extraData
             
         } catch {
-            ClientLogger.log("🐴❌", "Channel extra data decoding error: \(error)")
+            ClientLogger.log("🐴❌", "Channel extra data decoding error: \(error). "
+                + "Trying to recover by only decoding name and imageURL")
             
             guard let container = try? decoder.container(keyedBy: DecodingKeys.self) else {
                 return nil

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -18,6 +18,10 @@ public final class Channel: Codable {
         case cid
         /// A type.
         case type
+        /// A channel name.
+        case name
+        /// An image URL.
+        case imageURL = "image"
         /// A last message date.
         case lastMessageDate = "last_message_at"
         /// A user created by.
@@ -30,10 +34,6 @@ public final class Channel: Codable {
         case config
         /// A frozen flag.
         case frozen
-        /// A name.
-        case name
-        /// A image URL.
-        case imageURL = "image"
         /// Members.
         case members
     }
@@ -155,7 +155,6 @@ public final class Channel: Codable {
         let members = try container.decodeIfPresent([Member].self, forKey: .members) ?? []
         self.members = Set<Member>(members)
         invitedMembers = Set<Member>()
-        extraData = try? Self.extraDataType.init(from: decoder) // swiftlint:disable:this explicit_init
         let config = try container.decode(Config.self, forKey: .config)
         self.config = config
         created = try container.decodeIfPresent(Date.self, forKey: .created) ?? config.created
@@ -164,6 +163,29 @@ public final class Channel: Codable {
         lastMessageDate = try container.decodeIfPresent(Date.self, forKey: .lastMessageDate)
         frozen = try container.decode(Bool.self, forKey: .frozen)
         didLoad = true
+        extraData = decodeChannelExtraData(from: decoder)
+    }
+    
+    /// Safely decode channel extra data and if it fail try to decode only default properties: name, imageURL.
+    private func decodeChannelExtraData(from decoder: Decoder) -> ChannelExtraDataCodable? {
+        do {
+            var extraData = try Self.extraDataType.init(from: decoder) // swiftlint:disable:this explicit_init
+            extraData.imageURL = extraData.imageURL?.removingRandomSVG()
+            return extraData
+            
+        } catch {
+            ClientLogger.log("🐴❌", "Channel extra data decoding error: \(error)")
+            
+            guard let container = try? decoder.container(keyedBy: DecodingKeys.self) else {
+                return nil
+            }
+            
+            // Recovering the default channel extra data properties: name, imageURL.
+            var extraData = ChannelExtraData()
+            extraData.name = try? container.decodeIfPresent(String.self, forKey: .name)
+            extraData.imageURL = try? container.decodeIfPresent(URL.self, forKey: .imageURL)?.removingRandomSVG()
+            return extraData
+        }
     }
     
     deinit {

--- a/Sources/Client/Model/User/User.swift
+++ b/Sources/Client/Model/User/User.swift
@@ -162,7 +162,8 @@ public struct User: Codable {
             return extraData
             
         } catch {
-            ClientLogger.log("🐴❌", "User extra data decoding error: \(error)")
+            ClientLogger.log("🐴❌", "User extra data decoding error: \(error). "
+                + "Trying to recover by only decoding name and imageURL")
             
             guard let container = try? decoder.container(keyedBy: CodingKeys.self) else {
                 return nil

--- a/Sources/Client/Model/User/UserExtraData.swift
+++ b/Sources/Client/Model/User/UserExtraData.swift
@@ -11,9 +11,9 @@ import Foundation
 /// A user extra data protocol for custom user properties.
 /// The `name` and `avatarURL` is a part of user extra data properties.
 public protocol UserExtraDataCodable: Codable {
-    /// A channel name.
+    /// A user name.
     var name: String? { get set }
-    /// A channel image URL.
+    /// A user image URL.
     var avatarURL: URL? { get set }
 }
 

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		8A2DD9532385565B007775E9 /* MutedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2DD9522385565B007775E9 /* MutedUser.swift */; };
 		8A2DD95423855690007775E9 /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8BB2B02384580700C2F9DE /* Channel.swift */; };
 		8A2DD956238556A7007775E9 /* Member.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2DD955238556A7007775E9 /* Member.swift */; };
+		8A2E4F09246016410032565F /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2E4F08246016410032565F /* URL+Extensions.swift */; };
 		8A466E61241A3A4D003C21BA /* Client+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A466E60241A3A4D003C21BA /* Client+Request.swift */; };
 		8A466E63241A3A7D003C21BA /* Client+WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A466E62241A3A7D003C21BA /* Client+WebSocket.swift */; };
 		8A466E65241A3AAA003C21BA /* Client+Setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A466E64241A3AAA003C21BA /* Client+Setup.swift */; };
@@ -331,6 +332,7 @@
 		8A2DD95023849108007775E9 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		8A2DD9522385565B007775E9 /* MutedUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUser.swift; sourceTree = "<group>"; };
 		8A2DD955238556A7007775E9 /* Member.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Member.swift; sourceTree = "<group>"; };
+		8A2E4F08246016410032565F /* URL+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Extensions.swift"; sourceTree = "<group>"; };
 		8A30D07A237D81C20082B951 /* StringExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
 		8A466E60241A3A4D003C21BA /* Client+Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Client+Request.swift"; sourceTree = "<group>"; };
 		8A466E62241A3A7D003C21BA /* Client+WebSocket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Client+WebSocket.swift"; sourceTree = "<group>"; };
@@ -763,6 +765,7 @@
 				79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */,
 				8ACC7BC1241924AD000750E4 /* Data+Extensions.swift */,
 				8ACC7BB8241924AD000750E4 /* Bundle+Extensions.swift */,
+				8A2E4F08246016410032565F /* URL+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1653,6 +1656,7 @@
 				8ACC7C36241924AD000750E4 /* ClientLogger.swift in Sources */,
 				8ACC7C0B241924AD000750E4 /* Event.swift in Sources */,
 				8ACC7C33241924AD000750E4 /* ClientError.swift in Sources */,
+				8A2E4F09246016410032565F /* URL+Extensions.swift in Sources */,
 				8ACC7C04241924AD000750E4 /* Functions.swift in Sources */,
 				80B937A52434F5FC003D950E /* Array+Extensions.swift in Sources */,
 				8ACC7C3A241924AD000750E4 /* ClientURLSessionTaskDelegate.swift in Sources */,


### PR DESCRIPTION
If ExtraData fails on decoding for some property it will fail all properties.

This PR will add 2 things:
1. Show a decoding error in logs
2. Try to decode as a default extra data type.

The story:
We have a customer who has `imageURL` as an empty string and it fails to decode. Users, in this case, will be shown as ids instead of names.