### PR TITLE
Fixed rx crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix last message not set when sending first message to an empty channel [#246](https://github.com/GetStream/stream-chat-swift/pull/246)
 - Show in logs if extra data decoding failed for the `User` or `Channel` [#238](https://github.com/GetStream/stream-chat-swift/issues/238).
 - Recover the default extra data for User and Channel types [#238](https://github.com/GetStream/stream-chat-swift/issues/238).
+- Crashes on `channel.rx.events` and `channel.rx.unreadCount` [#248](https://github.com/GetStream/stream-chat-swift/issues/248).
 - It's now possible to access `Atomic` value within its own `update { }` block [#251](https://github.com/GetStream/stream-chat-swift/pull/251)
 
 # [2.1.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.1.1)

--- a/Sources/Core/Client/Channel/Channel+RxEvents.swift
+++ b/Sources/Core/Client/Channel/Channel+RxEvents.swift
@@ -21,10 +21,10 @@ public extension Reactive where Base == Channel {
     
     /// Observe all events for this channel.
     var events: Observable<StreamChatClient.Event> {
-        associated(to: base, key: &Channel.rxOnEvent) { [unowned base] in
+        associated(to: base, key: &Channel.rxOnEvent) { [weak base] in
             Observable<StreamChatClient.Event>.create({ observer in
-                let subscription = base.subscribe { observer.onNext($0) }
-                return Disposables.create { subscription.cancel() }
+                let subscription = base?.subscribe { observer.onNext($0) }
+                return Disposables.create { subscription?.cancel() }
             })
                 .share()
         }
@@ -48,8 +48,8 @@ public extension Reactive where Base == Channel {
     
     /// An observable channel unread count.
     var unreadCount: Observable<ChannelUnreadCount> {
-        .create { [unowned base] (observer) -> Disposable in
-            let subscription = base.subscribeToUnreadCount { (result) in
+        Observable<ChannelUnreadCount>.create { [weak base] (observer) -> Disposable in
+            let subscription = base?.subscribeToUnreadCount { result in
                 do {
                     let response = try result.get()
                     observer.onNext(response)
@@ -58,7 +58,7 @@ public extension Reactive where Base == Channel {
                 }
             }
             
-            return Disposables.create { subscription.cancel() }
+            return Disposables.create { subscription?.cancel() }
         }
     }
     


### PR DESCRIPTION
Fixed crashes on `channel.rx.events` and `channel.rx.unreadCount`.