### PR TITLE
[CIS-176] Migrate `Atomic` to v3

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		79280F4D24852FCA00CDEB89 /* DataChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79280F4C24852FCA00CDEB89 /* DataChange.swift */; };
 		79280F4F2485308100CDEB89 /* Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79280F4E2485308100CDEB89 /* Controller.swift */; };
 		79280F542485529500CDEB89 /* ChannelEventsHandler_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79280F522485528800CDEB89 /* ChannelEventsHandler_tests.swift */; };
+		79280F712487CD2B00CDEB89 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79280F6F2487CD2B00CDEB89 /* Atomic.swift */; };
+		79280F732487CD3100CDEB89 /* Atomic_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79280F702487CD2B00CDEB89 /* Atomic_tests.swift */; };
 		792A4F1B247FE84900EAF71D /* ChannelQueryUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F1A247FE84900EAF71D /* ChannelQueryUpdater.swift */; };
 		792A4F1D247FEA2200EAF71D /* ChannelListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F1C247FEA2200EAF71D /* ChannelListController.swift */; };
 		792A4F25247FF01800EAF71D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F24247FF01800EAF71D /* AppDelegate.swift */; };
@@ -422,6 +424,8 @@
 		79280F4C24852FCA00CDEB89 /* DataChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataChange.swift; sourceTree = "<group>"; };
 		79280F4E2485308100CDEB89 /* Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controller.swift; sourceTree = "<group>"; };
 		79280F522485528800CDEB89 /* ChannelEventsHandler_tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelEventsHandler_tests.swift; sourceTree = "<group>"; };
+		79280F6F2487CD2B00CDEB89 /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
+		79280F702487CD2B00CDEB89 /* Atomic_tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic_tests.swift; sourceTree = "<group>"; };
 		792A4F1A247FE84900EAF71D /* ChannelQueryUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelQueryUpdater.swift; sourceTree = "<group>"; };
 		792A4F1C247FEA2200EAF71D /* ChannelListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListController.swift; sourceTree = "<group>"; };
 		792A4F22247FF01800EAF71D /* V3SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = V3SampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -931,6 +935,8 @@
 		792A4F3A247FFB7600EAF71D /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				79280F6F2487CD2B00CDEB89 /* Atomic.swift */,
+				79280F702487CD2B00CDEB89 /* Atomic_tests.swift */,
 				792A4F3D247FFDE700EAF71D /* Codable+Extensions.swift */,
 				792A4F3E247FFDE700EAF71D /* Data+Gzip.swift */,
 				792A4F3B247FFBB400EAF71D /* Timers.swift */,
@@ -2230,6 +2236,7 @@
 				7962958C248147430078EB53 /* BaseURL.swift in Sources */,
 				792A4F5A24812D1A00EAF71D /* UserEndpointReponse.swift in Sources */,
 				792A4F4F2480EA3B00EAF71D /* Endpoint.swift in Sources */,
+				79280F712487CD2B00CDEB89 /* Atomic.swift in Sources */,
 				799C9440247D2FB9001F1104 /* User.swift in Sources */,
 				797A756824814F0D003CF16D /* BundleExtensions.swift in Sources */,
 				792A4F1B247FE84900EAF71D /* ChannelQueryUpdater.swift in Sources */,
@@ -2266,6 +2273,7 @@
 				799C9460247D77D6001F1104 /* DatabaseContainer_Tests.swift in Sources */,
 				799C945C247D59D8001F1104 /* ChatClient_tests.swift in Sources */,
 				799C9462247D78E2001F1104 /* Await.swift in Sources */,
+				79280F732487CD3100CDEB89 /* Atomic_tests.swift in Sources */,
 				79280F542485529500CDEB89 /* ChannelEventsHandler_tests.swift in Sources */,
 				799C9476247D7E94001F1104 /* TemporaryURLs.swift in Sources */,
 				799C9469247D791A001F1104 /* AssertResult.swift in Sources */,

