### PR TITLE
[CIS 122] Add test coverage for `Atomic`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Video uploads are now working, videos are treated as files [#239](https://github.com/GetStream/stream-chat-swift/issues/239)
 - Files over 20MB will correctly show file size warning [#239](https://github.com/GetStream/stream-chat-swift/issues/239)
 - Fix last message not set when sending first message to an empty channel [#246](https://github.com/GetStream/stream-chat-swift/pull/246)
-
-
-### 🐞 Fixed
 - Show in logs if extra data decoding failed for the `User` or `Channel` [#238](https://github.com/GetStream/stream-chat-swift/issues/238).
 - Recover the default extra data for User and Channel types [#238](https://github.com/GetStream/stream-chat-swift/issues/238).
+- It's now possible to access `Atomic` value within its own `update { }` block [#251](https://github.com/GetStream/stream-chat-swift/pull/251)
 
 # [2.1.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.1.1)
 _May 01, 2020_

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		794BDE4A2434BD7400BFBA1F /* NestableCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */; };
 		79A9E4F72449D3AF00599B95 /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */; };
 		79A9E4F92449DF2D00599B95 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F82449DF2D00599B95 /* Reachability.swift */; };
+		79CABB0724630AC600240052 /* AssertEventually.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CABB0624630AC600240052 /* AssertEventually.swift */; };
 		79D50C7724321BDA0052BA03 /* Client+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D50C7624321BDA0052BA03 /* Client+Events.swift */; };
 		79EE393C2453204E0034EBF3 /* StreamChatClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A50694F23CDEA31009F127A /* StreamChatClient.framework */; };
 		79EE3942245320610034EBF3 /* ClientTests00.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE6206923CF63F000AB3426 /* ClientTests00.swift */; };
@@ -309,6 +310,7 @@
 		795FCD1B23EB155000990F15 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+Gzip.swift"; sourceTree = "<group>"; };
 		79A9E4F82449DF2D00599B95 /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
+		79CABB0624630AC600240052 /* AssertEventually.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertEventually.swift; sourceTree = "<group>"; };
 		79D50C7624321BDA0052BA03 /* Client+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Client+Events.swift"; sourceTree = "<group>"; };
 		79EE39372453204E0034EBF3 /* StreamChatClientIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatClientIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		80B937A42434F5FC003D950E /* Array+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
@@ -637,6 +639,7 @@
 			isa = PBXGroup;
 			children = (
 				791664E1245AF8AF0020710B /* AssertNetworkRequest.swift */,
+				79CABB0624630AC600240052 /* AssertEventually.swift */,
 			);
 			path = "Custom Assertions";
 			sourceTree = "<group>";
@@ -1700,6 +1703,7 @@
 				8AFA57292418EC1700FD07EC /* StringExtensionsTests.swift in Sources */,
 				8AE6206E23CF658700AB3426 /* User+Tests.swift in Sources */,
 				791664E2245AF8AF0020710B /* AssertNetworkRequest.swift in Sources */,
+				79CABB0724630AC600240052 /* AssertEventually.swift in Sources */,
 				79411CD42462DC0A003972E9 /* ClientLoggerTests.swift in Sources */,
 				8AC0D94F23D4BA7D0080B8BC /* FilterTests.swift in Sources */,
 				791664DF245AC89E0020710B /* Client+DevicesTests.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		794BDE4A2434BD7400BFBA1F /* NestableCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */; };
 		79A9E4F72449D3AF00599B95 /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */; };
 		79A9E4F92449DF2D00599B95 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F82449DF2D00599B95 /* Reachability.swift */; };
+		79CABAFE2462A4E400240052 /* AtomicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79324B7A2462A08A00B2597E /* AtomicTests.swift */; };
 		79CABB0724630AC600240052 /* AssertEventually.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CABB0624630AC600240052 /* AssertEventually.swift */; };
 		79D50C7724321BDA0052BA03 /* Client+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D50C7624321BDA0052BA03 /* Client+Events.swift */; };
 		79EE393C2453204E0034EBF3 /* StreamChatClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A50694F23CDEA31009F127A /* StreamChatClient.framework */; };
