### PR TITLE
[CIS-179] Add Message translation endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
-### 🔄 Changed
+### ✅ Added
+- `Message.translate` for message translations. Please see [docs](https://getstream.io/chat/docs/translation/?language=swift) for more info [#319](https://github.com/GetStream/stream-chat-swift/issues/319)
 
 # [2.2.4](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.4)
 _June 12, 2020_

--- a/Sources/Client/Client/Client+Message.swift
+++ b/Sources/Client/Client/Client+Message.swift
@@ -130,6 +130,24 @@ public extension Client {
         return toggleFlagMessage(message, endpoint: .unflagMessage(message), completion)
     }
     
+    /// Translate a message
+    /// - Parameters:
+    ///   - message: Message to be translated. It's required that message has a valid id.
+    ///   - language: Destination language.
+    ///   - completion: Completion block to be called with translated message.
+    /// - Returns: Cancellable to control the request.
+    @discardableResult
+    func translate(message: Message,
+                   to language: Language,
+                   _ completion: @escaping Client.Completion<MessageResponse>) -> Cancellable {
+        if message.id.isEmpty {
+            completion(.failure(.emptyMessageId))
+            return Subscription.empty
+        }
+        
+        return request(endpoint: .translate(message, language), completion)
+    }
+    
     private func toggleFlagMessage(_ message: Message,
                                    endpoint: Endpoint,
                                    _ completion: @escaping Client.Completion<FlagMessageResponse>) -> Cancellable {

--- a/Sources/Client/Client/Endpoint.swift
+++ b/Sources/Client/Client/Endpoint.swift
@@ -90,6 +90,8 @@ public enum Endpoint {
     case flagMessage(Message)
     /// Unflag a message.
     case unflagMessage(Message)
+    /// Translate a message
+    case translate(Message, Language)
     
     // MARK: - User Endpoints
     
@@ -137,6 +139,8 @@ extension Endpoint {
             return "messages/\(messageId)"
         case .markAllRead:
             return "channels/read"
+        case let .translate(message, _):
+            return path(to: message.id, "translate")
         case .deleteChannel(let channel),
              .invite(_, let channel),
              .addMembers(_, let channel),
@@ -318,6 +322,9 @@ extension Endpoint {
             
         case .removeMembers(let members, _):
             return ["remove_members": members]
+            
+        case let .translate(_, language):
+            return ["language": language.languageCode]
         }
     }
     
@@ -375,7 +382,8 @@ extension Endpoint {
              .unflagUser,
              .flagMessage,
              .unflagMessage,
-             .ban:
+             .ban,
+             .translate:
             return false
         }
     }

--- a/Sources/Client/Model/LocalizedMessage.swift
+++ b/Sources/Client/Model/LocalizedMessage.swift
@@ -1,0 +1,66 @@
+//
+//  LocalizedMessage.swift
+//  StreamChatClient
+//
+//  Created by Bahadir Oncel on 15.06.2020.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+public struct LocalizedMessage: Decodable {
+    private static let translatedSuffix = "_text"
+    
+    private struct CodingKeys: CodingKey, Hashable {
+        var stringValue: String
+        
+        init(stringValue: String) {
+            self.stringValue = stringValue
+        }
+        
+        var intValue: Int?
+        
+        init?(intValue: Int) {
+            return  nil
+        }
+        
+        static let originalLanguage = CodingKeys(stringValue: "language")
+        
+        static func translated(to language: Language) -> CodingKeys {
+            CodingKeys(stringValue: language.languageCode + translatedSuffix)
+        }
+    }
+    
+    public let originalLanguage: String
+    public let translated: [Language: String]
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        originalLanguage = try container.decode(String.self, forKey: .originalLanguage)
+        
+        var translated = [Language: String]()
+        
+        for language in Language.allCases {
+            if let translatedText = try container.decodeIfPresent(String.self, forKey: .translated(to: language)) {
+                translated[language] = translatedText
+            }
+        }
+        
+        // If the user passed a custom language via `Language.custom`
+        let allKnownKeys = Set(Language.allCases.map(CodingKeys.translated)) + [CodingKeys.originalLanguage]
+        let unknownKeys = Set(container.allKeys).subtracting(allKnownKeys)
+        for key in unknownKeys {
+            let keyString = key.stringValue
+            guard let suffixRange = keyString.range(of: LocalizedMessage.translatedSuffix) else {
+                ClientLogger.log("❌", level: .error, "Unknown key in `translate` response: \(keyString), cannot decode")
+                continue
+            }
+            let unknownLanguageCode = String(keyString.prefix(upTo: suffixRange.lowerBound))
+            let translatedText = try container.decode(String.self, forKey: key)
+            translated[.custom(unknownLanguageCode)] = translatedText
+        }
+        
+        self.translated = translated
+    }
+}

