### PR TITLE
backport from v3 to v2 MockNetworkURLProtocol and RequestRecorderURLProtocol files

### DIFF
--- a/Sources/Client/Client/Client+Request.swift
+++ b/Sources/Client/Client/Client+Request.swift
@@ -78,6 +78,19 @@ extension Client {
         return Subscription { _  in task?.cancel() }
     }
     
+    /// Synchronously creates a new `URLRequest` with the data from the `Endpoint`. It also adds all required data
+    /// like an api key, etc.
+    /// - Parameter endpoint: The `Endpoint` to be encoded.
+    /// - Returns: a URLRequest for the given endpoint
+    func encodeRequest(for endpoint: Endpoint) throws -> URLRequest {
+        let queryItems = try self.queryItems(for: endpoint).get()
+        let url = try requestURL(for: endpoint, queryItems: queryItems).get()
+        
+        return try endpoint.isUploading
+            ? encodeRequestForUpload(for: endpoint, url: url).get()
+            : encodeRequest(for: endpoint, url: url).get()
+    }
+    
     private func prepareRequest<T: Decodable>(endpoint: Endpoint, _ completion: @escaping Completion<T>) -> URLSessionTask? {
         if let logger = logger {
             logger.log("Request: \(String(describing: endpoint).prefix(100))...", level: .debug)
@@ -90,12 +103,7 @@ extension Client {
         
         do {
             let task: URLSessionDataTask
-            let queryItems = try self.queryItems(for: endpoint).get()
-            let url = try requestURL(for: endpoint, queryItems: queryItems).get()
-            
-            let urlRequest = try endpoint.isUploading
-                ? encodeRequestForUpload(for: endpoint, url: url).get()
-                : encodeRequest(for: endpoint, url: url).get()
+            let urlRequest = try self.encodeRequest(for: endpoint)
             
             task = urlSession.dataTask(with: urlRequest) { [unowned self] in
                 // Parse the response.

--- a/Tests/Client/MockNetworkURLProtocol.swift
+++ b/Tests/Client/MockNetworkURLProtocol.swift
@@ -12,107 +12,140 @@ import XCTest
 
 /// This URLProtocol intercepts the network communication and provides mock responses for the registered endpoints.
 class MockNetworkURLProtocol: URLProtocol {
-
-    private static var responses: [PathAndMethod: MockResponse] = [:]
-
-    /// Cleans up all existing mock reponses.
+    static let testSessionHeaderKey = "MockNetworkURLProtocol_test_session_id"
+    
+    /// Starts a new recording session. Adds a unique identifier to the configuration headers and listens only
+    /// for the request with this id.
+    static func startTestSession(with configuration: inout URLSessionConfiguration) {
+        reset()
+        let newSessionId = UUID().uuidString
+        currentSessionId = newSessionId
+        
+        // MockNetworkURLProtocol always has to be first, but not if the RequestRecorderURLProtocol is presented
+        if let recorderProtocolIdx = configuration.protocolClasses?.firstIndex(where: { $0 is RequestRecorderURLProtocol.Type }) {
+            configuration.protocolClasses?.insert(MockNetworkURLProtocol.self, at: recorderProtocolIdx + 1)
+        } else {
+            configuration.protocolClasses?.insert(MockNetworkURLProtocol.self, at: 0)
+        }
+        
+        var existingHeaders = configuration.httpAdditionalHeaders ?? [:]
+        existingHeaders[MockNetworkURLProtocol.testSessionHeaderKey] = newSessionId
+        configuration.httpAdditionalHeaders = existingHeaders
+    }
+    
+    private static var responses: Atomic<[PathAndMethod: MockResponse]> = .init([:])
+    
+    /// If set, the mock protocol responds to requests with `testSessionHeaderKey` header value set to this value. If `nil`,
+    /// all requests are ignored.
+    static var currentSessionId: String?
+    
+    /// Cleans up all existing mock responses and current test session id.
     static func reset() {
-        Self.responses.removeAll()
+        Self.currentSessionId = nil
+        Self.responses.set([:])
     }
     
     override class func canInit(with request: URLRequest) -> Bool {
         guard
-            let path = request.url?.path.normalizedPath,
+            request.value(forHTTPHeaderField: testSessionHeaderKey) == currentSessionId,
+            let url = request.url,
             let method = request.httpMethod
         else { return false }
-
-        let key = PathAndMethod(path: path, method: method)
-        return responses.keys.contains(key)
+        
+        let key = PathAndMethod(url: url, method: method)
+        return responses.get().keys.contains(key)
     }
-
+    
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         // Overriding this function is required by the superclass.
-        return request
+        request
     }
-
+    
     // MARK: Instance methods
-
+    
     override func startLoading() {
         guard
-            let path = request.url?.path.normalizedPath,
+            let url = request.url,
             let method = request.httpMethod,
-            let mockResponse = Self.responses[.init(path: path, method: method)]
+            let mockResponse = Self.responses[.init(url: url, method: method)]
         else {
             fatalError("This should never happen. Check if the implementation of the `canInit` method is correct.")
         }
-
-        let httpResponse = HTTPURLResponse(
-            url: request.url!,
-            statusCode: mockResponse.responseCode,
-            httpVersion: "HTTP/1.1",
-            headerFields: nil
-        )!
-
-        self.client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .allowed)
-
+        
+        let httpResponse = HTTPURLResponse(url: request.url!,
+                                           statusCode: mockResponse.responseCode,
+                                           httpVersion: "HTTP/1.1",
+                                           headerFields: nil)!
+        
+        client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .allowed)
+        
         switch mockResponse.result {
         case let .success(data):
-            self.client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocol(self, didLoad: data)
         case let .failure(error):
-            self.client?.urlProtocol(self, didFailWithError: error)
+            client?.urlProtocol(self, didFailWithError: error)
         }
-
+        
         // Finish loading (required).
-        self.client?.urlProtocolDidFinishLoading(self)
-
+        client?.urlProtocolDidFinishLoading(self)
+        
         // Clean up
-        DispatchQueue.main.async {
-            Self.responses.removeValue(forKey: .init(path: path, method: method))
+        Self.responses.update {
+            var result = $0
+            result.removeValue(forKey: .init(url: url, method: method))
+            return result
         }
     }
-
+    
     override func stopLoading() {
         // Required by the superclass
     }
 }
 
 extension MockNetworkURLProtocol {
-
     /// Creates a successful mock response for the given endpoint.
     ///
     /// - Parameters:
     ///   - endpoint: The endpoint the mock response is registered for.
     ///   - statusCode: The HTTP status code used for the response.
     ///   - response: The JSON body of the response.
-    static func mockResponse(endpoint: Endpoint, statusCode: Int = 200, responseBody: [String: Any] = [:]) {
-        let jsonData: Data
-        do {
-            jsonData = try JSONSerialization.data(withJSONObject: responseBody, options: .prettyPrinted)
-        } catch {
-            fatalError("Error encoding mock responseBody to JSON: \(error)")
-        }
-
-        let key = PathAndMethod(path: endpoint.path.normalizedPath, method: endpoint.method.rawValue)
-        Self.responses[key] = MockResponse(result: .success(jsonData), responseCode: statusCode)
+    static func mockResponse(request: URLRequest, statusCode: Int = 200, responseBody: Data = Data([])) {
+        let key = PathAndMethod(url: request.url!, method: request.httpMethod!)
+        Self.responses[key] = MockResponse(result: .success(responseBody), responseCode: statusCode)
     }
-
+    
     /// Creates a failing mock response for the given endpoint.
     ///
     /// - Parameters:
     ///   - endpoint: The endpoint the mock response is registered for.
     ///   - statusCode: The HTTP status code used for the response.
     ///   - error: The error object used for the response.
-    static func mockResponse(endpoint: Endpoint, statusCode: Int = 400, error: Error) {
-        let key = PathAndMethod(path: endpoint.path.normalizedPath, method: endpoint.method.rawValue)
-
+    static func mockResponse(request: URLRequest, statusCode: Int = 400, error: Error) {
+        let key = PathAndMethod(url: request.url!, method: request.httpMethod!)
+        
         Self.responses[key] = MockResponse(result: .failure(error), responseCode: statusCode)
     }
 }
 
-/// Used for using the combination of `path` and `httpMethod` as a dictionary key.
+/// Used for using the combination of significat parts of the URL passed as parameter and `httpMethod` as a dictionary key.
+/// - Warning: ⚠️ Significant parts of the URL are used as keys instead of a URL because two URL's can be semantically identical but syntactially different
+/// Example: https//a.b.c/d?e=f&g=h and https//a.b.c/d?g=h&e=f
 private struct PathAndMethod: Hashable {
+    let scheme: String?
+    let host: String?
+    let port: Int?
     let path: String
+    let queryItems: [String: String?]
     let method: String
+    
+    init(url: URL, method: String) {
+        scheme = url.scheme
+        host = url.host
+        port = url.port
+        path = url.path
+        queryItems = url.queryItems
+        self.method = method
+    }
 }
 
 private struct MockResponse {
@@ -120,11 +153,21 @@ private struct MockResponse {
     let responseCode: Int
 }
 
-
-
 private extension String {
     /// Removes all leading `/` from the string.
     var normalizedPath: String {
-        String(drop(while: { $0 == "/"}))
+        String(drop(while: { $0 == "/" }))
+    }
+}
+
+private extension URL {
+    /// Returns a dictionary containing all URL query items
+    /// - the key is the query item name
+    /// - the value is the query item value
+    var queryItems: [String: String?] {
+        let queryItemsList = URLComponents(string: absoluteString)?
+            .queryItems?
+            .map { ($0.name, $0.value) }
+        return Dictionary(uniqueKeysWithValues: queryItemsList ?? [])
     }
 }

--- a/Tests/Client/MockNetworkURLProtocol.swift
+++ b/Tests/Client/MockNetworkURLProtocol.swift
@@ -133,17 +133,13 @@ extension MockNetworkURLProtocol {
 private struct PathAndMethod: Hashable {
     let scheme: String?
     let host: String?
-    let port: Int?
     let path: String
-    let queryItems: [String: String?]
     let method: String
     
     init(url: URL, method: String) {
         scheme = url.scheme
         host = url.host
-        port = url.port
         path = url.path
-        queryItems = url.queryItems
         self.method = method
     }
 }
@@ -157,17 +153,5 @@ private extension String {
     /// Removes all leading `/` from the string.
     var normalizedPath: String {
         String(drop(while: { $0 == "/" }))
-    }
-}
-
-private extension URL {
-    /// Returns a dictionary containing all URL query items
-    /// - the key is the query item name
-    /// - the value is the query item value
-    var queryItems: [String: String?] {
-        let queryItemsList = URLComponents(string: absoluteString)?
-            .queryItems?
-            .map { ($0.name, $0.value) }
-        return Dictionary(uniqueKeysWithValues: queryItemsList ?? [])
     }
 }

--- a/Tests/Client/RequestRecorderURLProtocol.swift
+++ b/Tests/Client/RequestRecorderURLProtocol.swift
@@ -1,8 +1,5 @@
 //
-//  RequestRecorderURLProtocol.swift
-//  StreamChatClientTests
-//
-//  Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2020 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -11,12 +8,24 @@ import XCTest
 /// This URLProtocol subclass allows to intercept the network communication
 /// and provides the latest network request made.
 class RequestRecorderURLProtocol: URLProtocol {
-
-    static let testSessionHeaderKey = "test_session_id"
+    static let testSessionHeaderKey = "RequestRecorderURLProtocol_test_session_id"
+    
+    /// Starts a new recording session. Adds a unique identifier to the configuration headers and listens only
+    /// for the request with this id.
+    static func startTestSession(with configuration: inout URLSessionConfiguration) {
+        reset()
+        let newSessionId = UUID().uuidString
+        currentSessionId = newSessionId
+        
+        configuration.protocolClasses?.insert(RequestRecorderURLProtocol.self, at: 0)
+        var existingHeaders = configuration.httpAdditionalHeaders ?? [:]
+        existingHeaders[RequestRecorderURLProtocol.testSessionHeaderKey] = newSessionId
+        configuration.httpAdditionalHeaders = existingHeaders
+    }
     
     private static var latestRequestExpectation: XCTestExpectation?
     private static var latestRequest: URLRequest?
-
+    
     /// Returns the latest network request this URLProtocol recorded.
     ///
     /// If no request has been made since the last time this function was invoked, it synchronously
@@ -28,15 +37,16 @@ class RequestRecorderURLProtocol: URLProtocol {
             // Delete the used request
             latestRequest = nil
         }
-
+        
         guard latestRequest == nil else { return latestRequest }
-
+        
         latestRequestExpectation = .init(description: "Wait for incoming request.")
         _ = XCTWaiter.wait(for: [latestRequestExpectation!], timeout: timeout)
         return latestRequest
     }
-
-    /// If set, records only requests with `testSessionHeaderKey` header value set to this value. If `nil`, records all requests.
+    
+    /// If set, records only requests with `testSessionHeaderKey` header value set to this value. If `nil`,
+    /// no requests are recorded.
     static var currentSessionId: String?
     
     /// Cleans up existing waiters and recorded requests. We have to explictly reset the state because URLProtocols
@@ -46,36 +56,32 @@ class RequestRecorderURLProtocol: URLProtocol {
         latestRequest = nil
         latestRequestExpectation = nil
     }
-
+    
     override class func canInit(with request: URLRequest) -> Bool {
-        guard let sessionId = currentSessionId else {
-            // No sessionId set, record all requests
-            record(request: request)
-            return false
-        }
+        guard let sessionId = currentSessionId else { return false }
         
         if sessionId == request.value(forHTTPHeaderField: testSessionHeaderKey) {
             record(request: request)
         }
         return false
     }
-
+    
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         // Overriding this function is required by the superclass.
-        return request
+        request
     }
-
+    
     private static func record(request: URLRequest) {
         latestRequest = request
         latestRequestExpectation?.fulfill()
     }
     
     // MARK: Instance methods
-
+    
     override func startLoading() {
         // Required by the superclass.
     }
-
+    
     override func stopLoading() {
         // Required by the superclass.
     }

--- a/Tests/Client/Unit Tests/Client+DevicesTests.swift
+++ b/Tests/Client/Unit Tests/Client+DevicesTests.swift
@@ -29,10 +29,12 @@ class Client_DevicesTests: ClientTestCase {
         // Setup
         let deviceId = "device_id_\(UUID().uuidString)"
         let timestamp = Date(timeIntervalSince1970: 123456789)
-
-        MockNetworkURLProtocol.mockResponse(endpoint: .devices(testUser), responseBody:
+        
+        let request = try client.encodeRequest(for: .devices(testUser))
+        let response = try JSONEncoder.stream.encode(
             ["devices": [ ["id": deviceId, "created_at": ISO8601DateFormatter().string(from: timestamp)] ]]
         )
+        MockNetworkURLProtocol.mockResponse(request: request, responseBody: response)
 
         // Action
         let result = try await { self.client.devices($0) }
@@ -44,8 +46,10 @@ class Client_DevicesTests: ClientTestCase {
 
     func test_getDevice_handlesError() throws {
         // Setup
+        
+        let request = try client.encodeRequest(for: .devices(testUser))
         let error = TestError.mockError()
-        MockNetworkURLProtocol.mockResponse(endpoint: .devices(testUser), error: error)
+        MockNetworkURLProtocol.mockResponse(request: request, error: error)
 
         // Action
         let result = try await { self.client.devices($0) }
@@ -100,8 +104,10 @@ class Client_DevicesTests: ClientTestCase {
     func test_addDeviceWithDeviceID_handlesSuccess() throws {
         // Setup
         let deviceId = "device_id_\(UUID().uuidString)"
-
-        MockNetworkURLProtocol.mockResponse(endpoint: .addDevice(deviceId: deviceId, testUser))
+        
+        let request = try client.encodeRequest(for: .addDevice(deviceId: deviceId, testUser))
+        let response = try JSONEncoder.stream.encode([String: String]())
+        MockNetworkURLProtocol.mockResponse(request: request, responseBody: response)
 
         // Action
         let result = try await { done in
@@ -117,9 +123,9 @@ class Client_DevicesTests: ClientTestCase {
     func test_addDeviceWithDeviceID_handlesError() throws {
         // Setup
         let deviceId = "device_id_\(UUID().uuidString)"
+        let request = try client.encodeRequest(for: .addDevice(deviceId: deviceId, testUser))
         let error = TestError.mockError()
-
-        MockNetworkURLProtocol.mockResponse(endpoint: .addDevice(deviceId: deviceId, testUser), error: error)
+        MockNetworkURLProtocol.mockResponse(request: request, error: error)
 
         // Action
         let result = try await { done in
@@ -167,7 +173,9 @@ class Client_DevicesTests: ClientTestCase {
         assert(user.devices == [device])
         assert(user.currentDevice == device)
 
-        MockNetworkURLProtocol.mockResponse(endpoint: .removeDevice(deviceId: device.id, testUser))
+        let request = try client.encodeRequest(for: .removeDevice(deviceId: device.id, testUser))
+        let response = try JSONEncoder.stream.encode([String: String]())
+        MockNetworkURLProtocol.mockResponse(request: request, responseBody: response)
 
         // Action
         let result = try await { done in
@@ -192,7 +200,8 @@ class Client_DevicesTests: ClientTestCase {
         assert(user.devices == [device])
         assert(user.currentDevice == device)
         
-        MockNetworkURLProtocol.mockResponse(endpoint: .removeDevice(deviceId: device.id, testUser), error: error)
+        let request = try client.encodeRequest(for: .removeDevice(deviceId: device.id, testUser))
+        MockNetworkURLProtocol.mockResponse(request: request, error: error)
 
         // Action
         let result = try await { done in

--- a/Tests/Client/Unit Tests/ClientTestCase.swift
+++ b/Tests/Client/Unit Tests/ClientTestCase.swift
@@ -17,22 +17,26 @@ class ClientTestCase: XCTestCase {
     
     var client: Client!
     var testSessionId: String!
+    var sessionConfiguration: URLSessionConfiguration!
     var testUser: User!
     let testToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.d1xKTlD_D0G-VsBoDBNbaLjO-2XWNA8rlTm4ru4sMHg"
     
     override func setUp() {
         super.setUp()
-        let sessionConfig = URLSessionConfiguration.default
-        sessionConfig.protocolClasses?.insert(RequestRecorderURLProtocol.self, at: 0)
-        sessionConfig.protocolClasses?.insert(MockNetworkURLProtocol.self, at: 1)
         
+        // Prepare URL Session
+        sessionConfiguration = URLSessionConfiguration.default
+        RequestRecorderURLProtocol.startTestSession(with: &sessionConfiguration)
+        MockNetworkURLProtocol.startTestSession(with: &sessionConfiguration)
+        
+        // Some random value to ensure the headers are respected
         testSessionId = UUID().uuidString
-        sessionConfig.httpAdditionalHeaders = [RequestRecorderURLProtocol.testSessionHeaderKey: testSessionId!]
+        sessionConfiguration.httpAdditionalHeaders = [RequestRecorderURLProtocol.testSessionHeaderKey: testSessionId!]
         
         let clientConfig = Client.Config(apiKey: "test_api_key")
         // We can create a new `Client` instance because we don't use `Client.shared` in tests.
         client = Client(config: clientConfig,
-                        defaultURLSessionConfiguration: sessionConfig,
+                        defaultURLSessionConfiguration: sessionConfiguration,
                         defaultWebSocketProviderType: WebSocketProviderMock.self)
         
         testUser = User(id: "broken-waterfall-5")


### PR DESCRIPTION
# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [X] Code changes are tested (add some information if not applicable)

## Description of the pull request
The goal of this PR is to back-port the implementations of `MockNetworkURLProtocol` and `RequestRecorderURLProtocol` from v3 to v2.

The main difference between `MockNetworkURLProtocol` v2 and v3 is that in the `canInit(with:)` v2 method compares endpoint paths but v3 compares the whole URL so now  in order to use `MockNetworkURLProtocol` it’s necessary to know the whole URL for each endpoint. The v3 `ApiClient` implementation extracted this functionality to a `RequestEncoder` protocol that is accessible from the outside but in v2 this functionality is coupled and hidden in the `Client`. Therefore I exposed this functionality in `Client` in a method called `encodeRequest(for:)`

After I completed the back-port I noticed that a couple of tests would fail sometimes. The reason is that the new `MockNetworkURLProtocol` compares URL's but two URL's can be semantically identical but syntactically different.  Example: `https//a.b.c/d?e=f&g=h` and `https//a.b.c/d?g=h&e=f`. There is no guarantee that encoding a URL for the same endpoint twice would result in the same absolute URL string because it uses dictionaries to hold query items and  traverse order doesn't matter in dictionaries.

To address this in the `MockNetworkURLProtocol` I modified the key in the responses dictionary to compare significant parts of the URL by replacing the whole URL key for the URL scheme, host, port and path. Please note that this PR only addresses this issue in v2 but not in v3 so future tests in v3 can fail because of this. Please let me know if you want me to fix the issue also in the v3 class implementation.