### PR TITLE
Add settings screen to v3 sample

### DIFF
--- a/Sample_v3/AppDelegate.swift
+++ b/Sample_v3/AppDelegate.swift
@@ -48,6 +48,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         LogConfig.showFunctionName = false
         
         LogConfig.level = .info
+        
+        LogStore.registerShared()
         return true
     }
 

--- a/Sample_v3/Extensions/UIStoryboard+Definitions.swift
+++ b/Sample_v3/Extensions/UIStoryboard+Definitions.swift
@@ -1,0 +1,15 @@
+//
+//  UIStoryboard+Definitions.swift
+//  StreamChatClient
+//
+//  Created by Matheus Cardoso on 19/08/20.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+extension UIStoryboard {
+    static let main = UIStoryboard(name: "Main", bundle: nil)
+    static let settings = UIStoryboard(name: "Settings", bundle: nil)
+    static let simpleChat =  UIStoryboard(name: "SimpleChat", bundle: nil)
+}

--- a/Sample_v3/Extensions/UIViewController+MoveToStoryboard.swift
+++ b/Sample_v3/Extensions/UIViewController+MoveToStoryboard.swift
@@ -1,0 +1,18 @@
+//
+//  UIViewController+MoveToStoryboard.swift
+//  StreamChatClient
+//
+//  Created by Matheus Cardoso on 19/08/20.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController {
+    func moveToStoryboard(_ storyboard: UIStoryboard, options: UIView.AnimationOptions = []) {
+        let initial = storyboard.instantiateInitialViewController()
+        UIView.transition(with: self.view.window!, duration: 0.5, options: options, animations: {
+            self.view.window?.rootViewController = initial
+        })
+    }
+}

--- a/Sample_v3/LogStore.swift
+++ b/Sample_v3/LogStore.swift
@@ -1,0 +1,24 @@
+//
+//  LogStore.swift
+//  StreamChatClient
+//
+//  Created by Matheus Cardoso on 20/08/20.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import StreamChatClient
+import Foundation
+
+class LogStore: BaseLogDestination {
+    var logs = ""
+    
+    static let shared = LogStore()
+    
+    static func registerShared() {
+        log.destinations.append(LogStore.shared)
+    }
+    
+    override func write(message: String) {
+        logs += message
+    }
+}

--- a/Sample_v3/Samples/LogsViewController.swift
+++ b/Sample_v3/Samples/LogsViewController.swift
@@ -1,0 +1,36 @@
+//
+//  LogsViewController.swift
+//  StreamChatClient
+//
+//  Created by Matheus Cardoso on 19/08/20.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+import StreamChatClient
+
+class LogsViewController: UIViewController {
+    @IBOutlet weak var textView: UITextView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        updateText()
+    }
+    
+    func updateText() {
+        textView.text = LogStore.shared.logs
+    }
+    
+    @IBAction func clearButtonPressed(_ sender: UIBarButtonItem) {
+        LogStore.shared.logs = ""
+        updateText()
+    }
+    
+    @IBAction func downButtonPressed(_ sender: Any) {
+        textView.scrollRangeToVisible(NSRange(..<textView.text.endIndex, in: textView.text))
+    }
+    
+    @IBAction func refreshButtonPressend(_ sender: Any) {
+        updateText()
+    }
+}

