### PR TITLE
[CIS-181][CIS-223] CI Improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Cache Carthage dependencies
-      uses: actions/cache@v1.1.0
+      uses: actions/cache@v2
       id: carthage-cache
       with:
         path: Carthage
@@ -66,7 +66,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Cache Carthage dependencies
-      uses: actions/cache@v1.1.0
+      uses: actions/cache@v2
       id: carthage-cache
       with:
         path: Carthage
@@ -126,7 +126,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Cache Carthage dependencies
-      uses: actions/cache@v1.1.0
+      uses: actions/cache@v2
       id: carthage-cache
       with:
         path: Carthage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
       run: bundle exec fastlane build_for_testing
     - name: Run all tests
       run: bundle exec fastlane test_without_building
-    # - name: Post Codecov report
-    #   run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }}
 
   run-danger:
     name: Run Danger
@@ -147,6 +145,8 @@ jobs:
       run: bundle exec fastlane carthage_bootstrap
     - name: Run v3 Tests (Debug)
       run: bundle exec fastlane test_v3
+    - name: Post Codecov report
+      run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }}
 
   build-and-test-v3-release:
     name: Run v3 Tests (Release)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       id: carthage-cache
       with:
         path: Carthage
-        key: ${{ runner.os }}-carthage-stable-${{ hashFiles('**/Cartfile.resolved') }}
+        key: ${{ runner.os }}-carthage-cache-${{ hashFiles('**/Cartfile.resolved') }}
     - name: Cache RubyGems
       uses: actions/cache@v1
       id: rubygem-cache
@@ -70,7 +70,7 @@ jobs:
       id: carthage-cache
       with:
         path: Carthage
-        key: ${{ runner.os }}-carthage-stable-${{ hashFiles('**/Cartfile.resolved') }}
+        key: ${{ runner.os }}-carthage-cache-${{ hashFiles('**/Cartfile.resolved') }}
     - name: Cache RubyGems
       uses: actions/cache@v1
       id: rubygem-cache
@@ -130,7 +130,7 @@ jobs:
       id: carthage-cache
       with:
         path: Carthage
-        key: ${{ runner.os }}-carthage-stable-${{ hashFiles('**/Cartfile.resolved') }}
+        key: ${{ runner.os }}-carthage-cache-${{ hashFiles('**/Cartfile.resolved') }}
     - name: Cache RubyGems
       uses: actions/cache@v1
       id: rubygem-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,26 @@ jobs:
       run: bundle exec fastlane test_without_building
     # - name: Post Codecov report
     #   run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }}
-    - name: Run Danger - Code conventions & linting
-      run: bundle exec danger
-      env:
-        GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+
+  run-danger:
+    name: Run Danger
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Cache RubyGems
+        uses: actions/cache@v1
+        id: rubygem-cache
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: ${{ runner.os }}-gem-
+      - name: Install RubyGems
+        if: steps.rubygem-cache.outputs.cache-hit != 'true'
+        run: bundle install
+      - name: Run Danger
+        run: bundle exec danger
+        env:
+          GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
 
   test-carthage-integration:
     name: Test Carthage integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         path: Carthage
         key: ${{ runner.os }}-carthage-cache-${{ hashFiles('**/Cartfile.resolved') }}
     - name: Cache RubyGems
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       id: rubygem-cache
       with:
         path: vendor/bundle
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Cache RubyGems
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         id: rubygem-cache
         with:
           path: vendor/bundle
@@ -72,7 +72,7 @@ jobs:
         path: Carthage
         key: ${{ runner.os }}-carthage-cache-${{ hashFiles('**/Cartfile.resolved') }}
     - name: Cache RubyGems
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       id: rubygem-cache
       with:
         path: vendor/bundle
@@ -90,7 +90,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Cache RubyGems
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       id: rubygem-cache
       with:
         path: vendor/bundle
@@ -108,7 +108,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Cache RubyGems
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       id: rubygem-cache
       with:
         path: vendor/bundle
@@ -132,7 +132,7 @@ jobs:
         path: Carthage
         key: ${{ runner.os }}-carthage-cache-${{ hashFiles('**/Cartfile.resolved') }}
     - name: Cache RubyGems
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       id: rubygem-cache
       with:
         path: vendor/bundle
@@ -154,13 +154,13 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Cache Carthage dependencies
-      uses: actions/cache@v1.1.0
+      uses: actions/cache@v2
       id: carthage-cache
       with:
         path: Carthage
