### PR TITLE
CIS-115 Test old iOS SDKs nightly

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -15,7 +15,7 @@ jobs:
       id: carthage-cache
       with:
         path: Carthage
-        key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+        key: ${{ runner.os }}-carthage-stable-${{ hashFiles('**/Cartfile.resolved') }}
     - name: Cache RubyGems
       uses: actions/cache@v1
       id: rubygem-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       id: carthage-cache
       with:
         path: Carthage
-        key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+        key: ${{ runner.os }}-carthage-stable-${{ hashFiles('**/Cartfile.resolved') }}
     - name: Cache RubyGems
       uses: actions/cache@v1
       id: rubygem-cache
@@ -56,7 +56,7 @@ jobs:
       id: carthage-cache
       with:
         path: Carthage
-        key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+        key: ${{ runner.os }}-carthage-stable-${{ hashFiles('**/Cartfile.resolved') }}
     - name: Cache RubyGems
       uses: actions/cache@v1
       id: rubygem-cache

--- a/.github/workflows/test-old-ios-versions.yml
+++ b/.github/workflows/test-old-ios-versions.yml
@@ -1,0 +1,64 @@
+name: Test-Old-iOS-Versions
+
+# TODO: run this nightly
+on:
+  push:
+    branches:
+      - test-integrations
+
+jobs:
+  test-ios-11:
+    name: Test iOS 11
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Cache Carthage dependencies
+      uses: actions/cache@v1.1.0
+      id: carthage-cache
+      with:
+        path: Carthage
+        key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+    - name: Cache RubyGems
+      uses: actions/cache@v1
+      id: rubygem-cache
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: ${{ runner.os }}-gem-
+    - name: Install RubyGems
+      if: steps.rubygem-cache.outputs.cache-hit != 'true'
+      run: bundle install
+    - name: Install Carthage dependencies
+      run: bundle exec fastlane carthage_bootstrap
+    - name: Install iOS 11.4 Simulator
+      run: bundle exec xcversion simulators --install='iOS 11.4'
+    - name: Run all backend integration tests
+      run: bundle exec fastlane test_backend_integration device:"iPhone 7 (11.4)"
+
+  test-ios-12:
+    name: Test iOS 12
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Cache Carthage dependencies
+      uses: actions/cache@v1.1.0
+      id: carthage-cache
+      with:
+        path: Carthage
+        key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+    - name: Cache RubyGems
+      uses: actions/cache@v1
+      id: rubygem-cache
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: ${{ runner.os }}-gem-
+    - name: Install RubyGems
+      if: steps.rubygem-cache.outputs.cache-hit != 'true'
+      run: bundle install
+    - name: Install Carthage dependencies
+      run: bundle exec fastlane carthage_bootstrap
+    - name: Install iOS 12.4 Simulator
+      run: bundle exec xcversion simulators --install='iOS 12.4'
+    - name: Run all backend integration tests
+      run: bundle exec fastlane test_backend_integration device:"iPhone 7 (12.4)"

--- a/.github/workflows/test-old-ios-versions.yml
+++ b/.github/workflows/test-old-ios-versions.yml
@@ -1,10 +1,8 @@
 name: Test-Old-iOS-Versions
 
-# TODO: run this nightly
 on:
-  push:
-    branches:
-      - test-integrations
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
 
 jobs:
   test-ios-11:

--- a/.github/workflows/test-old-ios-versions.yml
+++ b/.github/workflows/test-old-ios-versions.yml
@@ -17,7 +17,7 @@ jobs:
       id: carthage-cache
       with:
         path: Carthage
-        key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+        key: ${{ runner.os }}-carthage-stable-${{ hashFiles('**/Cartfile.resolved') }}
     - name: Cache RubyGems
       uses: actions/cache@v1
       id: rubygem-cache
@@ -45,7 +45,7 @@ jobs:
       id: carthage-cache
       with:
         path: Carthage
-        key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+        key: ${{ runner.os }}-carthage-stable-${{ hashFiles('**/Cartfile.resolved') }}
     - name: Cache RubyGems
       uses: actions/cache@v1
       id: rubygem-cache