--- a/Sample_v3/Samples/Settings.storyboard
+++ b/Sample_v3/Samples/Settings.storyboard
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="meh-NU-BcK">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Settings-->
+        <scene sceneID="tlK-ju-8TG">
+            <objects>
+                <tableViewController title="Settings" id="nNC-VA-MdE" customClass="SettingsViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="singleLineEtched" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="a8S-07-CT0">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemGray6Color" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <sections>
+                            <tableViewSection headerTitle="CURRENT USER" id="y7Q-nL-8Jk">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="ZFN-jW-TwC" detailTextLabel="jfg-Mc-T9V" style="IBUITableViewCellStyleSubtitle" id="d9g-6h-QSK">
+                                        <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="d9g-6h-QSK" id="mvE-ad-JXW">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Broken Waterfall (broken-waterfall-5)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ZFN-jW-TwC">
+                                                    <rect key="frame" x="20" y="5" width="286.5" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Unread messages: 0 - Unread channels: 0" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jfg-Mc-T9V">
+                                                    <rect key="frame" x="20" y="25.5" width="238" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="SWITCHES" id="Lel-5m-S2B">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Irj-Vb-Vpn" detailTextLabel="05O-Lv-q3B" style="IBUITableViewCellStyleSubtitle" id="sFK-J8-4XH">
+                                        <rect key="frame" x="0.0" y="155" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.5" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="sFK-J8-4XH" id="nuV-O6-fgr">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AIt-ZB-n5W">
+                                                    <rect key="frame" x="350" y="5.5" width="49" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <connections>
+                                                        <action selector="pushNotificationsSwitchValueChanged:" destination="nNC-VA-MdE" eventType="valueChanged" id="Tu3-i0-Hch"/>
+                                                    </connections>
+                                                </switch>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Push Notifications" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Irj-Vb-Vpn">
+                                                    <rect key="frame" x="20" y="5" width="139" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="You will receive notifications when mentioned" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="05O-Lv-q3B">
+                                                    <rect key="frame" x="20" y="25.5" width="257.5" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="accessoryView" destination="AIt-ZB-n5W" id="2Q3-RY-VX5"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Yof-Qp-Qd5" detailTextLabel="RMt-jI-DfQ" style="IBUITableViewCellStyleSubtitle" id="eBd-6N-3af">
+                                        <rect key="frame" x="0.0" y="198.5" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eBd-6N-3af" id="Ajy-0y-5wa">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xqO-r8-Hjs">
+                                                    <rect key="frame" x="350" y="5.5" width="49" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <connections>
+                                                        <action selector="webSocketsConnectionSwitchValueChanged:" destination="nNC-VA-MdE" eventType="valueChanged" id="tyc-OR-6Rk"/>
+                                                    </connections>
+                                                </switch>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="WebSockets Connection" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Yof-Qp-Qd5">
+                                                    <rect key="frame" x="20" y="5" width="188" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="You will receive events from WebSockets" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="RMt-jI-DfQ">
+                                                    <rect key="frame" x="20" y="25.5" width="231.5" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="accessoryView" destination="xqO-r8-Hjs" id="XJK-hc-TMB"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="NAVIGATION" id="LnS-jo-sEh">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="DtZ-H4-fTt" detailTextLabel="1Hf-Jo-UCc" style="IBUITableViewCellStyleSubtitle" id="l0r-Tc-pxq">
+                                        <rect key="frame" x="0.0" y="298" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="l0r-Tc-pxq" id="drO-Ol-hRw">
+                                            <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Console logs" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="DtZ-H4-fTt">
+                                                    <rect key="frame" x="20" y="5" width="99" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="If you're in a real device, you can still see the logs here" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="1Hf-Jo-UCc">
+                                                    <rect key="frame" x="20" y="25.5" width="309" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="IQp-kd-6bf" kind="show" id="Dqd-Nd-Qqk"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="8sT-M6-3zk" detailTextLabel="Tcr-h9-DIM" style="IBUITableViewCellStyleSubtitle" id="KER-SN-PBE">
+                                        <rect key="frame" x="0.0" y="341.5" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="KER-SN-PBE" id="4rg-OM-DOf">
+                                            <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Logout" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8sT-M6-3zk">
+                                                    <rect key="frame" x="20" y="5" width="53.5" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Disconnect to change credentials or switch sample" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Tcr-h9-DIM">
+                                                    <rect key="frame" x="20" y="25.5" width="288.5" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="TOOLS" id="Xz2-VO-ECZ">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="njR-Ps-EZJ" detailTextLabel="8qk-B1-Qdq" style="IBUITableViewCellStyleSubtitle" id="zo3-rA-1Bg">
+                                        <rect key="frame" x="0.0" y="441" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zo3-rA-1Bg" id="aPt-ba-3HT">
+                                            <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Receive random DM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="njR-Ps-EZJ">
+                                                    <rect key="frame" x="20" y="5" width="154" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Receive a DM from a random user" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8qk-B1-Qdq">
+                                                    <rect key="frame" x="20" y="25.5" width="191.5" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="nNC-VA-MdE" id="BEi-rh-UbZ"/>
+                            <outlet property="delegate" destination="nNC-VA-MdE" id="3pf-tl-VOl"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Settings" id="6yy-Dw-Haj"/>
+                    <connections>
+                        <outlet property="enablePushNotificationsSwitch" destination="AIt-ZB-n5W" id="KpU-6x-Etb"/>
+                        <outlet property="logoutCell" destination="KER-SN-PBE" id="kQx-km-vUB"/>
+                        <outlet property="userNameLabel" destination="ZFN-jW-TwC" id="zUN-Bx-2Pa"/>
+                        <outlet property="userSecondaryLabel" destination="jfg-Mc-T9V" id="UdM-SP-Yuf"/>
+                        <outlet property="webSocketsConnectionSwitch" destination="xqO-r8-Hjs" id="j6o-f2-JwW"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Bsx-81-Aam" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="982.60869565217399" y="1143.75"/>
+        </scene>
+        <!--Console Logs-->
+        <scene sceneID="UG2-Xv-eCH">
+            <objects>
+                <viewController id="IQp-kd-6bf" customClass="LogsViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="vdY-Kr-PSW">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Jls-Iw-RRZ">
+                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <fontDescription key="fontDescription" name="Courier-Bold" family="Courier" pointSize="17"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yQc-dy-wkK">
+                                <rect key="frame" x="0.0" y="813" width="414" height="49"/>
+                                <items>
+                                    <barButtonItem systemItem="trash" id="shX-QT-c6k">
+                                        <connections>
+                                            <action selector="clearButtonPressed:" destination="IQp-kd-6bf" id="IQ7-8q-md2"/>
+                                        </connections>
+                                    </barButtonItem>
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="fIv-H3-GsR"/>
+                                    <barButtonItem systemItem="refresh" id="BCH-47-42L">
+                                        <connections>
+                                            <action selector="refreshButtonPressend:" destination="IQp-kd-6bf" id="MOz-a2-iRn"/>
+                                        </connections>
+                                    </barButtonItem>
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="xFC-Iw-Mjo"/>
+                                    <barButtonItem title="Item" image="chevron.down" catalog="system" id="5AG-oW-8Dt">
+                                        <connections>
+                                            <action selector="downButtonPressed:" destination="IQp-kd-6bf" id="qg1-Hf-eS2"/>
+                                        </connections>
+                                    </barButtonItem>
+                                </items>
+                            </toolbar>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="Jls-Iw-RRZ" firstAttribute="bottom" secondItem="yQc-dy-wkK" secondAttribute="top" id="3iG-nv-zOc"/>
+                            <constraint firstItem="1ay-ga-Kha" firstAttribute="bottom" secondItem="yQc-dy-wkK" secondAttribute="bottom" id="HQl-6t-VtS"/>
+                            <constraint firstItem="yQc-dy-wkK" firstAttribute="centerX" secondItem="1ay-ga-Kha" secondAttribute="centerX" id="I7Z-gh-Hsf"/>
+                            <constraint firstItem="Jls-Iw-RRZ" firstAttribute="trailing" secondItem="vdY-Kr-PSW" secondAttribute="trailing" id="QkS-e2-rTk"/>
+                            <constraint firstItem="yQc-dy-wkK" firstAttribute="width" secondItem="vdY-Kr-PSW" secondAttribute="width" id="RWW-g8-M7p"/>
+                            <constraint firstItem="Jls-Iw-RRZ" firstAttribute="leading" secondItem="1ay-ga-Kha" secondAttribute="leading" id="fJE-La-IZB"/>
+                            <constraint firstItem="Jls-Iw-RRZ" firstAttribute="top" secondItem="1ay-ga-Kha" secondAttribute="top" id="qWo-Pa-2Zd"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="1ay-ga-Kha"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="Console Logs" id="Gsd-TT-jpG"/>
+                    <connections>
+                        <outlet property="textView" destination="Jls-Iw-RRZ" id="L5r-qa-9N1"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2gL-Yz-FRB" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1847.826086956522" y="1143.75"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="xLb-hz-vho">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="meh-NU-BcK" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="99h-4f-oAN">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="nNC-VA-MdE" kind="relationship" relationship="rootViewController" id="5qV-sf-4ml"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="spk-1s-Z7L" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="72.463768115942031" y="1143.75"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="chevron.down" catalog="system" width="128" height="72"/>
+    </resources>
+</document>