-        key: ${{ runner.os }}-carthage-stable-${{ hashFiles('**/Cartfile.resolved') }}
+        key: ${{ runner.os }}-carthage-cache-${{ hashFiles('**/Cartfile.resolved') }}
     - name: Cache RubyGems
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       id: rubygem-cache
       with:
         path: vendor/bundle

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,0 +1,32 @@
+name: Stres Tests (v3)
+
+on:
+  schedule:
+    - cron: '0 1 * * *' # run at 1AM UTC
+
+jobs:
+    v3-stress-tests:
+      name: Run Stress Tests (v3)
+      runs-on: macos-latest
+      steps:
+      - uses: actions/checkout@v1
+      - name: Cache Carthage dependencies
+        uses: actions/cache@v2
+        id: carthage-cache
+        with:
+          path: Carthage
+          key: ${{ runner.os }}-carthage-cache-${{ hashFiles('**/Cartfile.resolved') }}
+      - name: Cache RubyGems
+        uses: actions/cache@v1
+        id: rubygem-cache
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: ${{ runner.os }}-gem-
+      - name: Install RubyGems
+        if: steps.rubygem-cache.outputs.cache-hit != 'true'
+        run: bundle install
+      - name: Install Carthage dependencies
+        run: bundle exec fastlane carthage_bootstrap
+      - name: Run Stress Tests
+        run: bundle exec fastlane stress_test_v3

--- a/Dangerfile
+++ b/Dangerfile
@@ -39,6 +39,9 @@ if !has_changelog_escape && !git.modified_files.include?("CHANGELOG.md") && has_
     fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/GetStream/stream-chat-swift/blob/master/CHANGELOG.md).")
 end
 
+# Check all commits have correct format
+commit_lint.check
+
 swiftlint.config_file = '.swiftlint.yml'
 swiftlint.directory = 'Sources'
 swiftlint.lint_files inline_mode: true

--- a/Example/Carthage/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/Carthage/ChatExample.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		8AD5EC6D22E88C62005CFAC9 /* ChatExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChatExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AD5EC7C22E88C63005CFAC9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8AD5EC8422E88DBC005CFAC9 /* ChatExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ChatExample.entitlements; sourceTree = "<group>"; };
+		A57E5C7924C7438800187DC2 /* StreamChatClient_v3.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = StreamChatClient_v3.xctestplan; path = ../../StreamChatClient_v3.xctestplan; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -228,6 +229,7 @@
 		8AD5EC6422E88C62005CFAC9 = {
 			isa = PBXGroup;
 			children = (
+				A57E5C7924C7438800187DC2 /* StreamChatClient_v3.xctestplan */,
 				8A0A7E6F2301AC1E0033E6D9 /* StreamChat.xcodeproj */,
 				8AD5EC6F22E88C62005CFAC9 /* ChatExample */,
 				8AD5EC6E22E88C62005CFAC9 /* Products */,

--- a/Example/Carthage/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/Carthage/ChatExample.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		8AD5EC7C22E88C63005CFAC9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8AD5EC8422E88DBC005CFAC9 /* ChatExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ChatExample.entitlements; sourceTree = "<group>"; };
 		A57E5C7924C7438800187DC2 /* StreamChatClient_v3.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = StreamChatClient_v3.xctestplan; path = ../../StreamChatClient_v3.xctestplan; sourceTree = "<group>"; };
+		A57E5C8224C743A900187DC2 /* StreamChatClientStress_v3.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = StreamChatClientStress_v3.xctestplan; path = ../../StreamChatClientStress_v3.xctestplan; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -230,6 +231,7 @@
 			isa = PBXGroup;
 			children = (
 				A57E5C7924C7438800187DC2 /* StreamChatClient_v3.xctestplan */,
+				A57E5C8224C743A900187DC2 /* StreamChatClientStress_v3.xctestplan */,
 				8A0A7E6F2301AC1E0033E6D9 /* StreamChat.xcodeproj */,
 				8AD5EC6F22E88C62005CFAC9 /* ChatExample */,
 				8AD5EC6E22E88C62005CFAC9 /* Products */,

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "fastlane"
 gem "cocoapods"
 gem "danger"
 gem "danger-swiftlint"	
+gem "danger-commit_lint"
 gem "jazzy"
 gem "xcode-install"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,10 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
+    danger-commit_lint (0.0.7)
+      danger-plugin-api (~> 1.0)
+    danger-plugin-api (1.0.0)
+      danger (> 2.0)
     danger-swiftlint (0.24.2)
       danger
       rake (> 10)
@@ -301,6 +305,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods
   danger
+  danger-commit_lint
   danger-swiftlint
   fastlane
   fastlane-plugin-firebase_app_distribution