--- a/StreamChatClient_v3/Utils/Atomic.swift
+++ b/StreamChatClient_v3/Utils/Atomic.swift
@@ -1,0 +1,60 @@
+//
+// Atomic.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A mutable thread safe variable.
+///
+/// - Warning: Be aware that accessing and setting a value are two distinct operations, so using operators like `+=` results
+///  in two separate atomic operations. To work around this issue, you can access the wrapper directly and use the
+///  `mutate(_ changes:)` method:
+///  ```
+///    // Correct
+///    atomicValue = 1
+///    let value = atomicValue
+///
+///    atomicValue += 1 // Incorrect! Accessing and setting a value are two atomic operations.
+///    _atomicValue.mutate { $0 += 1 } // Correct
+///    _atomicValue { $0 += 1 } // Also possible
+///  ```
+///
+/// - Note: Even though the value guarded by `Atomic` is thread-safe, the `Atomic` struct itself is not. Mutating the instance
+/// itself from multiple threads can cause a crash.
+
+@propertyWrapper
+public struct Atomic<T> {
+  public var wrappedValue: T {
+    set {
+      mutate { $0 = newValue }
+    }
+
+    mutating get {
+      var currentValue: T!
+      mutate { currentValue = $0 }
+      return currentValue
+    }
+  }
+
+  private let lock = NSRecursiveLock()
+  private var _wrappedValue: T
+
+  /// Update the value safely.
+  /// - Parameter changes: a block with changes. It should return a new value.
+  public mutating func mutate(_ changes: (_ value: inout T) -> Void) {
+    lock.lock()
+    changes(&_wrappedValue)
+    lock.unlock()
+  }
+
+  /// Update the value safely.
+  /// - Parameter changes: a block with changes. It should return a new value.
+  mutating func callAsFunction(_ changes: (_ value: inout T) -> Void) {
+    mutate(changes)
+  }
+
+  public init(wrappedValue: T) {
+    self._wrappedValue = wrappedValue
+  }
+}

--- a/StreamChatClient_v3/Utils/Atomic_tests.swift
+++ b/StreamChatClient_v3/Utils/Atomic_tests.swift
@@ -1,0 +1,132 @@
+//
+// Atomic_tests.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient_v3
+import XCTest
+
+class AtomicTests: XCTestCase {
+  @Atomic var stringAtomicValue: String?
+  @Atomic var intAtomicValue: Int = 0
+
+  func test_Atomic_asPropertyWrapper() {
+    stringAtomicValue = nil
+    XCTAssertEqual(stringAtomicValue, nil)
+
+    stringAtomicValue = "Luke"
+    XCTAssertEqual(stringAtomicValue, "Luke")
+
+    _stringAtomicValue { value in
+      XCTAssertEqual(value, "Luke")
+      value = nil
+    }
+    XCTAssertEqual(stringAtomicValue, nil)
+  }
+
+  func test_Atomic_usedAsCounter() {
+    intAtomicValue = 0
+
+    // Count up to numberOfCycles
+    for _ in 0 ..< numberOfStressTestCycles {
+      DispatchQueue.random.async {
+        self._intAtomicValue { $0 += 1 }
+      }
+    }
+    AssertAsync.willBeEqual(intAtomicValue, numberOfStressTestCycles)
+
+    // Count down to zero
+    for _ in 0 ..< numberOfStressTestCycles {
+      DispatchQueue.random.async {
+        self._intAtomicValue { $0 -= 1 }
+      }
+    }
+    AssertAsync.willBeEqual(intAtomicValue, 0)
+  }
+}
+
+// MARK: - Stress tests
+
+extension AtomicTests {
+  /// Increase `numberOfStressTestCycles` significantly to properly stress-test `Atomic`.
+  var numberOfStressTestCycles: Int { 50 }
+
+  func test_Atomic_underHeavyLoad() {
+    for _ in 0 ..< 100 {
+      test_Atomic_usedAsCounter()
+      test_Atomic_usedWithCollection()
+      test_Atomic_whenSetAndGetCalledSimultaneously()
+      test_Atomic_whenCalledFromMainThred()
+    }
+  }
+
+  func test_Atomic_usedWithCollection() {
+    var atomicValue = Atomic<[String: Int]>(wrappedValue: [:])
+
+    for idx in 0 ..< numberOfStressTestCycles {
+      DispatchQueue.random.async {
+        atomicValue.mutate { $0["\(idx)"] = idx }
+      }
+    }
+
+    AssertAsync.willBeEqual(atomicValue.wrappedValue.count, numberOfStressTestCycles)
+  }
+
+  func test_Atomic_whenSetAndGetCalledSimultaneously() {
+    var atomicValue = Atomic<[String: Int]>(wrappedValue: [:])
+
+    for idx in 0 ..< numberOfStressTestCycles {
+      DispatchQueue.random.async {
+        atomicValue { $0["\(idx)"] = idx }
+      }
+
+      for _ in 0 ... 5 {
+        var value: [String: Int] { atomicValue.wrappedValue }
+        DispatchQueue.random.async {
+          _ = value
+        }
+      }
+    }
+
+    AssertAsync.willBeEqual(atomicValue.wrappedValue.count, numberOfStressTestCycles)
+  }
+
+  func test_Atomic_whenCalledFromMainThred() {
+    var value = Atomic<[String: Int]>(wrappedValue: [:])
+
+    for idx in 0 ..< numberOfStressTestCycles {
+      value { $0["\(idx)"] = idx }
+      value.wrappedValue = ["random": 2020]
+      _ = value.wrappedValue
+    }
+
+    XCTAssertEqual(value.wrappedValue, ["random": 2020])
+  }
+}
+
+private extension DispatchQueue {
+  private static let queueIdKey = DispatchSpecificKey<String>()
+  private static let testQueueId = UUID().uuidString
+
+  /// Returns one of the existing global Dispatch queues.
+  static var random: DispatchQueue {
+    let allQoS: [DispatchQoS.QoSClass] = [
+      .userInteractive,
+      .userInitiated,
+      .default
+    ]
+    return DispatchQueue.global(qos: allQoS.randomElement()!)
+  }
+
+  /// Creates a queue which can be later identified.
+  static var testQueue: DispatchQueue {
+    let queue = DispatchQueue(label: "Test queue")
+    queue.setSpecific(key: Self.queueIdKey, value: testQueueId)
+    return queue
+  }
+
+  /// Checks if the current queue is the queue created by `DispatchQueue.testQueue`.
+  static var isTestQueue: Bool {
+    DispatchQueue.getSpecific(key: queueIdKey) == testQueueId
+  }
+}

