### PR TITLE
[CIS-270] WebSocketTests improvements

### DIFF
--- a/StreamChatClient_v3/WebSocketClient/Engine/WebSocketEngine_Mock.swift
+++ b/StreamChatClient_v3/WebSocketClient/Engine/WebSocketEngine_Mock.swift
@@ -13,13 +13,13 @@ class WebSocketEngineMock: WebSocketEngine {
     weak var delegate: WebSocketEngineDelegate?
     
     /// How many times was `connect()` called
-    var connect_calledCount = 0
+    @Atomic var connect_calledCount = 0
     
     /// How many times was `disconnect()` called
-    var disconnect_calledCount = 0
+    @Atomic var disconnect_calledCount = 0
     
     /// How many times was `sendPing()` called
-    var sendPing_calledCount = 0
+    @Atomic var sendPing_calledCount = 0
     
     convenience init() {
         self.init(request: .init(url: URL(string: "test_url")!), sessionConfiguration: .default, callbackQueue: .main)

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
@@ -62,7 +62,7 @@ class WebSocketClient {
     private var reconnectionTimer: TimerControl?
     
     /// The queue on which web socket engine methods are called
-    private let engineQueue: DispatchQueue = .init(label: "io.getStream.chat.core.web_socket_engine_queue", qos: .default)
+    private let engineQueue: DispatchQueue = .init(label: "io.getStream.chat.core.web_socket_engine_queue", qos: .userInitiated)
     
     private let requestEncoder: RequestEncoder
     

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
@@ -56,7 +56,7 @@ class WebSocketClient {
     private let eventDecoder: AnyEventDecoder
     
     /// The web socket engine used to make the actual WS connection
-    lazy var engine: WebSocketEngine = createEngine()
+    private(set) lazy var engine: WebSocketEngine = createEngine()
     
     /// If in the `waitingForReconnect` state, this variable contains the reconnection timer.
     private var reconnectionTimer: TimerControl?
@@ -143,8 +143,8 @@ class WebSocketClient {
         
         connectionState = .connecting
         
-        engineQueue.async {
-            self.engine.connect()
+        engineQueue.async { [engine] in
+            engine.connect()
         }
     }
     
@@ -154,8 +154,8 @@ class WebSocketClient {
     /// - Parameter source: Additional information about the source of the disconnection. Default value is `.userInitiated`.
     func disconnect(source: ConnectionState.DisconnectionSource = .userInitiated) {
         connectionState = .disconnecting(source: source)
-        engineQueue.async {
-            self.engine.disconnect()
+        engineQueue.async { [engine] in
+            engine.disconnect()
         }
     }
     
@@ -301,8 +301,8 @@ extension WebSocketClient: WebSocketEngineDelegate {
 
 extension WebSocketClient: WebSocketPingControllerDelegate {
     func sendPing() {
-        engineQueue.async {
-            self.engine.sendPing()
+        engineQueue.async { [engine] in
+            engine.sendPing()
         }
     }
     

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
@@ -301,7 +301,9 @@ extension WebSocketClient: WebSocketEngineDelegate {
 
 extension WebSocketClient: WebSocketPingControllerDelegate {
     func sendPing() {
-        engine.sendPing()
+        engineQueue.async {
+            self.engine.sendPing()
+        }
     }
     
     func disconnectOnNoPongReceived() {

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient.swift
@@ -304,7 +304,7 @@ extension WebSocketClient: WebSocketPingControllerDelegate {
         engine.sendPing()
     }
     
-    func forceDisconnect() {
+    func disconnectOnNoPongReceived() {
         disconnect(source: .noPongReceived)
     }
 }

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient_Tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient_Tests.swift
@@ -71,7 +71,7 @@ class WebSocketClient_Tests: StressTestCase {
         // Check there are no memory leaks
         weak var weakReference = webSocketClient
         webSocketClient = nil
-        XCTAssertNil(weakReference)
+        AssertAsync.willBeNil(weakReference)
         
         super.tearDown()
     }

--- a/StreamChatClient_v3/WebSocketClient/WebSocketClient_Tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketClient_Tests.swift
@@ -283,6 +283,9 @@ class WebSocketClient_Tests: StressTestCase {
         // Simulate connection
         test_connectionFlow()
         
+        // Save the original engine reference
+        let oldEngine = engine
+        
         // Simulate connect endpoint is updated (i.e. new user is logged in)
         let newEndpoint = Endpoint<EmptyResponse>(path: .unique,
                                                   method: .get,
@@ -295,13 +298,17 @@ class WebSocketClient_Tests: StressTestCase {
         let newRequest = URLRequest(url: .unique())
         requestEncoder.encodeRequest = .success(newRequest)
         
-        // Reconnect and check the engine is recreated
+        // Disconnect
         assert(engine.disconnect_calledCount == 0)
         webSocketClient.disconnect()
         AssertAsync.willBeEqual(engine.disconnect_calledCount, 1)
         
+        // Reconnect again
         webSocketClient.connect()
         XCTAssertEqual(requestEncoder.encodeRequest_endpoint, AnyEndpoint(newEndpoint))
+        
+        // Check the engige got recreated
+        XCTAssert(engine !== oldEngine)
         
         AssertAsync {
             Assert.willBeEqual(self.engine.request, newRequest)

--- a/StreamChatClient_v3/WebSocketClient/WebSocketPingController.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketPingController.swift
@@ -10,7 +10,7 @@ protocol WebSocketPingControllerDelegate: AnyObject {
     func sendPing()
     
     /// `WebSocketPingController` will call it to force disconnect `WebSocketClient`.
-    func forceDisconnect()
+    func disconnectOnNoPongReceived()
 }
 
 /// The controller manages ping and pont timers. It send ping periodically to keep a web socket connection alive.
@@ -65,7 +65,7 @@ class WebSocketPingController {
         // Start pong timeout timer.
         pongTimeoutTimer = timerType.schedule(timeInterval: Self.pongTimeoutTimeInterval, queue: timerQueue) { [weak self] in
             log.info("WebSocket Pong timeout. Reconnect")
-            self?.delegate?.forceDisconnect()
+            self?.delegate?.disconnectOnNoPongReceived()
         }
         
         log.info("WebSocket Ping")

--- a/StreamChatClient_v3/WebSocketClient/WebSocketPingController_Tests.swift
+++ b/StreamChatClient_v3/WebSocketClient/WebSocketPingController_Tests.swift
@@ -66,7 +66,7 @@ extension WebSocketPingController_Tests: WebSocketPingControllerDelegate {
         pingCount += 1
     }
     
-    func forceDisconnect() {
+    func disconnectOnNoPongReceived() {
         disconnectCount += 1
     }
 }

--- a/TestResources_v3/Custom Assertions/AssertAsync.swift
+++ b/TestResources_v3/Custom Assertions/AssertAsync.swift
@@ -5,7 +5,7 @@
 import XCTest
 
 /// The default timeout value used by the `willBe___` family of assertions.
-let defaultTimeout: TimeInterval = 1
+let defaultTimeout: TimeInterval = TestRunnerEnvironment.isCI ? 5 : 1
 
 /// The default timeout value used by the `stays___` family of assertions.
 let defaultTimeoutForInversedExpecations: TimeInterval = TestRunnerEnvironment.isStressTest ? 0.001 : 0.1


### PR DESCRIPTION
### In this PR:

The `WebSocketTests` should (hopefully 🤞) be stable again. I must admit I'm not really sure what was happening and why.

The problem was caused by the fact, that we use a special queue to communicate with the engine, to ensure the engine commands are executed in the correct order when calling from different threads. This created some issues when we needed to re-create the engine because of the connection endpoint change.

The good thing is, that the original implementation where we did:
```swift
engineQueue.async {  self.engine.connect() }
```
was incorrect, so the tests correctly failed on this. We now capture the engine reference when we dispatch the call, so we're sure the "correct" engine receives the call.
```swift
engineQueue.async { [engine] in engine.connect() }
```

However, I'm not sure why it affected the tests the way it did. So it's possible this wasn't the root of the problem, or that there are more problems we're not aware of as of now.
