### PR TITLE
[CIS-145] Fix ChannelsPresenter not respecting filter for new channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed height rendering for a message for messages with a single line [#310](https://github.com/GetStream/stream-chat-swift/issues/310).
 - Fixed rendering of a message bubble curve more precisely [#310](https://github.com/GetStream/stream-chat-swift/issues/310).
 - Fixed scrolling to the current message when you go to the last page [#310](https://github.com/GetStream/stream-chat-swift/issues/310).
+- Fix ChannelsPresenter not respecting filter for new created/added channels [#313](https://github.com/GetStream/stream-chat-swift/issues/313)
 
 # [2.2.3](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.3)
 _June 05, 2020_

--- a/Sources/Core/Presenter/Channels/ChannelsPresenter+Rx.swift
+++ b/Sources/Core/Presenter/Channels/ChannelsPresenter+Rx.swift
@@ -69,7 +69,7 @@ private extension Reactive where Base == ChannelsPresenter {
                 
                 return true
             })
-            .map { [weak base] in base?.parse(event: $0) ?? .none }
+            .flatMap { [weak base] in base?.parse(event: $0) ?? Observable.just(.none) }
             .filter { $0 != .none }
             .asClientDriver()
     }


### PR DESCRIPTION
 Let's say we create our channel with filter:```channelsVC.presenter = .init(filter: .currentUserInMembers & .equal("id", to: "general")```and it initially shows a single channel (as expected).When our user is added to a new channel, websocket sends `notification_added_to_new_channel` event and ChannelsPresenter parses this and adds the new channel into list. Neither backend nor presenter does not check for the filters, so filters are disregarded for newly created channels.
