### PR TITLE
[CIS-169] APIClient implementation

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -30,7 +30,9 @@ has_test_changes = !git.modified_files.grep(/StreamChatCoreTests/).empty?
 has_meta_label = github.pr_labels.any? { |label| label.include? "meta" }
 has_no_changelog_tag = github.pr_body.include? "#no_changelog"
 has_skip_changelog_tag = github.pr_body.include? "#skip_changelog"
-has_changelog_escape = has_meta_label || has_no_changelog_tag || has_skip_changelog_tag
+has_v3_label = github.pr_labels.any? { |label| label.include? "v3" }
+
+has_changelog_escape = has_meta_label || has_no_changelog_tag || has_skip_changelog_tag || has_v3_label
 
 # Add a CHANGELOG entry for app changes
 if !has_changelog_escape && !git.modified_files.include?("CHANGELOG.md") && has_app_changes

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -146,6 +146,9 @@
 		79CABB0B24644C1500240052 /* VirtualTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CABB0A24644C1500240052 /* VirtualTimeTests.swift */; };
 		79CABB0D246457EE00240052 /* VirtualTimers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CABB0C246457EE00240052 /* VirtualTimers.swift */; };
 		79D50C7724321BDA0052BA03 /* Client+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D50C7624321BDA0052BA03 /* Client+Events.swift */; };
+		79DDF819249CE38B002F4412 /* MockNetworkURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF816249CE38B002F4412 /* MockNetworkURLProtocol.swift */; };
+		79DDF81A249CE38B002F4412 /* RequestRecorderURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF817249CE38B002F4412 /* RequestRecorderURLProtocol.swift */; };
+		79DDF81B249CE38B002F4412 /* AssertNetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF818249CE38B002F4412 /* AssertNetworkRequest.swift */; };
 		79EE393C2453204E0034EBF3 /* StreamChatClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A50694F23CDEA31009F127A /* StreamChatClient.framework */; };
 		79EE3942245320610034EBF3 /* ClientTests00.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE6206923CF63F000AB3426 /* ClientTests00.swift */; };
 		79EE3943245320650034EBF3 /* ClientTests01+Channels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1D042523D0FB560099AA7F /* ClientTests01+Channels.swift */; };
@@ -608,6 +611,9 @@
 		79CABB0A24644C1500240052 /* VirtualTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualTimeTests.swift; sourceTree = "<group>"; };
 		79CABB0C246457EE00240052 /* VirtualTimers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualTimers.swift; sourceTree = "<group>"; };
 		79D50C7624321BDA0052BA03 /* Client+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Client+Events.swift"; sourceTree = "<group>"; };
+		79DDF816249CE38B002F4412 /* MockNetworkURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNetworkURLProtocol.swift; sourceTree = "<group>"; };
+		79DDF817249CE38B002F4412 /* RequestRecorderURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestRecorderURLProtocol.swift; sourceTree = "<group>"; };
+		79DDF818249CE38B002F4412 /* AssertNetworkRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertNetworkRequest.swift; sourceTree = "<group>"; };
 		79EE39372453204E0034EBF3 /* StreamChatClientIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatClientIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		80B937A42434F5FC003D950E /* Array+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		8A0673B32445E0570042CFD3 /* Channel+Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Channel+Config.swift"; sourceTree = "<group>"; };
@@ -1268,6 +1274,7 @@
 		799C9452247D59B1001F1104 /* TestResources_v3 */ = {
 			isa = PBXGroup;
 			children = (
+				79DDF815249CE38B002F4412 /* Mock Network */,
 				798779F52498E47700015F8B /* MockEnpointResponses */,
 				79280F7E24891C6A00CDEB89 /* Virtual Time */,
 				799C9463247D7919001F1104 /* Custom Assertions */,
@@ -1300,6 +1307,16 @@
 				79BF83F1248F8F60007611A1 /* Logger.swift */,
 			);
 			path = Logger;
+			sourceTree = "<group>";
+		};
+		79DDF815249CE38B002F4412 /* Mock Network */ = {
+			isa = PBXGroup;
+			children = (
+				79DDF816249CE38B002F4412 /* MockNetworkURLProtocol.swift */,
+				79DDF817249CE38B002F4412 /* RequestRecorderURLProtocol.swift */,
+				79DDF818249CE38B002F4412 /* AssertNetworkRequest.swift */,
+			);
+			path = "Mock Network";
 			sourceTree = "<group>";
 		};
 		8A2E4F03245C69AA0032565F /* WebSocket */ = {
@@ -2538,6 +2555,8 @@
 			files = (
 				79A0E9AF2498BFD800E9BD50 /* WebSocketClient_Tests.swift in Sources */,
 				7964F3AA249A19EA002A09EC /* Filter_Tests.swift in Sources */,
+				79DDF819249CE38B002F4412 /* MockNetworkURLProtocol.swift in Sources */,
+				79DDF81B249CE38B002F4412 /* AssertNetworkRequest.swift in Sources */,
 				79877A2A2498E51500015F8B /* MemberModelDTO_Tests.swift in Sources */,
 				799C947D247E6114001F1104 /* TestError.swift in Sources */,
 				79877A2D2498E54400015F8B /* UserEndpoints_Tests.swift in Sources */,
@@ -2562,6 +2581,7 @@
 				79A0E9BC2498C31A00E9BD50 /* TypingStartCleanupMiddleware_Tests.swift in Sources */,
 				796610BB248E687000761629 /* EventMiddleware_Tests.swift in Sources */,
 				799C9469247D791A001F1104 /* AssertResult.swift in Sources */,
+				79DDF81A249CE38B002F4412 /* RequestRecorderURLProtocol.swift in Sources */,
 				79280F8224891C6A00CDEB89 /* VirtualTimer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		7964F3B8249A314D002A09EC /* ConsoleLogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7964F3B3249A314D002A09EC /* ConsoleLogDestination.swift */; };
 		7964F3B9249A314D002A09EC /* BaseLogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7964F3B4249A314D002A09EC /* BaseLogDestination.swift */; };
 		7964F3BA249A314D002A09EC /* LogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7964F3B5249A314D002A09EC /* LogDestination.swift */; };
+		7964F3BC249A5E60002A09EC /* RequestEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7964F3BB249A5E60002A09EC /* RequestEncoder.swift */; };
+		7964F3BE249A5E6E002A09EC /* RequestEncoder_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7964F3BD249A5E6E002A09EC /* RequestEncoder_Tests.swift */; };
 		796610B4248E518D00761629 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EDC122E9BAC5005CFAC9 /* Starscream.framework */; };
 		796610B5248E518D00761629 /* Starscream.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD5EDC122E9BAC5005CFAC9 /* Starscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		796610B9248E651800761629 /* EventMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796610B8248E651800761629 /* EventMiddleware.swift */; };
@@ -538,6 +540,8 @@
 		7964F3B3249A314D002A09EC /* ConsoleLogDestination.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsoleLogDestination.swift; sourceTree = "<group>"; };
 		7964F3B4249A314D002A09EC /* BaseLogDestination.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseLogDestination.swift; sourceTree = "<group>"; };
 		7964F3B5249A314D002A09EC /* LogDestination.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogDestination.swift; sourceTree = "<group>"; };
+		7964F3BB249A5E60002A09EC /* RequestEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestEncoder.swift; sourceTree = "<group>"; };
+		7964F3BD249A5E6E002A09EC /* RequestEncoder_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestEncoder_Tests.swift; sourceTree = "<group>"; };
 		796610B8248E651800761629 /* EventMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware.swift; sourceTree = "<group>"; };
 		796610BA248E687000761629 /* EventMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware_Tests.swift; sourceTree = "<group>"; };
 		7972C10E2497BD38001514AF /* Language.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Language.swift; sourceTree = "<group>"; };
@@ -1255,6 +1259,8 @@
 			isa = PBXGroup;
 			children = (
 				799C9442247D3DA7001F1104 /* APIClient.swift */,
+				7964F3BB249A5E60002A09EC /* RequestEncoder.swift */,
+				7964F3BD249A5E6E002A09EC /* RequestEncoder_Tests.swift */,
 				79877A122498E4EE00015F8B /* Endpoints */,
 			);
 			path = APIClient;
@@ -2510,6 +2516,7 @@
 				79877A272498E50D00015F8B /* MemberModelDTO.swift in Sources */,
 				7962958C248147430078EB53 /* BaseURL.swift in Sources */,
 				79A0E9B62498C2DD00E9BD50 /* HealthCheckFilterMiddleware.swift in Sources */,
+				7964F3BC249A5E60002A09EC /* RequestEncoder.swift in Sources */,
 				79280F712487CD2B00CDEB89 /* Atomic.swift in Sources */,
 				797A756824814F0D003CF16D /* BundleExtensions.swift in Sources */,
 				79877A192498E4EE00015F8B /* UserEndpoints.swift in Sources */,
@@ -2572,6 +2579,7 @@
 				79280F7D24891B1300CDEB89 /* WebSocketEngine_Tests.swift in Sources */,
 				799C9462247D78E2001F1104 /* Await.swift in Sources */,
 				79280F732487CD3100CDEB89 /* Atomic_Tests.swift in Sources */,
+				7964F3BE249A5E6E002A09EC /* RequestEncoder_Tests.swift in Sources */,
 				79877A2C2498E53B00015F8B /* ChannelEndpoints_Tests.swift in Sources */,
 				79877A292498E51500015F8B /* ChannelDTO_Tests.swift in Sources */,
 				799BE2EC248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		79D50C7724321BDA0052BA03 /* Client+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D50C7624321BDA0052BA03 /* Client+Events.swift */; };
 		79DDF80E249CB920002F4412 /* RequestDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF80D249CB920002F4412 /* RequestDecoder.swift */; };
 		79DDF810249CB92E002F4412 /* RequestDecoder_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF80F249CB92E002F4412 /* RequestDecoder_Tests.swift */; };
