### PR TITLE
[CIS-202] Create Combine wrapper for `ChannelListController`

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		792921C924C056F400116BBB /* ChannelListController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792921C824C056F400116BBB /* ChannelListController_Tests.swift */; };
 		792921CB24C077B400116BBB /* TestDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792921CA24C077B400116BBB /* TestDispatchQueue.swift */; };
 		792921CD24C07A9000116BBB /* QueueAwareDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792921CC24C07A9000116BBB /* QueueAwareDelegate.swift */; };
+		792921CF24C08D2F00116BBB /* ChannelListControllerPublishers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792921CE24C08D2F00116BBB /* ChannelListControllerPublishers.swift */; };
+		792921D124C1DAB200116BBB /* ChannelListControllerPublishers_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792921D024C1DAB200116BBB /* ChannelListControllerPublishers_Tests.swift */; };
 		792A4F1B247FE84900EAF71D /* ChannelListQueryUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F1A247FE84900EAF71D /* ChannelListQueryUpdater.swift */; };
 		792A4F1D247FEA2200EAF71D /* ChannelListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F1C247FEA2200EAF71D /* ChannelListController.swift */; };
 		792A4F25247FF01800EAF71D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F24247FF01800EAF71D /* AppDelegate.swift */; };
@@ -522,6 +524,8 @@
 		792921C824C056F400116BBB /* ChannelListController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListController_Tests.swift; sourceTree = "<group>"; };
 		792921CA24C077B400116BBB /* TestDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDispatchQueue.swift; sourceTree = "<group>"; };
 		792921CC24C07A9000116BBB /* QueueAwareDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueAwareDelegate.swift; sourceTree = "<group>"; };
+		792921CE24C08D2F00116BBB /* ChannelListControllerPublishers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListControllerPublishers.swift; sourceTree = "<group>"; };
+		792921D024C1DAB200116BBB /* ChannelListControllerPublishers_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListControllerPublishers_Tests.swift; sourceTree = "<group>"; };
 		792A4F1A247FE84900EAF71D /* ChannelListQueryUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListQueryUpdater.swift; sourceTree = "<group>"; };
 		792A4F1C247FEA2200EAF71D /* ChannelListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListController.swift; sourceTree = "<group>"; };
 		792A4F22247FF01800EAF71D /* V3SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = V3SampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1334,6 +1338,8 @@
 				799C944B247D5766001F1104 /* ChannelController.swift */,
 				792A4F1C247FEA2200EAF71D /* ChannelListController.swift */,
 				792921C824C056F400116BBB /* ChannelListController_Tests.swift */,
+				792921CE24C08D2F00116BBB /* ChannelListControllerPublishers.swift */,
+				792921D024C1DAB200116BBB /* ChannelListControllerPublishers_Tests.swift */,
 				79E2B83F24CAC8D60024752F /* ChangeAggregator.swift */,
 				793C14DB24BF2A0800B8BFB7 /* ChangeAggregator_Tests.swift */,
 			);
@@ -2532,6 +2538,7 @@
 				79280F4F2485308100CDEB89 /* Controller.swift in Sources */,
 				79877A252498E50D00015F8B /* TeamDTO.swift in Sources */,
 				7964F3B7249A314D002A09EC /* LogFormatter.swift in Sources */,
+				792921CF24C08D2F00116BBB /* ChannelListControllerPublishers.swift in Sources */,
 				792A4F40247FFDE700EAF71D /* Data+Gzip.swift in Sources */,
 				79E2B84024CAC8D60024752F /* ChangeAggregator.swift in Sources */,
 				796610B9248E651800761629 /* EventMiddleware.swift in Sources */,
@@ -2644,6 +2651,7 @@
 				799BE2EC248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift in Sources */,
 				79682C5024C061B20071578E /* ChannelListPayload_Tests.swift in Sources */,
 				79280F8424891C6A00CDEB89 /* VirtualTime.swift in Sources */,
+				792921D124C1DAB200116BBB /* ChannelListControllerPublishers_Tests.swift in Sources */,
 				799C9476247D7E94001F1104 /* TemporaryData.swift in Sources */,
 				792921C724C047DD00116BBB /* APIClient_Mock.swift in Sources */,
 				79A0E9BC2498C31A00E9BD50 /* TypingStartCleanupMiddleware_Tests.swift in Sources */,

