### PR TITLE
Fix URLSession headers not being assigned

### DIFF
--- a/Sources/Client/Client/Client+Request.swift
+++ b/Sources/Client/Client/Client+Request.swift
@@ -18,7 +18,8 @@ extension Client {
         logger?.log(headers: headers)
         let config = defaultURLSessionConfiguration
         config.waitsForConnectivity = true
-        config.httpAdditionalHeaders?.merge(headers, uniquingKeysWith: { (_, new) in new })
+        let oldHeaders = config.httpAdditionalHeaders ?? [:]
+        config.httpAdditionalHeaders = oldHeaders.merging(headers, uniquingKeysWith: { (_, new) in new })
         return URLSession(configuration: config, delegate: urlSessionTaskDelegate, delegateQueue: nil)
     }
     


### PR DESCRIPTION
Fixes 85690141eb3b48dd58663a9bbdaecacee1638221

```swift
config.httpAdditionalHeaders?.merge(headers, uniquingKeysWith: { (_, new) in new })
```
did not work when `config.httpAdditionalHeaders` is `nil`, which is when it's first setup

#no_changelog