### PR TITLE
[CIS-168] Finish WebSocketClient implementation Part 3: Implementation

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -102,6 +102,8 @@
 		799C9479247E3DEA001F1104 /* StreamChatModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 799C9477247E3DEA001F1104 /* StreamChatModel.xcdatamodeld */; };
 		799C947D247E6114001F1104 /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C947B247E6051001F1104 /* TestError.swift */; };
 		79A0E9AD2498BD0C00E9BD50 /* ChatClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9AC2498BD0C00E9BD50 /* ChatClient.swift */; };
+		79A0E9AF2498BFD800E9BD50 /* WebSocketClient_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9AE2498BFD800E9BD50 /* WebSocketClient_tests.swift */; };
+		79A0E9B02498C09900E9BD50 /* ConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C750BD2490D0130023F0B7 /* ConnectionState.swift */; };
 		79A9E4F72449D3AF00599B95 /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */; };
 		79A9E4F92449DF2D00599B95 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F82449DF2D00599B95 /* Reachability.swift */; };
 		79BF83EC248F8EDF007611A1 /* LogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BF83EB248F8EDF007611A1 /* LogDestination.swift */; };
@@ -536,6 +538,7 @@
 		799C9478247E3DEA001F1104 /* StreamChatModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = StreamChatModel.xcdatamodel; sourceTree = "<group>"; };
 		799C947B247E6051001F1104 /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		79A0E9AC2498BD0C00E9BD50 /* ChatClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatClient.swift; sourceTree = "<group>"; };
+		79A0E9AE2498BFD800E9BD50 /* WebSocketClient_tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSocketClient_tests.swift; sourceTree = "<group>"; };
 		79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+Gzip.swift"; sourceTree = "<group>"; };
 		79A9E4F82449DF2D00599B95 /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		79BF83EB248F8EDF007611A1 /* LogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LogDestination.swift; path = ../LogDestination.swift; sourceTree = "<group>"; };
@@ -1095,6 +1098,7 @@
 				79280F402484F4DD00CDEB89 /* Events */,
 				79280F76248917EB00CDEB89 /* Engine */,
 				799C9444247D3DD2001F1104 /* WebSocketClient.swift */,
+				79A0E9AE2498BFD800E9BD50 /* WebSocketClient_tests.swift */,
 				799BE2E9248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift */,
 				799BE2EB248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_tests.swift */,
 				797A756324814E7A003CF16D /* WebSocketPayload.swift */,
@@ -2355,6 +2359,7 @@
 				79BF83F4248F8F88007611A1 /* LogFormatter.swift in Sources */,
 				79280F4D24852FCA00CDEB89 /* DataChange.swift in Sources */,
 				79280F4424850B4300CDEB89 /* ChannelEventsHandler.swift in Sources */,
+				79A0E9B02498C09900E9BD50 /* ConnectionState.swift in Sources */,
 				799C9439247D2FB9001F1104 /* ChannelDTO.swift in Sources */,
 				799C9443247D3DA7001F1104 /* APIClient.swift in Sources */,
 				792A4F492480107A00EAF71D /* Sorting.swift in Sources */,
@@ -2402,6 +2407,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				79A0E9AF2498BFD800E9BD50 /* WebSocketClient_tests.swift in Sources */,
 				799C947D247E6114001F1104 /* TestError.swift in Sources */,
 				799C946A247D791A001F1104 /* AssertAsync.swift in Sources */,
 				79280F8324891C6A00CDEB89 /* VirtualTime_Tests.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		7962958C248147430078EB53 /* BaseURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7962958B248147430078EB53 /* BaseURL.swift */; };
 		796610B4248E518D00761629 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EDC122E9BAC5005CFAC9 /* Starscream.framework */; };
 		796610B5248E518D00761629 /* Starscream.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EDC122E9BAC5005CFAC9 /* Starscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		796610B9248E651800761629 /* EventMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796610B8248E651800761629 /* EventMiddleware.swift */; };
+		796610BB248E687000761629 /* EventMiddleware_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796610BA248E687000761629 /* EventMiddleware_tests.swift */; };
 		797A756424814E7A003CF16D /* WebSocketPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797A756324814E7A003CF16D /* WebSocketPayload.swift */; };
 		797A756624814EF8003CF16D /* SystemEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797A756524814EF8003CF16D /* SystemEnvironment.swift */; };
 		797A756824814F0D003CF16D /* BundleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797A756724814F0D003CF16D /* BundleExtensions.swift */; };
