### PR TITLE
[CIS-168] Finish WebSocketClient implementation Part 4: Middlewares

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -104,6 +104,8 @@
 		79A0E9AD2498BD0C00E9BD50 /* ChatClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9AC2498BD0C00E9BD50 /* ChatClient.swift */; };
 		79A0E9AF2498BFD800E9BD50 /* WebSocketClient_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9AE2498BFD800E9BD50 /* WebSocketClient_tests.swift */; };
 		79A0E9B02498C09900E9BD50 /* ConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C750BD2490D0130023F0B7 /* ConnectionState.swift */; };
+		79A0E9B62498C2DD00E9BD50 /* HealthCheckFilterMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9B42498C2DD00E9BD50 /* HealthCheckFilterMiddleware.swift */; };
+		79A0E9B72498C2E800E9BD50 /* HealthCheckFilterMiddleware_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9B32498C2DD00E9BD50 /* HealthCheckFilterMiddleware_tests.swift */; };
 		79A9E4F72449D3AF00599B95 /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */; };
 		79A9E4F92449DF2D00599B95 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F82449DF2D00599B95 /* Reachability.swift */; };
 		79BF83EC248F8EDF007611A1 /* LogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BF83EB248F8EDF007611A1 /* LogDestination.swift */; };
@@ -539,6 +541,8 @@
 		799C947B247E6051001F1104 /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		79A0E9AC2498BD0C00E9BD50 /* ChatClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatClient.swift; sourceTree = "<group>"; };
 		79A0E9AE2498BFD800E9BD50 /* WebSocketClient_tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSocketClient_tests.swift; sourceTree = "<group>"; };
+		79A0E9B32498C2DD00E9BD50 /* HealthCheckFilterMiddleware_tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCheckFilterMiddleware_tests.swift; sourceTree = "<group>"; };
+		79A0E9B42498C2DD00E9BD50 /* HealthCheckFilterMiddleware.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCheckFilterMiddleware.swift; sourceTree = "<group>"; };
 		79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+Gzip.swift"; sourceTree = "<group>"; };
 		79A9E4F82449DF2D00599B95 /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		79BF83EB248F8EDF007611A1 /* LogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LogDestination.swift; path = ../LogDestination.swift; sourceTree = "<group>"; };
@@ -1064,6 +1068,8 @@
 			children = (
 				796610B8248E651800761629 /* EventMiddleware.swift */,
 				796610BA248E687000761629 /* EventMiddleware_tests.swift */,
+				79A0E9B42498C2DD00E9BD50 /* HealthCheckFilterMiddleware.swift */,
+				79A0E9B32498C2DD00E9BD50 /* HealthCheckFilterMiddleware_tests.swift */,
 			);
 			path = EventMiddlewares;
 			sourceTree = "<group>";
@@ -2369,6 +2375,7 @@
 				79C750BB248FC4100023F0B7 /* ServerResponseError.swift in Sources */,
 				799BE2EA248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift in Sources */,
 				7962958C248147430078EB53 /* BaseURL.swift in Sources */,
+				79A0E9B62498C2DD00E9BD50 /* HealthCheckFilterMiddleware.swift in Sources */,
 				79BF83F6248F8F97007611A1 /* PrefixLogFormatter.swift in Sources */,
 				792A4F5A24812D1A00EAF71D /* UserEndpointReponse.swift in Sources */,
 				792A4F4F2480EA3B00EAF71D /* Endpoint.swift in Sources */,
@@ -2413,6 +2420,7 @@
 				79280F8324891C6A00CDEB89 /* VirtualTime_Tests.swift in Sources */,
 				79177A2D248A6A2600F053A2 /* AssertAsync+Events.swift in Sources */,
 				799C9468247D791A001F1104 /* AssertJSONEqual.swift in Sources */,
+				79A0E9B72498C2E800E9BD50 /* HealthCheckFilterMiddleware_tests.swift in Sources */,
 				799C9460247D77D6001F1104 /* DatabaseContainer_Tests.swift in Sources */,
 				799C945C247D59D8001F1104 /* ChatClient_Tests.swift in Sources */,
 				79280F7D24891B1300CDEB89 /* WebSocketEngine_Tests.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -106,6 +106,9 @@
 		79A0E9B02498C09900E9BD50 /* ConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C750BD2490D0130023F0B7 /* ConnectionState.swift */; };
 		79A0E9B62498C2DD00E9BD50 /* HealthCheckFilterMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9B42498C2DD00E9BD50 /* HealthCheckFilterMiddleware.swift */; };
 		79A0E9B72498C2E800E9BD50 /* HealthCheckFilterMiddleware_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9B32498C2DD00E9BD50 /* HealthCheckFilterMiddleware_tests.swift */; };