+		79DDF812249CD5AC002F4412 /* APIClient_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF811249CD5AC002F4412 /* APIClient_Tests.swift */; };
 		79DDF819249CE38B002F4412 /* MockNetworkURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF816249CE38B002F4412 /* MockNetworkURLProtocol.swift */; };
 		79DDF81A249CE38B002F4412 /* RequestRecorderURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF817249CE38B002F4412 /* RequestRecorderURLProtocol.swift */; };
 		79DDF81B249CE38B002F4412 /* AssertNetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF818249CE38B002F4412 /* AssertNetworkRequest.swift */; };
@@ -619,6 +620,7 @@
 		79D50C7624321BDA0052BA03 /* Client+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Client+Events.swift"; sourceTree = "<group>"; };
 		79DDF80D249CB920002F4412 /* RequestDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestDecoder.swift; sourceTree = "<group>"; };
 		79DDF80F249CB92E002F4412 /* RequestDecoder_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestDecoder_Tests.swift; sourceTree = "<group>"; };
+		79DDF811249CD5AC002F4412 /* APIClient_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient_Tests.swift; sourceTree = "<group>"; };
 		79DDF816249CE38B002F4412 /* MockNetworkURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNetworkURLProtocol.swift; sourceTree = "<group>"; };
 		79DDF817249CE38B002F4412 /* RequestRecorderURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestRecorderURLProtocol.swift; sourceTree = "<group>"; };
 		79DDF818249CE38B002F4412 /* AssertNetworkRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertNetworkRequest.swift; sourceTree = "<group>"; };
@@ -1263,6 +1265,7 @@
 			isa = PBXGroup;
 			children = (
 				799C9442247D3DA7001F1104 /* APIClient.swift */,
+				79DDF811249CD5AC002F4412 /* APIClient_Tests.swift */,
 				7964F3BB249A5E60002A09EC /* RequestEncoder.swift */,
 				7964F3BD249A5E6E002A09EC /* RequestEncoder_Tests.swift */,
 				79DDF80D249CB920002F4412 /* RequestDecoder.swift */,
@@ -2584,6 +2587,7 @@
 				799C9460247D77D6001F1104 /* DatabaseContainer_Tests.swift in Sources */,
 				799C945C247D59D8001F1104 /* ChatClient_Tests.swift in Sources */,
 				79280F7D24891B1300CDEB89 /* WebSocketEngine_Tests.swift in Sources */,
+				79DDF812249CD5AC002F4412 /* APIClient_Tests.swift in Sources */,
 				799C9462247D78E2001F1104 /* Await.swift in Sources */,
 				79280F732487CD3100CDEB89 /* Atomic_Tests.swift in Sources */,
 				7964F3BE249A5E6E002A09EC /* RequestEncoder_Tests.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		792A4F492480107A00EAF71D /* Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F452480107A00EAF71D /* Sorting.swift */; };
 		792A4F4B248010A600EAF71D /* QueryOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F4A248010A600EAF71D /* QueryOptions.swift */; };
 		792A4F4D248011E500EAF71D /* ChannelListQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F4C248011E500EAF71D /* ChannelListQuery.swift */; };
+		792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */; };
 		793612F62461437700944861 /* MockNetworkURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793612F52461437700944861 /* MockNetworkURLProtocol.swift */; };
 		793612FE2461684500944861 /* AssertResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793612FD2461684500944861 /* AssertResult.swift */; };
 		793613002461780400944861 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793612FF2461780400944861 /* Await.swift */; };
@@ -516,6 +517,7 @@
 		792A4F452480107A00EAF71D /* Sorting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sorting.swift; sourceTree = "<group>"; };
 		792A4F4A248010A600EAF71D /* QueryOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryOptions.swift; sourceTree = "<group>"; };
 		792A4F4C248011E500EAF71D /* ChannelListQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelListQuery.swift; sourceTree = "<group>"; };
+		792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OptionSet+Extensions.swift"; sourceTree = "<group>"; };
 		79324B7A2462A08A00B2597E /* AtomicTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
 		793612F52461437700944861 /* MockNetworkURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkURLProtocol.swift; sourceTree = "<group>"; };
 		793612FD2461684500944861 /* AssertResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertResult.swift; sourceTree = "<group>"; };
@@ -1081,6 +1083,7 @@
 				792A4F3B247FFBB400EAF71D /* Timers.swift */,
 				797A756524814EF8003CF16D /* SystemEnvironment.swift */,
 				797A756724814F0D003CF16D /* BundleExtensions.swift */,
+				792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2496,6 +2499,7 @@
 				792A4F1B247FE84900EAF71D /* ChannelQueryUpdater.swift in Sources */,
 				799C9479247E3DEA001F1104 /* StreamChatModel.xcdatamodeld in Sources */,
 				79877A1C2498E4EE00015F8B /* Endpoint.swift in Sources */,
+				792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */,
 				79A0E9AD2498BD0C00E9BD50 /* ChatClient.swift in Sources */,
 				792A4F39247FFACB00EAF71D /* WebSocketEngine.swift in Sources */,
 				79280F422484F4EC00CDEB89 /* Event.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -148,6 +148,8 @@
 		79CABB0B24644C1500240052 /* VirtualTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CABB0A24644C1500240052 /* VirtualTimeTests.swift */; };
 		79CABB0D246457EE00240052 /* VirtualTimers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CABB0C246457EE00240052 /* VirtualTimers.swift */; };
 		79D50C7724321BDA0052BA03 /* Client+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D50C7624321BDA0052BA03 /* Client+Events.swift */; };
+		79DDF80E249CB920002F4412 /* RequestDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF80D249CB920002F4412 /* RequestDecoder.swift */; };
+		79DDF810249CB92E002F4412 /* RequestDecoder_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF80F249CB92E002F4412 /* RequestDecoder_Tests.swift */; };
 		79DDF819249CE38B002F4412 /* MockNetworkURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF816249CE38B002F4412 /* MockNetworkURLProtocol.swift */; };
 		79DDF81A249CE38B002F4412 /* RequestRecorderURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF817249CE38B002F4412 /* RequestRecorderURLProtocol.swift */; };
 		79DDF81B249CE38B002F4412 /* AssertNetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF818249CE38B002F4412 /* AssertNetworkRequest.swift */; };
@@ -615,6 +617,8 @@
 		79CABB0A24644C1500240052 /* VirtualTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualTimeTests.swift; sourceTree = "<group>"; };
 		79CABB0C246457EE00240052 /* VirtualTimers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualTimers.swift; sourceTree = "<group>"; };
 		79D50C7624321BDA0052BA03 /* Client+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Client+Events.swift"; sourceTree = "<group>"; };
+		79DDF80D249CB920002F4412 /* RequestDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestDecoder.swift; sourceTree = "<group>"; };
+		79DDF80F249CB92E002F4412 /* RequestDecoder_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestDecoder_Tests.swift; sourceTree = "<group>"; };
 		79DDF816249CE38B002F4412 /* MockNetworkURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNetworkURLProtocol.swift; sourceTree = "<group>"; };
 		79DDF817249CE38B002F4412 /* RequestRecorderURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestRecorderURLProtocol.swift; sourceTree = "<group>"; };
 		79DDF818249CE38B002F4412 /* AssertNetworkRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertNetworkRequest.swift; sourceTree = "<group>"; };
@@ -1261,6 +1265,8 @@
 				799C9442247D3DA7001F1104 /* APIClient.swift */,
 				7964F3BB249A5E60002A09EC /* RequestEncoder.swift */,
 				7964F3BD249A5E6E002A09EC /* RequestEncoder_Tests.swift */,
+				79DDF80D249CB920002F4412 /* RequestDecoder.swift */,
+				79DDF80F249CB92E002F4412 /* RequestDecoder_Tests.swift */,
 				79877A122498E4EE00015F8B /* Endpoints */,
 			);
 			path = APIClient;
@@ -2483,6 +2489,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				79DDF80E249CB920002F4412 /* RequestDecoder.swift in Sources */,
 				79877A0A2498E4BC00015F8B /* Device.swift in Sources */,
 				79280F4F2485308100CDEB89 /* Controller.swift in Sources */,
 				79877A252498E50D00015F8B /* TeamDTO.swift in Sources */,
@@ -2580,6 +2587,7 @@
 				799C9462247D78E2001F1104 /* Await.swift in Sources */,
 				79280F732487CD3100CDEB89 /* Atomic_Tests.swift in Sources */,
 				7964F3BE249A5E6E002A09EC /* RequestEncoder_Tests.swift in Sources */,
+				79DDF810249CB92E002F4412 /* RequestDecoder_Tests.swift in Sources */,
 				79877A2C2498E53B00015F8B /* ChannelEndpoints_Tests.swift in Sources */,
 				79877A292498E51500015F8B /* ChannelDTO_Tests.swift in Sources */,
 				799BE2EC248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -139,7 +139,7 @@
 		79A9E4F72449D3AF00599B95 /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */; };
 		79A9E4F92449DF2D00599B95 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9E4F82449DF2D00599B95 /* Reachability.swift */; };
 		79BF83F2248F8F60007611A1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BF83F1248F8F60007611A1 /* Logger.swift */; };
-		79C750BB248FC4100023F0B7 /* ServerResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C750BA248FC4100023F0B7 /* ServerResponseError.swift */; };
+		79C750BB248FC4100023F0B7 /* ErrorPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C750BA248FC4100023F0B7 /* ErrorPayload.swift */; };
 		79CABAFE2462A4E400240052 /* AtomicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79324B7A2462A08A00B2597E /* AtomicTests.swift */; };
 		79CABB0724630AC600240052 /* AssertAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CABB0624630AC600240052 /* AssertAsync.swift */; };
 		79CABB0924644C0700240052 /* VirtualTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CABB0824644C0700240052 /* VirtualTime.swift */; };