--- a/Sources/Client/Model/Message/Message+Requests.swift
+++ b/Sources/Client/Model/Message/Message+Requests.swift
@@ -64,4 +64,31 @@ public extension Message {
     func unflag(_ completion: @escaping Client.Completion<FlagMessageResponse>) -> Cancellable {
         Client.shared.unflag(message: self, completion)
     }
+    
+    /// Translate a message
+    /// - Parameters:
+    ///   - language: Destination language.
+    ///   - completion: Completion block to be called with translated message.
+    /// - Returns: Cancellable to control the request.
+    @discardableResult
+    func translate(to language: Language,
+                   _ completion: @escaping Client.Completion<MessageResponse>) -> Cancellable {
+        Client.shared.translate(message: self, to: language, completion)
+    }
+    
+    /// Translate a message
+    /// - Parameters:
+    ///   - locale: Destination locale.
+    ///   - completion: Completion block to be called with translated message.
+    /// - Returns: Cancellable to control the request.
+    @discardableResult
+    func translate(to locale: Locale = .current,
+                   _ completion: @escaping Client.Completion<MessageResponse>) -> Cancellable {
+        guard let language = Language(locale: locale) else {
+            completion(.failure(ClientError.unexpectedError(description: "Unsupported locale", error: nil)))
+            return Subscription.empty
+        }
+        
+        return Client.shared.translate(message: self, to: language, completion)
+    }
 }

--- a/Sources/Client/Model/Message/Message.swift
+++ b/Sources/Client/Model/Message/Message.swift
@@ -29,6 +29,7 @@ public struct Message: Codable {
         case ownReactions = "own_reactions"
         case reactionScores = "reaction_scores"
         case isSilent = "silent"
+        case i18n
     }
     
     /// A custom extra data type for messages.
