### PR TITLE
[CIS-159] Implement message receiving

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		79877A2A2498E51500015F8B /* MemberModelDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A1D2498E50D00015F8B /* MemberModelDTO_Tests.swift */; };
 		79877A2B2498E51500015F8B /* UserModelDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A202498E50D00015F8B /* UserModelDTO_Tests.swift */; };
 		79877A2D2498E54400015F8B /* UserPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A162498E4EE00015F8B /* UserPayload_Tests.swift */; };
+		7990503224CEEAA600689CDC /* MessageDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */; };
 		799BE2EA248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799BE2E9248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift */; };
 		799BE2EC248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799BE2EB248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift */; };
 		799C941F247D2F80001F1104 /* StreamChatClient_v3.h in Headers */ = {isa = PBXBuildFile; fileRef = 799C941D247D2F80001F1104 /* StreamChatClient_v3.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -648,6 +649,7 @@
 		79877A202498E50D00015F8B /* UserModelDTO_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserModelDTO_Tests.swift; sourceTree = "<group>"; };
 		79877A212498E50D00015F8B /* MemberModelDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemberModelDTO.swift; sourceTree = "<group>"; };
 		79877A222498E50D00015F8B /* UserModelDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserModelDTO.swift; sourceTree = "<group>"; };
+		7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDTO_Tests.swift; sourceTree = "<group>"; };
 		799BE2E9248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketReconnectionStrategy.swift; sourceTree = "<group>"; };
 		799BE2EB248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketReconnectionStrategy_Tests.swift; sourceTree = "<group>"; };
 		799C941B247D2F80001F1104 /* StreamChatClient_v3.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatClient_v3.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1200,6 +1202,7 @@
 			isa = PBXGroup;
 			children = (
 				799C942D247D2FB9001F1104 /* MessageDTO.swift */,
+				7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */,
 				79877A1F2498E50D00015F8B /* TeamDTO.swift */,
 				79877A222498E50D00015F8B /* UserModelDTO.swift */,
 				79877A202498E50D00015F8B /* UserModelDTO_Tests.swift */,
@@ -2895,6 +2898,7 @@
 				8AC9CBE424C74ECB006E236C /* NotificationEvents_Tests.swift in Sources */,
 				79280F8224891C6A00CDEB89 /* VirtualTimer.swift in Sources */,
 				8A0C3BE224C1F74200CAFD19 /* MessageEvents_Tests.swift in Sources */,
+				7990503224CEEAA600689CDC /* MessageDTO_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		792921C924C056F400116BBB /* ChannelListController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792921C824C056F400116BBB /* ChannelListController_Tests.swift */; };
 		792921CB24C077B400116BBB /* TestDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792921CA24C077B400116BBB /* TestDispatchQueue.swift */; };
 		792921CD24C07A9000116BBB /* QueueAwareDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792921CC24C07A9000116BBB /* QueueAwareDelegate.swift */; };
-		792A4F1B247FE84900EAF71D /* ChannelListQueryUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F1A247FE84900EAF71D /* ChannelListQueryUpdater.swift */; };
 		792A4F1D247FEA2200EAF71D /* ChannelListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F1C247FEA2200EAF71D /* ChannelListController.swift */; };
 		792A4F25247FF01800EAF71D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F24247FF01800EAF71D /* AppDelegate.swift */; };
 		792A4F27247FF01800EAF71D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F26247FF01800EAF71D /* SceneDelegate.swift */; };
@@ -58,6 +57,7 @@
 		792A4F492480107A00EAF71D /* Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F452480107A00EAF71D /* Sorting.swift */; };
 		792A4F4B248010A600EAF71D /* QueryOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F4A248010A600EAF71D /* QueryOptions.swift */; };
 		792A4F4D248011E500EAF71D /* ChannelListQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F4C248011E500EAF71D /* ChannelListQuery.swift */; };
+		792CA62624CEE93700D70A5E /* ChannelListQueryUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F1A247FE84900EAF71D /* ChannelListQueryUpdater.swift */; };
 		792FCB4524A33B5B000290C7 /* EventDataProcessorMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4424A33B5B000290C7 /* EventDataProcessorMiddleware.swift */; };
 		792FCB4724A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4624A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift */; };
 		792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */; };