@@ -604,7 +604,7 @@
 		79A9E4F62449D3AF00599B95 /* Data+Gzip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+Gzip.swift"; sourceTree = "<group>"; };
 		79A9E4F82449DF2D00599B95 /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		79BF83F1248F8F60007611A1 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
-		79C750BA248FC4100023F0B7 /* ServerResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerResponseError.swift; sourceTree = "<group>"; };
+		79C750BA248FC4100023F0B7 /* ErrorPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorPayload.swift; sourceTree = "<group>"; };
 		79C750BD2490D0130023F0B7 /* ConnectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionState.swift; sourceTree = "<group>"; };
 		79CABB0624630AC600240052 /* AssertAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertAsync.swift; sourceTree = "<group>"; };
 		79CABB0824644C0700240052 /* VirtualTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualTime.swift; sourceTree = "<group>"; };
@@ -999,7 +999,7 @@
 			isa = PBXGroup;
 			children = (
 				79280F3E2484E3BA00CDEB89 /* ClientError.swift */,
-				79C750BA248FC4100023F0B7 /* ServerResponseError.swift */,
+				79C750BA248FC4100023F0B7 /* ErrorPayload.swift */,
 			);
 			path = Errors;
 			sourceTree = "<group>";
@@ -2505,7 +2505,7 @@
 				7937282A2498FFD300E13FE5 /* MemberEndpoints.swift in Sources */,
 				799C944C247D5766001F1104 /* ChannelController.swift in Sources */,
 				792A4F3F247FFDE700EAF71D /* Codable+Extensions.swift in Sources */,
-				79C750BB248FC4100023F0B7 /* ServerResponseError.swift in Sources */,
+				79C750BB248FC4100023F0B7 /* ErrorPayload.swift in Sources */,
 				799BE2EA248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift in Sources */,
 				79877A272498E50D00015F8B /* MemberModelDTO.swift in Sources */,
 				7962958C248147430078EB53 /* BaseURL.swift in Sources */,

--- a/StreamChatClient_v3/APIClient/APIClient_Tests.swift
+++ b/StreamChatClient_v3/APIClient/APIClient_Tests.swift
@@ -1,0 +1,307 @@
+//
+// APIClient_Tests.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient_v3
+import XCTest
+
+class APIClient_Tests: XCTestCase {
+    var apiClient: APIClient!
+    
+    var apiKey: APIKey!
+    var baseURL: URL!
+    var sessionConfiguration: URLSessionConfiguration!
+    
+    var uniqeHeaderValue: String!
+    
+    var encoder: TestRequestEncoder { apiClient.encoder as! TestRequestEncoder }
+    var decoder: TestRequestDecoder { apiClient.decoder as! TestRequestDecoder }
+    
+    override func setUp() {
+        super.setUp()
+        
+        let environment = APIClient.Environment(requestEncoderBuilder: TestRequestEncoder.init,
+                                                requestDecoderBuilder: TestRequestDecoder.init)
+        
+        apiKey = APIKey(.unique)
+        baseURL = .unique()
+        
+        // Prepare the URL protocol test environment
+        sessionConfiguration = URLSessionConfiguration.default
+        RequestRecorderURLProtocol.startTestSession(with: &sessionConfiguration)
+        MockNetworkURLProtocol.startTestSession(with: &sessionConfiguration)
+        
+        // Some random value to ensure the headers are respected
+        uniqeHeaderValue = .unique
+        sessionConfiguration.httpAdditionalHeaders?["unique_value"] = uniqeHeaderValue
+        
+        apiClient = APIClient(apiKey: apiKey, baseURL: baseURL, sessionConfiguration: sessionConfiguration,
+                              environment: environment)
+    }
+    
+    override func tearDown() {
+        // Test APIClient has no retain cycles after every test
+        weak var weakAPIClient = apiClient
+        apiClient = nil
+        XCTAssertNil(weakAPIClient)
+        
+        super.tearDown()
+    }
+    
+    func test_isInitializedWithCorrectValues() {
+        XCTAssertEqual(apiClient.baseURL, baseURL)
+        XCTAssertEqual(apiClient.apiKey, apiKey)
+        XCTAssertEqual(apiClient.session.configuration, sessionConfiguration)
+    }
+    
+    // MARK: - Connection Id handling
+    
+    func test_providesConnectionIdForEncoder() {
+        // Simulate WS client updated connection id
+        let connectionId1: ConnectionId = .unique
+        apiClient.webSocketClient(TestWebSocketClient(), didUpdateConectionState: .connected(connectionId: connectionId1))
+        
+        // Simulate encoder requested a connection id and check it's the correct one
+        var providedConnectionId1: ConnectionId?
+        encoder.connectionIdProviderDelegate?.provideConnectionId { providedConnectionId1 = $0 }
+        XCTAssertEqual(providedConnectionId1, connectionId1)
+        
+        // Simulate WS client is disconnecting
+        apiClient.webSocketClient(TestWebSocketClient(), didUpdateConectionState: .disconnecting(source: .userInitiated))
+        
+        // Request a connection id again
+        var providedConnectionId2: ConnectionId?
+        encoder.connectionIdProviderDelegate?.provideConnectionId { providedConnectionId2 = $0 }
+        
+        // No connection id should be returned
+        XCTAssertNil(providedConnectionId2)
+        
+        // Simulate WS reconnected and check the provided id is correct
+        let connectionId2: ConnectionId = .unique
+        apiClient.webSocketClient(TestWebSocketClient(), didUpdateConectionState: .connected(connectionId: connectionId2))
+        XCTAssertEqual(providedConnectionId2, connectionId2)
+    }
+    
+    func test_waitingRequestsAreFailed_whenAPIClientIsDeallocated() {
+        // Simulate encoder requested connection id
+        var providedConnectionId1: ConnectionId? = "some_value_that's_not_nil"
+        encoder.connectionIdProviderDelegate?.provideConnectionId { providedConnectionId1 = $0 }
+        
+        // Simulate `APIClient` is deallocated
+        apiClient = nil
+        
+        // Check the callback is called with `nil`
+        XCTAssertNil(providedConnectionId1)
+    }
+    
+    // MARK: - Request encoding / decoding
+    
+    func test_requestEncoderIsCalledWithEndpoint() {
+        // Setup mock encoder response (it's not actually used, we just need to return something)
+        let request = URLRequest(url: .unique())
+        encoder.encodeRequest = .success(request)
+        
+        // Create a test endpoint
+        let testEndpoint = Endpoint<Data>(path: .unique, method: .post, queryItems: nil, requiresConnectionId: false, body: nil)
+        
+        // Create a request
+        apiClient.request(endpoint: testEndpoint) { _ in }
+        
+        // Check the encoder is called with the correct endpoint
+        XCTAssertEqual(encoder.encodeRequest_endpoint, AnyEndpoint(testEndpoint))
+    }
+    
+    func test_requestEncoderFailingToEncode() throws {
+        // Setup mock encoder response to fail with `testError`
+        let testError = TestError()
+        encoder.encodeRequest = .failure(testError)
+        
+        // Create a test endpoint
+        let testEndpoint = Endpoint<Data>.mock()
+        
+        // Create a request and assert the result is failure
+        let result = try await { apiClient.request(endpoint: testEndpoint, completion: $0) }
+        AssertResultFailure(result, testError)
+    }
+    
+    // MARK: - Networking
+    
+    func test_callingRequest_createsNetworkRequest() {
+        // Create a test request and set it as a response from the encoder
+        let uniquePath: String = .unique
+        let uniqueQueryItem: String = .unique
+        var testRequest = URLRequest(url: URL(string: "test://test.test/\(uniquePath)?item=\(uniqueQueryItem)")!)
+        testRequest.httpMethod = "post"
+        testRequest.httpBody = try! JSONEncoder.stream.encode(TestUser(name: "Leia"))
+        testRequest.allHTTPHeaderFields?["surname"] = "Organa"
+        encoder.encodeRequest = .success(testRequest)
+        
+        // Create a test endpoint (it's actually ignored, because APIClient uses the testRequest returned from the encoder)
+        let testEndpoint = Endpoint<Data>.mock()
+        
+        // Create a request
+        apiClient.request(endpoint: testEndpoint) { _ in }
+        
+        // Check a network request is made with the values from `testRequest`
+        AssertNetworkRequest(method: .post,
+                             path: "/" + uniquePath,
+                             // the "name" header value comes from the request, "unique_value" from the session config
+                             headers: ["surname": "Organa", "unique_value": uniqeHeaderValue],
+                             queryParameters: ["item": uniqueQueryItem],
+                             body: ["name": "Leia"])
+    }
+    
+    func test_requestSuccess() throws {
+        // Create a test request and set it as a response from the encoder
+        let testRequest = URLRequest(url: .unique())
+        encoder.encodeRequest = .success(testRequest)
+        
+        // Set up a succssfull mock network response for the request
+        let mockResponseData = try JSONEncoder.stream.encode(TestUser(name: "Leia!"))
+        MockNetworkURLProtocol.mockResponse(request: testRequest, statusCode: 234, responseBody: mockResponseData)
+        
+        // Set up a decoder response
+        // ⚠️ Watch out: the user is different there, so we can distinguish between the incoming data
+        // to the encoder, and the outgoing data).
+        decoder.decodeRequestResponse = .success(TestUser(name: "Luke"))
+        
+        // Create a test endpoint (it's actually ignored, because APIClient uses the testRequest returned from the encoder)
+        let testEndpoint = Endpoint<TestUser>.mock()
+        
+        // Create a request and wait for the completion block
+        let result = try await { apiClient.request(endpoint: testEndpoint, completion: $0) }
+        
+        // Check the incoming data to the encoder is the URLResponse and data from the network
+        XCTAssertEqual(decoder.decodeRequestResponse_data, try! JSONEncoder.stream.encode(TestUser(name: "Leia!")))
+        XCTAssertEqual(decoder.decodeRequestResponse_response?.statusCode, 234)
+        
+        // Check the outgoing data from the encoder is the result data
+        AssertResultSuccess(result, TestUser(name: "Luke"))
+    }
+    
+    func test_requestFailure() throws {
+        // Create a test request and set it as a response from the encoder
+        let testRequest = URLRequest(url: .unique())
+        encoder.encodeRequest = .success(testRequest)
+        
+        let networkError = TestError()
+        let encoderError = TestError()
+        
+        // Set up a mock network response from the request
+        MockNetworkURLProtocol.mockResponse(request: testRequest, statusCode: 444, error: networkError)
+        
+        // Set up a decoder response to return `encoderError`
+        decoder.decodeRequestResponse = .failure(encoderError)
+        
+        // Create a test endpoint (it's actually ignored, because APIClient uses the testRequest returned from the encoder)
+        let testEndpoint = Endpoint<TestUser>.mock()
+        
+        // Create a request and wait for the completion block
+        let result = try await { apiClient.request(endpoint: testEndpoint, completion: $0) }
+        
+        // Check the incoming error to the encoder is the error from the response
+        XCTAssertEqual(decoder.decodeRequestResponse_error as? TestError, networkError)
+        
+        // Check the outgoing error from the encoder is the result data
+        AssertResultFailure(result, encoderError)
+    }
+}
+
+extension Endpoint {
+    static func mock() -> Endpoint<ResponseType> {
+        .init(path: .unique, method: .post, queryItems: nil, requiresConnectionId: false, body: nil)
+    }
+}
+
+private struct TestUser: Codable, Equatable {
+    let name: String
+}
+
+class TestRequestEncoder: RequestEncoder {
+    let init_baseURL: URL
+    let init_apiKey: APIKey
+    
+    weak var connectionIdProviderDelegate: ConnectionIdProviderDelegate?
+    
+    var encodeRequest: Result<URLRequest, Error>?
+    var encodeRequest_endpoint: AnyEndpoint?
+    var encodeRequest_completion: ((Result<URLRequest, Error>) -> Void)?
+    
+    func encodeRequest<ResponsePayload>(
+        for endpoint: Endpoint<ResponsePayload>,
+        completion: @escaping (Result<URLRequest, Error>) -> Void
+    ) where ResponsePayload: Decodable {
+        encodeRequest_endpoint = AnyEndpoint(endpoint)
+        encodeRequest_completion = completion
+        
+        if let result = encodeRequest {
+            completion(result)
+        }
+    }
+    
+    required init(baseURL: URL, apiKey: APIKey) {
+        init_baseURL = baseURL
+        init_apiKey = apiKey
+    }
+}
+
+class TestRequestDecoder: RequestDecoder {
+    var decodeRequestResponse: Result<Any, Error>?
+    
+    var decodeRequestResponse_data: Data?
+    var decodeRequestResponse_response: HTTPURLResponse?
+    var decodeRequestResponse_error: Error?
+    
+    func decodeRequestResponse<ResponseType>(data: Data?, response: URLResponse?, error: Error?) throws -> ResponseType
+        where ResponseType: Decodable {
+        decodeRequestResponse_data = data
+        decodeRequestResponse_response = response as? HTTPURLResponse
+        decodeRequestResponse_error = error
+        
+        guard let simulatedResponse = decodeRequestResponse else {
+            print("TestRequestDecoder simulated response not set. Throwing a TestError.")
+            throw TestError()
+        }
+        
+        switch simulatedResponse {
+        case let .success(response):
+            return response as! ResponseType
+        case let .failure(error):
+            throw error
+        }
+    }
+}
+
+struct AnyEndpoint: Equatable {
+    let path: String
+    let method: EndpointMethod
+    let queryItems: Encodable?
+    let requiresConnectionId: Bool
+    let body: Encodable?
+    let payloadType: Decodable.Type
+    
+    init<T: Decodable>(_ endpoint: Endpoint<T>) {
+        path = endpoint.path
+        method = endpoint.method
+        queryItems = endpoint.queryItems
+        requiresConnectionId = endpoint.requiresConnectionId
+        body = endpoint.body
+        payloadType = T.self
+    }
+    
+    static func == (lhs: AnyEndpoint, rhs: AnyEndpoint) -> Bool {
+        lhs.path == rhs.path
+            && lhs.method == rhs.method
+            && String(describing: lhs.queryItems) == String(describing: rhs.queryItems)
+            && lhs.requiresConnectionId == rhs.requiresConnectionId
+            && String(describing: lhs.body) == String(describing: rhs.body)
+            && String(describing: lhs.payloadType) == String(describing: rhs.payloadType)
+    }
+}
+
+private class TestWebSocketClient: WebSocketClient {
+    init() {
+        super.init(urlRequest: .init(url: .unique()), eventDecoder: EventDecoder<DefaultDataTypes>(), eventMiddlewares: [])
+    }
+}