+		79A0E9BB2498C31300E9BD50 /* TypingStartCleanupMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9B92498C31300E9BD50 /* TypingStartCleanupMiddleware.swift */; };
+		79A0E9BC2498C31A00E9BD50 /* TypingStartCleanupMiddleware_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9B82498C31300E9BD50 /* TypingStartCleanupMiddleware_tests.swift */; };
+		79A0E9BE2498C33100E9BD50 /* TypingEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9BD2498C33100E9BD50 /* TypingEvents.swift */; };
 		79A9E4F72449D3AF00599B95 /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */; };
 		79A9E4F92449DF2D00599B95 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F82449DF2D00599B95 /* Reachability.swift */; };
 		79BF83EC248F8EDF007611A1 /* LogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BF83EB248F8EDF007611A1 /* LogDestination.swift */; };
@@ -543,6 +546,9 @@
 		79A0E9AE2498BFD800E9BD50 /* WebSocketClient_tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSocketClient_tests.swift; sourceTree = "<group>"; };
 		79A0E9B32498C2DD00E9BD50 /* HealthCheckFilterMiddleware_tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCheckFilterMiddleware_tests.swift; sourceTree = "<group>"; };
 		79A0E9B42498C2DD00E9BD50 /* HealthCheckFilterMiddleware.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCheckFilterMiddleware.swift; sourceTree = "<group>"; };
+		79A0E9B82498C31300E9BD50 /* TypingStartCleanupMiddleware_tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypingStartCleanupMiddleware_tests.swift; sourceTree = "<group>"; };
+		79A0E9B92498C31300E9BD50 /* TypingStartCleanupMiddleware.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypingStartCleanupMiddleware.swift; sourceTree = "<group>"; };
+		79A0E9BD2498C33100E9BD50 /* TypingEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypingEvents.swift; sourceTree = "<group>"; };
 		79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+Gzip.swift"; sourceTree = "<group>"; };
 		79A9E4F82449DF2D00599B95 /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		79BF83EB248F8EDF007611A1 /* LogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LogDestination.swift; path = ../LogDestination.swift; sourceTree = "<group>"; };
@@ -955,6 +961,7 @@
 				79280F48248520B300CDEB89 /* EventDecoder.swift */,
 				79280F4A248523C000CDEB89 /* ConnectionEvents.swift */,
 				79280F46248515FA00CDEB89 /* ChannelEvents.swift */,
+				79A0E9BD2498C33100E9BD50 /* TypingEvents.swift */,
 			);
 			path = Events;
 			sourceTree = "<group>";
@@ -1070,6 +1077,8 @@
 				796610BA248E687000761629 /* EventMiddleware_tests.swift */,
 				79A0E9B42498C2DD00E9BD50 /* HealthCheckFilterMiddleware.swift */,
 				79A0E9B32498C2DD00E9BD50 /* HealthCheckFilterMiddleware_tests.swift */,
+				79A0E9B92498C31300E9BD50 /* TypingStartCleanupMiddleware.swift */,
+				79A0E9B82498C31300E9BD50 /* TypingStartCleanupMiddleware_tests.swift */,
 			);
 			path = EventMiddlewares;
 			sourceTree = "<group>";
@@ -2404,7 +2413,9 @@
 				792A4F532480F5AD00EAF71D /* ChannelEndpointResponse.swift in Sources */,
 				79280F3F2484E3BA00CDEB89 /* ClientError.swift in Sources */,
 				792A4F512480F55800EAF71D /* ChannelListEndpointResponse.swift in Sources */,
+				79A0E9BB2498C31300E9BD50 /* TypingStartCleanupMiddleware.swift in Sources */,
 				797A756424814E7A003CF16D /* WebSocketPayload.swift in Sources */,
+				79A0E9BE2498C33100E9BD50 /* TypingEvents.swift in Sources */,
 				799C945E247D7283001F1104 /* DatabaseContainer.swift in Sources */,
 				799C943E247D2FB9001F1104 /* Message.swift in Sources */,
 			);
