### PR TITLE
Improve keystroke tests

### DIFF
--- a/Sources/Client/Client/Client+Channel.swift
+++ b/Sources/Client/Client/Client+Channel.swift
@@ -313,7 +313,11 @@ public extension Client {
     ///   - completion: a completion block with `Event`.
     @discardableResult
     func send(eventType: EventType, to channel: Channel, _ completion: @escaping Client.Completion<Event>) -> Cancellable {
-        request(endpoint: .sendEvent(eventType, channel)) { [unowned self] (result: Result<EventResponse, ClientError>) in
+        #if DEBUG
+        outgoingEventsTestLogger?(eventType)
+        #endif
+        
+        return request(endpoint: .sendEvent(eventType, channel)) { [unowned self] (result: Result<EventResponse, ClientError>) in
             self.logger?.log("🎫 \(eventType.rawValue)")
             completion(result.map(to: \.event))
         }

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -133,6 +133,11 @@ public final class Client: Uploader {
         self.onUserUpdateObservers.values.forEach({ $0(newUser) })
     }
     
+    #if DEBUG
+    /// Called when a new outgoing event is about to be sent. Meant to be used only for testing purposes.
+    var outgoingEventsTestLogger: ((EventType) -> Void)?
+    #endif
+    
     // MARK: Unread Count Events
     
     /// Channels and messages unread counts.

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -128,6 +128,9 @@ public final class Channel: Codable {
     /// Checks for the channel data encoding is empty.
     var isEmpty: Bool { extraData == nil && members.isEmpty && invitedMembers.isEmpty }
     
+    /// Returns the current timestamp. Can be replaced in tests with mock time, if needed.
+    var currentTime: () -> Date = { Date() }
+    
     public init(type: ChannelType,
                 id: String,
                 members: [User],


### PR DESCRIPTION
#### In this PR:
- The tests for keystroke events now run synchronously

#no_changelog