### PR TITLE
CIS-198 Reconnect Web Socket if no pong is received

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -480,6 +480,7 @@
 		8ADA1EED2472F7CE00C4FC82 /* ChannelNamingStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADA1EEC2472F7CE00C4FC82 /* ChannelNamingStrategyTests.swift */; };
 		8ADA1EEF2473FD7800C4FC82 /* EventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADA1EEE2473FD7800C4FC82 /* EventTests.swift */; };
 		8AE6206E23CF658700AB3426 /* User+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6F69D1230ECCD300B8CC1F /* User+Tests.swift */; };
+		8AE8950D24D8660800E852EC /* PingPongEmojiFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */; };
 		8AFA57292418EC1700FD07EC /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A30D07A237D81C20082B951 /* StringExtensionsTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -1023,6 +1024,7 @@
 		8ADA1EEE2473FD7800C4FC82 /* EventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTests.swift; sourceTree = "<group>"; };
 		8AE6206923CF63F000AB3426 /* ClientTests00.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientTests00.swift; sourceTree = "<group>"; };
 		8AE6206C23CF642900AB3426 /* TestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
+		8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingPongEmojiFormatter.swift; sourceTree = "<group>"; };
 		8AFA57262418EB2500FD07EC /* ClientLoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientLoggerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1283,8 +1285,9 @@
 		7964F3AF249A314D002A09EC /* Formatter */ = {
 			isa = PBXGroup;
 			children = (
-				7964F3B0249A314D002A09EC /* PrefixLogFormatter.swift */,
 				7964F3B1249A314D002A09EC /* LogFormatter.swift */,
+				7964F3B0249A314D002A09EC /* PrefixLogFormatter.swift */,
+				8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */,
 			);
 			path = Formatter;
 			sourceTree = "<group>";
@@ -2760,6 +2763,7 @@
 				792A4F25247FF01800EAF71D /* AppDelegate.swift in Sources */,
 				792A4F27247FF01800EAF71D /* SceneDelegate.swift in Sources */,
 				792A4F29247FF01800EAF71D /* MasterViewController.swift in Sources */,
+				8AE8950D24D8660800E852EC /* PingPongEmojiFormatter.swift in Sources */,
 				792A4F2B247FF01800EAF71D /* DetailViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		79FC85E724ACCBC500A665ED /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FC85E624ACCBC500A665ED /* Token.swift */; };
 		80B937A52434F5FC003D950E /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B937A42434F5FC003D950E /* Array+Extensions.swift */; };
 		8A0673B42445E0570042CFD3 /* Channel+Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0673B32445E0570042CFD3 /* Channel+Config.swift */; };
+		8A08C6A624D437DF00DEF995 /* WebSocketPingController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */; };
 		8A0C3BBC24C0947400CAFD19 /* UserEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0C3BBB24C0947400CAFD19 /* UserEvents.swift */; };
 		8A0C3BBF24C0ACAB00CAFD19 /* UserPresence.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A0C3BBD24C0AC6400CAFD19 /* UserPresence.json */; };
 		8A0C3BC024C0ACAB00CAFD19 /* UserUnbanned.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A0C3BBE24C0AC7800CAFD19 /* UserUnbanned.json */; };
@@ -245,6 +246,7 @@
 		8A5B6A6124810C6B0082C023 /* Channel+KeystrokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5B6A6024810C6B0082C023 /* Channel+KeystrokeTests.swift */; };
 		8A5B6A6424810E660082C023 /* ClientTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5B6A6324810E660082C023 /* ClientTestCase.swift */; };
 		8A5D3EF924AF749200E2FE35 /* ChannelId_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5D3EF824AF749200E2FE35 /* ChannelId_Tests.swift */; };
