### PR TITLE
[CIS-174] Format Swift code in `/TestResources_v3` folder, too

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1745,7 +1745,9 @@
 				8AD5EDDA22E9C7BC005CFAC9 /* Cartfile */,
 				7920E84E2449C6EF00CCBFBF /* fastlane */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		8AD5EC9022E9A3E8005CFAC9 /* Products */ = {
 			isa = PBXGroup;

--- a/TestResources_v3/Await.swift
+++ b/TestResources_v3/Await.swift
@@ -1,14 +1,12 @@
 //
-//  Await.swift
-//  StreamChatClientTests
-//
-//  Copyright © 2020 Stream.io Inc. All rights reserved.
+// Await.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
 //
 
 import XCTest
 
 enum WaiterError: Error {
-    case waitingForResultTimedOut
+  case waitingForResultTimedOut
 }
 
 /// Allows calling an asynchronous function in the synchronous way in tests.
@@ -32,20 +30,19 @@ func await<T>(timeout: TimeInterval = 0.5,
               file: StaticString = #file,
               line: UInt = #line,
               _ action: @escaping (_ done: @escaping (T) -> Void) -> Void) throws -> T {
+  let expecation = XCTestExpectation(description: "Action completed")
+  var result: T?
+  action {
+    result = $0
+    expecation.fulfill()
+  }
 
-    let expecation = XCTestExpectation(description: "Action completed")
-    var result: T?
-    action {
-        result = $0
-        expecation.fulfill()
-    }
-
-    let waiterResult = XCTWaiter.wait(for: [expecation], timeout: timeout)
-    switch waiterResult {
-    case .completed where result != nil:
-        return result!
-    default:
-        XCTFail("Waiting for the result timed out", file: file, line: line)
-        throw WaiterError.waitingForResultTimedOut
-    }
+  let waiterResult = XCTWaiter.wait(for: [expecation], timeout: timeout)
+  switch waiterResult {
+  case .completed where result != nil:
+    return result!
+  default:
+    XCTFail("Waiting for the result timed out", file: file, line: line)
+    throw WaiterError.waitingForResultTimedOut
+  }
 }

--- a/TestResources_v3/Custom Assertions/AssertAsync.swift
+++ b/TestResources_v3/Custom Assertions/AssertAsync.swift
@@ -1,8 +1,6 @@
 //
-//  AssertAsync.swift
-//  StreamChatClientTests
-//
-//  Copyright © 2020 Stream.io Inc. All rights reserved.
+// AssertAsync.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
 //
 
 import XCTest
@@ -21,17 +19,16 @@ private let evaluationPeriod: TimeInterval = 0.001
 /// Internal representation for assertions. Not meant to be created and used directly. If you wan't to add an assertion,
 /// add a new static func to `extension Assert { }` and create the `Assertion` object inside.
 struct Assertion {
-    
-    enum State {
-        case active, idle
-    }
-    
-    let body: (_ elapsedTime: TimeInterval) -> State
-    
-    /// Evaluates the assertion.
-    func evaluate(elapsedTime: TimeInterval) -> State {
-        body(elapsedTime)
-    }
+  enum State {
+    case active, idle
+  }
+
+  let body: (_ elapsedTime: TimeInterval) -> State
+
+  /// Evaluates the assertion.
+  func evaluate(elapsedTime: TimeInterval) -> State {
+    body(elapsedTime)
+  }
 }
 
 // Syntax sugar to make assertion code more readable:
@@ -39,164 +36,163 @@ struct Assertion {
 typealias Assert = Assertion
 
 extension Assert {
-    
-    /// Periodically checks for the equality of the provided expressions. Fails if the expression results are not
-    /// equal within the `timeout` period.
-    ///
-    /// - Parameters:
-    ///   - expression1: The first expression to evaluate.
-    ///   - expression2: The first expression to evaluate.
-    ///   - timeout: The maximum time the function waits for the expression results to equal.
-    ///   - message: The message to print when the assertion fails.
-    ///
-    /// - Warning: ⚠️ Both expressions are evaluated repeatedly during the function execution. The expressions should not have
-    ///   any side effects which can affect their results.
-    static func willBeEqual<T: Equatable>(_ expression1: @autoclosure @escaping () -> T,
-                                          _ expression2: @autoclosure @escaping () -> T,
-                                          timeout: TimeInterval = defaultTimeout,
-                                          message: @autoclosure @escaping () -> String? = nil,
-                                          file: StaticString = #file,
-                                          line: UInt = #line) -> Assertion {
-        
-        // We can't use this as the default parameter because of the string interpolation.
-        var defaultMessage: String {
-            "\"\(String(describing: expression1()))\" not equal to \"\(String(describing: expression2()))\""
-        }
-    
-        return willBeTrue(expression1() == expression2(),
-                          timeout: timeout,
-                          message: message() ?? defaultMessage,
-                          file: file,
-                          line: line)
+  /// Periodically checks for the equality of the provided expressions. Fails if the expression results are not
+  /// equal within the `timeout` period.
+  ///
+  /// - Parameters:
+  ///   - expression1: The first expression to evaluate.
+  ///   - expression2: The first expression to evaluate.
+  ///   - timeout: The maximum time the function waits for the expression results to equal.
+  ///   - message: The message to print when the assertion fails.
+  ///
+  /// - Warning: ⚠️ Both expressions are evaluated repeatedly during the function execution. The expressions should not have
+  ///   any side effects which can affect their results.
+  static func willBeEqual<T: Equatable>(_ expression1: @autoclosure @escaping () -> T,
+                                        _ expression2: @autoclosure @escaping () -> T,
+                                        timeout: TimeInterval = defaultTimeout,
+                                        message: @autoclosure @escaping () -> String? = nil,
+                                        file: StaticString = #file,
+                                        line: UInt = #line) -> Assertion {
+    // We can't use this as the default parameter because of the string interpolation.
+    var defaultMessage: String {
+      "\"\(String(describing: expression1()))\" not equal to \"\(String(describing: expression2()))\""
     }
-    
-    /// Periodically checks if the expression evaluates to `nil`. Fails if the expression result is not `nil` within
-    /// the `timeout` period.
-    ///
-    /// - Parameters:
-    ///   - expression: The expression to evaluate.
-    ///   - timeout: The maximum time the function waits for the expression results to equal.
-    ///   - message: The message to print when the assertion fails.
-    ///
-    /// - Warning: ⚠️ The expression is evaluated repeatedly during the function execution. It should not have
-    ///   any side effects which can affect its result.
-    static func willBeNil<T>(_ expression1: @autoclosure @escaping () -> T?,
-                              timeout: TimeInterval = defaultTimeout,
-                              message: @autoclosure () -> String = "Failed to become `nil`",
-                              file: StaticString = #file,
-                              line: UInt = #line) -> Assertion {
-    
-        return willBeTrue(expression1() == nil,
-                          timeout: timeout,
-                          message: "Failed to become `nil`",
-                          file: file,
-                          line: line)
-    }
-    
-    /// Periodically checks if the expression evaluates to `TRUE`. Fails if the expression result is not `TRUE` within
-    /// the `timeout` period.
-    ///
-    /// - Parameters:
-    ///   - expression: The expression to evaluate.
-    ///   - timeout: The maximum time the function waits for the expression results to equal.
-    ///   - message: The message to print when the assertion fails.
-    ///
-    /// - Warning: ⚠️ The expression is evaluated repeatedly during the function execution. It should not have
-    ///   any side effects which can affect its result.
-    static func willBeTrue(_ expression: @autoclosure @escaping () -> Bool,
+
+    return willBeTrue(
+      expression1() == expression2(),
+      timeout: timeout,
+      message: message() ?? defaultMessage,
+      file: file,
+      line: line
+    )
+  }
+
+  /// Periodically checks if the expression evaluates to `nil`. Fails if the expression result is not `nil` within
+  /// the `timeout` period.
+  ///
+  /// - Parameters:
+  ///   - expression: The expression to evaluate.
+  ///   - timeout: The maximum time the function waits for the expression results to equal.
+  ///   - message: The message to print when the assertion fails.
+  ///
+  /// - Warning: ⚠️ The expression is evaluated repeatedly during the function execution. It should not have
+  ///   any side effects which can affect its result.
+  static func willBeNil<T>(_ expression1: @autoclosure @escaping () -> T?,
                            timeout: TimeInterval = defaultTimeout,
-                           message: @autoclosure @escaping () -> String = "Failed to become `TRUE`",
+                           message: @autoclosure () -> String = "Failed to become `nil`",
                            file: StaticString = #file,
                            line: UInt = #line) -> Assertion {
-        
-        Assertion { elapsedTime in
-            if elapsedTime < timeout {
-                if expression() {
-                    // Success
-                    return .idle
-                }
-            } else {
-                // Timeout
-                XCTFail(message(), file: file, line: line)
-                return .idle
-            }
-            
-            return .active
+    willBeTrue(
+      expression1() == nil,
+      timeout: timeout,
+      message: "Failed to become `nil`",
+      file: file,
+      line: line
+    )
+  }
+
+  /// Periodically checks if the expression evaluates to `TRUE`. Fails if the expression result is not `TRUE` within
+  /// the `timeout` period.
+  ///
+  /// - Parameters:
+  ///   - expression: The expression to evaluate.
+  ///   - timeout: The maximum time the function waits for the expression results to equal.
+  ///   - message: The message to print when the assertion fails.
+  ///
+  /// - Warning: ⚠️ The expression is evaluated repeatedly during the function execution. It should not have
+  ///   any side effects which can affect its result.
+  static func willBeTrue(_ expression: @autoclosure @escaping () -> Bool,
+                         timeout: TimeInterval = defaultTimeout,
+                         message: @autoclosure @escaping () -> String = "Failed to become `TRUE`",
+                         file: StaticString = #file,
+                         line: UInt = #line) -> Assertion {
+    Assertion { elapsedTime in
+      if elapsedTime < timeout {
+        if expression() {
+          // Success
+          return .idle
         }
-    }
+      } else {
+        // Timeout
+        XCTFail(message(), file: file, line: line)
+        return .idle
+      }
 
-    /// Periodically checks if the expression evaluates to `FALSE`. Fails if the expression result is not `FALSE` within
-    /// the `timeout` period.
-    ///
-    /// - Parameters:
-    ///   - expression: The expression to evaluate.
-    ///   - timeout: The maximum time the function waits for the expression results to equal.
-    ///   - message: The message to print when the assertion fails.
-    ///
-    /// - Warning: ⚠️ The expression is evaluated repeatedly during the function execution. It should not have
-    ///   any side effects which can affect its result.
-    static func willBeFalse(_ expression: @autoclosure @escaping () -> Bool,
-                            timeout: TimeInterval = defaultTimeout,
-                            message: @autoclosure @escaping () -> String = "Failed to become `TRUE`",
-                            file: StaticString = #file,
-                            line: UInt = #line) -> Assertion {
-        
-        willBeTrue(!expression(),
-                   timeout: timeout,
-                   message: "Failed to become `FALSE`",
-                   file: file,
-                   line: line)
+      return .active
     }
+  }
 
-    /// Periodically checks that the expression evaluates stays `FALSE` for the whole `timeout` period.. Fails if the expression
-    /// becommes `TRUE` before the end of the `timeout` period.
-    ///
-    /// - Parameters:
-    ///   - expression: The expression to evaluate.
-    ///   - timeout: The maximum time the function waits for the expression results to equal.
-    ///   - message: The message to print when the assertion fails.
-    ///
-    /// - Warning: ⚠️ The expression is evaluated repeatedly during the function execution. It should not have
-    ///   any side effects which can affect its result.
-    static func staysFalse(_ expression: @autoclosure @escaping () -> Bool,
-                           timeout: TimeInterval = defaultTimeoutForInversedExpecations,
-                           message: @autoclosure @escaping () -> String = "Failed to stay `FALSE`",
-                           file: StaticString = #file,
-                           line: UInt = #line) -> Assertion {
-        
-        staysTrue(!expression(), timeout: timeout, message: message(), file: file, line: line)
-    }
-
-    /// Periodically checks that the expression evaluates stays `TRUE` for the whole `timeout` period.. Fails if the expression
-    /// becommes `FALSE` before the end of the `timeout` period.
-    ///
-    /// - Parameters:
-    ///   - expression: The expression to evaluate.
-    ///   - timeout: The maximum time the function waits for the expression results to equal.
-    ///   - message: The message to print when the assertion fails.
-    ///
-    /// - Warning: ⚠️ The expression is evaluated repeatedly during the function execution. It should not have
-    ///   any side effects which can affect its result.
-    static func staysTrue(_ expression: @autoclosure @escaping () -> Bool,
-                          timeout: TimeInterval = defaultTimeoutForInversedExpecations,
-                          message: @autoclosure @escaping () -> String = "Failed to stay `TRUE`",
+  /// Periodically checks if the expression evaluates to `FALSE`. Fails if the expression result is not `FALSE` within
+  /// the `timeout` period.
+  ///
+  /// - Parameters:
+  ///   - expression: The expression to evaluate.
+  ///   - timeout: The maximum time the function waits for the expression results to equal.
+  ///   - message: The message to print when the assertion fails.
+  ///
+  /// - Warning: ⚠️ The expression is evaluated repeatedly during the function execution. It should not have
+  ///   any side effects which can affect its result.
+  static func willBeFalse(_ expression: @autoclosure @escaping () -> Bool,
+                          timeout: TimeInterval = defaultTimeout,
+                          message: @autoclosure @escaping () -> String = "Failed to become `TRUE`",
                           file: StaticString = #file,
                           line: UInt = #line) -> Assertion {
-        
-        Assertion { elapsedTime in
-            if elapsedTime >= timeout {
-                // Success
-                return .idle
-                
-            } else if expression() == false {
-                // Failure
-                XCTFail(message(), file: file, line: line)
-                return .idle
-            }
-            
-            return .active
-        }
+    willBeTrue(
+      !expression(),
+      timeout: timeout,
+      message: "Failed to become `FALSE`",
+      file: file,
+      line: line
+    )
+  }
+
+  /// Periodically checks that the expression evaluates stays `FALSE` for the whole `timeout` period.. Fails if the expression
+  /// becommes `TRUE` before the end of the `timeout` period.
+  ///
+  /// - Parameters:
+  ///   - expression: The expression to evaluate.
+  ///   - timeout: The maximum time the function waits for the expression results to equal.
+  ///   - message: The message to print when the assertion fails.
+  ///
+  /// - Warning: ⚠️ The expression is evaluated repeatedly during the function execution. It should not have
+  ///   any side effects which can affect its result.
+  static func staysFalse(_ expression: @autoclosure @escaping () -> Bool,
+                         timeout: TimeInterval = defaultTimeoutForInversedExpecations,
+                         message: @autoclosure @escaping () -> String = "Failed to stay `FALSE`",
+                         file: StaticString = #file,
+                         line: UInt = #line) -> Assertion {
+    staysTrue(!expression(), timeout: timeout, message: message(), file: file, line: line)
+  }
+
+  /// Periodically checks that the expression evaluates stays `TRUE` for the whole `timeout` period.. Fails if the expression
+  /// becommes `FALSE` before the end of the `timeout` period.
+  ///
+  /// - Parameters:
+  ///   - expression: The expression to evaluate.
+  ///   - timeout: The maximum time the function waits for the expression results to equal.
+  ///   - message: The message to print when the assertion fails.
+  ///
+  /// - Warning: ⚠️ The expression is evaluated repeatedly during the function execution. It should not have
+  ///   any side effects which can affect its result.
+  static func staysTrue(_ expression: @autoclosure @escaping () -> Bool,
+                        timeout: TimeInterval = defaultTimeoutForInversedExpecations,
+                        message: @autoclosure @escaping () -> String = "Failed to stay `TRUE`",
+                        file: StaticString = #file,
+                        line: UInt = #line) -> Assertion {
+    Assertion { elapsedTime in
+      if elapsedTime >= timeout {
+        // Success
+        return .idle
+
+      } else if expression() == false {
+        // Failure
+        XCTFail(message(), file: file, line: line)
+        return .idle
+      }
+
+      return .active
     }
+  }
 }
 
 // MARK: - Async runner
@@ -224,53 +220,51 @@ extension Assert {
 ///   }
 ///   ```
 struct AssertAsync {
-    
-    // This shouldn't be needed and it's just a workaround for https://bugs.swift.org/browse/SR-11628. Remove when possible.
-    @discardableResult
-    init(@AssertionBuilder singleBuilder: () -> Assertion) {
-        self.init(builder: {
-            let built = singleBuilder()
-            return [built]
-        })
-    }
-    
-    @discardableResult
-    init(@AssertionBuilder builder: () -> [Assertion]) {
-        var assertions = builder()
-        let startTimestamp = Date().timeIntervalSince1970
+  // This shouldn't be needed and it's just a workaround for https://bugs.swift.org/browse/SR-11628. Remove when possible.
+  @discardableResult
+  init(@AssertionBuilder singleBuilder: () -> Assertion) {
+    self.init(builder: {
+      let built = singleBuilder()
+      return [built]
+    })
+  }
 
-        while assertions.isEmpty == false {
-            let elapsedTime = Date().timeIntervalSince1970 - startTimestamp
-            // Evaluate and remove idle assertions
-            assertions = assertions.filter { $0.evaluate(elapsedTime: elapsedTime) == .active }
-            _ = XCTWaiter.wait(for: [.init()], timeout: evaluationPeriod)
-        }
+  @discardableResult
+  init(@AssertionBuilder builder: () -> [Assertion]) {
+    var assertions = builder()
+    let startTimestamp = Date().timeIntervalSince1970
+
+    while assertions.isEmpty == false {
+      let elapsedTime = Date().timeIntervalSince1970 - startTimestamp
+      // Evaluate and remove idle assertions
+      assertions = assertions.filter { $0.evaluate(elapsedTime: elapsedTime) == .active }
+      _ = XCTWaiter.wait(for: [.init()], timeout: evaluationPeriod)
     }
+  }
 }
 
 @_functionBuilder
 struct AssertionBuilder {
-    static func buildBlock(_ assertion: Assertion) -> Assertion {
-        assertion
-    }
-    
-    static func buildBlock(_ assertions: Assertion...) -> [Assertion] {
-        assertions
-    }
+  static func buildBlock(_ assertion: Assertion) -> Assertion {
+    assertion
+  }
+
+  static func buildBlock(_ assertions: Assertion...) -> [Assertion] {
+    assertions
+  }
 }
 
 extension AssertAsync {
-    
-    /// Blocks the current test execution and periodically checks for the equality of the provided expressions. Fails if
-    /// the expression results are not equal within the `timeout` period.
-    ///
-    /// - Parameters:
-    ///   - expression1: The first expression to evaluate.
-    ///   - expression2: The first expression to evaluate.
-    ///   - timeout: The maximum time the function waits for the expression results to equal.
-    ///   - message: The message to print when the assertion fails.
-    ///
-    /// - Warning: ⚠️ Both expressions are evaluated repeatedly during the function execution. The expressions should not have
+  /// Blocks the current test execution and periodically checks for the equality of the provided expressions. Fails if
+  /// the expression results are not equal within the `timeout` period.
+  ///
+  /// - Parameters:
+  ///   - expression1: The first expression to evaluate.
+  ///   - expression2: The first expression to evaluate.
+  ///   - timeout: The maximum time the function waits for the expression results to equal.
+  ///   - message: The message to print when the assertion fails.
+  ///
+  /// - Warning: ⚠️ Both expressions are evaluated repeatedly during the function execution. The expressions should not have
   ///   any side effects which can affect their results.
   static func willBeEqual<T: Equatable>(
     _ expression1: @autoclosure () -> T,
@@ -283,6 +277,7 @@ extension AssertAsync {
     _ = withoutActuallyEscaping(expression1) { expression1 in
       withoutActuallyEscaping(expression2) { expression2 in
         withoutActuallyEscaping(message) { message in
+
           AssertAsync {
             Assert.willBeEqual(
               expression1(),
@@ -290,35 +285,44 @@ extension AssertAsync {
               timeout: timeout,
               message: message(),
               file: file,
-              line: line)
+              line: line
+            )
           }
         }
       }
     }
   }
-    
-    /// Blocks the current test execution and periodically checks if the expression evaluates to `nil`. Fails if
-    /// the expression result is not `nil` within the `timeout` period.
-    ///
-    /// - Parameters:
-    ///   - expression: The expression to evaluate.
-    ///   - timeout: The maximum time the function waits for the expression results to equal.
-    ///   - message: The message to print when the assertion fails.
-    ///
-    /// - Warning: ⚠️ The expression is evaluated repeatedly during the function execution. It should not have
-    ///   any side effects which can affect its result.
-    static func willBeNil<T>(_ expression1: @autoclosure @escaping () -> T?,
-                              timeout: TimeInterval = defaultTimeout,
-                              message: @autoclosure @escaping () -> String = "Failed to become `nil`",
-                              file: StaticString = #file,
-                              line: UInt = #line) {
-    
+
+  /// Blocks the current test execution and periodically checks if the expression evaluates to `nil`. Fails if
+  /// the expression result is not `nil` within the `timeout` period.
+  ///
+  /// - Parameters:
+  ///   - expression: The expression to evaluate.
+  ///   - timeout: The maximum time the function waits for the expression results to equal.
+  ///   - message: The message to print when the assertion fails.
+  ///
+  /// - Warning: ⚠️ The expression is evaluated repeatedly during the function execution. It should not have
+  ///   any side effects which can affect its result.
+  static func willBeNil<T>(
+    _ expression1: @autoclosure () -> T?,
+    timeout: TimeInterval = defaultTimeout,
+    message: @autoclosure () -> String = "Failed to become `nil`",
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    _ = withoutActuallyEscaping(expression1) { expression1 in
+      withoutActuallyEscaping(message) { message in
+
         AssertAsync {
-            Assert.willBeTrue(expression1() == nil,
-                              timeout: timeout,
-                              message: message(),
-                              file: file,
-                              line: line)
+          Assert.willBeTrue(
+            expression1() == nil,
+            timeout: timeout,
+            message: message(),
+            file: file,
+            line: line
+          )
         }
+      }
     }
+  }
 }

--- a/TestResources_v3/Custom Assertions/AssertJSONEqual.swift
+++ b/TestResources_v3/Custom Assertions/AssertJSONEqual.swift
@@ -1,9 +1,6 @@
 //
-//  AssertJSONEqual.swift
-//  StreamChat
-//
-//  Created by Bahadir Oncel on 15.05.2020.
-//  Copyright © 2020 Stream.io Inc. All rights reserved.
+// AssertJSONEqual.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -11,7 +8,7 @@ import XCTest
 
 /// Helper function for creating NSError.
 func error(domain: String, code: Int = -1, message: @autoclosure () -> String) -> NSError {
-    NSError(domain: domain, code: code, userInfo: ["message:": message()])
+  NSError(domain: domain, code: code, userInfo: ["message:": message()])
 }
 
 /// Asserts the given 2 JSON Serializations are equal, by creating JSON objects from Data and comparing dictionaries.
@@ -25,34 +22,36 @@ func AssertJSONEqual(_ expression1: @autoclosure () throws -> Data,
                      _ expression2: @autoclosure () throws -> Data,
                      file: StaticString = #file,
                      line: UInt = #line) {
-    do {
-        guard let json1 = try JSONSerialization.jsonObject(with: expression1()) as? [String: Any] else {
-            throw error(domain: "AssertJSONEqual", message: "First expression is not a valid json object!")
-        }
-        guard let json2 = try JSONSerialization.jsonObject(with: expression2()) as? [String: Any] else {
-            throw error(domain: "AssertJSONEqual", message: "Second expression is not a valid json object!")
-        }
-        guard json1.keys == json2.keys else {
-            throw error(domain: "AssertJSONEqual", message: "JSON keys do not match")
-        }
-        try json1.forEach { (key, value) in
-            guard let value2 = json2[key] else {
-                throw error(domain: "AssertJSONEqual", message: "Expression 2 does not have value for \(key)")
-            }
-            if let nestedDict1 = value as? [String: Any] {
-                if let nestedDict2 = value2 as? [String: Any] {
-                    try AssertJSONEqual(JSONSerialization.data(withJSONObject: nestedDict1),
-                                        JSONSerialization.data(withJSONObject: nestedDict2),
-                                        file: file,
-                                        line: line)
-                } else {
-                    throw error(domain: "AssertJSONEqual", message:  "Values for key \(key) do not match")
-                }
-            } else if String(describing: value) != String(describing: value2) {
-                throw error(domain: "AssertJSONEqual", message: "Values for key \(key) do not match")
-            }
-        }
-    } catch {
-        XCTFail("Error: \(error)", file: file, line: line)
+  do {
+    guard let json1 = try JSONSerialization.jsonObject(with: expression1()) as? [String: Any] else {
+      throw error(domain: "AssertJSONEqual", message: "First expression is not a valid json object!")
     }
+    guard let json2 = try JSONSerialization.jsonObject(with: expression2()) as? [String: Any] else {
+      throw error(domain: "AssertJSONEqual", message: "Second expression is not a valid json object!")
+    }
+    guard json1.keys == json2.keys else {
+      throw error(domain: "AssertJSONEqual", message: "JSON keys do not match")
+    }
+    try json1.forEach { key, value in
+      guard let value2 = json2[key] else {
+        throw error(domain: "AssertJSONEqual", message: "Expression 2 does not have value for \(key)")
+      }
+      if let nestedDict1 = value as? [String: Any] {
+        if let nestedDict2 = value2 as? [String: Any] {
+          try AssertJSONEqual(
+            JSONSerialization.data(withJSONObject: nestedDict1),
+            JSONSerialization.data(withJSONObject: nestedDict2),
+            file: file,
+            line: line
+          )
+        } else {
+          throw error(domain: "AssertJSONEqual", message: "Values for key \(key) do not match")
+        }
+      } else if String(describing: value) != String(describing: value2) {
+        throw error(domain: "AssertJSONEqual", message: "Values for key \(key) do not match")
+      }
+    }
+  } catch {
+    XCTFail("Error: \(error)", file: file, line: line)
+  }
 }

--- a/TestResources_v3/Custom Assertions/AssertResult.swift
+++ b/TestResources_v3/Custom Assertions/AssertResult.swift
@@ -1,8 +1,6 @@
 //
-//  AssertResult.swift
-//  StreamChatClientTests
-//
-//  Copyright © 2020 Stream.io Inc. All rights reserved.
+// AssertResult.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
 //
 
 import XCTest
@@ -16,12 +14,11 @@ func AssertResultSuccess<T: Equatable, E: Error>(_ result: Result<T, E>,
                                                  _ referenceValue: T,
                                                  file: StaticString = #file,
                                                  line: UInt = #line) {
-
-    if case let .success(value) = result {
-        XCTAssertEqual(value, referenceValue, file: file, line: line)
-    } else {
-        XCTFail("Expected .success, got \(result).", file: file, line: line)
-    }
+  if case .success(let value) = result {
+    XCTAssertEqual(value, referenceValue, file: file, line: line)
+  } else {
+    XCTFail("Expected .success, got \(result).", file: file, line: line)
+  }
 }
 
 /// Asserts the provided `Result` object is `.failure(referenceError)`.
@@ -36,12 +33,11 @@ func AssertResultFailure<T: Equatable, E: Error>(_ result: Result<T, E>,
                                                  _ referenceError: Error,
                                                  file: StaticString = #file,
                                                  line: UInt = #line) {
-
-    if case let .failure(error) = result {
-        XCTAssertEqual(String(describing: error), String(describing: referenceError), file: file, line: line)
-    } else {
-        XCTFail("Expected .failure, got \(result).", file: file, line: line)
-    }
+  if case .failure(let error) = result {
+    XCTAssertEqual(String(describing: error), String(describing: referenceError), file: file, line: line)
+  } else {
+    XCTFail("Expected .failure, got \(result).", file: file, line: line)
+  }
 }
 
 /// Asserts the provided `Result` object is `.failure(referenceError)`.
@@ -53,10 +49,9 @@ func AssertResultFailure<T, E: Error & Equatable>(_ result: Result<T, E>,
                                                   _ referenceError: E,
                                                   file: StaticString = #file,
                                                   line: UInt = #line) {
-
-    if case let .failure(error) = result {
-        XCTAssertEqual(error, referenceError, file: file, line: line)
-    } else {
-        XCTFail("Expected .failure, got \(result).", file: file, line: line)
-    }
+  if case .failure(let error) = result {
+    XCTAssertEqual(error, referenceError, file: file, line: line)
+  } else {
+    XCTFail("Expected .failure, got \(result).", file: file, line: line)
+  }
 }

--- a/TestResources_v3/TemporaryURLs.swift
+++ b/TestResources_v3/TemporaryURLs.swift
@@ -1,25 +1,22 @@
 //
-//  TemporaryURLs.swift
-//  StreamChatClient_v3
-//
-//  Created by Vojta on 26/05/2020.
-//  Copyright © 2020 Stream.io Inc. All rights reserved.
+// TemporaryURLs.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
 
 extension URL {
-    /// Returns a unique URL that can be used for storing a temporary file.
-    static func newTemporaryFileURL() -> URL {
-        newTemporaryDirectoryURL().appendingPathComponent("temp_file")
-    }
-    
-    /// Creates a new temporary directory and returns its URL.
-    static func newTemporaryDirectoryURL() -> URL {
-        let directoryId = UUID().uuidString
-        let tempDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-        let newDirURL = tempDirectoryURL.appendingPathComponent(directoryId)
-        try! FileManager.default.createDirectory(at: newDirURL, withIntermediateDirectories: true, attributes: nil)
-        return newDirURL
-    }
+  /// Returns a unique URL that can be used for storing a temporary file.
+  static func newTemporaryFileURL() -> URL {
+    newTemporaryDirectoryURL().appendingPathComponent("temp_file")
+  }
+
+  /// Creates a new temporary directory and returns its URL.
+  static func newTemporaryDirectoryURL() -> URL {
+    let directoryId = UUID().uuidString
+    let tempDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    let newDirURL = tempDirectoryURL.appendingPathComponent(directoryId)
+    try! FileManager.default.createDirectory(at: newDirURL, withIntermediateDirectories: true, attributes: nil)
+    return newDirURL
+  }
 }

--- a/TestResources_v3/TestError.swift
+++ b/TestResources_v3/TestError.swift
@@ -1,14 +1,11 @@
 //
-//  TestErrors.swift
-//  StreamChatClient
-//
-//  Created by Vojta on 27/05/2020.
-//  Copyright © 2020 Stream.io Inc. All rights reserved.
+// TestError.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
 
 /// Uniquely indetifiable error that can be used in tests.
 struct TestError: Error, Equatable {
-    let id = UUID()
+  let id = UUID()
 }

--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-git diff --diff-filter=d --staged --name-only -- StreamChatClient_v3 | grep -e '\.swift$' | while read file; do
+git diff --diff-filter=d --staged --name-only -- StreamChatClient_v3 -- TestResources_v3 | grep -e '\.swift$' | while read file; do
   swiftformat "${file}";
   git add "$file";
 done


### PR DESCRIPTION
#### In this PR:

- The formatter is ran for `/TestResources_v3` folder, too
- Existing code is reformatted

#no_changelog