### PR TITLE
CIS-193 Improve ClientError printing

### DIFF
--- a/StreamChatClient_v3/APIClient/RequestDecoder.swift
+++ b/StreamChatClient_v3/APIClient/RequestDecoder.swift
@@ -79,6 +79,6 @@ struct DefaultRequestDecoder: RequestDecoder {
 extension ClientError {
     class ExpiredToken: ClientError {}
     class ResponseBodyEmpty: ClientError {
-        var localizedDescription = "Response body is empty."
+        override var localizedDescription: String { "Response body is empty." }
     }
 }

--- a/StreamChatClient_v3/APIClient/RequestEncoder.swift
+++ b/StreamChatClient_v3/APIClient/RequestEncoder.swift
@@ -176,9 +176,9 @@ protocol ConnectionIdProviderDelegate: AnyObject {
 }
 
 extension ClientError {
-    class InvalidURL: CustomMessageError {}
-    class InvalidJSON: CustomMessageError {}
-    class MissingConnectionId: CustomMessageError {}
+    class InvalidURL: ClientError {}
+    class InvalidJSON: ClientError {}
+    class MissingConnectionId: ClientError {}
 }
 
 /// A helper extension allowing to create `URLQueryItems` using a dictionary literal like:

--- a/StreamChatClient_v3/ChatClient.swift
+++ b/StreamChatClient_v3/ChatClient.swift
@@ -239,6 +239,6 @@ extension Client {
 extension ClientError {
     // An example of a simple error
     public class MissingLocalStorageURL: ClientError {
-        public let localizedDescription: String = "The URL provided in ChatClientConfig is `nil`."
+        override public var localizedDescription: String { "The URL provided in ChatClientConfig is `nil`." }
     }
 }

--- a/StreamChatClient_v3/Models/ChannelId.swift
+++ b/StreamChatClient_v3/Models/ChannelId.swift
@@ -22,6 +22,7 @@ public struct ChannelId: Hashable, CustomStringConvertible {
     init(cid: String) throws {
         if cid == ChannelId.any {
             self.init(type: .unknown, id: Self.any)
+            return
         }
         
         if cid.contains(ChannelId.separator) {

--- a/StreamChatClient_v3/Models/ChannelId.swift
+++ b/StreamChatClient_v3/Models/ChannelId.swift
@@ -70,5 +70,5 @@ extension ChannelId: Codable {
 }
 
 extension ClientError {
-    public class InvalidChannelId: CustomMessageError {}
+    public class InvalidChannelId: ClientError {}
 }

--- a/StreamChatClient_v3/WebSocketClient/Events/ChannelEvents.swift
+++ b/StreamChatClient_v3/WebSocketClient/Events/ChannelEvents.swift
@@ -18,11 +18,11 @@ public struct AddedToChannel<ExtraData: ExtraDataTypes>: ChannelEvent, EventWith
     init?(from eventPayload: EventPayload<ExtraData>) throws {
         guard eventPayload.eventType == Self.eventRawType else { return nil }
         guard eventPayload.channel != nil else {
-            throw ClientError.EventDecodingError("`channel` field can't be `nil` for the `AddedToChannel` event.")
+            throw ClientError.EventDecoding("`channel` field can't be `nil` for the `AddedToChannel` event.")
         }
         
         guard let cid = eventPayload.cid else {
-            throw ClientError.EventDecodingError("`cid` field can't be `nil` for the `AddedToChannel` event.")
+            throw ClientError.EventDecoding("`cid` field can't be `nil` for the `AddedToChannel` event.")
         }
         
         self.init(cid: cid, eventPayload: eventPayload)

--- a/StreamChatClient_v3/WebSocketClient/Events/ConnectionEvents.swift
+++ b/StreamChatClient_v3/WebSocketClient/Events/ConnectionEvents.swift
@@ -16,7 +16,7 @@ public struct HealthCheck: ConnectionEvent {
     init?<ExtraData: ExtraDataTypes>(from eventResponse: EventPayload<ExtraData>) throws {
         guard eventResponse.eventType == Self.eventRawType else { return nil }
         guard let connectionId = eventResponse.connectionId else {
-            throw ClientError.EventDecodingError(missingValue: "connectionId", eventType: "HealthCheck")
+            throw ClientError.EventDecoding(missingValue: "connectionId", eventType: "HealthCheck")
         }
         self.connectionId = connectionId
     }

--- a/StreamChatClient_v3/WebSocketClient/Events/EventDecoder.swift
+++ b/StreamChatClient_v3/WebSocketClient/Events/EventDecoder.swift
@@ -28,21 +28,17 @@ struct EventDecoder<ExtraData: ExtraDataTypes> {
 
 extension ClientError {
     public class UnsupportedEventType: ClientError {
-        public let localizedDescription = "The incoming event type is not supported. Ignoring."
+        override public var localizedDescription: String { "The incoming event type is not supported. Ignoring." }
     }
     
-    public class EventDecodingError: ClientError {
-        init(_ message: String, _ file: StaticString = #file, _ line: UInt = #line) {
-            localizedDescription = message
-            super.init(file, line)
+    public class EventDecoding: ClientError {
+        override init(_ message: String, _ file: StaticString = #file, _ line: UInt = #line) {
+            super.init(message, file, line)
         }
         
         init(missingValue: String, eventType: String, _ file: StaticString = #file, _ line: UInt = #line) {
-            localizedDescription = "`\(missingValue)` can't be `nil` for the `\(eventType)` event."
-            super.init(file, line)
+            super.init("`\(missingValue)` can't be `nil` for the `\(eventType)` event.", file, line)
         }
-        
-        let localizedDescription: String
     }
 }
 

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
@@ -224,7 +224,7 @@ extension WebSocketClient: WebSocketEngineDelegate {
             let webSocketError = message
                 .data(using: .utf8)
                 .map { try? JSONDecoder.default.decode(WebSocketErrorContainer.self, from: $0) }
-                .map { ClientError.WebSocketError(with: $0?.error) }
+                .map { ClientError.WebSocket(with: $0?.error) }
             
             if let webSocketError = webSocketError {
                 // If there is an error from the server, the connection is about to be disconnected
@@ -245,7 +245,7 @@ extension WebSocketClient: WebSocketEngineDelegate {
         }
         
         if shouldReconnect, let reconnectionDelay = reconnectionStrategy.reconnectionDelay(forConnectionError: disconnectionError) {
-            let clientError = disconnectionError.map { ClientError.WebSocketError(with: $0) }
+            let clientError = disconnectionError.map { ClientError.WebSocket(with: $0) }
             connectionState = .waitingForReconnect(error: clientError)
             
             reconnectionTimer = environment.timer
@@ -254,7 +254,7 @@ extension WebSocketClient: WebSocketEngineDelegate {
                 }
             
         } else {
-            connectionState = .notConnected(error: disconnectionError.map { ClientError.WebSocketError(with: $0) })
+            connectionState = .notConnected(error: disconnectionError.map { ClientError.WebSocket(with: $0) })
         }
     }
 }
@@ -277,7 +277,7 @@ extension Notification {
 }
 
 extension ClientError {
-    public class WebSocketError: ClientError {}
+    public class WebSocket: ClientError {}
 }
 
 /// WebSocket Error

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient_Tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient_Tests.swift
@@ -175,7 +175,7 @@ final class WebSocketClient_Tests: XCTestCase {
         AssertAsync {
             Assert.willBeEqual(self.reconnectionStrategy.reconnectionDelay_calledWithError as? WebSocketEngineError, testError)
             Assert.willBeEqual(self.webSocketClient.connectionState,
-                               .waitingForReconnect(error: ClientError.WebSocketError(with: testError)))
+                               .waitingForReconnect(error: ClientError.WebSocket(with: testError)))
         }
         
         // Simulate 10 seconds passed and check `connect` is not called yet


### PR DESCRIPTION
I went through existing cases for ClientError's. The idea to make ClientError more friendly on printing to confirm to `CustomStringConvertible` protocol. On the same time an error usually described by `localizedDescription` that used a lot in error subclasses, but we can't override variable in easier usage. So I made it as read only variable and now you can override it.

For example:
```swift
extension ClientError {
    class ImageURL: ClientError {
        override public var localizedDescription: String { "The image url is not valid." }
    }
}

let imageURLError = ClientError.ImageURL()
print(imageURLError)
// Error ImageURL in PrintError.playground:45 -> The image url is not valid.

// ClientError with some external error.
print(ClientError(with: imageURLError))
// Error ClientError in PrintError.playground:49 -> Error ImageURL in PrintError.playground:45 -> The image url is not valid.
```

On the same time you can create own initializer :
```Swift
extension ClientError {
    public class EventDecoding: ClientError {
        init(missingValue: String, eventType: String, _ file: StaticString = #file, _ line: UInt = #line) {
            super.init("`\(missingValue)` can't be `nil` for the `\(eventType)` event.", file, line)
        }
    }
}
```

Please try to avoid `Error` in subclasses in `ClientError` extensions:
```swift
extension ClientError {
    public class AnotherError: ClientError {} // ❌
}

extension ClientError {
    public class Another: ClientError {} // ✅
}
```

**Bugs**
- fixed ChannelId for the cid _any_.