--- a/.github/workflows/test-old-ios-versions.yml
+++ b/.github/workflows/test-old-ios-versions.yml
@@ -30,7 +30,7 @@ jobs:
       run: bundle exec fastlane carthage_bootstrap
     - name: Install iOS 11.4 Simulator
       run: bundle exec xcversion simulators --install='iOS 11.4'
-    - name: Run all backend integration tests
+    - name: Run all tests
       run: bundle exec fastlane test_backend_integration device:"iPhone 7 (11.4)"
 
   test-ios-12:
@@ -58,5 +58,5 @@ jobs:
       run: bundle exec fastlane carthage_bootstrap
     - name: Install iOS 12.4 Simulator
       run: bundle exec xcversion simulators --install='iOS 12.4'
-    - name: Run all backend integration tests
+    - name: Run all tests
       run: bundle exec fastlane test_backend_integration device:"iPhone 7 (12.4)"

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "cocoapods"
 gem "danger"
 gem "danger-swiftlint"	
 gem "jazzy"
+gem "xcode-install"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,9 @@ GEM
     word_wrap (1.0.0)
     xcinvoke (0.3.0)
       liferaft (~> 0.0.6)
+    xcode-install (2.6.4)
+      claide (>= 0.9.1, < 1.1.0)
+      fastlane (>= 2.1.0, < 3.0.0)
     xcodeproj (1.16.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
@@ -302,6 +305,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-firebase_app_distribution
   jazzy
+  xcode-install
 
 BUNDLED WITH
    2.0.2

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1910,7 +1910,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = Sources/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1929,7 +1929,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = Sources/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		791664E2245AF8AF0020710B /* AssertNetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664E1245AF8AF0020710B /* AssertNetworkRequest.swift */; };
 		791664E3245AF90A0020710B /* RequestRecorderURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */; };
 		791664E4245AF90A0020710B /* RequestRecorderURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791664DC245AC78B0020710B /* RequestRecorderURLProtocol.swift */; };
+		79411CD42462DC0A003972E9 /* ClientLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFA57262418EB2500FD07EC /* ClientLoggerTests.swift */; };
 		794BDE4A2434BD7400BFBA1F /* NestableCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */; };
 		79A9E4F72449D3AF00599B95 /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */; };
 		79A9E4F92449DF2D00599B95 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F82449DF2D00599B95 /* Reachability.swift */; };
@@ -21,7 +22,6 @@
 		79EE3942245320610034EBF3 /* ClientTests00.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE6206923CF63F000AB3426 /* ClientTests00.swift */; };
 		79EE3943245320650034EBF3 /* ClientTests01+Channels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1D042523D0FB560099AA7F /* ClientTests01+Channels.swift */; };
 		79EE3944245320690034EBF3 /* ClientTests02+Users.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC0D94B23D4ABC50080B8BC /* ClientTests02+Users.swift */; };
-		79EE39452453206E0034EBF3 /* ClientTests10+ClientLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFA57262418EB2500FD07EC /* ClientTests10+ClientLogger.swift */; };
 		79EE3946245321820034EBF3 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE6206C23CF642900AB3426 /* TestCase.swift */; };
 		79EE3947245322620034EBF3 /* User+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6F69D1230ECCD300B8CC1F /* User+Tests.swift */; };
 		80B937A52434F5FC003D950E /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B937A42434F5FC003D950E /* Array+Extensions.swift */; };
@@ -560,7 +560,7 @@
 		8AD5EDDC22E9C7BC005CFAC9 /* releasing.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = releasing.md; sourceTree = "<group>"; };
 		8AE6206923CF63F000AB3426 /* ClientTests00.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientTests00.swift; sourceTree = "<group>"; };
 		8AE6206C23CF642900AB3426 /* TestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
-		8AFA57262418EB2500FD07EC /* ClientTests10+ClientLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ClientTests10+ClientLogger.swift"; sourceTree = "<group>"; };
+		8AFA57262418EB2500FD07EC /* ClientLoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientLoggerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -709,6 +709,7 @@
 				8A30D07A237D81C20082B951 /* StringExtensionsTests.swift */,
 				7900717D244084E200E5246F /* QueryEncodingTests.swift */,
 				791664DE245AC89E0020710B /* Client+DevicesTests.swift */,
