### PR TITLE
CIS-219 Implement search with message_filter_conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
+### ✅ Added
+- Message search with filter for messages [#348](https://github.com/GetStream/stream-chat-swift/pull/348)
+  - `Client.search(filter: Filter, messageFilter: Filter, ...)` [#348](https://github.com/GetStream/stream-chat-swift/pull/348)
+  - `SearchQuery.init(filter: Filter, messageFilter: Filter, ...)` [#348](https://github.com/GetStream/stream-chat-swift/pull/348)
+- `Filter.exists(Key, Bool)` [#348](https://github.com/GetStream/stream-chat-swift/pull/348)
+
 ### 🔄 Changed
 
 # [2.2.6](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.6)

--- a/Sources/Client/Client/Client+Channels.swift
+++ b/Sources/Client/Client/Client+Channels.swift
@@ -14,7 +14,7 @@ public extension Client {
     
     /// A message search. Creates a `SearchQuery` with given parameters and call `search` with it.
     /// - Parameters:
-    ///   - filter: a filter for channels, e.g. `"members".in(["john"])`
+    ///   - filter: a filter for channels, e.g. `.in("members", ["john"])`
     ///   - query: a search query.
     ///   - pagination: a pagination. It works via the standard limit and offset parameters.
     ///   - completion: a completion block with `[Message]`.
@@ -28,7 +28,7 @@ public extension Client {
     
     /// A message search. Creates a `SearchQuery` with given parameters and call `search` with it.
     /// - Parameters:
-    ///   - filter: a filter for channels, e.g. `"members", .in(["john"])`
+    ///   - filter: a filter for channels, e.g. `.in("members", ["john"])`
     ///   - messageFilter: a filter for messages, e.g. `.exists("attachments", true)`
     ///   - pagination: a pagination. It works via the standard limit and offset parameters.
     ///   - completion: a completion block with `[Message]`.

--- a/Sources/Client/Client/Client+Channels.swift
+++ b/Sources/Client/Client/Client+Channels.swift
@@ -26,6 +26,20 @@ public extension Client {
         search(query: SearchQuery(filter: filter, query: query, pagination: pagination), completion)
     }
     
+    /// A message search. Creates a `SearchQuery` with given parameters and call `search` with it.
+    /// - Parameters:
+    ///   - filter: a filter for channels, e.g. `"members", .in(["john"])`
+    ///   - messageFilter: a filter for messages, e.g. `.exists("attachments", true)`
+    ///   - pagination: a pagination. It works via the standard limit and offset parameters.
+    ///   - completion: a completion block with `[Message]`.
+    @discardableResult
+    func search(filter: Filter,
+                messageFilter: Filter,
+                pagination: Pagination = [.channelsPageSize],
+                _ completion: @escaping Client.Completion<[Message]>) -> Cancellable {
+        search(query: SearchQuery(filter: filter, messageFilter: messageFilter, pagination: pagination), completion)
+    }
+    
     /// A message search with a given query (see `SearchQuery`).
     /// - Parameters:
     ///   - query: a search query.

--- a/Sources/Client/Model/Filter.swift
+++ b/Sources/Client/Model/Filter.swift
@@ -53,6 +53,8 @@ public enum Filter: Encodable, CustomStringConvertible {
     case autocomplete(Key, with: String)
     /// Contains operator
     case contains(Key, Encodable)
+    /// Exists operator
+    case exists(Key, Bool)
     /// A custom operator. Please make sure to provide a valid operator.
     /// Example:  `.custom("contains", key: "teams", value: "red")`
     case custom(String, key: Key, value: Encodable)
@@ -92,6 +94,8 @@ public enum Filter: Encodable, CustomStringConvertible {
             return "\(key) AUTOCOMPLETE \(object)"
         case let .contains(key, object):
             return "\(key) CONTAINS \(object)"
+        case let .exists(key, boolean):
+            return "\(key) EXISTS \(boolean)"
         case let .custom(`operator`, key, object):
             return "\(key) \(`operator`.uppercased()) \(object)"
         case .and(let filters):
@@ -155,6 +159,10 @@ public enum Filter: Encodable, CustomStringConvertible {
             keyOperand = key
             operatorName = "$contains"
             operand = object
+        case let .exists(key, boolean):
+            keyOperand = key
+            operatorName = "$exists"
+            operand = boolean
         case let .custom(`operator`, key, object):
             keyOperand = key
             operatorName = "$\(`operator`)"

--- a/Sources/Client/Model/SearchQuery.swift
+++ b/Sources/Client/Model/SearchQuery.swift
@@ -28,7 +28,7 @@ public struct SearchQuery: Encodable {
     
     /// A message search query.
     /// - Parameters:
-    ///   - filter: a filter for channels, e.g. `"members", .in(["john"])`
+    ///   - filter: a filter for channels, e.g. `.in("members", ["john"])`
     ///   - query: a search query.
     ///   - pagination: a pagination. It works via the standard limit and offset parameters.
     public init(filter: Filter, query: String, pagination: Pagination = [.channelsPageSize]) {
@@ -37,7 +37,7 @@ public struct SearchQuery: Encodable {
     
     /// A message search query.
     /// - Parameters:
-    ///   - filter: a filter for channels, e.g. `"members", .in(["john"])`
+    ///   - filter: a filter for channels, e.g. `.in("members", ["john"])`
     ///   - messageFilter: a filter for messages, e.g. `.exists("attachments", true)`
     ///   - pagination: a pagination. It works via the standard limit and offset parameters.
     public init(filter: Filter, messageFilter: Filter, pagination: Pagination = [.channelsPageSize]) {

--- a/Sources/Client/Model/SearchQuery.swift
+++ b/Sources/Client/Model/SearchQuery.swift
@@ -13,11 +13,14 @@ import Foundation
 public struct SearchQuery: Encodable {
     private enum CodingKeys: String, CodingKey {
         case filter = "filter_conditions"
+        case messageFilter = "message_filter_conditions"
         case query
     }
     
     /// A filter for channels, e.g. `"members".in(["john"])`
     public let filter: Filter
+    /// A fiter for messages, e.g. `.exists("attachments", true)`
+    public let messageFilter: Filter
     /// A search query.
     public let query: String
     /// A pagination. It works via the standard limit and offset parameters.
@@ -29,12 +32,26 @@ public struct SearchQuery: Encodable {
     ///   - query: a search query.
     ///   - pagination: a pagination. It works via the standard limit and offset parameters.
     public init(filter: Filter, query: String, pagination: Pagination = [.channelsPageSize]) {
+        self.init(filter: filter, messageFilter: .none, query: query, pagination: pagination)
+    }
+    
+    /// A message search query.
+    /// - Parameters:
+    ///   - filter: a filter for channels, e.g. `"members", .in(["john"])`
+    ///   - messageFilter: a filter for messages, e.g. `.exists("attachments", true)`
+    ///   - pagination: a pagination. It works via the standard limit and offset parameters.
+    public init(filter: Filter, messageFilter: Filter, pagination: Pagination = [.channelsPageSize]) {
+        self.init(filter: filter, messageFilter: messageFilter, query: "", pagination: pagination)
+    }
+    
+    init(filter: Filter, messageFilter: Filter, query: String, pagination: Pagination = [.channelsPageSize]) {
         ClientLogger.log("⚠️",
                          level: .debug,
                          "search is not guaranteed to return a result when no filter is specified. "
                             + "Please specify a valid filter. "
                             + "Break on \(#file) \(#line) to catch this issue.")
         self.filter = filter
+        self.messageFilter = messageFilter
         self.query = query
         self.pagination = pagination
     }
@@ -42,6 +59,7 @@ public struct SearchQuery: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(filter, forKey: .filter)
+        try container.encode(messageFilter, forKey: .messageFilter)
         try container.encode(query, forKey: .query)
         try pagination.encode(to: encoder)
     }

--- a/Tests/Client/Unit Tests/QueryEncodingTests.swift
+++ b/Tests/Client/Unit Tests/QueryEncodingTests.swift
@@ -52,7 +52,17 @@ final class QueryEncodingTests: XCTestCase {
                                   query: "hello",
                                   pagination: self.mediumPagination()) }
 
-        let expectedString = #"{"limit":10,"query":"hello","offset":20,"filter_conditions":{"$and":[{"members":{"$in":["john"]}},{"id":{"$autocomplete":"ro"}}]}}"#
+        let expectedString = #"{"limit":10,"query":"hello","offset":20,"filter_conditions":{"$and":[{"members":{"$in":["john"]}},{"id":{"$autocomplete":"ro"}}]},"message_filter_conditions":{}}"#
+
+        AssertJSONEqual(Data(expectedString.utf8), try encode(query()))
+    }
+    
+    func testSearchQueryMessageFilterEncoding() {
+        let query = { SearchQuery(filter: self.mediumFilter,
+                                  messageFilter: .exists("attachments", true),
+                                  pagination: self.mediumPagination()) }
+
+        let expectedString = #"{"limit":10,"query":"","offset":20,"filter_conditions":{"$and":[{"members":{"$in":["john"]}},{"id":{"$autocomplete":"ro"}}]},"message_filter_conditions":{"attachments":{"$exists":true}}}"#
 
         AssertJSONEqual(Data(expectedString.utf8), try encode(query()))
     }


### PR DESCRIPTION
Changes
- Added `Client.search(filter: Filter, messageFilter: Filter, ...)`
- Added `SearchQuery.init(filter: Filter, messageFilter: Filter, ...)`
- Added `Filter.exists(Key, Bool)`

API doesn't accept SearchQuery with `query` and `messageFilter` at the same time, that's why it has two initializers now.

Sample usage:

```swift
Client.shared.search(filter: .equal("id", to: "general"), messageFilter: .exists("attachments", true)) { result in
    switch result {
    case let .success(messages):
        print(messages)
    case let .failure(error):
        print(error)
    }
}
```