### PR TITLE
Fix RxSwift warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recover the default extra data for User and Channel types [#238](https://github.com/GetStream/stream-chat-swift/issues/238).
 - Crashes on `channel.rx.events` and `channel.rx.unreadCount` [#248](https://github.com/GetStream/stream-chat-swift/issues/248).
 - It's now possible to access `Atomic` value within its own `update { }` block [#251](https://github.com/GetStream/stream-chat-swift/pull/251)
+- Fixed warning in AutoCancellingSubscription [#254](https://github.com/GetStream/stream-chat-swift/issues/254)
 
 # [2.1.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.1.1)
 _May 01, 2020_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recover the default extra data for User and Channel types [#238](https://github.com/GetStream/stream-chat-swift/issues/238).
 - Crashes on `channel.rx.events` and `channel.rx.unreadCount` [#248](https://github.com/GetStream/stream-chat-swift/issues/248).
 - It's now possible to access `Atomic` value within its own `update { }` block [#251](https://github.com/GetStream/stream-chat-swift/pull/251)
-- Fixed warning in AutoCancellingSubscription [#254](https://github.com/GetStream/stream-chat-swift/issues/254)
+- Fixed warning in AutoCancellingSubscription [#256](https://github.com/GetStream/stream-chat-swift/issues/256)
 
 # [2.1.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.1.1)
 _May 01, 2020_

--- a/Sources/Core/Client/AutoCancellingSubscription.swift
+++ b/Sources/Core/Client/AutoCancellingSubscription.swift
@@ -64,20 +64,13 @@ extension ObservableType {
     }
     
     private func subscribe<T>(to onNext: @escaping Client.Completion<T>) -> Disposable where Element == T {
-        return subscribe({ event in
-            switch event {
-            case let .next(element):
-                onNext(.success(element))
-                
-            case .completed:
-                break
-                
-            case let .error(error):
-                if let clientError = error as? ClientError {
-                    onNext(.failure(clientError))
-                } else {
-                    onNext(.failure(.unexpectedError(description: error.localizedDescription, error: error)))
-                }
+        return subscribe(onNext: { (element) in
+            onNext(.success(element))
+        }, onError: { (error) in
+            if let clientError = error as? ClientError {
+                onNext(.failure(clientError))
+            } else {
+                onNext(.failure(.unexpectedError(description: error.localizedDescription, error: error)))
             }
         })
     }

--- a/Sources/Core/Client/AutoCancellingSubscription.swift
+++ b/Sources/Core/Client/AutoCancellingSubscription.swift
@@ -64,7 +64,7 @@ extension ObservableType {
     }
     
     private func subscribe<T>(to onNext: @escaping Client.Completion<T>) -> Disposable where Element == T {
-        return subscribe(onNext: { (element) in
+        subscribe(onNext: { (element) in
             onNext(.success(element))
         }, onError: { (error) in
             if let clientError = error as? ClientError {


### PR DESCRIPTION
RxSwift Event type can have unknown values in updates, better to not use switch on it