--- a/Sample_v3/Samples/Settings.storyboard
+++ b/Sample_v3/Samples/Settings.storyboard
@@ -37,7 +37,31 @@
                                                     <rect key="frame" x="20" y="25.5" width="238" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="8sT-M6-3zk" detailTextLabel="Tcr-h9-DIM" style="IBUITableViewCellStyleSubtitle" id="KER-SN-PBE">
+                                        <rect key="frame" x="0.0" y="99" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="KER-SN-PBE" id="4rg-OM-DOf">
+                                            <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Logout" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8sT-M6-3zk">
+                                                    <rect key="frame" x="20" y="5" width="53.5" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Disconnect to change credentials or switch sample" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Tcr-h9-DIM">
+                                                    <rect key="frame" x="20" y="25.5" width="288.5" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -48,7 +72,7 @@
                             <tableViewSection headerTitle="SWITCHES" id="Lel-5m-S2B">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Irj-Vb-Vpn" detailTextLabel="05O-Lv-q3B" style="IBUITableViewCellStyleSubtitle" id="sFK-J8-4XH">
-                                        <rect key="frame" x="0.0" y="155" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="198.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.5" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="sFK-J8-4XH" id="nuV-O6-fgr">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -82,7 +106,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Yof-Qp-Qd5" detailTextLabel="RMt-jI-DfQ" style="IBUITableViewCellStyleSubtitle" id="eBd-6N-3af">
-                                        <rect key="frame" x="0.0" y="198.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="242" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eBd-6N-3af" id="Ajy-0y-5wa">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -117,10 +141,10 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection headerTitle="NAVIGATION" id="LnS-jo-sEh">
+                            <tableViewSection headerTitle="TOOLS" id="Xz2-VO-ECZ">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="DtZ-H4-fTt" detailTextLabel="1Hf-Jo-UCc" style="IBUITableViewCellStyleSubtitle" id="l0r-Tc-pxq">
-                                        <rect key="frame" x="0.0" y="298" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="341.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="l0r-Tc-pxq" id="drO-Ol-hRw">
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
@@ -146,50 +170,22 @@
                                             <segue destination="IQp-kd-6bf" kind="show" id="Dqd-Nd-Qqk"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="8sT-M6-3zk" detailTextLabel="Tcr-h9-DIM" style="IBUITableViewCellStyleSubtitle" id="KER-SN-PBE">