@@ -71,7 +71,6 @@
 		793C14DC24BF2A0800B8BFB7 /* ChangeAggregator_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793C14DB24BF2A0800B8BFB7 /* ChangeAggregator_Tests.swift */; };
 		79411CD42462DC0A003972E9 /* ClientLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFA57262418EB2500FD07EC /* ClientLoggerTests.swift */; };
 		794927ED249E0BE2009D7EB7 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794927EC249E0BE2009D7EB7 /* ExtraData.swift */; };
-		794927F2249E3DE8009D7EB7 /* EventPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794927F0249E3DE6009D7EB7 /* EventPayload_Tests.swift */; };
 		794927F3249E3F77009D7EB7 /* NotificationAddedToChannel.json in Resources */ = {isa = PBXBuildFile; fileRef = 794927EE249E3D37009D7EB7 /* NotificationAddedToChannel.json */; };
 		794BDE4A2434BD7400BFBA1F /* NestableCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794BDE492434BD7400BFBA1F /* NestableCodingKey.swift */; };
 		7962958C248147430078EB53 /* BaseURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7962958B248147430078EB53 /* BaseURL.swift */; };
@@ -1381,8 +1380,8 @@
 			isa = PBXGroup;
 			children = (
 				799C9446247D50F3001F1104 /* Worker.swift */,
-				792921C424C0479700116BBB /* ChannelListQueryUpdater_Tests.swift */,
 				792A4F1A247FE84900EAF71D /* ChannelListQueryUpdater.swift */,
+				792921C424C0479700116BBB /* ChannelListQueryUpdater_Tests.swift */,
 				79682C4524BC9DAF0071578E /* ChannelUpdater.swift */,
 				79280F4524850ECC00CDEB89 /* Background */,
 			);
@@ -2754,6 +2753,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				792CA62624CEE93700D70A5E /* ChannelListQueryUpdater.swift in Sources */,
 				79DDF80E249CB920002F4412 /* RequestDecoder.swift in Sources */,
 				8AC9CBD624C73689006E236C /* NotificationEvents.swift in Sources */,
 				8A62706E24BF45360040BFD6 /* BanEnabling.swift in Sources */,
@@ -2799,8 +2799,6 @@
 				79CDE1DD24B321FE0003BD1D /* CurrentUserDTO.swift in Sources */,
 				797A756824814F0D003CF16D /* BundleExtensions.swift in Sources */,
 				79877A192498E4EE00015F8B /* UserPayload.swift in Sources */,
-				792A4F1B247FE84900EAF71D /* ChannelListQueryUpdater.swift in Sources */,
-				792A4F1B247FE84900EAF71D /* ChannelListQueryUpdater.swift in Sources */,
 				799C9479247E3DEA001F1104 /* StreamChatModel.xcdatamodeld in Sources */,
 				79877A1C2498E4EE00015F8B /* Endpoint.swift in Sources */,
 				792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */,
@@ -2889,9 +2887,7 @@
 				79280F8424891C6A00CDEB89 /* VirtualTime.swift in Sources */,
 				799C9476247D7E94001F1104 /* TemporaryData.swift in Sources */,
 				792921C724C047DD00116BBB /* APIClient_Mock.swift in Sources */,
-				794927F2249E3DE8009D7EB7 /* EventPayload_Tests.swift in Sources */,
 				79A0E9BC2498C31A00E9BD50 /* UserTypingStartCleanupMiddleware_Tests.swift in Sources */,
-				794927F2249E3DE8009D7EB7 /* EventPayload_Tests.swift in Sources */,
 				796610BB248E687000761629 /* EventMiddleware_Tests.swift in Sources */,
 				799C9469247D791A001F1104 /* AssertResult.swift in Sources */,
 				8AC9CBD424C7351D006E236C /* ReactionEvents_Tests.swift in Sources */,

