### PR TITLE
Fixed rx observing for the connection state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Upcoming
 
 ### ✅ Added
-- `avatarViewStyle` under `ChatViewStyle` for customizing Navigation Right Bar Button Item avatar [#241](https://github.com/GetStream/stream-chat-swift/issues/241)
+- `avatarViewStyle` under `ChatViewStyle` for customizing Navigation Right Bar Button Item avatar [#241](https://github.com/GetStream/stream-chat-swift/issues/241).
 - `logAssert(_:_:)` and `logAssertionFailure(_:)` functions added to `ClientLogger` [#231](https://github.com/GetStream/stream-chat-swift/issues/231).
 
 ### 🔄 Changed
@@ -39,10 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   since they were unused. Please use `init(channel:url:)` initializer. 
 
 ### 🐞 Fixed
-- Images taken directly from camera do not fail to upload [#236](https://github.com/GetStream/stream-chat-swift/issues/236)
-- Video uploads are now working, videos are treated as files [#239](https://github.com/GetStream/stream-chat-swift/issues/239)
-- Files over 20MB will correctly show file size warning [#239](https://github.com/GetStream/stream-chat-swift/issues/239)
-- Fix last message not set when sending first message to an empty channel [#246](https://github.com/GetStream/stream-chat-swift/pull/246)
+- Fix rx observing for the connection state [#249](https://github.com/GetStream/stream-chat-swift/issues/249).
+- Images taken directly from camera do not fail to upload [#236](https://github.com/GetStream/stream-chat-swift/issues/236).
+- Video uploads are now working, videos are treated as files [#239](https://github.com/GetStream/stream-chat-swift/issues/239).
+- Files over 20MB will correctly show file size warning [#239](https://github.com/GetStream/stream-chat-swift/issues/239).
+- Fix last message not set when sending first message to an empty channel [#246](https://github.com/GetStream/stream-chat-swift/pull/246).
 - Show in logs if extra data decoding failed for the `User` or `Channel` [#238](https://github.com/GetStream/stream-chat-swift/issues/238).
 - Recover the default extra data for User and Channel types [#238](https://github.com/GetStream/stream-chat-swift/issues/238).
 - It's now possible to access `Atomic` value within its own `update { }` block [#251](https://github.com/GetStream/stream-chat-swift/pull/251)

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -103,6 +103,8 @@ public final class Client: Uploader {
     
     /// A web socket client.
     lazy var webSocket = WebSocket()
+    /// The current connection state.
+    public var connectionState: ConnectionState { webSocket.connectionState }
     /// Check if API key and token are valid and the web socket is connected.
     public var isConnected: Bool { !apiKey.isEmpty && webSocket.isConnected }
     var needsToRecoverConnection = false

--- a/Sources/Client/WebSocket/WebSocket.swift
+++ b/Sources/Client/WebSocket/WebSocket.swift
@@ -26,8 +26,13 @@ final class WebSocket {
     private(set) var connectionId: String?
     private(set) var eventError: ClientErrorResponse?
     
-    private var connectionState = ConnectionState.notConnected {
-        didSet { publishEvent(.connectionChanged(connectionState)) }
+    var connectionState: ConnectionState { connectionStateAtomic.get(default: .notConnected) }
+    
+    private lazy var connectionStateAtomic =
+        Atomic<ConnectionState>(.notConnected, callbackQueue: nil) { [weak self] connectionState, _ in
+            if let connectionState = connectionState {
+                self?.publishEvent(.connectionChanged(connectionState))
+            }
     }
     
     private lazy var handshakeTimer =
@@ -94,7 +99,7 @@ extension WebSocket {
         
         logger?.log("Connecting...")
         logger?.log(webSocket.request)
-        connectionState = .connecting
+        connectionStateAtomic.set(.connecting)
         shouldReconnect = true
         
         DispatchQueue.main.async(execute: webSocket.connect)
@@ -105,7 +110,7 @@ extension WebSocket {
             return
         }
         
-        connectionState = .reconnecting
+        connectionStateAtomic.set(.reconnecting)
         let maxDelay: TimeInterval = min(500 + consecutiveFailures * 2000, 25000) / 1000
         let minDelay: TimeInterval = min(max(250, (consecutiveFailures - 1) * 2000), 25000) / 1000
         consecutiveFailures += 1
@@ -113,7 +118,7 @@ extension WebSocket {
         logger?.log("⏳ Reconnect in \(delay) sec")
         
         webSocket.callbackQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
-            self?.connectionState = .connecting
+            self?.connectionStateAtomic.set(.connecting)
             self?.connect()
         }
     }
@@ -163,11 +168,11 @@ extension WebSocket {
         
         if webSocket.isConnected {
             logger?.log("Disconnecting: \(reason)")
-            connectionState = .disconnecting
+            connectionStateAtomic.set(.disconnecting)
             webSocket.disconnect(forceTimeout: 0)
         } else {
             logger?.log("Skip disconnecting: WebSocket was not connected")
-            connectionState = .disconnected(nil)
+            connectionStateAtomic.set(.disconnected(nil))
         }
     }
     
@@ -223,7 +228,7 @@ extension WebSocket: WebSocketDelegate {
     
     func websocketDidConnect(socket: Starscream.WebSocketClient) {
         logger?.log("❤️ Connected. Waiting for the current user data and connectionId...")
-        connectionState = .connecting
+        connectionStateAtomic.set(.connecting)
     }
     
     func websocketDidReceiveMessage(socket: Starscream.WebSocketClient, text: String) {
@@ -236,7 +241,7 @@ extension WebSocket: WebSocketDelegate {
             logger?.log("🥰 Connected")
             self.connectionId = connectionId
             handshakeTimer.resume()
-            connectionState = .connected(UserConnection(user: user, connectionId: connectionId))
+            connectionStateAtomic.set(.connected(UserConnection(user: user, connectionId: connectionId)))
             return
             
         case let .messageNew(message, _, _, _) where message.user.isMuted:
@@ -264,13 +269,13 @@ extension WebSocket: WebSocketDelegate {
         
         if let eventError = eventError, eventError.code == ClientErrorResponse.tokenExpiredErrorCode {
             logger?.log("Disconnected. 🀄️ Token is expired")
-            connectionState = .disconnected(ClientError.expiredToken)
+            connectionStateAtomic.set(.disconnected(ClientError.expiredToken))
             return
         }
         
         guard let error = error else {
             logger?.log("💔 Disconnected")
-            connectionState = .disconnected(nil)
+            connectionStateAtomic.set(.disconnected(nil))
             
             if shouldReconnect {
                 reconnect()
@@ -290,7 +295,7 @@ extension WebSocket: WebSocketDelegate {
         logger?.log(error, message: "💔😡 Disconnected by error")
         logger?.log(eventError)
         ClientLogger.showConnectionAlert(error, jsonError: eventError)
-        connectionState = .disconnected(.websocketDisconnectError(error))
+        connectionStateAtomic.set(.disconnected(.websocketDisconnectError(error)))
         
         if shouldReconnect {
             reconnect()

--- a/Sources/Core/Client/Client+RxEvents.swift
+++ b/Sources/Core/Client/Client+RxEvents.swift
@@ -59,18 +59,19 @@ extension Client {
 
 extension Reactive where Base == Client {
     
+    /// Observe the connection state.
     public var connectionState: Observable<ConnectionState> {
         associated(to: base, key: &Client.rxOnConnect) { [unowned base] in
             base.rx.events
                 .filter({ _ in !base.isExpiredTokenInProgress })
-                .map({
+                .compactMap({
                     if case .connectionChanged(let state) = $0 {
                         return state
                     }
                     
                     return nil
                 })
-                .compactMap { $0 }
+                .startWith(base.connectionState)
                 .distinctUntilChanged()
                 .share(replay: 1)
         }

--- a/Sources/Core/Presenter/Presenter+Rx.swift
+++ b/Sources/Core/Presenter/Presenter+Rx.swift
@@ -21,7 +21,7 @@ extension Reactive  where Base: Presenter {
     public var connectionErrors: Driver<ViewChanges> {
         associated(to: base, key: &Presenter.rxConnectionErrorsKey) {
             Client.shared.rx.connectionState
-                .map({ connection -> ViewChanges? in
+                .compactMap({ connection -> ViewChanges? in
                     if case .disconnected(let error) = connection, let disconnectError = error {
                         return .error(disconnectError)
                     }
@@ -32,7 +32,6 @@ extension Reactive  where Base: Presenter {
                     
                     return nil
                 })
-                .compactMap { $0 }
                 .asDriver(onErrorJustReturn: .none)
         }
     }


### PR DESCRIPTION
For rx subscriptions important to start with an initial connection state.
I made `WebSocket.connectionState` as Atomic and shared it on `Client`.
Also, I added current values for Client unread count and user on subscribe.
