### PR TITLE
Fix clientId is required for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ✅ Added
 - Added `ClientLogger.iconEnabled`, `ClientLogger.dateEnabled`, and `ClientLogger.levelEnabled` to control what will be shown in logs.
   These will only be valid when `ClientLogger.logger` block is not customized (overridden) [#263](https://github.com/GetStream/stream-chat-swift/issues/263)
+  - `silent` property added to messages, see docs [here](https://getstream.io/chat/docs/silent_messages/?language=swift) [#264](https://github.com/GetStream/stream-chat-swift/issues/264)
 
 ### 🔄 Changed
 - `ClientLogger.logger` is deprecated, please use `ClientLogger.log` block to customize your log output [#263](https://github.com/GetStream/stream-chat-swift/issues/263)
 - Logs will now output log level, access it when overriding `ClientLogger.log` block [#263](https://github.com/GetStream/stream-chat-swift/issues/263)
 - By default, logs will not output emoji icons anymore, but all logs will now output date [#263](https://github.com/GetStream/stream-chat-swift/issues/263)
 
-
-### ✅ Added
-  - `silent` property added to messages, see docs in https://getstream.io/chat/docs/silent_messages/?language=swift [#264](https://github.com/GetStream/stream-chat-swift/issues/264)
+### 🐞 Fixed
+- `set(user:)` is not required for query (channels, users) unless `presence: true` or `state: true` is specified [#269](https://github.com/GetStream/stream-chat-swift/issues/269)
 
 # [2.2.0](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.0)
 _May 08, 2020_

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -114,7 +114,7 @@ public final class Client: Uploader {
     var needsToRecoverConnection = false
     
     let defaultURLSessionConfiguration: URLSessionConfiguration
-    lazy var urlSession = URLSession(configuration: self.defaultURLSessionConfiguration)
+    lazy var urlSession = setupURLSession()
     
     lazy var urlSessionTaskDelegate = ClientURLSessionTaskDelegate() // swiftlint:disable:this weak_delegate
     let callbackQueue: DispatchQueue?

--- a/Sources/Client/Client/Endpoint.swift
+++ b/Sources/Client/Client/Endpoint.swift
@@ -333,10 +333,13 @@ extension Endpoint {
     
     var requiresConnectionId: Bool {
         switch self {
-        case .users,
-             .updateUsers,
-             .channels,
-             .channel,
+        case .users(let query):
+            return query.options.contains(.presence) || query.options.contains(.state)
+        case .channels(let query):
+            return query.options.contains(.presence) || query.options.contains(.state)
+        case .channel(let query):
+            return query.options.contains(.presence) || query.options.contains(.state)
+        case .updateUsers,
              .stopWatching:
             return true
         case .guestToken,


### PR DESCRIPTION
Backend has informed me that it's not actually required unless presence or state is requested

Also fixed CHANGELOG since it was broken