+				8AFA57262418EB2500FD07EC /* ClientLoggerTests.swift */,
 			);
 			path = "Unit Tests";
 			sourceTree = "<group>";
@@ -1312,7 +1313,6 @@
 				8AE6206923CF63F000AB3426 /* ClientTests00.swift */,
 				8A1D042523D0FB560099AA7F /* ClientTests01+Channels.swift */,
 				8AC0D94B23D4ABC50080B8BC /* ClientTests02+Users.swift */,
-				8AFA57262418EB2500FD07EC /* ClientTests10+ClientLogger.swift */,
 			);
 			path = "Integration Tests";
 			sourceTree = "<group>";
@@ -1601,7 +1601,6 @@
 			files = (
 				791664E3245AF90A0020710B /* RequestRecorderURLProtocol.swift in Sources */,
 				79EE3942245320610034EBF3 /* ClientTests00.swift in Sources */,
-				79EE39452453206E0034EBF3 /* ClientTests10+ClientLogger.swift in Sources */,
 				79EE3944245320690034EBF3 /* ClientTests02+Users.swift in Sources */,
 				79EE3943245320650034EBF3 /* ClientTests01+Channels.swift in Sources */,
 				79EE3946245321820034EBF3 /* TestCase.swift in Sources */,
@@ -1701,6 +1700,7 @@
 				8AFA57292418EC1700FD07EC /* StringExtensionsTests.swift in Sources */,
 				8AE6206E23CF658700AB3426 /* User+Tests.swift in Sources */,
 				791664E2245AF8AF0020710B /* AssertNetworkRequest.swift in Sources */,
+				79411CD42462DC0A003972E9 /* ClientLoggerTests.swift in Sources */,
 				8AC0D94F23D4BA7D0080B8BC /* FilterTests.swift in Sources */,
 				791664DF245AC89E0020710B /* Client+DevicesTests.swift in Sources */,
 				791664DD245AC78B0020710B /* RequestRecorderURLProtocol.swift in Sources */,

--- a/Tests/Client/Unit Tests/ClientLoggerTests.swift
+++ b/Tests/Client/Unit Tests/ClientLoggerTests.swift
@@ -174,7 +174,7 @@ final class ClientLoggerTests: XCTestCase {
     }
     
     func testLogURLResponseWithInfoLevel() {
-        let urlResponse = HTTPURLResponse(url: testUrl, mimeType: nil, expectedContentLength: 1, textEncodingName: nil)
+        let urlResponse = HTTPURLResponse(url: testUrl, statusCode: 200, httpVersion: nil, headerFields: nil)!
         
         infoLogger.log(urlResponse, data: testData)
         
@@ -279,7 +279,7 @@ final class ClientLoggerTests: XCTestCase {
     }
     
     func testLogURLResponseWithDebugLevel() {
-        let urlResponse = HTTPURLResponse(url: testUrl, mimeType: nil, expectedContentLength: 1, textEncodingName: nil)
+        let urlResponse = HTTPURLResponse(url: testUrl, statusCode: 200, httpVersion: nil, headerFields: nil)!
         
         debugLogger.log(urlResponse, data: testData)
         

--- a/Tests/Client/Unit Tests/ClientLoggerTests.swift
+++ b/Tests/Client/Unit Tests/ClientLoggerTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import StreamChatClient
 
-final class ClientTests10_ClientLogger: XCTestCase {
+final class ClientLoggerTests: XCTestCase {
     private let teJstUser = User(id: "test")
     private let testUrl = "getstream.io".url!
     private let testFilter = Filter.in("members", ["test-member"])
@@ -34,6 +34,13 @@ final class ClientTests10_ClientLogger: XCTestCase {
         let logger = ClientLogger(icon: "🗣", level: .error)
         return logger
     }()
+    
+    override class func setUp() {
+        super.setUp()
+        
+        // Setup Client since Message initializer accesses User.current
+        Client.configureShared(.init(apiKey: "logger_test_api_key"))
+    }
     
     override func setUp() {
         super.setUp()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -136,24 +136,22 @@ lane :test_without_building do
 end
 
 desc "Runs integrations tests with backend. These tests make network connections so they're sometimes not reliable, hence we run them up to 3 times in case of failure"
-lane :test_backend_integration do
-  build_for_testing
-  
+lane :test_backend_integration do |options|
   @test_retries = 3
   
-  def run_tests
+  def run_tests(device)
     begin
-      scan(project: "StreamChat.xcodeproj", scheme: "StreamChat", test_without_building: true, only_testing: ["StreamChatClientIntegrationTests"])
+      scan(project: "StreamChat.xcodeproj", scheme: "StreamChat", clean: true, only_testing: ["StreamChatClientIntegrationTests"], devices: [device])
     rescue
     
       @test_retries -= 1
       if @test_retries > 0
-        run_tests
+        run_tests(device)
       end
     end
   end
   
-  run_tests
+  run_tests(options[:device])
 end
 
 desc "Tests SDK integrations with Carthage, Cocoapods and SPM"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -141,7 +141,7 @@ lane :test_backend_integration do |options|
   
   def run_tests(device)
     begin
-      scan(project: "StreamChat.xcodeproj", scheme: "StreamChat", clean: true, only_testing: ["StreamChatClientIntegrationTests"], devices: [device])
+      scan(project: "StreamChat.xcodeproj", scheme: "StreamChat", clean: true, devices: [device])
     rescue
     
       @test_retries -= 1

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -139,9 +139,11 @@ desc "Runs integrations tests with backend. These tests make network connections
 lane :test_backend_integration do |options|
   @test_retries = 3
   
+  scan(project: "StreamChat.xcodeproj", scheme: "StreamChat", clean: true, build_for_testing: true, devices: [options[:device]])
+  
   def run_tests(device)
     begin
-      scan(project: "StreamChat.xcodeproj", scheme: "StreamChat", clean: true, devices: [device])
+      scan(project: "StreamChat.xcodeproj", scheme: "StreamChat", test_without_building: true, devices: [device])
     rescue
     
       @test_retries -= 1

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -135,6 +135,27 @@ lane :test_without_building do
   scan(project: "StreamChat.xcodeproj", scheme: "StreamChat", test_without_building: true, only_testing: ["StreamChatClientTests"])
 end
 
+desc "Runs integrations tests with backend. These tests make network connections so they're sometimes not reliable, hence we run them up to 3 times in case of failure"
+lane :test_backend_integration do
+  build_for_testing
+  
+  @test_retries = 3
+  
+  def run_tests
+    begin
+      scan(project: "StreamChat.xcodeproj", scheme: "StreamChat", test_without_building: true, only_testing: ["StreamChatClientIntegrationTests"])
+    rescue
+    
+      @test_retries -= 1
+      if @test_retries > 0
+        run_tests
+      end
+    end
+  end
+  
+  run_tests
+end
+
 desc "Tests SDK integrations with Carthage, Cocoapods and SPM"
 lane :test_integrations do
   test_carthage_integration

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -45,6 +45,11 @@ Builds the project for testing
 fastlane test_without_building
 ```
 Runs all the tests without building
+### test_backend_integration
+```
+fastlane test_backend_integration
+```
+Runs integrations tests with backend. These tests make network connections so they're sometimes not reliable, hence we run them up to 3 times in case of failure
 ### test_integrations
 ```
 fastlane test_integrations

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -15,3 +15,5 @@ disable_concurrent_testing(true)
 configuration("Debug")
 
 result_bundle(true)
+
+skip_slack(true)


### PR DESCRIPTION
Test run here: https://github.com/GetStream/stream-chat-swift/runs/649869791?check_suite_focus=true

We're able to test iOS 11.4 and 12.4 (in parallel!), and we're using (we have to) backend integration test. The reported iOS12 crash was related to network request part, so I thought this makes sense to have!

Oh, also moved ClientLogger tests to Unit tests target since it was a unit test.
