### PR TITLE
[CIS-171] Extend v3 CI builds to Release config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,8 @@ jobs:
     - name: Test SPM integration
       run: bundle exec fastlane test_spm_integration  
       
-  build-and-test-v3:
-    name: Build and Test v3
+  build-and-test-v3-debug:
+    name: Run v3 Tests (Debug)
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
@@ -129,5 +129,31 @@ jobs:
       run: bundle install
     - name: Install Carthage dependencies
       run: bundle exec fastlane carthage_bootstrap
-    - name: Build v3 target and run all tests
+    - name: Run v3 Tests (Debug)
       run: bundle exec fastlane test_v3
+
+  build-and-test-v3-release:
+    name: Run v3 Tests (Release)
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Cache Carthage dependencies
+      uses: actions/cache@v1.1.0
+      id: carthage-cache
+      with:
+        path: Carthage
+        key: ${{ runner.os }}-carthage-stable-${{ hashFiles('**/Cartfile.resolved') }}
+    - name: Cache RubyGems
+      uses: actions/cache@v1
+      id: rubygem-cache
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: ${{ runner.os }}-gem-
+    - name: Install RubyGems
+      if: steps.rubygem-cache.outputs.cache-hit != 'true'
+      run: bundle install
+    - name: Install Carthage dependencies
+      run: bundle exec fastlane carthage_bootstrap
+    - name: Run v3 Tests (Release)
+      run: bundle exec fastlane test_v3_release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-and-test:
-    name: Build and Test
+    name: Build and Test v2
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -3435,6 +3435,224 @@
 			};
 			name = Release;
 		};
+		A57E5C6D24C6FA3900187DC2 /* ReleaseTests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = Sources/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					"$(SRCROOT)/Carthage/Build/iOS",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = ReleaseTests;
+		};
+		A57E5C6E24C6FA3900187DC2 /* ReleaseTests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 2.0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatClient;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+			};
+			name = ReleaseTests;
+		};
+		A57E5C6F24C6FA3900187DC2 /* ReleaseTests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 2.0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatCore;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+			};
+			name = ReleaseTests;
+		};
+		A57E5C7024C6FA3900187DC2 /* ReleaseTests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 2.0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChat;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+			};
+			name = ReleaseTests;
+		};
+		A57E5C7124C6FA3900187DC2 /* ReleaseTests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				MARKETING_VERSION = 0.0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatRealm;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+			};
+			name = ReleaseTests;
+		};
+		A57E5C7224C6FA3900187DC2 /* ReleaseTests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				INFOPLIST_FILE = Sources/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.stream.StreamChatClientIntegrationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = ReleaseTests;
+		};
+		A57E5C7324C6FA3900187DC2 /* ReleaseTests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatClientTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = ReleaseTests;
+		};
+		A57E5C7424C6FA3900187DC2 /* ReleaseTests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatCoreTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = ReleaseTests;
+		};
+		A57E5C7524C6FA3900187DC2 /* ReleaseTests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = D48F367GRM;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				INFOPLIST_FILE = StreamChatClient_v3/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "io.getstream.StreamChatClient-v3";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = ReleaseTests;
+		};
+		A57E5C7624C6FA3900187DC2 /* ReleaseTests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = D48F367GRM;
+				INFOPLIST_FILE = TestResources_v3/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "io.getstream.StreamChatClientTests-v3";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = ReleaseTests;
+		};
+		A57E5C7724C6FA3900187DC2 /* ReleaseTests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = D48F367GRM;
+				INFOPLIST_FILE = V3SampleApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.V3SampleApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = ReleaseTests;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -3443,6 +3661,7 @@
 			buildConfigurations = (
 				792A4F36247FF01900EAF71D /* Debug */,
 				792A4F37247FF01900EAF71D /* Release */,
