### PR TITLE
Improve test stability

### DIFF
--- a/Sources/Client/Client/Client+Request.swift
+++ b/Sources/Client/Client/Client+Request.swift
@@ -18,7 +18,7 @@ extension Client {
         logger?.log(headers: headers)
         let config = defaultURLSessionConfiguration
         config.waitsForConnectivity = true
-        config.httpAdditionalHeaders = headers
+        config.httpAdditionalHeaders?.merge(headers, uniquingKeysWith: { (_, new) in new })
         return URLSession(configuration: config, delegate: urlSessionTaskDelegate, delegateQueue: nil)
     }
     

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		79273EB4246AD1E900B0A574 /* Channel_SilentMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79273EB3246AD1E900B0A574 /* Channel_SilentMessageTests.swift */; };
 		79273EB6246AE1EF00B0A574 /* Client_SilentMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79273EB5246AE1EF00B0A574 /* Client_SilentMessageTests.swift */; };
 		79273EBA246AEC9200B0A574 /* SharedClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79273EB9246AEC9200B0A574 /* SharedClient.swift */; };
+		79273EC2246EB64E00B0A574 /* AssertJSONEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79273EC1246EB64E00B0A574 /* AssertJSONEqual.swift */; };
+		79273EC3246EB64E00B0A574 /* AssertJSONEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79273EC1246EB64E00B0A574 /* AssertJSONEqual.swift */; };
+		79273EC4246EB64E00B0A574 /* AssertJSONEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79273EC1246EB64E00B0A574 /* AssertJSONEqual.swift */; };
 		793612F62461437700944861 /* MockNetworkURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793612F52461437700944861 /* MockNetworkURLProtocol.swift */; };
 		793612FE2461684500944861 /* AssertResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793612FD2461684500944861 /* AssertResult.swift */; };
 		793613002461780400944861 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793612FF2461780400944861 /* Await.swift */; };
@@ -320,6 +323,7 @@
 		79273EB3246AD1E900B0A574 /* Channel_SilentMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Channel_SilentMessageTests.swift; sourceTree = "<group>"; };
 		79273EB5246AE1EF00B0A574 /* Client_SilentMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client_SilentMessageTests.swift; sourceTree = "<group>"; };
 		79273EB9246AEC9200B0A574 /* SharedClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedClient.swift; sourceTree = "<group>"; };
+		79273EC1246EB64E00B0A574 /* AssertJSONEqual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertJSONEqual.swift; sourceTree = "<group>"; };
 		79324B7A2462A08A00B2597E /* AtomicTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
 		793612F52461437700944861 /* MockNetworkURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkURLProtocol.swift; sourceTree = "<group>"; };
 		793612FD2461684500944861 /* AssertResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertResult.swift; sourceTree = "<group>"; };
@@ -663,6 +667,7 @@
 				791664E1245AF8AF0020710B /* AssertNetworkRequest.swift */,
 				793612FD2461684500944861 /* AssertResult.swift */,
 				79CABB0624630AC600240052 /* AssertAsync.swift */,
+				79273EC1246EB64E00B0A574 /* AssertJSONEqual.swift */,
 			);
 			path = "Custom Assertions";
 			sourceTree = "<group>";
@@ -1653,6 +1658,7 @@
 			files = (
 				791664E3245AF90A0020710B /* RequestRecorderURLProtocol.swift in Sources */,
 				79EE3942245320610034EBF3 /* ClientTests00.swift in Sources */,
+				79273EC2246EB64E00B0A574 /* AssertJSONEqual.swift in Sources */,
 				79EE3944245320690034EBF3 /* ClientTests02+Users.swift in Sources */,
 				79EE3943245320650034EBF3 /* ClientTests01+Channels.swift in Sources */,
 				79EE3946245321820034EBF3 /* TestCase.swift in Sources */,
@@ -1756,6 +1762,7 @@
 				8AFA57292418EC1700FD07EC /* StringExtensionsTests.swift in Sources */,
 				793613002461780400944861 /* Await.swift in Sources */,
 				8AE6206E23CF658700AB3426 /* User+Tests.swift in Sources */,
+				79273EC3246EB64E00B0A574 /* AssertJSONEqual.swift in Sources */,
 				79273EBA246AEC9200B0A574 /* SharedClient.swift in Sources */,
 				79CABAFE2462A4E400240052 /* AtomicTests.swift in Sources */,
 				791664E2245AF8AF0020710B /* AssertNetworkRequest.swift in Sources */,
@@ -1778,6 +1785,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				79273EC4246EB64E00B0A574 /* AssertJSONEqual.swift in Sources */,
 				8A6F69D2230ECCD300B8CC1F /* User+Tests.swift in Sources */,
 				791664E4245AF90A0020710B /* RequestRecorderURLProtocol.swift in Sources */,
 			);

