### PR TITLE
[CIS-222] Make ChannelNamingStrategy per user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Client.search(filter: Filter, messageFilter: Filter, ...)` [#348](https://github.com/GetStream/stream-chat-swift/pull/348)
   - `SearchQuery.init(filter: Filter, messageFilter: Filter, ...)` [#348](https://github.com/GetStream/stream-chat-swift/pull/348)
 - `Filter.exists(Key, Bool)` [#348](https://github.com/GetStream/stream-chat-swift/pull/348)
+- Channels created without explicit name/image will get default names generated for them, using their members' names [#366](https://github.com/GetStream/stream-chat-swift/issues/366)
 
 ### 🐞 Fixed
 - Reintroduce Hashable conformances removed in 2.2.1 [#368](https://github.com/GetStream/stream-chat-swift/pull/368)
 - `ChannelPresenter.lastMessage` not updated on message edited or deleted [#351](https://github.com/GetStream/stream-chat-swift/issues/351)
 - Link tap in messages sometimes not detected or detected in wrong place [#350](https://github.com/GetStream/stream-chat-swift/issues/350)
 - Device object sometimes failing to decode on API calls [#266](https://github.com/GetStream/stream-chat-swift/issues/266)
+- Direct message channel (created without explicit id, using `Client.shared.channel(type:members:)`) are named correctly [#366](https://github.com/GetStream/stream-chat-swift/issues/366)
 - Flagging current user's (own) messages are now allowed [#369](https://github.com/GetStream/stream-chat-swift/issues/369)
 
 # [2.2.6](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.6)

--- a/Sources/Client/Client/Client+Channel.swift
+++ b/Sources/Client/Client/Client+Channel.swift
@@ -19,13 +19,16 @@ public extension Client {
     ///   - members: a list of members.
     ///   - invitedMembers: a list of invited members.
     ///   - team: The team the channel belongs to.
+    ///   - namingStrategy: a naming strategy to generate a name and image for the channel based on members.
+    ///                     Only takes effect if `extraData` is `nil`.
     ///   - extraData: a channel extra data.
     func channel(type: ChannelType,
                  id: String,
                  members: [User] = [],
                  invitedMembers: [User] = [],
                  team: String = "",
-                 extraData: ChannelExtraDataCodable? = nil) -> Channel {
+                 extraData: ChannelExtraDataCodable? = nil,
+                 namingStrategy: ChannelNamingStrategy? = Channel.DefaultNamingStrategy(maxUserNames: 1)) -> Channel {
         Channel(type: type,
                 id: id,
                 members: members,
@@ -37,6 +40,7 @@ public extension Client {
                 lastMessageDate: nil,
                 frozen: false,
                 team: team,
+                namingStrategy: namingStrategy,
                 config: .init())
     }
     
@@ -54,24 +58,19 @@ public extension Client {
                  team: String = "",
                  extraData: ChannelExtraDataCodable? = nil,
                  namingStrategy: ChannelNamingStrategy? = Channel.DefaultNamingStrategy(maxUserNames: 1)) -> Channel {
-        var extraData = extraData
-        
-        if extraData == nil, let namingStrategy = namingStrategy {
-            extraData = namingStrategy.extraData(for: user, members: members)
-        }
-        
-        return Channel(type: type,
-                       id: "",
-                       members: members,
-                       invitedMembers: [],
-                       extraData: extraData,
-                       created: .init(),
-                       deleted: nil,
-                       createdBy: nil,
-                       lastMessageDate: nil,
-                       frozen: false,
-                       team: team,
-                       config: .init())
+        Channel(type: type,
+                id: "",
+                members: members,
+                invitedMembers: [],
+                extraData: extraData,
+                created: .init(),
+                deleted: nil,
+                createdBy: nil,
+                lastMessageDate: nil,
+                frozen: false,
+                team: team,
+                namingStrategy: namingStrategy,
+                config: .init())
     }
 }
 

--- a/Sources/Core/Presenter/Channel/ChannelPresenter.swift
+++ b/Sources/Core/Presenter/Channel/ChannelPresenter.swift
@@ -42,7 +42,10 @@ public final class ChannelPresenter: Presenter {
     let channelPublishSubject = PublishSubject<Channel>()
     
     private(set) lazy var channelAtomic = Atomic<Channel>(.unused, callbackQueue: .main) { [weak self] channel, oldChannel in
-        channel.banEnabling = oldChannel.banEnabling
+        if oldChannel.cid != Channel.unused.cid {
+            channel.namingStrategy = oldChannel.namingStrategy
+            channel.banEnabling = oldChannel.banEnabling
+        }
         self?.channelPublishSubject.onNext(channel)
     }
     
@@ -164,7 +167,10 @@ extension ChannelPresenter {
     ///     - showReplyInChannel: show a reply in the channel.
     ///     - parseMentionedUsers: whether to automatically parse mentions into the `message.mentionedUsers` property. Defaults to `true`.
     ///     - completion: a completion block with `MessageResponse`.
-    public func send(text: String, showReplyInChannel: Bool = false, parseMentionedUsers: Bool = true, _ completion: @escaping Client.Completion<MessageResponse>) {
+    public func send(text: String,
+                     showReplyInChannel: Bool = false,
+                     parseMentionedUsers: Bool = true,
+                     _ completion: @escaping Client.Completion<MessageResponse>) {
         rx.send(text: text, showReplyInChannel: showReplyInChannel, parseMentionedUsers: parseMentionedUsers).bindOnce(to: completion)
     }
     

--- a/Tests/Client/Unit Tests/Channel+SetupTests.swift
+++ b/Tests/Client/Unit Tests/Channel+SetupTests.swift
@@ -31,15 +31,15 @@ final class Channel_SetupTests: XCTestCase {
         XCTAssertNil(channel.name)
         XCTAssertNil(channel.imageURL)
         
-        channel = client.channel(type: .messaging, id: channelId, members: [currentUser])
+        channel = client.channel(type: .messaging, id: channelId, members: [currentUser], namingStrategy: nil)
         XCTAssertNil(channel.name)
         XCTAssertNil(channel.imageURL)
         
-        channel = client.channel(type: .messaging, id: channelId, members: [currentUser, user2])
+        channel = client.channel(type: .messaging, id: channelId, members: [currentUser, user2], namingStrategy: nil)
         XCTAssertNil(channel.name)
         XCTAssertNil(channel.imageURL)
         
-        channel = client.channel(type: .messaging, id: channelId, members: [currentUser, user2, user3])
+        channel = client.channel(type: .messaging, id: channelId, members: [currentUser, user2, user3], namingStrategy: nil)
         XCTAssertNil(channel.name)
         XCTAssertNil(channel.imageURL)
     }
@@ -58,17 +58,25 @@ final class Channel_SetupTests: XCTestCase {
         var extraData = ChannelExtraData(name: "test")
         channel = client.channel(type: .messaging, members: [currentUser, user1], extraData: extraData, namingStrategy: strategy)
         XCTAssertEqual(channel.name, extraData.name)
-        XCTAssertEqual(channel.imageURL, extraData.imageURL)
+        XCTAssertEqual(channel.imageURL, user1.avatarURL)
         
         extraData = ChannelExtraData(imageURL: URL(string: "http://extradata.com"))
         channel = client.channel(type: .messaging, members: [currentUser, user1], extraData: extraData, namingStrategy: strategy)
-        XCTAssertNil(channel.name)
+        XCTAssertEqual(channel.name, "2")
         XCTAssertEqual(channel.imageURL, extraData.imageURL)
     }
 }
 
 fileprivate struct MockNamingStrategy: ChannelNamingStrategy {
+    func name(for currentUser: User, members: [User]) -> String? {
+        "\(members.count)"
+    }
+    
+    func imageURL(for currentUser: User, members: [User]) -> URL? {
+        members.first(where: { $0.id != currentUser.id })?.avatarURL
+    }
+    
     func extraData(for currentUser: User, members: [User]) -> ChannelExtraDataCodable? {
-        ChannelExtraData(name: "\(members.count)", imageURL: members.first?.avatarURL)
+        ChannelExtraData(name: name(for: currentUser, members: members), imageURL: imageURL(for: currentUser, members: members))
     }
 }

--- a/Tests/Client/Unit Tests/ChannelNamingStrategyTests.swift
+++ b/Tests/Client/Unit Tests/ChannelNamingStrategyTests.swift
@@ -22,46 +22,43 @@ final class ChannelNamingStrategyTests: XCTestCase {
         
         var extraData = ChannelExtraData(name: user1.name, imageURL: user1.avatarURL)
         var strategyExtraData = strategy.extraData(for: currentUser, members: [user1, currentUser])
-        compareExtraData(lhs: extraData, rhs: strategyExtraData)
+        XCTAssertEqual(extraData.name, strategyExtraData?.name)
+        XCTAssertEqual(extraData.imageURL, strategyExtraData?.imageURL)
         
         extraData = ChannelExtraData(name: [user1.name, user2.name].joined(separator: ", "))
         strategyExtraData = strategy.extraData(for: currentUser, members: [user1, currentUser, user2])
-        compareExtraData(lhs: extraData, rhs: strategyExtraData)
+        XCTAssertEqual(extraData.name, strategyExtraData?.name)
         
         extraData = ChannelExtraData(name: [user1.name, user2.name, user3.name].joined(separator: ", ") + " and 1 more")
         strategyExtraData = strategy.extraData(for: currentUser, members: [user1, user2, user3, currentUser, user4])
-        compareExtraData(lhs: extraData, rhs: strategyExtraData)
+        XCTAssertEqual(extraData.name, strategyExtraData?.name)
     }
     
     func test_channelNamingStrategry_edgeCases() {
         var strategy = Channel.DefaultNamingStrategy(maxUserNames: -1)
         var extraData = ChannelExtraData(name: "1 member", imageURL: user1.avatarURL)
         var strategyExtraData = strategy.extraData(for: currentUser, members: [user1, currentUser])
-        compareExtraData(lhs: extraData, rhs: strategyExtraData)
+        XCTAssertEqual(extraData.name, strategyExtraData?.name)
+        XCTAssertEqual(extraData.imageURL, strategyExtraData?.imageURL)
         
         strategy = Channel.DefaultNamingStrategy(maxUserNames: 0)
         extraData = ChannelExtraData(name: "3 members")
         strategyExtraData = strategy.extraData(for: currentUser, members: [user1, user2, currentUser, user3])
-        compareExtraData(lhs: extraData, rhs: strategyExtraData)
+        XCTAssertEqual(extraData.name, strategyExtraData?.name)
 
         strategy = Channel.DefaultNamingStrategy(maxUserNames: 1)
         extraData = ChannelExtraData(name: user1.name + " and 1 more")
         strategyExtraData = strategy.extraData(for: currentUser, members: [user1, currentUser, user2])
-        compareExtraData(lhs: extraData, rhs: strategyExtraData)
+        XCTAssertEqual(extraData.name, strategyExtraData?.name)
         
         strategy = Channel.DefaultNamingStrategy(maxUserNames: 2)
         extraData = ChannelExtraData(name: user1.name + ", " + user2.name)
         strategyExtraData = strategy.extraData(for: currentUser, members: [currentUser, user1, user2])
-        compareExtraData(lhs: extraData, rhs: strategyExtraData)
+        XCTAssertEqual(extraData.name, strategyExtraData?.name)
         
         strategy = Channel.DefaultNamingStrategy(maxUserNames: 2)
         extraData = ChannelExtraData(name: user1.name + ", " + user2.name + " and 2 more")
         strategyExtraData = strategy.extraData(for: currentUser, members: [user1, currentUser, user2, user3, user4])
-        compareExtraData(lhs: extraData, rhs: strategyExtraData)
-    }
-    
-    private func compareExtraData(lhs: ChannelExtraDataCodable?, rhs: ChannelExtraDataCodable?) {
-        XCTAssertEqual(lhs?.name, rhs?.name)
-        XCTAssertEqual(lhs?.imageURL, rhs?.imageURL)
+        XCTAssertEqual(extraData.name, strategyExtraData?.name)
     }
 }


### PR DESCRIPTION
`ChannelNamingStrategy` was generating names correctly for a single user and was sending this name/image to backend. So if user1 created a DM with user2, user1 would correctly see the chat name as "user2" but user2 would also see "user2", since the name was sent to backend.
This PR fixes this: generated name/images are not send to backend or stored anywhere. This way, all users participating in a channel created without id (so backend generates the id, starting with `!member`) will get correct, legible name/images.
Also, there's no breaking change, API is compatible with old versions.