### PR TITLE
[CIS-170] Clean up the implementation of `Client` and add missing tests

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -3006,7 +3006,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = D48F367GRM;
 				INFOPLIST_FILE = V3SampleApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3025,7 +3025,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = D48F367GRM;
 				INFOPLIST_FILE = V3SampleApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/StreamChat.xcodeproj/xcshareddata/xcschemes/V3SampleApp.xcscheme
+++ b/StreamChat.xcodeproj/xcshareddata/xcschemes/V3SampleApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "792A4F21247FF01800EAF71D"
+               BuildableName = "V3SampleApp.app"
+               BlueprintName = "V3SampleApp"
+               ReferencedContainer = "container:StreamChat.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "792A4F21247FF01800EAF71D"
+            BuildableName = "V3SampleApp.app"
+            BlueprintName = "V3SampleApp"
+            ReferencedContainer = "container:StreamChat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "792A4F21247FF01800EAF71D"
+            BuildableName = "V3SampleApp.app"
+            BlueprintName = "V3SampleApp"
+            ReferencedContainer = "container:StreamChat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/StreamChatClient_v3/APIClient/APIClient_Tests.swift
+++ b/StreamChatClient_v3/APIClient/APIClient_Tests.swift
@@ -302,6 +302,7 @@ struct AnyEndpoint: Equatable {
 
 private class TestWebSocketClient: WebSocketClient {
     init() {
-        super.init(urlRequest: .init(url: .unique()), eventDecoder: EventDecoder<DefaultDataTypes>(), eventMiddlewares: [])
+        super.init(urlRequest: .init(url: .unique()), sessionConfiguration: .default,
+                   eventDecoder: EventDecoder<DefaultDataTypes>(), eventMiddlewares: [])
     }
 }

--- a/StreamChatClient_v3/APIClient/Endpoints/Endpoint.swift
+++ b/StreamChatClient_v3/APIClient/Endpoints/Endpoint.swift
@@ -18,3 +18,6 @@ enum EndpointMethod: String {
     case post = "POST"
     case delete = "DELETE"
 }
+
+/// A type representing empty response of an Endpoint.
+public struct EmptyResponse: Decodable {}

--- a/StreamChatClient_v3/ChatClient_Tests.swift
+++ b/StreamChatClient_v3/ChatClient_Tests.swift
@@ -9,17 +9,16 @@ import XCTest
 
 class ChatClient_Tests: XCTestCase {
     var user: User!
-    var queue: DispatchQueue!
     
     override func setUp() {
         super.setUp()
         user = User(id: UUID().uuidString)
-        queue = DispatchQueue(label: "test_queue")
     }
     
     // MARK: - Database stack tests
     
     func test_clientDatabaseStackInitialization_whenLocalStorageEnabled_respectsConfigValues() {
+        // Prepare a config with the local storage
         let storeFolderURL = URL.newTemporaryDirectoryURL()
         var config = ChatClientConfig()
         config.isLocalStorageEnabled = true
@@ -27,31 +26,36 @@ class ChatClient_Tests: XCTestCase {
         
         var usedDatabaseKind: DatabaseContainer.Kind?
         
+        // Create env object with custom database builder
         var env = ChatClient.Environment()
         env.databaseContainerBuilder = { kind in
             usedDatabaseKind = kind
             return DatabaseContainerMock()
         }
         
-        _ = ChatClient(currentUser: user, config: config, workerBuilders: [], callbackQueue: queue, environment: env)
+        // Create a `Client` and assert that a DB file is created on the provided URL
+        _ = ChatClient(currentUser: user, config: config, workerBuilders: [], environment: env)
             .persistentContainer
         
         XCTAssertEqual(usedDatabaseKind, .onDisk(databaseFileURL: storeFolderURL.appendingPathComponent(user.id)))
     }
     
     func test_clientDatabaseStackInitialization_whenLocalStorageDisabled() {
+        // Prepare a config with the in-memory storage
         var config = ChatClientConfig()
         config.isLocalStorageEnabled = false
         
         var usedDatabaseKind: DatabaseContainer.Kind?
         
+        // Create env object with custom database builder
         var env = ChatClient.Environment()
         env.databaseContainerBuilder = { kind in
             usedDatabaseKind = kind
             return DatabaseContainerMock()
         }
         
-        _ = ChatClient(currentUser: user, config: config, workerBuilders: [], callbackQueue: queue, environment: env)
+        // Create a `Client` and assert the correct DB kind is used
+        _ = ChatClient(currentUser: user, config: config, workerBuilders: [], environment: env)
             .persistentContainer
         
         XCTAssertEqual(usedDatabaseKind, .inMemory)
@@ -60,16 +64,20 @@ class ChatClient_Tests: XCTestCase {
     /// When the initialization of a local DB fails for some reason (i.e. incorrect URL),
     /// use a DB in the in-memory configuration
     func test_clientDatabaseStackInitialization_useInMemoryWhenOnDiskFails() {
+        // Prepare a config with the local storage
         let storeFolderURL = URL.newTemporaryDirectoryURL()
         var config = ChatClientConfig()
         config.isLocalStorageEnabled = true
         config.localStorageFolderURL = storeFolderURL
         
         var usedDatabaseKinds: [DatabaseContainer.Kind] = []
+        
+        // Prepare a queue with errors the db builder should return. We want to return an error only the first time
+        // when we expect the DB is created with the local DB option and we want it to fail.
         var errorsToReturn = Queue(TestError())
         
+        // Create env object and store all `kind`s it's called with.
         var env = ChatClient.Environment()
-        
         env.databaseContainerBuilder = { kind in
             usedDatabaseKinds.append(kind)
             // Return error for the first time
@@ -80,15 +88,165 @@ class ChatClient_Tests: XCTestCase {
             return DatabaseContainerMock()
         }
         
-        _ = ChatClient(currentUser: user, config: config, workerBuilders: [], callbackQueue: queue, environment: env)
+        // Create a chat client and assert `Client` tries to initialize the local DB, and when it fails, it falls back
+        // to the in-memory option.
+        _ = ChatClient(currentUser: user, config: config, workerBuilders: [], environment: env)
             .persistentContainer
         
         XCTAssertEqual(usedDatabaseKinds,
                        [.onDisk(databaseFileURL: storeFolderURL.appendingPathComponent(user.id)), .inMemory])
     }
+    
+    // MARK: - WebSocketClient tests
+    
+    func test_webSocketClientIsInitialized() throws {
+        // Use in-memory store
+        var config = ChatClientConfig()
+        config.isLocalStorageEnabled = false
+        config.baseURL = BaseURL(urlString: .unique)
+        
+        // Observe the parameters for WebSocketClient initialization
+        var wsInitializationParameters: (urlRequest: URLRequest,
+                                         sessionConfiguration: URLSessionConfiguration,
+                                         eventDecoder: AnyEventDecoder,
+                                         eventMiddlewares: [EventMiddleware])?
+        
+        var env = ChatClient.Environment()
+        env.webSocketClientBuilder = {
+            wsInitializationParameters = (urlRequest: $0, sessionConfiguration: $1, eventDecoder: $2, eventMiddlewares: $3)
+            return WebSocketClientMock()
+        }
+        
+        // Create a new chat client
+        let client = ChatClient(currentUser: user,
+                                config: config,
+                                workerBuilders: [MessageSender.init],
+                                environment: env)
+        
+        // Assert the init parameters are correct
+        let parameters = try XCTUnwrap(wsInitializationParameters)
+        let components = try XCTUnwrap(URLComponents(url: parameters.urlRequest.url!, resolvingAgainstBaseURL: false))
+        
+        XCTAssertEqual(components.scheme, "wss")
+        XCTAssertEqual(components.host, config.baseURL.webSocketBaseURL.host)
+        XCTAssertEqual(components.path, "/connect")
+        XCTAssertNotNil(components.queryItems?["json"])
+        
+        assertMandatoryHeaderFields(parameters.sessionConfiguration, token: client.token)
+        
+        XCTAssert(wsInitializationParameters?.eventDecoder is EventDecoder<DefaultDataTypes>)
+        
+        XCTAssertEqual(wsInitializationParameters?.eventMiddlewares.count, 2)
+        XCTAssert(wsInitializationParameters?.eventMiddlewares[0] is EventDataProcessorMiddleware<DefaultDataTypes>)
+        XCTAssert(wsInitializationParameters?.eventMiddlewares[1] is HealthCheckFilter)
+    }
+    
+    // MARK: - APIClient tests
+    
+    func test_apiClientIsInitialized() throws {
+        // Use in-memory store
+        var config = ChatClientConfig()
+        config.isLocalStorageEnabled = false
+        config.baseURL = BaseURL(urlString: .unique)
+        
+        // Observe the parameters for APIClient initialization
+        var apiInitializationParameters: (apiKey: APIKey,
+                                          baseURL: URL,
+                                          sessionConfiguration: URLSessionConfiguration)?
+        
+        var apiClientMock: APIClientMock!
+        var env = ChatClient.Environment()
+        env.apiClientBuilder = {
+            apiInitializationParameters = (apiKey: $0, baseURL: $1, sessionConfiguration: $2)
+            apiClientMock = APIClientMock()
+            return apiClientMock
+        }
+        
+        // Create a new chat client
+        let client = ChatClient(currentUser: user,
+                                config: config,
+                                workerBuilders: [MessageSender.init],
+                                environment: env)
+        
+        // Assert the init parameters are correct
+        let parameters = try XCTUnwrap(apiInitializationParameters)
+        
+        XCTAssertEqual(parameters.apiKey, config.apiKey)
+        
+        let components = try XCTUnwrap(URLComponents(url: parameters.baseURL, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(components.scheme, "https")
+        XCTAssertEqual(components.host, config.baseURL.restAPIBaseURL.host)
+        
+        assertMandatoryHeaderFields(parameters.sessionConfiguration, token: client.token)
+        
+        XCTAssertEqual(parameters.baseURL, config.baseURL.restAPIBaseURL)
+        
+        // Assert APIClient sets itself as WS connection state delegate
+        XCTAssert(client.webSocketClient.connectionStateDelegate === apiClientMock)
+    }
+    
+    // MARK: - Background workers tests
+    
+    func test_productionClientIsInitalizedWithAllMandatoryBackgroundWorkers() {
+        // Create a new Client with production configuration
+        let config = ChatClientConfig(apiKey: .init(.unique))
+        let client = Client<DefaultDataTypes>(currentUser: user, config: config)
+        
+        // Check all the mandatory background workers are initialized
+        XCTAssert(client.backgroundWorkers.contains { $0 is MessageSender })
+        XCTAssert(client.backgroundWorkers.contains { $0 is ChannelEventsHandler<DefaultDataTypes> })
+    }
+    
+    func test_backgroundWorkersAreInitialized() {
+        // Set up mocks for APIClient, WSClient and Database
+        let config = ChatClientConfig(apiKey: .init(.unique))
+        var environment = Client<DefaultDataTypes>.Environment()
+        environment.apiClientBuilder = { _, _, _ in APIClientMock() }
+        environment.webSocketClientBuilder = { _, _, _, _ in WebSocketClientMock() }
+        environment.databaseContainerBuilder = { _ in DatabaseContainerMock() }
+        
+        // Prepare a test worker
+        class TestWorker: Worker {
+            var init_database: DatabaseContainer?
+            var init_webSocketClient: WebSocketClient?
+            var init_apiClient: APIClient?
+            
+            override init(database: DatabaseContainer, webSocketClient: WebSocketClient, apiClient: APIClient) {
+                init_database = database
+                init_webSocketClient = webSocketClient
+                init_apiClient = apiClient
+                
+                super.init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+            }
+        }
+        
+        // Create a Client instance and check the TestWorker is initialized properly
+        let client = Client(currentUser: user,
+                            config: config,
+                            workerBuilders: [TestWorker.init],
+                            environment: environment)
+        
+        let testWorker = client.backgroundWorkers.first as? TestWorker
+        XCTAssert(testWorker?.init_database is DatabaseContainerMock)
+        XCTAssert(testWorker?.init_webSocketClient is WebSocketClientMock)
+        XCTAssert(testWorker?.init_apiClient is APIClientMock)
+    }
 }
 
 // MARK: - Local helpers
+
+extension ChatClient_Tests {
+    /// Asserts that URLSessionConfiguration contains all requier header fiedls
+    private func assertMandatoryHeaderFields(_ config: URLSessionConfiguration, token: String) {
+        let headers = config.httpAdditionalHeaders as? [String: String] ?? [:]
+        XCTAssertEqual(headers["X-Stream-Client"], "stream-chat-swift-client-\(SystemEnvironment.version)")
+        XCTAssertEqual(headers["X-Stream-Device"], SystemEnvironment.deviceModelName)
+        XCTAssertEqual(headers["X-Stream-OS"], SystemEnvironment.systemName)
+        XCTAssertEqual(headers["X-Stream-App-Environment"], SystemEnvironment.name)
+        XCTAssertEqual(headers["Stream-Auth-Type"], "jwt") // TODO: CIS-164
+        XCTAssertEqual(headers["Authorization"], token) // TODO: CIS-164
+    }
+}
 
 private class DatabaseContainerMock: DatabaseContainer {
     init() {
@@ -115,6 +273,6 @@ private struct Queue<Element> {
 
 private extension ChatClientConfig {
     init() {
-        self = .init(apiKey: APIKey("test_api_key"))
+        self = .init(apiKey: APIKey(.unique))
     }
 }

--- a/StreamChatClient_v3/Config/BaseURL.swift
+++ b/StreamChatClient_v3/Config/BaseURL.swift
@@ -12,10 +12,10 @@ public struct BaseURL: CustomStringConvertible {
     
     static let placeholderURL = URL(string: "https://getstream.io")!
     
-    public let baseURL: URL
-    public let wsURL: URL
+    public let restAPIBaseURL: URL
+    public let webSocketBaseURL: URL
     
-    public var description: String { baseURL.absoluteString }
+    public var description: String { restAPIBaseURL.absoluteString }
     
     /// Create a base URL from an URL string.
     ///
@@ -39,7 +39,7 @@ public struct BaseURL: CustomStringConvertible {
         }
         
         urlString = urlString.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        baseURL = URL(string: "https://\(urlString)/")!
-        wsURL = URL(string: "wss://\(urlString)/")!
+        restAPIBaseURL = URL(string: "https://\(urlString)/")!
+        webSocketBaseURL = URL(string: "wss://\(urlString)/")!
     }
 }

--- a/StreamChatClient_v3/WebSocketClient/Engine/URLSessionWebSocketEngine.swift
+++ b/StreamChatClient_v3/WebSocketClient/Engine/URLSessionWebSocketEngine.swift
@@ -9,17 +9,19 @@ import Foundation
 final class URLSessionWebSocketEngine: NSObject, WebSocketEngine, URLSessionDataDelegate, URLSessionWebSocketDelegate {
     private var task: URLSessionWebSocketTask?
     let request: URLRequest
+    let sessionConfiguration: URLSessionConfiguration
     var isConnected = false
     let callbackQueue: DispatchQueue
     weak var delegate: WebSocketEngineDelegate?
     
-    init(request: URLRequest, callbackQueue: DispatchQueue) {
+    init(request: URLRequest, sessionConfiguration: URLSessionConfiguration, callbackQueue: DispatchQueue) {
         self.request = request
+        self.sessionConfiguration = sessionConfiguration
         self.callbackQueue = callbackQueue
     }
     
     func connect() {
-        let session = URLSession(configuration: URLSessionConfiguration.default, delegate: self, delegateQueue: nil)
+        let session = URLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
         task = session.webSocketTask(with: request)
         doRead()
         task?.resume()

--- a/StreamChatClient_v3/WebSocketClient/Engine/WebSocketEngine.swift
+++ b/StreamChatClient_v3/WebSocketClient/Engine/WebSocketEngine.swift
@@ -11,7 +11,7 @@ protocol WebSocketEngine: AnyObject {
     var callbackQueue: DispatchQueue { get }
     var delegate: WebSocketEngineDelegate? { get set }
     
-    init(request: URLRequest, callbackQueue: DispatchQueue)
+    init(request: URLRequest, sessionConfiguration: URLSessionConfiguration, callbackQueue: DispatchQueue)
     func connect()
     func disconnect()
     func sendPing()

--- a/StreamChatClient_v3/WebSocketClient/Engine/WebSocketEngine_Tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/Engine/WebSocketEngine_Tests.swift
@@ -8,6 +8,7 @@ import Foundation
 
 class WebSocketEngineMock: WebSocketEngine {
     var request: URLRequest
+    var sessionConfiguration: URLSessionConfiguration
     var isConnected: Bool = false
     var callbackQueue: DispatchQueue
     weak var delegate: WebSocketEngineDelegate?
@@ -22,11 +23,12 @@ class WebSocketEngineMock: WebSocketEngine {
     var sendPing_calledCount = 0
     
     convenience init() {
-        self.init(request: .init(url: URL(string: "test_url")!), callbackQueue: .main)
+        self.init(request: .init(url: URL(string: "test_url")!), sessionConfiguration: .default, callbackQueue: .main)
     }
     
-    required init(request: URLRequest, callbackQueue: DispatchQueue) {
+    required init(request: URLRequest, sessionConfiguration: URLSessionConfiguration, callbackQueue: DispatchQueue) {
         self.request = request
+        self.sessionConfiguration = sessionConfiguration
         self.callbackQueue = callbackQueue
     }
     

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient_Tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient_Tests.swift
@@ -43,12 +43,13 @@ final class WebSocketClient_Tests: XCTestCase {
         reconnectionStrategy = MockReconnectionStrategy()
         
         var environment = WebSocketClient.Environment()
-        environment.engineBuilder = { _, _ in self.engine }
+        environment.engineBuilder = { _, _, _ in self.engine }
         environment.notificationCenterBuilder = { self.eventNotificationCenter }
         environment.timer = VirtualTimeTimer.self
         environment.backgroundTaskScheduler = backgroundTaskScheduler
         
         webSocketClient = WebSocketClient(urlRequest: reuqest,
+                                          sessionConfiguration: .default,
                                           eventDecoder: decoder,
                                           eventMiddlewares: [],
                                           reconnectionStrategy: reconnectionStrategy,

--- a/StreamChatClient_v3/Workers/Background/ChannelEventsHandler_Tests.swift
+++ b/StreamChatClient_v3/Workers/Background/ChannelEventsHandler_Tests.swift
@@ -56,6 +56,7 @@ class WebSocketClientMock: WebSocketClient {
         }
         
         super.init(urlRequest: URLRequest(url: URL(string: "test")!),
+                   sessionConfiguration: .default,
                    eventDecoder: MockDecoder(),
                    eventMiddlewares: [])
     }

--- a/V3SampleApp/AppDelegate.swift
+++ b/V3SampleApp/AppDelegate.swift
@@ -20,6 +20,8 @@ let chatClient: ChatClient = {
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    var window: UIWindow?
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
         LogConfig.formatters = [PrefixLogFormatter(prefixes: [.info: "𝒊", .debug: "🛠", .warning: "⚠️", .error: "🚨"])]
@@ -31,18 +33,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         LogConfig.level = .info
         
         chatClient.webSocketClient.connect()
+
+        if #available(iOS 11, *) {
+            self.window = UIWindow()
+            window?.rootViewController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController()
+            window?.makeKeyAndVisible()
+        }
         
         return true
     }
 
     // MARK: UISceneSession Lifecycle
 
+    @available(iOS 13.0, *)
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
+    @available(iOS 13.0, *)
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.

--- a/V3SampleApp/SceneDelegate.swift
+++ b/V3SampleApp/SceneDelegate.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 13, *)
 class SceneDelegate: UIResponder, UIWindowSceneDelegate, UISplitViewControllerDelegate {
 
     var window: UIWindow?


### PR DESCRIPTION
#### In this PR:

- We use the same `URLSessionConfigruation` for both `APIClient` and `WebSocketClient`
- We use the existing `RequestEncoder` to encode the initial request for `WebSockectClient`, too
- The implementation of `Client` is cleaned-up
- I added missing tests and documentation.

---

*Note 1:* Since `Client` in v3 acts like a controller, the tests are a little bit messy becase we need to mock everything and basically just check `Client` calls the mocks correctly.

*Note 2:* Setting the user + logging in/out is not handled in this PR and will be part of CIS-164