-                                        <rect key="frame" x="0.0" y="341.5" width="414" height="43.5"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="njR-Ps-EZJ" detailTextLabel="8qk-B1-Qdq" style="IBUITableViewCellStyleSubtitle" id="zo3-rA-1Bg">
+                                        <rect key="frame" x="0.0" y="385" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="KER-SN-PBE" id="4rg-OM-DOf">
-                                            <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.5" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zo3-rA-1Bg" id="aPt-ba-3HT">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Logout" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8sT-M6-3zk">
-                                                    <rect key="frame" x="20" y="5" width="53.5" height="20.5"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Clear local database" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="njR-Ps-EZJ">
+                                                    <rect key="frame" x="20" y="5" width="155.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Disconnect to change credentials or switch sample" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Tcr-h9-DIM">
-                                                    <rect key="frame" x="20" y="25.5" width="288.5" height="14.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                            <tableViewSection headerTitle="TOOLS" id="Xz2-VO-ECZ">
-                                <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="njR-Ps-EZJ" detailTextLabel="8qk-B1-Qdq" style="IBUITableViewCellStyleSubtitle" id="zo3-rA-1Bg">
-                                        <rect key="frame" x="0.0" y="441" width="414" height="43.5"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zo3-rA-1Bg" id="aPt-ba-3HT">
-                                            <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Receive random DM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="njR-Ps-EZJ">
-                                                    <rect key="frame" x="20" y="5" width="154" height="20.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Receive a DM from a random user" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8qk-B1-Qdq">
-                                                    <rect key="frame" x="20" y="25.5" width="191.5" height="14.5"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Clears all the locally saved data" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8qk-B1-Qdq">
+                                                    <rect key="frame" x="20" y="25.5" width="178" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
@@ -208,6 +204,7 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Settings" id="6yy-Dw-Haj"/>
                     <connections>
