### PR TITLE
[CIS-117] Add pre-commit hook

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,42 @@
+# Stream rules
+--header "\n{file}\nCopyright © {year} Stream.io Inc. All rights reserved.\n"
+--enable isEmpty
+--swiftversion 5.2
+
+# Rules inferred from Swift Standard Library: 
+--allman false
+--binarygrouping 4,7
+--closingparen balanced
+--commas inline
+--conflictmarkers reject
+--decimalgrouping none
+--elseposition same-line
+--empty void
+--exponentcase lowercase
+--exponentgrouping disabled
+--fractiongrouping disabled
+--fragment false
+--hexgrouping none
+--hexliteralcase lowercase
+--ifdef outdent
+--importgrouping alphabetized
+--indent 2
+--indentcase false
+--linebreaks lf
+--maxwidth none
+--nospaceoperators 
+--octalgrouping none
+--operatorfunc no-space
+--patternlet inline
+--ranges no-space
+--self init-only
+--selfrequired 
+--semicolons inline
+--stripunusedargs closure-only
+--tabwidth unspecified
+--trailingclosures 
+--trimwhitespace always
+--wraparguments before-first
+--wrapcollections before-first
+--wrapparameters preserve
+--xcodeindentation disabled

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Usage: ./bootstrap.sh
+# This script will install swiftformat, link git hooks and install required ruby gems.
+# You should have homebrew installed.
+# If you get `zsh: permission denied: ./bootstrap.sh` error, please run `chmod +x bootstrap.sh` first
+
+# Install swiftformat
+brew install swiftformat
+
+# Symlink hooks folder to .git/hooks folder
+set -eu
+ln -s ../../hooks/pre-commit.sh .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+echo "Symlink created successfully"
+
+# Install gems
+bundle install
+

--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+git diff --diff-filter=d --staged --name-only -- StreamChatClient_v3 | grep -e '\.swift$' | while read file; do
+  swiftformat "${file}";
+  git add "$file";
+done


### PR DESCRIPTION
Please run `./bootstrap.sh` after merging this PR to install pre-commit hook!
The hook only runs on /StreamChatClient_v3 folder for now, we'll continue to use swiftlint until v3 is released.

Swiftformat rule documentation: https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md
Rules are inferred from: https://github.com/apple/swift/tree/master/stdlib/public/core