### PR TITLE
[CIS-229] Improve test stability (part 1)

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     v3-stress-tests:
-      name: Run Stress Tests (v3)
+      name: Run Stress Tests (v3 - Debug)
       runs-on: macos-latest
       steps:
       - uses: actions/checkout@v1
@@ -30,3 +30,29 @@ jobs:
         run: bundle exec fastlane carthage_bootstrap
       - name: Run Stress Tests
         run: bundle exec fastlane stress_test_v3
+
+    v3-stress-tests_release:
+      name: Run Stress Tests (v3 - Release)
+      runs-on: macos-latest
+      steps:
+      - uses: actions/checkout@v1
+      - name: Cache Carthage dependencies
+        uses: actions/cache@v2
+        id: carthage-cache
+        with:
+          path: Carthage
+          key: ${{ runner.os }}-carthage-cache-${{ hashFiles('**/Cartfile.resolved') }}
+      - name: Cache RubyGems
+        uses: actions/cache@v1
+        id: rubygem-cache
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: ${{ runner.os }}-gem-
+      - name: Install RubyGems
+        if: steps.rubygem-cache.outputs.cache-hit != 'true'
+        run: bundle install
+      - name: Install Carthage dependencies
+        run: bundle exec fastlane carthage_bootstrap
+      - name: Run Stress Tests
+        run: bundle exec fastlane stress_test_v3_release

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "danger-swiftlint"
 gem "danger-commit_lint"
 gem "jazzy"
 gem "xcode-install"
+gem "json"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,6 +310,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-firebase_app_distribution
   jazzy
+  json
   xcode-install
 
 BUNDLED WITH

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		79877A2A2498E51500015F8B /* MemberModelDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A1D2498E50D00015F8B /* MemberModelDTO_Tests.swift */; };
 		79877A2B2498E51500015F8B /* UserModelDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A202498E50D00015F8B /* UserModelDTO_Tests.swift */; };
 		79877A2D2498E54400015F8B /* UserPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A162498E4EE00015F8B /* UserPayload_Tests.swift */; };
+		7988F6B124D010890004219B /* TestRunnerEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7988F6B024D010890004219B /* TestRunnerEnvironment.swift */; };
 		7990503224CEEAA600689CDC /* MessageDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */; };
 		799BE2EA248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799BE2E9248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift */; };
 		799BE2EC248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799BE2EB248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift */; };
@@ -649,6 +650,7 @@
 		79877A202498E50D00015F8B /* UserModelDTO_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserModelDTO_Tests.swift; sourceTree = "<group>"; };
 		79877A212498E50D00015F8B /* MemberModelDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemberModelDTO.swift; sourceTree = "<group>"; };
 		79877A222498E50D00015F8B /* UserModelDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserModelDTO.swift; sourceTree = "<group>"; };
+		7988F6B024D010890004219B /* TestRunnerEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestRunnerEnvironment.swift; sourceTree = "<group>"; };
 		7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDTO_Tests.swift; sourceTree = "<group>"; };
 		799BE2E9248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketReconnectionStrategy.swift; sourceTree = "<group>"; };
 		799BE2EB248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketReconnectionStrategy_Tests.swift; sourceTree = "<group>"; };
@@ -1467,6 +1469,7 @@
 				792921CC24C07A9000116BBB /* QueueAwareDelegate.swift */,
 				8A62705D24BE2CD70040BFD6 /* XCTestCase+MockJSON.swift */,
 				8A62706924BF02D80040BFD6 /* XCTAssertEqual+Difference.swift */,
+				7988F6B024D010890004219B /* TestRunnerEnvironment.swift */,
 			);
 			indentWidth = 4;
 			path = TestResources_v3;
@@ -2892,6 +2895,7 @@
 				792921C724C047DD00116BBB /* APIClient_Mock.swift in Sources */,
 				79A0E9BC2498C31A00E9BD50 /* UserTypingStartCleanupMiddleware_Tests.swift in Sources */,
 				796610BB248E687000761629 /* EventMiddleware_Tests.swift in Sources */,
+				7988F6B124D010890004219B /* TestRunnerEnvironment.swift in Sources */,
 				799C9469247D791A001F1104 /* AssertResult.swift in Sources */,
 				8AC9CBD424C7351D006E236C /* ReactionEvents_Tests.swift in Sources */,
 				79DDF81A249CE38B002F4412 /* RequestRecorderURLProtocol.swift in Sources */,