+                        <outlet property="clearLocalDatabaseCell" destination="zo3-rA-1Bg" id="Xcr-E0-sRt"/>
                         <outlet property="enablePushNotificationsSwitch" destination="AIt-ZB-n5W" id="KpU-6x-Etb"/>
                         <outlet property="logoutCell" destination="KER-SN-PBE" id="kQx-km-vUB"/>
                         <outlet property="userNameLabel" destination="ZFN-jW-TwC" id="zUN-Bx-2Pa"/>

--- a/Sample_v3/Samples/SettingsViewController.swift
+++ b/Sample_v3/Samples/SettingsViewController.swift
@@ -12,6 +12,7 @@ import UserNotifications
 
 class SettingsViewController: UITableViewController {
     @IBOutlet weak var logoutCell: UITableViewCell!
+    @IBOutlet weak var clearLocalDatabaseCell: UITableViewCell!
     @IBOutlet weak var enablePushNotificationsSwitch: UISwitch!
     @IBOutlet weak var webSocketsConnectionSwitch: UISwitch!
     
@@ -20,15 +21,7 @@ class SettingsViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        if let user = chatClient.currentUser {
-            userNameLabel.text = user.name ?? ""
-            userNameLabel.text! += " (\(user.id))"
-            
-            let unreadCount = user.unreadCount
-            userSecondaryLabel.text = "Unread messages: \(unreadCount.messages)\n"
-            userSecondaryLabel.text! += "Unread channels: \(unreadCount.channels)"
-        }
+        updateUserCell()
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -37,10 +30,34 @@ class SettingsViewController: UITableViewController {
         switch tableView.cellForRow(at: indexPath) {
         case logoutCell:
             logout()
+        case clearLocalDatabaseCell:
+            clearLocalDatabase()
         default:
             break
         }
     }
+}
+
+// MARK: - Current User
+extension SettingsViewController {
+    func updateUserCell() {
+        if let user = chatClient.currentUser {
+            userNameLabel.text = user.name ?? ""
+            userNameLabel.text! += " (\(user.id))"
+            
+            let unreadCount = user.unreadCount
+            userSecondaryLabel.text = "Unread messages: \(unreadCount.messages) - Unread channels: \(unreadCount.channels)"
+        }
+    }
+    
+    func logout() {
+        chatClient.disconnect()
+        moveToStoryboard(.main, options: .transitionFlipFromRight)
+    }
+}
+
+// MARK: - Switches
+extension SettingsViewController {
     @IBAction func pushNotificationsSwitchValueChanged(_ sender: Any) {
         // TODO: Enable/Disable push notifications
     }
@@ -50,7 +67,7 @@ class SettingsViewController: UITableViewController {
             webSocketsConnectionSwitch.isEnabled = false
             chatClient.connect { [weak self] error in
                 DispatchQueue.main.async {
-                    self?.webSocketsConnectionSwitch.isEnabled = true   
+                    self?.webSocketsConnectionSwitch.isEnabled = true
                     self?.webSocketsConnectionSwitch.setOn(error == nil, animated: true)
                 }
             }
@@ -60,10 +77,9 @@ class SettingsViewController: UITableViewController {
     }
 }
 
-// MARK: - Actions
+// MARK: - Tools
 extension SettingsViewController {
-    func logout() {
-        chatClient.disconnect()
-        moveToStoryboard(.main, options: .transitionFlipFromRight)
+    func clearLocalDatabase() {
+        // TODO: Clear local database
     }
 }

--- a/Sample_v3/Samples/SettingsViewController.swift
+++ b/Sample_v3/Samples/SettingsViewController.swift
@@ -1,0 +1,69 @@
+//
+//  SettingsViewController.swift
+//  Sample
+//
+//  Created by Matheus Cardoso on 19/08/20.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+import StreamChatClient
+import UserNotifications
+
+class SettingsViewController: UITableViewController {
+    @IBOutlet weak var logoutCell: UITableViewCell!
+    @IBOutlet weak var enablePushNotificationsSwitch: UISwitch!
+    @IBOutlet weak var webSocketsConnectionSwitch: UISwitch!
+    
+    @IBOutlet weak var userNameLabel: UILabel!
+    @IBOutlet weak var userSecondaryLabel: UILabel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        if let user = chatClient.currentUser {
+            userNameLabel.text = user.name ?? ""
+            userNameLabel.text! += " (\(user.id))"
+            
+            let unreadCount = user.unreadCount
+            userSecondaryLabel.text = "Unread messages: \(unreadCount.messages)\n"
+            userSecondaryLabel.text! += "Unread channels: \(unreadCount.channels)"
+        }
+    }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        
+        switch tableView.cellForRow(at: indexPath) {
+        case logoutCell:
+            logout()
+        default:
+            break
+        }
+    }
+    @IBAction func pushNotificationsSwitchValueChanged(_ sender: Any) {
+        // TODO: Enable/Disable push notifications
+    }
+    
+    @IBAction func webSocketsConnectionSwitchValueChanged(_ sender: Any) {
+        if webSocketsConnectionSwitch.isOn {
+            webSocketsConnectionSwitch.isEnabled = false
+            chatClient.connect { [weak self] error in
+                DispatchQueue.main.async {
+                    self?.webSocketsConnectionSwitch.isEnabled = true   
+                    self?.webSocketsConnectionSwitch.setOn(error == nil, animated: true)
+                }
+            }
+        } else {
+            chatClient.disconnect()
+        }
+    }
+}
+
+// MARK: - Actions
+extension SettingsViewController {
+    func logout() {
+        chatClient.disconnect()
+        moveToStoryboard(.main, options: .transitionFlipFromRight)
+    }
+}