@@ -2430,6 +2441,7 @@
 				79280F8424891C6A00CDEB89 /* VirtualTime.swift in Sources */,
 				79280F542485529500CDEB89 /* ChannelEventsHandler_Tests.swift in Sources */,
 				799C9476247D7E94001F1104 /* TemporaryURLs.swift in Sources */,
+				79A0E9BC2498C31A00E9BD50 /* TypingStartCleanupMiddleware_tests.swift in Sources */,
 				796610BB248E687000761629 /* EventMiddleware_tests.swift in Sources */,
 				799C9469247D791A001F1104 /* AssertResult.swift in Sources */,
 				79280F8224891C6A00CDEB89 /* VirtualTimer.swift in Sources */,

--- a/StreamChatClient_v3/ChatClient.swift
+++ b/StreamChatClient_v3/ChatClient.swift
@@ -127,7 +127,9 @@ public final class Client<ExtraData: ExtraDataTypes> {
     //      let webSocketProvider = defaultWebSocketProviderType.init(request: request, callbackQueue: callbackQueue)
 
     let middlewares: [EventMiddleware] = [
-      ]
+      // TODO: Add more middlewares
+      HealthCheckFilter()
+    ]
 
     return WebSocketClient(
       urlRequest: request,

--- a/StreamChatClient_v3/WebSocketClient/EventMiddlewares/HealthCheckFilterMiddleware.swift
+++ b/StreamChatClient_v3/WebSocketClient/EventMiddlewares/HealthCheckFilterMiddleware.swift
@@ -1,0 +1,17 @@
+//
+// HealthCheckFilterMiddleware.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Ignores HealthCheck events
+struct HealthCheckFilter: EventMiddleware {
+  func handle(event: Event, completion next: @escaping (Event?) -> Void) {
+    if event is HealthCheck {
+      next(nil)
+    } else {
+      next(event)
+    }
+  }
+}

--- a/StreamChatClient_v3/WebSocketClient/EventMiddlewares/HealthCheckFilterMiddleware_tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/EventMiddlewares/HealthCheckFilterMiddleware_tests.swift
@@ -1,0 +1,34 @@
+//
+// HealthCheckFilterMiddleware_tests.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient_v3
+import XCTest
+
+class HealthCheckFilterMiddlewareTests: XCTestCase {
+  /// A test event holding an `Int` value.
+  struct IntBasedEvent: Event, Equatable {
+    static var eventRawType: String { "test_only" }
+    let value: Int
+  }
+
+  var middleware: HealthCheckFilter!
+
+  override func setUp() {
+    super.setUp()
+    middleware = HealthCheckFilter()
+  }
+
+  func test_healthCheackEvent_isFiltered() throws {
+    let event = HealthCheck(connectionId: UUID().uuidString)
+    let result = try await { self.middleware.handle(event: event, completion: $0) }
+    XCTAssertNil(result)
+  }
+
+  func test_nonHealthCheackEvent_isForwarded() throws {
+    let event = IntBasedEvent(value: .random(in: 0 ... 100))
+    let result = try await { self.middleware.handle(event: event, completion: $0) }
+    XCTAssertEqual(result as? IntBasedEvent, event)
+  }
+}

--- a/StreamChatClient_v3/WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware.swift
+++ b/StreamChatClient_v3/WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware.swift
@@ -1,0 +1,47 @@
+//
+// TypingStartCleanupMiddleware.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Automatically sends a `TypingStop` event if it hasn't come in a specified time after `TypingStart`.
+class TypingStartCleanupMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
+  /// The maximum time the incoming `typingStart` event is valid before a `typingStop` event is emitted automatically.
+  static var incomingTypingStartEventTimeout: TimeInterval { 30 }
+
+  /// Creates a new `TypingStartCleanupMiddleware`
+  ///
+  /// - Parameter excludedUsers: A set of users for which the `typingStart` event shouldn't be cleaned up automatically.
+  init(excludedUsers: Set<UserModel<ExtraData.User>>) {
+    self.excludedUsers = excludedUsers
+  }
+
+  let excludedUsers: Set<UserModel<ExtraData.User>>
+
+  var typingEventTimeoutTimerControls: [UserModel<ExtraData.User>: TimerControl] = [:]
+  var timer: Timer.Type = DefaultTimer.self
+
+  func handle(event: Event, completion: @escaping (Event?) -> Void) {
+    switch event {
+    case let event as TypingStop<ExtraData> where excludedUsers.contains(event.user) == false:
+      typingEventTimeoutTimerControls[event.user]?.cancel()
+      typingEventTimeoutTimerControls[event.user] = nil
+
+    case let event as TypingStart<ExtraData> where excludedUsers.contains(event.user) == false:
+      let user = event.user
+      typingEventTimeoutTimerControls[user]?.cancel()
+
+      let stopTypingEventTimerControl = timer.schedule(timeInterval: Self.incomingTypingStartEventTimeout, queue: .global()) {
+        let typingStopEvent = TypingStop<ExtraData>(user: user)
+        completion(typingStopEvent)
+      }
+
+      typingEventTimeoutTimerControls[user] = stopTypingEventTimerControl
+
+    default: break
+    }
+
+    completion(event)
+  }
+}

