### PR TITLE
[CIS-231] Fix flagging current user's messages are not allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ChannelPresenter.lastMessage` not updated on message edited or deleted [#351](https://github.com/GetStream/stream-chat-swift/issues/351)
 - Link tap in messages sometimes not detected or detected in wrong place [#350](https://github.com/GetStream/stream-chat-swift/issues/350)
 - Device object sometimes failing to decode on API calls [#266](https://github.com/GetStream/stream-chat-swift/issues/266)
+- Flagging current user's (own) messages are now allowed [#369](https://github.com/GetStream/stream-chat-swift/issues/369)
 
 # [2.2.6](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.6)
 _July 07, 2020_

--- a/Sources/Client/Client/Client+Message.swift
+++ b/Sources/Client/Client/Client+Message.swift
@@ -95,11 +95,6 @@ public extension Client {
             return Subscription.empty
         }
         
-        if message.user.isCurrent {
-            completion(.success(.init(messageId: message.id, created: Date(), updated: Date())))
-            return Subscription.empty
-        }
-        
         let completion = doAfter(completion) { _ in
             Message.flaggedIds.insert(message.id)
         }


### PR DESCRIPTION
As discussed in slack. 