+		8A618E4524D19D510003D83C /* WebSocketPingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A618E4424D19D510003D83C /* WebSocketPingController.swift */; };
 		8A62704E24B8660A0040BFD6 /* EventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A62704D24B8660A0040BFD6 /* EventType.swift */; };
 		8A62705024B867190040BFD6 /* EventPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A62704F24B867190040BFD6 /* EventPayload.swift */; };
 		8A62705C24BE2BC00040BFD6 /* UserTypingEvent_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A62705B24BE2BC00040BFD6 /* UserTypingEvent_Tests.swift */; };
@@ -708,6 +710,7 @@
 		79FC85E624ACCBC500A665ED /* Token.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
 		80B937A42434F5FC003D950E /* Array+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		8A0673B32445E0570042CFD3 /* Channel+Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Channel+Config.swift"; sourceTree = "<group>"; };
+		8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketPingController_Tests.swift; sourceTree = "<group>"; };
 		8A0C3BBB24C0947400CAFD19 /* UserEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEvents.swift; sourceTree = "<group>"; };
 		8A0C3BBD24C0AC6400CAFD19 /* UserPresence.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = UserPresence.json; sourceTree = "<group>"; };
 		8A0C3BBE24C0AC7800CAFD19 /* UserUnbanned.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = UserUnbanned.json; sourceTree = "<group>"; };
@@ -776,6 +779,7 @@
 		8A5B6A6024810C6B0082C023 /* Channel+KeystrokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Channel+KeystrokeTests.swift"; sourceTree = "<group>"; };
 		8A5B6A6324810E660082C023 /* ClientTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientTestCase.swift; sourceTree = "<group>"; };
 		8A5D3EF824AF749200E2FE35 /* ChannelId_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelId_Tests.swift; sourceTree = "<group>"; };
+		8A618E4424D19D510003D83C /* WebSocketPingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketPingController.swift; sourceTree = "<group>"; };
 		8A62704D24B8660A0040BFD6 /* EventType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventType.swift; sourceTree = "<group>"; };
 		8A62704F24B867190040BFD6 /* EventPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventPayload.swift; sourceTree = "<group>"; };
 		8A62705B24BE2BC00040BFD6 /* UserTypingEvent_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTypingEvent_Tests.swift; sourceTree = "<group>"; };
@@ -1375,6 +1379,8 @@
 				79280F76248917EB00CDEB89 /* Engine */,
 				799C9444247D3DD2001F1104 /* WebSocketClient.swift */,
 				79A0E9AE2498BFD800E9BD50 /* WebSocketClient_Tests.swift */,
+				8A618E4424D19D510003D83C /* WebSocketPingController.swift */,
+				8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */,
 				799BE2E9248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift */,
 				799BE2EB248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift */,
 				797A756324814E7A003CF16D /* WebSocketConnectPayload.swift */,
@@ -2844,6 +2850,7 @@
 				79877A0B2498E4BC00015F8B /* MemberModel.swift in Sources */,
 				792FCB4524A33B5B000290C7 /* EventDataProcessorMiddleware.swift in Sources */,
 				79A0E9BE2498C33100E9BD50 /* UserTypingEvent.swift in Sources */,
+				8A618E4524D19D510003D83C /* WebSocketPingController.swift in Sources */,
 				8A62704E24B8660A0040BFD6 /* EventType.swift in Sources */,
 				799C945E247D7283001F1104 /* DatabaseContainer.swift in Sources */,
 				79877A092498E4BC00015F8B /* UserModel.swift in Sources */,
@@ -2892,6 +2899,7 @@
 				8A0CC9EB24C601F600705CF9 /* MemberEvents_Tests.swift in Sources */,
 				8A62705C24BE2BC00040BFD6 /* UserTypingEvent_Tests.swift in Sources */,
 				799BE2EC248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift in Sources */,
+				8A08C6A624D437DF00DEF995 /* WebSocketPingController_Tests.swift in Sources */,
 				8A62706C24BF3DBC0040BFD6 /* ChannelEvents_Tests.swift in Sources */,
 				79280F8424891C6A00CDEB89 /* VirtualTime.swift in Sources */,
 				799C9476247D7E94001F1104 /* TemporaryData.swift in Sources */,