--- a/Sample_v3/Samples/SimpleChat/MasterViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/MasterViewController.swift
@@ -28,7 +28,7 @@ class MasterViewController: UITableViewController {
         channelListController.startUpdating()
         
         // Do any additional setup after loading the view.
-        navigationItem.leftBarButtonItem = editButtonItem
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Settings", style: .plain, target: self, action: #selector(handleSettingsButton))
 
         let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(insertNewObject(_:)))
         navigationItem.rightBarButtonItem = addButton
@@ -43,6 +43,14 @@ class MasterViewController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         clearsSelectionOnViewWillAppear = splitViewController!.isCollapsed
         super.viewWillAppear(animated)
+    }
+    
+    @objc func handleSettingsButton(_ sender: Any) {
+        guard let settingsViewController = UIStoryboard.settings.instantiateInitialViewController() else {
+            return
+        }
+        
+        present(settingsViewController, animated: true)
     }
 
     @objc

--- a/Sample_v3/Samples/SimpleChat/SimpleChat.storyboard
+++ b/Sample_v3/Samples/SimpleChat/SimpleChat.storyboard
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="LxB-C7-hWF">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -64,18 +65,26 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" textLabel="Upg-v8-wcW" style="IBUITableViewCellStyleDefault" id="W2n-we-iYD">
-                                <rect key="frame" x="0.0" y="28" width="414" height="47.5"/>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" textLabel="KC1-Rc-dsO" detailTextLabel="Scs-Wu-zzc" style="IBUITableViewCellStyleValue1" id="W2n-we-iYD">
+                                <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="W2n-we-iYD" id="rqX-7l-GNm">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="47.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Upg-v8-wcW">
-                                            <rect key="frame" x="20" y="0.0" width="374" height="47.5"/>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="#️⃣  channel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="KC1-Rc-dsO">
+                                            <rect key="frame" x="20" y="12" width="92" height="20.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
-                                            <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Scs-Wu-zzc">
+                                            <rect key="frame" x="331" y="12" width="44" height="20.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
                                 </tableViewCellContentView>

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -154,10 +154,16 @@
 		79DDF81B249CE38B002F4412 /* AssertNetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF818249CE38B002F4412 /* AssertNetworkRequest.swift */; };
 		79E2B84024CAC8D60024752F /* ListDatabaseObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E2B83F24CAC8D60024752F /* ListDatabaseObserver.swift */; };
 		79FC85E724ACCBC500A665ED /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FC85E624ACCBC500A665ED /* Token.swift */; };