--- a/StreamChatClient_v3/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/StreamChatClient_v3/APIClient/Endpoints/ChannelEndpoints.swift
@@ -10,9 +10,9 @@ extension Endpoint {
         -> Endpoint<ChannelListPayload<ExtraData>> {
         .init(path: "channels",
               method: .get,
-              queryItems: [],
-              jsonQueryItems: ["payload": query],
-              body: nil)
+              queryItems: nil,
+              requiresConnectionId: query.options.contains(oneOf: [.presence, .state, .watch]),
+              body: ["payload": query])
     }
 }
 

--- a/StreamChatClient_v3/APIClient/Endpoints/Endpoint.swift
+++ b/StreamChatClient_v3/APIClient/Endpoints/Endpoint.swift
@@ -7,16 +7,14 @@ import Foundation
 
 struct Endpoint<ResponseType: Decodable> {
     let path: String
-    let method: Method
-    let queryItems: [URLQueryItem]
-    let jsonQueryItems: [String: Encodable]? // This applies only for GET requests, can we maybe reuse `body` for that?
-    let body: Data?
+    let method: EndpointMethod
+    let queryItems: Encodable?
+    let requiresConnectionId: Bool
+    let body: Encodable?
 }
 
-extension Endpoint {
-    enum Method: String {
-        case get = "GET"
-        case post = "POST"
-        case delete = "DELETE"
-    }
+enum EndpointMethod: String {
+    case get = "GET"
+    case post = "POST"
+    case delete = "DELETE"
 }

--- a/StreamChatClient_v3/APIClient/RequestDecoder.swift
+++ b/StreamChatClient_v3/APIClient/RequestDecoder.swift
@@ -1,0 +1,84 @@
+//
+// RequestDecoder.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An object responsible for handling incoming URL request response and decoding it.
+protocol RequestDecoder {
+    /// Decodes an incoming URL request response.
+    ///
+    /// - Parameters:
+    ///   - data: The incoming data.
+    ///   - response: The response object from the network.
+    ///   - error: An error object returned by the data task.
+    ///
+    /// - Throws: An error if the decoding fails.
+    func decodeRequestResponse<ResponseType: Decodable>(data: Data?, response: URLResponse?, error: Error?) throws -> ResponseType
+}
+
+/// The default implementation of `RequestDecoder`.
+struct DefaultRequestDecoder: RequestDecoder {
+    func decodeRequestResponse<ResponseType: Decodable>(data: Data?, response: URLResponse?, error: Error?) throws -> ResponseType {
+        // Handle the error case
+        guard error == nil else {
+            let error = error!
+            switch (error as NSError).code {
+            case NSURLErrorCancelled:
+                log.info("The request was cancelled.")
+            case NSURLErrorNetworkConnectionLost:
+                log.info("The network connection was lost.")
+            default:
+                log.error(error)
+            }
+            
+            throw error
+        }
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ClientError.Unexpected("Expecting `HTTPURLResponse` but received: \(response?.description ?? "nil").")
+        }
+        
+        guard let data = data, data.isEmpty == false else {
+            throw ClientError.ResponseBodyEmpty()
+        }
+        
+        // TODO: improve
+        log.info("URL request response: \(httpResponse), data: \(String(data: data, encoding: .utf8) ?? data.description))")
+        
+        guard httpResponse.statusCode < 400 else {
+            guard let serverError = try? JSONDecoder.default.decode(ErrorPayload.self, from: data) else {
+                throw ClientError.Unknown("Unknown error. Server response: \(httpResponse).")
+            }
+            
+            // TODO: 👇
+//                if errorResponse.message.contains("was deactivated") {
+//                    webSocket.disconnect(reason: "JSON response error: the client was deactivated")
+//                }
+            
+            if ErrorPayload.tokenInvadlidErrorCodes ~= serverError.code {
+                log.info("Request failed because of an experied token.")
+                throw ClientError.ExpiredToken()
+            }
+            
+            throw ClientError(with: serverError)
+        }
+        
+        do {
+            let decodedPayload = try JSONDecoder.default.decode(ResponseType.self, from: data)
+            return decodedPayload
+            
+        } catch {
+            log.error(error)
+            throw error
+        }
+    }
+}
+
+extension ClientError {
+    class ExpiredToken: ClientError {}
+    class ResponseBodyEmpty: ClientError {
+        var localizedDescription = "Response body is empty."
+    }
+}