@@ -75,6 +76,8 @@ public struct Message: Codable {
     public private(set) var reactionScores: [String: Int]
     /// Flag for silent messages. Silent messages won't increase the unread count. See https://getstream.io/chat/docs/silent_messages/?language=swift
     public var isSilent: Bool
+    /// Internationalization and localization for the message. Only available for messages returned via `message.translate()`
+    public var i18n: LocalizedMessage?
     
     /// Check if the message is ephemeral, e.g. Giphy preview.
     public var isEphemeral: Bool { type == .ephemeral }
@@ -211,6 +214,7 @@ public struct Message: Codable {
         latestReactions = (try? container.decode([Reaction].self, forKey: .latestReactions)) ?? []
         ownReactions = (try? container.decode([Reaction].self, forKey: .ownReactions)) ?? []
         reactionScores = try container.decodeIfPresent([String: Int].self, forKey: .reactionScores) ?? [:]
+        i18n = try container.decodeIfPresent(LocalizedMessage.self, forKey: .i18n)
         extraData = try? Self.extraDataType?.init(from: decoder) // swiftlint:disable:this explicit_init
     }
     

--- a/Sources/Client/Utils/Language.swift
+++ b/Sources/Client/Utils/Language.swift
@@ -1,0 +1,210 @@
+//
+//  Language.swift
+//  StreamChatClient
+//
+//  Created by Bahadir Oncel on 15.06.2020.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+public enum Language: Hashable {
+    case afrikaans
+    case albanian
+    case amharic
+    case arabic
+    case azerbaijani
+    case bengali
+    case bosnian
+    case bulgarian
+    case chineseSimplified
+    case chineseTraditional
+    case croatian
+    case czech
+    case danish
+    case dari
+    case dutch
+    case english
+    case estonian
+    case finnish
+    case french
+    case frenchCanada
+    case georgian
+    case german
+    case greek
+    case hausa
+    case hebrew
+    case hindi
+    case hungarian
+    case indonesian
+    case italian
+    case japanese
+    case korean
+    case latvian
+    case malay
+    case norwegian
+    case persian
+    case pashto
+    case polish
+    case portuguese
+    case romanian
+    case russian
+    case serbian
+    case slovak
+    case slovenian
+    case somali
+    case spanish
+    case spanishMexico
+    case swahili
+    case swedish
+    case tagalog
+    case tamil
+    case thai
+    case turkish
+    case ukrainian
+    case urdu
+    case vietnamese
+    case custom(String)
+    
+    var languageCode: String {
+        switch self {
+        case .afrikaans:
+            return "af"
+        case .albanian:
+            return "sq"
+        case .amharic:
+            return "am"
+        case .arabic:
+            return "ar"
+        case .azerbaijani:
+            return "az"
+        case .bengali:
+            return "bn"
+        case .bosnian:
+            return "bs"
+        case .bulgarian:
+            return "bg"
+        case .chineseSimplified:
+            return "zh"
+        case .chineseTraditional:
+            return "zh-TW"
+        case .croatian:
+            return "hr"
+        case .czech:
+            return "cs"
+        case .danish:
+            return "da"
+        case .dari:
+            return "fa-AF"
+        case .dutch:
+            return "nl"
+        case .english:
+            return "en"
+        case .estonian:
+            return "et"
+        case .finnish:
+            return "fi"
+        case .french:
+            return "fr"
+        case .frenchCanada:
+            return "fr-CA"
+        case .georgian:
+            return "ka"
+        case .german:
+            return "de"
+        case .greek:
+            return "el"
+        case .hausa:
+            return "ha"
+        case .hebrew:
+            return "he"
+        case .hindi:
+            return "hi"
+        case .hungarian:
+            return "hu"
+        case .indonesian:
+            return "id"
+        case .italian:
+            return "it"
+        case .japanese:
+            return "ja"
+        case .korean:
+            return "ko"
+        case .latvian:
+            return "lv"
+        case .malay:
+            return "ms"
+        case .norwegian:
+            return "no"
+        case .persian:
+            return "fa"
+        case .pashto:
+            return "ps"
+        case .polish:
+            return "pl"
+        case .portuguese:
+            return "pt"
+        case .romanian:
+            return "ro"
+        case .russian:
+            return "ru"
+        case .serbian:
+            return "sr"
+        case .slovak:
+            return "sk"
+        case .slovenian:
+            return "sl"
+        case .somali:
+            return "so"
+        case .spanish:
+            return "es"
+        case .spanishMexico:
+            return "es-MX"
+        case .swahili:
+            return "sw"
+        case .swedish:
+            return "sv"
+        case .tagalog:
+            return "tl"
+        case .tamil:
+            return "ta"
+        case .thai:
+            return "th"
+        case .turkish:
+            return "tr"
+        case .ukrainian:
+            return "uk"
+        case .urdu:
+            return "ur"
+        case .vietnamese:
+            return "vi"
+        case let .custom(languageCode):
+            return languageCode
+        }
+    }
+
+    init?(locale: Locale) {
+        guard let languageCode = locale.languageCode else { return nil }
+        let regionCode = locale.regionCode ?? ""
+        let fullLanguageCode = languageCode + (regionCode.isEmpty ? "" : "-\(regionCode)")
+        
+        guard let language = Language.allCases.first(where: { $0.languageCode == fullLanguageCode }) else {
+            return nil
+        }
+        
+        self = language
+    }
+    
+    /// Compiler cannot synthesize it since `.custom` has associated value
+    static var allCases: [Language] = [.afrikaans, .albanian, .amharic, .arabic, .azerbaijani,
+                                       .bengali, .bosnian, .bulgarian, .chineseSimplified, .chineseTraditional,
+                                       .croatian, .czech, .danish, .dari, .dutch,
+                                       .english, .estonian, .finnish, .french, .frenchCanada,
+                                       .georgian, .german, .greek, .hausa, .hebrew,
+                                       .hindi, .hungarian, .indonesian, .italian, .japanese,
+                                       .korean, .latvian, .malay, .norwegian, .persian,
+                                       .pashto, .polish, .portuguese, .romanian, .russian,
+                                       .serbian, .slovak, .slovenian, .somali, .spanish,
+                                       .spanishMexico, .swahili, .swedish, .tagalog, .tamil,
+                                       .thai, .turkish, .ukrainian, .urdu, .vietnamese]
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -72,6 +72,8 @@
 		796610B5248E518D00761629 /* Starscream.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EDC122E9BAC5005CFAC9 /* Starscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		796610B9248E651800761629 /* EventMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796610B8248E651800761629 /* EventMiddleware.swift */; };
 		796610BB248E687000761629 /* EventMiddleware_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796610BA248E687000761629 /* EventMiddleware_tests.swift */; };