--- a/StreamChatClient_v3/WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware_tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware_tests.swift
@@ -1,0 +1,64 @@
+//
+// TypingStartCleanupMiddleware_tests.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient_v3
+import XCTest
+
+class TypingStartCleanupMiddlewareTests: XCTestCase {
+  var middleware: TypingStartCleanupMiddleware<DefaultDataTypes>!
+  var currentUser: User!
+
+  var time: VirtualTime!
+  var typingStartTimeout: TimeInterval { type(of: middleware).incomingTypingStartEventTimeout }
+
+  override func setUp() {
+    super.setUp()
+
+    currentUser = User(id: "Luke")
+    middleware = TypingStartCleanupMiddleware(excludedUsers: [currentUser])
+
+    time = VirtualTime()
+    VirtualTimeTimer.time = time
+    middleware.timer = VirtualTimeTimer.self
+  }
+
+  func test_stopTypingEvent_notSentForExcludedUsers() {
+    var result: [EquatableEvent?] = []
+    let typingStartEvent = TypingStart<DefaultDataTypes>(user: currentUser)
+    // Handle a new TypingStart event for the current user and collect resulting events
+    middleware.handle(event: typingStartEvent) {
+      result.append($0.map(EquatableEvent.init))
+    }
+
+    // Simulate time passed for the `typingStartTimeout` period
+    time.run(numberOfSeconds: typingStartTimeout + 1)
+
+    XCTAssertEqual(result, [typingStartEvent].asEquatable())
+  }
+
+  func test_stopTypingEvent_sentAfterTimeout() {
+    // Simulate some user started typing
+    let otherUser = User(id: UUID().uuidString)
+
+    var result: [EquatableEvent?] = []
+    let typingStartEvent = TypingStart<DefaultDataTypes>(user: otherUser)
+    // Handle a new TypingStart event for the current user and collect resulting events
+    middleware.handle(event: typingStartEvent) {
+      result.append($0.map(EquatableEvent.init))
+    }
+
+    // Wait for some timeout shorter than `typingStartTimeout` and assert only `TypingStart` event is sent
+    time.run(numberOfSeconds: typingStartTimeout - 1)
+    XCTAssertEqual(result, [typingStartEvent.asEquatable])
+
+    // Wait for more time and expect a `typingStop` event.
+    time.run(numberOfSeconds: 2)
+    XCTAssertEqual(result, [typingStartEvent.asEquatable, TypingStop<DefaultDataTypes>(user: otherUser).asEquatable])
+
+    // Wait much longer and assert no more `typingStop` events.
+    time.run(numberOfSeconds: 5 + typingStartTimeout)
+    XCTAssertEqual(result, [typingStartEvent.asEquatable, TypingStop<DefaultDataTypes>(user: otherUser).asEquatable])
+  }
+}

--- a/StreamChatClient_v3/WebSocketClient/Events/TypingEvents.swift
+++ b/StreamChatClient_v3/WebSocketClient/Events/TypingEvents.swift
@@ -1,0 +1,18 @@
+//
+// TypingEvents.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+// TODO: These are just placeholder events!
+
+struct TypingStart<ExtraData: ExtraDataTypes>: Event {
+  static var eventRawType: String { "typing.start" }
+  let user: UserModel<ExtraData.User>
+}
+
+struct TypingStop<ExtraData: ExtraDataTypes>: Event {
+  static var eventRawType: String { "typing.stop" }
+  let user: UserModel<ExtraData.User>
+}


### PR DESCRIPTION
### In this PR:

The work on [CIS-168] turned out to be so massive I decided to split it the PR into multiple parts.

This part contains example implementations of 2 event middlewares:
 - `HealthCheckFilter`
 - `TypingStartCleanupMiddleware`

#no_changelog


[CIS-168]: https://stream-io.atlassian.net/browse/CIS-168