--- a/StreamChatClient_v3/Database/DTOs/ChannelDTO_Tests.swift
+++ b/StreamChatClient_v3/Database/DTOs/ChannelDTO_Tests.swift
@@ -100,7 +100,7 @@ class ChannelDTO_Tests: XCTestCase {
             Assert.willBeEqual(payload.messages[0].mentionedUsers.count, loadedChannel?.latestMessages.first?.mentionedUsers.count)
             Assert.willBeEqual(payload.messages[0].parentId, loadedChannel?.latestMessages.first?.parentId)
             Assert.willBeEqual(payload.messages[0].reactionScores, loadedChannel?.latestMessages.first?.reactionScores)
-            Assert.willBeEqual(Int32(payload.messages[0].replyCount), loadedChannel?.latestMessages.first?.replyCount)
+            Assert.willBeEqual(payload.messages[0].replyCount, loadedChannel?.latestMessages.first?.replyCount)
             
             // Message user
             Assert.willBeEqual(payload.messages[0].user.id, loadedChannel?.latestMessages.first?.author.id)
@@ -311,7 +311,7 @@ class ChannelDTO_Tests: XCTestCase {
             Assert.willBeEqual(payload.messages[0].mentionedUsers.count, loadedChannel?.latestMessages.first?.mentionedUsers.count)
             Assert.willBeEqual(payload.messages[0].parentId, loadedChannel?.latestMessages.first?.parentId)
             Assert.willBeEqual(payload.messages[0].reactionScores, loadedChannel?.latestMessages.first?.reactionScores)
-            Assert.willBeEqual(Int32(payload.messages[0].replyCount), loadedChannel?.latestMessages.first?.replyCount)
+            Assert.willBeEqual(payload.messages[0].replyCount, loadedChannel?.latestMessages.first?.replyCount)
             
             // Message user
             Assert.willBeEqual(payload.messages[0].user.id, loadedChannel?.latestMessages.first?.author.id)

--- a/StreamChatClient_v3/Database/DTOs/MessageDTO.swift
+++ b/StreamChatClient_v3/Database/DTOs/MessageDTO.swift
@@ -84,6 +84,11 @@ extension NSManagedObjectContext {
         
         return dto
     }
+    
+    func loadMessage<ExtraData: ExtraDataTypes>(id: MessageId) -> MessageModel<ExtraData>? {
+        guard let dto = MessageDTO.load(id: id, context: self) else { return nil }
+        return .init(fromDTO: dto)
+    }
 }
 
 extension MessageModel {

--- a/StreamChatClient_v3/Database/DTOs/MessageDTO.swift
+++ b/StreamChatClient_v3/Database/DTOs/MessageDTO.swift
@@ -98,7 +98,7 @@ extension MessageModel {
         args = dto.args
         parentId = dto.parentId
         showReplyInChannel = dto.showReplyInChannel
-        replyCount = dto.replyCount
+        replyCount = Int(dto.replyCount)
         extraData = try! JSONDecoder.default.decode(ExtraData.Message.self, from: dto.extraData)
         isSilent = dto.isSilent
         reactionScores = dto.reactionScores

--- a/StreamChatClient_v3/Database/DTOs/MessageDTO_Tests.swift
+++ b/StreamChatClient_v3/Database/DTOs/MessageDTO_Tests.swift
@@ -1,0 +1,162 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient_v3
+import XCTest
+
+class MessageDTO_Tests: XCTestCase {
+    var database: DatabaseContainer!
+    
+    override func setUp() {
+        super.setUp()
+        database = try! DatabaseContainer(kind: .inMemory)
+    }
+    
+    func test_messagePayload_isStoredAndLoadedFromDB() {
+        let userId: UserId = .unique
+        let messageId: MessageId = .unique
+        let channelId: ChannelId = .unique
+        
+        let channelPayload: ChannelPayload<DefaultDataTypes> = dummyPayload(with: channelId)
+        
+        let userPayload: UserPayload<NameAndImageExtraData> = .init(id: userId,
+                                                                    role: .admin,
+                                                                    created: .unique,
+                                                                    updated: .unique,
+                                                                    lastActiveDate: .unique,
+                                                                    isOnline: true,
+                                                                    isInvisible: true,
+                                                                    isBanned: true,
+                                                                    extraData: .init(name: "Anakin",
+                                                                                     imageURL: URL(string: UUID().uuidString)))
+        
+        let messagePayload: MessagePayload<DefaultDataTypes> = .init(id: messageId,
+                                                                     type: .regular,
+                                                                     user: userPayload,
+                                                                     created: .unique,
+                                                                     updated: .unique,
+                                                                     deleted: nil,
+                                                                     text: "No, I am your father 🤯",
+                                                                     command: "some command",
+                                                                     args: "some args",
+                                                                     parentId: nil,
+                                                                     showReplyInChannel: false,
+                                                                     mentionedUsers: [userPayload],
+                                                                     replyCount: 0,
+                                                                     extraData: .init(),
+                                                                     reactionScores: ["shock": 1000],
+                                                                     isSilent: false)
+        
+        // Asynchronously save the payload to the db
+        database.write { session in
+            // Create the channel first
+            try! session.saveChannel(payload: channelPayload, query: nil)
+            
+            // Save the message
+            try! session.saveMessage(payload: messagePayload, for: channelId)
+        }
+        
+        // Load the message from the db and check the fields are correct
+        var loadedMessage: MessageModel<DefaultDataTypes>? {
+            database.viewContext.loadMessage(id: messageId)
+        }
+        
+        AssertAsync {
+            Assert.willBeEqual(loadedMessage?.id, messagePayload.id)
+            Assert.willBeEqual(loadedMessage?.type, messagePayload.type)
+            Assert.willBeEqual(loadedMessage?.author.id, messagePayload.user.id)
+            Assert.willBeEqual(loadedMessage?.createdDate, messagePayload.created)
+            Assert.willBeEqual(loadedMessage?.updatedDate, messagePayload.updated)
+            Assert.willBeEqual(loadedMessage?.deletedDate, messagePayload.deleted)
+            Assert.willBeEqual(loadedMessage?.text, messagePayload.text)
+            Assert.willBeEqual(loadedMessage?.command, messagePayload.command)
+            Assert.willBeEqual(loadedMessage?.args, messagePayload.args)
+            Assert.willBeEqual(loadedMessage?.parentId, messagePayload.parentId)
+            Assert.willBeEqual(loadedMessage?.showReplyInChannel, messagePayload.showReplyInChannel)
+            Assert.willBeEqual(loadedMessage?.mentionedUsers.map { $0.id }, messagePayload.mentionedUsers.map { $0.id })
+            Assert.willBeEqual(loadedMessage?.replyCount, messagePayload.replyCount)
+            Assert.willBeEqual(loadedMessage?.extraData, messagePayload.extraData)
+            Assert.willBeEqual(loadedMessage?.reactionScores, messagePayload.reactionScores)
+            Assert.willBeEqual(loadedMessage?.isSilent, messagePayload.isSilent)
+        }
+    }
+    
+    func test_messagePayload_withExtraData_isStoredAndLoadedFromDB() {
+        struct DeathStarMetadata: MessageExtraData {
+            let isSectedDeathStarPlanIncluded: Bool
+        }
+        
+        enum SecretExtraData: ExtraDataTypes {
+            typealias Message = DeathStarMetadata
+        }
+        
+        let userId: UserId = .unique
+        let messageId: MessageId = .unique
+        let channelId: ChannelId = .unique
+        
+        let channelPayload: ChannelPayload<DefaultDataTypes> = dummyPayload(with: channelId)
+        
+        let userPayload: UserPayload<NameAndImageExtraData> = .init(id: userId,
+                                                                    role: .admin,
+                                                                    created: .unique,
+                                                                    updated: .unique,
+                                                                    lastActiveDate: .unique,
+                                                                    isOnline: true,
+                                                                    isInvisible: true,
+                                                                    isBanned: true,
+                                                                    extraData: .init(name: "Anakin",
+                                                                                     imageURL: URL(string: UUID().uuidString)))
+        
+        let messagePayload: MessagePayload<SecretExtraData> = .init(id: messageId,
+                                                                    type: .regular,
+                                                                    user: userPayload,
+                                                                    created: .unique,
+                                                                    updated: .unique,
+                                                                    deleted: nil,
+                                                                    text: "No, I am your father 🤯",
+                                                                    command: "some command",
+                                                                    args: "some args",
+                                                                    parentId: nil,
+                                                                    showReplyInChannel: false,
+                                                                    mentionedUsers: [userPayload],
+                                                                    replyCount: 0,
+                                                                    extraData: .init(isSectedDeathStarPlanIncluded: true),
+                                                                    reactionScores: ["shock": 1000],
+                                                                    isSilent: false)
+        
+        // Asynchronously save the payload to the db
+        database.write { session in
+            // Create the channel first
+            try! session.saveChannel(payload: channelPayload, query: nil)
+            
+            // Save the message
+            try! session.saveMessage(payload: messagePayload, for: channelId)
+        }
+        
+        // Load the message from the db and check the fields are correct
+        var loadedMessage: MessageModel<SecretExtraData>? {
+            database.viewContext.loadMessage(id: messageId)
+        }
+        
+        AssertAsync {
+            Assert.willBeEqual(loadedMessage?.id, messagePayload.id)
+            Assert.willBeEqual(loadedMessage?.type, messagePayload.type)
+            Assert.willBeEqual(loadedMessage?.author.id, messagePayload.user.id)
+            Assert.willBeEqual(loadedMessage?.createdDate, messagePayload.created)
+            Assert.willBeEqual(loadedMessage?.updatedDate, messagePayload.updated)
+            Assert.willBeEqual(loadedMessage?.deletedDate, messagePayload.deleted)
+            Assert.willBeEqual(loadedMessage?.text, messagePayload.text)
+            Assert.willBeEqual(loadedMessage?.command, messagePayload.command)
+            Assert.willBeEqual(loadedMessage?.args, messagePayload.args)
+            Assert.willBeEqual(loadedMessage?.parentId, messagePayload.parentId)
+            Assert.willBeEqual(loadedMessage?.showReplyInChannel, messagePayload.showReplyInChannel)
+            Assert.willBeEqual(loadedMessage?.mentionedUsers.map { $0.id }, messagePayload.mentionedUsers.map { $0.id })
+            Assert.willBeEqual(loadedMessage?.replyCount, messagePayload.replyCount)
+            Assert.willBeEqual(loadedMessage?.extraData.isSectedDeathStarPlanIncluded,
+                               messagePayload.extraData.isSectedDeathStarPlanIncluded)
+            Assert.willBeEqual(loadedMessage?.reactionScores, messagePayload.reactionScores)
+            Assert.willBeEqual(loadedMessage?.isSilent, messagePayload.isSilent)
+        }
+    }
+}

--- a/StreamChatClient_v3/Database/DatabaseSession.swift
+++ b/StreamChatClient_v3/Database/DatabaseSession.swift
@@ -73,5 +73,14 @@ extension DatabaseSession {
                 currentUserDTO.unreadMessagesCount = Int16(unreadCount.messages)
             }
         }
+        
+        // Save message data (must be always done after the channel data!)
+        if let message = payload.message {
+            if let cid = payload.cid {
+                try saveMessage(payload: message, for: cid)
+            } else {
+                log.error("Message payload \(message) can't be saved because `cid` is missing. Ignoring.")
+            }
+        }
     }
 }