--- a/StreamChatClient_v3/APIClient/RequestDecoder_Tests.swift
+++ b/StreamChatClient_v3/APIClient/RequestDecoder_Tests.swift
@@ -1,0 +1,71 @@
+//
+// RequestDecoder_Tests.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient_v3
+import XCTest
+
+class RequestDecoder_Tests: XCTestCase {
+    var decoder: RequestDecoder!
+    
+    override func setUp() {
+        super.setUp()
+        decoder = DefaultRequestDecoder()
+    }
+    
+    func test_decodingSuccessfullResponse() throws {
+        // Prepare test data simulating successful response
+        let response = HTTPURLResponse(url: .unique(), statusCode: 200, httpVersion: nil, headerFields: nil)
+        let testUser = TestUser(name: "Luke", age: 22)
+        let data = try JSONEncoder.stream.encode(testUser)
+        
+        // Decode it and check the results is `testUser`
+        let decoded: TestUser = try decoder.decodeRequestResponse(data: data, response: response, error: nil)
+        XCTAssertEqual(decoded, testUser)
+    }
+    
+    func test_decodingResponseWithError() {
+        let testError = TestError()
+        
+        // Check decoding with an incoming error "throws" the same error
+        XCTAssertThrowsError(try {
+            let _: Data = try self.decoder.decodeRequestResponse(data: nil, response: nil, error: testError)
+        }()) { (error) in
+            XCTAssertEqual(error as? TestError, testError)
+        }
+    }
+    
+    func test_decodingResponseWithServerError() throws {
+        // Prepare test data to simulate error payload from the server
+        let errorPayload = ErrorPayload(code: 0, message: "Test", statusCode: 400)
+        let data = try JSONEncoder.stream.encode(errorPayload)
+        let response = HTTPURLResponse(url: .unique(), statusCode: 400, httpVersion: nil, headerFields: nil)
+        
+        // Decode and check the thrown error is created from the server error payload
+        XCTAssertThrowsError(try {
+            let _: Data = try self.decoder.decodeRequestResponse(data: data, response: response, error: nil)
+        }()) { (error) in
+            XCTAssert((error as? ClientError)?.underlyingError is ErrorPayload)
+        }
+    }
+    
+    func test_decodingResponseWithServerError_containingExpiredToken() throws {
+        // Prepare test data to simulate the "token expired" server error
+        let errorPayload = ErrorPayload(code: 40, message: "Test", statusCode: 400)
+        let data = try JSONEncoder.stream.encode(errorPayload)
+        let response = HTTPURLResponse(url: .unique(), statusCode: 400, httpVersion: nil, headerFields: nil)
+        
+        // Decode and check the error type is correct
+        XCTAssertThrowsError(try {
+            let _: Data = try self.decoder.decodeRequestResponse(data: data, response: response, error: nil)
+        }()) { (error) in
+            XCTAssert(error is ClientError.ExpiredToken)
+        }
+    }
+}
+
+private struct TestUser: Codable, Equatable {
+    let name: String
+    let age: Int
+}

--- a/StreamChatClient_v3/APIClient/RequestEncoder.swift
+++ b/StreamChatClient_v3/APIClient/RequestEncoder.swift
@@ -1,0 +1,192 @@
+//
+// RequestEncoder.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// On object responsible for creating a `URLRequest`, and encoding all required and `Endpoint` specific data to it.
+protocol RequestEncoder {
+    /// A delegate the encoder uses for obtaining the current `connectionId`.
+    ///
+    /// Trying to encode an `Endpoint` with the `requiresConnectionId` set to `true` without setting the delegate
+    var connectionIdProviderDelegate: ConnectionIdProviderDelegate? { get set }
+    
+    /// Asynchronously creates a new `URLRequest` with the data from the `Endpoint`. It also adds all required data
+    /// like an api key, etc.
+    ///
+    /// - Parameters:
+    ///   - endpoint: The `Endpoint` to be encoded.
+    ///   - completion: Called when the encoded `URLRequest` is ready. Called with en `Error` if the encoding fails.
+    func encodeRequest<ResponsePayload: Decodable>(for endpoint: Endpoint<ResponsePayload>,
+                                                   completion: @escaping (Result<URLRequest, Error>) -> Void)
+    
+    /// Creates a new `RequestEncoder`.
+    ///
+    /// - Parameters:
+    ///   - baseURL: The base URL for all requests.
+    ///   - apiKey: The app specific API key.
+    init(baseURL: URL, apiKey: APIKey)
+}
+
+/// The default implementation of `RequestEncoder`.
+struct DefaultRequestEncoder: RequestEncoder {
+    let baseURL: URL
+    let apiKey: APIKey
+    
+    weak var connectionIdProviderDelegate: ConnectionIdProviderDelegate?
+    
+    func encodeRequest<ResponsePayload: Decodable>(for endpoint: Endpoint<ResponsePayload>,
+                                                   completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        var request: URLRequest
+        
+        do {
+            // Prepare the URL
+            var url = try encodeRequestURL(for: endpoint)
+            url = try url.appendingQueryItems(["api_key": apiKey.apiKeyString])
+            
+            // Create a request
+            request = URLRequest(url: url)
+            request.httpMethod = endpoint.method.rawValue
+            
+            // Encode endpoint-specific query items
+            if let queryItems = endpoint.queryItems {
+                try encodeJSONToQueryItems(request: &request, data: queryItems)
+            }
+            
+            try encodeRequestBody(request: &request, endpoint: endpoint)
+            
+        } catch {
+            completion(.failure(error))
+            return
+        }
+        
+        if endpoint.requiresConnectionId {
+            log.assert(connectionIdProviderDelegate != nil,
+                       "The endpoind requiers `connectionId` but `connectionIdProviderDelegate` is not set.")
+            
+            connectionIdProviderDelegate?.provideConnectionId { (connectionId) in
+                guard let connectionId = connectionId else {
+                    completion(.failure(ClientError.MissingConnectionId("Failed to get `connectionId`, request can't be created.")))
+                    return
+                }
+                
+                do {
+                    request.url = try request.url?.appendingQueryItems(["connection_id": connectionId])
+                } catch {
+                    completion(.failure(error))
+                    return
+                }
+                
+                completion(.success(request))
+            }
+            
+        } else {
+            completion(.success(request))
+        }
+    }
+    
+    init(baseURL: URL, apiKey: APIKey) {
+        self.baseURL = baseURL
+        self.apiKey = apiKey
+    }
+    
+    // MARK: - Private
+    
+    private func encodeRequestURL<T: Decodable>(for endpoint: Endpoint<T>) throws -> URL {
+        var urlComponents = URLComponents()
+        urlComponents.scheme = baseURL.scheme
+        urlComponents.host = baseURL.host
+        urlComponents.path = baseURL.path
+        
+        guard var url = urlComponents.url else {
+            throw ClientError.InvalidURL("URL can't be created using components: \(urlComponents)")
+        }
+        
+        url = url.appendingPathComponent(endpoint.path)
+        return url
+    }
+    
+    private func encodeRequestBody<T: Decodable>(request: inout URLRequest, endpoint: Endpoint<T>) throws {
+        switch endpoint.method {
+        case .get, .delete:
+            try encodeGETRequestBody(request: &request, endpoint: endpoint)
+        case .post:
+            try encodePOSTRequestBody(request: &request, endpoint: endpoint)
+        }
+    }
+    
+    private func encodeGETRequestBody<T: Decodable>(request: inout URLRequest, endpoint: Endpoint<T>) throws {
+        log.assert(endpoint.method == .get, "Endpoint method is \(endpoint.method) but must be GET.")
+        log.assert(request.url != nil, "Request URL must not be `nil`.")
+        
+        guard let body = endpoint.body else { return }
+        try encodeJSONToQueryItems(request: &request, data: body)
+    }
+    
+    private func encodePOSTRequestBody<T: Decodable>(request: inout URLRequest, endpoint: Endpoint<T>) throws {
+        log.assert(endpoint.method == .post, "Request method is \(endpoint.method) but must be POST.")
+        guard let body = endpoint.body else { return }
+        
+        request.httpBody = try JSONEncoder.stream.encode(AnyEncodable(body))
+    }
+    
+    private func encodeJSONToQueryItems(request: inout URLRequest, data: Encodable) throws {
+        let data = try JSONEncoder.stream.encode(AnyEncodable(data))
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ClientError.InvalidJSON("Data is not a valid JSON: \(String(data: data, encoding: .utf8) ?? "nil")")
+        }
+        
+        let bodyQueryItems = json.compactMap { (key, value) -> URLQueryItem? in
+            // If the `value` is a JSON, encode it like that
+            if let jsonValue = value as? [String: Any] {
+                do {
+                    let jsonStringValue = try JSONSerialization.data(withJSONObject: jsonValue)
+                    return URLQueryItem(name: key, value: String(data: jsonStringValue, encoding: .utf8))
+                } catch {
+                    log.error("Skipping encoding data for key:`\(key)` because it's not a valid JSON: "
+                        + "\(String(data: data, encoding: .utf8) ?? "nil")")
+                }
+            }
+            
+            return URLQueryItem(name: key, value: String(describing: value))
+        }
+        
+        log.assert(request.url != nil, "Request URL must not be `nil`.")
+        request.url = try request.url!.appendingQueryItems(bodyQueryItems)
+    }
+}
+
+private extension URL {
+    func appendingQueryItems(_ items: [URLQueryItem]) throws -> URL {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            throw ClientError.InvalidURL("Can't create `URLComponents` from the url: \(self).")
+        }
+        let existingQueryItems = components.queryItems ?? []
+        components.queryItems = existingQueryItems + items
+        guard let newURL = components.url else {
+            throw ClientError.InvalidURL("Can't create a new `URL` after appending query items: \(items).")
+        }
+        return newURL
+    }
+}
+
+protocol ConnectionIdProviderDelegate: AnyObject {
+    func provideConnectionId(completion: @escaping (_ connectionId: ConnectionId?) -> Void)
+}
+
+extension ClientError {
+    class InvalidURL: CustomMessageError {}
+    class InvalidJSON: CustomMessageError {}
+    class MissingConnectionId: CustomMessageError {}
+}
+
+/// A helper extension allowing to create `URLQueryItems` using a dictionary literal like:
+/// ```
+/// let queryItems = ["item1": "Luke", "item2": nil, "item3": "Leia"]
+/// ```
+extension Array: ExpressibleByDictionaryLiteral where Element == URLQueryItem {
+    public init(dictionaryLiteral elements: (String, String?)...) {
+        self = elements.map(URLQueryItem.init)
+    }
+}