--- a/StreamChatClient_v3/Controllers/ChannelListController.swift
+++ b/StreamChatClient_v3/Controllers/ChannelListController.swift
@@ -105,6 +105,8 @@ public class ChannelListControllerGeneric<ExtraData: ExtraDataTypes>: Controller
             return
         }
         
+        state = .active
+        
         channels = fetchedResultsController.fetchedObjects!.lazy.map(ChannelModel<ExtraData>.create)
         
         delegateCallback {

--- a/StreamChatClient_v3/Controllers/ChannelListControllerPublishers.swift
+++ b/StreamChatClient_v3/Controllers/ChannelListControllerPublishers.swift
@@ -1,0 +1,121 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import UIKit
+
+@available(iOS 13, *)
+extension Client {
+    /// Creates a new `ChannelListController.Publishers` object with the provided channel query.
+    ///
+    /// - Parameter query: The query specify the filter and sorting of the channels the controller should fetch.
+    /// - Returns: A new instance of `ChannelListController.Publishers`.
+    ///
+    @available(iOS 13, *)
+    public func channelListControllerPublishers(query: ChannelListQuery) -> ChannelListControllerGeneric<ExtraData>.Publishers {
+        let controller = ChannelListControllerGeneric(query: query, client: self)
+        return .init(controller: controller)
+    }
+}
+
+/// Describes possible states of Controller's remote activity.
+public enum RemoteActivity {
+    /// The controller is not listening for updates. Call `startUpdating` to fetch the remote data and start listening for changes.
+    case none
+    
+    /// Controller actively tries to refresh the local data.
+    case fetchingRemoteData
+    
+    /// Controller is listening for incoming changes.
+    case listening
+    
+    /// Remote data fetch failed. Controller might still be able to show the recent incoming changes, but it's possible
+    /// the presented data are not complete.
+    case failed(error: Error?)
+}
+
+@available(iOS 13, *)
+extension ChannelListControllerGeneric {
+    /// An object which wraps `ChannelListController` and exposes its properties as Publishers.
+    public class Publishers {
+        /// Publishes changes to the remote activity state. You can use this publisher to show activity indicator to users
+        /// if the controller is fetching the remote data.
+        public var remoteActivityPublisher: AnyPublisher<RemoteActivity, Never> {
+            remoteActivity
+                // Is something like this the way to keep `Publishers` object alive if there is a subscriber?
+                .map { [self] in _ = self; return $0 }
+                .eraseToAnyPublisher()
+        }
+        
+        /// Publishes the changes to the list of channels matching the query. You can use this publisher to animate changes
+        /// to the channel list, or to simply reload all your the data.
+        ///
+        /// Alternatively, you can use `channelsDiffableDatasourcePublisher` which provides similar functionality using the
+        /// `NSDiffableDataSource` API.
+        ///
+        /// - Note: ⚠️ The publisher publishes only **changes** to the list of channels. Use the `channels` property to load
+        /// the initial data before subscribing to the publisher.
+        public var channelChangesPublisher: AnyPublisher<[Change<ChannelModel<ExtraData>>], Never> {
+            channelChanges
+                .map { [self] in _ = self; return $0 }
+                .eraseToAnyPublisher()
+        }
+        
+        // TODO: Implement
+        public var channelsDiffableDatasourcePublisher:
+            AnyPublisher<NSDiffableDataSourceSnapshot<ChannelListSection, ChannelModel<ExtraData>>, Never>! = nil
+        
+        /// The channels matching the query. If you want to react to changes in this field, subscribe to `channelChanges` publisher.
+        public var channels: [ChannelModel<ExtraData>] {
+            // Start observing changes if needed
+            if controller.state == .idle {
+                controller.startUpdating()
+            }
+            
+            return controller.channels
+        }
+        
+        /// The underlying controller instance of this wrapper.
+        let controller: ChannelListControllerGeneric
+        
+        /// A backing subject for `remoteActivityPublisher`.
+        private let remoteActivity: CurrentValueSubject<RemoteActivity, Never> = .init(.none)
+        
+        /// A backing subject for `channelChangesPublisher`.
+        private let channelChanges: PassthroughSubject<[Change<ChannelModel<ExtraData>>], Never> = .init()
+        
+        /// Creates a new `ChannelListControllerGeneric.Publishers` object.
+        /// - Parameter controller: The controller instance this wrapper wraps. The wrapper sets itself as the controller's
+        /// delegate, so be sure you always provide a fresh instance of the controller to the wrapper.
+        init(controller: ChannelListControllerGeneric) {
+            self.controller = controller
+            controller.setDelegate(self)
+        }
+    }
+}
+
+// TODO: for diffable datasource
+public enum ChannelListSection {
+    case main
+}
+
+@available(iOS 13, *)
+extension ChannelListControllerGeneric.Publishers: ChannelListControllerDelegateGeneric {
+    public func controllerWillStartFetchingRemoteData(_ controller: Controller) {
+        remoteActivity.send(.fetchingRemoteData)
+    }
+    
+    public func controllerDidStopFetchingRemoteData(_ controller: Controller, withError error: Error?) {
+        if let error = error {
+            remoteActivity.send(.failed(error: error))
+        } else {
+            remoteActivity.send(.listening)
+        }
+    }
+    
+    public func controller(_ controller: ChannelListControllerGeneric<ExtraData>,
+                           didChangeChannels changes: [Change<ChannelModel<ExtraData>>]) {
+        channelChanges.send(changes)
+    }
+}

--- a/StreamChatClient_v3/Controllers/ChannelListControllerPublishers_Tests.swift
+++ b/StreamChatClient_v3/Controllers/ChannelListControllerPublishers_Tests.swift
@@ -1,0 +1,109 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+@testable import StreamChatClient_v3
+import XCTest
+
+@available(iOS 13,*)
+class ChannelListControllerPublishers_Tests: XCTestCase {
+    // The references are weak to make sure the publishers keep these objects alive.
+    var client: ChatClient!
+    var query: ChannelListQuery!
+    
+    var cancellables: Set<AnyCancellable>!
+    
+    // Publishers reference. Once you set up the chain, set this to `nil` to test the existing subscriptions keep the
+    // underlying `Publishers` object alive.
+    var publishers: ChannelListController.Publishers?
+    
+    // Weak reference to underlying `ChannelListController`. It's weak because we want to test `Publishers` keeps a strong
+    // reference to it.
+    weak var controller: ChannelListController?
+    
+    override func setUp() {
+        super.setUp()
+        client = ChatClient(config: ChatClientConfig(apiKey: .init(.unique)))
+        query = ChannelListQuery(filter: .in("members", ["Luke"]))
+        
+        publishers = client.channelListControllerPublishers(query: query)
+        controller = publishers?.controller
+        
+        cancellables = []
+    }
+    
+    override func tearDown() {
+        // Clear up all cancellables and check `publishers` were deallocated
+        cancellables.removeAll()
+        publishers = nil
+        XCTAssertNil(publishers)
+    }
+    
+    func test_accessingChannelsStartsObserving() {
+        XCTAssertEqual(controller?.state, .idle)
+        _ = publishers?.channels
+        XCTAssertEqual(controller?.state, .active)
+    }
+    
+    func test_channelsAreExposed() {
+        // Let's just check the `channels` property of the controller is forwarded properly in `Publishers`
+        XCTAssert(controller!.channels as AnyObject === publishers!.channels as AnyObject)
+    }
+    
+    func test_remoteActivityPublisher() {
+        // Setup Recording publishers
+        var recording = Record<RemoteActivity, Never>.Recording()
+        
+        // Setup the chain
+        publishers!
+            .remoteActivityPublisher
+            .sink(receiveValue: { recording.receive($0) })
+            .store(in: &cancellables)
+        
+        // Remove the strong reference to `Publishers` object. The chain should keep it alive.
+        publishers = nil
+        
+        // Simulate delegate calls
+        controller?.anyDelegate?.controllerWillStartFetchingRemoteData(controller!)
+        controller?.anyDelegate?.controllerDidStopFetchingRemoteData(controller!, withError: nil)
+        let error = TestError()
+        controller?.anyDelegate?.controllerDidStopFetchingRemoteData(controller!, withError: error)
+        
+        XCTAssertEqual(recording.output, [.none, .fetchingRemoteData, .listening, .failed(error: error)])
+    }
+    
+    func test_channelChangesPublisher() {
+        // Setup Recording publishers
+        var recording = Record<[Change<Channel>], Never>.Recording()
+        
+        // Setup the chain
+        publishers!
+            .channelChangesPublisher
+            .sink(receiveValue: { recording.receive($0) })
+            .store(in: &cancellables)
+        
+        // Remove the strong reference to `Publishers` object. The chain should keep it alive.
+        publishers = nil
+        
+        // Simulate delegate calls
+        let insertedChannel = Channel(cid: .unique, extraData: .init(name: "Luke", imageURL: nil))
+        let movedChannel = Channel(cid: .unique, extraData: .init(name: "Leia", imageURL: nil))
+        
+        controller?.anyDelegate?.controller(controller!, didChangeChannels: [.insert(insertedChannel, index: [0, 1])])
+        controller?.anyDelegate?.controller(controller!, didChangeChannels: [
+            .move(movedChannel, fromIndex: [1, 0], toIndex: [2, 0])
+        ])
+        
+        XCTAssertEqual(recording.output, [
+            [.insert(insertedChannel, index: [0, 1])],
+            [.move(movedChannel, fromIndex: [1, 0], toIndex: [2, 0])]
+        ])
+    }
+}
+
+extension RemoteActivity: Equatable {
+    public static func == (lhs: RemoteActivity, rhs: RemoteActivity) -> Bool {
+        String(describing: lhs) == String(describing: rhs)
+    }
+}

--- a/StreamChatClient_v3/Controllers/ChannelListController_Tests.swift
+++ b/StreamChatClient_v3/Controllers/ChannelListController_Tests.swift
@@ -64,6 +64,12 @@ class ChannelListController_Tests: XCTestCase {
         XCTAssertEqual(controller.channels.map { $0.cid }, [cidMatchingQuery])
     }
     
+    func test_startUpdating_changeControllerState() throws {
+        XCTAssertEqual(controller.state, .idle)
+        controller.startUpdating()
+        XCTAssertEqual(controller.state, .active)
+    }
+    
     func test_startUpdating_callsChannelQueryUpdater() {
         // Simulate `startUpdating` calls and catch the completion
         var completionCalled = false

--- a/StreamChatClient_v3/Controllers/Controller.swift
+++ b/StreamChatClient_v3/Controllers/Controller.swift
@@ -6,6 +6,18 @@ import Foundation
 
 /// The base class for all controllers. Not meant to be used directly.
 public class Controller {
+    /// Describes the possible states of Controller
+    public enum State: Equatable {
+        /// The controller is idle. Call `startUpdating` to start listening for changes.
+        case idle
+        
+        /// The controller is active and is listening to changes.
+        case active
+    }
+    
+    /// The current state of the Controller.
+    public internal(set) var state: State = .idle
+    
     /// The queue which is used to perform callback calls. The default value is `.main`.
     public var callbackQueue: DispatchQueue = .main
 }

--- a/StreamChatClient_v3/Models/ChannelModel.swift
+++ b/StreamChatClient_v3/Models/ChannelModel.swift
@@ -142,9 +142,13 @@ public protocol ChannelExtraData: Codable & Hashable {}
 public protocol AnyChannel {}
 extension ChannelModel: AnyChannel {}
 
-extension ChannelModel: Equatable {
+extension ChannelModel: Hashable {
     public static func == (lhs: ChannelModel<ExtraData>, rhs: ChannelModel<ExtraData>) -> Bool {
         lhs.cid == rhs.cid
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(cid)
     }
 }
 


### PR DESCRIPTION
### In this PR:

This is just exploration work and a proof of concept. However, I think it's worth it to review and merge this, so we have some base for further improvements.

*Changes:*

- `Controller`s have a `state` variable that allows tracking, whether the controller is in the active or inactive state.

- `ChannelListController.Publishers` object wraps `ChannelListController` and exposes its properties via publishers. The main trick here is that the `Publishers` object sets itself as the controller's delegate. It contains a couple of "backing" subjects, that acts as private parent publishers for the publicly exposed ones.