--- a/TestResources_v3/TestRunnerEnvironment.swift
+++ b/TestResources_v3/TestRunnerEnvironment.swift
@@ -1,0 +1,13 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+struct TestRunnerEnvironment {
+    /// `true` if the tests are currently running on the CI. We get this information by checking for the custom `CI` environment
+    /// variable passed in to the process.
+    static var isCI: Bool {
+        ProcessInfo.processInfo.environment["CI"] == "TRUE"
+    }
+}

--- a/TestResources_v3/XCTAssertEqual+Difference.swift
+++ b/TestResources_v3/XCTAssertEqual+Difference.swift
@@ -6,8 +6,13 @@ import Foundation
 import XCTest
 
 public func XCTAssertEqual<T: Equatable>(_ expected: T, _ received: T, file: StaticString = #file, line: UInt = #line) {
-    XCTAssertTrue(expected == received,
-                  "Found difference for \n" + diff(expected, received).joined(separator: ", "), file: file, line: line)
+    if TestRunnerEnvironment.isCI {
+        // Use built-in `XCTAssertEqual` when running on the CI to get CI-friendly logs.
+        XCTAssertEqual(expected, received, "", file: file, line: line)
+    } else {
+        XCTAssertTrue(expected == received,
+                      "Found difference for \n" + diff(expected, received).joined(separator: ", "), file: file, line: line)
+    }
 }
 
 // MARK: - Difference

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "TestResources_v3/"
+  - "**/*_Tests.swift"
+  - "**/*_Mock.swift"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -305,3 +305,26 @@ lane :stress_test_v3 do
     )      
   }
 end
+
+desc "Runs stress tests for v3 in Release config"
+lane :stress_test_v3_release do
+  scan(
+    project: "StreamChat.xcodeproj",
+    scheme: "StreamChatClient_v3",
+    configuration: "ReleaseTests",
+    clean: true,
+    build_for_testing: true
+  )
+
+  setCIEnvironmentVariable("../StreamChatClientStress_v3.xctestplan")
+
+  stress_tests_cycles.times {
+    scan(
+      project: "StreamChat.xcodeproj", 
+      scheme: "StreamChatClient_v3",
+      configuration: "ReleaseTests",
+      test_without_building: true,
+      testplan: "StreamChatClientStress_v3"
+    )      
+  }
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,6 +1,8 @@
 fastlane_version "2.68.0"
 default_platform :ios
 
+require 'json'
+
 # The number of times the stress test suite is ran
 stress_tests_cycles = 25
 
@@ -245,8 +247,21 @@ lane :get_next_issue_number do
   UI.success "Next markdown link is copied to your clipboard! ⬆️"
 end
 
+# Adds "CI=TRUE" environment variable to the provided test plan file
+def setCIEnvironmentVariable(testPlanFile)
+  file = File.read(testPlanFile)
+  data_hash = JSON.parse(file)
+  data_hash['defaultOptions']['environmentVariableEntries'] = [{"key"=>"CI", "value"=>"TRUE"}]
+  File.write(testPlanFile, JSON.pretty_generate(data_hash))
+
+  puts "✅ `CI=TRUE` ENV variable added to " + testPlanFile
+end
+
 desc "Runs tests for v3 in Debug config"
 lane :test_v3 do
+
+  setCIEnvironmentVariable("../StreamChatClient_v3.xctestplan")
+
   scan(
     project: "StreamChat.xcodeproj", 
     scheme: "StreamChatClient_v3", 
@@ -258,6 +273,9 @@ end
 
 desc "Runs tests for v3 in Release config"
 lane :test_v3_release do
+
+  setCIEnvironmentVariable("../StreamChatClient_v3.xctestplan")
+
   scan(
     project: "StreamChat.xcodeproj", 
     scheme: "StreamChatClient_v3", 
@@ -275,6 +293,8 @@ lane :stress_test_v3 do
     clean: true,
     build_for_testing: true
   )
+
+  setCIEnvironmentVariable("../StreamChatClientStress_v3.xctestplan")
 
   stress_tests_cycles.times {
     scan(

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -90,6 +90,11 @@ Runs tests for v3 in Release config
 fastlane stress_test_v3
 ```
 Runs stress tests for v3
+### stress_test_v3_release
+```
+fastlane stress_test_v3_release
+```
+Runs stress tests for v3 in Release config
 
 ----
 


### PR DESCRIPTION
### In this PR

This is just some preliminary work for improving test stability. The logs from the CI currently doesn't say much because the `Difference` library output is not visible thanks to `xcpretty` formatter.

- This PR adds a `CI=TRUE` env variable for tests when we run on the CI. When this is set, we don't use the `Difference` library.

- I also added a stress test suite for release configuration, since we see different behavior for debug and release configurations.

- Codecov coverage now properly ignores the test files. This causes the code coverage to drop for this PR.
