### PR TITLE
Feature/backport url mock helpers

### DIFF
--- a/Sources/Client/Client/Client+Request.swift
+++ b/Sources/Client/Client/Client+Request.swift
@@ -93,7 +93,6 @@ extension Client {
             ? encodeRequestForUpload(for: endpoint, url: url).get()
             : encodeRequest(for: endpoint, url: url).get()
     }
-
     
     private func prepareRequest<T: Decodable>(endpoint: Endpoint, _ completion: @escaping Completion<T>) -> URLSessionTask? {
         if let logger = logger {

--- a/Tests/Client/Custom Assertions/AssertJSONEqual.swift
+++ b/Tests/Client/Custom Assertions/AssertJSONEqual.swift
@@ -15,7 +15,7 @@ func error(domain: String, code: Int = -1, message: @autoclosure () -> String) -
 }
 
 /// Asserts the given 2 JSON Serializations are equal, by creating JSON objects from Data and comparing dictionaries.
-/// Recursively calls itself for nested dictionaries.
+/// Recursively calls itself for nested dictionaries and generates a failure if the expressions are not equal.
 /// - Parameters:
 ///   - expression1: JSON object 1, as Data. From string, you can do `Data(jsonString.utf8)`
 ///   - expression2: JSON object 2, as Data.
@@ -25,72 +25,52 @@ func AssertJSONEqual(_ expression1: @autoclosure () throws -> Data,
                      _ expression2: @autoclosure () throws -> Data,
                      file: StaticString = #file,
                      line: UInt = #line) {
-    do {
-        guard let json1 = try JSONSerialization.jsonObject(with: expression1()) as? [String: Any] else {
-            throw error(domain: "AssertJSONEqual", message: "First expression is not a valid json object!")
-        }
-        guard let json2 = try JSONSerialization.jsonObject(with: expression2()) as? [String: Any] else {
-            throw error(domain: "AssertJSONEqual", message: "Second expression is not a valid json object!")
-        }
-        guard json1.keys == json2.keys else {
-            throw error(domain: "AssertJSONEqual", message: "JSON keys do not match")
-        }
-        try json1.forEach { (key, value) in
-            guard let value2 = json2[key] else {
-                throw error(domain: "AssertJSONEqual", message: "Expression 2 does not have value for \(key)")
-            }
-            if let nestedDict1 = value as? [String: Any] {
-                if let nestedDict2 = value2 as? [String: Any] {
-                    try AssertJSONEqual(JSONSerialization.data(withJSONObject: nestedDict1),
-                                        JSONSerialization.data(withJSONObject: nestedDict2),
-                                        file: file,
-                                        line: line)
-                } else {
-                    throw error(domain: "AssertJSONEqual", message:  "Values for key \(key) do not match")
-                }
-            } else if String(describing: value) != String(describing: value2) {
-                throw error(domain: "AssertJSONEqual", message: "Values for key \(key) do not match")
-            }
-        }
-    } catch {
-        XCTFail("Error: \(error)", file: file, line: line)
-    }
+    
+    guard let error = try CheckJSONEqual(expression1(), expression2()) else { return }
+    XCTFail("Error: \(error)", file: file, line: line)
 }
 
 /// Compares the given 2 JSON Serializations are equal, by creating JSON objects from Data and comparing dictionaries.
-/// Recursively calls itself for nested dictionaries.
+/// Recursively calls itself for nested dictionaries and returns an error if the expressions are not equal.
 /// - Parameters:
 ///   - expression1: JSON object 1, as Data. From string, you can do `Data(jsonString.utf8)`
 ///   - expression2: JSON object 2, as Data.
-func isJSONEqual(_ expression1: @autoclosure () throws -> Data,
-                 _ expression2: @autoclosure () throws -> Data) -> Bool {
+func CheckJSONEqual(_ expression1: @autoclosure () throws -> Data,
+                    _ expression2: @autoclosure () throws -> Data) -> NSError? {
     do {
         guard let json1 = try JSONSerialization.jsonObject(with: expression1()) as? [String: Any] else {
-            return false
+            return error(domain: "AssertJSONEqual",
+                         message: "First expression is not a valid json object!")
         }
         guard let json2 = try JSONSerialization.jsonObject(with: expression2()) as? [String: Any] else {
-            return false
+            return error(domain: "AssertJSONEqual",
+                         message: "Second expression is not a valid json object!")
         }
         guard json1.keys == json2.keys else {
-            return false
+            return error(domain: "AssertJSONEqual",
+                         message: "JSON keys do not match")
         }
-        return try json1.allSatisfy { (key, value) in
+        
+        for (key, value) in json1 {
             guard let value2 = json2[key] else {
-                return false
+                return error(domain: "AssertJSONEqual",
+                             message: "Expression 2 does not have value for \(key)")
             }
             if let nestedDict1 = value as? [String: Any] {
                 if let nestedDict2 = value2 as? [String: Any] {
-                    return try isJSONEqual(JSONSerialization.data(withJSONObject: nestedDict1),
-                                           JSONSerialization.data(withJSONObject: nestedDict2))
+                    return try CheckJSONEqual(JSONSerialization.data(withJSONObject: nestedDict1),
+                                              JSONSerialization.data(withJSONObject: nestedDict2))
                 } else {
-                    return false
+                    return error(domain: "AssertJSONEqual",
+                                 message: "Values for key \(key) do not match")
                 }
             } else if String(describing: value) != String(describing: value2) {
-                return false
+                return error(domain: "AssertJSONEqual",
+                             message: "Values for key \(key) do not match")
             }
-            return true
         }
+        return nil
     } catch {
-        return false
+        return error as NSError
     }
 }

--- a/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
+++ b/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
@@ -102,7 +102,7 @@ extension Assert {
         let requestsMatchingByPathDescription = requestsMatchingByPath
             .map { request in
                 request.description +
-                "Match failure: " +
+                "⛔️ Match failure: " +
                 request.matches(method, path, headers, queryParameters, body).failureMessage
             }.joined(separator: "\n")
 
@@ -150,11 +150,11 @@ private extension URLRequest {
         guard let url = self.url else { return "" }
         let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
         
-        return "URLRequest:\n" +
-            "url=\(url.absoluteString)\n" +
-            "method=\(httpMethod ?? "")\n" +
-            "headers=\(allHTTPHeaderFields ?? [:])\n" +
-            "queryItems=\(String(describing: queryItems))\n\n"
+        return "☏ URLRequest:\n" +
+            "➔ url=\(url.absoluteString)\n" +
+            "➔ method=\(httpMethod ?? "")\n" +
+            "➔ headers=\(allHTTPHeaderFields ?? [:])\n" +
+            "➔ queryItems=\(String(describing: queryItems))\n\n"
     }
     
     /// Returns `true` if the given parameters match the current `URLRequest`. Otherwise returns `false`.

--- a/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
+++ b/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
@@ -134,7 +134,7 @@ private extension URLRequest {
             }
         }
         
-        /// If the value is a failure it returns its message. Othewise it returns theempty string.
+        /// If the value is a failure it returns its message. Othewise it returns the empty string.
         var failureMessage: String {
             switch self {
             case .failure(let message):
@@ -145,7 +145,7 @@ private extension URLRequest {
         }
     }
     
-    /// String description of request URL, HTTP method, headers and query items
+    /// String description of request: URL, HTTP method, headers and query items
     var description: String {
         guard let url = self.url else { return "" }
         let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
@@ -157,7 +157,8 @@ private extension URLRequest {
             "queryItems=\(String(describing: queryItems))\n\n"
     }
     
-    /// Returns `true` if the given path matches the current `URLRequest`. Otherwise returns `false`.
+    /// Returns `success` if the given path matches the current `URLRequest`.
+    /// Otherwise returns `failure` with a String describing the why it does not match.
     func matches(path: String) -> Bool {
         guard let url = self.url,
             let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
@@ -246,6 +247,9 @@ private extension URLRequest {
                 return MatchResult.from(errorMessage)
         }
         
+        // Check if the body data JSON are equal if they are not then the error is appended
+        // to the previous errors. If they are equal and there are no previous errors then
+        // it returns `success` but if there are pending errors then it returns `failure`.
         return CheckJSONEqual(assertingBodyData, bodyData)
             .map { MatchResult.failure("\(errorMessage)\n  - \($0)") }
             ?? MatchResult.from(errorMessage)

--- a/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
+++ b/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
@@ -145,7 +145,7 @@ private extension URLRequest {
         }
     }
     
-    /// String description of request: URL, HTTP method, headers and query items
+    /// String description of a request: URL, HTTP method, headers and query items
     var description: String {
         guard let url = self.url else { return "" }
         let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
@@ -157,8 +157,7 @@ private extension URLRequest {
             "queryItems=\(String(describing: queryItems))\n\n"
     }
     
-    /// Returns `success` if the given path matches the current `URLRequest`.
-    /// Otherwise returns `failure` with a String describing the why it does not match.
+    /// Returns `true` if the given parameters match the current `URLRequest`. Otherwise returns `false`.
     func matches(path: String) -> Bool {
         guard let url = self.url,
             let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
@@ -168,7 +167,8 @@ private extension URLRequest {
         return true
     }
     
-    /// Returns `true` if the given parameters match the current `URLRequest`. Otherwise returns `false`.
+    /// Returns `success` if the given path matches the current `URLRequest`.
+    /// Otherwise returns `failure` with a String describing the why it does not match.
     func matches(_ method: Endpoint.Method,
                  _ path: String,
                  _ headers: [String: String]?,

--- a/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
+++ b/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
@@ -38,18 +38,10 @@ extension Assert {
         
         return Assert.willBeTrue(RequestRecorderURLProtocol.recordedRequests.contains {
             $0.matches(method, path, headers, queryParameters, body).isSuccess
-        }, message: "Failed to find a matching request in the recorded request array",
+        }, message: "Failed to find a matching request in the recorded request list:\n" +
+            RequestRecorderURLProtocol.recordedRequests.map { $0.description }.joined(separator: "\n"),
            file: file,
            line: line)
-    }
-    
-    private func findMatch(in requests: [URLRequest],
-                           method: Endpoint.Method,
-                           path: String,
-                           headers: [String: String]?,
-                           queryParameters: [String: String]?,
-                           body: [String: Any]?) -> URLRequest.MatchResult {
-        return .success
     }
 }
 
@@ -68,6 +60,17 @@ private extension URLRequest {
             default: return false
             }
         }
+    }
+    
+    var description: String {
+        guard let url = self.url else { return "" }
+        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
+        
+        return "URLRequest:\n" +
+            "url=\(url.absoluteString)\n" +
+            "method=\(httpMethod ?? "")\n" +
+            "headers=\(allHTTPHeaderFields ?? [:])\n" +
+            "queryItems=\(String(describing: queryItems))\n\n"
     }
     
     /// Returns `true` if the given parameters match the current `URLRequest`. Otherwise returns `false`.

--- a/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
+++ b/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
@@ -34,11 +34,11 @@ extension Assert {
                                body: [String: Any]?,
                                timeout: TimeInterval = 0.5,
                                file: StaticString = #file,
-                               line: UInt = #line) {
+                               line: UInt = #line) -> Assertion {
         
-        AssertAsync.willBeTrue(RequestRecorderURLProtocol.recordedRequests.contains {
+        return Assert.willBeTrue(RequestRecorderURLProtocol.recordedRequests.contains {
             $0.matches(method, path, headers, queryParameters, body)
-        }, message: "AssertNetworkRequest failed to find a matching request")
+        }, message: "Failed to find a matching request in the recorded request array")
     }
 }
 

--- a/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
+++ b/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
@@ -9,6 +9,45 @@ import XCTest
 @testable import StreamChatClient
 
 
+extension AssertAsync {
+    /// Synchronously waits for a network request that matches its properties with the given parameters.
+    ///
+    /// The function periodically checks the `RequestRecorderURLProtocol.recordedRequests` and If no request matches the
+    /// given parameters within the `timeout` period, this assertion fails with the time-out error.
+    ///
+    /// The values specified in the `headers`, `queryParameters` and `body` represents the mandatory subset of
+    /// the values the request must have. A request is valid even when it contains additional parameters than
+    /// the ones specified in these values.
+    ///
+    /// - Parameters:
+    ///   - method: The HTTP method the request.
+    ///   - path: The `path` part of the request's URL.
+    ///   - headers: The headers required for the request.
+    ///   - queryParameters: The query parameters required for the request.
+    ///   - body: The expected body of the request.
+    ///   - timeout: The maximum time this function waits for a request to match the given parameters.
+    ///
+    static func networkRequest(method: Endpoint.Method,
+                               path: String,
+                               headers: [String: String]?,
+                               queryParameters: [String: String]?,
+                               body: [String: Any]?,
+                               timeout: TimeInterval = 0.5,
+                               file: StaticString = #file,
+                               line: UInt = #line) {
+        AssertAsync {
+            Assert.networkRequest(method: method,
+                                  path: path,
+                                  headers: headers,
+                                  queryParameters: queryParameters,
+                                  body: body,
+                                  timeout: timeout,
+                                  file: file,
+                                  line: line)
+        }
+    }
+}
+
 extension Assert {
     /// Synchronously waits for a network request that matches its properties with the given parameters.
     ///

--- a/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
+++ b/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
@@ -9,36 +9,37 @@ import XCTest
 @testable import StreamChatClient
 
 
-/// Synchronously waits for a network request that matches its properties with the given parameters.
-///
-/// The function periodically checks the `RequestRecorderURLProtocol.recordedRequests` and If no request matches the
-/// given parameters within the `timeout` period, this assertion fails with the time-out error.
-///
-/// The values specified in the `headers`, `queryParameters` and `body` represents the mandatory subset of
-/// the values the request must have. A request is valid even when it contains additional parameters than
-/// the ones specified in these values.
-///
-/// - Parameters:
-///   - method: The HTTP method the request.
-///   - path: The `path` part of the request's URL.
-///   - headers: The headers required for the request.
-///   - queryParameters: The query parameters required for the request.
-///   - body: The expected body of the request.
-///   - timeout: The maximum time this function waits for a request to match the given parameters.
-///
-func AssertNetworkRequest(method: Endpoint.Method,
-                          path: String,
-                          headers: [String: String]?,
-                          queryParameters: [String: String]?,
-                          body: [String: Any]?,
-                          timeout: TimeInterval = 0.5,
-                          file: StaticString = #file,
-                          line: UInt = #line) {
-    
-    AssertAsync.willBeTrue(RequestRecorderURLProtocol.recordedRequests.contains {
-        $0.matches(method, path, headers, queryParameters, body)
-    }, message: "AssertNetworkRequest failed to find a matching request")
-    
+extension Assert {
+    /// Synchronously waits for a network request that matches its properties with the given parameters.
+    ///
+    /// The function periodically checks the `RequestRecorderURLProtocol.recordedRequests` and If no request matches the
+    /// given parameters within the `timeout` period, this assertion fails with the time-out error.
+    ///
+    /// The values specified in the `headers`, `queryParameters` and `body` represents the mandatory subset of
+    /// the values the request must have. A request is valid even when it contains additional parameters than
+    /// the ones specified in these values.
+    ///
+    /// - Parameters:
+    ///   - method: The HTTP method the request.
+    ///   - path: The `path` part of the request's URL.
+    ///   - headers: The headers required for the request.
+    ///   - queryParameters: The query parameters required for the request.
+    ///   - body: The expected body of the request.
+    ///   - timeout: The maximum time this function waits for a request to match the given parameters.
+    ///
+    static func networkRequest(method: Endpoint.Method,
+                               path: String,
+                               headers: [String: String]?,
+                               queryParameters: [String: String]?,
+                               body: [String: Any]?,
+                               timeout: TimeInterval = 0.5,
+                               file: StaticString = #file,
+                               line: UInt = #line) {
+        
+        AssertAsync.willBeTrue(RequestRecorderURLProtocol.recordedRequests.contains {
+            $0.matches(method, path, headers, queryParameters, body)
+        }, message: "AssertNetworkRequest failed to find a matching request")
+    }
 }
 
 private extension URLRequest {

--- a/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
+++ b/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
@@ -168,7 +168,7 @@ private extension URLRequest {
     }
     
     /// Returns `success` if the given path matches the current `URLRequest`.
-    /// Otherwise returns `failure` with a String describing the why it does not match.
+    /// Otherwise returns `failure` with a String describing the reason it does not match.
     func matches(_ method: Endpoint.Method,
                  _ path: String,
                  _ headers: [String: String]?,

--- a/Tests/Client/MockNetworkURLProtocol.swift
+++ b/Tests/Client/MockNetworkURLProtocol.swift
@@ -12,106 +12,120 @@ import XCTest
 
 /// This URLProtocol intercepts the network communication and provides mock responses for the registered endpoints.
 class MockNetworkURLProtocol: URLProtocol {
-
-    private static var responses: [PathAndMethod: MockResponse] = [:]
-
-    /// Cleans up all existing mock reponses.
+    static let testSessionHeaderKey = "MockNetworkURLProtocol_test_session_id"
+    
+    /// Starts a new recording session. Adds a unique identifier to the configuration headers and listens only
+    /// for the request with this id.
+    static func startTestSession(with configuration: inout URLSessionConfiguration) {
+        reset()
+        let newSessionId = UUID().uuidString
+        currentSessionId = newSessionId
+        
+        // MockNetworkURLProtocol always has to be first, but not if the RequestRecorderURLProtocol is presented
+        if let recorderProtocolIdx = configuration.protocolClasses?.firstIndex(where: { $0 is RequestRecorderURLProtocol.Type }) {
+            configuration.protocolClasses?.insert(MockNetworkURLProtocol.self, at: recorderProtocolIdx + 1)
+        } else {
+            configuration.protocolClasses?.insert(MockNetworkURLProtocol.self, at: 0)
+        }
+        
+        var existingHeaders = configuration.httpAdditionalHeaders ?? [:]
+        existingHeaders[MockNetworkURLProtocol.testSessionHeaderKey] = newSessionId
+        configuration.httpAdditionalHeaders = existingHeaders
+    }
+    
+    @Atomic private static var responses: [PathAndMethod: MockResponse] = [:]
+    
+    /// If set, the mock protocol responds to requests with `testSessionHeaderKey` header value set to this value. If `nil`,
+    /// all requests are ignored.
+    static var currentSessionId: String?
+    
+    /// Cleans up all existing mock responses and current test session id.
     static func reset() {
+        Self.currentSessionId = nil
         Self.responses.removeAll()
     }
     
     override class func canInit(with request: URLRequest) -> Bool {
         guard
-            let path = request.url?.path.normalizedPath,
+            request.value(forHTTPHeaderField: testSessionHeaderKey) == currentSessionId,
+            let url = request.url,
             let method = request.httpMethod
         else { return false }
-
-        let key = PathAndMethod(path: path, method: method)
+        
+        let key = PathAndMethod(url: url, method: method)
         return responses.keys.contains(key)
     }
-
+    
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         // Overriding this function is required by the superclass.
-        return request
+        request
     }
-
+    
     // MARK: Instance methods
-
+    
     override func startLoading() {
         guard
-            let path = request.url?.path.normalizedPath,
+            let url = request.url,
             let method = request.httpMethod,
-            let mockResponse = Self.responses[.init(path: path, method: method)]
+            let mockResponse = Self.responses[.init(url: url, method: method)]
         else {
             fatalError("This should never happen. Check if the implementation of the `canInit` method is correct.")
         }
-
-        let httpResponse = HTTPURLResponse(
-            url: request.url!,
-            statusCode: mockResponse.responseCode,
-            httpVersion: "HTTP/1.1",
-            headerFields: nil
-        )!
-
-        self.client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .allowed)
-
+        
+        let httpResponse = HTTPURLResponse(url: request.url!,
+                                           statusCode: mockResponse.responseCode,
+                                           httpVersion: "HTTP/1.1",
+                                           headerFields: nil)!
+        
+        client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .allowed)
+        
         switch mockResponse.result {
         case let .success(data):
-            self.client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocol(self, didLoad: data)
         case let .failure(error):
-            self.client?.urlProtocol(self, didFailWithError: error)
+            client?.urlProtocol(self, didFailWithError: error)
         }
-
+        
         // Finish loading (required).
-        self.client?.urlProtocolDidFinishLoading(self)
-
+        client?.urlProtocolDidFinishLoading(self)
+        
         // Clean up
-        DispatchQueue.main.async {
-            Self.responses.removeValue(forKey: .init(path: path, method: method))
-        }
+        Self.responses.removeValue(forKey: .init(url: url, method: method))
     }
-
+    
     override func stopLoading() {
         // Required by the superclass
     }
 }
 
 extension MockNetworkURLProtocol {
-
     /// Creates a successful mock response for the given endpoint.
     ///
     /// - Parameters:
     ///   - endpoint: The endpoint the mock response is registered for.
     ///   - statusCode: The HTTP status code used for the response.
     ///   - response: The JSON body of the response.
-    static func mockResponse(endpoint: Endpoint, statusCode: Int = 200, responseBody: [String: Any] = [:]) {
-        let jsonData: Data
-        do {
-            jsonData = try JSONSerialization.data(withJSONObject: responseBody, options: .prettyPrinted)
-        } catch {
-            fatalError("Error encoding mock responseBody to JSON: \(error)")
-        }
-
-        let key = PathAndMethod(path: endpoint.path.normalizedPath, method: endpoint.method.rawValue)
-        Self.responses[key] = MockResponse(result: .success(jsonData), responseCode: statusCode)
+    static func mockResponse(request: URLRequest, statusCode: Int = 200, responseBody: Data = Data([])) {
+        let key = PathAndMethod(url: request.url!, method: request.httpMethod!)
+        Self.responses[key] = MockResponse(result: .success(responseBody), responseCode: statusCode)
     }
-
+    
     /// Creates a failing mock response for the given endpoint.
     ///
     /// - Parameters:
     ///   - endpoint: The endpoint the mock response is registered for.
     ///   - statusCode: The HTTP status code used for the response.
     ///   - error: The error object used for the response.
-    static func mockResponse(endpoint: Endpoint, statusCode: Int = 400, error: Error) {
-        let key = PathAndMethod(path: endpoint.path.normalizedPath, method: endpoint.method.rawValue)
-
+    static func mockResponse(request: URLRequest, statusCode: Int = 400, error: Error) {
+        let key = PathAndMethod(url: request.url!, method: request.httpMethod!)
+        
         Self.responses[key] = MockResponse(result: .failure(error), responseCode: statusCode)
     }
 }
 
 /// Used for using the combination of `path` and `httpMethod` as a dictionary key.
 private struct PathAndMethod: Hashable {
-    let path: String
+    let url: URL
     let method: String
 }
 
@@ -120,11 +134,9 @@ private struct MockResponse {
     let responseCode: Int
 }
 
-
-
 private extension String {
     /// Removes all leading `/` from the string.
     var normalizedPath: String {
-        String(drop(while: { $0 == "/"}))
+        String(drop(while: { $0 == "/" }))
     }
 }

--- a/Tests/Client/MockNetworkURLProtocol.swift
+++ b/Tests/Client/MockNetworkURLProtocol.swift
@@ -142,7 +142,6 @@ private struct PathAndMethod: Hashable {
         path = url.path
         self.method = method
     }
-
 }
 
 private struct MockResponse {

--- a/Tests/Client/MockNetworkURLProtocol.swift
+++ b/Tests/Client/MockNetworkURLProtocol.swift
@@ -127,10 +127,22 @@ extension MockNetworkURLProtocol {
     }
 }
 
-/// Used for using the combination of `path` and `httpMethod` as a dictionary key.
+/// Used for using the combination of significat parts of the URL passed as parameter and `httpMethod` as a dictionary key.
+/// - Warning: ⚠️ Significant parts of the URL are used as keys instead of a URL because two URL's can be semantically identical but syntactially different
+/// Example: https//a.b.c/d?e=f&g=h and https//a.b.c/d?g=h&e=f
 private struct PathAndMethod: Hashable {
-    let url: URL
+    let scheme: String?
+    let host: String?
+    let path: String
     let method: String
+    
+    init(url: URL, method: String) {
+        scheme = url.scheme
+        host = url.host
+        path = url.path
+        self.method = method
+    }
+
 }
 
 private struct MockResponse {

--- a/Tests/Client/RequestRecorderURLProtocol.swift
+++ b/Tests/Client/RequestRecorderURLProtocol.swift
@@ -11,12 +11,24 @@ import XCTest
 /// This URLProtocol subclass allows to intercept the network communication
 /// and provides the latest network request made.
 class RequestRecorderURLProtocol: URLProtocol {
-
-    static let testSessionHeaderKey = "test_session_id"
+    static let testSessionHeaderKey = "RequestRecorderURLProtocol_test_session_id"
+    
+    /// Starts a new recording session. Adds a unique identifier to the configuration headers and listens only
+    /// for the request with this id.
+    static func startTestSession(with configuration: inout URLSessionConfiguration) {
+        reset()
+        let newSessionId = UUID().uuidString
+        currentSessionId = newSessionId
+        
+        configuration.protocolClasses?.insert(RequestRecorderURLProtocol.self, at: 0)
+        var existingHeaders = configuration.httpAdditionalHeaders ?? [:]
+        existingHeaders[RequestRecorderURLProtocol.testSessionHeaderKey] = newSessionId
+        configuration.httpAdditionalHeaders = existingHeaders
+    }
     
     private static var latestRequestExpectation: XCTestExpectation?
     private static var latestRequest: URLRequest?
-
+    
     /// Returns the latest network request this URLProtocol recorded.
     ///
     /// If no request has been made since the last time this function was invoked, it synchronously
@@ -28,15 +40,16 @@ class RequestRecorderURLProtocol: URLProtocol {
             // Delete the used request
             latestRequest = nil
         }
-
+        
         guard latestRequest == nil else { return latestRequest }
-
+        
         latestRequestExpectation = .init(description: "Wait for incoming request.")
         _ = XCTWaiter.wait(for: [latestRequestExpectation!], timeout: timeout)
         return latestRequest
     }
-
-    /// If set, records only requests with `testSessionHeaderKey` header value set to this value. If `nil`, records all requests.
+    
+    /// If set, records only requests with `testSessionHeaderKey` header value set to this value. If `nil`,
+    /// no requests are recorded.
     static var currentSessionId: String?
     
     /// Cleans up existing waiters and recorded requests. We have to explictly reset the state because URLProtocols
@@ -46,36 +59,32 @@ class RequestRecorderURLProtocol: URLProtocol {
         latestRequest = nil
         latestRequestExpectation = nil
     }
-
+    
     override class func canInit(with request: URLRequest) -> Bool {
-        guard let sessionId = currentSessionId else {
-            // No sessionId set, record all requests
-            record(request: request)
-            return false
-        }
+        guard let sessionId = currentSessionId else { return false }
         
         if sessionId == request.value(forHTTPHeaderField: testSessionHeaderKey) {
             record(request: request)
         }
         return false
     }
-
+    
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         // Overriding this function is required by the superclass.
-        return request
+        request
     }
-
+    
     private static func record(request: URLRequest) {
         latestRequest = request
         latestRequestExpectation?.fulfill()
     }
     
     // MARK: Instance methods
-
+    
     override func startLoading() {
         // Required by the superclass.
     }
-
+    
     override func stopLoading() {
         // Required by the superclass.
     }

--- a/Tests/Client/Unit Tests/Client+DevicesTests.swift
+++ b/Tests/Client/Unit Tests/Client+DevicesTests.swift
@@ -16,7 +16,7 @@ class Client_DevicesTests: ClientTestCase {
         client.devices { _ in }
 
         // Assert
-        AssertNetworkRequest(
+        Assert.networkRequest(
             method: .get,
             path: "/devices",
             headers: ["Content-Type": "application/json"],
@@ -66,7 +66,7 @@ class Client_DevicesTests: ClientTestCase {
         client.addDevice(deviceId: testDeviceId)
 
         // Assert
-        AssertNetworkRequest(
+        Assert.networkRequest(
             method: .post,
             path: "/devices",
             headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
@@ -87,7 +87,7 @@ class Client_DevicesTests: ClientTestCase {
         client.addDevice(deviceToken: deviceToken)
 
         // Assert
-        AssertNetworkRequest(
+        Assert.networkRequest(
             method: .post,
             path: "/devices",
             headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
@@ -149,7 +149,7 @@ class Client_DevicesTests: ClientTestCase {
         client.removeDevice(deviceId: testDeviceId)
 
         // Assert
-        AssertNetworkRequest(
+        Assert.networkRequest(
             method: .delete,
             path: "/devices",
             headers: ["Content-Type": "application/json"],

--- a/Tests/Client/Unit Tests/Client+DevicesTests.swift
+++ b/Tests/Client/Unit Tests/Client+DevicesTests.swift
@@ -30,9 +30,12 @@ import XCTest
 //        let deviceId = "device_id_\(UUID().uuidString)"
 //        let timestamp = Date(timeIntervalSince1970: 123456789)
 //
-//        MockNetworkURLProtocol.mockResponse(endpoint: .devices(testUser), responseBody:
+//        let request = try client.encodeRequest(for: .devices(testUser))
+//        let response = try JSONEncoder.stream.encode(
 //            ["devices": [ ["id": deviceId, "created_at": ISO8601DateFormatter().string(from: timestamp)] ]]
 //        )
+//        MockNetworkURLProtocol.mockResponse(request: request, responseBody: response)
+//
 //
 //        // Action
 //        let result = try await { self.client.devices($0) }
@@ -44,9 +47,10 @@ import XCTest
 //
 //    func test_getDevice_handlesError() throws {
 //        // Setup
+//        let request = try client.encodeRequest(for: .devices(testUser))
 //        let error = TestError.mockError()
-//        MockNetworkURLProtocol.mockResponse(endpoint: .devices(testUser), error: error)
-//
+//        MockNetworkURLProtocol.mockResponse(request: request, error: error)
+//        
 //        // Action
 //        let result = try await { self.client.devices($0) }
 //
@@ -101,7 +105,9 @@ import XCTest
 //        // Setup
 //        let deviceId = "device_id_\(UUID().uuidString)"
 //
-//        MockNetworkURLProtocol.mockResponse(endpoint: .addDevice(deviceId: deviceId, testUser))
+//        let request = try client.encodeRequest(for: .addDevice(deviceId: deviceId, testUser))
+//        let response = try JSONEncoder.stream.encode([String: String]())
+//        MockNetworkURLProtocol.mockResponse(request: request, responseBody: response)
 //
 //        // Action
 //        let result = try await { done in
@@ -117,9 +123,9 @@ import XCTest
 //    func test_addDeviceWithDeviceID_handlesError() throws {
 //        // Setup
 //        let deviceId = "device_id_\(UUID().uuidString)"
+//        let request = try client.encodeRequest(for: .addDevice(deviceId: deviceId, testUser))
 //        let error = TestError.mockError()
-//
-//        MockNetworkURLProtocol.mockResponse(endpoint: .addDevice(deviceId: deviceId, testUser), error: error)
+//        MockNetworkURLProtocol.mockResponse(request: request, error: error)
 //
 //        // Action
 //        let result = try await { done in
@@ -167,7 +173,9 @@ import XCTest
 //        assert(user.devices == [device])
 //        assert(user.currentDevice == device)
 //
-//        MockNetworkURLProtocol.mockResponse(endpoint: .removeDevice(deviceId: device.id, testUser))
+//        let request = try client.encodeRequest(for: .removeDevice(deviceId: device.id, testUser))
+//        let response = try JSONEncoder.stream.encode([String: String]())
+//        MockNetworkURLProtocol.mockResponse(request: request, responseBody: response)
 //
 //        // Action
 //        let result = try await { done in
@@ -192,7 +200,8 @@ import XCTest
 //        assert(user.devices == [device])
 //        assert(user.currentDevice == device)
 //        
-//        MockNetworkURLProtocol.mockResponse(endpoint: .removeDevice(deviceId: device.id, testUser), error: error)
+//        let request = try client.encodeRequest(for: .removeDevice(deviceId: device.id, testUser))
+//        MockNetworkURLProtocol.mockResponse(request: request, error: error)
 //
 //        // Action
 //        let result = try await { done in

--- a/Tests/Client/Unit Tests/Client+DevicesTests.swift
+++ b/Tests/Client/Unit Tests/Client+DevicesTests.swift
@@ -15,15 +15,13 @@ class Client_DevicesTests: ClientTestCase {
         // Action
         client.devices { _ in }
         
-        AssertAsync {
-            .networkRequest(
-                method: .get,
-                path: "/devices",
-                headers: ["Content-Type": "application/json"],
-                queryParameters: ["api_key": "test_api_key"],
-                body: nil
-            )
-        }
+        AssertAsync.networkRequest(
+            method: .get,
+            path: "/devices",
+            headers: ["Content-Type": "application/json"],
+            queryParameters: ["api_key": "test_api_key"],
+            body: nil
+        )
     }
 
     func test_getDevice_handlesSuccess() throws {
@@ -67,19 +65,17 @@ class Client_DevicesTests: ClientTestCase {
         client.addDevice(deviceId: testDeviceId)
 
         // Assert
-        AssertAsync {
-            .networkRequest(
-                method: .post,
-                path: "/devices",
-                headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
-                queryParameters: ["api_key": "test_api_key"],
-                body: [
-                    "user_id": testUser.id,
-                    "id": testDeviceId,
-                    "push_provider": "apn",
-                ]
-            )
-        }
+        AssertAsync.networkRequest(
+            method: .post,
+            path: "/devices",
+            headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
+            queryParameters: ["api_key": "test_api_key"],
+            body: [
+                "user_id": testUser.id,
+                "id": testDeviceId,
+                "push_provider": "apn",
+            ]
+        )
     }
 
     func test_addDeviceWithDeviceToken_createsRequest() {
@@ -90,19 +86,16 @@ class Client_DevicesTests: ClientTestCase {
         client.addDevice(deviceToken: deviceToken)
 
         // Assert
-        AssertAsync {
-            .networkRequest(
-                method: .post,
-                path: "/devices",
-                headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
-                queryParameters: ["api_key": "test_api_key"],
-                body: [
-                    "user_id": testUser.id,
-                    "id": "01020304", // the hexadecimal representation of the data
-                    "push_provider": "apn",
-                ]
-            )
-        }
+        AssertAsync.networkRequest(
+            method: .post,
+            path: "/devices",
+            headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
+            queryParameters: ["api_key": "test_api_key"],
+            body: [
+                "user_id": testUser.id,
+                "id": "01020304", // the hexadecimal representation of the data
+                "push_provider": "apn",
+            ])
     }
 
     func test_addDeviceWithDeviceID_handlesSuccess() throws {
@@ -154,18 +147,16 @@ class Client_DevicesTests: ClientTestCase {
         client.removeDevice(deviceId: testDeviceId)
 
         // Assert
-        AssertAsync {
-            .networkRequest(
-                method: .delete,
-                path: "/devices",
-                headers: ["Content-Type": "application/json"],
-                queryParameters: [
-                    "api_key": "test_api_key",
-                    "id": testDeviceId,
-                ],
-                body: nil
-            )
-        }
+        AssertAsync.networkRequest(
+            method: .delete,
+            path: "/devices",
+            headers: ["Content-Type": "application/json"],
+            queryParameters: [
+                "api_key": "test_api_key",
+                "id": testDeviceId,
+            ],
+            body: nil
+        )
     }
 
     func test_removeDevice_handlesSuccess() throws {

--- a/Tests/Client/Unit Tests/Client+DevicesTests.swift
+++ b/Tests/Client/Unit Tests/Client+DevicesTests.swift
@@ -14,15 +14,16 @@ class Client_DevicesTests: ClientTestCase {
     func test_getDevice_createsRequest() {
         // Action
         client.devices { _ in }
-
-        // Assert
-        Assert.networkRequest(
-            method: .get,
-            path: "/devices",
-            headers: ["Content-Type": "application/json"],
-            queryParameters: ["api_key": "test_api_key"],
-            body: nil
-        )
+        
+        AssertAsync {
+            .networkRequest(
+                method: .get,
+                path: "/devices",
+                headers: ["Content-Type": "application/json"],
+                queryParameters: ["api_key": "test_api_key"],
+                body: nil
+            )
+        }
     }
 
     func test_getDevice_handlesSuccess() throws {
@@ -66,17 +67,19 @@ class Client_DevicesTests: ClientTestCase {
         client.addDevice(deviceId: testDeviceId)
 
         // Assert
-        Assert.networkRequest(
-            method: .post,
-            path: "/devices",
-            headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
-            queryParameters: ["api_key": "test_api_key"],
-            body: [
-                "user_id": testUser.id,
-                "id": testDeviceId,
-                "push_provider": "apn",
-            ]
-        )
+        AssertAsync {
+            .networkRequest(
+                method: .post,
+                path: "/devices",
+                headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
+                queryParameters: ["api_key": "test_api_key"],
+                body: [
+                    "user_id": testUser.id,
+                    "id": testDeviceId,
+                    "push_provider": "apn",
+                ]
+            )
+        }
     }
 
     func test_addDeviceWithDeviceToken_createsRequest() {
@@ -87,17 +90,19 @@ class Client_DevicesTests: ClientTestCase {
         client.addDevice(deviceToken: deviceToken)
 
         // Assert
-        Assert.networkRequest(
-            method: .post,
-            path: "/devices",
-            headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
-            queryParameters: ["api_key": "test_api_key"],
-            body: [
-                "user_id": testUser.id,
-                "id": "01020304", // the hexadecimal representation of the data
-                "push_provider": "apn",
-            ]
-        )
+        AssertAsync {
+            .networkRequest(
+                method: .post,
+                path: "/devices",
+                headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
+                queryParameters: ["api_key": "test_api_key"],
+                body: [
+                    "user_id": testUser.id,
+                    "id": "01020304", // the hexadecimal representation of the data
+                    "push_provider": "apn",
+                ]
+            )
+        }
     }
 
     func test_addDeviceWithDeviceID_handlesSuccess() throws {
@@ -149,16 +154,18 @@ class Client_DevicesTests: ClientTestCase {
         client.removeDevice(deviceId: testDeviceId)
 
         // Assert
-        Assert.networkRequest(
-            method: .delete,
-            path: "/devices",
-            headers: ["Content-Type": "application/json"],
-            queryParameters: [
-                "api_key": "test_api_key",
-                "id": testDeviceId,
-            ],
-            body: nil
-        )
+        AssertAsync {
+            .networkRequest(
+                method: .delete,
+                path: "/devices",
+                headers: ["Content-Type": "application/json"],
+                queryParameters: [
+                    "api_key": "test_api_key",
+                    "id": testDeviceId,
+                ],
+                body: nil
+            )
+        }
     }
 
     func test_removeDevice_handlesSuccess() throws {

--- a/Tests/Client/Unit Tests/Client+DevicesTests.swift
+++ b/Tests/Client/Unit Tests/Client+DevicesTests.swift
@@ -8,211 +8,211 @@
 import XCTest
 @testable import StreamChatClient
 
-//class Client_DevicesTests: ClientTestCase {
-//
-//    // MARK: - getDevice() tests
-//    func test_getDevice_createsRequest() {
-//        // Action
-//        client.devices { _ in }
-//
-//        // Assert
-//        AssertNetworkRequest(
-//            method: .get,
-//            path: "/devices",
-//            headers: ["Content-Type": "application/json"],
-//            queryParameters: ["api_key": "test_api_key"],
-//            body: nil
-//        )
-//    }
-//
-//    func test_getDevice_handlesSuccess() throws {
-//        // Setup
-//        let deviceId = "device_id_\(UUID().uuidString)"
-//        let timestamp = Date(timeIntervalSince1970: 123456789)
-//
-//        let request = try client.encodeRequest(for: .devices(testUser))
-//        let response = try JSONEncoder.stream.encode(
-//            ["devices": [ ["id": deviceId, "created_at": ISO8601DateFormatter().string(from: timestamp)] ]]
-//        )
-//        MockNetworkURLProtocol.mockResponse(request: request, responseBody: response)
-//
-//        // Action
-//        let result = try await { self.client.devices($0) }
-//
-//        // Assert
-//        AssertResultSuccess(result, [Device(deviceId, created: timestamp)])
-//        XCTAssertEqual(self.client.user.devices, [Device(deviceId, created: timestamp)])
-//    }
-//
-//    func test_getDevice_handlesError() throws {
-//        // Setup
-//        let request = try client.encodeRequest(for: .devices(testUser))
-//        let error = TestError.mockError()
-//        MockNetworkURLProtocol.mockResponse(request: request, error: error)
-//
-//        // Action
-//        let result = try await { self.client.devices($0) }
-//
-//        // Assert
-//        AssertResultFailure(result, ClientError.requestFailed(error))
-//    }
-//
-//    // MARK: - addDevice() tests
-//
-//    func test_addDeviceWithDeviceID_createsRequest() {
-//        let testDeviceId = "device_id_\(UUID())"
-//
-//        // Action
-//        client.addDevice(deviceId: testDeviceId)
-//
-//        // Assert
-//        AssertNetworkRequest(
-//            method: .post,
-//            path: "/devices",
-//            headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
-//            queryParameters: ["api_key": "test_api_key"],
-//            body: [
-//                "user_id": testUser.id,
-//                "id": testDeviceId,
-//                "push_provider": "apn",
-//            ]
-//        )
-//    }
-//
-//    func test_addDeviceWithDeviceToken_createsRequest() {
-//        // Setup
-//        let deviceToken = Data([1, 2, 3, 4])
-//
-//        // Action
-//        client.addDevice(deviceToken: deviceToken)
-//
-//        // Assert
-//        AssertNetworkRequest(
-//            method: .post,
-//            path: "/devices",
-//            headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
-//            queryParameters: ["api_key": "test_api_key"],
-//            body: [
-//                "user_id": testUser.id,
-//                "id": "01020304", // the hexadecimal representation of the data
-//                "push_provider": "apn",
-//            ]
-//        )
-//    }
-//
-//    func test_addDeviceWithDeviceID_handlesSuccess() throws {
-//        // Setup
-//        let deviceId = "device_id_\(UUID().uuidString)"
-//
-//        let request = try client.encodeRequest(for: .addDevice(deviceId: deviceId, testUser))
-//        let response = try JSONEncoder.stream.encode([String: String]())
-//        MockNetworkURLProtocol.mockResponse(request: request, responseBody: response)
-//
-//        // Action
-//        let result = try await { done in
-//            self.client.addDevice(deviceId: deviceId) { done($0) }
-//        }
-//
-//        // Assert
-//        AssertResultSuccess(result, .empty)
-//        XCTAssertTrue(self.client.user.devices.contains(where: { $0.id == deviceId }))
-//        XCTAssertTrue(self.client.user.currentDevice?.id == deviceId)
-//    }
-//
-//    func test_addDeviceWithDeviceID_handlesError() throws {
-//        // Setup
-//        let deviceId = "device_id_\(UUID().uuidString)"
-//        let request = try client.encodeRequest(for: .addDevice(deviceId: deviceId, testUser))
-//        let error = TestError.mockError()
-//        MockNetworkURLProtocol.mockResponse(request: request, error: error)
-//
-//        // Action
-//        let result = try await { done in
-//            self.client.addDevice(deviceId: deviceId) { done($0) }
-//        }
-//
-//        AssertResultFailure(result, ClientError.requestFailed(error))
-//
-//        AssertAsync {
-//            Assert.staysFalse(self.client.user.devices.contains(where: { $0.id == deviceId }));
-//            Assert.staysFalse(self.client.user.currentDevice?.id == deviceId)
-//        }
-//    }
-//
-//    // MARK: - removeDevice() tests
-//
-//    func test_removeDevice_createsRequest() {
-//        // Setup
-//        let testDeviceId = "device_id_\(UUID())"
-//
-//        // Action
-//        client.removeDevice(deviceId: testDeviceId)
-//
-//        // Assert
-//        AssertNetworkRequest(
-//            method: .delete,
-//            path: "/devices",
-//            headers: ["Content-Type": "application/json"],
-//            queryParameters: [
-//                "api_key": "test_api_key",
-//                "id": testDeviceId,
-//            ],
-//            body: nil
-//        )
-//    }
-//
-//    func test_removeDevice_handlesSuccess() throws {
-//        // Setup
-//        let device = Device("device_id_\(UUID().uuidString)")
-//        var user = client.user
-//        user.devices = [device]
-//        user.currentDevice = device
-//        client.set(user: user, token: "test_token")
-//
-//        assert(user.devices == [device])
-//        assert(user.currentDevice == device)
-//
-//        let request = try client.encodeRequest(for: .removeDevice(deviceId: device.id, testUser))
-//        let response = try JSONEncoder.stream.encode([String: String]())
-//        MockNetworkURLProtocol.mockResponse(request: request, responseBody: response)
-//
-//        // Action
-//        let result = try await { done in
-//            self.client.removeDevice(deviceId: device.id) { done($0) }
-//        }
-//
-//        // Assert
-//        AssertResultSuccess(result, .empty)
-//        XCTAssertTrue(self.client.user.devices.allSatisfy { $0.id != device.id })
-//        XCTAssertTrue(self.client.user.currentDevice?.id != device.id)
-//    }
-//
-//    func test_removeDevice_handlesError() throws {
-//        // Setup
-//        let error = TestError.mockError()
-//        let device = Device("device_id_\(UUID().uuidString)")
-//        var user = client.user
-//        user.devices = [device]
-//        user.currentDevice = device
-//        client.set(user: user, token: "test_token")
-//
-//        assert(user.devices == [device])
-//        assert(user.currentDevice == device)
-//
-//        let request = try client.encodeRequest(for: .removeDevice(deviceId: device.id, testUser))
-//        MockNetworkURLProtocol.mockResponse(request: request, error: error)
-//
-//        // Action
-//        let result = try await { done in
-//            self.client.removeDevice(deviceId: device.id) { done($0) }
-//        }
-//
-//        // Assert
-//        AssertResultFailure(result, ClientError.requestFailed(error))
-//
-//        AssertAsync {
-//            Assert.staysTrue(self.client.user.devices.contains(where: { $0.id == device.id }))
-//            Assert.staysTrue(self.client.user.currentDevice?.id == device.id)
-//        }
-//    }
-//}
+class Client_DevicesTests: ClientTestCase {
+
+    // MARK: - getDevice() tests
+    func test_getDevice_createsRequest() {
+        // Action
+        client.devices { _ in }
+
+        // Assert
+        AssertNetworkRequest(
+            method: .get,
+            path: "/devices",
+            headers: ["Content-Type": "application/json"],
+            queryParameters: ["api_key": "test_api_key"],
+            body: nil
+        )
+    }
+
+    func test_getDevice_handlesSuccess() throws {
+        // Setup
+        let deviceId = "device_id_\(UUID().uuidString)"
+        let timestamp = Date(timeIntervalSince1970: 123456789)
+
+        let request = try client.encodeRequest(for: .devices(testUser))
+        let response = try JSONEncoder.stream.encode(
+            ["devices": [ ["id": deviceId, "created_at": ISO8601DateFormatter().string(from: timestamp)] ]]
+        )
+        MockNetworkURLProtocol.mockResponse(request: request, responseBody: response)
+
+        // Action
+        let result = try await { self.client.devices($0) }
+
+        // Assert
+        AssertResultSuccess(result, [Device(deviceId, created: timestamp)])
+        XCTAssertEqual(self.client.user.devices, [Device(deviceId, created: timestamp)])
+    }
+
+    func test_getDevice_handlesError() throws {
+        // Setup
+        let request = try client.encodeRequest(for: .devices(testUser))
+        let error = TestError.mockError()
+        MockNetworkURLProtocol.mockResponse(request: request, error: error)
+
+        // Action
+        let result = try await { self.client.devices($0) }
+
+        // Assert
+        AssertResultFailure(result, ClientError.requestFailed(error))
+    }
+
+    // MARK: - addDevice() tests
+
+    func test_addDeviceWithDeviceID_createsRequest() {
+        let testDeviceId = "device_id_\(UUID())"
+
+        // Action
+        client.addDevice(deviceId: testDeviceId)
+
+        // Assert
+        AssertNetworkRequest(
+            method: .post,
+            path: "/devices",
+            headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
+            queryParameters: ["api_key": "test_api_key"],
+            body: [
+                "user_id": testUser.id,
+                "id": testDeviceId,
+                "push_provider": "apn",
+            ]
+        )
+    }
+
+    func test_addDeviceWithDeviceToken_createsRequest() {
+        // Setup
+        let deviceToken = Data([1, 2, 3, 4])
+
+        // Action
+        client.addDevice(deviceToken: deviceToken)
+
+        // Assert
+        AssertNetworkRequest(
+            method: .post,
+            path: "/devices",
+            headers: ["Content-Type": "application/json", "Content-Encoding": "gzip"],
+            queryParameters: ["api_key": "test_api_key"],
+            body: [
+                "user_id": testUser.id,
+                "id": "01020304", // the hexadecimal representation of the data
+                "push_provider": "apn",
+            ]
+        )
+    }
+
+    func test_addDeviceWithDeviceID_handlesSuccess() throws {
+        // Setup
+        let deviceId = "device_id_\(UUID().uuidString)"
+
+        let request = try client.encodeRequest(for: .addDevice(deviceId: deviceId, testUser))
+        let response = try JSONEncoder.stream.encode([String: String]())
+        MockNetworkURLProtocol.mockResponse(request: request, responseBody: response)
+
+        // Action
+        let result = try await { done in
+            self.client.addDevice(deviceId: deviceId) { done($0) }
+        }
+
+        // Assert
+        AssertResultSuccess(result, .empty)
+        XCTAssertTrue(self.client.user.devices.contains(where: { $0.id == deviceId }))
+        XCTAssertTrue(self.client.user.currentDevice?.id == deviceId)
+    }
+
+    func test_addDeviceWithDeviceID_handlesError() throws {
+        // Setup
+        let deviceId = "device_id_\(UUID().uuidString)"
+        let request = try client.encodeRequest(for: .addDevice(deviceId: deviceId, testUser))
+        let error = TestError.mockError()
+        MockNetworkURLProtocol.mockResponse(request: request, error: error)
+
+        // Action
+        let result = try await { done in
+            self.client.addDevice(deviceId: deviceId) { done($0) }
+        }
+
+        AssertResultFailure(result, ClientError.requestFailed(error))
+
+        AssertAsync {
+            Assert.staysFalse(self.client.user.devices.contains(where: { $0.id == deviceId }));
+            Assert.staysFalse(self.client.user.currentDevice?.id == deviceId)
+        }
+    }
+
+    // MARK: - removeDevice() tests
+
+    func test_removeDevice_createsRequest() {
+        // Setup
+        let testDeviceId = "device_id_\(UUID())"
+
+        // Action
+        client.removeDevice(deviceId: testDeviceId)
+
+        // Assert
+        AssertNetworkRequest(
+            method: .delete,
+            path: "/devices",
+            headers: ["Content-Type": "application/json"],
+            queryParameters: [
+                "api_key": "test_api_key",
+                "id": testDeviceId,
+            ],
+            body: nil
+        )
+    }
+
+    func test_removeDevice_handlesSuccess() throws {
+        // Setup
+        let device = Device("device_id_\(UUID().uuidString)")
+        var user = client.user
+        user.devices = [device]
+        user.currentDevice = device
+        client.set(user: user, token: "test_token")
+
+        assert(user.devices == [device])
+        assert(user.currentDevice == device)
+
+        let request = try client.encodeRequest(for: .removeDevice(deviceId: device.id, testUser))
+        let response = try JSONEncoder.stream.encode([String: String]())
+        MockNetworkURLProtocol.mockResponse(request: request, responseBody: response)
+
+        // Action
+        let result = try await { done in
+            self.client.removeDevice(deviceId: device.id) { done($0) }
+        }
+
+        // Assert
+        AssertResultSuccess(result, .empty)
+        XCTAssertTrue(self.client.user.devices.allSatisfy { $0.id != device.id })
+        XCTAssertTrue(self.client.user.currentDevice?.id != device.id)
+    }
+
+    func test_removeDevice_handlesError() throws {
+        // Setup
+        let error = TestError.mockError()
+        let device = Device("device_id_\(UUID().uuidString)")
+        var user = client.user
+        user.devices = [device]
+        user.currentDevice = device
+        client.set(user: user, token: "test_token")
+
+        assert(user.devices == [device])
+        assert(user.currentDevice == device)
+
+        let request = try client.encodeRequest(for: .removeDevice(deviceId: device.id, testUser))
+        MockNetworkURLProtocol.mockResponse(request: request, error: error)
+
+        // Action
+        let result = try await { done in
+            self.client.removeDevice(deviceId: device.id) { done($0) }
+        }
+
+        // Assert
+        AssertResultFailure(result, ClientError.requestFailed(error))
+
+        AssertAsync {
+            Assert.staysTrue(self.client.user.devices.contains(where: { $0.id == device.id }))
+            Assert.staysTrue(self.client.user.currentDevice?.id == device.id)
+        }
+    }
+}

--- a/Tests/Client/Unit Tests/Client+DevicesTests.swift
+++ b/Tests/Client/Unit Tests/Client+DevicesTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import StreamChatClient
 
 //class Client_DevicesTests: ClientTestCase {
-//    
+//
 //    // MARK: - getDevice() tests
 //    func test_getDevice_createsRequest() {
 //        // Action
@@ -36,7 +36,6 @@ import XCTest
 //        )
 //        MockNetworkURLProtocol.mockResponse(request: request, responseBody: response)
 //
-//
 //        // Action
 //        let result = try await { self.client.devices($0) }
 //
@@ -50,7 +49,7 @@ import XCTest
 //        let request = try client.encodeRequest(for: .devices(testUser))
 //        let error = TestError.mockError()
 //        MockNetworkURLProtocol.mockResponse(request: request, error: error)
-//        
+//
 //        // Action
 //        let result = try await { self.client.devices($0) }
 //
@@ -133,7 +132,7 @@ import XCTest
 //        }
 //
 //        AssertResultFailure(result, ClientError.requestFailed(error))
-//                
+//
 //        AssertAsync {
 //            Assert.staysFalse(self.client.user.devices.contains(where: { $0.id == deviceId }));
 //            Assert.staysFalse(self.client.user.currentDevice?.id == deviceId)
@@ -199,7 +198,7 @@ import XCTest
 //
 //        assert(user.devices == [device])
 //        assert(user.currentDevice == device)
-//        
+//
 //        let request = try client.encodeRequest(for: .removeDevice(deviceId: device.id, testUser))
 //        MockNetworkURLProtocol.mockResponse(request: request, error: error)
 //
@@ -210,7 +209,7 @@ import XCTest
 //
 //        // Assert
 //        AssertResultFailure(result, ClientError.requestFailed(error))
-//        
+//
 //        AssertAsync {
 //            Assert.staysTrue(self.client.user.devices.contains(where: { $0.id == device.id }))
 //            Assert.staysTrue(self.client.user.currentDevice?.id == device.id)

--- a/Tests/Client/Unit Tests/ClientTestCase.swift
+++ b/Tests/Client/Unit Tests/ClientTestCase.swift
@@ -17,22 +17,25 @@ class ClientTestCase: XCTestCase {
     
     var client: Client!
     var testSessionId: String!
+    var sessionConfiguration: URLSessionConfiguration!
     var testUser: User!
     let testToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.d1xKTlD_D0G-VsBoDBNbaLjO-2XWNA8rlTm4ru4sMHg"
     
     override func setUp() {
         super.setUp()
-        let sessionConfig = URLSessionConfiguration.default
-        sessionConfig.protocolClasses?.insert(RequestRecorderURLProtocol.self, at: 0)
-        sessionConfig.protocolClasses?.insert(MockNetworkURLProtocol.self, at: 1)
+        // Prepare URL Session
+        sessionConfiguration = URLSessionConfiguration.default
+        RequestRecorderURLProtocol.startTestSession(with: &sessionConfiguration)
+        MockNetworkURLProtocol.startTestSession(with: &sessionConfiguration)
         
+        // Some random value to ensure the headers are respected
         testSessionId = UUID().uuidString
-        sessionConfig.httpAdditionalHeaders = [RequestRecorderURLProtocol.testSessionHeaderKey: testSessionId!]
+        sessionConfiguration.httpAdditionalHeaders = [RequestRecorderURLProtocol.testSessionHeaderKey: testSessionId!]
         
         let clientConfig = Client.Config(apiKey: "test_api_key")
         // We can create a new `Client` instance because we don't use `Client.shared` in tests.
         client = Client(config: clientConfig,
-                        defaultURLSessionConfiguration: sessionConfig,
+                        defaultURLSessionConfiguration: sessionConfiguration,
                         defaultWebSocketProviderType: WebSocketProviderMock.self)
         
         testUser = User(id: "broken-waterfall-5")


### PR DESCRIPTION
# Submit a pull request

## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [X] Code changes are tested (add some information if not applicable)

## Description of the pull request
This PR is replacing the closed PR #364 because that one was created from a forked repo

The goal of this PR is to back-port the implementations of `MockNetworkURLProtocol` and `RequestRecorderURLProtocol` from v3 to v2.

The main difference between `MockNetworkURLProtocol` v2 and v3 is that in the `canInit(with:)` v2 method compares endpoint paths but v3 compares the whole URL so now  in order to use `MockNetworkURLProtocol` it’s necessary to know the whole URL for each endpoint. The v3 `ApiClient` implementation extracted this functionality to a `RequestEncoder` protocol that is accessible from the outside but in v2 this functionality is coupled and hidden in the `Client`. Therefore I exposed this functionality in `Client` in a method called `encodeRequest(for:)`

After I completed the back-port I noticed that a couple of tests would fail sometimes. The reason is that the new `MockNetworkURLProtocol` compares URL's but two URL's can be semantically identical but syntactically different.  Example: `https//a.b.c/d?e=f&g=h` and `https//a.b.c/d?g=h&e=f`. There is no guarantee that encoding a URL for the same endpoint twice would result in the same absolute URL string because it uses dictionaries to hold query items and  traverse order doesn't matter in dictionaries.

To address this in the `MockNetworkURLProtocol` I modified the key in the responses dictionary to compare significant parts of the URL by replacing the whole URL key for the URL scheme, host, port and path. Please note that this PR only addresses this issue in v2 but not in v3 so future tests in v3 can fail because of this. Please let me know if you want me to fix the issue also in the v3 class implementation.

Also I changed the `RequestRecorderURLProtocol` to instead of waiting for the first matching request to record all requests in the given period until one matches because some tests were failing because the SDK can make other requests.

#skip_changelog