+				A57E5C7724C6FA3900187DC2 /* ReleaseTests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3452,6 +3671,7 @@
 			buildConfigurations = (
 				799C9421247D2F80001F1104 /* Debug */,
 				799C9422247D2F80001F1104 /* Release */,
+				A57E5C7524C6FA3900187DC2 /* ReleaseTests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3461,6 +3681,7 @@
 			buildConfigurations = (
 				799C945A247D59B1001F1104 /* Debug */,
 				799C945B247D59B1001F1104 /* Release */,
+				A57E5C7624C6FA3900187DC2 /* ReleaseTests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3470,6 +3691,7 @@
 			buildConfigurations = (
 				79EE393F2453204E0034EBF3 /* Debug */,
 				79EE39402453204E0034EBF3 /* Release */,
+				A57E5C7224C6FA3900187DC2 /* ReleaseTests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3479,6 +3701,7 @@
 			buildConfigurations = (
 				8A50696123CDEA31009F127A /* Debug */,
 				8A50696223CDEA31009F127A /* Release */,
+				A57E5C6E24C6FA3900187DC2 /* ReleaseTests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3488,6 +3711,7 @@
 			buildConfigurations = (
 				8A50696423CDEA31009F127A /* Debug */,
 				8A50696523CDEA31009F127A /* Release */,
+				A57E5C7324C6FA3900187DC2 /* ReleaseTests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3497,6 +3721,7 @@
 			buildConfigurations = (
 				8A559D29230D937C00E66096 /* Debug */,
 				8A559D2A230D937C00E66096 /* Release */,
+				A57E5C7424C6FA3900187DC2 /* ReleaseTests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3506,6 +3731,7 @@
 			buildConfigurations = (
 				8A8BB29A238452B600C2F9DE /* Debug */,
 				8A8BB29B238452B600C2F9DE /* Release */,
+				A57E5C7124C6FA3900187DC2 /* ReleaseTests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3515,6 +3741,7 @@
 			buildConfigurations = (
 				8AD5EC9522E9A3E8005CFAC9 /* Debug */,
 				8AD5EC9622E9A3E8005CFAC9 /* Release */,
+				A57E5C6D24C6FA3900187DC2 /* ReleaseTests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3524,6 +3751,7 @@
 			buildConfigurations = (
 				8AD5EC9822E9A3E8005CFAC9 /* Debug */,
 				8AD5EC9922E9A3E8005CFAC9 /* Release */,
+				A57E5C7024C6FA3900187DC2 /* ReleaseTests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3533,6 +3761,7 @@
 			buildConfigurations = (
 				8AD5ECA522E9B355005CFAC9 /* Debug */,
 				8AD5ECA622E9B355005CFAC9 /* Release */,
+				A57E5C6F24C6FA3900187DC2 /* ReleaseTests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -242,7 +242,12 @@ lane :get_next_issue_number do
   UI.success "Next markdown link is copied to your clipboard! ⬆️"
 end
 
-desc "Runs tests for v3 scheme"
+desc "Runs tests for v3 in Debug config"
 lane :test_v3 do
   scan(project: "StreamChat.xcodeproj", scheme: "StreamChatClient_v3", clean: true)
+end
+
+desc "Runs tests for v3 in Release config"
+lane :test_v3_release do
+  scan(project: "StreamChat.xcodeproj", scheme: "StreamChatClient_v3", clean: true, configuration: "ReleaseTests")
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -79,7 +79,12 @@ Get next PR number from github to be used in CHANGELOG
 ```
 fastlane test_v3
 ```
-Runs tests for v3 scheme
+Runs tests for v3 in Debug config
+### test_v3_release
+```
+fastlane test_v3_release
+```
+Runs tests for v3 in Release config
 
 ----
 


### PR DESCRIPTION
### In this PR:

CI now has a new job that builds and tests the v3 target in the Release configuration, too. I added a new configuration named `ReleaseTests`. This one inherits from `Release` but it has `enableTestability` set to `true`.
