### PR TITLE
[CIS-245] Event observing

### DIFF
--- a/Sources_v3/Controllers/ChannelController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController_Tests.swift
@@ -515,7 +515,8 @@ private class TestDelegate: QueueAwareDelegate, ChannelControllerDelegate {
     var didStopFetchingRemoteDataCalledCounter = 0
     var didUpdateChannel_channel: EntityChange<Channel>?
     var didUpdateMessages_messages: [ListChange<Message>]?
-    
+    var didReceiveMemberEvent_event: MemberEvent?
+
     func controllerWillStartFetchingRemoteData(_ controller: Controller) {
         willStartFetchingRemoteDataCalledCounter += 1
         validateQueue()
@@ -535,13 +536,19 @@ private class TestDelegate: QueueAwareDelegate, ChannelControllerDelegate {
         didUpdateChannel_channel = channel
         validateQueue()
     }
+
+    func channelController(_ channelController: ChannelController, didReceiveMemberEvent event: MemberEvent) {
+        didReceiveMemberEvent_event = event
+        validateQueue()
+    }
 }
 
 /// A concrete `ChannelControllerDelegateGeneric` implementation allowing capturing the delegate calls.
 private class TestDelegateGeneric: QueueAwareDelegate, ChannelControllerDelegateGeneric {
     var didUpdateChannel_channel: EntityChange<Channel>?
     var didUpdateMessages_messages: [ListChange<Message>]?
-    
+    var didReceiveMemberEvent_event: MemberEvent?
+
     func channelController(_ channelController: ChannelController, didUpdateMessages changes: [ListChange<Message>]) {
         didUpdateMessages_messages = changes
         validateQueue()
@@ -549,6 +556,11 @@ private class TestDelegateGeneric: QueueAwareDelegate, ChannelControllerDelegate
     
     func channelController(_ channelController: ChannelController, didUpdateChannel channel: EntityChange<Channel>) {
         didUpdateChannel_channel = channel
+        validateQueue()
+    }
+
+    func channelController(_ channelController: ChannelController, didReceiveMemberEvent event: MemberEvent) {
+        didReceiveMemberEvent_event = event
         validateQueue()
     }
 }

--- a/Sources_v3/WebSocketClient/Events/MemberEvents.swift
+++ b/Sources_v3/WebSocketClient/Events/MemberEvents.swift
@@ -4,39 +4,39 @@
 
 import Foundation
 
-public struct MemberAddedEvent<ExtraData: ExtraDataTypes>: EventWithMemberPayload, EventWithChannelId {
+public struct MemberAddedEvent: EventWithMemberPayload, EventWithChannelId {
     public let userId: UserId
     public let cid: ChannelId
     
     let payload: Any
     
-    init(from response: EventPayload<ExtraData>) throws {
+    init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
         userId = try response.value(at: \.memberContainer?.member?.user.id)
         cid = try response.value(at: \.cid)
         payload = response
     }
 }
 
-public struct MemberUpdatedEvent<ExtraData: ExtraDataTypes>: EventWithMemberPayload, EventWithChannelId {
+public struct MemberUpdatedEvent: EventWithMemberPayload, EventWithChannelId {
     public let userId: UserId
     public let cid: ChannelId
     
     let payload: Any
     
-    init(from response: EventPayload<ExtraData>) throws {
+    init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
         userId = try response.value(at: \.memberContainer?.member?.user.id)
         cid = try response.value(at: \.cid)
         payload = response
     }
 }
 
-public struct MemberRemovedEvent<ExtraData: ExtraDataTypes>: EventWithUserPayload, EventWithChannelId {
+public struct MemberRemovedEvent: EventWithUserPayload, EventWithChannelId {
     public let userId: UserId
     public let cid: ChannelId
     
     let payload: Any
     
-    init(from response: EventPayload<ExtraData>) throws {
+    init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
         userId = try response.value(at: \.user?.id)
         cid = try response.value(at: \.cid)
         payload = response

--- a/Sources_v3/WebSocketClient/Events/MemberEvents.swift
+++ b/Sources_v3/WebSocketClient/Events/MemberEvents.swift
@@ -4,7 +4,12 @@
 
 import Foundation
 
-public struct MemberAddedEvent: EventWithMemberPayload, EventWithChannelId {
+public protocol MemberEvent: Event {
+    var userId: UserId { get }
+    var cid: ChannelId { get }
+}
+
+public struct MemberAddedEvent: EventWithMemberPayload, EventWithChannelId, MemberEvent {
     public let userId: UserId
     public let cid: ChannelId
     
@@ -17,7 +22,7 @@ public struct MemberAddedEvent: EventWithMemberPayload, EventWithChannelId {
     }
 }
 
-public struct MemberUpdatedEvent: EventWithMemberPayload, EventWithChannelId {
+public struct MemberUpdatedEvent: EventWithMemberPayload, EventWithChannelId, MemberEvent {
     public let userId: UserId
     public let cid: ChannelId
     
@@ -30,7 +35,7 @@ public struct MemberUpdatedEvent: EventWithMemberPayload, EventWithChannelId {
     }
 }
 
-public struct MemberRemovedEvent: EventWithUserPayload, EventWithChannelId {
+public struct MemberRemovedEvent: EventWithUserPayload, EventWithChannelId, MemberEvent {
     public let userId: UserId
     public let cid: ChannelId
     

--- a/Sources_v3/WebSocketClient/Events/MemberEvents_Tests.swift
+++ b/Sources_v3/WebSocketClient/Events/MemberEvents_Tests.swift
@@ -10,21 +10,21 @@ class MemberEvents_Tests: XCTestCase {
     
     func test_added() throws {
         let json = XCTestCase.mockData(fromFile: "MemberAdded")
-        let event = try eventDecoder.decode(from: json) as? MemberAddedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? MemberAddedEvent
         XCTAssertEqual(event?.userId, "steep-moon-9")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_9125"))
     }
     
     func test_updated() throws {
         let json = XCTestCase.mockData(fromFile: "MemberUpdated")
-        let event = try eventDecoder.decode(from: json) as? MemberUpdatedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? MemberUpdatedEvent
         XCTAssertEqual(event?.userId, "steep-moon-9")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_9125"))
     }
     
     func test_removed() throws {
         let json = XCTestCase.mockData(fromFile: "MemberRemoved")
-        let event = try eventDecoder.decode(from: json) as? MemberRemovedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? MemberRemovedEvent
         XCTAssertEqual(event?.userId, "steep-moon-9")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_9125"))
     }

--- a/Sources_v3/Workers/EventObservers/EventObserver.swift
+++ b/Sources_v3/Workers/EventObservers/EventObserver.swift
@@ -1,0 +1,29 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The type is designed to observe events conforming to `Event` protocol delivered via `NotificationCenter`
+class EventObserver {
+    private let stopObserving: () -> Void
+
+    init<EventType>(
+        notificationCenter: NotificationCenter,
+        tranform: @escaping (Event) -> EventType?,
+        callback: @escaping (EventType) -> Void
+    ) {
+        let observer = notificationCenter.addObserver(forName: .NewEventReceived, object: nil, queue: nil) {
+            guard let event = $0.event.flatMap(tranform) else { return }
+            callback(event)
+        }
+
+        stopObserving = { [weak notificationCenter] in
+            notificationCenter?.removeObserver(observer)
+        }
+    }
+
+    deinit {
+        stopObserving()
+    }
+}

--- a/Sources_v3/Workers/EventObservers/EventObserver_Tests.swift
+++ b/Sources_v3/Workers/EventObservers/EventObserver_Tests.swift
@@ -1,0 +1,86 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class EventObserver_Tests: XCTestCase {
+    var notificationCenter: NotificationCenter!
+    var eventToDeliver: HealthCheckEvent!
+    var observer: EventObserver?
+    var eventNotification: Notification {
+        .init(newEventReceived: eventToDeliver, sender: self)
+    }
+
+    // MARK: - Setup
+
+    override func setUp() {
+        super.setUp()
+
+        notificationCenter = NotificationCenter()
+        eventToDeliver = HealthCheckEvent(connectionId: .unique)
+    }
+
+    override func tearDown() {
+        notificationCenter = nil
+        eventToDeliver = nil
+        observer = nil
+        
+        super.tearDown()
+    }
+
+    // MARK: - Calling back tests
+
+    func test_callbackIsNotCalled_ifObserverIsDeallocated() {
+        var callbackExecutionCount = 0
+
+        // Create observer and count callback executions
+        observer = .init(notificationCenter: notificationCenter,
+                         tranform: { $0 as? HealthCheckEvent },
+                         callback: { _ in callbackExecutionCount += 1 })
+
+        // Send event notification
+        notificationCenter.post(eventNotification)
+        // Assert callback is called
+        AssertAsync.willBeEqual(callbackExecutionCount, 1)
+
+        // Release the observer
+        observer = nil
+
+        // Send event notification
+        notificationCenter.post(eventNotification)
+        // Assert callback is not called one more time
+        AssertAsync.staysEqual(callbackExecutionCount, 1)
+    }
+
+    func test_callbackIsCalled_ifEventCastSucceeds() {
+        var receivedEvent: HealthCheckEvent?
+
+        // Create observer and catch event coming to callback
+        observer = EventObserver(notificationCenter: notificationCenter,
+                                 tranform: { $0 as? HealthCheckEvent },
+                                 callback: { receivedEvent = $0 })
+
+        // Send event notification
+        notificationCenter.post(eventNotification)
+
+        // Assert event is received
+        AssertAsync.willBeEqual(receivedEvent?.connectionId, eventToDeliver.connectionId)
+    }
+
+    func test_callbackIsNotCalled_ifEventCastFails() {
+        var receivedEvent: Event?
+
+        // Create observer and catch event coming to callback
+        observer = EventObserver(notificationCenter: notificationCenter,
+                                 tranform: { $0 as? MemberAddedEvent },
+                                 callback: { receivedEvent = $0 })
+
+        // Send event notification
+        notificationCenter.post(eventNotification)
+
+        // Assert none event is received
+        AssertAsync.staysTrue(receivedEvent == nil)
+    }
+}

--- a/Sources_v3/Workers/EventObservers/MemberEventObserver.swift
+++ b/Sources_v3/Workers/EventObservers/MemberEventObserver.swift
@@ -1,0 +1,32 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+final class MemberEventObserver: EventObserver {
+    init(
+        notificationCenter: NotificationCenter,
+        filter: @escaping (MemberEvent) -> Bool,
+        callback: @escaping (MemberEvent) -> Void
+    ) {
+        super.init(notificationCenter: notificationCenter, tranform: { $0 as? MemberEvent }) {
+            guard filter($0) else { return }
+            callback($0)
+        }
+    }
+}
+
+extension MemberEventObserver {
+    convenience init(notificationCenter: NotificationCenter, callback: @escaping (MemberEvent) -> Void) {
+        self.init(notificationCenter: notificationCenter,
+                  filter: { _ in true },
+                  callback: callback)
+    }
+
+    convenience init(notificationCenter: NotificationCenter, cid: ChannelId, callback: @escaping (MemberEvent) -> Void) {
+        self.init(notificationCenter: notificationCenter,
+                  filter: { $0.cid == cid },
+                  callback: callback)
+    }
+}

--- a/Sources_v3/Workers/EventObservers/MemberEventObserver_Tests.swift
+++ b/Sources_v3/Workers/EventObservers/MemberEventObserver_Tests.swift
@@ -1,0 +1,71 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class MemberEventObserver_Tests: XCTestCase {
+    var eventNotificationCenter: NotificationCenter!
+    var observer: MemberEventObserver!
+    
+    // MARK: - Setup
+
+    override func setUp() {
+        super.setUp()
+
+        eventNotificationCenter = NotificationCenter()
+    }
+
+    override func tearDown() {
+        eventNotificationCenter = nil
+        observer = nil
+        
+        super.tearDown()
+    }
+    
+    func test_onlyMemberEventsAreObserved_whenNoFilterIsSpecified() {
+        let memberEvent = TestMemberEvent.unique
+        let otherEvent = OtherEvent()
+        
+        var receivedEvents: [MemberEvent] = []
+        observer = MemberEventObserver(notificationCenter: eventNotificationCenter,
+                                       callback: { receivedEvents.append($0) })
+        
+        // Post a member event and verify it's received
+        eventNotificationCenter.post(.init(newEventReceived: memberEvent, sender: self))
+        AssertAsync.willBeEqual(receivedEvents as? [TestMemberEvent], [memberEvent])
+        
+        // Post a non-member event and verify it's not received
+        eventNotificationCenter.post(.init(newEventReceived: otherEvent, sender: self))
+        AssertAsync.staysEqual(receivedEvents as? [TestMemberEvent], [memberEvent])
+    }
+    
+    func test_cidFilterIsAppliedToMemberEvents_whenSpecified() {
+        let channelId: ChannelId = .unique
+        let matchingMemberEvent = TestMemberEvent(userId: .unique, cid: channelId)
+        let otherMemberEvent = TestMemberEvent.unique
+        
+        var receivedEvents: [MemberEvent] = []
+        observer = MemberEventObserver(notificationCenter: eventNotificationCenter,
+                                       cid: channelId,
+                                       callback: { receivedEvents.append($0) })
+        
+        // Post a member event matching the filter and verify it's received
+        eventNotificationCenter.post(.init(newEventReceived: matchingMemberEvent, sender: self))
+        AssertAsync.willBeEqual(receivedEvents as? [TestMemberEvent], [matchingMemberEvent])
+        
+        // Post a non-matching event and verify it's not received
+        eventNotificationCenter.post(.init(newEventReceived: otherMemberEvent, sender: self))
+        AssertAsync.staysEqual(receivedEvents as? [TestMemberEvent], [matchingMemberEvent])
+    }
+}
+
+private struct TestMemberEvent: MemberEvent, Equatable {
+    static var unique: TestMemberEvent = .init(userId: .unique, cid: .unique)
+    
+    let userId: UserId
+    let cid: ChannelId
+}
+
+private struct OtherEvent: Event {}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -226,6 +226,8 @@
 		DAFAD6A124DC476A0043ED06 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFAD6A024DC476A0043ED06 /* Result+Extensions.swift */; };
 		DAFAD6A324DD8E1A0043ED06 /* ChannelEditDetailPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFAD6A224DD8E1A0043ED06 /* ChannelEditDetailPayload.swift */; };
 		F62D143E24DD70190081D241 /* ChannelUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */; };
+		F63CC36F24E591840052844D /* EventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC36E24E591840052844D /* EventObserver.swift */; };
+		F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37024E591990052844D /* EventObserver_Tests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -493,6 +495,8 @@
 		DAFAD6A024DC476A0043ED06 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		DAFAD6A224DD8E1A0043ED06 /* ChannelEditDetailPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelEditDetailPayload.swift; sourceTree = "<group>"; };
 		F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelUpdater_Mock.swift; sourceTree = "<group>"; };
+		F63CC36E24E591840052844D /* EventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver.swift; sourceTree = "<group>"; };
+		F63CC37024E591990052844D /* EventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver_Tests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -806,6 +810,7 @@
 				79682C4524BC9DAF0071578E /* ChannelUpdater.swift */,
 				F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */,
 				7952B3B424D45D9400AC53D4 /* ChannelUpdater_Tests.swift */,
+				F63CC36D24E591690052844D /* EventObservers */,
 				79280F4524850ECC00CDEB89 /* Background */,
 			);
 			path = Workers;
@@ -1087,6 +1092,15 @@
 			path = Requests;
 			sourceTree = "<group>";
 		};
+		F63CC36D24E591690052844D /* EventObservers */ = {
+			isa = PBXGroup;
+			children = (
+				F63CC36E24E591840052844D /* EventObserver.swift */,
+				F63CC37024E591990052844D /* EventObserver_Tests.swift */,
+			);
+			path = EventObservers;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -1287,6 +1301,7 @@
 				79280F4F2485308100CDEB89 /* Controller.swift in Sources */,
 				79877A252498E50D00015F8B /* TeamDTO.swift in Sources */,
 				7964F3B7249A314D002A09EC /* LogFormatter.swift in Sources */,
+				F63CC36F24E591840052844D /* EventObserver.swift in Sources */,
 				8A0D649724E579A50017A3C0 /* GuestEndpoints.swift in Sources */,
 				8A62705024B867190040BFD6 /* EventPayload.swift in Sources */,
 				792A4F40247FFDE700EAF71D /* Data+Gzip.swift in Sources */,
@@ -1388,6 +1403,7 @@
 				79DDF819249CE38B002F4412 /* MockNetworkURLProtocol.swift in Sources */,
 				7922F30A24DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift in Sources */,
 				8A62705E24BE2CD70040BFD6 /* XCTestCase+MockJSON.swift in Sources */,
+				F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */,
 				79DDF81B249CE38B002F4412 /* AssertNetworkRequest.swift in Sources */,
 				79877A2A2498E51500015F8B /* MemberModelDTO_Tests.swift in Sources */,
 				799C947D247E6114001F1104 /* TestError.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -228,6 +228,8 @@
 		F62D143E24DD70190081D241 /* ChannelUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */; };
 		F63CC36F24E591840052844D /* EventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC36E24E591840052844D /* EventObserver.swift */; };
 		F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37024E591990052844D /* EventObserver_Tests.swift */; };
+		F63CC37324E592D30052844D /* MemberEventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37224E592D30052844D /* MemberEventObserver.swift */; };
+		F63CC37524E592DD0052844D /* MemberEventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -497,6 +499,8 @@
 		F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelUpdater_Mock.swift; sourceTree = "<group>"; };
 		F63CC36E24E591840052844D /* EventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver.swift; sourceTree = "<group>"; };
 		F63CC37024E591990052844D /* EventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver_Tests.swift; sourceTree = "<group>"; };
+		F63CC37224E592D30052844D /* MemberEventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventObserver.swift; sourceTree = "<group>"; };
+		F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventObserver_Tests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1097,6 +1101,8 @@
 			children = (
 				F63CC36E24E591840052844D /* EventObserver.swift */,
 				F63CC37024E591990052844D /* EventObserver_Tests.swift */,
+				F63CC37224E592D30052844D /* MemberEventObserver.swift */,
+				F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */,
 			);
 			path = EventObservers;
 			sourceTree = "<group>";
@@ -1357,6 +1363,7 @@
 				79280F47248515FA00CDEB89 /* ChannelEvents.swift in Sources */,
 				79877A182498E4EE00015F8B /* ChannelEndpoints.swift in Sources */,
 				7964F3BA249A314D002A09EC /* LogDestination.swift in Sources */,
+				F63CC37324E592D30052844D /* MemberEventObserver.swift in Sources */,
 				79877A0C2498E4BC00015F8B /* ChannelType.swift in Sources */,
 				79280F4B248523C000CDEB89 /* ConnectionEvents.swift in Sources */,
 				DAFAD6A324DD8E1A0043ED06 /* ChannelEditDetailPayload.swift in Sources */,
@@ -1415,6 +1422,7 @@
 				8A0D649324E5794C0017A3C0 /* CurrentUserPayload.swift in Sources */,
 				8A0D64AE24E5853F0017A3C0 /* Controller_Tests.swift in Sources */,
 				8A0C3BC924C0BBAB00CAFD19 /* UserEvents_Tests.swift in Sources */,
+				F63CC37524E592DD0052844D /* MemberEventObserver_Tests.swift in Sources */,
 				792FCB4724A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift in Sources */,
 				79877A2B2498E51500015F8B /* UserModelDTO_Tests.swift in Sources */,
 				792921C524C0479700116BBB /* ChannelListQueryUpdater_Tests.swift in Sources */,


### PR DESCRIPTION
**This PR:**

- introduces `MemberEvent`
- introduces `EventObserver` and `MemberEventObserver` for event-listening
- updates member events to be non-generic and have only generic `init`
- updates `ChannelController` to listen for and deliver `MemberEvent` from it's channel