### PR TITLE
Add lane for getting next issue number

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -176,3 +176,17 @@ lane :test_spm_integration do
     build_for_testing: true
   )
 end
+
+desc "Get next PR number from github to be used in CHANGELOG"
+lane :get_next_issue_number do
+  result = github_api(api_token: ENV["GITHUB_TOKEN"], path: "/repos/GetStream/stream-chat-swift/issues")
+  
+  next_issue_number = result[:json][0]["number"] + 1
+  next_issue_link = "[##{next_issue_number}](https://github.com/GetStream/stream-chat-swift/issues/#{next_issue_number})"
+  
+  clipboard(value: next_issue_link)
+  
+  UI.success "The next PR / Issue will have number: #{next_issue_number}"
+  UI.success "So the next markdown link is: #{next_issue_link}"
+  UI.success "Next markdown link is copied to your clipboard! ⬆️"
+end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -65,6 +65,11 @@ Tests integration with Cocoapods by building Cocoapods Example
 fastlane test_spm_integration
 ```
 Tests integration with SPM by building SPM Example
+### get_next_issue_number
+```
+fastlane get_next_issue_number
+```
+Get next PR number from github to be used in CHANGELOG
 
 ----
 


### PR DESCRIPTION
As we're adding issue numbers in our CHANGELOG, this lane can help us determine the next issue number, preventing unnecessary commits
