### PR TITLE
[CIS-229] Improve test stability (part 3)

### DIFF
--- a/StreamChatClient_v3/APIClient/APIClient_Tests.swift
+++ b/StreamChatClient_v3/APIClient/APIClient_Tests.swift
@@ -27,6 +27,7 @@ class APIClient_Tests: StressTestCase {
         sessionConfiguration = URLSessionConfiguration.default
         RequestRecorderURLProtocol.startTestSession(with: &sessionConfiguration)
         MockNetworkURLProtocol.startTestSession(with: &sessionConfiguration)
+        sessionConfiguration.httpMaximumConnectionsPerHost = Int.max
         
         // Some random value to ensure the headers are respected
         uniqeHeaderValue = .unique
@@ -43,6 +44,9 @@ class APIClient_Tests: StressTestCase {
         weak var weakAPIClient = apiClient
         apiClient = nil
         XCTAssertNil(weakAPIClient)
+        
+        RequestRecorderURLProtocol.reset()
+        MockNetworkURLProtocol.reset()
         
         super.tearDown()
     }

--- a/StreamChatClient_v3/APIClient/APIClient_Tests.swift
+++ b/StreamChatClient_v3/APIClient/APIClient_Tests.swift
@@ -220,7 +220,7 @@ class TestRequestDecoder: RequestDecoder {
         decodeRequestResponse_error = error
         
         guard let simulatedResponse = decodeRequestResponse else {
-            print("TestRequestDecoder simulated response not set. Throwing a TestError.")
+            log.warning("TestRequestDecoder simulated response not set. Throwing a TestError.")
             throw TestError()
         }
         

--- a/StreamChatClient_v3/Controllers/ChannelListController_Tests.swift
+++ b/StreamChatClient_v3/Controllers/ChannelListController_Tests.swift
@@ -138,12 +138,9 @@ class ChannelListController_Tests: StressTestCase {
                 try session.saveChannel(payload: self.dummyPayload(with: cid), query: self.query)
             }, completion: $0)
         }
-        // 2. Simulate callback from ChangeAggregator
-        let channel: Channel = client.databaseContainer.viewContext.loadChannel(cid: cid)!
-        env.changeAggregator?.onChange?([.insert(channel, index: [0, 0])])
         
         // Assert the resulting value is updated
-        XCTAssertEqual(controller.channels.map { $0.cid }, [cid])
+        AssertAsync.willBeEqual(controller.channels.map { $0.cid }, [cid])
     }
     
     // MARK: - Delegate tests

--- a/TestResources_v3/Await.swift
+++ b/TestResources_v3/Await.swift
@@ -8,6 +8,10 @@ enum WaiterError: Error {
     case waitingForResultTimedOut
 }
 
+/// The maximum time `await` waits for the wrapped function to complete. When running stress tests, this value
+/// is much higher because the system might be under very heavy load.
+private let awaitTimeout: TimeInterval = TestRunnerEnvironment.isStressTest ? 5 : 1
+
 /// Allows calling an asynchronous function in the synchronous way in tests.
 ///
 /// Example usage:
