### PR TITLE
Add parseMentionedUsers parameter to Client.send(message: ...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
+### ✅ Added
+- `parseMentionedUsers: Bool = true` parameter in `Client.send(message: ...)`. Setting to false allows custom mention parsing logic. [#338](https://github.com/GetStream/stream-chat-swift/issues/338)
+
 ### 🔄 Changed
 
 # [2.2.6](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Upcoming
 
 ### ✅ Added
-- `parseMentionedUsers: Bool = true` parameter in `Client.send(message: ...)`. Setting to false allows custom mention parsing logic. [#338](https://github.com/GetStream/stream-chat-swift/issues/338)
+- Parameters to allow custom mention parsing logic. If set to `false`, `Message.mentionedUsers` is not overridden on send. [#338](https://github.com/GetStream/stream-chat-swift/issues/338)
+  - `parseMentionedUsers: Bool = true` parameter in `Client.send(message: ...)`.
+  - `parseMentionedUsers: Bool = true` parameter in `ChannelPresenter.send(text: ...)`.
+  - `parseMentionedUsersOnSend: Bool = true` property in `ChatViewController`. 
 
 ### 🔄 Changed
 

--- a/Sources/Client/Client/Client+Channel.swift
+++ b/Sources/Client/Client/Client+Channel.swift
@@ -238,6 +238,7 @@ public extension Client {
     /// - Parameters:
     ///   - message: a message.
     ///   - channel: a channel.
+    ///   - parseMentionedUsers: whether to automatically parse mentions into the `message.mentionedUsers` property. Defaults to `true`.
     ///   - completion: a completion block with `MessageResponse`.
     @discardableResult
     func send(message: Message, to channel: Channel, parseMentionedUsers: Bool = true, _ completion: @escaping Client.Completion<MessageResponse>) -> Cancellable {

--- a/Sources/Client/Client/Client+Channel.swift
+++ b/Sources/Client/Client/Client+Channel.swift
@@ -241,7 +241,8 @@ public extension Client {
     ///   - parseMentionedUsers: whether to automatically parse mentions into the `message.mentionedUsers` property. Defaults to `true`.
     ///   - completion: a completion block with `MessageResponse`.
     @discardableResult
-    func send(message: Message, to channel: Channel, parseMentionedUsers: Bool = true, _ completion: @escaping Client.Completion<MessageResponse>) -> Cancellable {
+    func send(message: Message, to channel: Channel, parseMentionedUsers: Bool = true,
+              _ completion: @escaping Client.Completion<MessageResponse>) -> Cancellable {
         let completion = doAfter(completion) { [unowned self] response in
             if response.message.isBan, !self.user.isBanned {
                 self.userAtomic.isBanned = true

--- a/Sources/Core/Client/Channel/Channel+RxRequests.swift
+++ b/Sources/Core/Client/Channel/Channel+RxRequests.swift
@@ -86,9 +86,11 @@ public extension Reactive where Base == Channel {
     // MARK: - Message
     
     /// Send a new message or update with a given `message.id`.
-    /// - Parameter message: a message.
-    func send(message: Message) -> Observable<MessageResponse> {
-        Client.shared.rx.send(message: message, to: base)
+    /// - Parameters:
+    ///   - message: a message.
+    ///   - parseMentionedUsers: whether to automatically parse mentions into the `message.mentionedUsers` property. Defaults to `true`.
+    func send(message: Message, parseMentionedUsers: Bool = true) -> Observable<MessageResponse> {
+        Client.shared.rx.send(message: message, to: base, parseMentionedUsers: parseMentionedUsers)
     }
     
     /// Send a message action for a given ephemeral message.

--- a/Sources/Core/Client/Client+RxChannel.swift
+++ b/Sources/Core/Client/Client+RxChannel.swift
@@ -120,9 +120,10 @@ public extension Reactive where Base == Client {
     /// - Parameters:
     ///   - message: a message.
     ///   - channel: a channel.
-    func send(message: Message, to channel: Channel) -> Observable<MessageResponse> {
+    ///   - parseMentionedUsers: whether to automatically parse mentions into the `message.mentionedUsers` property. Defaults to `true`.
+    func send(message: Message, to channel: Channel, parseMentionedUsers: Bool = true) -> Observable<MessageResponse> {
         connected(request({ [unowned base] completion in
-            base.send(message: message, to: channel, completion)
+            base.send(message: message, to: channel, parseMentionedUsers: parseMentionedUsers, completion)
         }))
     }
     

--- a/Sources/Core/Presenter/Channel/ChannelPresenter+RxRequests.swift
+++ b/Sources/Core/Presenter/Channel/ChannelPresenter+RxRequests.swift
@@ -109,9 +109,11 @@ public extension Reactive where Base == ChannelPresenter {
     /// - Parameters:
     ///   - text: a message text.
     ///   - showReplyInChannel: show a reply in the channel.
+    ///   - parseMentionedUsers: whether to automatically parse mentions into the `message.mentionedUsers` property. Defaults to `true`.
     /// - Returns: an observable `MessageResponse`.
-    func send(text: String, showReplyInChannel: Bool = false) -> Observable<MessageResponse> {
-        base.channel.rx.send(message: base.createMessage(with: text, showReplyInChannel: showReplyInChannel))
+    func send(text: String, showReplyInChannel: Bool = false, parseMentionedUsers: Bool = true) -> Observable<MessageResponse> {
+        let message = base.createMessage(with: text, showReplyInChannel: showReplyInChannel)
+        return base.channel.rx.send(message: message, parseMentionedUsers: parseMentionedUsers)
             .do(onNext: { [weak base] in base?.updateEphemeralMessage($0.message) })
             .observeOn(MainScheduler.instance)
     }

--- a/Sources/Core/Presenter/Channel/ChannelPresenter.swift
+++ b/Sources/Core/Presenter/Channel/ChannelPresenter.swift
@@ -162,9 +162,10 @@ extension ChannelPresenter {
     /// - Parameters:
     ///     - text: a message text
     ///     - showReplyInChannel: show a reply in the channel.
+    ///     - parseMentionedUsers: whether to automatically parse mentions into the `message.mentionedUsers` property. Defaults to `true`.
     ///     - completion: a completion block with `MessageResponse`.
-    public func send(text: String, showReplyInChannel: Bool = false, _ completion: @escaping Client.Completion<MessageResponse>) {
-        rx.send(text: text, showReplyInChannel: showReplyInChannel).bindOnce(to: completion)
+    public func send(text: String, showReplyInChannel: Bool = false, parseMentionedUsers: Bool = true, _ completion: @escaping Client.Completion<MessageResponse>) {
+        rx.send(text: text, showReplyInChannel: showReplyInChannel, parseMentionedUsers: parseMentionedUsers).bindOnce(to: completion)
     }
     
     func createMessage(with text: String, showReplyInChannel: Bool) -> Message {

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
@@ -193,7 +193,9 @@ extension ChatViewController {
         // in case their internet is slow and message isn't sent immediately
         composerView.sendButton.isEnabled = false
         
-        presenter?.rx.send(text: text, showReplyInChannel: composerView.alsoSendToChannelButton.isSelected)
+        presenter?.rx.send(text: text,
+                           showReplyInChannel: composerView.alsoSendToChannelButton.isSelected,
+                           parseMentionedUsers: parseMentionedUsersOnSend)
             .subscribe(
                 onNext: { [weak self] messageResponse in
                     if messageResponse.message.type == .error {

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -48,6 +48,9 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
     /// A default preferred order to display the emojis in the reaction view
     open var defaultPreferredEmojiOrder: [String] { ["👍", "❤️", "😂", "😲", "😔", "😠"] }
     
+    /// Whether to automatically parse mentions into the `message.mentionedUsers` property on send. Defaults to `true`.
+    open var parseMentionedUsersOnSend = true
+    
     /// A dispose bag for rx subscriptions.
     public let disposeBag = DisposeBag()
     /// A list of table view items, e.g. messages.


### PR DESCRIPTION
I opted to add parseMentionedUsers parameter with default true to avoid a breaking change

Closes #338 
