### PR TITLE
Fix infinite loop when `URLSessionWebSocketTask` fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🐞 Fixed
 - `set(user:)` is not required for query (channels, users) unless `presence: true` or `state: true` is specified [#269](https://github.com/GetStream/stream-chat-swift/issues/269)
 - Fix crash in iOS12 caused by abstract URLSession instance [#272](https://github.com/GetStream/stream-chat-swift/issues/272)
+- Fix infinite loop when the web socket connection fails (iOS13 only) [#273](https://github.com/GetStream/stream-chat-swift/pull/273).
 
 # [2.2.0](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.0)
 _May 08, 2020_

--- a/Sources/Client/WebSocket/Provider/URLSessionWebSocketProvider.swift
+++ b/Sources/Client/WebSocket/Provider/URLSessionWebSocketProvider.swift
@@ -48,14 +48,14 @@ final class URLSessionWebSocketProvider: NSObject, WebSocketProvider, URLSession
                 if case .string(let string) = message {
                     self.callDelegateInCallbackQueue { $0?.websocketDidReceiveMessage(string) }
                 }
+                self.doRead()
+                
             case .failure(let error):
                 self.disconnect(with: WebSocketProviderError(reason: error.localizedDescription,
                                                              code: (error as NSError).code,
                                                              providerType: URLSessionWebSocketProvider.self,
                                                              providerError: error))
             }
-            
-            self.doRead()
         }
     }
     


### PR DESCRIPTION
### In this PR:

- The original implementation didn't behave correctly when the WS connection fails and ended up in the infinite loop and crashed.

- We do not want to call `doRead()` again when the connection fails.