+		7972C10F2497BD38001514AF /* Language.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7972C10E2497BD38001514AF /* Language.swift */; };
+		7972C1112497BF66001514AF /* LocalizedMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7972C1102497BF66001514AF /* LocalizedMessage.swift */; };
 		797A756424814E7A003CF16D /* WebSocketPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797A756324814E7A003CF16D /* WebSocketPayload.swift */; };
 		797A756624814EF8003CF16D /* SystemEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797A756524814EF8003CF16D /* SystemEnvironment.swift */; };
 		797A756824814F0D003CF16D /* BundleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797A756724814F0D003CF16D /* BundleExtensions.swift */; };
@@ -510,6 +512,8 @@
 		7962958B248147430078EB53 /* BaseURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseURL.swift; sourceTree = "<group>"; };
 		796610B8248E651800761629 /* EventMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware.swift; sourceTree = "<group>"; };
 		796610BA248E687000761629 /* EventMiddleware_tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware_tests.swift; sourceTree = "<group>"; };
+		7972C10E2497BD38001514AF /* Language.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Language.swift; sourceTree = "<group>"; };
+		7972C1102497BF66001514AF /* LocalizedMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedMessage.swift; sourceTree = "<group>"; };
 		797A756324814E7A003CF16D /* WebSocketPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketPayload.swift; sourceTree = "<group>"; };
 		797A756524814EF8003CF16D /* SystemEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemEnvironment.swift; sourceTree = "<group>"; };
 		797A756724814F0D003CF16D /* BundleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleExtensions.swift; sourceTree = "<group>"; };
@@ -1386,6 +1390,7 @@
 				8ACC7BB9241924AD000750E4 /* Timers.swift */,
 				8ACC7C4F241924B5000750E4 /* AssociatedValue.swift */,
 				794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */,
+				7972C10E2497BD38001514AF /* Language.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1423,6 +1428,7 @@
 				8ACC7BE6241924AD000750E4 /* SearchQuery.swift */,
 				8ACC7BE7241924AD000750E4 /* Device.swift */,
 				8ACC7BE8241924AD000750E4 /* BanEnabling.swift */,
+				7972C1102497BF66001514AF /* LocalizedMessage.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -2526,6 +2532,7 @@
 				8ACC7C26241924AD000750E4 /* Pagination.swift in Sources */,
 				8ACC7C03241924AD000750E4 /* String+Extensions.swift in Sources */,
 				8AAE233B245B00CF0080EB00 /* StarscreamWebSocketProvider.swift in Sources */,
+				7972C10F2497BD38001514AF /* Language.swift in Sources */,
 				8ACC7C05241924AD000750E4 /* Result+Extensions.swift in Sources */,
 				8ACC7C11241924AD000750E4 /* Message.swift in Sources */,
 				8ACC7C28241924AD000750E4 /* SearchQuery.swift in Sources */,
@@ -2538,6 +2545,7 @@
 				79A9E4F72449D3AF00599B95 /* Data+Gzip.swift in Sources */,
 				8A466E63241A3A7D003C21BA /* Client+WebSocket.swift in Sources */,
 				8ACC7C0D241924AD000750E4 /* AttachmentType.swift in Sources */,
+				7972C1112497BF66001514AF /* LocalizedMessage.swift in Sources */,
 				8ACC7C13241924AD000750E4 /* MessageAction.swift in Sources */,
 				8ACC7C24241924AD000750E4 /* ChannelResponse.swift in Sources */,
 				8AB2A02D242534EA00CE54F6 /* UserExtraData.swift in Sources */,


### PR DESCRIPTION
### DoD

- [x] Docs updated

### Usage
```swift
message.translate(to: .german) { result in
  let germanText = result.value!.message.i18n?.translated[.german]
}
```
API looks very close to other SDKs