--- a/Tests/Client/Custom Assertions/AssertJSONEqual.swift
+++ b/Tests/Client/Custom Assertions/AssertJSONEqual.swift
@@ -1,0 +1,58 @@
+//
+//  AssertJSONEqual.swift
+//  StreamChat
+//
+//  Created by Bahadir Oncel on 15.05.2020.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+/// Helper function for creating NSError.
+func error(domain: String, code: Int = -1, message: @autoclosure () -> String) -> NSError {
+    NSError(domain: domain, code: code, userInfo: ["message:": message()])
+}
+
+/// Asserts the given 2 JSON Serializations are equal, by creating JSON objects from Data and comparing dictionaries.
+/// Recursively calls itself for nested dictionaries.
+/// - Parameters:
+///   - expression1: JSON object 1, as Data. From string, you can do `Data(jsonString.utf8)`
+///   - expression2: JSON object 2, as Data.
+///   - file: file the assert is being made
+///   - line: line the assert is being made.
+func AssertJSONEqual(_ expression1: @autoclosure () throws -> Data,
+                     _ expression2: @autoclosure () throws -> Data,
+                     file: StaticString = #file,
+                     line: UInt = #line) {
+    do {
+        guard let json1 = try JSONSerialization.jsonObject(with: expression1()) as? [String: Any] else {
+            throw error(domain: "AssertJSONEqual", message: "First expression is not a valid json object!")
+        }
+        guard let json2 = try JSONSerialization.jsonObject(with: expression2()) as? [String: Any] else {
+            throw error(domain: "AssertJSONEqual", message: "Second expression is not a valid json object!")
+        }
+        guard json1.keys == json2.keys else {
+            throw error(domain: "AssertJSONEqual", message: "JSON keys do not match")
+        }
+        try json1.forEach { (key, value) in
+            guard let value2 = json2[key] else {
+                throw error(domain: "AssertJSONEqual", message: "Expression 2 does not have value for \(key)")
+            }
+            if let nestedDict1 = value as? [String: Any] {
+                if let nestedDict2 = value2 as? [String: Any] {
+                    try AssertJSONEqual(JSONSerialization.data(withJSONObject: nestedDict1),
+                                        JSONSerialization.data(withJSONObject: nestedDict2),
+                                        file: file,
+                                        line: line)
+                } else {
+                    throw error(domain: "AssertJSONEqual", message:  "Values for key \(key) do not match")
+                }
+            } else if String(describing: value) != String(describing: value2) {
+                throw error(domain: "AssertJSONEqual", message: "Values for key \(key) do not match")
+            }
+        }
+    } catch {
+        XCTFail("Error: \(error)", file: file, line: line)
+    }
+}

