### PR TITLE
Fix image & video uploads from camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Client.shared` triggers assertion failure when used without configuring [#231](https://github.com/GetStream/stream-chat-swift/issues/231).
 - `Client.Config` triggers assertion failure when created with an empty API key value [#231](https://github.com/GetStream/stream-chat-swift/issues/231).
 - Assigning an empty string to `Client.apiKey` triggers assertion failure [#231](https://github.com/GetStream/stream-chat-swift/issues/231).
+- Changed title of camera upload button from _Upload from a camera_ to _Upload from camera_ [#239](https://github.com/GetStream/stream-chat-swift/issues/239)
+- Deprecated 2 public initializers from `UploadingItem` [#239](https://github.com/GetStream/stream-chat-swift/issues/239):
+  ```swift
+  public init(attachment:previewImage:previewImageGifData:)
+  ```
+  and
+  ```swift
+  public init(attachment:fileName:)
+  ```
+  since they were unused. Please use `init(channel:url:)` initializer. 
+
+### 🐞 Fixed
+- Images taken directly from camera do not fail to upload [#236](https://github.com/GetStream/stream-chat-swift/issues/236)
+- Video uploads are now working, videos are treated as files [#239](https://github.com/GetStream/stream-chat-swift/issues/239)
+- Files over 20MB will correctly show file size warning [#239](https://github.com/GetStream/stream-chat-swift/issues/239)
+
 
 # [2.1.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.1.1)
 _May 01, 2020_

--- a/Sources/Core/Presenter/UploadingItem.swift
+++ b/Sources/Core/Presenter/UploadingItem.swift
@@ -72,7 +72,7 @@ public final class UploadingItem: Equatable {
                 fileName: String? = nil,
                 fileType: AttachmentFileType? = nil,
                 fileSize: Int64 = 0,
-                extraData: Codable? = nil) {
+                extraData: Codable? = nil) throws {
         self.channel = channel
         self.url = url
         self.type = type
@@ -97,7 +97,7 @@ public final class UploadingItem: Equatable {
             self.fileType = .jpeg
         }
         
-        encodeData()
+        try encodeData()
     }
     
     /// Init an uploader item with a given uploaded image attachment.
@@ -137,18 +137,21 @@ public final class UploadingItem: Equatable {
         extraData = nil
     }
     
-    private func encodeData() {
+    private func encodeData() throws {
         guard type != .file, type != .video else {
             guard let url = url else {
                 error = .emptyBody(description: "Invalid URL: \(self.url?.absoluteString ?? "<unknown>")")
-                return
+                throw error!
             }
             
             do {
                 self.mimeType = fileType.mimeType
                 data = try Data(contentsOf: url)
             } catch {
-                self.error = .unexpectedError(description: error.localizedDescription, error: error)
+                self.error = .unexpectedError(description: "Cannot get data for url \(url): "
+                                                            + error.localizedDescription,
+                                              error: error)
+                throw self.error!
             }
             
             return
@@ -172,7 +175,7 @@ public final class UploadingItem: Equatable {
             
             error = .emptyBody(description: errorDescription)
             data = nil
-            return
+            throw error!
         }
         
         self.mimeType = mimeType

--- a/Sources/Core/Presenter/UploadingItem.swift
+++ b/Sources/Core/Presenter/UploadingItem.swift
@@ -106,6 +106,7 @@ public final class UploadingItem: Equatable {
     ///     - attachment: an uploaded attachment.
     ///     - previewImage: a preview of the uploaded image.
     ///     - previewImageGifData: a preview of the uploaded gif image data.
+    @available(*, deprecated, message: "Please use `init(channel:url:)` initializer")
     public init(attachment: Attachment, previewImage image: UIImage, previewImageGifData gifData: Data? = nil) {
         channel = nil
         url = attachment.url
@@ -118,12 +119,13 @@ public final class UploadingItem: Equatable {
         self.attachment = attachment
         extraData = nil
     }
-    
+
     /// Init an uploader item with a given uploaded file.
     ///
     /// - Parameters:
     ///   - attachment: an uploaded file attachment.
     ///   - fileName: an uploaded file name.
+    @available(*, deprecated, message: "Please use `init(channel:url:)` initializer")
     public init(attachment: Attachment, fileName: String) {
         channel = nil
         url = attachment.url

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
@@ -466,34 +466,33 @@ extension ChatViewController {
             do {
                 let pickedImage = try result.get()
                 
-                guard let fileURL = pickedImage.fileURL else {
-                    ClientLogger.log("📁", "File URL cannot be determined for file named: \(pickedImage.fileName)")
-                    return
-                }
-                
-                let fileSizeResource = try fileURL.resourceValues(forKeys: [.fileSizeKey])
-                
-                if let fileSize = fileSizeResource.fileSize,
-                   fileSize >= 20 * 1_048_576 { // 20 MB Upload limit
-                    self.show(errorMessage: "File size exceeds limit of 20MB")
-                    return
-                }
-                
                 guard let presenter = self.presenter, let image = pickedImage.image else {
                     return
                 }
                 
-                let extraData = presenter.imageAttachmentExtraDataCallback?(fileURL,
+                let extraData = presenter.imageAttachmentExtraDataCallback?(pickedImage.fileURL,
                                                                             image,
                                                                             pickedImage.isVideo,
                                                                             presenter.channel)
                 
-                let uploaderItem = UploadingItem(channel: presenter.channel, pickedImage: pickedImage, extraData: extraData)
-                self.composerView.addImageUploaderItem(uploaderItem)
+                let uploaderItem = try UploadingItem(channel: presenter.channel, pickedImage: pickedImage, extraData: extraData)
+                
+                guard let data = uploaderItem.data, data.count < 20 * 1024 * 1024 else {
+                    self.show(errorMessage: "File size exceeds limit of 20MB")
+                    return
+                }
+                
+                if case .image = uploaderItem.type {
+                    self.composerView.addImageUploaderItem(uploaderItem)
+                } else {
+                    self.composerView.addFileUploaderItem(uploaderItem)
+                }
             } catch let error as ImagePickerError {
                 self.showImagePickerAlert(for: error)
+            } catch let error as ClientError {
+                ClientLogger.log("🌄", "Error when trying to create file for uploading: \(error)")
             } catch {
-                ClientLogger.log("📁", "Error occurred when trying to get file size: \(error)")
+                ClientLogger.log("🌄", "Unknown error: \(error)")
             }
         }
         
@@ -509,9 +508,19 @@ extension ChatViewController {
             .subscribe(onNext: { [weak self] in
                 if let self = self, let presenter = self.presenter {
                     $0.forEach { url in
-                        let extraData = presenter.fileAttachmentExtraDataCallback?(url, presenter.channel)
-                        let uploaderItem = UploadingItem(channel: presenter.channel, url: url, extraData: extraData)
-                        self.composerView.addFileUploaderItem(uploaderItem)
+                        do {
+                            let extraData = presenter.fileAttachmentExtraDataCallback?(url, presenter.channel)
+                            let uploaderItem = try UploadingItem(channel: presenter.channel, url: url, extraData: extraData)
+                            
+                            guard let data = uploaderItem.data, data.count < 20 * 1024 * 1024 else {
+                                self.show(errorMessage: "File size exceeds limit of 20MB")
+                                return
+                            }
+                            
+                            self.composerView.addFileUploaderItem(uploaderItem)
+                        } catch {
+                            ClientLogger.log("📁", "Error occurred when trying to add file in url: \(url), error: \(error)")
+                        }
                     }
                 }
             })

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
@@ -369,7 +369,7 @@ extension ChatViewController {
                     UIImagePickerController.isSourceTypeAvailable(.camera) {
                     addButtonToAddFileView(container,
                                            icon: UIImage.Icons.camera,
-                                           title: "Upload from a camera",
+                                           title: "Upload from camera",
                                            sourceType: .photo(.camera)) { [weak self] in
                                             self?.showImagePicker(composerAddFileViewSourceType: $0)
                     }

--- a/Sources/UI/Chat/Composer/UploaderItem+UIImagePickerController.swift
+++ b/Sources/UI/Chat/Composer/UploaderItem+UIImagePickerController.swift
@@ -12,7 +12,7 @@ import StreamChatCore
 import Photos.PHPhotoLibrary
 
 extension UploadingItem {
-    convenience init(channel: Channel, pickedImage: PickedImage, extraData: Codable? = nil) {
+    convenience init(channel: Channel, pickedImage: PickedImage, extraData: Codable? = nil) throws {
         let fileName = pickedImage.fileName
         var fileType = AttachmentFileType.generic
         
@@ -27,13 +27,13 @@ extension UploadingItem {
             fileType = AttachmentFileType(ext: ext)
         }
         
-        self.init(channel: channel,
-                  url: pickedImage.fileURL,
-                  type: pickedImage.isVideo ? .video : .image,
-                  image: pickedImage.image,
-                  fileName: fileName,
-                  fileType: fileType,
-                  extraData: extraData)
+        try self.init(channel: channel,
+                      url: pickedImage.fileURL,
+                      type: pickedImage.isVideo ? .video : .image,
+                      image: pickedImage.image,
+                      fileName: fileName,
+                      fileType: fileType,
+                      extraData: extraData)
     }
 }
 


### PR DESCRIPTION
Since images coming from camera have no local fileURL, our uploads were failing. I've moved the size check logic into UploadingItem, now size check is being done on uploadingItem.data
Moreover, we've broken video uploads some time in the past and this PR fixes them too. Tested and working.
Fixes #236