### PR TITLE
Add `PinStyle` for `ComposerViewStyle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ✅ Added
 - `Message.translate` for message translations. Please see [docs](https://getstream.io/chat/docs/translation/?language=swift) for more info [#319](https://github.com/GetStream/stream-chat-swift/issues/319)
 - `user.unbanned` event added [#319](https://github.com/GetStream/stream-chat-swift/issues/319)
+- `PinStyle` for `ComposerViewStyle` with options [#329](https://github.com/GetStream/stream-chat-swift/issues/329):
+  - `.floating` - shows `ComposerView` over messages (by default).
+  - `.solid` - shows messages above `ComposerView` with a `ComposerViewStyle` top edge inset.
 
 # [2.2.4](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.4)
 _June 12, 2020_

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
@@ -74,9 +74,19 @@ extension Reactive where Base: ChatViewController {
                     } else {
                         chatViewController.keyboardIsVisible = false
                     }
-                    
-                    chatViewController.view.layoutIfNeeded()
                 }
+                
+                chatViewController.tableView.setNeedsLayout()
+                chatViewController.view.layoutIfNeeded()
+            }
+            
+            // Update the table view bottom constraint for the `.solid` `ComposerView` `PinStyle`.
+            if chatViewController.style.composer.pinStyle == .solid {
+                let tableViewBottomConstraint = keyboardNotification.isVisible
+                    ? keyboardNotification.height
+                    : chatViewController.tableViewBottomInset
+                
+                chatViewController.tableViewBottomConstraint?.update(offset: -tableViewBottomConstraint)
             }
             
             if let animation = keyboardNotification.animation {

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -85,13 +85,27 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
         tableView.separatorStyle = .none
         tableView.dataSource = self
         tableView.delegate = self
+        tableView.showsHorizontalScrollIndicator = false
         tableView.registerMessageCell(style: style.incomingMessage)
         tableView.registerMessageCell(style: style.outgoingMessage)
         tableView.register(cellType: StatusTableViewCell.self)
-        let bottomInset = style.composer.height + style.composer.edgeInsets.top + style.composer.edgeInsets.bottom
-        tableView.contentInset = UIEdgeInsets(top: style.incomingMessage.edgeInsets.top, left: 0, bottom: bottomInset, right: 0)
         view.insertSubview(tableView, at: 0)
-        tableView.makeEdgesEqualToSuperview()
+        
+        if style.composer.pinStyle == .solid {
+            tableView.contentInset = UIEdgeInsets(top: style.incomingMessage.edgeInsets.top, left: 0, bottom: 0, right: 0)
+            
+            tableView.snp.makeConstraints { make in
+                make.left.top.right.equalToSuperview()
+                tableViewBottomConstraint = make.bottom.equalToSuperview().offset(-tableViewBottomInset).constraint
+            }
+        } else {
+            tableView.contentInset = UIEdgeInsets(top: style.incomingMessage.edgeInsets.top,
+                                                  left: 0,
+                                                  bottom: tableViewBottomInset,
+                                                  right: 0)
+            
+            tableView.makeEdgesEqualToSuperview()
+        }
         
         let footerView = ChatFooterView(frame: CGRect(width: 0, height: .chatFooterHeight))
         footerView.backgroundColor = tableView.backgroundColor
@@ -99,6 +113,13 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
         
         return tableView
     }()
+    
+    var tableViewBottomConstraint: Constraint?
+    
+    var tableViewBottomInset: CGFloat {
+        let bottomInset = style.composer.height + style.composer.edgeInsets.top + style.composer.edgeInsets.bottom
+        return style.composer.pinStyle == .solid ? bottomInset + .safeAreaBottom : bottomInset
+    }
     
     private lazy var minMessageHeight = 2 * (style.incomingMessage.avatarViewStyle?.size ?? CGFloat.messageAvatarSize)
         + style.incomingMessage.edgeInsets.top

--- a/Sources/UI/Style/ComposerViewStyle.swift
+++ b/Sources/UI/Style/ComposerViewStyle.swift
@@ -44,6 +44,9 @@ public struct ComposerViewStyle: Equatable {
     /// - Note: Set it to nil to disable this feature.
     public var replyInChannelViewStyle: ReplyInChannelViewStyle?
     
+    /// A pin style to setup `ComposerView` presentation over messages.
+    public var pinStyle: PinStyle
+    
     /// Composer states.
     ///
     /// For example:
@@ -75,6 +78,7 @@ public struct ComposerViewStyle: Equatable {
                 edgeInsets: UIEdgeInsets = .all(.messageEdgePadding),
                 sendButtonVisibility: ChatViewStyleVisibility = .whenActive,
                 replyInChannelViewStyle: ReplyInChannelViewStyle? = .init(color: .chatGray, selectedColor: .black),
+                pinStyle: PinStyle = .floating,
                 states: States = [.active: .init(tintColor: .chatLightBlue, borderWidth: 2),
                                   .edit: .init(tintColor: .chatGreen, borderWidth: 2),
                                   .disabled: .init(tintColor: .chatGray, borderWidth: 2)]) {
@@ -89,6 +93,7 @@ public struct ComposerViewStyle: Equatable {
         self.edgeInsets = edgeInsets
         self.sendButtonVisibility = sendButtonVisibility
         self.replyInChannelViewStyle = replyInChannelViewStyle
+        self.pinStyle = pinStyle
         self.states = states
     }
     
@@ -122,6 +127,14 @@ extension ComposerViewStyle {
             self.tintColor = tintColor
             self.borderWidth = borderWidth
         }
+    }
+    
+    /// A pin style to setup `ComposerView` presentation over messages.
+    public enum PinStyle {
+        /// Shows `ComposerView` over messages. It's by default.
+        case floating
+        /// Shows messages above `ComposerView` with a `ComposerViewStyle` top edge inset.
+        case solid
     }
 }
 


### PR DESCRIPTION
`PinStyle` for `ComposerViewStyle` with options:
  - `.floating` - shows `ComposerView` over messages (by default).
  - `.solid` - shows messages above `ComposerView` with a `ComposerViewStyle` top edge inset.
