### PR TITLE
[CIS-196] Handle incoming Event data

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		792A4F4D248011E500EAF71D /* ChannelListQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F4C248011E500EAF71D /* ChannelListQuery.swift */; };
 		792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */; };
 		792FCB4B24A3D52A000290C7 /* DatabaseSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4A24A3D52A000290C7 /* DatabaseSession.swift */; };
+		792FCB4D24A3D56D000290C7 /* DatabaseSession_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4C24A3D56D000290C7 /* DatabaseSession_Tests.swift */; };
 		793612F62461437700944861 /* MockNetworkURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793612F52461437700944861 /* MockNetworkURLProtocol.swift */; };
 		793612FE2461684500944861 /* AssertResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793612FD2461684500944861 /* AssertResult.swift */; };
 		793613002461780400944861 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793612FF2461780400944861 /* Await.swift */; };
@@ -530,6 +531,7 @@
 		792A4F4C248011E500EAF71D /* ChannelListQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelListQuery.swift; sourceTree = "<group>"; };
 		792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OptionSet+Extensions.swift"; sourceTree = "<group>"; };
 		792FCB4A24A3D52A000290C7 /* DatabaseSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSession.swift; sourceTree = "<group>"; };
+		792FCB4C24A3D56D000290C7 /* DatabaseSession_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSession_Tests.swift; sourceTree = "<group>"; };
 		79324B7A2462A08A00B2597E /* AtomicTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
 		793612F52461437700944861 /* MockNetworkURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkURLProtocol.swift; sourceTree = "<group>"; };
 		793612FD2461684500944861 /* AssertResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertResult.swift; sourceTree = "<group>"; };
@@ -1249,6 +1251,7 @@
 				799C945D247D7283001F1104 /* DatabaseContainer.swift */,
 				799C945F247D77D6001F1104 /* DatabaseContainer_Tests.swift */,
 				792FCB4A24A3D52A000290C7 /* DatabaseSession.swift */,
+				792FCB4C24A3D56D000290C7 /* DatabaseSession_Tests.swift */,
 				792A4F18247EA97000EAF71D /* DTOs */,
 			);
 			path = Database;
@@ -2605,6 +2608,7 @@
 				79DDF810249CB92E002F4412 /* RequestDecoder_Tests.swift in Sources */,
 				79877A2C2498E53B00015F8B /* ChannelEndpoints_Tests.swift in Sources */,
 				79877A292498E51500015F8B /* ChannelDTO_Tests.swift in Sources */,
+				792FCB4D24A3D56D000290C7 /* DatabaseSession_Tests.swift in Sources */,
 				799BE2EC248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift in Sources */,
 				79280F8424891C6A00CDEB89 /* VirtualTime.swift in Sources */,
 				79280F542485529500CDEB89 /* ChannelEventsHandler_Tests.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		792A4F492480107A00EAF71D /* Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F452480107A00EAF71D /* Sorting.swift */; };
 		792A4F4B248010A600EAF71D /* QueryOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F4A248010A600EAF71D /* QueryOptions.swift */; };
 		792A4F4D248011E500EAF71D /* ChannelListQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F4C248011E500EAF71D /* ChannelListQuery.swift */; };
+		792FCB4524A33B5B000290C7 /* EventDataProcessorMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4424A33B5B000290C7 /* EventDataProcessorMiddleware.swift */; };
+		792FCB4724A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4624A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift */; };
 		792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */; };
 		792FCB4B24A3D52A000290C7 /* DatabaseSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4A24A3D52A000290C7 /* DatabaseSession.swift */; };
 		792FCB4D24A3D56D000290C7 /* DatabaseSession_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4C24A3D56D000290C7 /* DatabaseSession_Tests.swift */; };
@@ -529,6 +531,8 @@
 		792A4F452480107A00EAF71D /* Sorting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sorting.swift; sourceTree = "<group>"; };
 		792A4F4A248010A600EAF71D /* QueryOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryOptions.swift; sourceTree = "<group>"; };
 		792A4F4C248011E500EAF71D /* ChannelListQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelListQuery.swift; sourceTree = "<group>"; };
+		792FCB4424A33B5B000290C7 /* EventDataProcessorMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDataProcessorMiddleware.swift; sourceTree = "<group>"; };
+		792FCB4624A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDataProcessorMiddleware_Tests.swift; sourceTree = "<group>"; };
 		792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OptionSet+Extensions.swift"; sourceTree = "<group>"; };
 		792FCB4A24A3D52A000290C7 /* DatabaseSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSession.swift; sourceTree = "<group>"; };
 		792FCB4C24A3D56D000290C7 /* DatabaseSession_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSession_Tests.swift; sourceTree = "<group>"; };
@@ -1164,6 +1168,8 @@
 				79A0E9B32498C2DD00E9BD50 /* HealthCheckFilterMiddleware_Tests.swift */,
 				79A0E9B92498C31300E9BD50 /* TypingStartCleanupMiddleware.swift */,
 				79A0E9B82498C31300E9BD50 /* TypingStartCleanupMiddleware_Tests.swift */,
+				792FCB4424A33B5B000290C7 /* EventDataProcessorMiddleware.swift */,
+				792FCB4624A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift */,
 			);
 			path = EventMiddlewares;
 			sourceTree = "<group>";
@@ -2573,6 +2579,7 @@
 				79A0E9BB2498C31300E9BD50 /* TypingStartCleanupMiddleware.swift in Sources */,
 				797A756424814E7A003CF16D /* WebSocketPayload.swift in Sources */,
 				79877A0B2498E4BC00015F8B /* MemberModel.swift in Sources */,
+				792FCB4524A33B5B000290C7 /* EventDataProcessorMiddleware.swift in Sources */,
 				79A0E9BE2498C33100E9BD50 /* TypingEvents.swift in Sources */,
 				799C945E247D7283001F1104 /* DatabaseContainer.swift in Sources */,
 				79877A092498E4BC00015F8B /* UserModel.swift in Sources */,