--- a/StreamChatClient_v3/APIClient/RequestEncoder_Tests.swift
+++ b/StreamChatClient_v3/APIClient/RequestEncoder_Tests.swift
@@ -1,0 +1,175 @@
+//
+// RequestEncoder_Tests.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient_v3
+import XCTest
+
+class RequestEncoder_Tests: XCTestCase {
+    var encoder: RequestEncoder!
+    var baseURL: URL!
+    var apiKey: APIKey!
+    fileprivate var connectionIdProvider: TestConnectionIdProviderDelegate!
+    
+    override func setUp() {
+        super.setUp()
+        
+        apiKey = APIKey(.unique)
+        baseURL = .unique()
+        encoder = DefaultRequestEncoder(baseURL: baseURL, apiKey: apiKey)
+        
+        connectionIdProvider = TestConnectionIdProviderDelegate()
+        encoder.connectionIdProviderDelegate = connectionIdProvider
+    }
+    
+    func test_requiredQueryItems() throws {
+        // Prepare a new endpoint
+        let endpoint = Endpoint<Data>(path: .unique,
+                                      method: .get,
+                                      queryItems: nil,
+                                      requiresConnectionId: false,
+                                      body: nil)
+        
+        // Encode the request and wait for the result
+        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        
+        // Check the required query item values are present
+        let urlComponents = try XCTUnwrap(URLComponents(url: request.url!, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(urlComponents.queryItems?["api_key"], apiKey.apiKeyString)
+    }
+    
+    func test_endpointRequiringConectionId() throws {
+        // Prepare an endpoint that requires connection id
+        let endpoint = Endpoint<Data>(path: .unique,
+                                      method: .get,
+                                      queryItems: nil,
+                                      requiresConnectionId: true,
+                                      body: nil)
+        
+        // Set a new connection id
+        let connectionId = String.unique
+        connectionIdProvider.connectionId = connectionId
+        
+        // Encode the request and wait for the result
+        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        
+        // Check the connection id is set
+        let urlComponents = try XCTUnwrap(URLComponents(url: request.url!, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(urlComponents.queryItems?["connection_id"], connectionId)
+    }
+    
+    func test_encodingRequestURL() throws {
+        let testStringValue = String.unique
+        
+        // Prepare a request with query items
+        let endpoint = Endpoint<Data>(path: .unique,
+                                      method: .post,
+                                      queryItems: ["stringValue": testStringValue],
+                                      requiresConnectionId: false,
+                                      body: nil)
+        
+        // Encode the request and wait for the result
+        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        
+        // Check the URL is set up correctly
+        XCTAssertEqual(request.httpMethod, endpoint.method.rawValue)
+        XCTAssertEqual(request.url?.scheme, baseURL.scheme)
+        XCTAssertEqual(request.url?.host, baseURL.host)
+        XCTAssertEqual(request.url?.path, "/" + endpoint.path)
+        
+        // Check custom query items
+        let urlComponenets = try XCTUnwrap(URLComponents(url: request.url!, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(urlComponenets.queryItems?["stringValue"], testStringValue)
+    }
+    
+    func test_encodingRequestBody_POST() throws {
+        // Prepare a POST endpoint with JSON body
+        let endpoint = Endpoint<Data>(path: .unique,
+                                      method: .post,
+                                      queryItems: nil,
+                                      requiresConnectionId: false,
+                                      body: TestUser(name: "Luke", age: 22))
+        
+        // Encode the request and wait for the result
+        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        
+        // Check the body is present
+        let body = try XCTUnwrap(request.httpBody)
+        let serializedBody = try JSONDecoder.stream.decode(TestUser.self, from: body)
+        
+        XCTAssertEqual(serializedBody, endpoint.body as! TestUser)
+    }
+    
+    func test_encodingRequestBody_GET() throws {
+        // Prepare a GET endpoint with JSON body
+        let endpoint = Endpoint<Data>(path: .unique,
+                                      method: .get,
+                                      queryItems: nil,
+                                      requiresConnectionId: false,
+                                      body: [
+                                          "user1": TestUser(name: "Luke", age: 22),
+                                          "user2": TestUser(name: "Leia", age: 22)
+                                      ])
+        
+        // Encode the request and wait for the result
+        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        
+        // Check both JSONs are present in the query items
+        let urlComponents = try XCTUnwrap(URLComponents(url: request.url!, resolvingAgainstBaseURL: false))
+        
+        let user1String = try XCTUnwrap(urlComponents.queryItems?["user1"])
+        let user1JSON = try JSONDecoder.default.decode(TestUser.self, from: user1String.data(using: .utf8)!)
+        XCTAssertEqual(user1JSON, TestUser(name: "Luke", age: 22))
+        
+        let user2String = try XCTUnwrap(urlComponents.queryItems?["user2"])
+        let user2JSON = try JSONDecoder.default.decode(TestUser.self, from: user2String.data(using: .utf8)!)
+        XCTAssertEqual(user2JSON, TestUser(name: "Leia", age: 22))
+    }
+    
+    func test_encodingGETRequestBody_withQueryItems() throws {
+        // Prepare a GET endpoint with both, the query items and JSON body
+        let endpoint = Endpoint<Data>(path: .unique,
+                                      method: .get,
+                                      queryItems: ["father": "Anakin"],
+                                      requiresConnectionId: false,
+                                      body: ["user": TestUser(name: "Luke", age: 22)])
+        
+        // Encode the request and wait for the result
+        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        
+        let urlComponents = try XCTUnwrap(URLComponents(url: request.url!, resolvingAgainstBaseURL: false))
+        
+        // Check the query item
+        XCTAssertEqual(urlComponents.queryItems?["father"], "Anakin")
+        
+        // Check the query-item encoded body
+        let userString = try XCTUnwrap(urlComponents.queryItems?["user"])
+        let userJSON = try JSONDecoder.default.decode(TestUser.self, from: userString.data(using: .utf8)!)
+        XCTAssertEqual(userJSON, TestUser(name: "Luke", age: 22))
+    }
+}
+
+class TestConnectionIdProviderDelegate: ConnectionIdProviderDelegate {
+    var connectionId: ConnectionId?
+    var connectionWaiters: [(ConnectionId?) -> Void] = []
+    
+    func provideConnectionId(completion: @escaping (ConnectionId?) -> Void) {
+        connectionWaiters.append(completion)
+        if let connectionId = connectionId {
+            completion(connectionId)
+        }
+    }
+}
+
+private struct TestUser: Codable, Equatable {
+    let name: String
+    let age: Int
+}
+
+extension Array where Element == URLQueryItem {
+    /// Returns the value of the URLQueryItem with the given name. Returns `nil` if the query item doesn't exist.
+    subscript(_ name: String) -> String? {
+        first(where: { $0.name == name }).flatMap { $0.value }
+    }
+}

--- a/StreamChatClient_v3/ChatClient.swift
+++ b/StreamChatClient_v3/ChatClient.swift
@@ -97,7 +97,7 @@ public final class Client<ExtraData: ExtraDataTypes> {
         urlComponents.scheme = baseURL.wsURL.scheme
         urlComponents.host = baseURL.wsURL.host
         urlComponents.path = baseURL.wsURL.path.appending("connect")
-        urlComponents.queryItems = [URLQueryItem(name: "api_key", value: config.apiKey)]
+        urlComponents.queryItems = [URLQueryItem(name: "api_key", value: config.apiKey.apiKeyString)]
         
 //      if user.isAnonymous {
 //          urlComponents.queryItems?.append(URLQueryItem(name: "stream-auth-type", value: "anonymous"))

--- a/StreamChatClient_v3/ChatClient_Tests.swift
+++ b/StreamChatClient_v3/ChatClient_Tests.swift
@@ -115,6 +115,6 @@ private struct Queue<Element> {
 
 private extension ChatClientConfig {
     init() {
-        self = .init(apiKey: "test_api_key")
+        self = .init(apiKey: APIKey("test_api_key"))
     }
 }

--- a/StreamChatClient_v3/Config/ChatClientConfig.swift
+++ b/StreamChatClient_v3/Config/ChatClientConfig.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-/// A configuration object used to configure a `ChatClient` instance.
+/// A configuration object used to configure a `Client` instance.
 ///
 /// The default configuration can be changed the following way:
 ///   ```
@@ -15,9 +15,9 @@ import Foundation
 ///   ```
 ///
 public struct ChatClientConfig {
-    public let apiKey: String
+    public let apiKey: APIKey
     
-    /// The folder ChatClient uses to store its database files.
+    /// The folder `Client` uses to store its local cache files.
     public var localStorageFolderURL: URL? = {
         let urls = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
         return urls.first
@@ -29,7 +29,7 @@ public struct ChatClientConfig {
     
     public var channel = Channel()
     
-    public init(apiKey: String) {
+    public init(apiKey: APIKey) {
         self.apiKey = apiKey
     }
 }
@@ -45,5 +45,19 @@ extension ChatClientConfig {
     
     public struct Message {
         // something
+    }
+}
+
+/// The API key of the app. You can obtain this value ... TODO
+public struct APIKey: Equatable {
+    /// The string representation of the API key
+    public let apiKeyString: String
+    
+    /// Creates a new `APIKey` from the provided string. Fails, if the string is empty.
+    ///
+    /// - Warning: The `apiKeyString` must be a non-empty value, otherwise an assertion failure is raised.
+    public init(_ apiKeyString: String) {
+        log.assert(apiKeyString.isEmpty == false, "APIKey can't be initialize with an empty string.")
+        self.apiKeyString = apiKeyString
     }
 }

--- a/StreamChatClient_v3/Errors/ClientError.swift
+++ b/StreamChatClient_v3/Errors/ClientError.swift
@@ -22,6 +22,15 @@ public class ClientError: Error {
     }
 }
 
+public class CustomMessageError: ClientError {
+    public let localizedDescription: String
+    
+    init(_ message: String, _ file: StaticString = #file, _ line: UInt = #line) {
+        localizedDescription = message
+        super.init(file, line)
+    }
+}
+
 extension ClientError {
     public class Unexpected: ClientError {
         public private(set) lazy var localizedDescription: String = "Unexpect error: \(String(describing: underlyingError))"
@@ -31,6 +40,8 @@ extension ClientError {
             localizedDescription = description
         }
     }
+    
+    public class Unknown: CustomMessageError {}
 }
 
 // This should probably live only in the test target since it's not "true" equatable

--- a/StreamChatClient_v3/Errors/ErrorPayload.swift
+++ b/StreamChatClient_v3/Errors/ErrorPayload.swift
@@ -1,12 +1,12 @@
 //
-// ServerResponseError.swift
+// ErrorPayload.swift
 // Copyright © 2020 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
 
 /// A parsed server response error.
-struct ServerResponseError: LocalizedError, Decodable, CustomDebugStringConvertible, Error {
+struct ErrorPayload: LocalizedError, Codable, CustomDebugStringConvertible, Equatable {
     /// The error codes for token-related errors. Typically, a refreshed token is required to recover.
     static let tokenInvadlidErrorCodes = 40 ... 43
     

--- a/StreamChatClient_v3/Utils/Codable+Extensions.swift
+++ b/StreamChatClient_v3/Utils/Codable+Extensions.swift
@@ -145,18 +145,3 @@ struct AnyEncodable: Encodable {
         try encodable.encode(to: encoder)
     }
 }
-
-// MARK: - Safe Helpers
-
-//
-// extension Encodable {
-//    func encodeSafely(to encoder: Encoder, logMessage: String? = nil) {
-//        do {
-//            try encode(to: encoder)
-//        } catch {
-//            if let logMessage = logMessage {
-//                Client.shared.logger?.log(error, message: "⚠️ \(logMessage): \(encoder)")
-//            }
-//        }
-//    }
-// }

--- a/StreamChatClient_v3/Utils/Logger/Logger.swift
+++ b/StreamChatClient_v3/Utils/Logger/Logger.swift
@@ -197,7 +197,7 @@ public class Logger {
     ///   - condition: The condition to test.
     ///   - message: A custom message to log if `condition` is evaluated to false.
     public func assert(_ condition: @autoclosure () -> Bool,
-                       message: @autoclosure () -> Any,
+                       _ message: @autoclosure () -> Any,
                        functionName: StaticString = #function,
                        fileName: StaticString = #file,
                        lineNumber: UInt = #line) {

--- a/StreamChatClient_v3/Utils/OptionSet+Extensions.swift
+++ b/StreamChatClient_v3/Utils/OptionSet+Extensions.swift
@@ -1,0 +1,18 @@
+//
+// OptionSet+Extensions.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension OptionSet {
+    /// Checks if the option set contains at least one of the provided options.
+    func contains(oneOf members: [Element]) -> Bool {
+        for member in members {
+            if contains(member) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
@@ -282,7 +282,7 @@ extension ClientError {
 /// WebSocket Error
 struct WebSocketErrorContainer: Decodable {
     /// A server error was received.
-    let error: ServerResponseError
+    let error: ErrorPayload
 }
 
 /// Used for starting and ending background tasks. `UIApplication` which conforms to `BackgroundTaskScheduler` automatically.

--- a/StreamChatClient_v3/WebSocketClient/WebSocketReconnectionStrategy.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketReconnectionStrategy.swift
@@ -34,8 +34,8 @@ class DefaultReconnectionStrategy: WebSocketClientReconnectionStrategy {
         }
         
         if
-            let serverInitiatedError = error as? ServerResponseError,
-            ServerResponseError.tokenInvadlidErrorCodes ~= serverInitiatedError.code {
+            let serverInitiatedError = error as? ErrorPayload,
+            ErrorPayload.tokenInvadlidErrorCodes ~= serverInitiatedError.code {
             // Don't reconnect on invalid token errors
             return nil
         }

--- a/StreamChatClient_v3/WebSocketClient/WebSocketReconnectionStrategy_Tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketReconnectionStrategy_Tests.swift
@@ -54,13 +54,13 @@ final class DefaultReconnectionStrategy_Tests: XCTestCase {
     func test_returnsNilForInvalidTokenErrors() {
         let invalidTokenErrorCodes = [40, 41, 42, 43]
         invalidTokenErrorCodes.forEach { invalidTokenErrorCode in
-            let error = ServerResponseError(code: invalidTokenErrorCode, message: "", statusCode: 0)
+            let error = ErrorPayload(code: invalidTokenErrorCode, message: "", statusCode: 0)
             let delay = strategy.reconnectionDelay(forConnectionError: error)
             XCTAssertNil(delay)
         }
         
         // Check other error codes return a non-nil delay
-        let error = ServerResponseError(code: 66, message: "", statusCode: 0)
+        let error = ErrorPayload(code: 66, message: "", statusCode: 0)
         let delay = strategy.reconnectionDelay(forConnectionError: error)
         XCTAssertNotNil(delay)
     }

--- a/StreamChatClient_v3/Workers/Background/ChannelEventsHandler_Tests.swift
+++ b/StreamChatClient_v3/Workers/Background/ChannelEventsHandler_Tests.swift
@@ -63,6 +63,6 @@ class WebSocketClientMock: WebSocketClient {
 
 class APIClientMock: APIClient {
     init() {
-        super.init(apiKey: "", baseURL: URL(string: "test")!, sessionConfiguration: .default)
+        super.init(apiKey: APIKey("test_app"), baseURL: URL(string: "test")!, sessionConfiguration: .default)
     }
 }

--- a/TestResources_v3/Await.swift
+++ b/TestResources_v3/Await.swift
@@ -29,7 +29,7 @@ enum WaiterError: Error {
 func await<T>(timeout: TimeInterval = 0.5,
               file: StaticString = #file,
               line: UInt = #line,
-              _ action: @escaping (_ done: @escaping (T) -> Void) -> Void) throws -> T {
+              _ action: (_ done: @escaping (T) -> Void) -> Void) throws -> T {
     let expecation = XCTestExpectation(description: "Action completed")
     var result: T?
     action {

--- a/TestResources_v3/Mock Network/AssertNetworkRequest.swift
+++ b/TestResources_v3/Mock Network/AssertNetworkRequest.swift
@@ -1,0 +1,136 @@
+//
+// AssertNetworkRequest.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient_v3
+import XCTest
+
+/// Synchronously waits for a network request to be made and asserts its properties.
+///
+/// The function always uses the latest request `RequestRecorderURLProtocol` records. If no request has
+/// been made within the `timeout` period, this assertion fails with the time-out error.
+///
+/// The values specified in the `headers`, `queryParameters` and `body` represents the mandatory subset of
+/// the values the request must have. A request is valid even when it contains additional parameters than
+/// the ones specified in these values.
+///
+/// - Parameters:
+///   - method: The HTTP method the request.
+///   - path: The `path` part of the request's URL.
+///   - headers: The headers required for the request.
+///   - queryParameters: The query parameters required for the request.
+///   - body: The expected body of the request.
+///   - timeout: The maximum time this function waits for a request to be made.
+///
+func AssertNetworkRequest(method: EndpointMethod,
+                          path: String,
+                          headers: [String: String]?,
+                          queryParameters: [String: String]?,
+                          body: [String: Any]?,
+                          timeout: TimeInterval = 0.5,
+                          file: StaticString = #file,
+                          line: UInt = #line) {
+    guard let request = RequestRecorderURLProtocol.waitForRequest(timeout: timeout) else {
+        XCTFail("Waiting for request timed out. No request was made.", file: file, line: line)
+        return
+    }
+    
+    var errorMessage = ""
+    defer {
+        if !errorMessage.isEmpty {
+            XCTFail("AssertNetworkRequest failed:" + errorMessage, file: file, line: line)
+        }
+    }
+    
+    // Check method
+    if method.rawValue != request.httpMethod {
+        errorMessage += "\n  - Incorrect method: expected \"\(method.rawValue)\" got \"\(request.httpMethod ?? "_")\""
+    }
+    
+    guard let url = request.url, let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+        errorMessage += "\n  - Missing URL"
+        return
+    }
+    
+    // Check path
+    if components.path != path {
+        errorMessage += "\n  - Incorrect path: expected \"\(path)\" got \"\(components.path)\""
+    }
+    
+    // Check headers
+    let requestHeaders = request.allHTTPHeaderFields ?? [:]
+    headers?.forEach { (key, value) in
+        if let requestHeaderValue = requestHeaders[key] {
+            if value != requestHeaderValue {
+                errorMessage += "\n  - Incorrect header value for \"\(key)\": expected \"\(value)\" got \"\(requestHeaderValue)\""
+            }
+            
+        } else {
+            errorMessage += "\n  - Missing header value for \"\(key)\""
+        }
+    }
+    
+    // Check query parameters
+    let items = components.queryItems ?? []
+    queryParameters?.forEach { (key, value) in
+        if let requestValue = items[key] {
+            if value != requestValue {
+                errorMessage += "\n  - Incorrect query value for \"\(key)\": expected \"\(value)\" got \"\(requestValue)\""
+            }
+            
+        } else {
+            errorMessage += "\n  - Missing query value for \"\(key)\""
+        }
+    }
+    
+    // Check the request body
+    var requestBodyData: Data?
+    
+    if let data = request.httpBody {
+        requestBodyData = data
+    }
+    
+    if let stream = request.httpBodyStream {
+        requestBodyData = Data(reading: stream)
+    }
+    
+    guard let bodyData = requestBodyData else {
+        if body != nil {
+            errorMessage += "\n  - Missing request body"
+        }
+        return
+    }
+    
+    guard let assertingBody = body else {
+        errorMessage += "\n  - Incorrect body. Expected `nil`, got: \(bodyData.description)"
+        return
+    }
+    
+    guard let assertingBodyData = try? JSONSerialization.data(withJSONObject: assertingBody) else {
+        errorMessage += "\n  - Asserting body is not a valid JSON object"
+        return
+    }
+    
+    AssertJSONEqual(assertingBodyData, bodyData)
+}
+
+private extension Data {
+    /// Creates a new Data instance from the provided InputStream. It opens and closes the stream during the process.
+    init(reading input: InputStream) {
+        self.init()
+        input.open()
+        
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        while input.hasBytesAvailable {
+            let read = input.read(buffer, maxLength: bufferSize)
+            if (read == 0) {
+                break // added
+            }
+            append(buffer, count: read)
+        }
+        buffer.deallocate()
+        input.close()
+    }
+}

--- a/TestResources_v3/Mock Network/MockNetworkURLProtocol.swift
+++ b/TestResources_v3/Mock Network/MockNetworkURLProtocol.swift
@@ -1,0 +1,140 @@
+//
+// MockNetworkURLProtocol.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+@testable import StreamChatClient_v3
+
+/// This URLProtocol intercepts the network communication and provides mock responses for the registered endpoints.
+class MockNetworkURLProtocol: URLProtocol {
+    static let testSessionHeaderKey = "MockNetworkURLProtocol_test_session_id"
+    
+    /// Starts a new recording session. Adds a unique identifier to the configuration headers and listens only
+    /// for the request with this id.
+    static func startTestSession(with configuration: inout URLSessionConfiguration) {
+        reset()
+        let newSessionId = UUID().uuidString
+        currentSessionId = newSessionId
+        
+        // MockNetworkURLProtocol always has to be first, but not if the RequestRecorderURLProtocol is presented
+        if let recorderProtocolIdx = configuration.protocolClasses?.firstIndex(where: { $0 is RequestRecorderURLProtocol.Type }) {
+            configuration.protocolClasses?.insert(MockNetworkURLProtocol.self, at: recorderProtocolIdx + 1)
+        } else {
+            configuration.protocolClasses?.insert(MockNetworkURLProtocol.self, at: 0)
+        }
+        
+        var existingHeaders = configuration.httpAdditionalHeaders ?? [:]
+        existingHeaders[MockNetworkURLProtocol.testSessionHeaderKey] = newSessionId
+        configuration.httpAdditionalHeaders = existingHeaders
+    }
+    
+    @Atomic private static var responses: [PathAndMethod: MockResponse] = [:]
+    
+    /// If set, the mock protocol responds to requests with `testSessionHeaderKey` header value set to this value. If `nil`,
+    /// all requests are ignored.
+    static var currentSessionId: String?
+    
+    /// Cleans up all existing mock responses and current test session id.
+    static func reset() {
+        Self.currentSessionId = nil
+        Self.responses.removeAll()
+    }
+    
+    override class func canInit(with request: URLRequest) -> Bool {
+        guard
+            request.value(forHTTPHeaderField: testSessionHeaderKey) == currentSessionId,
+            let url = request.url,
+            let method = request.httpMethod
+        else { return false }
+        
+        let key = PathAndMethod(url: url, method: method)
+        return responses.keys.contains(key)
+    }
+    
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        // Overriding this function is required by the superclass.
+        request
+    }
+    
+    // MARK: Instance methods
+    
+    override func startLoading() {
+        guard
+            let url = request.url,
+            let method = request.httpMethod,
+            let mockResponse = Self.responses[.init(url: url, method: method)]
+        else {
+            fatalError("This should never happen. Check if the implementation of the `canInit` method is correct.")
+        }
+        
+        let httpResponse = HTTPURLResponse(url: request.url!,
+                                           statusCode: mockResponse.responseCode,
+                                           httpVersion: "HTTP/1.1",
+                                           headerFields: nil)!
+        
+        client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .allowed)
+        
+        switch mockResponse.result {
+        case let .success(data):
+            client?.urlProtocol(self, didLoad: data)
+        case let .failure(error):
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+        
+        // Finish loading (required).
+        client?.urlProtocolDidFinishLoading(self)
+        
+        // Clean up
+        Self.responses.removeValue(forKey: .init(url: url, method: method))
+    }
+    
+    override func stopLoading() {
+        // Required by the superclass
+    }
+}
+
+extension MockNetworkURLProtocol {
+    /// Creates a successful mock response for the given endpoint.
+    ///
+    /// - Parameters:
+    ///   - endpoint: The endpoint the mock response is registered for.
+    ///   - statusCode: The HTTP status code used for the response.
+    ///   - response: The JSON body of the response.
+    static func mockResponse(request: URLRequest, statusCode: Int = 200, responseBody: Data = Data([])) {
+        let key = PathAndMethod(url: request.url!, method: request.httpMethod!)
+        Self.responses[key] = MockResponse(result: .success(responseBody), responseCode: statusCode)
+    }
+    
+    /// Creates a failing mock response for the given endpoint.
+    ///
+    /// - Parameters:
+    ///   - endpoint: The endpoint the mock response is registered for.
+    ///   - statusCode: The HTTP status code used for the response.
+    ///   - error: The error object used for the response.
+    static func mockResponse(request: URLRequest, statusCode: Int = 400, error: Error) {
+        let key = PathAndMethod(url: request.url!, method: request.httpMethod!)
+        
+        Self.responses[key] = MockResponse(result: .failure(error), responseCode: statusCode)
+    }
+}
+
+/// Used for using the combination of `path` and `httpMethod` as a dictionary key.
+private struct PathAndMethod: Hashable {
+    let url: URL
+    let method: String
+}
+
+private struct MockResponse {
+    let result: Result<Data, Error>
+    let responseCode: Int
+}
+
+private extension String {
+    /// Removes all leading `/` from the string.
+    var normalizedPath: String {
+        String(drop(while: { $0 == "/" }))
+    }
+}

--- a/TestResources_v3/Mock Network/RequestRecorderURLProtocol.swift
+++ b/TestResources_v3/Mock Network/RequestRecorderURLProtocol.swift
@@ -1,0 +1,89 @@
+//
+// RequestRecorderURLProtocol.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+/// This URLProtocol subclass allows to intercept the network communication
+/// and provides the latest network request made.
+class RequestRecorderURLProtocol: URLProtocol {
+    static let testSessionHeaderKey = "RequestRecorderURLProtocol_test_session_id"
+    
+    /// Starts a new recording session. Adds a unique identifier to the configuration headers and listens only
+    /// for the request with this id.
+    static func startTestSession(with configuration: inout URLSessionConfiguration) {
+        reset()
+        let newSessionId = UUID().uuidString
+        currentSessionId = newSessionId
+        
+        configuration.protocolClasses?.insert(RequestRecorderURLProtocol.self, at: 0)
+        var existingHeaders = configuration.httpAdditionalHeaders ?? [:]
+        existingHeaders[RequestRecorderURLProtocol.testSessionHeaderKey] = newSessionId
+        configuration.httpAdditionalHeaders = existingHeaders
+    }
+    
+    private static var latestRequestExpectation: XCTestExpectation?
+    private static var latestRequest: URLRequest?
+    
+    /// Returns the latest network request this URLProtocol recorded.
+    ///
+    /// If no request has been made since the last time this function was invoked, it synchronously
+    /// waits for the next request to be made.
+    ///
+    /// - Parameter timeout: Specifies the time the function waits for a new request to be made.
+    static func waitForRequest(timeout: TimeInterval) -> URLRequest? {
+        defer {
+            // Delete the used request
+            latestRequest = nil
+        }
+        
+        guard latestRequest == nil else { return latestRequest }
+        
+        latestRequestExpectation = .init(description: "Wait for incoming request.")
+        _ = XCTWaiter.wait(for: [latestRequestExpectation!], timeout: timeout)
+        return latestRequest
+    }
+    
+    /// If set, records only requests with `testSessionHeaderKey` header value set to this value. If `nil`,
+    /// no requests are recorded.
+    static var currentSessionId: String?
+    
+    /// Cleans up existing waiters and recorded requests. We have to explictly reset the state because URLProtocols
+    /// work with static variables.
+    static func reset() {
+        currentSessionId = nil
+        latestRequest = nil
+        latestRequestExpectation = nil
+    }
+    
+    override class func canInit(with request: URLRequest) -> Bool {
+        guard let sessionId = currentSessionId else { return false }
+        
+        if sessionId == request.value(forHTTPHeaderField: testSessionHeaderKey) {
+            record(request: request)
+        }
+        return false
+    }
+    
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        // Overriding this function is required by the superclass.
+        request
+    }
+    
+    private static func record(request: URLRequest) {
+        latestRequest = request
+        latestRequestExpectation?.fulfill()
+    }
+    
+    // MARK: Instance methods
+    
+    override func startLoading() {
+        // Required by the superclass.
+    }
+    
+    override func stopLoading() {
+        // Required by the superclass.
+    }
+}

--- a/TestResources_v3/TemporaryData.swift
+++ b/TestResources_v3/TemporaryData.swift
@@ -9,7 +9,7 @@ import StreamChatClient_v3
 extension URL {
     /// Returns a unique random URL
     static func unique() -> URL {
-        URL(string: "temporary_\(UUID().uuidString)")!
+        URL(string: "test://temporary_\(UUID().uuidString)")!
     }
     
     /// Returns a unique URL that can be used for storing a temporary file.

--- a/V3SampleApp/AppDelegate.swift
+++ b/V3SampleApp/AppDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 @testable import StreamChatClient_v3
 
 let chatClient: ChatClient = {
-    var config = ChatClientConfig(apiKey: "qk4nn7rpcn75")
+    var config = ChatClientConfig(apiKey: APIKey("qk4nn7rpcn75"))
     config.isLocalStorageEnabled = false
     
     let user = User(id: "broken-waterfall-5", name: "Tester", avatarURL: nil)


### PR DESCRIPTION
#### In this PR:

- Danger changelog warning is skipped for `v3` PRs. Having a changelog is not necessary until `v3` is released.
- `v2` test helpers were updated, improved, and migrated to `v3`. It would be good to backport them to `v2`, too, since they are more reliable now (CIS-195).
- `APIKey` is now a custom struct. This was done mainly to avoid the unnecessary `isEmpty` checks down the road.
 - The fields of `Endpoint` are simplified and we use `Encodable?` for both, the query items and the body.
- `v2` `APIClient` is split into 3 separate objects:
  - `RequestEncoder` -> converts `Endpoint` to `URLRequest` and takes care of encoding all the requierd and endpoint-specific values.
  - `RequestDecoder` -> used to handle the response from the network and decode it.
  - `APIClient` -> Orchestrates everything and takes care of the actual networking.

---

⚠️ As with all `v3` PRs, this is not a complete and final solution, and it's definitely lacking certain functionality (i.e. request canceling, etc.). This will be added when we need it.