@@ -308,4 +313,4 @@ DEPENDENCIES
   xcode-install
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/StreamChat.xcodeproj/xcshareddata/xcschemes/StreamChatClient_v3.xcscheme
+++ b/StreamChat.xcodeproj/xcshareddata/xcschemes/StreamChatClient_v3.xcscheme
@@ -27,6 +27,12 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:StreamChatClient_v3.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/StreamChat.xcodeproj/xcshareddata/xcschemes/StreamChatClient_v3.xcscheme
+++ b/StreamChat.xcodeproj/xcshareddata/xcschemes/StreamChatClient_v3.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1140"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -31,6 +31,9 @@
          <TestPlanReference
             reference = "container:StreamChatClient_v3.xctestplan"
             default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:StreamChatClientStress_v3.xctestplan">
          </TestPlanReference>
       </TestPlans>
       <Testables>

--- a/StreamChatClientStress_v3.xctestplan
+++ b/StreamChatClientStress_v3.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "307F0A53-35D5-47DF-9FC7-AA184EB1EAAF",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testExecutionOrdering" : "random"
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:StreamChat.xcodeproj",
+        "identifier" : "799C9450247D59B1001F1104",
+        "name" : "StreamChatClientTests_v3"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/StreamChatClient_v3.xctestplan
+++ b/StreamChatClient_v3.xctestplan
@@ -1,0 +1,32 @@
+{
+  "configurations" : [
+    {
+      "id" : "9182A9B9-62BE-41D9-8197-F0D17378AE69",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:StreamChat.xcodeproj",
+          "identifier" : "799C941A247D2F80001F1104",
+          "name" : "StreamChatClient_v3"
+        }
+      ]
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:StreamChat.xcodeproj",
+        "identifier" : "799C9450247D59B1001F1104",
+        "name" : "StreamChatClientTests_v3"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -244,10 +244,24 @@ end
 
 desc "Runs tests for v3 in Debug config"
 lane :test_v3 do
-  scan(project: "StreamChat.xcodeproj", scheme: "StreamChatClient_v3", clean: true, code_coverage: true)
+  scan(
+    project: "StreamChat.xcodeproj", 
+    scheme: "StreamChatClient_v3", 
+    testplan: "StreamChatClient_v3",
+    configuration: "Debug",
+    clean: true, 
+    code_coverage: true
+    )
 end
 
 desc "Runs tests for v3 in Release config"
 lane :test_v3_release do
-  scan(project: "StreamChat.xcodeproj", scheme: "StreamChatClient_v3", clean: true, configuration: "ReleaseTests")
+  scan(
+    project: "StreamChat.xcodeproj", 
+    scheme: "StreamChatClient_v3", 
+    testplan: "StreamChatClient_v3",
+    configuration: "ReleaseTests",
+    clean: true, 
+    code_coverage: true
+  )
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -244,7 +244,7 @@ end
 
 desc "Runs tests for v3 in Debug config"
 lane :test_v3 do
-  scan(project: "StreamChat.xcodeproj", scheme: "StreamChatClient_v3", clean: true)
+  scan(project: "StreamChat.xcodeproj", scheme: "StreamChatClient_v3", clean: true, code_coverage: true)
 end
 
 desc "Runs tests for v3 in Release config"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,6 +1,9 @@
 fastlane_version "2.68.0"
 default_platform :ios
 
+# The number of times the stress test suite is ran
+stress_tests_cycles = 25
+
 before_all do
   if is_ci
     setup_ci()
@@ -264,4 +267,23 @@ lane :test_v3_release do
     clean: true, 
     code_coverage: true
   )
+end
+
+desc "Runs stress tests for v3"
+lane :stress_test_v3 do
+  scan(
+    project: "StreamChat.xcodeproj",
+    scheme: "StreamChatClient_v3",
+    clean: true,
+    build_for_testing: true
+  )
+
+  stress_tests_cycles.times {
+    scan(
+      project: "StreamChat.xcodeproj", 
+      scheme: "StreamChatClient_v3", 
+      test_without_building: true,
+      testplan: "StreamChatClientStress_v3"
+    )      
+  }
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -85,6 +85,11 @@ Runs tests for v3 in Debug config
 fastlane test_v3_release
 ```
 Runs tests for v3 in Release config
+### stress_test_v3
+```
+fastlane stress_test_v3
+```
+Runs stress tests for v3
 
 ----
 


### PR DESCRIPTION
### In this PR

- Danger now runs in a separate job to ensure it's always reported, even though the tests fail.

- CodeCov is reported for LLC v3

- I added a restore key to Carthage cache, which should help us with getting faster builds.

- Danger now lints commit messages and emits an error, if the commit message doesn't follow the standards (starts with a capitalized letter, doesn't end with `.`)

- I converted the existing v3 tests to a test plan. This allowed me to introduce a new "stress" test plan with random test ordering.

- This stress test is ran every nigh at 1am.