@@ -2594,6 +2601,7 @@
 				799C946A247D791A001F1104 /* AssertAsync.swift in Sources */,
 				79280F8324891C6A00CDEB89 /* VirtualTime_Tests.swift in Sources */,
 				7937282C249900CB00E13FE5 /* MemberEndpoints_Tests.swift in Sources */,
+				792FCB4724A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift in Sources */,
 				79877A2B2498E51500015F8B /* UserModelDTO_Tests.swift in Sources */,
 				79177A2D248A6A2600F053A2 /* AssertAsync+Events.swift in Sources */,
 				799C9468247D791A001F1104 /* AssertJSONEqual.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		792A4F4B248010A600EAF71D /* QueryOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F4A248010A600EAF71D /* QueryOptions.swift */; };
 		792A4F4D248011E500EAF71D /* ChannelListQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F4C248011E500EAF71D /* ChannelListQuery.swift */; };
 		792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */; };
+		792FCB4B24A3D52A000290C7 /* DatabaseSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4A24A3D52A000290C7 /* DatabaseSession.swift */; };
 		793612F62461437700944861 /* MockNetworkURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793612F52461437700944861 /* MockNetworkURLProtocol.swift */; };
 		793612FE2461684500944861 /* AssertResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793612FD2461684500944861 /* AssertResult.swift */; };
 		793613002461780400944861 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793612FF2461780400944861 /* Await.swift */; };
@@ -526,6 +527,7 @@
 		792A4F4A248010A600EAF71D /* QueryOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryOptions.swift; sourceTree = "<group>"; };
 		792A4F4C248011E500EAF71D /* ChannelListQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelListQuery.swift; sourceTree = "<group>"; };
 		792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OptionSet+Extensions.swift"; sourceTree = "<group>"; };
+		792FCB4A24A3D52A000290C7 /* DatabaseSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSession.swift; sourceTree = "<group>"; };
 		79324B7A2462A08A00B2597E /* AtomicTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
 		793612F52461437700944861 /* MockNetworkURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkURLProtocol.swift; sourceTree = "<group>"; };
 		793612FD2461684500944861 /* AssertResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertResult.swift; sourceTree = "<group>"; };
@@ -1240,6 +1242,7 @@
 				799C9477247E3DEA001F1104 /* StreamChatModel.xcdatamodeld */,
 				799C945D247D7283001F1104 /* DatabaseContainer.swift */,
 				799C945F247D77D6001F1104 /* DatabaseContainer_Tests.swift */,
+				792FCB4A24A3D52A000290C7 /* DatabaseSession.swift */,
 				792A4F18247EA97000EAF71D /* DTOs */,
 			);
 			path = Database;
@@ -2502,6 +2505,7 @@
 				7964F3B9249A314D002A09EC /* BaseLogDestination.swift in Sources */,
 				792A4F472480107A00EAF71D /* Filter.swift in Sources */,
 				792A4F4B248010A600EAF71D /* QueryOptions.swift in Sources */,
+				792FCB4B24A3D52A000290C7 /* DatabaseSession.swift in Sources */,
 				792A4F1D247FEA2200EAF71D /* ChannelListController.swift in Sources */,
 				79280F49248520B300CDEB89 /* EventDecoder.swift in Sources */,
 				799C9449247D5211001F1104 /* MessageSender.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -65,6 +65,8 @@
 		7937282C249900CB00E13FE5 /* MemberEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7937282B249900CB00E13FE5 /* MemberEndpoints_Tests.swift */; };
 		79411CD42462DC0A003972E9 /* ClientLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFA57262418EB2500FD07EC /* ClientLoggerTests.swift */; };
 		794927ED249E0BE2009D7EB7 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794927EC249E0BE2009D7EB7 /* ExtraData.swift */; };
+		794927F2249E3DE8009D7EB7 /* Event_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794927F0249E3DE6009D7EB7 /* Event_Tests.swift */; };
+		794927F3249E3F77009D7EB7 /* Event.json in Resources */ = {isa = PBXBuildFile; fileRef = 794927EE249E3D37009D7EB7 /* Event.json */; };
 		794BDE4A2434BD7400BFBA1F /* NestableCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */; };
 		7962958C248147430078EB53 /* BaseURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7962958B248147430078EB53 /* BaseURL.swift */; };
 		7964F3A4249A0ACF002A09EC /* ChannelListQueryDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7964F3A3249A0ACF002A09EC /* ChannelListQueryDTO.swift */; };
@@ -535,6 +537,8 @@
 		793728292498FFD300E13FE5 /* MemberEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEndpoints.swift; sourceTree = "<group>"; };
 		7937282B249900CB00E13FE5 /* MemberEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEndpoints_Tests.swift; sourceTree = "<group>"; };
 		794927EC249E0BE2009D7EB7 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
+		794927EE249E3D37009D7EB7 /* Event.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Event.json; sourceTree = "<group>"; };
+		794927F0249E3DE6009D7EB7 /* Event_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event_Tests.swift; sourceTree = "<group>"; };
 		794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestableCodingKey.swift; sourceTree = "<group>"; };
 		795FCD1B23EB155000990F15 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		7962958B248147430078EB53 /* BaseURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseURL.swift; sourceTree = "<group>"; };
@@ -1020,6 +1024,7 @@
 			isa = PBXGroup;
 			children = (
 				79280F412484F4EC00CDEB89 /* Event.swift */,
+				794927F0249E3DE6009D7EB7 /* Event_Tests.swift */,
 				79280F48248520B300CDEB89 /* EventDecoder.swift */,
 				79280F4A248523C000CDEB89 /* ConnectionEvents.swift */,
 				79280F46248515FA00CDEB89 /* ChannelEvents.swift */,
@@ -1169,6 +1174,7 @@
 				798779F82498E47700015F8B /* OtherUser.json */,
 				798779F92498E47700015F8B /* CurrentUser.json */,
 				798779FA2498E47700015F8B /* ChannelsQuery.json */,
