### PR TITLE
[CIS 256] Implement mute/unmute channel functionality

### DIFF
--- a/StreamChatClient_v3/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/StreamChatClient_v3/APIClient/Endpoints/ChannelEndpoints.swift
@@ -21,4 +21,12 @@ extension Endpoint {
               requiresConnectionId: query.options.contains(oneOf: [.presence, .state, .watch]),
               body: query)
     }
+
+    static func muteChannel(cid: ChannelId, mute: Bool) -> Endpoint<EmptyResponse> {
+        .init(path: "moderation/\(mute ? "mute" : "unmute")/channel",
+              method: .post,
+              queryItems: nil,
+              requiresConnectionId: true,
+              body: ["channel_cid": cid])
+    }
 }

--- a/StreamChatClient_v3/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/StreamChatClient_v3/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -5,4 +5,57 @@
 @testable import StreamChatClient_v3
 import XCTest
 
-final class ChannelEndpoints_Tests: XCTestCase {}
+final class ChannelEndpoints_Tests: XCTestCase {
+    func test_channels_buildsCorrectly() {
+        let filter = Filter.in("member", ["Luke"])
+
+        let testCases: [(ChannelListQuery, Bool)] = [
+            (.init(filter: filter, options: .state), true),
+            (.init(filter: filter, options: .presence), true),
+            (.init(filter: filter, options: .watch), true),
+            (.init(filter: filter, options: .all), true),
+            (.init(filter: filter, options: []), false)
+        ]
+
+        for (query, requiresConnectionId) in testCases {
+            let expectedEndpoint = Endpoint<ChannelListPayload<DefaultDataTypes>>(path: "channels",
+                                                                                  method: .get,
+                                                                                  queryItems: nil,
+                                                                                  requiresConnectionId: requiresConnectionId,
+                                                                                  body: ["payload": query])
+
+            // Build endpoint
+            let endpoint: Endpoint<ChannelListPayload<DefaultDataTypes>> = .channels(query: query)
+
+            // Assert endpoint is built correctly
+            XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        }
+    }
+
+    func test_channel_buildsCorrectly() {
+        let channelID = ChannelId(type: .livestream, id: "qwerty")
+
+        let testCases: [(ChannelQuery<DefaultDataTypes>, Bool)] = [
+            (.init(channelId: channelID, options: .state), true),
+            (.init(channelId: channelID, options: .presence), true),
+            (.init(channelId: channelID, options: .watch), true),
+            (.init(channelId: channelID, options: .all), true),
+            (.init(channelId: channelID, options: []), false)
+        ]
+
+        for (query, requiresConnectionId) in testCases {
+            let expectedEndpoint =
+                Endpoint<ChannelPayload<DefaultDataTypes>>(path: "channels/\(query.cid.type.rawValue)/\(query.cid.id)/query",
+                                                           method: .post,
+                                                           queryItems: nil,
+                                                           requiresConnectionId: requiresConnectionId,
+                                                           body: query)
+
+            // Build endpoint
+            let endpoint: Endpoint<ChannelPayload<DefaultDataTypes>> = .channel(query: query)
+
+            // Assert endpoint is built correctly
+            XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        }
+    }
+}

--- a/StreamChatClient_v3/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/StreamChatClient_v3/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -58,4 +58,27 @@ final class ChannelEndpoints_Tests: XCTestCase {
             XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
         }
     }
+
+    func test_muteChannel_buildsCorrectly() {
+        let testCases = [
+            (true, "moderation/mute/channel"),
+            (false, "moderation/unmute/channel")
+        ]
+
+        for (mute, path) in testCases {
+            let channelID = ChannelId.unique
+
+            let expectedEndpoint = Endpoint<EmptyResponse>(path: path,
+                                                           method: .post,
+                                                           queryItems: nil,
+                                                           requiresConnectionId: true,
+                                                           body: ["channel_cid": channelID])
+
+            // Build endpoint
+            let endpoint: Endpoint<EmptyResponse> = .muteChannel(cid: channelID, mute: mute)
+
+            // Assert endpoint is built correctly
+            XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        }
+    }
 }

--- a/StreamChatClient_v3/Controllers/ChannelListController.swift
+++ b/StreamChatClient_v3/Controllers/ChannelListController.swift
@@ -41,6 +41,11 @@ public class ChannelListControllerGeneric<ExtraData: ExtraDataTypes>: Controller
         .channelQueryUpdaterBuilder(client.databaseContainer,
                                     client.webSocketClient,
                                     client.apiClient)
