### PR TITLE
Removed forced optional type used in `Atomic`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   public init(attachment:fileName:)
   ```
   since they were unused. Please use `init(channel:url:)` initializer. 
+- `Atomic.get(default: T) -> T` function was deprecated for non-optional `T` [#241](https://github.com/GetStream/stream-chat-swift/issues/241)
+- `Atomic.get()` no longer returns an optional type if the wrapped type itself is not optional  [#241](https://github.com/GetStream/stream-chat-swift/issues/241)
+- `Atomic.init(_:)` requires the initial value for non-optional `T` [#241](https://github.com/GetStream/stream-chat-swift/issues/241)
+- `Atomic.DidSetCallback` signature changed from `(_ value: T?, _ oldValue: T?) -> Void` to `(_ value: T, _ oldValue: T) -> Void` [#241](https://github.com/GetStream/stream-chat-swift/issues/241)
 
 ### 🐞 Fixed
 - Fix rx observing for the connection state [#249](https://github.com/GetStream/stream-chat-swift/issues/249).

--- a/Sources/Client/Client/Client+UnreadCount.swift
+++ b/Sources/Client/Client/Client+UnreadCount.swift
@@ -72,7 +72,7 @@ extension Client {
 extension Client {
     func updateChannelsForWatcherAndUnreadCount(event: Event) {
         if case .notificationMarkAllRead(let messageRead, _) = event {
-            watchingChannelsAtomic.get(default: [:]).forEach {
+            watchingChannelsAtomic.get().forEach {
                 $0.value.forEach {
                     if let channel = $0.value {
                         channel.resetUnreadCount(messageRead: messageRead)
@@ -115,7 +115,7 @@ extension Client {
 extension Client {
     // Update unread and watcher counts for all channels with the same cid.
     func refreshWatchingChannels(with channel: Channel) {
-        guard let weakWatchingChannels = watchingChannelsAtomic.get(default: [:])[channel.cid], !weakWatchingChannels.isEmpty else {
+        guard let weakWatchingChannels = watchingChannelsAtomic.get()[channel.cid], !weakWatchingChannels.isEmpty else {
             watchingChannelsAtomic.add(channel, key: channel.cid)
             return
         }

--- a/Sources/Client/Client/Client+WebSocket.swift
+++ b/Sources/Client/Client/Client+WebSocket.swift
@@ -81,7 +81,8 @@ extension Client {
     private func restoreWatchingChannels() {
         watchingChannelsAtomic.flush()
         
-        guard let keys = watchingChannelsAtomic.get()?.keys, !keys.isEmpty else {
+        let keys = watchingChannelsAtomic.get().keys
+        guard !keys.isEmpty else {
             return
         }
         

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -81,7 +81,7 @@ public final class Channel: Codable {
     /// Checks if read events evalable for the current user.
     public var readEventsEnabled: Bool { config.readEventsEnabled && members.contains(Member.current) }
     /// Returns the current unread count.
-    public var unreadCount: ChannelUnreadCount { unreadCountAtomic.get(default: .noUnread) }
+    public var unreadCount: ChannelUnreadCount { unreadCountAtomic.get() }
     
     private(set) lazy var unreadCountAtomic = Atomic<ChannelUnreadCount>(.noUnread, callbackQueue: .main) { [weak self] _, _ in
         if let self = self {
@@ -90,7 +90,7 @@ public final class Channel: Codable {
     }
     
     /// Online watchers in the channel.
-    public var watcherCount: Int { watcherCountAtomic.get(default: 0) }
+    public var watcherCount: Int { watcherCountAtomic.get() }
     
     private(set) lazy var watcherCountAtomic = Atomic(0, callbackQueue: .main) { [weak self] _, _ in
         if let self = self {
@@ -98,7 +98,7 @@ public final class Channel: Codable {
         }
     }
     
-    let unreadMessageReadAtomic = Atomic<MessageRead>()
+    let unreadMessageReadAtomic = Atomic<MessageRead?>(nil)
     /// Unread message state for the current user.
     public var unreadMessageRead: MessageRead? { unreadMessageReadAtomic.get() }
     /// Checks if the current status of the channel is unread.

--- a/Sources/Client/Utils/Atomic.swift
+++ b/Sources/Client/Utils/Atomic.swift
@@ -9,6 +9,9 @@
 import Foundation
 
 /// A mutable thread safe variable.
+///
+/// - Note: Even though the value guarded by `Atomic` is thread-safe, the `Atomic` class itself is not. Mutating the instance
+/// itself from multiple threads can cause a crash.
 @dynamicMemberLookup
 public final class Atomic<T> {
     /// A didSet callback type.

--- a/Sources/Client/Utils/Atomic.swift
+++ b/Sources/Client/Utils/Atomic.swift
@@ -12,11 +12,11 @@ import Foundation
 @dynamicMemberLookup
 public final class Atomic<T> {
     /// A didSet callback type.
-    public typealias DidSetCallback = (_ value: T?, _ oldValue: T?) -> Void
+    public typealias DidSetCallback = (_ value: T, _ oldValue: T) -> Void
 
     private let lock = NSRecursiveLock()
 
-    private var value: T? {
+    private var value: T {
         didSet {
             if let callbackQueue = callbackQueue {
                 callbackQueue.async {
@@ -32,25 +32,26 @@ public final class Atomic<T> {
     private var didSet: DidSetCallback?
     private var callbackQueue: DispatchQueue?
 
-    /// Init a Atomic.
+    /// Creates a new `Atomic` instance.
     ///
     /// - Parameters:
-    ///   - value: an initial value.
-    ///   - didSet: a didSet callback.
-    public init(_ value: T? = nil, callbackQueue: DispatchQueue? = .global(qos: .userInitiated), _ didSet: DidSetCallback? = nil) {
+    ///   - value: The initial value.
+    ///   - callbackQueue: The queue which is used for `didSet` callback calls.
+    ///   - didSet: Called after the current value of `Atomic` is changed.
+    public init(_ value: T, callbackQueue: DispatchQueue? = .global(qos: .userInitiated), _ didSet: DidSetCallback? = nil) {
         self.value = value
         self.callbackQueue = callbackQueue
         self.didSet = didSet
     }
     
     /// Set a value.
-    public func set(_ newValue: T?) {
+    public func set(_ newValue: T) {
         lock.lock()
         value = newValue
         lock.unlock()
     }
 
-    public func get() -> T? {
+    public func get() -> T {
         lock.lock(); defer { lock.unlock() }
         return value
 
@@ -60,17 +61,16 @@ public final class Atomic<T> {
     ///
     /// - Parameter default: a default value.
     /// - Returns: a stored value or default.
+    @available (*, deprecated, message: "Using `get(default:)` for non-optional types is deprecated because it has no effect.")
     public func get(default: T) -> T {
-        get() ?? `default`
+        get()
     }
     
     /// Update the value safely.
     /// - Parameter changes: a block with changes. It should return a new value.
-    public func update(_ changes: (T) -> T?) {
+    public func update(_ changes: (T) -> T) {
         lock.lock()
-        if let currentValue = value {
-            value = changes(currentValue)
-        }
+        value = changes(value)
         lock.unlock()
     }
 }
@@ -104,17 +104,44 @@ public extension Atomic {
     }
     
     /// Accesses a sub value by the given keypath.
-    subscript<Element>(dynamicMember keyPath: WritableKeyPath<T, Element>) -> Element? {
+    subscript<Element>(dynamicMember keyPath: WritableKeyPath<T, Element>) -> Element {
         get {
-            return get()?[keyPath: keyPath]
+            return get()[keyPath: keyPath]
         }
         set {
-            if let newValue = newValue {
-                update(keyPath, to: newValue)
-            }
+            update(keyPath, to: newValue)
         }
     }
 }
+
+// MARK: - Helpers for optional T
+
+// swiftlint:disable syntactic_sugar
+extension Atomic {
+    
+    /// Creates a new `Atomic` instance with the initial value of `nil`.
+    ///
+    /// - Parameters:
+    ///   - callbackQueue: The queue which is used for `didSet` callback calls.
+    ///   - didSet: Called after the current value of `Atomic` is changed.
+    public convenience init<Wrapped>(callbackQueue: DispatchQueue? = .global(qos: .userInitiated),
+                                     _ didSet: DidSetCallback? = nil) where T == Optional<Wrapped> {
+        self.init(.none, callbackQueue: callbackQueue, didSet)
+    }
+    
+    /// Returns the current value if not `nil` or returns the default value.
+    ///
+    /// - Parameter default: The value used if the current value of `Atomic` is `nil`.
+    public func get<Wrapped>(default: Wrapped) -> Wrapped where T == Optional<Wrapped> {
+        switch get() {
+        case .none:
+            return `default`
+        case let .some(some):
+            return some
+        }
+    }
+}
+// swiftlint:enable syntactic_sugar
 
 // MARK: - Helper for Collection
 
@@ -123,7 +150,7 @@ public extension Atomic where T: Collection {
     // swiftlint:disable:next syntactic_sugar
     subscript<Key: Hashable, Value>(key: Key) -> Value? where T == Dictionary<Key, Value> {
         lock.lock(); defer { lock.unlock() }
-        return value?[key]
+        return value[key]
     }
 }
 

--- a/Sources/Client/WebSocket/WebSocket.swift
+++ b/Sources/Client/WebSocket/WebSocket.swift
@@ -26,13 +26,11 @@ final class WebSocket {
     private(set) var connectionId: String?
     private(set) var eventError: ClientErrorResponse?
     
-    var connectionState: ConnectionState { connectionStateAtomic.get(default: .notConnected) }
+    var connectionState: ConnectionState { connectionStateAtomic.get() }
     
     private lazy var connectionStateAtomic =
         Atomic<ConnectionState>(.notConnected, callbackQueue: nil) { [weak self] connectionState, _ in
-            if let connectionState = connectionState {
-                self?.publishEvent(.connectionChanged(connectionState))
-            }
+            self?.publishEvent(.connectionChanged(connectionState))
     }
     
     private lazy var handshakeTimer =

--- a/Sources/Core/Presenter/Channel/ChannelPresenter.swift
+++ b/Sources/Core/Presenter/Channel/ChannelPresenter.swift
@@ -41,18 +41,13 @@ public final class ChannelPresenter: Presenter {
     let channelId: String
     let channelPublishSubject = PublishSubject<Channel>()
     
-    private(set) lazy var channelAtomic = Atomic<Channel>(callbackQueue: .main) { [weak self] channel, oldChannel in
-        if let channel = channel {
-            if let oldChannel = oldChannel {
-                channel.banEnabling = oldChannel.banEnabling
-            }
-            
-            self?.channelPublishSubject.onNext(channel)
-        }
+    private(set) lazy var channelAtomic = Atomic<Channel>(.unused, callbackQueue: .main) { [weak self] channel, oldChannel in
+        channel.banEnabling = oldChannel.banEnabling
+        self?.channelPublishSubject.onNext(channel)
     }
     
     /// A channel (see `Channel`).
-    public var channel: Channel { channelAtomic.get(default: .unused) }
+    public var channel: Channel { channelAtomic.get() }
     /// A parent message for replies.
     public let parentMessage: Message?
     /// Query options.
@@ -61,7 +56,7 @@ public final class ChannelPresenter: Presenter {
     public var editMessage: Message?
     /// Show statuses separators, e.g. Today
     public var showStatuses = true
-    let lastMessageAtomic = Atomic<Message>()
+    let lastMessageAtomic = Atomic<Message?>()
     /// The last parsed message from WebSocket events.
     public var lastMessage: Message? { lastMessageAtomic.get() }
     var lastAddedOwnMessage: Message?

--- a/Tests/Client/Unit Tests/AtomicTests.swift
+++ b/Tests/Client/Unit Tests/AtomicTests.swift
@@ -182,7 +182,6 @@ extension AtomicTests {
     }
 
     func test_Atomic_whenSetAndGetCalledSimultaneously() {
-
         var atomicValue: Atomic<[String: Int]>! = .init([:])
 
         for idx in 0..<numberOfStressTestCycles {
@@ -196,7 +195,9 @@ extension AtomicTests {
             }
 
             for _ in 0...5 {
-                DispatchQueue.random.async {
+                // We need to capture the value explicitly. Without this the tests randomly crashes after
+                // `atomicValue` is assigned to `nil`.
+                DispatchQueue.random.async { [atomicValue] in
                     _ = atomicValue?.get()
                 }
             }

--- a/Tests/Client/Unit Tests/AtomicTests.swift
+++ b/Tests/Client/Unit Tests/AtomicTests.swift
@@ -51,6 +51,24 @@ class AtomicTests: XCTestCase {
         XCTAssertEqual(atomicValue.get(), Helper(elements: [1, 2]))
     }
 
+    func test_Atomic_keyPathHelpersWithOptionalElement() {
+        // Setup
+        struct Helper: Equatable {
+            var elements: [Int]? = []
+        }
+        let atomicValue: Atomic<Helper> = Atomic(Helper())
+
+        // Actions
+        atomicValue.update(\.elements, to: [0])
+        XCTAssertEqual(atomicValue.get(), Helper(elements: [0]))
+
+        atomicValue.elements = [1]
+        XCTAssertEqual(atomicValue.get(), Helper(elements: [1]))
+
+        atomicValue.elements = nil
+        XCTAssertEqual(atomicValue.get(), Helper(elements: nil))
+    }
+    
     func test_Atomic_dictionaryHelpers() {
         let atomicValue = Atomic(["Luke": 1])
         XCTAssertEqual(atomicValue["Luke"], 1)
@@ -82,6 +100,20 @@ class AtomicTests: XCTestCase {
         }
 
         XCTAssertEqual(atomicValue.get(), "Leia")
+    }
+    
+    func test_Atomic_withOptionalType() {
+        let atomicValue: Atomic<String?> = Atomic(nil)
+        XCTAssertEqual(atomicValue.get(), nil)
+        
+        atomicValue.set("Luke")
+        XCTAssertEqual(atomicValue.get(), "Luke")
+        
+        atomicValue.update { (current) -> String? in
+            XCTAssertEqual(atomicValue.get(), "Luke")
+            return nil
+        }
+        XCTAssertEqual(atomicValue.get(), nil)
     }
 }
 

--- a/Tests/Client/Unit Tests/AtomicTests.swift
+++ b/Tests/Client/Unit Tests/AtomicTests.swift
@@ -79,7 +79,7 @@ class AtomicTests: XCTestCase {
         let atomicValue = Atomic("Luke")
 
         // Action
-        atomicValue.update { (oldValue) -> String? in
+        atomicValue.update { (oldValue) -> String in
             // The current value should be same as `oldValue`
             XCTAssertEqual(atomicValue.get(), oldValue)
 
@@ -172,7 +172,7 @@ extension AtomicTests {
             }
         }
 
-        AssertEqualEventually(atomicValue.get()?.count, numberOfStressTestCycles)
+        AssertEqualEventually(atomicValue.get().count, numberOfStressTestCycles)
 
         // Check for memory leaks
         weak var weakValue = atomicValue
@@ -202,7 +202,7 @@ extension AtomicTests {
             }
         }
 
-        AssertEqualEventually(atomicValue.get()?.count, numberOfStressTestCycles)
+        AssertEqualEventually(atomicValue.get().count, numberOfStressTestCycles)
 
         // Check for memory leaks
         weak var weakValue = atomicValue


### PR DESCRIPTION
### In the PR:
- `value` in `Atomic` is no longer treated as `Optional` by default
- `Atomic` stress tests random crash (hopefully) fixed 🤞 

---

@buh  @b-onc Please review and test this **extremely** carefully. I touched a lot of different parts of the app and could easily introduce some copy-paste/typo kind of bug 🙏 