--- a/StreamChatClient_v3/Database/DatabaseSession_Tests.swift
+++ b/StreamChatClient_v3/Database/DatabaseSession_Tests.swift
@@ -53,4 +53,69 @@ class DatabaseSession_Tests: XCTestCase {
             AssertAsync.willBeEqual(loadedMember?.id, member.user.id)
         }
     }
+    
+    func test_messageData_isSavedToDatabase() throws {
+        // Prepare an Event payload with a message data
+        let channelId: ChannelId = .unique
+        let messageId: MessageId = .unique
+        
+        let channelPayload: ChannelDetailPayload<DefaultDataTypes> = dummyPayload(with: channelId).channel
+        
+        let userPayload: UserPayload<NameAndImageExtraData> = .init(id: .unique,
+                                                                    role: .admin,
+                                                                    created: .unique,
+                                                                    updated: .unique,
+                                                                    lastActiveDate: .unique,
+                                                                    isOnline: true,
+                                                                    isInvisible: true,
+                                                                    isBanned: true,
+                                                                    extraData: .init(name: "Anakin",
+                                                                                     imageURL: URL(string: UUID().uuidString)))
+        
+        let messagePayload = MessagePayload<DefaultDataTypes>(id: messageId,
+                                                              type: .regular,
+                                                              user: userPayload,
+                                                              created: .unique,
+                                                              updated: .unique,
+                                                              text: "No, I am your father 🤯",
+                                                              showReplyInChannel: false,
+                                                              mentionedUsers: [],
+                                                              replyCount: 0,
+                                                              extraData: .init(),
+                                                              reactionScores: [:],
+                                                              isSilent: false)
+        
+        let eventPayload: EventPayload<DefaultDataTypes> = .init(eventType: .messageNew,
+                                                                 connectionId: .unique,
+                                                                 cid: channelId,
+                                                                 currentUser: nil,
+                                                                 user: nil,
+                                                                 createdBy: nil,
+                                                                 memberContainer: nil,
+                                                                 channel: channelPayload,
+                                                                 message: messagePayload,
+                                                                 reaction: nil,
+                                                                 watcherCount: nil,
+                                                                 unreadCount: nil,
+                                                                 createdAt: nil,
+                                                                 isChannelHistoryCleared: false,
+                                                                 banReason: nil,
+                                                                 banExpiredAt: nil)
+        
+        // Save the event payload to DB
+        database.write { session in
+            try session.saveEvent(payload: eventPayload)
+        }
+        
+        // Try to load the saved message from DB
+        var loadedMessage: MessageModel<DefaultDataTypes>? {
+            database.viewContext.loadMessage(id: messageId)
+        }
+        AssertAsync.willBeTrue(loadedMessage != nil)
+        
+        // Verify the channel has the message
+        let loadedChannel: ChannelModel<DefaultDataTypes> = try XCTUnwrap(database.viewContext.loadChannel(cid: channelId))
+        let message = try XCTUnwrap(loadedMessage)
+        XCTAssert(loadedChannel.latestMessages.contains(message))
+    }
 }