+
+    private lazy var channelUpdater: ChannelUpdater<ExtraData> = environment
+        .channelUpdaterBuilder(client.databaseContainer,
+                               client.webSocketClient,
+                               client.apiClient)
     
     /// A type-erased delegate.
     private(set) var anyDelegate: AnyChannelListControllerDelegate<ExtraData>?
@@ -132,6 +137,36 @@ public class ChannelListControllerGeneric<ExtraData: ExtraDataTypes>: Controller
         where Delegate.ExtraData == ExtraData
     {
         anyDelegate = AnyChannelListControllerDelegate(delegate)
+    }
+}
+
+// MARK: - Channel muting
+
+public extension ChannelListControllerGeneric {
+    /// Mutes the channel with provided **cid**.
+    /// - Parameters:
+    ///   - cid: The channel identifier.
+    ///   - completion: Called when the channel is muted. If the api-call fails, the completion
+    /// is called with an error.
+    func muteChannel(cid: ChannelId, completion: ((Error?) -> Void)? = nil) {
+        channelUpdater.muteChannel(cid: cid, mute: true) { [weak self] error in
+            self?.callbackQueue.async {
+                completion?(error)
+            }
+        }
+    }
+
+    /// Unmutes the channel with provided **cid**.
+    /// - Parameters:
+    ///   - cid: The channel identifier.
+    ///   - completion: Called when the channel is unmuted. If the api-call fails, the completion
+    /// is called with an error.
+    func unmuteChannel(cid: ChannelId, completion: ((Error?) -> Void)? = nil) {
+        channelUpdater.muteChannel(cid: cid, mute: false) { [weak self] error in
+            self?.callbackQueue.async {
+                completion?(error)
+            }
+        }
     }
 }
 

--- a/StreamChatClient_v3/Workers/ChannelUpdater.swift
+++ b/StreamChatClient_v3/Workers/ChannelUpdater.swift
@@ -1,5 +1,4 @@
 //
-// ChannelUpdater.swift
 // Copyright © 2020 Stream.io Inc. All rights reserved.
 //
 
@@ -15,6 +14,17 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
                     completion?(nil)
                 }
             } catch {
+                completion?(error)
+            }
+        }
+    }
+
+    func muteChannel(cid: ChannelId, mute: Bool, completion: ((Error?) -> Void)? = nil) {
+        apiClient.request(endpoint: .muteChannel(cid: cid, mute: mute)) {
+            switch $0 {
+            case .success:
+                completion?(nil)
+            case let .failure(error):
                 completion?(error)
             }
         }

--- a/V3SampleApp/MasterViewController.swift
+++ b/V3SampleApp/MasterViewController.swift
@@ -11,6 +11,11 @@ import StreamChatClient_v3
 
 class MasterViewController: UITableViewController {
 
+    private lazy var longPressRecognizer = UILongPressGestureRecognizer(
+        target: self,
+        action: #selector(handleLongPress)
+    )
+
     lazy var channelListController: ChannelListController = chatClient
         .channelListController(query: ChannelListQuery(filter: .in("members", ["broken-waterfall-5"]), options: [.watch]))
     
@@ -31,6 +36,8 @@ class MasterViewController: UITableViewController {
             let controllers = split.viewControllers
             detailViewController = (controllers[controllers.count-1] as! UINavigationController).topViewController as? DetailViewController
         }
+
+        tableView.addGestureRecognizer(longPressRecognizer)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -80,6 +87,34 @@ class MasterViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+    }
+
+}
+
+// MARK: - Private
+
+private extension MasterViewController {
+    @objc
+    func handleLongPress(_ gestureRecognizer: UILongPressGestureRecognizer) {
+        guard
+            let indexPath = tableView.indexPathForRow(at: gestureRecognizer.location(in: tableView)),
+            gestureRecognizer.state == .began
+            else { return }
+
+        let selectedChannel = channelListController.channels[indexPath.row]
+
+        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        actionSheet.addAction(
+            UIAlertAction(title: "Mute", style: .default) { _ in
+                self.channelListController.muteChannel(cid: selectedChannel.cid)
+            }
+        )
+        actionSheet.addAction(
+            UIAlertAction(title: "Unmute", style: .default) { _ in
+                self.channelListController.unmuteChannel(cid: selectedChannel.cid)
+            }
+        )
+        present(actionSheet, animated: true)
     }
 }
 


### PR DESCRIPTION
**This PR:**
- adds `muteChannel` endpoint;
- exposes muting channel functionality via `ChannelListController`;
- adds channel mute/unmute functionality to `V3SampleApp`.