+		8008C18124ED64D300F5BCCE /* UIViewController+MoveToStoryboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8008C17F24ED64C000F5BCCE /* UIViewController+MoveToStoryboard.swift */; };
+		8008C18424ED65AB00F5BCCE /* UIStoryboard+Definitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8008C18224ED65A500F5BCCE /* UIStoryboard+Definitions.swift */; };
+		8008C18724EDBCFF00F5BCCE /* LogsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8008C18524EDBCF500F5BCCE /* LogsViewController.swift */; };
+		8008C18A24EEB8CA00F5BCCE /* LogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8008C18824EEB8BD00F5BCCE /* LogStore.swift */; };
 		804B126924E6C820002B00EA /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804B126724E6C80B002B00EA /* LoginViewController.swift */; };
 		804B127124E712F1002B00EA /* MasterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F28247FF01800EAF71D /* MasterViewController.swift */; };
 		804B127224E712F5002B00EA /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F2A247FF01800EAF71D /* DetailViewController.swift */; };
 		804B127324E712FA002B00EA /* SimpleChat.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 804B126B24E712C2002B00EA /* SimpleChat.storyboard */; };
+		804B127524ED596C002B00EA /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804B127424ED596C002B00EA /* SettingsViewController.swift */; };
+		804B127724ED59FE002B00EA /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 804B127624ED59FE002B00EA /* Settings.storyboard */; };
 		8A08C6A624D437DF00DEF995 /* WebSocketPingController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */; };
 		8A0C3BBC24C0947400CAFD19 /* UserEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0C3BBB24C0947400CAFD19 /* UserEvents.swift */; };
 		8A0C3BBF24C0ACAB00CAFD19 /* UserPresence.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A0C3BBD24C0AC6400CAFD19 /* UserPresence.json */; };
@@ -413,8 +419,14 @@
 		79DDF818249CE38B002F4412 /* AssertNetworkRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertNetworkRequest.swift; sourceTree = "<group>"; };
 		79E2B83F24CAC8D60024752F /* ListDatabaseObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListDatabaseObserver.swift; sourceTree = "<group>"; };
 		79FC85E624ACCBC500A665ED /* Token.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
+		8008C17F24ED64C000F5BCCE /* UIViewController+MoveToStoryboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+MoveToStoryboard.swift"; sourceTree = "<group>"; };
+		8008C18224ED65A500F5BCCE /* UIStoryboard+Definitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+Definitions.swift"; sourceTree = "<group>"; };
+		8008C18524EDBCF500F5BCCE /* LogsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsViewController.swift; sourceTree = "<group>"; };
+		8008C18824EEB8BD00F5BCCE /* LogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogStore.swift; sourceTree = "<group>"; };
 		804B126724E6C80B002B00EA /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		804B126B24E712C2002B00EA /* SimpleChat.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SimpleChat.storyboard; sourceTree = "<group>"; };
+		804B127424ED596C002B00EA /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
+		804B127624ED59FE002B00EA /* Settings.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Settings.storyboard; sourceTree = "<group>"; };
 		8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketPingController_Tests.swift; sourceTree = "<group>"; };
 		8A0C3BBB24C0947400CAFD19 /* UserEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEvents.swift; sourceTree = "<group>"; };
 		8A0C3BBD24C0AC6400CAFD19 /* UserPresence.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = UserPresence.json; sourceTree = "<group>"; };
@@ -637,9 +649,11 @@
 			isa = PBXGroup;
 			children = (
 				792A4F24247FF01800EAF71D /* AppDelegate.swift */,
