### PR TITLE
[CIS-68] Automatically send `typingStop` event after a timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `disableLocalNotifications` added to `Notifications` for disabling local notifications [#290](https://github.com/GetStream/stream-chat-swift/pull/290)
 - Send a keystroke event for the current user: `channel.keystroke {}`. The method will automatically send a typing stop event after 15 seconds after the last call of `keystroke()`. [#281](https://github.com/GetStream/stream-chat-swift/pull/281)
 - Send a stop typing event for the current user: `stopTyping {}`. Usually, you don't need to call this method directly. [#281](https://github.com/GetStream/stream-chat-swift/pull/281)
+- Automatically send a `typingStop` event if it's not received in 30 seconds after the latest `typingStart` event [#282](https://github.com/GetStream/stream-chat-swift/issues/282).
 - Add support for multi-tenancy. Refer to [docs](https://getstream.io/chat/docs/multi_tenant_chat/?language=swift) for more info [#295](https://github.com/GetStream/stream-chat-swift/issues/295)
 
 ### 🔄 Changed

--- a/Sources/Client/Client/Client+WebSocket.swift
+++ b/Sources/Client/Client/Client+WebSocket.swift
@@ -121,6 +121,11 @@ extension Client: WebSocketEventDelegate {
         
         return true
     }
+    
+    func shouldAutomaticallySendTypingStopEvent(for user: User) -> Bool {
+        // Don't clean up current user's typing events
+        self.user != user
+    }
 }
 
 private struct WebSocketPayload: Encodable {

--- a/Sources/Client/Client/Client+WebSocket.swift
+++ b/Sources/Client/Client/Client+WebSocket.swift
@@ -47,30 +47,9 @@ extension Client {
         let webSocketOptions = stayConnectedInBackground ? WebSocketOptions.stayConnectedInBackground : []
         let webSocketProvider = defaultWebSocketProviderType.init(request: request, callbackQueue: callbackQueue)
         
-        return WebSocket(webSocketProvider, options: webSocketOptions, logger: logger) { [unowned self] event in
-            guard case .connectionChanged(let connectionState) = event else {
-                if case .notificationMutesUpdated(let user, _, _) = event {
-                    self.userAtomic.set(user)
-                    return
-                }
-                
-                self.updateUserUnreadCount(event: event) // User unread counts should be updated before channels unread counts.
-                self.updateChannelsForWatcherAndUnreadCount(event: event)
-                return
-            }
-            
-            if case .connected(let userConnection) = connectionState {
-                self.unreadCountAtomic.set(userConnection.user.unreadCount)
-                self.userAtomic.set(userConnection.user)
-                self.recoverConnection()
-                
-                if self.isExpiredTokenInProgress {
-                    self.performInCallbackQueue { [unowned self] in self.sendWaitingRequests() }
-                }
-            } else if case .reconnecting = connectionState {
-                self.needsToRecoverConnection = true
-            }
-        }
+        let webSocket = WebSocket(webSocketProvider, options: webSocketOptions, logger: logger)
+        webSocket.eventDelegate = self
+        return webSocket
     }
     
     private func recoverConnection() {
@@ -98,6 +77,49 @@ extension Client {
                           messagesLimit: [.limit(1)],
                           options: .watch) { _ in }
         }
+    }
+}
+
+extension Client: WebSocketEventDelegate {
+    func shouldPublishEvent(_ event: Event) -> Bool {
+        switch event {
+        case .connectionChanged(let connectionState):
+            if case .connected(let userConnection) = connectionState {
+                unreadCountAtomic.set(userConnection.user.unreadCount)
+                userAtomic.set(userConnection.user)
+                recoverConnection()
+                
+                if isExpiredTokenInProgress {
+                    performInCallbackQueue { [unowned self] in self.sendWaitingRequests() }
+                }
+            } else if case .reconnecting = connectionState {
+                needsToRecoverConnection = true
+            }
+            
+            return true
+            
+        case .notificationMutesUpdated(let user, _, _):
+            userAtomic.set(user)
+            return true
+            
+        case let .messageNew(message, _, _, _) where message.user != user && user.isMuted(user: message.user):
+            // FIXIT: This shouldn't be by default.
+            logger?.log("Skip a message (\(message.id)) from muted user (\(message.user.id)): \(message.textOrArgs)", level: .info)
+            return false
+            
+        case let .typingStart(user, _, _), let .typingStop(user, _, _):
+            if user != self.user, self.user.isMuted(user: user) {
+                logger?.log("Skip typing events from muted user (\(user.id))", level: .info)
+                return false
+            }
+            
+        default: break
+        }
+        
+        updateUserUnreadCount(event: event) // User unread counts should be updated before channels unread counts.
+        updateChannelsForWatcherAndUnreadCount(event: event)
+        
+        return true
     }
 }
 

--- a/Sources/Client/Model/User/User.swift
+++ b/Sources/Client/Model/User/User.swift
@@ -89,7 +89,7 @@ public struct User: Codable {
     /// Checks if the user can be muted.
     public var canBeMuted: Bool { !isCurrent }
     /// Checks if the user is muted.
-    public var isMuted: Bool { isCurrent ? false : Client.shared.user.mutedUsers.first(where: { $0.user == self }) != nil }
+    public var isMuted: Bool { isCurrent ? false : Client.shared.user.isMuted(user: self) }
     /// Returns the user as a member.
     public var asMember: Member { Member(self) }
     /// Checks if the user is flagged (locally).
@@ -203,6 +203,10 @@ public struct User: Codable {
         if isAnonymous {
             try container.encode(true, forKey: .isAnonymous)
         }
+    }
+    
+    func isMuted(user: User) -> Bool {
+        mutedUsers.contains { $0.user == user }
     }
 }
 

--- a/Sources/Client/WebSocket/WebSocket.swift
+++ b/Sources/Client/WebSocket/WebSocket.swift
@@ -70,7 +70,7 @@ final class WebSocket {
 
 extension WebSocket {
     
-    /// Connect to websocket.
+    /// Connect to web socket.
     /// - Note:
     ///     - Skip if the Internet is not available.
     ///     - Skip if it's already connected.
@@ -199,7 +199,7 @@ extension WebSocket {
         provider.callbackQueue.async { [weak self] in
             self?.onEventObservers[subscription.uuid] = handler
             
-            // Reply the last connectoin state.
+            // Reply the last connection state.
             if eventTypes.contains(.connectionChanged), let connectionState = self?.connectionState {
                 handler(.connectionChanged(connectionState))
             }
@@ -374,6 +374,6 @@ struct WebSocketOptions: OptionSet {
 
 /// WebSocket Error
 private struct ErrorContainer: Decodable {
-    /// A server error was recieved.
+    /// A server error was received.
     let error: ClientErrorResponse
 }

--- a/Tests/Client/Custom Assertions/AssertAsync.swift
+++ b/Tests/Client/Custom Assertions/AssertAsync.swift
@@ -313,4 +313,28 @@ extension AssertAsync {
                               line: line)
         }
     }
+    
+    /// Blocks the current test execution and periodically checks that the expression evaluates stays `TRUE` for
+    /// the whole `timeout` period.. Fails if the expression becommes `FALSE` before the end of the `timeout` period.
+    ///
+    /// - Parameters:
+    ///   - expression: The expression to evaluate.
+    ///   - timeout: The maximum time the function waits for the expression results to equal.
+    ///   - message: The message to print when the assertion fails.
+    ///
+    /// - Warning: ⚠️ The expression is evaluated repeatedly during the function execution. It should not have
+    ///   any side effects which can affect its result.
+    static func staysTrue(_ expression: @autoclosure () -> Bool,
+                          timeout: TimeInterval = defaultTimeoutForInversedExpecations,
+                          message: @autoclosure () -> String = "Failed to stay `TRUE`",
+                          file: StaticString = #file,
+                          line: UInt = #line) {
+        _ = withoutActuallyEscaping(expression) { expression in
+            withoutActuallyEscaping(message) { message in
+                AssertAsync {
+                    Assert.staysTrue(expression(), timeout: timeout, message: message(), file: file, line: line)
+                }
+            }
+        }
+    }
 }

--- a/Tests/Client/Unit Tests/WebSocket/WebSocketTests.swift
+++ b/Tests/Client/Unit Tests/WebSocket/WebSocketTests.swift
@@ -20,14 +20,10 @@ final class WebSocketTests: XCTestCase {
     var connectionId: String!
     var user: User!
     
-    var emittedEvents: [Event]!
-    
     let logger = ClientLogger(icon: "🦄", level: .info)
     
     override func setUp() {
         super.setUp()
-        
-        emittedEvents = []
         
         time = VirtualTime()
         VirtualTimeTimer.time = time

--- a/Tests/Client/Unit Tests/WebSocket/WebSocketTests.swift
+++ b/Tests/Client/Unit Tests/WebSocket/WebSocketTests.swift
@@ -31,8 +31,7 @@ final class WebSocketTests: XCTestCase {
         socketProvider = WebSocketProviderMock()
         webSocket = WebSocket(socketProvider,
                               options: [],
-                              timerType: VirtualTimeTimer.self,
-                              onEvent: { self.emittedEvents.append($0) })
+                              timerType: VirtualTimeTimer.self)
         
         connectionId = UUID().uuidString
         user = User(id: "test_user_\(UUID().uuidString)")


### PR DESCRIPTION
Stop showing a user typing if a user doesn't send a stop typing event after 30 sec.

**Note:** I moved a logic related to the current user from WebSocket to the Client to make tests work.