--- a/TestResources_v3/Custom Assertions/AssertAsync.swift
+++ b/TestResources_v3/Custom Assertions/AssertAsync.swift
@@ -271,23 +271,31 @@ extension AssertAsync {
     ///   - message: The message to print when the assertion fails.
     ///
     /// - Warning: ⚠️ Both expressions are evaluated repeatedly during the function execution. The expressions should not have
-    ///   any side effects which can affect their results.
-    static func willBeEqual<T: Equatable>(_ expression1: @autoclosure @escaping () -> T,
-                                          _ expression2: @autoclosure @escaping () -> T,
-                                          timeout: TimeInterval = defaultTimeout,
-                                          message: @autoclosure @escaping () -> String? = nil,
-                                          file: StaticString = #file,
-                                          line: UInt = #line) {
-    
-        AssertAsync {
-            Assert.willBeEqual(expression1(),
-                               expression2(),
-                               timeout: timeout,
-                               message: message(),
-                               file: file,
-                               line: line)
+  ///   any side effects which can affect their results.
+  static func willBeEqual<T: Equatable>(
+    _ expression1: @autoclosure () -> T,
+    _ expression2: @autoclosure () -> T,
+    timeout: TimeInterval = defaultTimeout,
+    message: @autoclosure () -> String? = nil,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    _ = withoutActuallyEscaping(expression1) { expression1 in
+      withoutActuallyEscaping(expression2) { expression2 in
+        withoutActuallyEscaping(message) { message in
+          AssertAsync {
+            Assert.willBeEqual(
+              expression1(),
+              expression2(),
+              timeout: timeout,
+              message: message(),
+              file: file,
+              line: line)
+          }
         }
+      }
     }
+  }
     
     /// Blocks the current test execution and periodically checks if the expression evaluates to `nil`. Fails if
     /// the expression result is not `nil` within the `timeout` period.


### PR DESCRIPTION
#### In this PR:`
- `AssertAsync.willBeEqual` no longer takes `@escaping` closures (we don't need to use `self` on the caller site)
- The basic functionality of `Atomic` is migrated to v3
- Added option to use it as a property wrapper

#no_changelog