### PR TITLE
Fix emojis in reaction view displayed in inconsistent order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
+### ✅ Added
+- `ChatViewController.preferredEmojiOrder` to specify order of emojis in reaction view [#337](https://github.com/GetStream/stream-chat-swift/pull/337)
+
 ### 🔄 Changed
+
+### 🐞 Fixed
+- Emojis in reaction view not displayed consistent order [#332](https://github.com/GetStream/stream-chat-swift/issues/332)
 
 # [2.2.5](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.5)
 _June 24, 2020_

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Reactions.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Reactions.swift
@@ -80,7 +80,7 @@ extension ChatViewController {
         let convertedOrigin = tableView.convert(cell.frame, to: view).origin
         let position = CGPoint(x: convertedOrigin.x + locationInView.x, y: convertedOrigin.y + locationInView.y)
         
-        reactionsView.show(emojiReactionTypes: emojiReactionTypes, at: position, for: message) { [weak self] type, score in
+        reactionsView.show(emojiReactionTypes: emojiReactionTypes, at: position, for: message, with: preferredEmojiOrder) { [weak self] type, score in
             guard let self = self,
                 let emojiReactionsType = self.emojiReactionTypes[type],
                 let presenter = self.presenter,

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Reactions.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Reactions.swift
@@ -12,7 +12,28 @@ import StreamChatCore
 import SnapKit
 
 /// A type for emoji reactions by reaction types.
-public typealias EmojiReactionTypes = [String: (emoji: String, maxScore: Int)]
+public typealias EmojiReaction = (emoji: String, maxScore: Int)
+public typealias EmojiReactionTypes = [String: EmojiReaction]
+
+extension EmojiReactionTypes {
+    func sorted(with preferredEmojiOrder: [String]) -> [Element] {
+        sorted(by: {
+            let lhsIndex = preferredEmojiOrder.index(of: $0.value.emoji)
+            let rhsIndex = preferredEmojiOrder.index(of: $1.value.emoji)
+            
+            switch (lhsIndex, rhsIndex) {
+            case (.some(let lhs), .some(let rhs)):
+                return lhs < rhs
+            case (.some(let lhs), .none):
+                return true
+            case (.none, .some(let rhs)):
+                return false
+            case (.none, .none):
+                return $0.value.emoji < $1.value.emoji
+            }
+        })
+    }
+}
 
 extension ChatViewController {
     

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -42,6 +42,12 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
         ["like": ("👍", 1), "love": ("❤️", 1), "haha": ("😂", 1), "wow": ("😲", 1), "sad": ("😔", 1), "angry": ("😠", 1)]
     }
     
+    /// A preferred order to display the emojis in the reaction view
+    public lazy var preferredEmojiOrder = defaultPreferredEmojiOrder
+    
+    /// A default preferred order to display the emojis in the reaction view
+    open var defaultPreferredEmojiOrder: [String] { ["👍", "❤️", "😂", "😲", "😔", "😠"] }
+    
     /// A dispose bag for rx subscriptions.
     public let disposeBag = DisposeBag()
     /// A list of table view items, e.g. messages.

--- a/Sources/UI/Views/ReactionsView.swift
+++ b/Sources/UI/Views/ReactionsView.swift
@@ -36,6 +36,8 @@ final class ReactionsView: UIView {
         return view
     }()
     
+    public var preferredEmojiOrder = ["👍", "❤️", "😂", "😲", "😔", "😠"]
+    
     func show(emojiReactionTypes: EmojiReactionTypes, at point: CGPoint, for message: Message, completion: @escaping Completion) {
         addSubview(reactionsView)
         self.emojiReactionTypes = emojiReactionTypes
@@ -59,7 +61,7 @@ final class ReactionsView: UIView {
         reactionsView.transform = .init(scaleX: 0.5, y: 0.5)
         alpha = 0
         
-        emojiReactionTypes.forEach { (reactionType, emoji) in
+        emojiReactionTypes.sorted(with: preferredEmojiOrder).forEach { (reactionType, emoji) in
             let users = message.latestReactions.filter({ $0.type == reactionType }).compactMap({ $0.user })
             let reaction: Reaction
             let score = message.reactionScores[reactionType] ?? 0

--- a/Sources/UI/Views/ReactionsView.swift
+++ b/Sources/UI/Views/ReactionsView.swift
@@ -36,9 +36,7 @@ final class ReactionsView: UIView {
         return view
     }()
     
-    public var preferredEmojiOrder = ["👍", "❤️", "😂", "😲", "😔", "😠"]
-    
-    func show(emojiReactionTypes: EmojiReactionTypes, at point: CGPoint, for message: Message, completion: @escaping Completion) {
+    func show(emojiReactionTypes: EmojiReactionTypes, at point: CGPoint, for message: Message, with preferredEmojiOrder: [String], completion: @escaping Completion) {
         addSubview(reactionsView)
         self.emojiReactionTypes = emojiReactionTypes
         reactionScores = message.reactionScores


### PR DESCRIPTION
I had to make it a little more complex than just sorting with < since that yields:
<img width="294" alt="Screen Shot 2020-06-30 at 22 01 44" src="https://user-images.githubusercontent.com/5606812/86196189-134ba800-bb29-11ea-9247-87bbadbd295c.png">
And that's a weird order to have. It makes more sense to have this which is in line with most social platforms:
<img width="298" alt="Screen Shot 2020-06-30 at 22 39 39" src="https://user-images.githubusercontent.com/5606812/86196210-1e9ed380-bb29-11ea-8a4e-f461e6bebe4a.png">

Ideally, the dictionary would be an array of `(type: String, (emoji: String, maxScore: String))`, but this would break API for `defaultEmojiReactionTypes`.

Closes #332 