+				794927EE249E3D37009D7EB7 /* Event.json */,
 			);
 			path = MockEnpointResponses;
 			sourceTree = "<group>";
@@ -2398,6 +2404,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				794927F3249E3F77009D7EB7 /* Event.json in Resources */,
 				798779FB2498E47700015F8B /* Member.json in Resources */,
 				798779FD2498E47700015F8B /* OtherUser.json in Resources */,
 				798779FE2498E47700015F8B /* CurrentUser.json in Resources */,
@@ -2603,6 +2610,7 @@
 				79280F542485529500CDEB89 /* ChannelEventsHandler_Tests.swift in Sources */,
 				799C9476247D7E94001F1104 /* TemporaryData.swift in Sources */,
 				79A0E9BC2498C31A00E9BD50 /* TypingStartCleanupMiddleware_Tests.swift in Sources */,
+				794927F2249E3DE8009D7EB7 /* Event_Tests.swift in Sources */,
 				796610BB248E687000761629 /* EventMiddleware_Tests.swift in Sources */,
 				799C9469247D791A001F1104 /* AssertResult.swift in Sources */,
 				79DDF81A249CE38B002F4412 /* RequestRecorderURLProtocol.swift in Sources */,

--- a/StreamChatClient_v3/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/StreamChatClient_v3/APIClient/Endpoints/ChannelEndpoints.swift
@@ -84,6 +84,8 @@ struct ChannelDetailPayload<ExtraData: ExtraDataTypes>: Decodable {
     /// Checks if the channel is frozen.
     public let isFrozen: Bool
     
+    let members: [MemberPayload<ExtraData.User>]?
+    
     let memberCount: Int
     
     /// A list of users to invite in the channel.
@@ -141,6 +143,8 @@ struct ChannelDetailPayload<ExtraData: ExtraDataTypes>: Decodable {
         memberCount = try container.decode(Int.self, forKey: .memberCount)
         updated = try container.decode(Date.self, forKey: .updated)
         
+        members = try container.decodeIfPresent([MemberPayload<ExtraData.User>].self, forKey: .members)
+        
         extraData = try ExtraData.Channel(from: decoder)
     }
     
@@ -158,7 +162,8 @@ struct ChannelDetailPayload<ExtraData: ExtraDataTypes>: Decodable {
         config: ChannelConfig,
         isFrozen: Bool,
         memberCount: Int,
-        team: String
+        team: String,
+        members: [MemberPayload<ExtraData.User>]?
     ) {
         self.cid = cid
         self.extraData = extraData
@@ -172,6 +177,7 @@ struct ChannelDetailPayload<ExtraData: ExtraDataTypes>: Decodable {
         self.isFrozen = isFrozen
         self.memberCount = memberCount
         self.team = team
+        self.members = members
     }
 }
 

--- a/StreamChatClient_v3/APIClient/Endpoints/MemberEndpoints.swift
+++ b/StreamChatClient_v3/APIClient/Endpoints/MemberEndpoints.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 struct MemberPayload<ExtraData: UserExtraData>: Decodable {
-    let roleRawValue: String
+    let roleRawValue: String?
     let created: Date
     let updated: Date
     

--- a/StreamChatClient_v3/ChatClient.swift
+++ b/StreamChatClient_v3/ChatClient.swift
@@ -133,6 +133,7 @@ public final class Client<ExtraData: ExtraDataTypes> {
         
         let middlewares: [EventMiddleware] = [
             // TODO: Add more middlewares
+            EventDataProcessorMiddleware<ExtraData>(database: self.persistentContainer),
             HealthCheckFilter()
         ]
         

--- a/StreamChatClient_v3/Database/DTOs/ChannelDTO_Tests.swift
+++ b/StreamChatClient_v3/Database/DTOs/ChannelDTO_Tests.swift
@@ -189,8 +189,8 @@ class ChannelModelDTO_Tests: XCTestCase {
     }
 }
 
-extension ChannelModelDTO_Tests {
-    private func dummyPayload(with channelId: ChannelId) -> ChannelPayload<DefaultDataTypes> {
+extension XCTestCase {
+    func dummyPayload(with channelId: ChannelId) -> ChannelPayload<DefaultDataTypes> {
         let creator: UserPayload<NameAndImageExtraData> = .init(id: .unique,
                                                                 created: .unique,
                                                                 updated: .unique,
@@ -258,7 +258,8 @@ extension ChannelModelDTO_Tests {
                                                                                            updated: .unique),
                                                                              isFrozen: true,
                                                                              memberCount: 100,
-                                                                             team: ""),
+                                                                             team: "",
+                                                                             members: nil),
                                                               watcherCount: 10,
                                                               members: [member])
         
@@ -271,7 +272,7 @@ extension ChannelModelDTO_Tests {
         typealias User = NoExtraData
     }
     
-    private func dummyPayloadWithNoExtraData(with channelId: ChannelId) -> ChannelPayload<NoExtraDataTypes> {
+    func dummyPayloadWithNoExtraData(with channelId: ChannelId) -> ChannelPayload<NoExtraDataTypes> {
         let creator: UserPayload<NoExtraData> = .init(id: .unique,
                                                       created: .unique,
                                                       updated: .unique,
@@ -334,7 +335,8 @@ extension ChannelModelDTO_Tests {
                                                                                            updated: .unique),
                                                                              isFrozen: true,
                                                                              memberCount: 100,
-                                                                             team: ""),
+                                                                             team: "",
+                                                                             members: nil),
                                                               watcherCount: 10,
                                                               members: [member])
         

--- a/StreamChatClient_v3/Database/DTOs/TeamDTO.swift
+++ b/StreamChatClient_v3/Database/DTOs/TeamDTO.swift
@@ -9,10 +9,10 @@ import CoreData
 
 @objc(TeamDTO)
 class TeamDTO: NSManagedObject {
-    @NSManaged fileprivate var id: String
+    @NSManaged var id: String
     
     // MARK: - Relationships
     
-    @NSManaged fileprivate var channels: Set<ChannelDTO>
-    @NSManaged fileprivate var users: Set<UserDTO>
+    @NSManaged var channels: Set<ChannelDTO>
+    @NSManaged var users: Set<UserDTO>
 }

--- a/StreamChatClient_v3/Database/DatabaseContainer.swift
+++ b/StreamChatClient_v3/Database/DatabaseContainer.swift
@@ -112,34 +112,6 @@ extension DatabaseContainer {
     }
 }
 
-extension NSManagedObjectContext: DatabaseSession {}
-
-protocol DatabaseSession {
-    // MARK: -  User
-    
-    @discardableResult func saveUser<ExtraData: UserExtraData>(payload: UserPayload<ExtraData>) throws -> UserDTO
-    func loadUser<ExtraData: UserExtraData>(id: UserId) -> UserModel<ExtraData>?
-    
-    // MARK: -  Member
-    
-    @discardableResult func saveMember<ExtraData: UserExtraData>(payload: MemberPayload<ExtraData>, channelId: ChannelId)
-        throws -> MemberDTO
-    func loadMember<ExtraData: UserExtraData>(id: UserId, channelId: ChannelId) -> MemberModel<ExtraData>?
-    
-    // MARK: -  Channel model
-    
-    @discardableResult func saveChannel<ExtraData: ExtraDataTypes>(payload: ChannelPayload<ExtraData>,
-                                                                   query: ChannelListQuery?) throws -> ChannelDTO
-    func loadChannel<ExtraData: ExtraDataTypes>(cid: ChannelId) -> ChannelModel<ExtraData>?
-}
-
-extension DatabaseSession {
-    @discardableResult func saveChannel<ExtraData: ExtraDataTypes>(payload: ChannelPayload<ExtraData>) throws
-        -> ChannelDTO {
-            try saveChannel(payload: payload, query: nil)
-        }
-}
-
 // WIP
 
 class ReadOnlyContext: NSManagedObjectContext {

--- a/StreamChatClient_v3/Database/DatabaseContainer.swift
+++ b/StreamChatClient_v3/Database/DatabaseContainer.swift
@@ -73,9 +73,7 @@ class DatabaseContainer: NSPersistentContainer {
         viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
         viewContext.automaticallyMergesChangesFromParent = true
     }
-}
-
-extension DatabaseContainer {
+    
     /// Use this method to safely mutate the content of the database.
     ///
     /// - Parameter actions: A block that performs the actual mutation.

--- a/StreamChatClient_v3/Database/DatabaseContainer_Tests.swift
+++ b/StreamChatClient_v3/Database/DatabaseContainer_Tests.swift
@@ -3,6 +3,7 @@
 // Copyright © 2020 Stream.io Inc. All rights reserved.
 //
 
+import CoreData
 @testable import StreamChatClient_v3
 import XCTest
 
@@ -20,5 +21,29 @@ class DatabaseContainer_Tests: XCTestCase {
     func test_databaseContainer_propagatesError_wnenInitializedWithIncorrectURL() {
         let dbURL = URL(fileURLWithPath: "/") // This URL is not writable
         XCTAssertThrowsError(try DatabaseContainer(kind: .onDisk(databaseFileURL: dbURL)))
+    }
+    
+    func test_writeCompletionBlockIsCalled() throws {
+        let container = try DatabaseContainer(kind: .inMemory)
+        
+        // Write a valid entity to DB and wait for the completion block to be called
+        let successCompletion = try await { container.write({ session in
+            let context = session as! NSManagedObjectContext
+            let teamDTO = NSEntityDescription.insertNewObject(forEntityName: "TeamDTO", into: context) as! TeamDTO
+            teamDTO.id = .unique
+        }, completion: $0) }
+        
+        // Assert the completion was called with `nil` error value
+        XCTAssertNil(successCompletion)
+        
+        // Write an invalid entity to DB and wait for the completion block to be called with error
+        let errorCompletion = try await { container.write({ session in
+            let context = session as! NSManagedObjectContext
+            NSEntityDescription.insertNewObject(forEntityName: "TeamDTO", into: context)
+            // Team id is not set, this should produce an error
+        }, completion: $0) }
+        
+        // Assert the completion was called with an error
+        XCTAssertNotNil(errorCompletion)
     }
 }

--- a/StreamChatClient_v3/Database/DatabaseSession.swift
+++ b/StreamChatClient_v3/Database/DatabaseSession.swift
@@ -34,5 +34,13 @@ extension DatabaseSession {
     @discardableResult func saveChannel<ExtraData: ExtraDataTypes>(payload: ChannelPayload<ExtraData>) throws
         -> ChannelDTO {
             try saveChannel(payload: payload, query: nil)
+        }
+    
+    // MARK: -  Event
+    
+    func saveEvent<ExtraData: ExtraDataTypes>(payload: EventPayload<ExtraData>) throws {
+        if let channelDetailPayload = payload.channel {
+            try saveChannel(payload: channelDetailPayload, query: nil)
+        }
     }
 }

--- a/StreamChatClient_v3/Database/DatabaseSession.swift
+++ b/StreamChatClient_v3/Database/DatabaseSession.swift
@@ -1,0 +1,34 @@
+//
+// DatabaseSession.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+
+extension NSManagedObjectContext: DatabaseSession {}
+
+protocol DatabaseSession {
+    // MARK: -  User
+    
+    @discardableResult func saveUser<ExtraData: UserExtraData>(payload: UserPayload<ExtraData>) throws -> UserDTO
+    func loadUser<ExtraData: UserExtraData>(id: UserId) -> UserModel<ExtraData>?
+    
+    // MARK: -  Member
+    
+    @discardableResult func saveMember<ExtraData: UserExtraData>(payload: MemberPayload<ExtraData>, channelId: ChannelId)
+        throws -> MemberDTO
+    func loadMember<ExtraData: UserExtraData>(id: UserId, channelId: ChannelId) -> MemberModel<ExtraData>?
+    
+    // MARK: -  Channel model
+    
+    @discardableResult func saveChannel<ExtraData: ExtraDataTypes>(payload: ChannelPayload<ExtraData>,
+                                                                   query: ChannelListQuery?) throws -> ChannelDTO
+    func loadChannel<ExtraData: ExtraDataTypes>(cid: ChannelId) -> ChannelModel<ExtraData>?
+}
+
+extension DatabaseSession {
+    @discardableResult func saveChannel<ExtraData: ExtraDataTypes>(payload: ChannelPayload<ExtraData>) throws
+        -> ChannelDTO {
+            try saveChannel(payload: payload, query: nil)
+    }
+}

--- a/StreamChatClient_v3/Database/DatabaseSession.swift
+++ b/StreamChatClient_v3/Database/DatabaseSession.swift
@@ -23,6 +23,10 @@ protocol DatabaseSession {
     
     @discardableResult func saveChannel<ExtraData: ExtraDataTypes>(payload: ChannelPayload<ExtraData>,
                                                                    query: ChannelListQuery?) throws -> ChannelDTO
+    
+    @discardableResult func saveChannel<ExtraData: ExtraDataTypes>(payload: ChannelDetailPayload<ExtraData>,
+                                                                   query: ChannelListQuery?) throws -> ChannelDTO
+    
     func loadChannel<ExtraData: ExtraDataTypes>(cid: ChannelId) -> ChannelModel<ExtraData>?
 }
 

--- a/StreamChatClient_v3/Database/DatabaseSession_Tests.swift
+++ b/StreamChatClient_v3/Database/DatabaseSession_Tests.swift
@@ -1,0 +1,35 @@
+//
+// DatabaseSession_Tests.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient_v3
+import XCTest
+
+class DatabaseSession_Tests: XCTestCase {
+    var database: DatabaseContainer!
+    
+    override func setUp() {
+        super.setUp()
+        database = try! DatabaseContainer(kind: .inMemory)
+    }
+    
+    func test_eventPayloadChannelData_isSavedToDatabase() {
+        // Prepare an Event payload with a channel data
+        let channelId: ChannelId = .unique
+        let channelPayload = dummyPayload(with: channelId)
+        let eventPayload = EventPayload(eventType: "test_event", connectionId: .unique, channel: channelPayload.channel,
+                                        currentUser: nil, cid: channelPayload.channel.cid)
+        
+        // Save the event payload to DB
+        database.write { (session) in
+            try session.saveEvent(payload: eventPayload)
+        }
+        
+        // Try to load the saved channel from DB
+        var loadedChannel: ChannelModel<DefaultDataTypes>? {
+            database.viewContext.loadChannel(cid: channelId)
+        }
+        AssertAsync.willBeEqual(loadedChannel?.cid, channelId)
+    }
+}

--- a/StreamChatClient_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/StreamChatClient_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -58,7 +58,7 @@
         </uniquenessConstraints>
     </entity>
     <entity name="TeamDTO" representedClassName="TeamDTO" syncable="YES">
-        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="id" attributeType="String"/>
         <relationship name="channels" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="team" inverseEntity="ChannelDTO"/>
         <relationship name="users" toMany="YES" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="teams" inverseEntity="UserDTO"/>
         <uniquenessConstraints>

--- a/StreamChatClient_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/StreamChatClient_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -32,7 +32,7 @@
         </uniquenessConstraints>
     </entity>
     <entity name="MemberDTO" representedClassName="MemberDTO" syncable="YES">
-        <attribute name="channelRoleRaw" attributeType="String"/>
+        <attribute name="channelRoleRaw" optional="YES" attributeType="String"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="inviteAcceptedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="inviteRejectedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>

--- a/StreamChatClient_v3/Models/ChannelId.swift
+++ b/StreamChatClient_v3/Models/ChannelId.swift
@@ -10,10 +10,6 @@ public struct ChannelId: Hashable, CustomStringConvertible {
     private static let any = "*"
     private static let separator: Character = ":"
     
-    enum Error: Swift.Error {
-        case decoding(String)
-    }
-    
     let rawValue: String
     
     /// Init a ChannelId.
@@ -34,7 +30,7 @@ public struct ChannelId: Hashable, CustomStringConvertible {
             let id = String(channelPair[1])
             self.init(type: type, id: id)
         } else {
-            throw ChannelId.Error.decoding(cid)
+            throw ClientError.InvalidChannelId("The channel id has invalid format and can't be decoded: \(cid)")
         }
     }
     
@@ -70,4 +66,8 @@ extension ChannelId: Codable {
             try container.encode(rawValue)
         }
     }
+}
+
+extension ClientError {
+    public class InvalidChannelId: CustomMessageError {}
 }

--- a/StreamChatClient_v3/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware.swift
+++ b/StreamChatClient_v3/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware.swift
@@ -1,0 +1,41 @@
+//
+// EventDataProcessorMiddleware.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A middleware which saves the incoming data from the Event to the database.
+struct EventDataProcessorMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
+    let database: DatabaseContainer
+    
+    func handle(event: Event, completion: @escaping (Event?) -> Void) {
+        guard let eventWithPayload = (event as? EventWithPayload) else {
+            completion(event)
+            return
+        }
+        
+        guard let payload = eventWithPayload.payload as? EventPayload<ExtraData> else {
+            log.assert(false, """
+            Type mismatch between `EventPayload.ExtraData` and `EventDataProcessorMiddleware.ExtraData`."
+                EventPayload type: \(type(of: eventWithPayload.payload))
+                EventDataProcessorMiddleware type: \(type(of: self))
+            """)
+            completion(nil)
+            return
+        }
+        
+        database.write({ (session) in
+            try session.saveEvent(payload: payload)
+        }, completion: { (error) in
+            if let error = error {
+                log.error("Failed saving incoming `Event` data to DB. Error: \(error)")
+                completion(nil)
+                return
+            }
+            
+            log.debug("Event data saved to db: \(payload)")
+            completion(event)
+        })
+    }
+}

--- a/StreamChatClient_v3/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
@@ -1,0 +1,96 @@
+//
+// EventDataProcessorMiddleware_Tests.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient_v3
+import XCTest
+
+class EventDataProcessorMiddlewaree_Tests: XCTestCase {
+    var middleware: EventDataProcessorMiddleware<DefaultDataTypes>!
+    fileprivate var database: TestDatabaseContainer!
+    
+    override func setUp() {
+        super.setUp()
+        database = try! TestDatabaseContainer(kind: .inMemory)
+        middleware = EventDataProcessorMiddleware(database: database)
+    }
+    
+    func test_eventWithPayload_isSavedToDB() throws {
+        // Prepare an Event with a payload with channel data
+        struct TestEvent: Event, EventWithPayload {
+            static var eventRawType: String { "test event with payload" }
+            let payload: Any
+        }
+        
+        let channelId: ChannelId = .unique
+        let channelPayload = dummyPayload(with: channelId)
+        let eventPayload = EventPayload(eventType: "test_event", connectionId: .unique, channel: channelPayload.channel,
+                                        currentUser: nil, cid: channelPayload.channel.cid)
+        
+        let testEvent = TestEvent(payload: eventPayload)
+        
+        // Let the middleware handle the event
+        let completion = try await { middleware.handle(event: testEvent, completion: $0) }
+        
+        // Assert the channel data is saved and the event is forwarded
+        var loadedChannel: ChannelModel<DefaultDataTypes>? {
+            database.viewContext.loadChannel(cid: channelId)
+        }
+        XCTAssertEqual(loadedChannel?.cid, channelId)
+        XCTAssertEqual(completion?.asEquatable, testEvent.asEquatable)
+    }
+    
+    func test_eventWithInvalidPayload_isNotForwarded() throws {
+        // Prepare an Event with an invalid payload data
+        struct TestEvent: Event, EventWithPayload {
+            static var eventRawType: String { "test event with payload" }
+            let payload: Any
+        }
+        
+        // This is not really used, we just need to have something to create the event with
+        let somePayload = EventPayload<DefaultDataTypes>(eventType: "test_event", connectionId: nil, channel: nil,
+                                                         currentUser: nil, cid: nil)
+        
+        let testEvent = TestEvent(payload: somePayload)
+        
+        // Simulate the DB fails to save the payload
+        database.write_errorResponse = TestError()
+        
+        // Let the middleware handle the event
+        let completion = try await { middleware.handle(event: testEvent, completion: $0) }
+        
+        // Assert the event is not forwarded
+        XCTAssertNil(completion)
+    }
+    
+    func test_eventWithoutPayload_isForwarded() throws {
+        // Prepare an Event without a payload
+        struct TestEvent: Event {
+            static var eventRawType: String { "test event without payload" }
+        }
+        
+        let testEvent = TestEvent()
+        
+        // Let the middleware handle the event
+        let completion = try await { middleware.handle(event: testEvent, completion: $0) }
+        
+        // Assert the event is forwarded
+        XCTAssertEqual(completion?.asEquatable, testEvent.asEquatable)
+    }
+}
+
+/// A testable subclass of DatabaseContainer allowing response simulation.
+private class TestDatabaseContainer: DatabaseContainer {
+    /// If set, the `write` completion block is called with this value.
+    var write_errorResponse: Error?
+    
+    override func write(_ actions: @escaping (DatabaseSession) throws -> Void, completion: @escaping (Error?) -> Void) {
+        if let error = write_errorResponse {
+            super.write(actions, completion: { _ in })
+            completion(error)
+        } else {
+            super.write(actions, completion: completion)
+        }
+    }
+}

--- a/StreamChatClient_v3/WebSocketClient/EventMiddlewares/HealthCheckFilterMiddleware_Tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/EventMiddlewares/HealthCheckFilterMiddleware_Tests.swift
@@ -21,7 +21,7 @@ class HealthCheckFilterMiddleware_Tests: XCTestCase {
     }
     
     func test_healthCheackEvent_isFiltered() throws {
-        let event = HealthCheck(connectionId: UUID().uuidString)
+        let event = HealthCheck(connectionId: .unique)
         let result = try await { self.middleware.handle(event: event, completion: $0) }
         XCTAssertNil(result)
     }
@@ -30,5 +30,12 @@ class HealthCheckFilterMiddleware_Tests: XCTestCase {
         let event = IntBasedEvent(value: .random(in: 0 ... 100))
         let result = try await { self.middleware.handle(event: event, completion: $0) }
         XCTAssertEqual(result as? IntBasedEvent, event)
+    }
+}
+
+extension HealthCheck {
+    init(connectionId: String) {
+        try! self.init(from: EventPayload<DefaultDataTypes>(eventType: HealthCheck.eventRawType, connectionId: connectionId,
+                                                            channel: nil, currentUser: nil, cid: nil))!
     }
 }

