### PR TITLE
[CIS-299] Make test mocks thread safe

### DIFF
--- a/Sources_v3/APIClient/APIClient_Mock.swift
+++ b/Sources_v3/APIClient/APIClient_Mock.swift
@@ -7,15 +7,15 @@ import Foundation
 
 /// Mock implementation of APIClient allowing easy control and simulation of responses.
 class APIClientMock: APIClient {
-    var request_allRecordedCalls: [(endpoint: AnyEndpoint, completion: Any?)] = []
+    @Atomic var request_allRecordedCalls: [(endpoint: AnyEndpoint, completion: Any?)] = []
     
     /// The last endpoint `request` function was called with.
-    var request_endpoint: AnyEndpoint?
-    var request_completion: Any?
+    @Atomic var request_endpoint: AnyEndpoint?
+    @Atomic var request_completion: Any?
     
-    var init_sessionConfiguration: URLSessionConfiguration
-    var init_requestEncoder: RequestEncoder
-    var init_requestDecoder: RequestDecoder
+    @Atomic var init_sessionConfiguration: URLSessionConfiguration
+    @Atomic var init_requestEncoder: RequestEncoder
+    @Atomic var init_requestDecoder: RequestDecoder
     
     override init(sessionConfiguration: URLSessionConfiguration, requestEncoder: RequestEncoder, requestDecoder: RequestDecoder) {
         init_sessionConfiguration = sessionConfiguration

--- a/Sources_v3/APIClient/APIClient_Mock.swift
+++ b/Sources_v3/APIClient/APIClient_Mock.swift
@@ -16,6 +16,13 @@ class APIClientMock: APIClient {
     @Atomic var init_sessionConfiguration: URLSessionConfiguration
     @Atomic var init_requestEncoder: RequestEncoder
     @Atomic var init_requestDecoder: RequestDecoder
+
+    // Cleans up all recorded values
+    func cleanUp() {
+        request_allRecordedCalls = []
+        request_endpoint = nil
+        request_completion = nil
+    }
     
     override init(sessionConfiguration: URLSessionConfiguration, requestEncoder: RequestEncoder, requestDecoder: RequestDecoder) {
         init_sessionConfiguration = sessionConfiguration

--- a/Sources_v3/ChatClient_Tests.swift
+++ b/Sources_v3/ChatClient_Tests.swift
@@ -497,14 +497,14 @@ class ChatClient_Tests: StressTestCase {
 
 /// A helper class which provides mock environment for Client.
 private class TestEnvironment<ExtraData: ExtraDataTypes> {
-    var apiClient: APIClientMock?
-    var webSocketClient: WebSocketClientMock?
-    var databaseContainer: DatabaseContainerMock?
+    @Atomic var apiClient: APIClientMock?
+    @Atomic var webSocketClient: WebSocketClientMock?
+    @Atomic var databaseContainer: DatabaseContainerMock?
     
-    var requestEncoder: TestRequestEncoder?
-    var requestDecoder: TestRequestDecoder?
+    @Atomic var requestEncoder: TestRequestEncoder?
+    @Atomic var requestDecoder: TestRequestDecoder?
     
-    var eventDecoder: EventDecoder<ExtraData>?
+    @Atomic var eventDecoder: EventDecoder<ExtraData>?
     
     lazy var environment: Client<ExtraData>.Environment = { [unowned self] in
         .init(apiClientBuilder: {
@@ -604,7 +604,7 @@ private struct Queue<Element> {
         storage = elements
     }
     
-    private var storage = [Element]()
+    @Atomic private var storage = [Element]()
     mutating func push(_ element: Element) {
         storage.append(element)
     }
@@ -633,8 +633,8 @@ class WebSocketClientMock: WebSocketClient {
     let init_reconnectionStrategy: WebSocketClientReconnectionStrategy
     let init_environment: WebSocketClient.Environment
     
-    var connect_calledCounter = 0
-    var disconnect_calledCounter = 0
+    @Atomic var connect_calledCounter = 0
+    @Atomic var disconnect_calledCounter = 0
     
     override init(
         connectEndpoint: Endpoint<EmptyResponse>,
@@ -663,11 +663,11 @@ class WebSocketClientMock: WebSocketClient {
     }
     
     override func connect() {
-        connect_calledCounter += 1
+        _connect_calledCounter { $0 += 1 }
     }
     
     override func disconnect(source: ConnectionState.DisconnectionSource = .userInitiated) {
-        disconnect_calledCounter += 1
+        _disconnect_calledCounter { $0 += 1 }
     }
 }
 

--- a/Sources_v3/ChatClient_Tests.swift
+++ b/Sources_v3/ChatClient_Tests.swift
@@ -25,6 +25,8 @@ class ChatClient_Tests: StressTestCase {
     }
     
     override func tearDown() {
+        testEnv.apiClient?.cleanUp()
+        
         weak var weak_testEnv = testEnv
         testEnv = nil
         XCTAssertNil(weak_testEnv)

--- a/Sources_v3/Workers/Background/MessageSender.swift
+++ b/Sources_v3/Workers/Background/MessageSender.swift
@@ -41,7 +41,6 @@ class MessageSender<ExtraData: ExtraDataTypes>: Worker {
             self?.observer.onChange = { self?.handleChanges(changes: $0) }
             do {
                 try self?.observer.startObserving()
-                try self?.observer.startObserving()
                 
                 // Send the existing unsent message first. We can simulate callback from the observer and ignore
                 // the index path completely.

--- a/Sources_v3/Workers/Background/MessageSender_Tests.swift
+++ b/Sources_v3/Workers/Background/MessageSender_Tests.swift
@@ -31,6 +31,31 @@ class MessageSender_Tests: StressTestCase {
         try! database.createChannel(cid: cid)
     }
     
+    override func tearDown() {
+        apiClient.cleanUp()
+        
+        weak var weak_webSocketClient = webSocketClient
+        weak var weak_apiClient = apiClient
+        weak var weak_database = database
+        weak var weak_sender = sender
+
+        webSocketClient = nil
+        apiClient = nil
+        database = nil
+        sender = nil
+        
+        // We need to assert asynchronously, because there can be some callbacks happening
+        // on the background queue, that keeps the worker alive, until they have finished.
+        AssertAsync {
+            Assert.willBeNil(weak_webSocketClient)
+            Assert.willBeNil(weak_apiClient)
+            Assert.willBeNil(weak_database)
+            Assert.willBeNil(weak_sender)
+        }
+
+        super.tearDown()
+    }
+    
     func test_senderSendsMessage_withPendingSendLocalState() throws {
         var message1Id: MessageId!
         var message2Id: MessageId!

--- a/Sources_v3/Workers/ChannelListQueryUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelListQueryUpdater_Tests.swift
@@ -22,6 +22,12 @@ class ChannelListQueryUpdater_Tests: StressTestCase {
         queryUpdater = ChannelListQueryUpdater(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
     }
     
+    override func tearDown() {
+        apiClient.cleanUp()
+        
+        super.tearDown()
+    }
+    
     func test_makesCorrectAPICall() {
         // Simulate `update` call
         let query = ChannelListQuery(filter: .in("member", ["Luke"]))

--- a/Sources_v3/Workers/ChannelUpdater_Mock.swift
+++ b/Sources_v3/Workers/ChannelUpdater_Mock.swift
@@ -7,45 +7,45 @@ import XCTest
 
 /// Mock implementation of ChannelUpdater
 class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
-    var update_channelQuery: ChannelQuery<ExtraData>?
-    var update_channelCreatedCallback: ((ChannelId) -> Void)?
-    var update_completion: ((Error?) -> Void)?
+    @Atomic var update_channelQuery: ChannelQuery<ExtraData>?
+    @Atomic var update_channelCreatedCallback: ((ChannelId) -> Void)?
+    @Atomic var update_completion: ((Error?) -> Void)?
 
-    var updateChannel_payload: ChannelEditDetailPayload<ExtraData>?
-    var updateChannel_completion: ((Error?) -> Void)?
+    @Atomic var updateChannel_payload: ChannelEditDetailPayload<ExtraData>?
+    @Atomic var updateChannel_completion: ((Error?) -> Void)?
 
-    var muteChannel_cid: ChannelId?
-    var muteChannel_mute: Bool?
-    var muteChannel_completion: ((Error?) -> Void)?
+    @Atomic var muteChannel_cid: ChannelId?
+    @Atomic var muteChannel_mute: Bool?
+    @Atomic var muteChannel_completion: ((Error?) -> Void)?
 
-    var deleteChannel_cid: ChannelId?
-    var deleteChannel_completion: ((Error?) -> Void)?
+    @Atomic var deleteChannel_cid: ChannelId?
+    @Atomic var deleteChannel_completion: ((Error?) -> Void)?
 
-    var hideChannel_cid: ChannelId?
-    var hideChannel_userId: UserId?
-    var hideChannel_clearHistory: Bool?
-    var hideChannel_completion: ((Error?) -> Void)?
+    @Atomic var hideChannel_cid: ChannelId?
+    @Atomic var hideChannel_userId: UserId?
+    @Atomic var hideChannel_clearHistory: Bool?
+    @Atomic var hideChannel_completion: ((Error?) -> Void)?
 
-    var showChannel_cid: ChannelId?
-    var showChannel_userId: UserId?
-    var showChannel_completion: ((Error?) -> Void)?
+    @Atomic var showChannel_cid: ChannelId?
+    @Atomic var showChannel_userId: UserId?
+    @Atomic var showChannel_completion: ((Error?) -> Void)?
     
-    var addMembers_cid: ChannelId?
-    var addMembers_userIds: Set<UserId>?
-    var addMembers_completion: ((Error?) -> Void)?
+    @Atomic var addMembers_cid: ChannelId?
+    @Atomic var addMembers_userIds: Set<UserId>?
+    @Atomic var addMembers_completion: ((Error?) -> Void)?
     
-    var removeMembers_cid: ChannelId?
-    var removeMembers_userIds: Set<UserId>?
-    var removeMembers_completion: ((Error?) -> Void)?
+    @Atomic var removeMembers_cid: ChannelId?
+    @Atomic var removeMembers_userIds: Set<UserId>?
+    @Atomic var removeMembers_completion: ((Error?) -> Void)?
 
-    var createNewMessage_cid: ChannelId?
-    var createNewMessage_text: String?
-    var createNewMessage_command: String?
-    var createNewMessage_arguments: String?
-    var createNewMessage_parentMessageId: MessageId?
-    var createNewMessage_showReplyInChannel: Bool?
-    var createNewMessage_extraData: ExtraData.Message?
-    var createNewMessage_completion: ((Result<MessageId, Error>) -> Void)?
+    @Atomic var createNewMessage_cid: ChannelId?
+    @Atomic var createNewMessage_text: String?
+    @Atomic var createNewMessage_command: String?
+    @Atomic var createNewMessage_arguments: String?
+    @Atomic var createNewMessage_parentMessageId: MessageId?
+    @Atomic var createNewMessage_showReplyInChannel: Bool?
+    @Atomic var createNewMessage_extraData: ExtraData.Message?
+    @Atomic var createNewMessage_completion: ((Result<MessageId, Error>) -> Void)?
     
     override func update(
         channelQuery: ChannelQuery<ExtraData>,

--- a/Sources_v3/Workers/ChannelUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelUpdater_Tests.swift
@@ -24,6 +24,12 @@ class ChannelUpdater_Tests: StressTestCase {
         channelUpdater = ChannelUpdater(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
     }
     
+    override func tearDown() {
+        apiClient.cleanUp()
+        
+        super.tearDown()
+    }
+    
     func test_updateChannelQuery_makesCorrectAPICall() {
         // Simulate `update(channelQuery:)` call
         let query = ChannelQuery<ExtraData>(cid: .unique)


### PR DESCRIPTION
### In this PR

- Add `Atomic` wrapper to mock classes
- Fix bug in `MessageSender` background init
- `APIClientMock` records all completion blocks so we have to explicitly call `cleanUp()` on it to release them.