@@ -306,6 +307,7 @@
 		791664DE245AC89E0020710B /* Client+DevicesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Client+DevicesTests.swift"; sourceTree = "<group>"; };
 		791664E1245AF8AF0020710B /* AssertNetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertNetworkRequest.swift; sourceTree = "<group>"; };
 		7920E84E2449C6EF00CCBFBF /* fastlane */ = {isa = PBXFileReference; lastKnownFileType = folder; path = fastlane; sourceTree = "<group>"; };
+		79324B7A2462A08A00B2597E /* AtomicTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
 		794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestableCodingKey.swift; sourceTree = "<group>"; };
 		795FCD1B23EB155000990F15 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+Gzip.swift"; sourceTree = "<group>"; };
@@ -707,6 +709,7 @@
 		8AC0D94D23D4BA640080B8BC /* Unit Tests */ = {
 			isa = PBXGroup;
 			children = (
+				79324B7A2462A08A00B2597E /* AtomicTests.swift */,
 				8AC0D94E23D4BA7D0080B8BC /* FilterTests.swift */,
 				465D64C1231808A2006BAE42 /* AttachmentTypeTests.swift */,
 				8A30D07A237D81C20082B951 /* StringExtensionsTests.swift */,
@@ -1702,6 +1705,7 @@
 			files = (
 				8AFA57292418EC1700FD07EC /* StringExtensionsTests.swift in Sources */,
 				8AE6206E23CF658700AB3426 /* User+Tests.swift in Sources */,
+				79CABAFE2462A4E400240052 /* AtomicTests.swift in Sources */,
 				791664E2245AF8AF0020710B /* AssertNetworkRequest.swift in Sources */,
 				79CABB0724630AC600240052 /* AssertEventually.swift in Sources */,
 				79411CD42462DC0A003972E9 /* ClientLoggerTests.swift in Sources */,

--- a/Tests/Client/Custom Assertions/AssertEventually.swift
+++ b/Tests/Client/Custom Assertions/AssertEventually.swift
@@ -1,0 +1,43 @@
+//
+//  AssertNetworkRequest.swift
+//  StreamChatClientTests
+//
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import XCTest
+
+/// The default timeout value use by the `Assert___Eventually` family of functions.
+private let defaultTimeout: TimeInterval = 1
+
+/// How big is the period between expression evaluations.
+private let evaluationPeriod: TimeInterval = 0.001
+
+
+/// Blocks the current test execution and periodically checks for the equality of the provided expressions. Fails if
+/// the expression results are not equal within the `timeout` period.
+///
+/// - Parameters:
+///   - expression1: The first expression to evaluate.
+///   - expression2: The first expression to evaluate.
+///   - timeout: The maximum time the function waits for the expression results to equal.
+///
+/// - Warning: ⚠️ Both expressions are evaluated repeatedly during the function execution. The expressions should not have
+///   any side effects which can affect their results.
+func AssertEqualEventually<T: Equatable>(_ expression1: @autoclosure () -> T?,
+                                         _ expression2: @autoclosure () -> T?,
+                                         timeout: TimeInterval = defaultTimeout,
+                                         file: StaticString = #file,
+                                         line: UInt = #line) {
+
+    let startTimestamp = Date().timeIntervalSince1970
+
+    while Date().timeIntervalSince1970 - startTimestamp < timeout {
+        if expression1() == expression2() {
+            return
+        }
+        _ = XCTWaiter.wait(for: [.init()], timeout: evaluationPeriod)
+    }
+
+    XCTAssertEqual(expression1(), expression2(), file: file, line: line)
+}

--- a/Tests/Client/Custom Assertions/AssertEventually.swift
+++ b/Tests/Client/Custom Assertions/AssertEventually.swift
@@ -41,3 +41,30 @@ func AssertEqualEventually<T: Equatable>(_ expression1: @autoclosure () -> T?,
 
     XCTAssertEqual(expression1(), expression2(), file: file, line: line)
 }
+
+
+/// Blocks the current test execution and periodically checks if the expression evaluates to `nil`. Fails if
+/// the expression result is not `nil` within the `timeout` period.
+///
+/// - Parameters:
+///   - expression: The expression to evaluate.
+///   - timeout: The maximum time the function waits for the expression results to equal.
+///
+/// - Warning: ⚠️ The expression is evaluated repeatedly during the function execution. It should not have
+///   any side effects which can affect its result.
+func AssertNilEventually<T>(_ expression: @autoclosure () -> T?,
+                            timeout: TimeInterval = defaultTimeout,
+                            file: StaticString = #file,
+                            line: UInt = #line) {
+
+    let startTimestamp = Date().timeIntervalSince1970
+
+    while Date().timeIntervalSince1970 - startTimestamp < timeout {
+        if expression() == nil {
+            return
+        }
+        _ = XCTWaiter.wait(for: [.init()], timeout: evaluationPeriod)
+    }
+
+    XCTAssertNil(expression(), file: file, line: line)
+}

--- a/Tests/Client/Unit Tests/AtomicTests.swift
+++ b/Tests/Client/Unit Tests/AtomicTests.swift
@@ -1,0 +1,104 @@
+//
+//  AtomicTests.swift
+//  StreamChatClientTests
+//
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import XCTest
+@testable import StreamChatClient
+
+class AtomicTests: XCTestCase {
+
+    func test_Atomic_whenValueChanged_callsDidSetCallback() {
+        // Setup
+        let initialValue = "Anakin"
+        let newValue = "Vader"
+
+        var callbackNewValue: String?
+        var callbackOldValue: String?
+
+        let atomicValue = Atomic(initialValue, callbackQueue: .testQueue) {
+            XCTAssertTrue(DispatchQueue.isTestQueue, "Callback called on an incorrect queue.")
+            callbackNewValue = $0
+            callbackOldValue = $1
+        }
+        assert(atomicValue.get() == initialValue)
+
+        // Action
+        atomicValue.set(newValue)
+
+        // Assert
+        AssertEqualEventually(callbackNewValue, newValue)
+        AssertEqualEventually(callbackOldValue, initialValue)
+    }
+
+    func test_Atomic_keyPathHelpers() {
+        // Setup
+        struct Helper: Equatable {
+            var elements: [Int] = []
+        }
+        let atomicValue = Atomic(Helper())
+
+        // Actions
+        atomicValue.update(\.elements, to: [0])
+        XCTAssertEqual(atomicValue.get(), Helper(elements: [0]))
+
+        atomicValue.elements = [1]
+        XCTAssertEqual(atomicValue.get(), Helper(elements: [1]))
+
+        atomicValue.append(to: \.elements, 2)
+        XCTAssertEqual(atomicValue.get(), Helper(elements: [1, 2]))
+    }
+
+    func test_Atomic_dictionaryHelpers() {
+        let atomicValue = Atomic(["Luke": 1])
+        XCTAssertEqual(atomicValue["Luke"], 1)
+    }
+
+    func test_Atomic_whenCalledRecursively() {
+        // Setup
+        let atomicValue = Atomic("Luke")
+
+        // Action
+        atomicValue.update { (oldValue) -> String? in
+            // The current value should be same as `oldValue`
+            XCTAssertEqual(atomicValue.get(), oldValue)
+
+            atomicValue.set("Skywalker")
+            // The current value should be updated
+            XCTAssertEqual(atomicValue.get(), "Skywalker")
+
+            atomicValue.update { oldValue in
+                // The current value should be same as `oldValue`
+                XCTAssertEqual(atomicValue.get(), oldValue)
+                return "Vader!"
+            }
+            // The current value should be updated
+            XCTAssertEqual(atomicValue.get(), "Vader!")
+
+            // Finally, the return value from `update` closure should override previous changes
+            return "Leia"
+        }
+
+        XCTAssertEqual(atomicValue.get(), "Leia")
+    }
+}
+
+private extension DispatchQueue {
+
+    private static let queueIdKey = DispatchSpecificKey<String>()
+    private static let testQueueId = UUID().uuidString
+
+    /// Creates a queue which can be later identified.
+    static var testQueue: DispatchQueue {
+        let queue = DispatchQueue(label: "Test queue")
+        queue.setSpecific(key: Self.queueIdKey, value: testQueueId)
+        return queue
+    }
+
+    /// Checks if the current queue is the queue created by `DispatchQueue.testQueue`.
+    static var isTestQueue: Bool {
+        DispatchQueue.getSpecific(key: queueIdKey) == testQueueId
+    }
+}


### PR DESCRIPTION
### In this PR:

- I created two new async assertions `AssertEqualEventually` and `AssertNilEventually`. They are inspired by [Nimble](https://github.com/Quick/Nimble) and they allow us to write async assertions as they were synchronous.

- I added a test suite for `Atomic` and changed its implementation from using `DispatchQueue` to `NSRecursiveLock`.

---

[Closes #252]