--- a/Tests/Client/RequestRecorderURLProtocol.swift
+++ b/Tests/Client/RequestRecorderURLProtocol.swift
@@ -12,6 +12,8 @@ import XCTest
 /// and provides the latest network request made.
 class RequestRecorderURLProtocol: URLProtocol {
 
+    static let testSessionHeaderKey = "test_session_id"
+    
     private static var latestRequestExpectation: XCTestExpectation?
     private static var latestRequest: URLRequest?
 
@@ -34,16 +36,27 @@ class RequestRecorderURLProtocol: URLProtocol {
         return latestRequest
     }
 
+    /// If set, records only requests with `testSessionHeaderKey` header value set to this value. If `nil`, records all requests.
+    static var currentSessionId: String?
+    
     /// Cleans up existing waiters and recorded requests. We have to explictly reset the state because URLProtocols
     /// work with static variables.
     static func reset() {
+        currentSessionId = nil
         latestRequest = nil
         latestRequestExpectation = nil
     }
 
     override class func canInit(with request: URLRequest) -> Bool {
-        latestRequest = request
-        latestRequestExpectation?.fulfill()
+        guard let sessionId = currentSessionId else {
+            // No sessionId set, record all requests
+            record(request: request)
+            return false
+        }
+        
+        if sessionId == request.value(forHTTPHeaderField: testSessionHeaderKey) {
+            record(request: request)
+        }
         return false
     }
 
@@ -52,6 +65,11 @@ class RequestRecorderURLProtocol: URLProtocol {
         return request
     }
 
+    private static func record(request: URLRequest) {
+        latestRequest = request
+        latestRequestExpectation?.fulfill()
+    }
+    
     // MARK: Instance methods
 
     override func startLoading() {

--- a/Tests/Client/Unit Tests/Channel_SilentMessageTests.swift
+++ b/Tests/Client/Unit Tests/Channel_SilentMessageTests.swift
@@ -11,15 +11,15 @@ import XCTest
 
 class Channel_SilentMessageTests: XCTestCase {
     
-    private static let config = Client.Config(apiKey: "client_silentMessageTests")
-    private let config = Channel_SilentMessageTests.config
-    private var client: Client {
-        Client(config: config)
+    let client = sharedClient
+    
+    override func setUp() {
+        super.setUp()
+        
+        client.unreadCountAtomic.set(.noUnread)
     }
     
     func test_silentMessage_doesNotIncreaseUnreadCount() {
-        let client = self.client
-        
         let channel = client.channel(type: .messaging, id: "test-silent-message")
         
         let message = Message(text: "test", silent: true, user: .init(id: "test-sender"))
@@ -35,8 +35,6 @@ class Channel_SilentMessageTests: XCTestCase {
     }
     
     func test_silentMentionMessage_doesNotIncreaseUnreadCount() {
-        let client = self.client
-        
         client.userAtomic.set(.init(id: "test-mention"))
         
         let channel = client.channel(type: .messaging, id: "test-silent-message")
@@ -55,8 +53,6 @@ class Channel_SilentMessageTests: XCTestCase {
     }
     
     func test_silentDeletedMessage_doesNotDecreaseUnreadCount() {
-        let client = self.client
-        
         let channel = client.channel(type: .messaging, id: "test-silent-message")
         
         let message = Message(text: "test", silent: true, user: .init(id: "test-sender"), mentionedUsers: [User(id: "test-mention")])

--- a/Tests/Client/Unit Tests/Client+DevicesTests.swift
+++ b/Tests/Client/Unit Tests/Client+DevicesTests.swift
@@ -24,16 +24,25 @@ class Client_DevicesTests: XCTestCase {
         sessionConfig.protocolClasses?.insert(RequestRecorderURLProtocol.self, at: 0)
         sessionConfig.protocolClasses?.insert(MockNetworkURLProtocol.self, at: 1)
 
+        let testSessionId = UUID().uuidString
+        sessionConfig.httpAdditionalHeaders = [RequestRecorderURLProtocol.testSessionHeaderKey: testSessionId]
+        
         let clientConfig = Client.Config(apiKey: "test_api_key")
         // We can create a new `Client` instance because we don't use `Client.shared` in tests.
         client = Client(config: clientConfig, defaultURLSessionConfiguration: sessionConfig)
 
         testUser = User(id: "test_user_\(UUID())")
         client.set(user: testUser, token: "test_token")
+        
+        // Prepare the test environment
+        RequestRecorderURLProtocol.reset()
+        RequestRecorderURLProtocol.currentSessionId = testSessionId
+        
+        MockNetworkURLProtocol.reset()
     }
 
-    override func tearDown() {
-        // Reset all recorded requests and prepare it for another run
+    override class func tearDown() {
+        // Make sure everything is cleaned up
         RequestRecorderURLProtocol.reset()
         MockNetworkURLProtocol.reset()
         super.tearDown()

--- a/Tests/Client/Unit Tests/Client_SilentMessageTests.swift
+++ b/Tests/Client/Unit Tests/Client_SilentMessageTests.swift
@@ -11,15 +11,15 @@ import XCTest
 
 class Client_SilentMessageTests: XCTestCase {
     
-    private static let config = Client.Config(apiKey: "client_silentMessageTests")
-    private let config = Client_SilentMessageTests.config
-    private var client: Client {
-        Client(config: config)
+    let client = sharedClient
+    
+    override func setUp() {
+        super.setUp()
+        
+        client.unreadCountAtomic.set(.noUnread)
     }
     
     func test_silentMessage_doesNotIncreaseUnreadCount() {
-        let client = self.client
-        
         let channel = client.channel(type: .messaging, id: "test-silent-message")
         
         let message = Message(text: "test", silent: true, user: User(id: "test-sender"))
@@ -34,7 +34,6 @@ class Client_SilentMessageTests: XCTestCase {
     }
     
     func test_silentMentionMessage_doesNotIncreaseUnreadCount() {
-        let client = self.client
         client.userAtomic.set(.init(id: "test-mention"))
         
         let channel = client.channel(type: .messaging, id: "test-silent-message")
@@ -51,8 +50,6 @@ class Client_SilentMessageTests: XCTestCase {
     }
     
     func test_silentDeletedMessage_doesNotDecreaseUnreadCount() {
-        let client = sharedClient // since `updateUserUnreadCount` touches shared instance
-        
         client.userAtomic.set(.init(id: "test-mention"))
         
         let channel = client.channel(type: .messaging, id: "test-silent-message")

--- a/Tests/Client/Unit Tests/QueryEncodingTests.swift
+++ b/Tests/Client/Unit Tests/QueryEncodingTests.swift
@@ -23,20 +23,6 @@ final class QueryEncodingTests: XCTestCase {
     private let mediumPagination: () -> Pagination = { [.limit(10), .offset(20)] }
     private let complexPagination: () -> Pagination = { [.limit(10), .offset(10), .greaterThan("42"), .lessThan("92")] }
     
-    /// NOTE
-    /// Under the hood, `Pagination` is a Set, and Sets are unordered. This causes encodings to have nondeterministic string outputs.
-    /// For example, `complexPagination` can be encoded in any combination of its `PaginationOption`s. So both:
-    /// `{"id_gt":"42","id_lt":"92","offset":10,"limit":10}`
-    /// and
-    /// `{"id_lt":"92","id_gt":"42","offset":10,"limit":10}`
-    /// are valid, although our tests will fail for the latter.
-    /// If we assume the ordering is purely random, we have 1/4! chance of getting the ordering we are searching for.
-    /// For 1 roll, this means 1/24 = 0,041
-    /// For n rolls, our chances of getting the ordering we want _at least once_ is 1-(23/24)^n
-    /// So for 100 rolls, our chance of getting it once is 1-(23/24)^100 = 0,985
-    /// That's why we encode and compare the strings (up to) 100 times, to have a confidence interval of %98,5.
-    /// See `func nonDeterministicAssertEqual`
-    
     func testChannelQueryEncoding() {
         let query = { ChannelQuery(channel: self.channel,
                                    messagesPagination: self.simplePagination(),
@@ -46,7 +32,7 @@ final class QueryEncodingTests: XCTestCase {
         
         let expectedString = #"{"messages":{"limit":10},"watch":true,"watchers":{"id_gt":"42","id_lt":"92","offset":10,"limit":10},"members":{"limit":10,"offset":20}}"#
         
-        nonDeterministicAssertEqual(expectedString, try encode(query()))
+        AssertJSONEqual(Data(expectedString.utf8), try encode(query()))
     }
     
     func testChannelsQueryEncoding() {
@@ -55,74 +41,40 @@ final class QueryEncodingTests: XCTestCase {
                                     pagination: self.complexPagination(),
                                     messagesLimit: self.mediumPagination(),
                                     options: .presence) }
-        
+
         let expectedString = #"{"offset":10,"sort":[{"field":"name","direction":1}],"filter_conditions":{"id":42},"message_limit":10,"presence":true,"limit":10,"id_lt":"92","id_gt":"42"}"#
-        
-        nonDeterministicAssertEqual(expectedString, try encode(query()))
+
+        AssertJSONEqual(Data(expectedString.utf8), try encode(query()))
     }
-    
+
     func testSearchQueryEncoding() {
         let query = { SearchQuery(filter: self.mediumFilter,
                                   query: "hello",
                                   pagination: self.mediumPagination()) }
-        
+
         let expectedString = #"{"limit":10,"query":"hello","offset":20,"filter_conditions":{"$and":[{"members":{"$in":["john"]}},{"id":{"$autocomplete":"ro"}}]}}"#
-        
-        nonDeterministicAssertEqual(expectedString, try encode(query()))
+
+        AssertJSONEqual(Data(expectedString.utf8), try encode(query()))
     }
-    
+
     func testUsersQueryEncoding() {
         let query = { UsersQuery(filter: self.complexFilter,
                                sort: .init("name", isAscending: true),
                                options: .all) }
-        
+
         let expectedString = #"{"presence":true,"state":true,"watch":true,"sort":{"field":"name","direction":1},"filter_conditions":{"$and":[{"members":{"$in":["john"]}},{"unread_count":0},{"$or":[{"id":{"$gt":42}},{"$and":[{"avatar":{"$ne":"null"}},{"name":{"$autocomplete":"ro"}}]}]}]}}"#
-        
-        nonDeterministicAssertEqual(expectedString, try encode(query()))
+
+        AssertJSONEqual(Data(expectedString.utf8), try encode(query()))
     }
     
-    private func error(with message: String) -> NSError {
-        NSError(domain: "QueryGenerationTests", code: -1, userInfo: ["message:": message])
-    }
-    
-    /// - Returns: the string representation of the data
+    /// - Returns: Encoded data
     /// - Throws: Error to fail the test
-    private func encode<T: Encodable>(_ data: T) throws -> String {
+    private func encode<T: Encodable>(_ data: T) throws -> Data {
         do {
             let encoded = try encoder.encode(data)
-            guard let stringRep = String(data: encoded, encoding: .utf8) else {
-                throw error(with: "Failed to get string representation for data")
-            }
-            return stringRep
+            return encoded
         } catch let err {
-            throw error(with: "Error during encoding: \(err)")
+            throw error(domain: "QueryEncodingTests", message: "Error during encoding: \(err)")
         }
-    }
-    
-    private func nonDeterministicAssertEqual<T>(_ expression1: @autoclosure () throws -> T,
-                                                _ expression2: @autoclosure () throws -> T,
-                                                tryUpTo times: Int = 100) where T : StringProtocol {
-        var equal = false
-        
-        do {
-            let expr1 = try expression1()
-            let expr2 = try expression2()
-            
-            guard expr1.count == expr2.count else {
-                throw error(with: "Representation lenghts don't match")
-            }
-            
-            equal = equal || (expr1 == expr2)
-            
-            for _ in 0..<(times - 1) {
-                if equal { break }
-                try equal = equal || (expression1() == expression2())
-            }
-        } catch {
-            XCTFail("Threw \(error)")
-            return
-        }
-        
-        XCTAssert(equal, "Encoding did not match expected")
     }
 }

--- a/Tests/Client/Unit Tests/WebSocket/WebSocketTests.swift
+++ b/Tests/Client/Unit Tests/WebSocket/WebSocketTests.swift
@@ -12,7 +12,10 @@ import XCTest
 final class WebSocketTests: XCTestCase {
     
     let mockProvider = WebSocketProviderMock(request: URLRequest(url: URL(string: "http://test.com")!), callbackQueue: .main)
-    let logger = ClientLogger(icon: "🦄", level: .info)
+    let logger: ClientLogger = {
+        ClientLogger.log = { _, _, _, _ in }
+        return ClientLogger(icon: "🦄", level: .info)
+    }()
     
     override static func setUp() {
         // Change the default time interval to ping connection for 2 sec.


### PR DESCRIPTION
### In this PR:

- Make`RequestRecorderURLProtocol` record only selected requests if needed

#no_changelog