### PR TITLE
[CIS-258] User unread count

### DIFF
--- a/Sample_v3/Samples/SettingsViewController.swift
+++ b/Sample_v3/Samples/SettingsViewController.swift
@@ -19,9 +19,19 @@ class SettingsViewController: UITableViewController {
     @IBOutlet weak var userNameLabel: UILabel!
     @IBOutlet weak var userSecondaryLabel: UILabel!
     
+    private lazy var currentUserController: CurrentUserController = {
+        let controller = chatClient.currentUserController()
+        controller.delegate = self
+        return controller
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        updateUserCell()
+        
+        currentUserController.startUpdating { [weak self] _ in
+            guard let self = self else { return }
+            self.updateUserCell(with: self.currentUserController.currentUser)
+        }
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -40,8 +50,8 @@ class SettingsViewController: UITableViewController {
 
 // MARK: - Current User
 extension SettingsViewController {
-    func updateUserCell() {
-        if let user = chatClient.currentUser {
+    func updateUserCell(with user: CurrentUser?) {
+        if let user = user {
             userNameLabel.text = user.name ?? ""
             userNameLabel.text! += " (\(user.id))"
             
@@ -81,5 +91,12 @@ extension SettingsViewController {
 extension SettingsViewController {
     func clearLocalDatabase() {
         // TODO: Clear local database
+    }
+}
+
+// MARK: - CurrentUserControllerDelegate
+extension SettingsViewController: CurrentUserControllerDelegate {
+    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser change: EntityChange<CurrentUser>) {
+        updateUserCell(with: change.item)
     }
 }

--- a/Sources_v3/APIClient/Endpoints/Payloads/CurrentUserPayloads.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/CurrentUserPayloads.swift
@@ -10,8 +10,8 @@ class CurrentUserPayload<ExtraData: UserExtraData>: UserPayload<ExtraData> {
     let devices: [Device]
     /// Muted users.
     let mutedUsers: [MutedUser<ExtraData>]
-    
-    // TODO: Add unread counts
+    /// Unread channel and message counts
+    let unreadCount: UnreadCount?
     
     init(
         id: String,
@@ -25,10 +25,12 @@ class CurrentUserPayload<ExtraData: UserExtraData>: UserPayload<ExtraData> {
         teams: [String] = [],
         extraData: ExtraData,
         devices: [Device] = [],
-        mutedUsers: [MutedUser<ExtraData>] = []
+        mutedUsers: [MutedUser<ExtraData>] = [],
+        unreadCount: UnreadCount? = nil
     ) {
         self.devices = devices
         self.mutedUsers = mutedUsers
+        self.unreadCount = unreadCount
         
         super.init(id: id,
                    role: role,
@@ -46,6 +48,7 @@ class CurrentUserPayload<ExtraData: UserExtraData>: UserPayload<ExtraData> {
         let container = try decoder.container(keyedBy: UserPayloadsCodingKeys.self)
         devices = try container.decodeIfPresent([Device].self, forKey: .devices) ?? []
         mutedUsers = try container.decodeIfPresent([MutedUser<ExtraData>].self, forKey: .mutedUsers) ?? []
+        unreadCount = try? UnreadCount(from: decoder)
         
         try super.init(from: decoder)
     }

--- a/Sources_v3/ChatClient.swift
+++ b/Sources_v3/ChatClient.swift
@@ -45,19 +45,6 @@ public class Client<ExtraData: ExtraDataTypes> {
     /// The id of the currently logged in user.
     @Atomic public var currentUserId: UserId = .anonymous
     
-    /// The currently logged-in user data.
-    ///
-    /// Returns `nil` if the user is not fully logged-in yet. Always wait for the `setUser` completion block before
-    /// accessing this value.
-    public var currentUser: CurrentUserModel<ExtraData.User>? {
-        guard let user: CurrentUserModel<ExtraData.User> = databaseContainer.viewContext.currentUser()?.asModel() else {
-            log.error("You're trying to access the current user but the connection is not fully estabilshed. " +
-                "Wait for the completion block to be called before accessing the current user data.")
-            return nil
-        }
-        return user
-    }
-    
     /// The config object of the `Client` instance. This can't be mutated and can only be set when initializing a `Client` instance.
     public let config: ChatClientConfig
     

--- a/Sources_v3/ChatClient_Tests.swift
+++ b/Sources_v3/ChatClient_Tests.swift
@@ -279,7 +279,7 @@ class ChatClient_Tests: StressTestCase {
         
         // The current userId should be set, but the user is not loaded before the connection is established
         XCTAssertTrue(client.currentUserId.isAnonymousUser)
-        XCTAssertNil(client.currentUser)
+        XCTAssertNil(testEnv.databaseContainer?.viewContext.currentUser())
     }
     
     func test_settingAnonymousUser() {
@@ -363,13 +363,17 @@ class ChatClient_Tests: StressTestCase {
             .webSocketClient(testEnv.webSocketClient!,
                              didUpdateConectionState: .connected(connectionId: .unique))
         
+        var currentUser: CurrentUserDTO? {
+            testEnv.databaseContainer?.viewContext.currentUser()
+        }
+        
         // Check the completion is called and the current user model is available
         AssertAsync {
             // Completion is called
             Assert.willBeTrue(setUserCompletionCalled)
             
-            // Current user data are available
-            Assert.willBeEqual(client.currentUser?.id, newUserId)
+            // Current user is available
+            Assert.willBeEqual(currentUser?.user.id, newUserId)
             
             // The token is updated
             Assert.willBeEqual(client.provideToken(), newUserToken)
@@ -441,13 +445,16 @@ class ChatClient_Tests: StressTestCase {
             .webSocketClient(testEnv.webSocketClient!,
                              didUpdateConectionState: .connected(connectionId: .unique))
         
+        var currentUser: CurrentUserDTO? {
+            testEnv.databaseContainer?.viewContext.currentUser()
+        }
+        
         // Check the completion is called and the current user model is available
         AssertAsync {
             // Completion is called
             Assert.willBeTrue(setUserCompletionCalled)
-            
-            // Current user data are available
-            Assert.willBeEqual(client.currentUser?.id, newUser.userId)
+            // Current user is available
+            Assert.willBeEqual(currentUser?.user.id, newUser.userId)
         }
     }
     

--- a/Sources_v3/Controllers/ChannelController.swift
+++ b/Sources_v3/Controllers/ChannelController.swift
@@ -170,7 +170,7 @@ public class ChannelControllerGeneric<ExtraData: ExtraDataTypes>: Controller, De
             let observer = EntityDatabaseObserver(context: self.client.databaseContainer.viewContext,
                                                   fetchRequest: ChannelDTO.fetchRequest(for: self.channelQuery.cid),
                                                   itemCreator: ChannelModel<ExtraData>.create)
-            observer.onChange = { change in
+            observer.onChange { change in
                 self.delegateCallback { $0?.channelController(self, didUpdateChannel: change) }
             }
 

--- a/Sources_v3/Controllers/CurrentUserController.swift
+++ b/Sources_v3/Controllers/CurrentUserController.swift
@@ -1,0 +1,287 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+public extension Client {
+    /// Creates a new `CurrentUserControllerGeneric`
+    /// - Returns: A new instance of `ChannelController`.
+    func currentUserController() -> CurrentUserControllerGeneric<ExtraData> {
+        .init(client: self, environment: .init())
+    }
+}
+
+/// A convenience typealias for `CurrentUserControllerGeneric` with `DefaultDataTypes`
+public typealias CurrentUserController = CurrentUserControllerGeneric<DefaultDataTypes>
+
+/// `CurrentUserControllerGeneric` allows to observer current user updates
+public final class CurrentUserControllerGeneric<ExtraData: ExtraDataTypes>: Controller, DelegateCallable {
+    /// The `ChatClient` instance this controller belongs to.
+    public let client: Client<ExtraData>
+    
+    private let environment: Environment
+
+    /// Used for observing the curren-user changes in a database.
+    private lazy var currentUserObserver = createUserObserver()
+        .onChange { [unowned self] change in
+            self.delegateCallback {
+                $0?.currentUserController(self, didChangeCurrentUser: change)
+            }
+        }
+        .onFieldChange(\.unreadCount) { [unowned self] change in
+            self.delegateCallback {
+                $0?.currentUserController(self, didChangeCurrentUserUnreadCount: change.unreadCount)
+            }
+        }
+
+    /// A type-erased delegate.
+    private(set) var anyDelegate: AnyCurrentUserControllerDelegate<ExtraData>? {
+        didSet { stateDelegate = anyDelegate }
+    }
+    
+    /// The currently logged-in user.
+    /// Always returns `nil` if `startUpdating` was not called
+    /// To observe the updates of this value, set your class as a delegate of this controller and call `startUpdating`.
+    public var currentUser: CurrentUserModel<ExtraData.User>? {
+        guard state != .inactive else {
+            log.warning("Accessing `currentUser` fields before calling `startUpdating()` always results in `nil`.")
+            return nil
+        }
+
+        return currentUserObserver.item
+    }
+
+    /// The unread messages and channels count for the current user.
+    /// Always returns `noUnread` if `startUpdating` was not called.
+    /// To observe the updates of this value, set your class as a delegate of this controller and call `startUpdating`.
+    public var unreadCount: UnreadCount {
+        currentUser?.unreadCount ?? .noUnread
+    }
+
+    /// Creates a new `CurrentUserControllerGeneric`.
+    /// - Parameters:
+    ///   - client: The `Client` instance this controller belongs to.
+    ///   - environment: The source of internal dependencies
+    init(client: Client<ExtraData>, environment: Environment) {
+        self.client = client
+        self.environment = environment
+    }
+    
+    /// Starts updating the results.
+    ///
+    /// It **synchronously** loads the data for the referenced objects from the local cache.
+    /// The `currentUser` and `unreadCount` properties are immediately available once this method returns.
+    /// Any further changes to the data are communicated using `delegate`.
+    ///
+    /// - Parameter completion: Called when the controller has finished fetching data from a database.
+    /// If the data fetching fails, the `error` variable contains more details about the problem.
+    public func startUpdating(_ completion: ((Error?) -> Void)? = nil) {
+        do {
+            try currentUserObserver.startObserving()
+        } catch {
+            callback { completion?(ClientError.FetchFailed()) }
+            return
+        }
+        
+        state = .localDataFetched
+
+        callback { completion?(nil) }
+    }
+}
+
+// MARK: - Environment
+
+extension CurrentUserControllerGeneric {
+    struct Environment {
+        var currentUserObserverBuilder: (
+            _ context: NSManagedObjectContext,
+            _ fetchRequest: NSFetchRequest<CurrentUserDTO>,
+            _ itemCreator: @escaping (CurrentUserDTO) -> CurrentUserModel<ExtraData.User>,
+            _ fetchedResultsControllerType: NSFetchedResultsController<CurrentUserDTO>.Type
+        ) -> EntityDatabaseObserver<CurrentUserModel<ExtraData.User>, CurrentUserDTO> = EntityDatabaseObserver.init
+    }
+}
+
+// MARK: - Private
+
+private extension EntityChange where Item == UnreadCount {
+    var unreadCount: UnreadCount {
+        switch self {
+        case let .create(count):
+            return count
+        case let .update(count):
+            return count
+        case .remove:
+            return .noUnread
+        }
+    }
+}
+
+private extension CurrentUserControllerGeneric {
+    func createUserObserver() -> EntityDatabaseObserver<CurrentUserModel<ExtraData.User>, CurrentUserDTO> {
+        environment.currentUserObserverBuilder(client.databaseContainer.viewContext,
+                                               CurrentUserDTO.defaultFetchRequest,
+                                               { $0.asModel() }, // swiftlint:disable:this opening_brace
+                                               NSFetchedResultsController<CurrentUserDTO>.self)
+    }
+}
+
+// MARK: - Delegates
+
+/// `CurrentUserController` uses this protocol to communicate changes to its delegate.
+///
+/// This protocol can be used only when no custom extra data are specified.
+/// If you're using custom extra data types, please use `CurrentUserControllerDelegateGeneric` instead.
+public protocol CurrentUserControllerDelegate: ControllerStateDelegate {
+    /// The controller observed a change in the `UnreadCount`.
+    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUserUnreadCount: UnreadCount)
+    
+    /// The controller observed a change in the `CurrentUser` entity.
+    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser: EntityChange<CurrentUser>)
+}
+
+public extension CurrentUserControllerDelegate {
+    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUserUnreadCount: UnreadCount) {}
+    
+    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser: EntityChange<CurrentUser>) {}
+}
+
+/// `CurrentUserControllerGeneric` uses this protocol to communicate changes to its delegate.
+///
+/// If you're **not** using custom extra data types, you can use a convenience version of this protocol
+/// named `CurrentUserControllerDelegate`, which hides the generic types, and make the usage easier.
+public protocol CurrentUserControllerDelegateGeneric: ControllerStateDelegate {
+    associatedtype ExtraData: ExtraDataTypes
+    
+    /// The controller observed a change in the `UnreadCount`.
+    func currentUserController(_ controller: CurrentUserControllerGeneric<ExtraData>, didChangeCurrentUserUnreadCount: UnreadCount)
+    
+    /// The controller observed a change in the `CurrentUser` entity.
+    func currentUserController(
+        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        didChangeCurrentUser: EntityChange<CurrentUserModel<ExtraData.User>>
+    )
+}
+
+public extension CurrentUserControllerDelegateGeneric {
+    func currentUserController(
+        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        didChangeCurrentUserUnreadCount: UnreadCount
+    ) {}
+    
+    func currentUserController(
+        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        didChangeCurrentUser: EntityChange<CurrentUserModel<ExtraData.User>>
+    ) {}
+}
+
+final class AnyCurrentUserControllerDelegate<ExtraData: ExtraDataTypes>: CurrentUserControllerDelegateGeneric {
+    weak var wrappedDelegate: AnyObject?
+    
+    private var _controllerDidChangeState: (
+        Controller,
+        Controller.State
+    ) -> Void
+    
+    private var _controllerDidChangeCurrentUserUnreadCount: (
+        CurrentUserControllerGeneric<ExtraData>,
+        UnreadCount
+    ) -> Void
+    
+    private var _controllerDidChangeCurrentUser: (
+        CurrentUserControllerGeneric<ExtraData>,
+        EntityChange<CurrentUserModel<ExtraData.User>>
+    ) -> Void
+
+    init(
+        wrappedDelegate: AnyObject?,
+        controllerDidChangeState: @escaping (
+            Controller,
+            Controller.State
+        ) -> Void,
+        controllerDidChangeCurrentUserUnreadCount: @escaping (
+            CurrentUserControllerGeneric<ExtraData>,
+            UnreadCount
+        ) -> Void,
+        controllerDidChangeCurrentUser: @escaping (
+            CurrentUserControllerGeneric<ExtraData>,
+            EntityChange<CurrentUserModel<ExtraData.User>>
+        ) -> Void
+    ) {
+        self.wrappedDelegate = wrappedDelegate
+        _controllerDidChangeCurrentUserUnreadCount = controllerDidChangeCurrentUserUnreadCount
+        _controllerDidChangeState = controllerDidChangeState
+        _controllerDidChangeCurrentUser = controllerDidChangeCurrentUser
+    }
+
+    func controller(_ controller: Controller, didChangeState state: Controller.State) {
+        _controllerDidChangeState(controller, state)
+    }
+
+    func currentUserController(
+        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        didChangeCurrentUserUnreadCount unreadCount: UnreadCount
+    ) {
+        _controllerDidChangeCurrentUserUnreadCount(controller, unreadCount)
+    }
+    
+    func currentUserController(
+        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        didChangeCurrentUser user: EntityChange<CurrentUserModel<ExtraData.User>>
+    ) {
+        _controllerDidChangeCurrentUser(controller, user)
+    }
+}
+
+extension AnyCurrentUserControllerDelegate {
+    convenience init<Delegate: CurrentUserControllerDelegateGeneric>(_ delegate: Delegate) where Delegate.ExtraData == ExtraData {
+        self.init(wrappedDelegate: delegate,
+                  controllerDidChangeState: { [weak delegate] in delegate?.controller($0, didChangeState: $1) },
+                  controllerDidChangeCurrentUserUnreadCount: { [weak delegate] in
+                      delegate?.currentUserController($0, didChangeCurrentUserUnreadCount: $1)
+                  },
+                  controllerDidChangeCurrentUser: { [weak delegate] in
+                      delegate?.currentUserController($0, didChangeCurrentUser: $1)
+                  })
+    }
+}
+
+extension AnyCurrentUserControllerDelegate where ExtraData == DefaultDataTypes {
+    convenience init(_ delegate: CurrentUserControllerDelegate?) {
+        self.init(wrappedDelegate: delegate,
+                  controllerDidChangeState: { [weak delegate] in delegate?.controller($0, didChangeState: $1) },
+                  controllerDidChangeCurrentUserUnreadCount: { [weak delegate] in
+                      delegate?.currentUserController($0, didChangeCurrentUserUnreadCount: $1)
+                  }, controllerDidChangeCurrentUser: { [weak delegate] in
+                      delegate?.currentUserController($0, didChangeCurrentUser: $1)
+                  })
+    }
+}
+ 
+public extension CurrentUserControllerGeneric {
+    /// Sets the provided object as a delegate of this controller.
+    ///
+    /// - Note: If you don't use custom extra data types, you can set the delegate directly using `controller.delegate = self`.
+    /// Due to the current limits of Swift and the way it handles protocols with associated types, it's required to use this
+    /// method to set the delegate, if you're using custom extra data types.
+    ///
+    /// - Parameter delegate: The object used as a delegate. It's referenced weakly, so you need to keep the object
+    /// alive if you want keep receiving updates.
+    func setDelegate<Delegate: CurrentUserControllerDelegateGeneric>(_ delegate: Delegate?) where Delegate.ExtraData == ExtraData {
+        anyDelegate = delegate.flatMap(AnyCurrentUserControllerDelegate.init)
+    }
+}
+
+public extension CurrentUserController {
+    /// Set the delegate of `CurrentUserController` to observe the changes in the system.
+    ///
+    /// - Note: The delegate can be set directly only if you're **not** using custom extra data types. Due to the current
+    /// limits of Swift and the way it handles protocols with associated types, it's required to use `setDelegate` method
+    /// instead to set the delegate, if you're using custom extra data types.
+    var delegate: CurrentUserControllerDelegate? {
+        set { anyDelegate = AnyCurrentUserControllerDelegate(newValue) }
+        get { anyDelegate?.wrappedDelegate as? CurrentUserControllerDelegate }
+    }
+}

--- a/Sources_v3/Controllers/CurrentUserController_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController_Tests.swift
@@ -1,0 +1,341 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChatClient
+import XCTest
+
+final class CurrentUserController_Tests: StressTestCase {
+    private var env: TestEnvironment!
+    private var client: ChatClient!
+    private var controller: CurrentUserController!
+    private var controllerCallbackQueueID: UUID!
+    private var callbackQueueID: UUID { controllerCallbackQueueID }
+    
+    // MARK: - Setup
+    
+    override func setUp() {
+        super.setUp()
+        
+        env = TestEnvironment()
+        client = Client(config: ChatClientConfig(apiKey: .init(.unique)),
+                        workerBuilders: [Worker.init],
+                        environment: env.clientEnvironment)
+        controller = CurrentUserController(client: client, environment: env.currentUserControllerEnvironment)
+        controllerCallbackQueueID = UUID()
+        controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)
+    }
+    
+    override func tearDown() {
+        weak var weak_env = env
+        weak var weak_client = client
+        weak var weak_controller = controller
+        
+        env = nil
+        client = nil
+        controller = nil
+        controllerCallbackQueueID = nil
+        
+        // We need to assert asynchronously, because there can be some delegate callbacks happening
+        // on the background queue, that keeps the controller alive, until they have finished.
+        AssertAsync {
+            Assert.willBeNil(weak_env)
+            Assert.willBeNil(weak_client)
+            Assert.willBeNil(weak_controller)
+        }
+        
+        super.tearDown()
+    }
+    
+    // MARK: Controller
+
+    func test_initialState() {
+        // Assert client is assigned correctly
+        XCTAssertTrue(controller.client === client)
+        
+        // Assert initial state is correct
+        XCTAssertEqual(controller.state, .inactive)
+        
+        // Assert user is nil
+        XCTAssertNil(controller.currentUser)
+        
+        // Assert unread-count is zero
+        XCTAssertEqual(controller.unreadCount, .noUnread)
+    }
+    
+    func test_startUpdating_changesStateCorrectly_ifCompletesWithAnyError() throws {
+        // Start updating
+        _ = try await(controller.startUpdating)
+        
+        // Assert state changes to `.localDataFetched`
+        XCTAssertEqual(controller.state, .localDataFetched)
+    }
+    
+    func test_startUpdating_stateStaysInactive_ifCompletesWithError() throws {
+        // Update mock observer to throws the error
+        env.currentUserObserverStartUpdatingError = TestError()
+
+        // Start updating
+        _ = try await(controller.startUpdating)
+        
+        // Assert state stays inative
+        XCTAssertEqual(controller.state, .inactive)
+    }
+    
+    func test_startUpdating_propogatesError() throws {
+        // Update mock observer to throws the error
+        env.currentUserObserverStartUpdatingError = TestError()
+        
+        // Start updating and catch the error
+        let startUpdatingError = try await(controller.startUpdating)
+        
+        // Assert error is propogated
+        XCTAssertNotNil(startUpdatingError)
+    }
+    
+    func test_correctDataIsAvailable_whenStartUpdatingCompletes() throws {
+        let unreadCount = UnreadCount(channels: 10, messages: 212)
+        let userPayload: CurrentUserPayload<NoExtraData> = .dummy(userId: .unique, role: .user, unreadCount: unreadCount)
+
+        // Save user to the db
+        try env.databaseContainer.writeSynchronously {
+            try $0.saveCurrentUser(payload: userPayload)
+        }
+        
+        // Start updating
+        _ = try await(controller.startUpdating)
+        
+        // Assert user exists
+        XCTAssertEqual(controller.unreadCount, unreadCount)
+        XCTAssertEqual(controller.currentUser?.id, userPayload.id)
+    }
+    
+    // MARK: - Delegate
+    
+    func test_delegate_isAssignedCorrectly() {
+        let delegate = TestDelegate()
+        
+        // Set the delegate
+        controller.delegate = delegate
+        
+        // Assert the delegate is assigned correctly
+        XCTAssert(controller.delegate === delegate)
+    }
+
+    func test_delegate_isNotifiedAboutStateChanges() throws {
+        // Set the delegate
+        let delegate = TestDelegate()
+        delegate.expectedQueueId = controllerCallbackQueueID
+        controller.delegate = delegate
+        
+        // Assert no state changes received so far
+        XCTAssertNil(delegate.state)
+        
+        // Start updating
+        let startUpdatingError = try await(controller.startUpdating)
+        
+        // Assert `startUpdating` finished without any error
+        XCTAssertNil(startUpdatingError)
+        
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .localDataFetched)
+    }
+    
+    func test_genericDelegate_isNotifiedAboutStateChanges() throws {
+        // Set the delegate
+        let delegate = TestDelegateGeneric()
+        delegate.expectedQueueId = controllerCallbackQueueID
+        controller.setDelegate(delegate)
+        
+        // Assert no state changes received so far
+        XCTAssertNil(delegate.state)
+        
+        // Start updating
+        let startUpdatingError = try await(controller.startUpdating)
+        
+        // Assert `startUpdating` finished without any error
+        XCTAssertNil(startUpdatingError)
+        
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .localDataFetched)
+    }
+    
+    func test_delegate_isNotifiedAboutCreatedUser() throws {
+        let extraData = NameAndImageExtraData(name: .unique, imageURL: .unique())
+        let currentUserPayload: CurrentUserPayload<DefaultDataTypes.User> = .dummy(userId: .unique,
+                                                                                   role: .user,
+                                                                                   extraData: extraData)
+        
+        // Set the delegate
+        let delegate = TestDelegate()
+        delegate.expectedQueueId = controllerCallbackQueueID
+        controller.delegate = delegate
+
+        // Start updating
+        let startUpdatingError = try await(controller.startUpdating)
+        
+        // Assert `startUpdating` finished without any error
+        XCTAssertNil(startUpdatingError)
+
+        // Simulate saving current user to a database
+        try env.databaseContainer.writeSynchronously {
+            try $0.saveCurrentUser(payload: currentUserPayload)
+        }
+        
+        // Assert delegate received correct entity change
+        AssertAsync {
+            Assert.willBeEqual(delegate.didChangeCurrentUser_change?.fieldChange(\.id), .create(currentUserPayload.id))
+            Assert.willBeEqual(delegate.didChangeCurrentUser_change?.fieldChange(\.extraData), .create(extraData))
+        }
+    }
+    
+    func test_delegate_isNotifiedAboutUpdatedUser() throws {
+        var extraData = NameAndImageExtraData(name: .unique, imageURL: .unique())
+        var currentUserPayload: CurrentUserPayload<DefaultDataTypes.User> = .dummy(userId: .unique,
+                                                                                   role: .user,
+                                                                                   extraData: extraData)
+        
+        // Set the delegate
+        let delegate = TestDelegate()
+        delegate.expectedQueueId = controllerCallbackQueueID
+        controller.delegate = delegate
+
+        // Start updating
+        let startUpdatingError = try await(controller.startUpdating)
+        
+        // Assert `startUpdating` finished without any error
+        XCTAssertNil(startUpdatingError)
+
+        // Simulate saving current user to a database
+        try env.databaseContainer.writeSynchronously {
+            try $0.saveCurrentUser(payload: currentUserPayload)
+        }
+        
+        // Update current user data
+        extraData = NameAndImageExtraData(name: .unique, imageURL: .unique())
+        currentUserPayload = .dummy(userId: currentUserPayload.id,
+                                    role: currentUserPayload.role,
+                                    extraData: extraData)
+        
+        // Simulate updating current user in a database
+        try env.databaseContainer.writeSynchronously {
+            try $0.saveCurrentUser(payload: currentUserPayload)
+        }
+        
+        // Assert delegate received correct entity change
+        AssertAsync {
+            Assert.willBeEqual(delegate.didChangeCurrentUser_change?.fieldChange(\.id), .update(currentUserPayload.id))
+            Assert.willBeEqual(delegate.didChangeCurrentUser_change?.fieldChange(\.extraData), .update(extraData))
+        }
+    }
+
+    func test_delegate_isNotifiedAboutUnreadCount_whenUserIsCreated() throws {
+        let unreadCount = UnreadCount(channels: 10, messages: 15)
+        
+        // Set the delegate
+        let delegate = TestDelegate()
+        delegate.expectedQueueId = controllerCallbackQueueID
+        controller.delegate = delegate
+
+        // Start updating
+        let startUpdatingError = try await(controller.startUpdating)
+        
+        // Assert `startUpdating` finished without any error
+        XCTAssertNil(startUpdatingError)
+
+        // Simulate saving current user to a database
+        try env.databaseContainer.writeSynchronously {
+            let currentUserPayload: CurrentUserPayload<DefaultDataTypes.User> = .dummy(userId: .unique,
+                                                                                       role: .user,
+                                                                                       unreadCount: unreadCount)
+            try $0.saveCurrentUser(payload: currentUserPayload)
+        }
+
+        // Assert delegate received correct unread count
+        AssertAsync.willBeEqual(delegate.didChangeCurrentUserUnreadCount_count, unreadCount)
+    }
+    
+    func test_delegate_isNotifiedAboutDeletedUser() {
+        // TODO: Write the test once the db flushing is fixed
+        XCTAssertTrue(true)
+    }
+    
+    func test_delegate_isNotifiedAboutNoUnreadCount_whenUserIsDeleted() {
+        // TODO: Write the test once the db flushing is fixed
+        XCTAssertTrue(true)
+    }
+}
+
+private class TestDelegate: QueueAwareDelegate, CurrentUserControllerDelegate {
+    @Atomic var state: Controller.State?
+    @Atomic var didChangeCurrentUser_change: EntityChange<CurrentUser>?
+    @Atomic var didChangeCurrentUserUnreadCount_count: UnreadCount?
+    
+    func controller(_ controller: Controller, didChangeState state: Controller.State) {
+        self.state = state
+        validateQueue()
+    }
+
+    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser change: EntityChange<CurrentUser>) {
+        didChangeCurrentUser_change = change
+        validateQueue()
+    }
+    
+    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUserUnreadCount count: UnreadCount) {
+        didChangeCurrentUserUnreadCount_count = count
+        validateQueue()
+    }
+}
+
+private class TestDelegateGeneric: QueueAwareDelegate, CurrentUserControllerDelegateGeneric {
+    @Atomic var state: Controller.State?
+    @Atomic var didChangeCurrentUser_change: EntityChange<CurrentUser>?
+    @Atomic var didChangeCurrentUserUnreadCount_count: UnreadCount?
+   
+    func controller(_ controller: Controller, didChangeState state: Controller.State) {
+        self.state = state
+        validateQueue()
+    }
+    
+    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser change: EntityChange<CurrentUser>) {
+        didChangeCurrentUser_change = change
+        validateQueue()
+    }
+    
+    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUserUnreadCount count: UnreadCount) {
+        didChangeCurrentUserUnreadCount_count = count
+        validateQueue()
+    }
+}
+
+private class TestEnvironment {
+    var currentUserObserver: MockEntityObserver<CurrentUser, CurrentUserDTO>!
+    var currentUserObserverStartUpdatingError: Error?
+
+    lazy var currentUserControllerEnvironment: CurrentUserController
+        .Environment = .init(currentUserObserverBuilder: { [unowned self] in
+            self.currentUserObserver = .init(context: $0, fetchRequest: $1, itemCreator: $2, fetchedResultsControllerType: $3)
+            self.currentUserObserver.startUpdatingError = self.currentUserObserverStartUpdatingError
+            return self.currentUserObserver!
+        })
+    
+    var databaseContainer: DatabaseContainerMock!
+    
+    lazy var clientEnvironment: ChatClient.Environment = .init(databaseContainerBuilder: { [unowned self] in
+        self.databaseContainer = try! DatabaseContainerMock(kind: $0)
+        return self.databaseContainer
+    })
+}
+
+private class MockEntityObserver<Item, DTO: NSManagedObject>: EntityDatabaseObserver<Item, DTO> {
+    var startUpdatingError: Error?
+    
+    override func startObserving() throws {
+        if let error = startUpdatingError {
+            throw error
+        } else {
+            try super.startObserving()
+        }
+    }
+}

--- a/Sources_v3/Controllers/EntityDatabaseObserver.swift
+++ b/Sources_v3/Controllers/EntityDatabaseObserver.swift
@@ -148,6 +148,32 @@ extension EntityDatabaseObserver {
         listeners.append(listener)
         return self
     }
+    
+    /// A builder-function that adds new listener for the specific `Item` field
+    /// and returns the updated `EntityDatabaseObserver` instance
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key-path of the specific field
+    ///   - listener: The listener that will be called when the new field change comes (from N the same sequential
+    ///   changes only the first will be delivered)
+    /// - Returns: The updated current `EntityDatabaseObserver` instance with the new listener added
+    @discardableResult
+    func onFieldChange<Value: Equatable>(
+        _ keyPath: KeyPath<Item, Value>,
+        do listener: @escaping (EntityChange<Value>) -> Void
+    ) -> EntityDatabaseObserver {
+        //The value that stores the last received `EntityChange<Value>` and is captured by ref by the closure
+        var lastChange: EntityChange<Value>?
+        
+        return onChange {
+            let change = $0.fieldChange(keyPath)
+            
+            if change != lastChange {
+                listener(change)
+                lastChange = change
+            }
+        }
+    }
 }
 
 private extension ListChangeAggregator {

--- a/Sources_v3/Controllers/EntityDatabaseObserver.swift
+++ b/Sources_v3/Controllers/EntityDatabaseObserver.swift
@@ -17,6 +17,20 @@ public enum EntityChange<Item> {
     case remove(_ item: Item)
 }
 
+extension EntityChange {
+    /// Returns the underlaying item that was changed
+    public var item: Item {
+        switch self {
+        case let .create(item):
+            return item
+        case let .update(item):
+            return item
+        case let .remove(item):
+            return item
+        }
+    }
+}
+
 extension EntityChange: Equatable where Item: Equatable {}
 
 extension EntityChange {

--- a/Sources_v3/Controllers/EntityDatabaseObserver.swift
+++ b/Sources_v3/Controllers/EntityDatabaseObserver.swift
@@ -29,6 +29,19 @@ extension EntityChange {
             return item
         }
     }
+    
+    /// Returns `EntityChange` of the same type but for the specific field
+    func fieldChange<Value>(_ path: KeyPath<Item, Value>) -> EntityChange<Value> {
+        let field = item[keyPath: path]
+        switch self {
+        case .create:
+            return .create(field)
+        case .update:
+            return .update(field)
+        case .remove:
+            return .remove(field)
+        }
+    }
 }
 
 extension EntityChange: Equatable where Item: Equatable {}

--- a/Sources_v3/Controllers/EntityDatabaseObserver_Tests.swift
+++ b/Sources_v3/Controllers/EntityDatabaseObserver_Tests.swift
@@ -16,6 +16,18 @@ class EntityChange_Tests: XCTestCase {
         XCTAssertEqual(EntityChange.update(updatedItem).item, updatedItem)
         XCTAssertEqual(EntityChange.remove(removedItem).item, removedItem)
     }
+    
+    func test_fieldChange() {
+        let createdItem = TestItem.unique
+        let updatedItem = TestItem.unique
+        let removedItem = TestItem.unique
+        
+        let path = \TestItem.value
+
+        XCTAssertEqual(EntityChange.create(createdItem).fieldChange(path), .create(createdItem.value))
+        XCTAssertEqual(EntityChange.update(updatedItem).fieldChange(path), .update(updatedItem.value))
+        XCTAssertEqual(EntityChange.remove(removedItem).fieldChange(path), .remove(removedItem.value))
+    }
 }
 
 class EntityDatabaseObserver_Tests: XCTestCase {

--- a/Sources_v3/Controllers/EntityDatabaseObserver_Tests.swift
+++ b/Sources_v3/Controllers/EntityDatabaseObserver_Tests.swift
@@ -128,3 +128,16 @@ class EntityDatabaseObserver_Tests: XCTestCase {
         AssertAsync.willBeEqual(listener2Changes, expectedChanges)
     }
 }
+
+private struct TestItem: Equatable {
+    static var unique: Self { .init(id: .unique, value: .unique) }
+    
+    var id: String
+    var value: String?
+}
+
+private extension TestManagedObject {
+    var model: TestItem {
+        .init(id: testId, value: testValue)
+    }
+}

--- a/Sources_v3/Controllers/EntityDatabaseObserver_Tests.swift
+++ b/Sources_v3/Controllers/EntityDatabaseObserver_Tests.swift
@@ -6,6 +6,18 @@ import CoreData
 @testable import StreamChatClient
 import XCTest
 
+class EntityChange_Tests: XCTestCase {
+    func test_item() {
+        let createdItem: String = .unique
+        let updatedItem: String = .unique
+        let removedItem: String = .unique
+
+        XCTAssertEqual(EntityChange.create(createdItem).item, createdItem)
+        XCTAssertEqual(EntityChange.update(updatedItem).item, updatedItem)
+        XCTAssertEqual(EntityChange.remove(removedItem).item, removedItem)
+    }
+}
+
 class EntityDatabaseObserver_Tests: XCTestCase {
     var observer: EntityDatabaseObserver<String, TestManagedObject>!
     var fetchRequest: NSFetchRequest<TestManagedObject>!

--- a/Sources_v3/Controllers/EntityDatabaseObserver_Tests.swift
+++ b/Sources_v3/Controllers/EntityDatabaseObserver_Tests.swift
@@ -9,7 +9,7 @@ import XCTest
 class EntityDatabaseObserver_Tests: XCTestCase {
     var observer: EntityDatabaseObserver<String, TestManagedObject>!
     var fetchRequest: NSFetchRequest<TestManagedObject>!
-    var database: DatabaseContainer!
+    var database: DatabaseContainerMock!
     
     override func setUp() {
         super.setUp()
@@ -30,9 +30,7 @@ class EntityDatabaseObserver_Tests: XCTestCase {
     func test_observingChanges() throws {
         let testId: String = .unique
         fetchRequest.predicate = NSPredicate(format: "testId == %@", testId)
-        
-        observer.onChange = { print($0) }
-        
+                
         try observer.startObserving()
         XCTAssertNil(observer.item)
         
@@ -75,5 +73,34 @@ class EntityDatabaseObserver_Tests: XCTestCase {
         }
         
         AssertAsync.willBeEqual(observer.item, nil)
+    }
+    
+    func test_onChange_worksForMultipleListeners() throws {
+        let testId: String = .unique
+        let testValue: String = .unique
+        fetchRequest.predicate = NSPredicate(format: "testId == %@", testId)
+
+        //Add two listeners
+        var listener1Changes: [EntityChange<String>] = []
+        var listener2Changes: [EntityChange<String>] = []
+        
+        observer
+            .onChange { listener1Changes.append($0) }
+            .onChange { listener2Changes.append($0) }
+        
+        //Start observing
+        try observer.startObserving()
+
+        // Insert a new entity matching the predicate
+        try database.writeSynchronously {
+            let new = TestManagedObject(context: $0 as! NSManagedObjectContext)
+            new.testValue = testValue
+            new.testId = testId
+        }
+        
+        // Assert both listeners receive expected changes
+        let expectedChanges = [EntityChange.create(testValue)]
+        AssertAsync.willBeEqual(listener1Changes, expectedChanges)
+        AssertAsync.willBeEqual(listener2Changes, expectedChanges)
     }
 }

--- a/Sources_v3/Controllers/EntityDatabaseObserver_Tests.swift
+++ b/Sources_v3/Controllers/EntityDatabaseObserver_Tests.swift
@@ -31,7 +31,7 @@ class EntityChange_Tests: XCTestCase {
 }
 
 class EntityDatabaseObserver_Tests: XCTestCase {
-    var observer: EntityDatabaseObserver<String, TestManagedObject>!
+    private var observer: EntityDatabaseObserver<TestItem, TestManagedObject>!
     var fetchRequest: NSFetchRequest<TestManagedObject>!
     var database: DatabaseContainerMock!
     
@@ -44,7 +44,7 @@ class EntityDatabaseObserver_Tests: XCTestCase {
                                               modelName: "TestDataModel",
                                               bundle: Bundle(for: EntityDatabaseObserver_Tests.self))
         
-        observer = .init(context: database.viewContext, fetchRequest: fetchRequest, itemCreator: { $0.testValue })
+        observer = .init(context: database.viewContext, fetchRequest: fetchRequest, itemCreator: { $0.model })
     }
     
     func test_initialValues() {
@@ -67,7 +67,7 @@ class EntityDatabaseObserver_Tests: XCTestCase {
             new.testValue = testValue2_atInsert
         }
         
-        AssertAsync.willBeEqual(observer.item, testValue2_atInsert)
+        AssertAsync.willBeEqual(observer.item, .init(id: testId, value: testValue2_atInsert))
         
         // Modify the entity matching the predicate
         let testValue2_modified: String = .unique
@@ -82,8 +82,8 @@ class EntityDatabaseObserver_Tests: XCTestCase {
             result[0].testValue = testValue2_modified
         }
         
-        AssertAsync.willBeEqual(observer.item, testValue2_modified)
-        
+        AssertAsync.willBeEqual(observer.item, .init(id: testId, value: testValue2_modified))
+
         // Modify the entity so it no longer matches the predicate
         database.write {
             let context = $0 as! NSManagedObjectContext
@@ -100,13 +100,12 @@ class EntityDatabaseObserver_Tests: XCTestCase {
     }
     
     func test_onChange_worksForMultipleListeners() throws {
-        let testId: String = .unique
-        let testValue: String = .unique
-        fetchRequest.predicate = NSPredicate(format: "testId == %@", testId)
+        let testItem = TestItem(id: .unique, value: .unique)
+        fetchRequest.predicate = NSPredicate(format: "testId == %@", testItem.id)
 
         //Add two listeners
-        var listener1Changes: [EntityChange<String>] = []
-        var listener2Changes: [EntityChange<String>] = []
+        var listener1Changes: [EntityChange<TestItem>] = []
+        var listener2Changes: [EntityChange<TestItem>] = []
         
         observer
             .onChange { listener1Changes.append($0) }
@@ -118,12 +117,12 @@ class EntityDatabaseObserver_Tests: XCTestCase {
         // Insert a new entity matching the predicate
         try database.writeSynchronously {
             let new = TestManagedObject(context: $0 as! NSManagedObjectContext)
-            new.testValue = testValue
-            new.testId = testId
+            new.testValue = testItem.value
+            new.testId = testItem.id
         }
         
         // Assert both listeners receive expected changes
-        let expectedChanges = [EntityChange.create(testValue)]
+        let expectedChanges = [EntityChange.create(testItem)]
         AssertAsync.willBeEqual(listener1Changes, expectedChanges)
         AssertAsync.willBeEqual(listener2Changes, expectedChanges)
     }

--- a/Sources_v3/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO.swift
@@ -58,10 +58,22 @@ extension NSManagedObjectContext: CurrentUserDatabaseSession {
         dto.mutedUsers = [] // TODO: mutedUsers
         dto.user = try saveUser(payload: payload)
         
-        // TODO: unread counts
+        if let unreadCount = payload.unreadCount {
+            try saveCurrentUserUnreadCount(count: unreadCount)
+        }
+        
         // TODO: devices
         
         return dto
+    }
+    
+    func saveCurrentUserUnreadCount(count: UnreadCount) throws {
+        guard let dto = currentUser() else {
+            throw ClientError.CurrentUserDoesNotExist()
+        }
+        
+        dto.unreadChannelsCount = Int16(count.channels)
+        dto.unreadMessagesCount = Int16(count.messages)
     }
     
     func currentUser() -> CurrentUserDTO? { .load(context: self) }

--- a/Sources_v3/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO.swift
@@ -14,6 +14,15 @@ class CurrentUserDTO: NSManagedObject {
     
     @NSManaged var mutedUsers: Set<UserDTO>
     @NSManaged var user: UserDTO
+    
+    /// Returns a default fetch request for the current user.
+    static var defaultFetchRequest: NSFetchRequest<CurrentUserDTO> {
+        let request = NSFetchRequest<CurrentUserDTO>(entityName: CurrentUserDTO.entityName)
+        // Sorting doesn't matter here as soon as we have a single current-user in a database.
+        // It's here to make the request safe for FRC
+        request.sortDescriptors = [.init(keyPath: \CurrentUserDTO.unreadMessagesCount, ascending: true)]
+        return request
+    }
 }
 
 extension CurrentUserDTO {

--- a/Sources_v3/Database/DTOs/CurrentUserDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO_Tests.swift
@@ -39,11 +39,12 @@ class CurrentUserModelDTO_Tests: XCTestCase {
             Assert.willBeEqual(payload.createdAt, loadedCurrentUser?.user.userCreatedAt)
             Assert.willBeEqual(payload.updatedAt, loadedCurrentUser?.user.userUpdatedAt)
             Assert.willBeEqual(payload.lastActiveAt, loadedCurrentUser?.user.lastActivityAt)
+            Assert.willBeEqual(Int16(payload.unreadCount!.messages), loadedCurrentUser?.unreadMessagesCount)
+            Assert.willBeEqual(Int16(payload.unreadCount!.channels), loadedCurrentUser?.unreadChannelsCount)
             Assert.willBeEqual(payload.extraData, loadedCurrentUser.map {
                 try? JSONDecoder.default.decode(NameAndImageExtraData.self, from: $0.user.extraData)
             })
-            
-            // TODO: Teams, Mutes, Unread counts, Devices
+            // TODO: Teams, Mutes, Devices
         }
     }
     
@@ -70,11 +71,13 @@ class CurrentUserModelDTO_Tests: XCTestCase {
             Assert.willBeEqual(payload.createdAt, loadedCurrentUser?.user.userCreatedAt)
             Assert.willBeEqual(payload.updatedAt, loadedCurrentUser?.user.userUpdatedAt)
             Assert.willBeEqual(payload.lastActiveAt, loadedCurrentUser?.user.lastActivityAt)
+            Assert.willBeEqual(Int16(payload.unreadCount!.messages), loadedCurrentUser?.unreadMessagesCount)
+            Assert.willBeEqual(Int16(payload.unreadCount!.channels), loadedCurrentUser?.unreadChannelsCount)
             Assert.willBeEqual(payload.extraData, loadedCurrentUser.map {
                 try? JSONDecoder.default.decode(NoExtraData.self, from: $0.user.extraData)
             })
             
-            // TODO: Teams, Mutes, Unread counts, Devices
+            // TODO: Teams, Mutes, Devices
         }
     }
 }

--- a/Sources_v3/Database/DatabaseSession.swift
+++ b/Sources_v3/Database/DatabaseSession.swift
@@ -21,6 +21,10 @@ protocol CurrentUserDatabaseSession {
     /// if the save fails.
     @discardableResult
     func saveCurrentUser<ExtraData: UserExtraData>(payload: CurrentUserPayload<ExtraData>) throws -> CurrentUserDTO
+
+    /// Updates the `CurrentUserDTO` with the provided unread.
+    /// If there is no current user, the error will be thown
+    func saveCurrentUserUnreadCount(count: UnreadCount) throws
     
     /// Returns `CurrentUserDTO` from the DB. Returns `nil` if no `CurrentUserDTO` exists.
     func currentUser() -> CurrentUserDTO?
@@ -116,12 +120,11 @@ extension DatabaseSession {
         }
         
         if let currentUserPayload = payload.currentUser {
-            let currentUserDTO = try saveCurrentUser(payload: currentUserPayload)
-            
-            if let unreadCount = payload.unreadCount {
-                currentUserDTO.unreadChannelsCount = Int16(unreadCount.channels)
-                currentUserDTO.unreadMessagesCount = Int16(unreadCount.messages)
-            }
+            try saveCurrentUser(payload: currentUserPayload)
+        }
+        
+        if let unreadCount = payload.unreadCount {
+            try saveCurrentUserUnreadCount(count: unreadCount)
         }
         
         // Save message data (must be always done after the channel data!)

--- a/Sources_v3/Models/CurrentUser.swift
+++ b/Sources_v3/Models/CurrentUser.swift
@@ -18,6 +18,9 @@ extension UserId {
     }
 }
 
+/// A convenience typealias for `CurrentUserModel` with the default data type.
+public typealias CurrentUser = CurrentUserModel<DefaultDataTypes.User>
+
 public class CurrentUserModel<ExtraData: UserExtraData>: UserModel<ExtraData> {
     // MARK: - Public
     

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -248,6 +248,8 @@
 		F63CC37324E592D30052844D /* MemberEventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37224E592D30052844D /* MemberEventObserver.swift */; };
 		F63CC37524E592DD0052844D /* MemberEventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */; };
 		F67415C024F0129800C3222F /* UnreadCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67415BF24F0129800C3222F /* UnreadCount.swift */; };
+		F688643624E6DA8700A71361 /* CurrentUserController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F688643524E6DA8700A71361 /* CurrentUserController.swift */; };
+		F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -537,6 +539,8 @@
 		F63CC37224E592D30052844D /* MemberEventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventObserver.swift; sourceTree = "<group>"; };
 		F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventObserver_Tests.swift; sourceTree = "<group>"; };
 		F67415BF24F0129800C3222F /* UnreadCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadCount.swift; sourceTree = "<group>"; };
+		F688643524E6DA8700A71361 /* CurrentUserController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserController.swift; sourceTree = "<group>"; };
+		F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserController_Tests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -928,6 +932,8 @@
 				793C14DB24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift */,
 				792AF91524D812440010097B /* EntityDatabaseObserver.swift */,
 				7922F30924DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift */,
+				F688643524E6DA8700A71361 /* CurrentUserController.swift */,
+				F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -1464,6 +1470,7 @@
 				DAEAF4B324DAD99E0015FB28 /* HideChannelRequest.swift in Sources */,
 				792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */,
 				79A0E9AD2498BD0C00E9BD50 /* ChatClient.swift in Sources */,
+				F688643624E6DA8700A71361 /* CurrentUserController.swift in Sources */,
 				792A4F39247FFACB00EAF71D /* WebSocketEngine.swift in Sources */,
 				79280F422484F4EC00CDEB89 /* Event.swift in Sources */,
 				79682C4A24BF37C80071578E /* MessagePayloads.swift in Sources */,
@@ -1520,6 +1527,7 @@
 				7964F3AA249A19EA002A09EC /* Filter_Tests.swift in Sources */,
 				F67415C024F0129800C3222F /* UnreadCount.swift in Sources */,
 				79DDF819249CE38B002F4412 /* MockNetworkURLProtocol.swift in Sources */,
+				F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */,
 				7922F30A24DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift in Sources */,
 				8A62705E24BE2CD70040BFD6 /* XCTestCase+MockJSON.swift in Sources */,
 				F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37024E591990052844D /* EventObserver_Tests.swift */; };
 		F63CC37324E592D30052844D /* MemberEventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37224E592D30052844D /* MemberEventObserver.swift */; };
 		F63CC37524E592DD0052844D /* MemberEventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */; };
+		F67415C024F0129800C3222F /* UnreadCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67415BF24F0129800C3222F /* UnreadCount.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -535,6 +536,7 @@
 		F63CC37024E591990052844D /* EventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver_Tests.swift; sourceTree = "<group>"; };
 		F63CC37224E592D30052844D /* MemberEventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventObserver.swift; sourceTree = "<group>"; };
 		F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventObserver_Tests.swift; sourceTree = "<group>"; };
+		F67415BF24F0129800C3222F /* UnreadCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadCount.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -572,6 +574,7 @@
 				790B9E3124DC221A005455AA /* UserPayload.swift */,
 				79F3ABEB24EAE0B900AB9505 /* UserRequestBody.swift */,
 				8A0D649224E5794C0017A3C0 /* CurrentUserPayload.swift */,
+				F67415BF24F0129800C3222F /* UnreadCount.swift */,
 			);
 			path = "Dummy data";
 			sourceTree = "<group>";
@@ -1515,6 +1518,7 @@
 				793C14DC24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift in Sources */,
 				79A0E9AF2498BFD800E9BD50 /* WebSocketClient_Tests.swift in Sources */,
 				7964F3AA249A19EA002A09EC /* Filter_Tests.swift in Sources */,
+				F67415C024F0129800C3222F /* UnreadCount.swift in Sources */,
 				79DDF819249CE38B002F4412 /* MockNetworkURLProtocol.swift in Sources */,
 				7922F30A24DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift in Sources */,
 				8A62705E24BE2CD70040BFD6 /* XCTestCase+MockJSON.swift in Sources */,

--- a/Tests_v3/Dummy data/CurrentUserPayload.swift
+++ b/Tests_v3/Dummy data/CurrentUserPayload.swift
@@ -7,7 +7,12 @@ import Foundation
 
 extension CurrentUserPayload {
     /// Returns a dummy current user payload with the given UserId and extra data
-    static func dummy<T: UserExtraData>(userId: UserId, role: UserRole, extraData: T = .defaultValue) -> CurrentUserPayload<T> {
+    static func dummy<T: UserExtraData>(
+        userId: UserId,
+        role: UserRole,
+        unreadCount: UnreadCount? = .dummy,
+        extraData: T = .defaultValue
+    ) -> CurrentUserPayload<T> {
         .init(id: userId,
               role: role,
               createdAt: .unique,
@@ -19,6 +24,7 @@ extension CurrentUserPayload {
               teams: [],
               extraData: extraData,
               devices: [.init(.unique)],
-              mutedUsers: [])
+              mutedUsers: [],
+              unreadCount: unreadCount)
     }
 }

--- a/Tests_v3/Dummy data/UnreadCount.swift
+++ b/Tests_v3/Dummy data/UnreadCount.swift
@@ -1,0 +1,12 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChatClient
+
+extension UnreadCount {
+    static var dummy: Self {
+        .init(channels: 10, messages: 323)
+    }
+}


### PR DESCRIPTION
**This PR:**

- Introduces `CurrentUserController`
- Removes `currentUser` from `ChatClient`
- Updates `EntityDatabaseObserver` to have multiple listeners
- Adds `unreadCount` to `CurrentUserPayload`
- Updates `CurrentUserDatabaseSession` to manage unread-count