### PR TITLE
Reintroduce Hashable conformances removed in 2.2.1

### DIFF
--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -397,3 +397,10 @@ public struct HiddenChannelResponse: Decodable, Equatable {
     /// An event created date.
     public let created: Date
 }
+
+// MARK: - Hashable
+extension Channel: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(cid)
+    }
+}

--- a/Sources/Client/Model/Channel/ChannelResponse.swift
+++ b/Sources/Client/Model/Channel/ChannelResponse.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A channel response.
-public struct ChannelResponse: Decodable {
+public struct ChannelResponse: Decodable, Hashable {
     private enum CodingKeys: String, CodingKey {
         case channel
         case messages

--- a/Sources/Client/Model/Message/Attachment/Attachment.swift
+++ b/Sources/Client/Model/Message/Attachment/Attachment.swift
@@ -176,7 +176,7 @@ public struct Attachment: Codable {
     }
 }
 
-extension Attachment: Equatable {
+extension Attachment: Hashable {
     public static func == (lhs: Attachment, rhs: Attachment) -> Bool {
         lhs.title == rhs.title
             && lhs.author == rhs.author
@@ -185,6 +185,16 @@ extension Attachment: Equatable {
             && lhs.url == rhs.url
             && lhs.imageURL == rhs.imageURL
             && lhs.file == rhs.file
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
+        hasher.combine(author)
+        hasher.combine(text)
+        hasher.combine(type)
+        hasher.combine(url)
+        hasher.combine(imageURL)
+        hasher.combine(file)
     }
 }
 

--- a/Sources/Client/Model/Message/Attachment/AttachmentFile.swift
+++ b/Sources/Client/Model/Message/Attachment/AttachmentFile.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// An attachment file description.
-public struct AttachmentFile: Codable, Equatable {
+public struct AttachmentFile: Codable, Hashable {
     private enum CodingKeys: String, CodingKey {
         case mimeType = "mime_type"
         case size = "file_size"

--- a/Sources/Client/Model/Message/Attachment/AttachmentType.swift
+++ b/Sources/Client/Model/Message/Attachment/AttachmentType.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// An attachment type.
-public enum AttachmentType: RawRepresentable, Codable, Equatable, ExpressibleByStringLiteral {
+public enum AttachmentType: RawRepresentable, Codable, Hashable, ExpressibleByStringLiteral {
     /// An attachment type.
     case unknown
     case custom(String)

--- a/Sources/Client/Model/Message/Message.swift
+++ b/Sources/Client/Model/Message/Message.swift
@@ -317,3 +317,10 @@ public struct FlagMessageResponse: Decodable {
     /// A updated date.
     public let updated: Date
 }
+
+// MARK: - Hashable
+extension Message: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}

--- a/Sources/Client/Model/Message/MessageRead.swift
+++ b/Sources/Client/Model/Message/MessageRead.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A message read state. User + last read date + unread message count.
-public struct MessageRead: Decodable, Equatable {
+public struct MessageRead: Decodable, Hashable {
     private enum CodingKeys: String, CodingKey {
         case user
         case lastReadDate = "last_read"

--- a/Sources/Core/Presenter/Channel/ChannelPresenter+TypingUsers.swift
+++ b/Sources/Core/Presenter/Channel/ChannelPresenter+TypingUsers.swift
@@ -32,7 +32,7 @@ extension ChannelPresenter {
 }
 
 /// A typing user.
-public struct TypingUser: Equatable {
+public struct TypingUser: Hashable {
     /// A time interval for a users typing timeout.
     public static let timeout: TimeInterval = 30
     
@@ -43,5 +43,9 @@ public struct TypingUser: Equatable {
     
     public static func == (lhs: TypingUser, rhs: TypingUser) -> Bool {
         lhs.user == rhs.user
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(user)
     }
 }

--- a/Sources/UI/Style/ChannelViewStyle.swift
+++ b/Sources/UI/Style/ChannelViewStyle.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// A channel view style.
-public struct ChannelViewStyle {
+public struct ChannelViewStyle: Hashable {
     /// A background color.
     public var backgroundColor: UIColor
     /// A separator style.

--- a/Sources/UI/Style/ChatViewStyle.swift
+++ b/Sources/UI/Style/ChatViewStyle.swift
@@ -58,7 +58,7 @@ public struct ChatViewStyle {
 ///
 /// - always: show an element always visible, even if it disabled.
 /// - whenActive: an element will be hidden until it will change own state to active.
-public enum ChatViewStyleVisibility {
+public enum ChatViewStyleVisibility: Hashable {
     case none
     case always
     case whenActive

--- a/Sources/UI/Style/ComposerViewStyle.swift
+++ b/Sources/UI/Style/ComposerViewStyle.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// A composer style.
-public struct ComposerViewStyle: Equatable {
+public struct ComposerViewStyle: Hashable {
     /// A composer states type.
     ///
     /// For example:
@@ -113,7 +113,7 @@ extension ComposerViewStyle {
     }
     
     /// A composer style.
-    public struct Style: Equatable {
+    public struct Style: Hashable {
         /// A tint color. Also used as border color.
         public var tintColor: UIColor
         /// A border width.
@@ -139,7 +139,7 @@ extension ComposerViewStyle {
 }
 
 extension ComposerViewStyle {
-    public struct ReplyInChannelViewStyle: Equatable {
+    public struct ReplyInChannelViewStyle: Hashable {
         /// A default button text.
         public static let defaultText = "Also send to the channel"
         

--- a/Sources/UI/Style/SeparatorStyle.swift
+++ b/Sources/UI/Style/SeparatorStyle.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// A separator style.
-public struct SeparatorStyle {
+public struct SeparatorStyle: Hashable {
     
     public static let none = SeparatorStyle(tableStyle: .none)
     


### PR DESCRIPTION
Reintroducing all hashable conformances removed here:

https://github.com/GetStream/stream-chat-swift/compare/2.2.0...2.2.1

Some of them are now auto-generated

#no_changelog