### PR TITLE
[CIS-152] Add testing lane for v3 and run on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,4 +104,22 @@ jobs:
       if: steps.rubygem-cache.outputs.cache-hit != 'true'
       run: bundle install
     - name: Test SPM integration
-      run: bundle exec fastlane test_spm_integration
+      run: bundle exec fastlane test_spm_integration  
+      
+  build-and-test-v3:
+    name: Build and Test v3
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Cache RubyGems
+      uses: actions/cache@v1
+      id: rubygem-cache
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: ${{ runner.os }}-gem-
+    - name: Install RubyGems
+      if: steps.rubygem-cache.outputs.cache-hit != 'true'
+      run: bundle install
+    - name: Build v3 target and run all tests
+      run: bundle exec fastlane test_v3

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -239,3 +239,8 @@ lane :get_next_issue_number do
   UI.success "So the next markdown link is: #{next_issue_link}"
   UI.success "Next markdown link is copied to your clipboard! ⬆️"
 end
+
+desc "Runs tests for v3 scheme"
+lane :test_v3 do
+  scan(project: "StreamChat.xcodeproj", scheme: "StreamChatClient_v3", clean: true)
+end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -75,6 +75,11 @@ Tests integration with SPM by building SPM Example
 fastlane get_next_issue_number
 ```
 Get next PR number from github to be used in CHANGELOG
+### test_v3
+```
+fastlane test_v3
+```
+Runs tests for v3 scheme
 
 ----
 


### PR DESCRIPTION
Danger and codecov obviously disabled for v3 targets for now. Carthage is not needed for v3 tests since it has no dependencies.
