### PR TITLE
[CIS-186] Fix Channel.team not being encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ✅ Added
 - `ClientLogger.showConnectionErrorAlert` flag to control showing the UI alert for WebSocket errors. It's turned off by default. [#303](https://github.com/GetStream/stream-chat-swift/issues/303)
 
+### 🐞 Fixed
+- `Channel.team` not being correctly encoded for multi-tenant enabled clients [#308](https://github.com/GetStream/stream-chat-swift/issues/308)
+
 # [2.2.3](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.3)
 _June 05, 2020_
 

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -46,6 +46,7 @@ public final class Channel: Codable {
         case imageURL = "image"
         case members
         case invites
+        case team
     }
     
     /// A custom extra data type for channels.
@@ -126,7 +127,7 @@ public final class Channel: Codable {
     let currentUserTypingTimerControlAtomic = Atomic<TimerControl?>()
     
     /// Checks for the channel data encoding is empty.
-    var isEmpty: Bool { extraData == nil && members.isEmpty && invitedMembers.isEmpty }
+    var isEmpty: Bool { extraData == nil && members.isEmpty && invitedMembers.isEmpty && team.isBlank }
     
     /// Returns the current timestamp. Can be replaced in tests with mock time, if needed.
     var currentTime: () -> Date = { Date() }
@@ -210,6 +211,8 @@ public final class Channel: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: EncodingKeys.self)
         extraData?.encodeSafely(to: encoder, logMessage: "📦 when encoding a channel extra data")
+      
+      try container.encode(team, forKey: .team)
         
         var allMembers = members
         


### PR DESCRIPTION
Creating channels with `team` was failing due to `team` not being encoded