+				8008C18824EEB8BD00F5BCCE /* LogStore.swift */,
 				792A4F26247FF01800EAF71D /* SceneDelegate.swift */,
-				804B126724E6C80B002B00EA /* LoginViewController.swift */,
 				792A4F2C247FF01800EAF71D /* Main.storyboard */,
+				804B126724E6C80B002B00EA /* LoginViewController.swift */,
+				8008C17E24ED647900F5BCCE /* Extensions */,
 				804B126D24E712CC002B00EA /* Samples */,
 				792A4F2F247FF01900EAF71D /* Assets.xcassets */,
 				792A4F31247FF01900EAF71D /* LaunchScreen.storyboard */,
@@ -953,9 +967,21 @@
 			path = "Mock Network";
 			sourceTree = "<group>";
 		};
+		8008C17E24ED647900F5BCCE /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				8008C17F24ED64C000F5BCCE /* UIViewController+MoveToStoryboard.swift */,
+				8008C18224ED65A500F5BCCE /* UIStoryboard+Definitions.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		804B126D24E712CC002B00EA /* Samples */ = {
 			isa = PBXGroup;
 			children = (
+				804B127624ED59FE002B00EA /* Settings.storyboard */,
+				804B127424ED596C002B00EA /* SettingsViewController.swift */,
+				8008C18524EDBCF500F5BCCE /* LogsViewController.swift */,
 				804B126E24E712D0002B00EA /* SimpleChat */,
 			);
 			path = Samples;
@@ -1255,6 +1281,7 @@
 				792A4F30247FF01900EAF71D /* Assets.xcassets in Resources */,
 				804B127324E712FA002B00EA /* SimpleChat.storyboard in Resources */,
 				792A4F2E247FF01800EAF71D /* Main.storyboard in Resources */,
+				804B127724ED59FE002B00EA /* Settings.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1340,8 +1367,13 @@
 			files = (
 				804B127124E712F1002B00EA /* MasterViewController.swift in Sources */,
 				804B126924E6C820002B00EA /* LoginViewController.swift in Sources */,
+				8008C18A24EEB8CA00F5BCCE /* LogStore.swift in Sources */,
+				8008C18424ED65AB00F5BCCE /* UIStoryboard+Definitions.swift in Sources */,
+				804B127524ED596C002B00EA /* SettingsViewController.swift in Sources */,
 				792A4F25247FF01800EAF71D /* AppDelegate.swift in Sources */,
+				8008C18724EDBCFF00F5BCCE /* LogsViewController.swift in Sources */,
 				804B127224E712F5002B00EA /* DetailViewController.swift in Sources */,
+				8008C18124ED64D300F5BCCE /* UIViewController+MoveToStoryboard.swift in Sources */,
 				792A4F27247FF01800EAF71D /* SceneDelegate.swift in Sources */,
 				8AE8950D24D8660800E852EC /* PingPongEmojiFormatter.swift in Sources */,
 			);


### PR DESCRIPTION
Few options for now, but to expand as the methods become available. This screen will be accessible from all samples and the main purpose is to assist in development. Also left a couple placeholders which I think should be available.

| Settings | Logs |
|-|-|
|<img width="552" alt="Screen Shot 2020-08-20 at 22 16 13" src="https://user-images.githubusercontent.com/5606812/90841489-30d00d80-e333-11ea-9fce-b18cb70e3a99.png">|<img width="552" alt="Screen Shot 2020-08-20 at 22 06 06" src="https://user-images.githubusercontent.com/5606812/90841517-3d546600-e333-11ea-8093-ae2d592a5296.png">|