--- a/StreamChatClient_v3/WebSocketClient/Events/ChannelEvents.swift
+++ b/StreamChatClient_v3/WebSocketClient/Events/ChannelEvents.swift
@@ -20,7 +20,7 @@ public struct AddedToChannel<ExtraData: ExtraDataTypes>: ChannelEvent {
     
     let channelPayload: ChannelPayload<ExtraData>
     
-    init?(from eventResponse: EventResponse<ExtraData>) throws {
+    init?(from eventResponse: EventPayload<ExtraData>) throws {
         guard eventResponse.eventType == Self.eventRawType else { return nil }
         guard let channel = eventResponse.channelPayload else {
             throw ClientError.EventDecodingError("`channel` field can't be `nil` for the RemovedFromChannel event.")

--- a/StreamChatClient_v3/WebSocketClient/Events/ConnectionEvents.swift
+++ b/StreamChatClient_v3/WebSocketClient/Events/ConnectionEvents.swift
@@ -13,7 +13,7 @@ public struct HealthCheck: ConnectionEvent {
     public static var eventRawType: String { "health.check" }
     public let connectionId: String
     
-    init?<ExtraData: ExtraDataTypes>(from eventResponse: EventResponse<ExtraData>) throws {
+    init?<ExtraData: ExtraDataTypes>(from eventResponse: EventPayload<ExtraData>) throws {
         guard eventResponse.eventType == Self.eventRawType else { return nil }
         guard let connectionId = eventResponse.connectionId else {
             throw ClientError.EventDecodingError(missingValue: "connectionId", eventType: "HealthCheck")

--- a/StreamChatClient_v3/WebSocketClient/Events/ConnectionEvents.swift
+++ b/StreamChatClient_v3/WebSocketClient/Events/ConnectionEvents.swift
@@ -20,8 +20,4 @@ public struct HealthCheck: ConnectionEvent {
         }
         self.connectionId = connectionId
     }
-    
-    init(connectionId: String) {
-        self.connectionId = connectionId
-    }
 }

--- a/StreamChatClient_v3/WebSocketClient/Events/Event.swift
+++ b/StreamChatClient_v3/WebSocketClient/Events/Event.swift
@@ -5,8 +5,29 @@
 
 import Foundation
 
-/// An `Event` object represent an event in the chat system.
+/// An `Event` object representing an event in the chat system.
 public protocol Event {
     /// The underlying raw type of the incoming string.
     static var eventRawType: String { get }
+}
+
+/// The DTO object mirroring the JSON representation of an event.
+struct EventPayload<ExtraData: ExtraDataTypes>: Decodable {
+    let eventType: String
+    
+    let connectionId: String?
+    
+    let channel: ChannelDetailPayload<ExtraData>?
+    
+    let currentUser: UserPayload<ExtraData.User>? // TODO: Create CurrentUserPayload?
+    
+    let cid: ChannelId?
+    
+    private enum CodingKeys: String, CodingKey {
+        case connectionId = "connection_id"
+        case channel
+        case eventType = "type"
+        case currentUser = "me"
+        case cid
+    }
 }

--- a/StreamChatClient_v3/WebSocketClient/Events/Event.swift
+++ b/StreamChatClient_v3/WebSocketClient/Events/Event.swift
@@ -31,3 +31,10 @@ struct EventPayload<ExtraData: ExtraDataTypes>: Decodable {
         case cid
     }
 }
+
+/// An internal protocol marking the Events carrying the payload. This payload can be then used for additional work,
+/// i.e. for storing the data to the database.
+protocol EventWithPayload: Event {
+    /// Type-erased event payload. Cast it to `EventPayload<ExtraData>` when you need to use it.
+    var payload: Any { get }
+}

--- a/StreamChatClient_v3/WebSocketClient/Events/EventDecoder.swift
+++ b/StreamChatClient_v3/WebSocketClient/Events/EventDecoder.swift
@@ -52,18 +52,3 @@ protocol AnyEventDecoder {
 }
 
 extension EventDecoder: AnyEventDecoder {}
-
-/// The DTO object mirroring the JSON representation of the event.
-struct EventPayload<ExtraData: ExtraDataTypes>: Decodable {
-    let connectionId: String?
-    
-    let channelPayload: ChannelPayload<ExtraData>?
-    
-    let eventType: String
-    
-    private enum CodingKeys: String, CodingKey {
-        case connectionId = "connection_id"
-        case channelPayload = "channel"
-        case eventType = "type"
-    }
-}

--- a/StreamChatClient_v3/WebSocketClient/Events/EventDecoder.swift
+++ b/StreamChatClient_v3/WebSocketClient/Events/EventDecoder.swift
@@ -8,13 +8,13 @@ import Foundation
 /// A lightweight object for decoding incoming events.
 struct EventDecoder<ExtraData: ExtraDataTypes> {
     /// All supported event types by this decoder.
-    let eventParsers: [(EventResponse<ExtraData>) throws -> Event?] = [
+    let eventParsers: [(EventPayload<ExtraData>) throws -> Event?] = [
         HealthCheck.init,
         AddedToChannel.init
     ]
     
     func decode(data: Data) throws -> Event {
-        let response = try JSONDecoder.default.decode(EventResponse<ExtraData>.self, from: data)
+        let response = try JSONDecoder.default.decode(EventPayload<ExtraData>.self, from: data)
         
         for parser in eventParsers {
             if let decoded = try parser(response) {
@@ -54,7 +54,7 @@ protocol AnyEventDecoder {
 extension EventDecoder: AnyEventDecoder {}
 
 /// The DTO object mirroring the JSON representation of the event.
-struct EventResponse<ExtraData: ExtraDataTypes>: Decodable {
+struct EventPayload<ExtraData: ExtraDataTypes>: Decodable {
     let connectionId: String?
     
     let channelPayload: ChannelPayload<ExtraData>?

--- a/StreamChatClient_v3/WebSocketClient/Events/Event_Tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/Events/Event_Tests.swift
@@ -1,0 +1,32 @@
+//
+// Event_Tests.swift
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient_v3
+import XCTest
+
+class EventPayload_Tests: XCTestCase {
+    let eventJSON: Data = {
+        let url = Bundle(for: UserEndpointPayload_Tests.self).url(forResource: "Event", withExtension: "json")!
+        return try! Data(contentsOf: url)
+    }()
+    
+    func test_eventJSON_isSerialized_withDefaultExtraData() throws {
+        let payload = try JSONDecoder.default.decode(EventPayload<DefaultDataTypes>.self, from: eventJSON)
+        
+        XCTAssertNotNil(payload.channel)
+    }
+    
+    func test_eventJSON_isSerialized_withNoExtraData() throws {
+        enum NoExtraDataTypes: ExtraDataTypes {
+            typealias User = NoExtraData
+            typealias Channel = NoExtraData
+            typealias Message = NoExtraData
+        }
+        
+        let payload = try JSONDecoder.default.decode(EventPayload<NoExtraDataTypes>.self, from: eventJSON)
+        
+        XCTAssertNotNil(payload.channel)
+    }
+}

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
@@ -204,7 +204,8 @@ extension WebSocketClient: WebSocketEngineDelegate {
     
     func websocketDidReceiveMessage(_ message: String) {
         do {
-            let event = try eventDecoder.decode(data: message.data(using: .utf8)!)
+            let messageData = Data(message.utf8)
+            let event = try eventDecoder.decode(data: messageData)
             
             if let event = event as? HealthCheck {
                 if connectionState.isConnected == false {

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
@@ -67,7 +67,7 @@ class WebSocketClient {
     private var reconnectionTimer: TimerControl?
     
     /// The queue on which web socket engine methods are called
-    private let engineQueue: DispatchQueue = .init(label: "io.getStream.chat.core.web_socket_engine_queeu", qos: .default)
+    private let engineQueue: DispatchQueue = .init(label: "io.getStream.chat.core.web_socket_engine_queue", qos: .default)
     
     /// The request used to establish web socket connection
     private let urlRequest: URLRequest

--- a/TestResources_v3/MockEnpointResponses/Event.json
+++ b/TestResources_v3/MockEnpointResponses/Event.json
@@ -1,0 +1,92 @@
+{
+    
+    "__comment": "TODO: Add more objects to this JSON for tests",
+    
+    "channel" : {
+        "created_by" : {
+            "id" : "broken-waterfall-5",
+            "banned" : false,
+            "unread_channels" : 0,
+            "totalUnreadCount" : 0,
+            "extraData" : {
+                "name" : "Tester"
+            },
+            "last_active" : "2020-06-20T12:56:19.460539Z",
+            "created_at" : "2019-12-12T15:33:46.488935Z",
+            "unreadChannels" : 0,
+            "unread_count" : 0,
+            "image" : "https:\/\/getstream.io\/random_svg\/?id=broken-waterfall-5&amp;name=Broken+waterfall",
+            "updated_at" : "2020-06-20T13:22:54.004853Z",
+            "role" : "user",
+            "total_unread_count" : 0,
+            "online" : true,
+            "name" : "broken-waterfall-5"
+        },
+        "frozen" : false,
+        "config" : {
+            "automod_behavior" : "flag",
+            "reactions" : true,
+            "typing_events" : true,
+            "mutes" : true,
+            "max_message_length" : 5000,
+            "created_at" : "2019-03-21T15:49:15.40182Z",
+            "automod" : "AI",
+            "read_events" : true,
+            "commands" : [
+                {
+                    "set" : "fun_set",
+                    "args" : "[text]",
+                    "name" : "giphy",
+                    "description" : "Post a random gif to the channel"
+                }
+            ],
+            "connect_events" : true,
+            "replies" : true,
+            "updated_at" : "2020-03-17T18:54:09.460881Z",
+            "url_enrichment" : true,
+            "search" : false,
+            "message_retention" : "infinite",
+            "uploads" : true,
+            "name" : "messaging"
+        },
+        "id" : "new_channel_2766",
+        "created_at" : "2020-06-20T13:23:03.587914Z",
+        "members" : [
+            {
+                "created_at" : "2020-06-20T13:23:03.591034Z",
+                "user_id" : "broken-waterfall-5",
+                "updated_at" : "2020-06-20T13:23:03.591034Z",
+                "user" : {
+                    "id" : "broken-waterfall-5",
+                    "banned" : false,
+                    "unread_channels" : 0,
+                    "totalUnreadCount" : 0,
+                    "extraData" : {
+                        "name" : "Tester"
+                    },
+                    "last_active" : "2020-06-20T12:56:19.460539Z",
+                    "created_at" : "2019-12-12T15:33:46.488935Z",
+                    "unreadChannels" : 0,
+                    "unread_count" : 0,
+                    "image" : "https:\/\/getstream.io\/random_svg\/?id=broken-waterfall-5&amp;name=Broken+waterfall",
+                    "updated_at" : "2020-06-20T13:22:54.004853Z",
+                    "role" : "user",
+                    "total_unread_count" : 0,
+                    "online" : true,
+                    "name" : "broken-waterfall-5"
+                }
+            }
+        ],
+        "member_count" : 1,
+        "type" : "messaging",
+        "updated_at" : "2020-06-20T13:23:03.587914Z",
+        "name" : "Channel 2766",
+        "cid" : "messaging:new_channel_2766"
+    },
+    "unread_channels" : 1,
+    "created_at" : "2020-06-20T13:23:03.600075563Z",
+    "total_unread_count" : 1,
+    "unread_count" : 1,
+    "type" : "notification.added_to_channel",
+    "cid" : "messaging:new_channel_2766"
+}

--- a/V3SampleApp/AppDelegate.swift
+++ b/V3SampleApp/AppDelegate.swift
@@ -13,7 +13,7 @@ let chatClient: ChatClient = {
     var config = ChatClientConfig(apiKey: APIKey("qk4nn7rpcn75"))
     config.isLocalStorageEnabled = false
     
-    let user = User(id: "broken-waterfall-5", name: "Tester", avatarURL: nil)
+    let user = User(id: "broken-waterfall-5", name: "Tester", imageURL: nil)
     return ChatClient(currentUser: user, config: config)
 }()
 


### PR DESCRIPTION
#### In this PR:

The main goal of this PR is to prepare the basic infrastructure for Event handling and saving the incoming data to DB. 

### Problem
In v2, the data of the event are simply part of the event object itself. This is no longer possible because all data live in the DB. The desired behavior, when an event comes, is to parse the JSON data, save then to DB, and **then** publish the event to listeners.

However, we can't simply attach the `EventPayload` to `Event` for two reasons:
  - `EventPayload` is internal and we don't want to leak this information to users
  - `EventPayload` is generic over `ExtraData` and we don't want to introduce associated type to `Event` protocol

### Solution

I created a new internal protocol `EventWithPayload` to which events, where it is desirable to save the additional data, conform. The payload itself is then included in the event in a type-erased form, to make our lives easier.

Then I created `EventDataProcessorMiddleware` which takes care of saving the data, and I added it to `WebSocketClient` middlewares.
