### PR TITLE
[CIS-263] Remove unneeded readEventsEnabled check in Channel.markRead function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Upcoming
 
 ### 🔄 Changed
+- Remove the need for querying members in order to mark a channel as read [#280](https://github.com/GetStream/stream-chat-swift/issues/280)
 
 # [2.2.7](https://github.com/GetStream/stream-chat-swift/releases/tag/2.2.7)
 _July 29, 2020_
@@ -27,7 +28,6 @@ _July 29, 2020_
 - All iOS versions will use Starscream as default websocket provider until native provider issue is resolved. See [#315](https://github.com/GetStream/stream-chat-swift/issues/315). [#357](https://github.com/GetStream/stream-chat-swift/issues/357)
 
 ### 🐞 Fixed
-- Remove need for member query in order to mark channel as read. [#280](https://github.com/GetStream/stream-chat-swift/issues/280)
 - Reintroduce Hashable conformances removed in 2.2.1 [#368](https://github.com/GetStream/stream-chat-swift/pull/368)
 - `ChannelPresenter.lastMessage` not updated on message edited or deleted [#351](https://github.com/GetStream/stream-chat-swift/issues/351)
 - Link tap in messages sometimes not detected or detected in wrong place [#350](https://github.com/GetStream/stream-chat-swift/issues/350)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ _July 29, 2020_
 - All iOS versions will use Starscream as default websocket provider until native provider issue is resolved. See [#315](https://github.com/GetStream/stream-chat-swift/issues/315). [#357](https://github.com/GetStream/stream-chat-swift/issues/357)
 
 ### 🐞 Fixed
+- Remove need for member query in order to mark channel as read. [#280](https://github.com/GetStream/stream-chat-swift/issues/280)
 - Reintroduce Hashable conformances removed in 2.2.1 [#368](https://github.com/GetStream/stream-chat-swift/pull/368)
 - `ChannelPresenter.lastMessage` not updated on message edited or deleted [#351](https://github.com/GetStream/stream-chat-swift/issues/351)
 - Link tap in messages sometimes not detected or detected in wrong place [#350](https://github.com/GetStream/stream-chat-swift/issues/350)

--- a/Sources/Client/Client/Client+Channel.swift
+++ b/Sources/Client/Client/Client+Channel.swift
@@ -299,10 +299,6 @@ public extension Client {
     ///   - completion: a completion block with `Event`.
     @discardableResult
     func markRead(channel: Channel, _ completion: @escaping Client.Completion<Event>) -> Cancellable {
-        guard channel.readEventsEnabled else {
-            return Subscription.empty
-        }
-        
         logger?.log("🎫 Mark Read")
         
         return request(endpoint: .markRead(channel)) { (result: Result<EventResponse, ClientError>) in

--- a/Sources/Client/Client/Client+Channel.swift
+++ b/Sources/Client/Client/Client+Channel.swift
@@ -296,11 +296,10 @@ public extension Client {
     /// Mark messages in the channel as read.
     /// - Parameters:
     ///   - channel: a channel.
-    ///   - skipReadEventsEnabledCheck: if true, an API call is made even if the current user is not present in the channel's member list. Default is false.
     ///   - completion: a completion block with `Event`.
     @discardableResult
-    func markRead(channel: Channel, skipReadEventsEnabledCheck: Bool = false, _ completion: @escaping Client.Completion<Event>) -> Cancellable {
-        guard skipReadEventsEnabledCheck || channel.readEventsEnabled else {
+    func markRead(channel: Channel, _ completion: @escaping Client.Completion<Event>) -> Cancellable {
+        guard channel.readEventsEnabled else {
             return Subscription.empty
         }
         

--- a/Sources/Client/Client/Client+Channel.swift
+++ b/Sources/Client/Client/Client+Channel.swift
@@ -296,9 +296,14 @@ public extension Client {
     /// Mark messages in the channel as read.
     /// - Parameters:
     ///   - channel: a channel.
+    ///   - skipReadEventsEnabledCheck: if true, an API call is made even if the current user is not present in the channel's member list. Default is false.
     ///   - completion: a completion block with `Event`.
     @discardableResult
-    func markRead(channel: Channel, _ completion: @escaping Client.Completion<Event>) -> Cancellable {
+    func markRead(channel: Channel, skipReadEventsEnabledCheck: Bool = false, _ completion: @escaping Client.Completion<Event>) -> Cancellable {
+        guard skipReadEventsEnabledCheck || channel.readEventsEnabled else {
+            return Subscription.empty
+        }
+        
         logger?.log("🎫 Mark Read")
         
         return request(endpoint: .markRead(channel)) { (result: Result<EventResponse, ClientError>) in


### PR DESCRIPTION
This is a possible performance-related breaking change for people using the low-level SDK. Something to consider in review: maybe it's better to add a parameter with default value (skipReadEventsEnabledCheck: Bool = false) and allow the check to be skipped explicitly to avoid the breaking change.

This shouldn't impact usage in Core and UI, since the check is already done in ChannelPresenter:

https://github.com/GetStream/stream-chat-swift/blob/93341063a9e52cfd42617416081f5948a4a3449b/Sources/Core/Presenter/Channel/ChannelPresenter%2BRxRequests.swift#L123-L126

Closes #280