### PR TITLE
Preparation for 1-1 channel creation

### DIFF
--- a/Sources_v3/Query/ChannelQuery.swift
+++ b/Sources_v3/Query/ChannelQuery.swift
@@ -63,7 +63,19 @@ public struct ChannelQuery<ExtraData: ExtraDataTypes>: Encodable {
         watchersPagination = []
         self.options = options
     }
-    
+
+    /// Init a channel query.
+    /// - Parameters:
+    ///   - cid: New `ChannelId` for channel query..
+    ///   - channelQuery: ChannelQuery with old cid.
+    init(cid: ChannelId, channelQuery: Self) {
+        self.init(cid: cid,
+                  messagesPagination: channelQuery.messagesPagination,
+                  membersPagination: channelQuery.membersPagination,
+                  watchersPagination: channelQuery.watchersPagination,
+                  options: channelQuery.options)
+    }
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 

--- a/Sources_v3/Workers/ChannelUpdater_Mock.swift
+++ b/Sources_v3/Workers/ChannelUpdater_Mock.swift
@@ -8,6 +8,7 @@ import XCTest
 /// Mock implementation of ChannelUpdater
 class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
     var update_channelQuery: ChannelQuery<ExtraData>?
+    var update_channelCreatedCallback: ((ChannelId) -> Void)?
     var update_completion: ((Error?) -> Void)?
 
     var updateChannel_payload: ChannelEditDetailPayload<ExtraData>?
@@ -29,8 +30,13 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
     var showChannel_userId: UserId?
     var showChannel_completion: ((Error?) -> Void)?
 
-    override func update(channelQuery: ChannelQuery<ExtraData>, completion: ((Error?) -> Void)? = nil) {
+    override func update(
+        channelQuery: ChannelQuery<ExtraData>,
+        channelCreatedCallback: ((ChannelId) -> Void)?,
+        completion: ((Error?) -> Void)?
+    ) {
         update_channelQuery = channelQuery
+        update_channelCreatedCallback = channelCreatedCallback
         update_completion = completion
     }
 


### PR DESCRIPTION
**In this PR:**

- Add possibility to reset DB observers on receiving channel id from backend

**Q:** If we will stick to this changes, should we also perform them to `ChannelListController` for unification even though they are not needed from technical perspective at the moment?