### PR TITLE
Disable Danger commit length rule

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -39,8 +39,9 @@ if !has_changelog_escape && !git.modified_files.include?("CHANGELOG.md") && has_
     fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/GetStream/stream-chat-swift/blob/master/CHANGELOG.md).")
 end
 
-# Check all commits have correct format
-commit_lint.check
+# Check all commits have correct format. Disable the length rule, since it's hardcoded
+# to 50 and GitHub has the limit 80.
+commit_lint.check disable: [:subject_length]
 
 swiftlint.config_file = '.swiftlint.yml'
 swiftlint.directory = 'Sources'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -253,7 +253,6 @@ lane :test_v3 do
     testplan: "StreamChatClient_v3",
     configuration: "Debug",
     clean: true, 
-    code_coverage: true
     )
 end
 
@@ -264,8 +263,7 @@ lane :test_v3_release do
     scheme: "StreamChatClient_v3", 
     testplan: "StreamChatClient_v3",
     configuration: "ReleaseTests",
-    clean: true, 
-    code_coverage: true
+    clean: true,
   )
 end
 


### PR DESCRIPTION
It's too aggressive (50 chars - GitHub has 80) and it can't be easily configured.