--- a/StreamChatClient_v3/Models/Message.swift
+++ b/StreamChatClient_v3/Models/Message.swift
@@ -29,3 +29,13 @@ public struct MessageModel<ExtraData: ExtraDataTypes> {
 public typealias Message = MessageModel<DefaultDataTypes>
 
 public protocol MessageExtraData: Codable & Hashable {}
+
+extension MessageModel: Hashable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}

--- a/StreamChatClient_v3/Models/Message.swift
+++ b/StreamChatClient_v3/Models/Message.swift
@@ -17,8 +17,8 @@ public struct MessageModel<ExtraData: ExtraDataTypes> {
     public let args: String?
     public let parentId: String?
     public let showReplyInChannel: Bool
-    public let extraData: ExtraData.Message?
     public let replyCount: Int
+    public let extraData: ExtraData.Message
     public let isSilent: Bool
     public let reactionScores: [String: Int]
     

--- a/StreamChatClient_v3/Models/Message.swift
+++ b/StreamChatClient_v3/Models/Message.swift
@@ -17,8 +17,8 @@ public struct MessageModel<ExtraData: ExtraDataTypes> {
     public let args: String?
     public let parentId: String?
     public let showReplyInChannel: Bool
-    public let replyCount: Int32
     public let extraData: ExtraData.Message?
+    public let replyCount: Int
     public let isSilent: Bool
     public let reactionScores: [String: Int]
     


### PR DESCRIPTION
### In this PR

- Added missing tests for `MessagePayload`

- Some polishing of `MessageModel`: Unread count is `Int`, extra data are non-optional. 

- Incoming message data are saved to the DB. The rest is happening automatically :magic:

![message_receive](https://user-images.githubusercontent.com/6388510/88537945-c9ae8a00-d00e-11ea-9582-4508a152b104.gif)