@@ -25,7 +29,7 @@ enum WaiterError: Error {
 /// - Throws: `WaiterError.waitingForResultTimedOut` if `action` doesn't call the completion closure within the `timeout` period.
 ///
 /// - Returns: The result of `action`.
-func await<T>(timeout: TimeInterval = 1,
+func await<T>(timeout: TimeInterval = awaitTimeout,
               file: StaticString = #file,
               line: UInt = #line,
               _ action: (_ done: @escaping (T) -> Void) -> Void) throws -> T {

--- a/TestResources_v3/Mock Network/RequestRecorderURLProtocol.swift
+++ b/TestResources_v3/Mock Network/RequestRecorderURLProtocol.swift
@@ -34,11 +34,7 @@ class RequestRecorderURLProtocol: URLProtocol {
     ///
     /// - Parameter timeout: Specifies the time the function waits for a new request to be made.
     static func waitForRequest(timeout: TimeInterval) -> URLRequest? {
-        defer {
-            // Delete the used request
-            latestRequest = nil
-        }
-        
+        defer { reset() }
         guard latestRequest == nil else { return latestRequest }
         
         latestRequestExpectation = .init(description: "Wait for incoming request.")
@@ -73,6 +69,10 @@ class RequestRecorderURLProtocol: URLProtocol {
     }
     
     private static func record(request: URLRequest) {
+        guard latestRequest == nil else {
+            print("Reqeust for \(String(describing: currentSessionId)) already recoded. Skipping.")
+            return
+        }
         latestRequest = request
         latestRequestExpectation?.fulfill()
     }

--- a/TestResources_v3/Mock Network/RequestRecorderURLProtocol.swift
+++ b/TestResources_v3/Mock Network/RequestRecorderURLProtocol.swift
@@ -70,7 +70,7 @@ class RequestRecorderURLProtocol: URLProtocol {
     
     private static func record(request: URLRequest) {
         guard latestRequest == nil else {
-            print("Reqeust for \(String(describing: currentSessionId)) already recoded. Skipping.")
+            log.info("Request for \(String(describing: currentSessionId)) already recoded. Skipping.")
             return
         }
         latestRequest = request

--- a/TestResources_v3/StressTestCase.swift
+++ b/TestResources_v3/StressTestCase.swift
@@ -7,8 +7,8 @@ import XCTest
 class StressTestCase: XCTestCase {
     override func invokeTest() {
         if TestRunnerEnvironment.isStressTest {
-            // Invoke the test 1k times
-            for _ in 0 ... 1000 {
+            // Invoke the test 100 times
+            for _ in 0 ... 100 {
                 autoreleasepool {
                     super.invokeTest()
                 }

--- a/TestResources_v3/Virtual Time/VirtualTime.swift
+++ b/TestResources_v3/Virtual Time/VirtualTime.swift
@@ -12,7 +12,7 @@ class VirtualTime {
     /// Specifies the number of seconds the execution pauses for after the virtual time is advanced.
     ///
     /// This is needed to give the system time to execute async tasks properly. Typically, you don't need to change this value.
-    var timeAdvanceExecutionDelay: TimeInterval = 0.01
+    var timeAdvanceExecutionDelay: TimeInterval = 1 / 1_000_000
     
     var scheduledTimers: [VirtualTime.TimerControl] = []
     var currentTime: Seconds

--- a/TestResources_v3/XCTAssertEqual+Difference.swift
+++ b/TestResources_v3/XCTAssertEqual+Difference.swift
@@ -5,10 +5,10 @@
 import Foundation
 import XCTest
 
-public func XCTAssertEqual<T: Equatable>(_ expected: T, _ received: T, file: StaticString = #file, line: UInt = #line) {
+public func XCTAssertEqual<T: Equatable>(_ received: T, _ expected: T, file: StaticString = #file, line: UInt = #line) {
     if TestRunnerEnvironment.isCI {
         // Use built-in `XCTAssertEqual` when running on the CI to get CI-friendly logs.
-        XCTAssertEqual(expected, received, "", file: file, line: line)
+        XCTAssertEqual(received, expected, "", file: file, line: line)
     } else {
         XCTAssertTrue(expected == received,
                       "Found difference for \n" + diff(expected, received).joined(separator: ", "), file: file, line: line)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -251,10 +251,17 @@ end
 def setCIEnvironmentVariable(testPlanFile)
   file = File.read(testPlanFile)
   data_hash = JSON.parse(file)
-  data_hash['defaultOptions']['environmentVariableEntries'] = [{"key"=>"CI", "value"=>"TRUE"}]
+
+  # Create the `environmentVariableEntries` array if it doesn't exist
+  data_hash['defaultOptions']['environmentVariableEntries'] ||= []
+
+  # Append the `CI` ENV variable
+  data_hash['defaultOptions']['environmentVariableEntries'] << {"key"=>"CI", "value"=>"TRUE"}
   File.write(testPlanFile, JSON.pretty_generate(data_hash))
 
   puts "✅ `CI=TRUE` ENV variable added to " + testPlanFile
+  puts "Current testplan ENV variables:"
+  puts data_hash['defaultOptions']['environmentVariableEntries']
 end
 
 desc "Runs tests for v3 in Debug config"


### PR DESCRIPTION
### In this PR

This is the last PR of the series. I'm reluctant to say our stress tests are stable, but they are definitely **more** stable than before. I hope we won't see many regressions, at least for existing tests.

- I made some small changes to our test infrastructure. I made a couple of timeouts bigger when running stress tests, and in general, made our setup more CI-friendly.

- There was a race condition in the way we asserted network requests. It's fixed.

- There was a race condition in `ChannelListController` tests, it should be fixed now.