### PR TITLE
Fix new messages/updates not given for ChannelPresenter initialized with ChannelResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ _June 05, 2020_
 
 ### 🐞 Fixed
 - Fixed `rx.connectionState` observation when a user logged out and login again [#284](https://github.com/GetStream/stream-chat-swift/issues/284).
+- Fixed updates not happening in `ChannelPresenter` initialized with `ChannelResponse` and queryOptions containing `.watch` [#301](https://github.com/GetStream/stream-chat-swift/pull/301)
 
 # [2.2.2](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.2)
 _May 27, 2020_

--- a/Sources/Core/Presenter/Channel/ChannelPresenter+RxRequests.swift
+++ b/Sources/Core/Presenter/Channel/ChannelPresenter+RxRequests.swift
@@ -34,7 +34,9 @@ extension Reactive where Base == ChannelPresenter {
                         return Void()
                     })
                     .asDriver(onErrorJustReturn: ())
-                : Driver.just(()))
+                : (base.channel.didLoad // If presenter is initialized with a ChannelResponse, query the channel with given options
+                ? base.channel.rx.query(options: base.queryOptions).map({ _ in return Void() }).asDriver(onErrorJustReturn: ())
+                : Driver.just(())))
                 // Merge all view changes from all sources.
                 .flatMapLatest({ [weak base] _ -> Driver<ViewChanges> in
                     guard let base = base else {

--- a/Sources/Core/Presenter/Channel/ChannelPresenter+RxRequests.swift
+++ b/Sources/Core/Presenter/Channel/ChannelPresenter+RxRequests.swift
@@ -35,8 +35,8 @@ extension Reactive where Base == ChannelPresenter {
                     })
                     .asDriver(onErrorJustReturn: ())
                 : (base.channel.didLoad // If presenter is initialized with a ChannelResponse, query the channel with given options
-                ? base.channel.rx.query(options: base.queryOptions).map({ _ in return Void() }).asDriver(onErrorJustReturn: ())
-                : Driver.just(())))
+                  ? base.channel.rx.query(options: base.queryOptions).map({ _ in return Void() }).asDriver(onErrorJustReturn: ())
+                  : Driver.just(())))
                 // Merge all view changes from all sources.
                 .flatMapLatest({ [weak base] _ -> Driver<ViewChanges> in
                     guard let base = base else {

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -154,7 +154,6 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
             presenter.reload()
         } else {
             refreshTableView(scrollToBottom: true, animated: false)
-            presenter.channel.query(options: presenter.queryOptions) { _ in }
         }
         
         needsToReload = false

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -154,6 +154,7 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
             presenter.reload()
         } else {
             refreshTableView(scrollToBottom: true, animated: false)
+            presenter.channel.query(options: presenter.queryOptions) { _ in }
         }
         
         needsToReload = false


### PR DESCRIPTION
## Reproducing the bug

1. Initialize ChatViewController
2. Make queryChannels without queryOptions eg: `Client.shared.queryChannels(filter: .equal("id", to: "general2")) { ... }`
3. Use the ChannelResponse to initialize a ChannelPresenter with queryOptions .all, eg: `ChannelPresenter(response: response, queryOptions: .all)`
4. Set the ChatViewController presenter to it and display the view controller
5. Sending a message won't show up and no other updates are given

Logs without bug: http://dontpad.com/working_logs_jqwelqkwej1
Logs with bug: http://dontpad.com/bug_logs_lqwenqkwej12

## Explanation

The .watch (or .all) query option given to ChannelPresenter does not seem to take effect.

If a ChannelPresenter is initialized with a ChannelResponse and it already contains items, it won't run `presenter.reload()` in `ChatViewController`'s  `viewDidLoad`:

```swift
        if presenter.isEmpty {
            presenter.reload()
        } else {
            refreshTableView(scrollToBottom: true, animated: false)
        }
```

But that call is needed to make an initial query that watches the channel (if .watch is included in the query options). This happens in `ChannelPresenter+RxRequests.swift#L68`

## Proposal

My proposal is to call `channel.query` somewhere with the query options given to `ChannelsPresenter`. I did it in the else of the snippet mentioned, but I feel there must be a better place to do it.
