### PR TITLE
Fix increasing username label font size in message cell causing cut off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🔄 Changed
 
 ### 🐞 Fixed
-- Fix increasing username label font size (`MessageViewStyle.nameFont`) in message cell causing cut off [#333](https://github.com/GetStream/stream-chat-swift/issues/333)
+- Increasing username label font size (`MessageViewStyle.nameFont`) in message cell caused cut off [#333](https://github.com/GetStream/stream-chat-swift/issues/333)
 
 # [2.2.5](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.5)
 _June 24, 2020_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔄 Changed
 
+### 🐞 Fixed
+- Fix increasing username label font size (`MessageViewStyle.nameFont`) in message cell causing cut off [#333](https://github.com/GetStream/stream-chat-swift/issues/333)
+
 # [2.2.5](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.5)
 _June 24, 2020_
 

--- a/Sources/UI/Chat/Cells/MessageTableViewCell.swift
+++ b/Sources/UI/Chat/Cells/MessageTableViewCell.swift
@@ -59,6 +59,7 @@ open class MessageTableViewCell: UITableViewCell, Reusable {
                 height = max(height, avatarViewStyle.radius - self.style.spacing.vertical)
             }
             
+            height = max(height, style.nameFont.lineHeight)
             $0.height.equalTo(height).priority(999)
         }
         


### PR DESCRIPTION
<img width="216" alt="Screen Shot 2020-06-30 at 21 41 57" src="https://user-images.githubusercontent.com/5606812/86190966-391e8000-bb1c-11ea-9ef6-f48ca3e5a31a.png">

Closes #333 