--- a/StreamChatClient_v3/Utils/Logger/Formatter/PingPongEmojiFormatter.swift
+++ b/StreamChatClient_v3/Utils/Logger/Formatter/PingPongEmojiFormatter.swift
@@ -1,0 +1,12 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import StreamChatClient_v3
+
+/// Formats the given WebSocket ping/pong log message with the emoji prefix: 🏓
+public class PingPongEmojiFormatter: LogFormatter {
+    public func format(logDetails: LogDetails, message: String) -> String {
+        (message.contains("WebSocket Ping") || message.contains("WebSocket Pong") ? "🏓 " : "") + message
+    }
+}

--- a/StreamChatClient_v3/Utils/Logger/Formatter/PrefixLogFormatter.swift
+++ b/StreamChatClient_v3/Utils/Logger/Formatter/PrefixLogFormatter.swift
@@ -6,7 +6,7 @@ import Foundation
 
 /// Formats the given log message with the given prefixes by log level.
 /// Useful for emphasizing different leveled messages on console, when used as:
-/// `prefixes: [.info: "𝒊", .debug: "🛠", .error: "❌", .fault: "🚨"]`
+/// `prefixes: [.info: "ℹ️", .debug: "🛠", .error: "❌", .fault: "🚨"]`
 public class PrefixLogFormatter: LogFormatter {
     private let prefixes: [LogLevel: String]
     

--- a/StreamChatClient_v3/WebSocketClient/ConnectionState.swift
+++ b/StreamChatClient_v3/WebSocketClient/ConnectionState.swift
@@ -18,6 +18,9 @@ public enum ConnectionState: Equatable {
         
         /// The system initiated web socket disconnecting.
         case systemInitiated
+        
+        /// `WebSocketPingController` didn't get a pong response.
+        case noPongReceived
     }
     
     /// The web socket is not connected. Optionally contains an error, if the connection was disconnected due to an error.

--- a/StreamChatClient_v3/WebSocketClient/Engine/WebSocketEngine_Mock.swift
+++ b/StreamChatClient_v3/WebSocketClient/Engine/WebSocketEngine_Mock.swift
@@ -59,8 +59,42 @@ class WebSocketEngineMock: WebSocketEngine {
         delegate?.websocketDidReceiveMessage(String(data: data, encoding: .utf8)!)
     }
     
+    func simulatePong() {
+        simulateMessageReceived(.healthCheckEvent(userId: .unique, connectionId: .unique))
+    }
+    
     func simulateDisconnect(_ error: WebSocketEngineError? = nil) {
         isConnected = false
         delegate?.websocketDidDisconnect(error: error)
+    }
+}
+
+extension Dictionary {
+    /// Helper function to create a `health.check` event JSON with the given `userId` and `connectId`.
+    static func healthCheckEvent(userId: String, connectionId: String) -> [String: Any] {
+        [
+            "created_at": "2020-05-02T13:21:03.862065063Z",
+            "me": [
+                "id": userId,
+                "banned": false,
+                "unread_channels": 0,
+                "mutes": [],
+                "last_active": "2020-05-02T13:21:03.849219Z",
+                "created_at": "2019-06-05T15:01:52.847807Z",
+                "devices": [],
+                "invisible": false,
+                "unread_count": 0,
+                "channel_mutes": [],
+                "image": "https://i.imgur.com/EgEPqWZ.jpg",
+                "updated_at": "2020-05-02T13:21:03.855468Z",
+                "role": "user",
+                "total_unread_count": 0,
+                "online": true,
+                "name": "Steep Moon",
+                "test": 1
+            ],
+            "type": "health.check",
+            "connection_id": connectionId
+        ]
     }
 }

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient_Tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient_Tests.swift
@@ -243,40 +243,21 @@ class WebSocketClient_Tests: StressTestCase {
     
     // MARK: - Ping Controller
     
-    func test_pingIsSentPeriodically() {
-        // Simulate connection
+    func test_webSocketPingController_connectionStateDidChange_calledWhenConnectionChanges() {
         test_connectionFlow()
-        XCTAssertEqual(pingController.connectionStateDidChangeCount, 3)
-        XCTAssertEqual(pingController.pongRecievedCount, 1)
-        assert(engine.sendPing_calledCount == 0)
-        
-        // Simulate time longer than pingTimeInterval and assert `engine.sendPing` was called
-        time.run(numberOfSeconds: WebSocketPingController.pingTimeInterval)
-        engine.simulatePong()
-        XCTAssertEqual(engine.sendPing_calledCount, 1)
-        XCTAssertEqual(pingController.pongRecievedCount, 2)
+        XCTAssertEqual(3, pingController.connectionStateDidChangeCount)
     }
     
-    func test_pongTimeout() {
-        // Simulate connection
+    func test_webSocketPingController_ping_callsEngineWithPing() {
         test_connectionFlow()
-        XCTAssertEqual(engine.connect_calledCount, 1)
-        
-        reconnectionStrategy.reconnectionDelay = 1
-        var timeInterval = WebSocketPingController.pingTimeInterval
-        
-        // Simulate time longer than pingTimeInterval and assert `engine.sendPing` was called
-        assert(engine.sendPing_calledCount == 0)
-        time.run(numberOfSeconds: timeInterval)
+        webSocketClient.sendPing()
         XCTAssertEqual(engine.sendPing_calledCount, 1)
-        timeInterval += WebSocketPingController.pongTimeoutTimeInterval
-        time.run(numberOfSeconds: timeInterval)
-        XCTAssertEqual(engine.disconnect_calledCount, 1)
+    }
+    
+    func test_webSocketPingController_forceReconnect_disconnectsEngine() {
+        test_connectionFlow()
+        webSocketClient.forceDisconnect()
         XCTAssertFalse(webSocketClient.connectionState.isConnected)
-        
-        AssertAsync {
-            Assert.willBeTrue(self.engine.connect_calledCount == 2)
-        }
     }
     
     func test_changingConnectEndpointAndReconnecting() {

--- a/StreamChatClient_v3/WebSocketClient/WebSocketPingController.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketPingController.swift
@@ -1,0 +1,78 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The controller manages ping and pont timers. It send ping periodically to keep a web socket connection alive.
+/// After ping is sent, a pong waiting timer is started and if it does not come, a force disconnect is called.
+class WebSocketPingController {
+    /// The time interval to ping connection to keep it alive.
+    static let pingTimeInterval: TimeInterval = 25
+    /// The time interval for pong timeout.
+    static let pongTimeoutTimeInterval: TimeInterval = 3
+    
+    private let timerType: Timer.Type
+    private let timerQueue: DispatchQueue
+    
+    /// The timer used for scheduling `ping` calls
+    private lazy var pingTimerControl: RepeatingTimerControl =
+        timerType.scheduleRepeating(timeInterval: Self.pingTimeInterval, queue: timerQueue) { [weak self] in self?.sendPing() }
+    
+    /// The pong timeout timer.
+    private var pongTimeoutTimer: TimerControl?
+    /// An action for `WebSocketClient` to send a ping.
+    private let ping: () -> Void
+    /// An action for `WebSocketClient` to force disconnect and reconnect.
+    private let forceReconnect: () -> Void
+    
+    /// Creates a ping controller.
+    /// - Parameters:
+    ///   - timerType: a timer type.
+    ///   - timerQueue: a timer dispatch queue.
+    ///   - ping: an action for `WebSocketClient` to send a ping.
+    ///   - forceReconnect: an action for `WebSocketClient` to force disconnect and reconnect.
+    init(timerType: Timer.Type,
+         timerQueue: DispatchQueue,
+         ping: @escaping () -> Void,
+         forceReconnect: @escaping () -> Void) {
+        self.timerType = timerType
+        self.timerQueue = timerQueue
+        self.ping = ping
+        self.forceReconnect = forceReconnect
+    }
+    
+    func connectionStateDidChange(_ connectionState: ConnectionState) {
+        cancelPongTimeoutTimer()
+        
+        if connectionState.isConnected {
+            log.info("Resume WebSocket Ping timer")
+            pingTimerControl.resume()
+        } else {
+            pingTimerControl.suspend()
+        }
+    }
+    
+    // MARK: - Ping
+    
+    private func sendPing() {
+        // Start pong timeout timer.
+        pongTimeoutTimer = timerType.schedule(timeInterval: Self.pongTimeoutTimeInterval, queue: timerQueue) { [weak self] in
+            log.info("WebSocket Pong timeout. Reconnect")
+            self?.forceReconnect()
+        }
+        
+        log.info("WebSocket Ping")
+        ping()
+    }
+    
+    func pongRecieved() {
+        log.info("WebSocket Pong")
+        cancelPongTimeoutTimer()
+    }
+    
+    private func cancelPongTimeoutTimer() {
+        pongTimeoutTimer?.cancel()
+        pongTimeoutTimer = nil
+    }
+}

--- a/StreamChatClient_v3/WebSocketClient/WebSocketPingController_Tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketPingController_Tests.swift
@@ -1,0 +1,56 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient_v3
+import XCTest
+
+class WebSocketPingController_Tests: XCTestCase {
+    var time: VirtualTime!
+    var pingController: WebSocketPingController!
+    var pingCount = 0
+    var reconnectCount = 0
+    
+    override func setUp() {
+        super.setUp()
+        time = VirtualTime()
+        VirtualTimeTimer.time = time
+        
+        pingCount = 0
+        reconnectCount = 0
+        
+        pingController = .init(timerType: VirtualTimeTimer.self,
+                               timerQueue: .main,
+                               ping: { [unowned self] in self.pingCount += 1 },
+                               forceReconnect: { [unowned self] in self.reconnectCount += 1 })
+    }
+    
+    func test_startStopPingTimer() throws {
+        // Checks ping timer doesn't work until
+        time.run(numberOfSeconds: WebSocketPingController.pingTimeInterval + 1)
+        XCTAssertEqual(0, pingCount)
+        
+        pingController.connectionStateDidChange(.connected(connectionId: .unique))
+        time.run(numberOfSeconds: WebSocketPingController.pingTimeInterval)
+        XCTAssertEqual(1, pingCount)
+        
+        pingController.connectionStateDidChange(.waitingForConnectionId)
+        time.run(numberOfSeconds: WebSocketPingController.pingTimeInterval + 1)
+        XCTAssertEqual(1, pingCount)
+    }
+    
+    func test_pingPongReconnect() throws {
+        pingController.connectionStateDidChange(.connected(connectionId: .unique))
+        
+        time.run(numberOfSeconds: WebSocketPingController.pingTimeInterval)
+        XCTAssertEqual(1, pingCount)
+        pingController.pongRecieved()
+        time.run(numberOfSeconds: WebSocketPingController.pongTimeoutTimeInterval)
+        XCTAssertEqual(0, reconnectCount)
+        
+        time.run(numberOfSeconds: WebSocketPingController.pingTimeInterval)
+        XCTAssertEqual(2, pingCount)
+        time.run(numberOfSeconds: WebSocketPingController.pongTimeoutTimeInterval)
+        XCTAssertEqual(1, reconnectCount)
+    }
+}

--- a/StreamChatClient_v3/WebSocketClient/WebSocketPingController_Tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketPingController_Tests.swift
@@ -9,7 +9,7 @@ class WebSocketPingController_Tests: XCTestCase {
     var time: VirtualTime!
     var pingController: WebSocketPingController!
     var pingCount = 0
-    var reconnectCount = 0
+    var disconnectCount = 0
     
     override func setUp() {
         super.setUp()
@@ -17,40 +17,56 @@ class WebSocketPingController_Tests: XCTestCase {
         VirtualTimeTimer.time = time
         
         pingCount = 0
-        reconnectCount = 0
+        disconnectCount = 0
         
-        pingController = .init(timerType: VirtualTimeTimer.self,
-                               timerQueue: .main,
-                               ping: { [unowned self] in self.pingCount += 1 },
-                               forceReconnect: { [unowned self] in self.reconnectCount += 1 })
+        pingController = .init(timerType: VirtualTimeTimer.self, timerQueue: .main)
+        pingController.delegate = self
     }
     
     func test_startStopPingTimer() throws {
-        // Checks ping timer doesn't work until
+        // Checks ping timer doesn't work until it get the connect state is connected.
         time.run(numberOfSeconds: WebSocketPingController.pingTimeInterval + 1)
         XCTAssertEqual(0, pingCount)
         
+        // Send connection state as connected and check if a ping was send after ping timer time interval.
         pingController.connectionStateDidChange(.connected(connectionId: .unique))
         time.run(numberOfSeconds: WebSocketPingController.pingTimeInterval)
         XCTAssertEqual(1, pingCount)
         
+        // Send connection state as not connected and check if a ping was not send after ping timer time interval.
         pingController.connectionStateDidChange(.waitingForConnectionId)
         time.run(numberOfSeconds: WebSocketPingController.pingTimeInterval + 1)
-        XCTAssertEqual(1, pingCount)
+        XCTAssertEqual(1, pingCount) // The counter should be still the same value.
     }
     
     func test_pingPongReconnect() throws {
+        // Send connection state as connected to start the ping timer.
         pingController.connectionStateDidChange(.connected(connectionId: .unique))
         
+        // Send ping.
         time.run(numberOfSeconds: WebSocketPingController.pingTimeInterval)
         XCTAssertEqual(1, pingCount)
+        // Send pong.
         pingController.pongRecieved()
+        // Checks it didn't call disconnect after a pong timeout time interval.
         time.run(numberOfSeconds: WebSocketPingController.pongTimeoutTimeInterval)
-        XCTAssertEqual(0, reconnectCount)
+        XCTAssertEqual(0, disconnectCount)
         
+        // Send ping again.
         time.run(numberOfSeconds: WebSocketPingController.pingTimeInterval)
         XCTAssertEqual(2, pingCount)
+        // Don't send pong and `disconnectCount` should be increased by 1 after a pong timeout time interval.
         time.run(numberOfSeconds: WebSocketPingController.pongTimeoutTimeInterval)
-        XCTAssertEqual(1, reconnectCount)
+        XCTAssertEqual(1, disconnectCount)
+    }
+}
+
+extension WebSocketPingController_Tests: WebSocketPingControllerDelegate {
+    func sendPing() {
+        pingCount += 1
+    }
+    
+    func forceDisconnect() {
+        disconnectCount += 1
     }
 }

--- a/V3SampleApp/AppDelegate.swift
+++ b/V3SampleApp/AppDelegate.swift
@@ -22,7 +22,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
-        LogConfig.formatters = [PrefixLogFormatter(prefixes: [.info: "ℹ️", .debug: "🛠", .warning: "⚠️", .error: "🚨"])]
+        LogConfig.formatters = [PrefixLogFormatter(prefixes: [.info: "ℹ️", .debug: "🛠", .warning: "⚠️", .error: "🚨"]),
+                                PingPongEmojiFormatter()]
         
         LogConfig.showThreadName = false
         LogConfig.showDate = false


### PR DESCRIPTION
- Added `WebSocketPingController`:
  - ping by repeating timer
  - checks if pong was received otherwise call force disconnect
  - resume/suspend ping timer when connection state did change.
- Added tests for `WebSocketPingController`.
- Integrated `WebSocketPingController` to `WebSocketClient` and removed internal ping timer.
- Updated `WebSocketClient` tests.