@@ -499,6 +501,8 @@
 		794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestableCodingKey.swift; sourceTree = "<group>"; };
 		795FCD1B23EB155000990F15 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		7962958B248147430078EB53 /* BaseURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseURL.swift; sourceTree = "<group>"; };
+		796610B8248E651800761629 /* EventMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware.swift; sourceTree = "<group>"; };
+		796610BA248E687000761629 /* EventMiddleware_tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware_tests.swift; sourceTree = "<group>"; };
 		797A756324814E7A003CF16D /* WebSocketPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketPayload.swift; sourceTree = "<group>"; };
 		797A756524814EF8003CF16D /* SystemEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemEnvironment.swift; sourceTree = "<group>"; };
 		797A756724814F0D003CF16D /* BundleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleExtensions.swift; sourceTree = "<group>"; };
@@ -1052,6 +1056,15 @@
 			path = Config;
 			sourceTree = "<group>";
 		};
+		796610B7248E64EC00761629 /* EventMiddlewares */ = {
+			isa = PBXGroup;
+			children = (
+				796610B8248E651800761629 /* EventMiddleware.swift */,
+				796610BA248E687000761629 /* EventMiddleware_tests.swift */,
+			);
+			path = EventMiddlewares;
+			sourceTree = "<group>";
+		};
 		799C9415247D2F38001F1104 /* StreamChatClient_v3 */ = {
 			isa = PBXGroup;
 			children = (
@@ -1078,6 +1091,7 @@
 		799C9426247D2FB9001F1104 /* WebSocketClient */ = {
 			isa = PBXGroup;
 			children = (
+				796610B7248E64EC00761629 /* EventMiddlewares */,
 				79280F402484F4DD00CDEB89 /* Events */,
 				79280F76248917EB00CDEB89 /* Engine */,
 				799C9444247D3DD2001F1104 /* WebSocketClient.swift */,
@@ -2326,6 +2340,7 @@
 			files = (
 				79280F4F2485308100CDEB89 /* Controller.swift in Sources */,
 				792A4F40247FFDE700EAF71D /* Data+Gzip.swift in Sources */,
+				796610B9248E651800761629 /* EventMiddleware.swift in Sources */,
 				799C943F247D2FB9001F1104 /* Channel.swift in Sources */,
 				792A4F472480107A00EAF71D /* Filter.swift in Sources */,
 				792A4F4B248010A600EAF71D /* QueryOptions.swift in Sources */,
@@ -2401,6 +2416,7 @@
 				79280F8424891C6A00CDEB89 /* VirtualTime.swift in Sources */,
 				79280F542485529500CDEB89 /* ChannelEventsHandler_Tests.swift in Sources */,
 				799C9476247D7E94001F1104 /* TemporaryURLs.swift in Sources */,
+				796610BB248E687000761629 /* EventMiddleware_tests.swift in Sources */,
 				799C9469247D791A001F1104 /* AssertResult.swift in Sources */,
 				79280F8224891C6A00CDEB89 /* VirtualTimer.swift in Sources */,
 			);

--- a/StreamChatClient_v3/WebSocketClient/ConnectionState.swift
+++ b/StreamChatClient_v3/WebSocketClient/ConnectionState.swift
@@ -46,4 +46,12 @@ public enum ConnectionState: Equatable {
     }
     return false
   }
+
+  /// Returns false if the connection state is in the `notConnected` state.
+  public var isActive: Bool {
+    if case .notConnected = self {
+      return false
+    }
+    return true
+  }
 }

--- a/StreamChatClient_v3/WebSocketClient/EventMiddlewares/EventMiddleware.swift
+++ b/StreamChatClient_v3/WebSocketClient/EventMiddlewares/EventMiddleware.swift
@@ -1,0 +1,48 @@
+//
+// EventMiddleware.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An object used to pre-process incoming `Event`.
+protocol EventMiddleware {
+  /// Process the incoming event and call completion when done. `completion` can be called multiple times if
+  /// the functionality requires it.
+  ///
+  /// - Parameters:
+  ///   - event: The incoming `Event`.
+  ///   - completion: Called when the event processing is done. If called with `nil`, no middlewares down the
+  ///   chain are called.
+  func handle(event: Event, completion: @escaping (Event?) -> Void)
+}
+
+extension Array where Element == EventMiddleware {
+  /// Evaluates an array of `EventMiddleware`s in the order they're specified in the array. It's not guaranteed that
+  /// all middlewares are called. If a middleware returns `nil`, no middlewares down in the chain are called.
+  ///
+  /// - Parameters:
+  ///   - event: The event to be pre-processed.
+  ///   - completion: Called when the event pre-processing is finished. Be aware that `completion` can be called
+  ///   multiple times for a single event.
+  func process(event: Event, completion: @escaping (Event?) -> Void) {
+    guard isEmpty == false else { completion(event); return }
+    evaluate(idx: startIndex, event: event, completion: completion)
+  }
+
+  private func evaluate(idx: Int, event: Event, completion: @escaping (Event?) -> Void) {
+    let middleware = self[idx]
+    middleware.handle(event: event) { event in
+      let nextIdx = idx + 1
+      if nextIdx == self.endIndex {
+        completion(event)
+
+      } else if let event = event {
+        self.evaluate(idx: nextIdx, event: event, completion: completion)
+
+      } else {
+        completion(nil)
+      }
+    }
+  }
+}

--- a/StreamChatClient_v3/WebSocketClient/EventMiddlewares/EventMiddleware_tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/EventMiddlewares/EventMiddleware_tests.swift
@@ -1,0 +1,52 @@
+//
+// EventMiddleware_tests.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient_v3
+import XCTest
+
+class EventMiddlewareTests: XCTestCase {
+  /// A test middleware that can be initiated with a closure/
+  struct ClosureBasedMiddleware: EventMiddleware {
+    let closure: (_ event: Event, _ completion: @escaping (Event?) -> Void) -> Void
+
+    func handle(event: Event, completion: @escaping (Event?) -> Void) {
+      closure(event, completion)
+    }
+  }
+
+  /// A test event holding an `Int` value.
+  struct IntBasedEvent: Event, Equatable {
+    static var eventRawType: String { "test_only" }
+    let value: Int
+  }
+
+  func test_middlewareEvaluation() throws {
+    let chain: [EventMiddleware] = [
+      // Adds `1` to the event synchronously
+      ClosureBasedMiddleware { event, completion in
+        let event = event as! IntBasedEvent
+        completion(IntBasedEvent(value: event.value + 1))
+      },
+
+      // Adds `1` to the event synchronously and resets it to `0` asynchronously
+      ClosureBasedMiddleware { event, completion in
+        let event = event as! IntBasedEvent
+        DispatchQueue.main.async {
+          completion(IntBasedEvent(value: 0))
+        }
+        completion(IntBasedEvent(value: event.value + 1))
+      }
+    ]
+
+    // Evaluate the middlewares and record the events
+    var result: [IntBasedEvent?] = []
+    chain.process(event: IntBasedEvent(value: 0)) {
+      result.append($0 as? IntBasedEvent)
+    }
+
+    // Check we have two callbacks with correct results
+    AssertAsync.willBeEqual(result, [IntBasedEvent(value: 2), IntBasedEvent(value: 0)])
+  }
+}

--- a/StreamChatClient_v3/WebSocketClient/Events/ConnectionEvents.swift
+++ b/StreamChatClient_v3/WebSocketClient/Events/ConnectionEvents.swift
@@ -20,4 +20,8 @@ public struct HealthCheck: ConnectionEvent {
     }
     self.connectionId = connectionId
   }
+
+  init(connectionId: String) {
+    self.connectionId = connectionId
+  }
 }

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
@@ -9,59 +9,141 @@ class WebSocketClient {
   /// The time interval to ping connection to keep it alive.
   static let pingTimeInterval: TimeInterval = 25
 
-  /// The notification center `WebSocketClient` uses to send notification about incoming events.
-  let notificationCenter: NotificationCenter
+  /// Additional options for configuring web socket behavior.
+  struct Options: OptionSet {
+    let rawValue: Int
+    /// When the app enters background, `WebSocketClient` starts a long term background task and stays connected.
+    static let staysConnectedInBackground = Options(rawValue: 1 << 0)
+  }
 
-  // This should probably live somewhere else
-  private(set) var connectionId: String? {
+  /// The notification center `WebSocketClient` uses to send notifications about incoming events.
+  private(set) lazy var notificationCenter: NotificationCenter = environment.notificationCenterBuilder()
+
+  /// The current state the web socket connection.
+  @Atomic private(set) var connectionState: ConnectionState = .notConnected() {
     didSet {
-      guard let connectionId = connectionId else { return }
-      connectionIdWaiters.forEach { $0(connectionId) }
-      connectionIdWaiters.removeAll()
+      if connectionState.isConnected {
+        pingTimer.resume()
+      } else {
+        pingTimer.suspend()
+      }
+
+      if case .notConnected = connectionState {
+        // No reconnection attempts are scheduled
+        cancelBackgroundTaskIfNeeded()
+      }
     }
   }
 
-  private var connectionIdWaiters: [(String) -> Void] = []
+  /// Web socket connection options
+  var options: Options = [.staysConnectedInBackground]
+
+  /// Event middlewares used to pre-process incoming events before they are published
+  var middlewares: [EventMiddleware]
 
   /// The decoder used to decode incoming events
   private let eventDecoder: AnyEventDecoder
 
   /// The web socket engine used to make the actual WS connection
-  private let engine: WebSocketEngine
+  private lazy var engine: WebSocketEngine = {
+    let engine = self.environment.engineBuilder(self.urlRequest, self.engineQueue)
+    engine.delegate = self
+    return engine
+  }()
 
-  private let options: WebSocketOptions = []
-
-  private var consecutiveFailures: TimeInterval = 0
-  private var shouldReconnect = false
-
-  private var backgroundTask: UIBackgroundTaskIdentifier = .invalid
-
-//  private(set) var eventError: ClientErrorResponse?
-
-//  var connectionState: ConnectionState { connectionStateAtomic.get() }
-//
-//  private lazy var connectionStateAtomic =
-//      Atomic<ConnectionState>(.notConnected, callbackQueue: nil) { [weak self] connectionState, _ in
-//          self?.publishEvent(.connectionChanged(connectionState))
-//  }
-
-  private lazy var handshakeTimer = environment.timer
+  /// The timer used for scheduling `ping` calls
+  private lazy var pingTimer = environment.timer
     .scheduleRepeating(
       timeInterval: WebSocketClient.pingTimeInterval,
       queue: engine.callbackQueue
     ) { [weak self] in
-//          self?.logger?.log("🏓➡️", level: .info)
       self?.engine.sendPing()
     }
 
+  /// If in the `waitingForReconnect` state, this variable contains the reconnection timer.
+  private var reconnectionTimer: TimerControl?
+
+  /// The queue on which web socket engine methods are called
+  private let engineQueue: DispatchQueue = .init(label: "io.getStream.chat.core.web_socket_engine_queeu", qos: .default)
+
+  /// The request used to establish web socket connection
+  private let urlRequest: URLRequest
+
+  /// An object describing reconnection behavior after the web socket is disconnected.
+  private var reconnectionStrategy: WebSocketClientReconnectionStrategy
+
+  /// Used for starting and ending background tasks. Typically, this is provided by `UIApplication` which conforms
+  /// to `BackgroundTaskScheduler` automatically.
+  private lazy var backgroundTaskScheduler: BackgroundTaskScheduler = environment.backgroundTaskScheduler
+
+  /// The identifier of the currently running background task. `nil` of no background task is running.
+  private var activeBackgroundTask: UIBackgroundTaskIdentifier?
+
+  /// An object containing external dependencies of `WebSocketClient`
   private let environment: Environment
 
-  /// Checks if the web socket is connected and `connectionId` is not nil.
-  var isConnected: Bool { connectionId != nil && engine.isConnected }
+  init(
+    urlRequest: URLRequest,
+    eventDecoder: AnyEventDecoder,
+    eventMiddlewares: [EventMiddleware],
+    reconnectionStrategy: WebSocketClientReconnectionStrategy = DefaultReconnectionStrategy(),
+    environment: Environment = .init()
+  ) {
+    self.environment = environment
+    self.urlRequest = urlRequest
+    self.middlewares = eventMiddlewares
+    self.reconnectionStrategy = reconnectionStrategy
+    self.eventDecoder = eventDecoder
 
+    startListeningForAppStateUpdates()
+  }
+
+  private func startListeningForAppStateUpdates() {
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(handleAppDidEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil
+    )
+
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(handleAppDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil
+    )
+  }
+
+  @objc
+  private func handleAppDidEnterBackground() {
+    guard options.contains(.staysConnectedInBackground), connectionState.isActive else { return }
+
+    let backgroundTask = backgroundTaskScheduler.beginBackgroundTask { [weak self] in
+      self?.disconnect(source: .systemInitiated)
+    }
+
+    if backgroundTask != .invalid {
+      activeBackgroundTask = backgroundTask
+    } else {
+      // Can't initiate a background task, close the connection
+      disconnect(source: .systemInitiated)
+    }
+  }
+
+  @objc
+  private func handleAppDidBecomeActive() {
+    cancelBackgroundTaskIfNeeded()
+  }
+
+  private func cancelBackgroundTaskIfNeeded() {
+    if let backgroundTask = activeBackgroundTask {
+      backgroundTaskScheduler.endBackgroundTask(backgroundTask)
+      activeBackgroundTask = nil
+    }
+  }
+}
+
+extension WebSocketClient {
+  /// An object encapsulating all dependencies of `WebSocketClient`.
   struct Environment {
-    var notificationCenter: NotificationCenter = .init()
     var timer: Timer.Type = DefaultTimer.self
+
+    var notificationCenterBuilder: () -> NotificationCenter = NotificationCenter.init
+
     var engineBuilder: (_ request: URLRequest, _ callbackQueue: DispatchQueue) -> WebSocketEngine = {
       if #available(iOS 13, *) {
         return URLSessionWebSocketEngine(request: $0, callbackQueue: $1)
@@ -69,128 +151,42 @@ class WebSocketClient {
         return StarscreamWebSocketProvider(request: $0, callbackQueue: $1)
       }
     }
-  }
 
-  init(
-    urlRequest: URLRequest,
-    eventDecoder: AnyEventDecoder,
-    callbackQueue: DispatchQueue,
-    environment: Environment = .init()
-  ) {
-    self.environment = environment
-    self.engine = environment.engineBuilder(urlRequest, callbackQueue)
-    self.notificationCenter = environment.notificationCenter
-    self.eventDecoder = eventDecoder
-    engine.delegate = self
+    var backgroundTaskScheduler: BackgroundTaskScheduler = UIApplication.shared
   }
 }
 
 extension WebSocketClient {
-  /// Connect to web socket.
-  /// - Note:
-  ///     - Skip if the Internet is not available.
-  ///     - Skip if it's already connected.
-  ///     - Skip if it's reconnecting.
-  public func connect() {
-    cancelBackgroundWork()
-
-//        if isConnected || connectionState == .connecting || connectionState == .reconnecting {
-//            if let logger = logger {
-//                let reasons = [(isConnected ? " isConnected with connectionId = \(connectionId ?? "n/a")" : nil),
-//                               (connectionState == .reconnecting ? " isReconnecting" : nil),
-//                               (connectionState == .connecting ? "isConnecting" : nil),
-//                               (provider.isConnected ? "\(provider).isConnected" : nil)]
-//
-//                logger.log("SKIP connect: \(reasons.compactMap({ $0 }).joined(separator: ", "))")
-//            }
-//
-//            return
-//        }
-//
-//        if provider.isConnected {
-//            provider.disconnect()
-//        }
-
-//        logger?.log("Connecting...")
-//        logger?.log(provider.request)
-//        connectionStateAtomic.set(.connecting)
-    shouldReconnect = true
-
-    DispatchQueue.main.async(execute: engine.connect)
-  }
-
-  private func reconnect() {
-//        guard connectionState != .reconnecting else {
-//            return
-//        }
-//
-//        connectionStateAtomic.set(.reconnecting)
-//        let maxDelay: TimeInterval = min(0.5 + consecutiveFailures * 2, 25)
-//        let minDelay: TimeInterval = min(max(0.25, (consecutiveFailures - 1) * 2), 25)
-//        consecutiveFailures += 1
-//        let delay = TimeInterval.random(in: minDelay...maxDelay)
-//        logger?.log("⏳ Reconnect in \(delay) sec")
-//
-//        Timer.schedule(timeInterval: delay, queue: provider.callbackQueue) { [weak self] in
-//            self?.connectionStateAtomic.set(.notConnected)
-//            self?.connect()
-//        }
-  }
-
-  func disconnectInBackground() {
-//        provider.callbackQueue.async(execute: disconnectInBackgroundInWebSocketQueue)
-  }
-
-  private func disconnectInBackgroundInWebSocketQueue() {
-    guard options.contains(.stayConnectedInBackground) else {
-      disconnect(reason: "Going into background, stayConnectedInBackground is disabled")
+  /// Connects the web connect.
+  ///
+  /// Calling this method has no effect is the web socket is already connected, or is in the connecting phase.
+  func connect() {
+    switch connectionState {
+    // Calling connect in the following states has no effect
+    case .connecting, .waitingForConnectionId, .connected(connectionId: _):
       return
+    default: break
     }
 
-    if backgroundTask != .invalid {
-      UIApplication.shared.endBackgroundTask(backgroundTask)
-    }
+    // Cancel the reconnection timer if exists
+    reconnectionTimer?.cancel()
 
-    backgroundTask = UIApplication.shared.beginBackgroundTask { [weak self] in
-      self?.disconnect(reason: "Processing finished in background")
-      self?.backgroundTask = .invalid
-    }
+    connectionState = .connecting
 
-    if backgroundTask == .invalid {
-      disconnect(reason: "Can't create a background task")
+    engineQueue.async {
+      self.engine.connect()
     }
   }
 
-  private func cancelBackgroundWork() {
-//        logger?.log("Cancelling background work...")
-
-    if backgroundTask != .invalid {
-      UIApplication.shared.endBackgroundTask(backgroundTask)
-      backgroundTask = .invalid
-//            logger?.log("💜 Background mode off")
+  /// Disconnects the web socket.
+  ///
+  /// Calling this function has no effect, if the connection is in an inactive state.
+  /// - Parameter source: Additional information about the source of the disconnection. Default value is `.userInitiated`.
+  func disconnect(source: ConnectionState.DisconnectionSource = .userInitiated) {
+    connectionState = .disconnecting(source: source)
+    engineQueue.async {
+      self.engine.disconnect()
     }
-  }
-
-  func disconnect(reason: String) {
-    shouldReconnect = false
-    consecutiveFailures = 0
-    clearStateAfterDisconnect()
-
-//        if provider.isConnected {
-//            logger?.log("Disconnecting: \(reason)")
-//            connectionStateAtomic.set(.disconnecting)
-//            provider.disconnect()
-//        } else {
-//            logger?.log("Skip disconnecting: WebSocket was not connected")
-//            connectionStateAtomic.set(.disconnected(nil))
-//        }
-  }
-
-  private func clearStateAfterDisconnect() {
-//        logger?.log("Clearing state after disconnect...")
-    handshakeTimer.suspend()
-    connectionId = nil
-    cancelBackgroundWork()
   }
 }
 
@@ -198,188 +194,72 @@ extension WebSocketClient {
 
 extension WebSocketClient: WebSocketEngineDelegate {
   func websocketDidConnect() {
-//        logger?.log("❤️ Connected. Waiting for the current user data and connectionId...")
-//        connectionStateAtomic.set(.connecting)
+    connectionState = .waitingForConnectionId
   }
 
   func websocketDidReceiveMessage(_ message: String) {
-    log.debug(message)
-
     do {
       let event = try eventDecoder.decode(data: message.data(using: .utf8)!)
-      notificationCenter.post(Notification(newEventReceived: event, sender: self))
 
       if let event = event as? HealthCheck {
-        connectionId = event.connectionId
+        if connectionState.isConnected == false {
+          connectionState = .connected(connectionId: event.connectionId)
+          reconnectionStrategy.sucessfullyConnected()
+        }
+      }
+
+      middlewares.process(event: event) { [weak self] event in
+        guard let self = self, let event = event else { return }
+        self.notificationCenter.post(Notification(newEventReceived: event, sender: self))
       }
 
     } catch {
-      log.error(error)
+      // Check if the message contains an error object from the server
+      let webSocketError = message
+        .data(using: .utf8)
+        .map { try? JSONDecoder.default.decode(WebSocketErrorContainer.self, from: $0) }
+        .map { ClientError.WebSocketError(with: $0?.error) }
+
+      if let webSocketError = webSocketError {
+        // If there is an error from the server, the connection is about to be disconnected
+        connectionState = .disconnecting(source: .serverInitiated(error: webSocketError))
+      }
+    }
+  }
+
+  func websocketDidDisconnect(error engineError: WebSocketEngineError?) {
+    // Reconnection shouldn't happen for manually initiated disconnect
+    let shouldReconnect = connectionState != .disconnecting(source: .userInitiated)
+
+    let disconnectionError: Error?
+    if case .disconnecting(.serverInitiated(let webSocketError)) = connectionState {
+      disconnectionError = webSocketError?.underlyingError
+    } else {
+      disconnectionError = engineError
     }
 
-//        guard let event = parseEvent(with: message) else {
-//            return
-//        }
-//
-//        switch event {
-//        case let .healthCheck(user, connectionId):
-//            logger?.log("🥰 Connected")
-//            self.connectionId = connectionId
-//            handshakeTimer.resume()
-//            connectionStateAtomic.set(.connected(UserConnection(user: user, connectionId: connectionId)))
-//            return
-//
-//        case let .messageNew(message, _, _, _) where message.user.isMuted:
-//            logger?.log("Skip a message (\(message.id)) from muted user (\(message.user.id)): \(message.textOrArgs)", level: .info)
-//            return
-//        case let .typingStart(user, _, _), let .typingStop(user, _, _):
-//            if user.isMuted {
-//                logger?.log("Skip typing events from muted user (\(user.id))", level: .info)
-//                return
-//            }
-//        default:
-//            break
-//        }
-//
-//        if isConnected {
-//            publishEvent(event)
-//        }
-  }
+    if shouldReconnect, let reconnectionDelay = reconnectionStrategy.reconnectionDelay(forConnectionError: disconnectionError) {
+      let clientError = disconnectionError.map { ClientError.WebSocketError(with: $0) }
+      connectionState = .waitingForReconnect(error: clientError)
 
-  func websocketDidDisconnect(error: WebSocketEngineError?) {
-//        logger?.log("Parsing WebSocket disconnect... (error: \(error?.localizedDescription ?? "<nil>"))")
-//        clearStateAfterDisconnect()
-//
-//        if let eventError = eventError, eventError.code == ClientErrorResponse.tokenExpiredErrorCode {
-//            logger?.log("Disconnected. 🀄️ Token is expired")
-//            connectionStateAtomic.set(.disconnected(ClientError.expiredToken))
-//            return
-//        }
-//
-//        guard let error = error else {
-//            logger?.log("💔 Disconnected")
-//            connectionStateAtomic.set(.disconnected(nil))
-//
-//            if shouldReconnect {
-//                reconnect()
-//            } else {
-//                consecutiveFailures = 0
-//            }
-//
-//            return
-//        }
-//
-//        if isStopError(error) {
-//            logger?.log("💔 Disconnected with Stop code")
-//            consecutiveFailures = 0
-//            connectionStateAtomic.set(.disconnected(.websocketDisconnectError(error)))
-//            return
-//        }
-//
-//        logger?.log(error, message: "💔😡 Disconnected by error")
-//        logger?.log(eventError)
-//        ClientLogger.showConnectionAlert(error, jsonError: eventError)
-//        connectionStateAtomic.set(.disconnected(.websocketDisconnectError(error)))
-//
-//        if shouldReconnect {
-//            reconnect()
-//        }
-  }
+      reconnectionTimer = environment.timer
+        .schedule(timeInterval: reconnectionDelay, queue: engineQueue) { [weak self] in
+          self?.connect()
+        }
 
-//    private func isStopError(_ error: WebSocketProviderError) -> Bool {
-//        guard InternetConnection.shared.isAvailable else {
-//            return true
-//        }
-//
-//        if let eventError = eventError, eventError.code == WebSocketProviderError.stopErrorCode {
-//            return true
-//        }
-//
-//        if error.code == WebSocketProviderError.stopErrorCode {
-//            return true
-//        }
-//
-//        return false
-//    }
-
-//    private func parseEvent(with message: String) -> Event? {
-//        guard let data = message.data(using: .utf8) else {
-//            logger?.log("📦 Can't get a data from the message: \(message)", level: .error)
-//            return nil
-//        }
-//
-//        eventError = nil
-//
-//        do {
-//            let event = try JSONDecoder.default.decode(Event.self, from: data)
-//            consecutiveFailures = 0
-//
-//            // Skip pong events.
-//            if case .pong = event {
-//                logger?.log("⬅️🏓", level: .info)
-//                return nil
-//            }
-//
-//            // Log event.
-//            if let logger = logger {
-//                var userId = ""
-//
-//                if let user = event.user {
-//                    userId = user.isAnonymous ? " 👺" : " 👤 \(user.id)"
-//                }
-//
-//                if let cid = event.cid {
-//                    logger.log("\(event.type) 🆔 \(cid)\(userId)")
-//                } else {
-//                    logger.log("\(event.type)\(userId)")
-//                }
-//
-//                logger.log(data)
-//            }
-//
-//            return event
-//
-//        } catch {
-//            if let errorContainer = try? JSONDecoder.default.decode(ErrorContainer.self, from: data) {
-//                eventError = errorContainer.error
-//            } else {
-//                logger?.log(error, message: "😡 Decode response")
-//            }
-//
-//            logger?.log(data, forceToShowData: true)
-//        }
-//
-//        return nil
-//    }
-}
-
-struct WebSocketOptions: OptionSet {
-  let rawValue: Int
-
-  static let stayConnectedInBackground = WebSocketOptions(rawValue: 1 << 0)
-
-  init(rawValue: Int) {
-    self.rawValue = rawValue
-  }
-}
-
-// Something like this?
-extension WebSocketClient: ConnectionIdProvider {
-  func requestConnectionId(completion: @escaping ((String?) -> Void)) {
-    if let connectionId = self.connectionId {
-      completion(connectionId)
     } else {
-      connectionIdWaiters.append(completion)
+      connectionState = .notConnected(error: disconnectionError.map { ClientError.WebSocketError(with: $0) })
     }
   }
 }
 
 extension Notification.Name {
-  static let NewEventReceived = Notification.Name("co.getStream.chat.core.new_event_received")
+  /// The name of the notification posted when a new event is published/
+  static let NewEventReceived = Notification.Name("io.getStream.chat.core.new_event_received")
 }
 
 extension Notification {
-  private static let eventKey = "co.getStream.chat.core.event_key"
+  private static let eventKey = "io.getStream.chat.core.event_key"
 
   init(newEventReceived event: Event, sender: Any) {
     self.init(name: .NewEventReceived, object: sender, userInfo: [Self.eventKey: event])
@@ -389,3 +269,21 @@ extension Notification {
     userInfo?[Self.eventKey] as? Event
   }
 }
+
+extension ClientError {
+  public class WebSocketError: ClientError {}
+}
+
+/// WebSocket Error
+struct WebSocketErrorContainer: Decodable {
+  /// A server error was received.
+  let error: ServerResponseError
+}
+
+/// Used for starting and ending background tasks. `UIApplication` which conforms to `BackgroundTaskScheduler` automatically.
+protocol BackgroundTaskScheduler {
+  func beginBackgroundTask(expirationHandler: (() -> Void)?) -> UIBackgroundTaskIdentifier
+  func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier)
+}
+
+extension UIApplication: BackgroundTaskScheduler {}

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient_tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient_tests.swift
@@ -1,0 +1,495 @@
+//
+// WebSocketClient_tests.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient_v3
+import XCTest
+
+final class WebSocketClientTests: XCTestCase {
+  struct TestEvent: Event, Equatable {
+    static let eventRawType = "test_event"
+    let id = UUID()
+  }
+
+  // The longest time WebSocket waits to reconnect.
+  let maxReconnectTimeout: VirtualTime.Seconds = 25
+
+  var webSocketClient: WebSocketClient!
+
+  var time: VirtualTime!
+  var reuqest: URLRequest!
+  private var decoder: EventDecoderMock!
+  private var reconnectionStrategy: MockReconnectionStrategy!
+  var engine: WebSocketEngineMock!
+  var connectionId: String!
+  var user: User!
+  var backgroundTaskScheduler: MockBackgroundTaskScheduler!
+
+  var eventNotificationCenter: NotificationCenter!
+
+  override func setUp() {
+    super.setUp()
+
+    time = VirtualTime()
+    VirtualTimeTimer.time = time
+
+    reuqest = URLRequest(url: URL.newUniqueURL())
+    decoder = EventDecoderMock()
+    engine = WebSocketEngineMock()
+    backgroundTaskScheduler = MockBackgroundTaskScheduler()
+
+    eventNotificationCenter = NotificationCenter()
+    reconnectionStrategy = MockReconnectionStrategy()
+
+    var environment = WebSocketClient.Environment()
+    environment.engineBuilder = { _, _ in self.engine }
+    environment.notificationCenterBuilder = { self.eventNotificationCenter }
+    environment.timer = VirtualTimeTimer.self
+    environment.backgroundTaskScheduler = backgroundTaskScheduler
+
+    webSocketClient = WebSocketClient(
+      urlRequest: reuqest,
+      eventDecoder: decoder,
+      eventMiddlewares: [],
+      reconnectionStrategy: reconnectionStrategy,
+      environment: environment
+    )
+
+    connectionId = UUID().uuidString
+    user = User(id: "test_user_\(UUID().uuidString)")
+  }
+
+  override func tearDown() {
+    // Check there are no memory leaks
+    weak var weakReference = webSocketClient
+    webSocketClient = nil
+    XCTAssertNil(weakReference)
+
+    super.tearDown()
+  }
+
+  // MARK: - Connection tests
+
+  func test_connectionFlow() {
+    assert(webSocketClient.connectionState == .notConnected())
+    assert(engine.connect_calledCount == 0)
+
+    // Call `connect`, it should change connection state and call `connect` on the engine
+    webSocketClient.connect()
+    XCTAssertEqual(webSocketClient.connectionState, .connecting)
+    AssertAsync.willBeEqual(engine.connect_calledCount, 1)
+
+    // Simulate the engine is connected and check the connection state is updated
+    engine.simulateConnectionSuccess()
+    AssertAsync.willBeEqual(webSocketClient.connectionState, .waitingForConnectionId)
+
+    // Simulate a health check event is received and the connection state is updated
+    decoder.decodedEvent = HealthCheck(connectionId: connectionId)
+    engine.simulateMessageReceived()
+
+    AssertAsync.willBeEqual(webSocketClient.connectionState, .connected(connectionId: connectionId))
+  }
+
+  func test_callingConnect_whenAlreadyConnected_hasNoEffect() {
+    // Simulate connection
+    test_connectionFlow()
+
+    assert(webSocketClient.connectionState == .connected(connectionId: connectionId))
+    assert(engine.connect_calledCount == 1)
+
+    // Call connect and assert it has no effect
+    webSocketClient.connect()
+    AssertAsync {
+      Assert.staysTrue(self.engine.connect_calledCount == 1)
+      Assert.staysTrue(self.webSocketClient.connectionState == .connected(connectionId: self.connectionId))
+    }
+  }
+
+  func test_callingConnect_whenWaitingForReconnection_connectsImmediately() {
+    // Simulate reconnection state
+    test_connectionFlow()
+    assert(reconnectionStrategy.reconnectionDelay_calledWithError == nil)
+    reconnectionStrategy.reconnectionDelay = 20
+    engine.simulateDisconnect()
+
+    assert(webSocketClient.connectionState == .waitingForReconnect())
+    // Reset counters
+    engine.connect_calledCount = 0
+    engine.disconnect_calledCount = 0
+
+    // Call connect and assert calls `connect`
+    webSocketClient.connect()
+    AssertAsync {
+      Assert.willBeTrue(self.webSocketClient.connectionState == .connecting)
+      Assert.willBeTrue(self.engine.connect_calledCount == 1)
+    }
+  }
+
+  func test_disconnect() {
+    // Simulate connection
+    test_connectionFlow()
+
+    assert(webSocketClient.connectionState == .connected(connectionId: connectionId))
+    assert(engine.disconnect_calledCount == 0)
+
+    // Call `disconnect`, it should change connection state and call `disconnect` on the engine
+    webSocketClient.disconnect()
+    XCTAssertEqual(webSocketClient.connectionState, .disconnecting(source: .userInitiated))
+    AssertAsync.willBeEqual(engine.disconnect_calledCount, 1)
+
+    // Simulate the engine is disconnected and check the connection state is updated
+    engine.simulateDisconnect()
+    AssertAsync.willBeEqual(webSocketClient.connectionState, .notConnected())
+  }
+
+  func test_reconnectionStrategy_successfullyConnectedIsCalled() {
+    assert(reconnectionStrategy.sucessfullyConnected_calledCount == 0)
+
+    // Simulate connection
+    webSocketClient.connect()
+    engine.simulateConnectionSuccess()
+
+    // `sucessfullyConnected` shouldn't be called before the first health check event arrives
+    AssertAsync.staysTrue(reconnectionStrategy.sucessfullyConnected_calledCount == 0)
+
+    // Simulate a health check event
+    decoder.decodedEvent = HealthCheck(connectionId: connectionId)
+    engine.simulateMessageReceived()
+
+    // `sucessfullyConnected` should be called now
+    AssertAsync.willBeEqual(reconnectionStrategy.sucessfullyConnected_calledCount, 1)
+  }
+
+  func test_reconnectionStrategy_reconnectionDelayIsRequestedAndUsed() {
+    // Simulate connection
+    test_connectionFlow()
+    assert(reconnectionStrategy.reconnectionDelay_calledWithError == nil)
+    engine.connect_calledCount = 0 // Reset the counter
+
+    // Make the reconnection strategy return 20 seconds
+    reconnectionStrategy.reconnectionDelay = 20
+
+    // Simulate the engine disconnects
+    let testError = WebSocketEngineError(reason: UUID().uuidString, code: 0, engineError: nil)
+    engine.simulateDisconnect(testError)
+
+    AssertAsync {
+      Assert.willBeEqual(self.reconnectionStrategy.reconnectionDelay_calledWithError as? WebSocketEngineError, testError)
+      Assert.willBeEqual(
+        self.webSocketClient.connectionState,
+        .waitingForReconnect(error: ClientError.WebSocketError(with: testError))
+      )
+    }
+
+    // Simulate 10 seconds passed and check `connect` is not called yet
+    time.run(numberOfSeconds: 10)
+    AssertAsync.staysEqual(engine.connect_calledCount, 0)
+
+    // Simulate another 11 seconds passed and `connect` is called now
+    time.run(numberOfSeconds: 11)
+    AssertAsync.willBeEqual(engine.connect_calledCount, 1)
+  }
+
+  func test_reconnectionStrategy_reconnectionNotHappeningWhenNilIsReturned() {
+    // Simulate connection
+    test_connectionFlow()
+    engine.connect_calledCount = 0 // Reset the counter
+
+    // Make the reconnection strategy return `nil``
+    reconnectionStrategy.reconnectionDelay = nil
+
+    // Simulate the engine disconnects and check `connectionState` is updated
+    engine.simulateDisconnect()
+    AssertAsync.willBeEqual(webSocketClient.connectionState, .notConnected())
+
+    // Simulate time passed and make sure `connect` is not called
+    time.run(numberOfSeconds: 60)
+    AssertAsync.staysTrue(engine.connect_calledCount == 0)
+  }
+
+  func test_reconnectionStrategy_notCalledWhenDisconnectedManually() {
+    // Simulate connection
+    test_connectionFlow()
+    engine.connect_calledCount = 0 // Reset the counter
+
+    // Make the reconnection return 10 seconds
+    reconnectionStrategy.reconnectionDelay = 10
+
+    // Simulate manual disconnect
+    webSocketClient.disconnect()
+    engine.simulateDisconnect()
+
+    // Simulate time passed and make sure `connect` is not called
+    time.run(numberOfSeconds: 60)
+    AssertAsync.staysTrue(engine.connect_calledCount == 0)
+  }
+
+  func test_pingIsSentPeriodically() {
+    // Simulate connection
+    test_connectionFlow()
+
+    let pingInterval = WebSocketClient.pingTimeInterval
+    assert(engine.sendPing_calledCount == 0)
+
+    // Simulate time longer than pingTimeInterval and assert `engine.sendPing` was called
+    time.run(numberOfSeconds: pingInterval + 1)
+    XCTAssertEqual(engine.sendPing_calledCount, 1)
+
+    // Simulate time 3x longer than pingTimeInterval and assert 3 more pings
+    time.run(numberOfSeconds: 3 * pingInterval)
+    XCTAssertEqual(engine.sendPing_calledCount, 1 + 3)
+  }
+
+  // MARK: - Event handling tests
+
+  func test_incomingEventIsPublished() {
+    // Simulate connection
+    test_connectionFlow()
+
+    // Make the decoder always return TestEvent
+    let testEvent = TestEvent()
+    decoder.decodedEvent = testEvent
+
+    // Start logging events
+    let eventLogger = EventLogger(eventNotificationCenter)
+
+    // Simulate incoming data
+    let incomingData = UUID().uuidString.data(using: .utf8)!
+    engine.simulateMessageReceived(incomingData)
+
+    // Assert that the decoder is used with correct data and the event decoder returns is published
+    AssertAsync {
+      Assert.willBeEqual(self.decoder.decode_calledWithData, incomingData)
+      Assert.willBeEqual(eventLogger.events, [testEvent])
+    }
+  }
+
+  func test_incomingEvent_processedUsingMiddlewares() {
+    // Simulate connection
+    test_connectionFlow()
+
+    // Make the decoder return an event
+    let incomingEvent = TestEvent()
+    decoder.decodedEvent = incomingEvent
+
+    let processedEvent = TestEvent()
+    webSocketClient.middlewares = [ClosureBasedMiddleware { middlewareIncomingEvent, completion in
+      XCTAssertEqual(incomingEvent.asEquatable, middlewareIncomingEvent.asEquatable)
+      completion(processedEvent)
+    }]
+
+    // Start logging events
+    let eventLogger = EventLogger(eventNotificationCenter)
+
+    // Simulate incoming event
+    engine.simulateMessageReceived()
+
+    // Assert the published event is the one from the middleware
+    AssertAsync.willBeEqual(eventLogger.equatableEvents, [processedEvent.asEquatable])
+  }
+
+  // MARK: - Background task tests
+
+  func test_backgroundTaskIsCreated_whenWebSocketIsConnected_andAppGoesToBackground() {
+    // Simulate connection
+    test_connectionFlow()
+    assert(backgroundTaskScheduler.beginBackgroundTask_called == false)
+
+    // Set up mock response
+    backgroundTaskScheduler.beginBackgroundTask = UIBackgroundTaskIdentifier(rawValue: .random(in: 1 ... 100))
+
+    // Simulate app going to the background
+    NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+    // Check a new background task is scheduled
+    AssertAsync.willBeTrue(backgroundTaskScheduler.beginBackgroundTask_called)
+  }
+
+  func test_backgroundTaskIsNotCreated_whenWebSocketIsConnected_appGoesToBackground_andBackgroundConnectionIsForbidden() {
+    // Simulate connection
+    test_connectionFlow()
+    assert(backgroundTaskScheduler.beginBackgroundTask_called == false)
+
+    // Turn off background connection
+    webSocketClient.options.remove(.staysConnectedInBackground)
+
+    // Set up mock response
+    backgroundTaskScheduler.beginBackgroundTask = UIBackgroundTaskIdentifier(rawValue: .random(in: 1 ... 100))
+
+    // Simulate app going to the background
+    NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+    // Check a new background task is scheduled
+    AssertAsync.staysTrue(backgroundTaskScheduler.beginBackgroundTask_called == false)
+  }
+
+  func test_backgroundTaskIsNotCreated_whenWebSocketIsNotConnected_andAppGoesToBackground() {
+    assert(backgroundTaskScheduler.beginBackgroundTask_called == false)
+
+    // Simulate app going to the background
+    NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+    // Check a new background task is not scheduled
+    AssertAsync.staysTrue(backgroundTaskScheduler.beginBackgroundTask_called == false)
+  }
+
+  func test_backgroundTaskIsNotCreated_whenWebSocketIsDisconnected_andAppGoesToBackground() {
+    // Simulate disconnection
+    test_disconnect()
+
+    assert(backgroundTaskScheduler.beginBackgroundTask_called == false)
+
+    // Simulate app going to the background
+    NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+    // Check a new background task is not scheduled
+    AssertAsync.staysTrue(backgroundTaskScheduler.beginBackgroundTask_called == false)
+  }
+
+  func test_connectionIsTerminated_whenBackgroundTaskCantBeInitiated() {
+    // Simulate connection and start a background task
+    test_connectionFlow()
+
+    assert(engine.disconnect_calledCount == 0)
+
+    // Simulate the background task can't be scheduled
+    backgroundTaskScheduler.beginBackgroundTask = .invalid
+    NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+    // Check the connection is terminated
+    AssertAsync {
+      Assert.willBeEqual(self.engine.disconnect_calledCount, 1)
+      Assert.willBeEqual(self.webSocketClient.connectionState, .disconnecting(source: .systemInitiated))
+    }
+  }
+
+  func test_connectionIsTerminated_whenBackgroundTaskFinishesExecution() {
+    // Simulate connection and start a background task
+    test_connectionFlow()
+    backgroundTaskScheduler.beginBackgroundTask = UIBackgroundTaskIdentifier(rawValue: .random(in: 1 ... 100))
+    NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+    assert(engine.disconnect_calledCount == 0)
+
+    // Simulate the background task finishes execution
+    backgroundTaskScheduler.beginBackgroundTask_expirationHandler?()
+
+    // Check the connection is terminated
+    AssertAsync {
+      Assert.willBeEqual(self.engine.disconnect_calledCount, 1)
+      Assert.willBeEqual(self.webSocketClient.connectionState, .disconnecting(source: .systemInitiated))
+    }
+  }
+
+  func test_backgroundTaskIsCancelled_whenAppBecomesActive() {
+    // Simulate connection and start a background task
+    test_connectionFlow()
+    let task = UIBackgroundTaskIdentifier(rawValue: .random(in: 1 ... 100))
+    backgroundTaskScheduler.beginBackgroundTask = task
+    NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+    // Wait for `beginBackgroundTask` being called since it can be done asynchronously
+    AssertAsync.willBeTrue(backgroundTaskScheduler.beginBackgroundTask_called)
+    assert(backgroundTaskScheduler.endBackgroundTask_called == nil)
+
+    // Simulate an app going to the foreground
+    NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+    // Check the background task is terminated
+    AssertAsync.willBeEqual(backgroundTaskScheduler.endBackgroundTask_called, task)
+  }
+
+  func test_backgroundTaskIsCancelled_whenDisconnected() {
+    // Simulate connection and start a background task
+    test_connectionFlow()
+    let task = UIBackgroundTaskIdentifier(rawValue: .random(in: 1 ... 100))
+    backgroundTaskScheduler.beginBackgroundTask = task
+    NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+    // Wait for `beginBackgroundTask` being called since it can be done asynchronously
+    AssertAsync.willBeTrue(backgroundTaskScheduler.beginBackgroundTask_called)
+    assert(backgroundTaskScheduler.endBackgroundTask_called == nil)
+
+    // Simulate the connection is terminated
+    webSocketClient.disconnect()
+    engine.simulateDisconnect()
+
+    // Check the background task is terminated
+    AssertAsync.willBeEqual(backgroundTaskScheduler.endBackgroundTask_called, task)
+  }
+}
+
+// MARK: - Helpers
+
+private class EventDecoderMock: AnyEventDecoder {
+  var decode_calledWithData: Data?
+  var decodedEvent: Event!
+
+  func decode(data: Data) throws -> Event {
+    decode_calledWithData = data
+    return decodedEvent
+  }
+}
+
+private class EventLogger {
+  var events: [Event] = []
+  var equatableEvents: [EquatableEvent] { events.map(EquatableEvent.init) }
+
+  init(_ notificationCenter: NotificationCenter) {
+    notificationCenter.addObserver(self, selector: #selector(handleNewEvent), name: .NewEventReceived, object: nil)
+  }
+
+  @objc func handleNewEvent(_ notification: Notification) {
+    events.append(notification.event!)
+  }
+}
+
+private class MockReconnectionStrategy: WebSocketClientReconnectionStrategy {
+  var sucessfullyConnected_calledCount: Int = 0
+  var reconnectionDelay_calledWithError: Error?
+
+  var reconnectionDelay: TimeInterval?
+
+  func sucessfullyConnected() {
+    sucessfullyConnected_calledCount += 1
+  }
+
+  func reconnectionDelay(forConnectionError error: Error?) -> TimeInterval? {
+    reconnectionDelay_calledWithError = error
+    return reconnectionDelay
+  }
+}
+
+extension WebSocketEngineError: Equatable {
+  public static func ==(lhs: WebSocketEngineError, rhs: WebSocketEngineError) -> Bool {
+    String(describing: lhs) == String(describing: rhs)
+  }
+}
+
+/// A test middleware that can be initiated with a closure/
+private struct ClosureBasedMiddleware: EventMiddleware {
+  let closure: (_ event: Event, _ completion: @escaping (Event?) -> Void) -> Void
+
+  func handle(event: Event, completion: @escaping (Event?) -> Void) {
+    closure(event, completion)
+  }
+}
+
+class MockBackgroundTaskScheduler: BackgroundTaskScheduler {
+  var beginBackgroundTask_called: Bool = false
+  var beginBackgroundTask_expirationHandler: (() -> Void)?
+  var beginBackgroundTask: UIBackgroundTaskIdentifier!
+
+  var endBackgroundTask_called: UIBackgroundTaskIdentifier?
+
+  func beginBackgroundTask(expirationHandler: (() -> Void)?) -> UIBackgroundTaskIdentifier {
+    beginBackgroundTask_called = true
+    beginBackgroundTask_expirationHandler = expirationHandler
+    return beginBackgroundTask
+  }
+
+  func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier) {
+    endBackgroundTask_called = identifier
+  }
+}

--- a/StreamChatClient_v3/Workers/Background/ChannelEventsHandler_tests.swift
+++ b/StreamChatClient_v3/Workers/Background/ChannelEventsHandler_tests.swift
@@ -58,7 +58,7 @@ class WebSocketClientMock: WebSocketClient {
     super.init(
       urlRequest: URLRequest(url: URL(string: "test")!),
       eventDecoder: MockDecoder(),
-      callbackQueue: .main
+      eventMiddlewares: []
     )
   }
 }


### PR DESCRIPTION
### In this PR:

The work on [CIS-168] turned out to be so massive I decided to split it the PR into multiple parts.

This part contains the actual migration of `WebSocketClient` to v3. Important bits:
- It's not 1-to-1 conversion, I tried to clean up, simplify, and formalize the patterns we use
- Missing pieces:
  - logging [CIS-184]
  - reacting to internet connection changes [CIS-185]

#no_changelog


[CIS-168]: https://stream-io.atlassian.net/browse/CIS-168
[CIS-184]: https://stream-io.atlassian.net/browse/CIS-184
[CIS-185]: https://stream-io.atlassian.net/browse/CIS-185