### PR TITLE
[CIS-61] Mute/unmute a channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✅ Added
 - `ChannelsPresenter.delete` & `ChannelsPresenter.rx.delete` methods to delete a channel and remove it from items list [#394](https://github.com/GetStream/stream-chat-swift/pull/394)
+- Mute/unmute a channel [#428](https://github.com/GetStream/stream-chat-swift/issues/428)
+  - `Client.shared.mute(channel: channel) {}` or `channel.mute {}`
+  - `Client.shared.rx.mute(channel: channel)` or `channel.rx.mute()`
+- `.notificationChannelMutesUpdated` event type to get the current user updated when a channel was muted or unmuted [#428](https://github.com/GetStream/stream-chat-swift/issues/428) 
 
 ### 🐞 Fixed
 - Channels list (ChannelsViewController) not updated when recreating a channel after deleting it [#392](https://github.com/GetStream/stream-chat-swift/issues/392)

--- a/Sample/Sources/DarkChannelsViewController.swift
+++ b/Sample/Sources/DarkChannelsViewController.swift
@@ -166,16 +166,22 @@ final class DarkChannelsViewController: ChannelsViewController {
         alertController.addAction(.init(title: "Cancel", style: .cancel, handler: { _ in }))
         
         alertController.addAction(.init(title: "Hide", style: .default, handler: { [weak self] _ in
-            if let self = self {
-                self.presenter.hide(channelPresenter)
-            }
+            self?.presenter.hide(channelPresenter)
         }))
         
         alertController.addAction(.init(title: "Hide and Clear History", style: .default, handler: { [weak self] _ in
-            if let self = self {
-                self.presenter.hide(channelPresenter, clearHistory: true)
-            }
+            self?.presenter.hide(channelPresenter, clearHistory: true)
         }))
+        
+        if Client.shared.user.mutedChannels.firstIndex(where: { $0.channel.cid == channelPresenter.channel.cid }) != nil {
+            alertController.addAction(.init(title: "Unmute", style: .default, handler: { [weak self] _ in
+                self?.presenter.unmute(channelPresenter)
+            }))
+        } else {
+            alertController.addAction(.init(title: "Mute", style: .default, handler: { [weak self] _ in
+                self?.presenter.mute(channelPresenter)
+            }))
+        }
         
         if (channelPresenter.channel.createdBy?.isCurrent ?? false) {
             alertController.addAction(.init(title: "Rename", style: .default, handler: { [weak self] _ in

--- a/Sources/Client/Client/Client+Channel.swift
+++ b/Sources/Client/Client/Client+Channel.swift
@@ -182,6 +182,24 @@ public extension Client {
         request(endpoint: .showChannel(channel, user), completion)
     }
     
+    /// Mutes a channel.
+    /// - Parameters:
+    ///   - channel: a channel.
+    ///   - completion: an empty completion block.
+    @discardableResult
+    func mute(channel: Channel, _ completion: @escaping Client.Completion<MutedChannelResponse> = { _ in }) -> Cancellable {
+        request(endpoint: .muteChannel(channel), completion)
+    }
+    
+    /// Unmutes a channel.
+    /// - Parameters:
+    ///   - channel: a channel.
+    ///   - completion: an empty completion block.
+    @discardableResult
+    func unmute(channel: Channel, _ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> Cancellable {
+        request(endpoint: .unmuteChannel(channel), completion)
+    }
+    
     /// Update channel data.
     /// - Parameters:
     ///   - channel: a channel.

--- a/Sources/Client/Client/Client+WebSocket.swift
+++ b/Sources/Client/Client/Client+WebSocket.swift
@@ -90,7 +90,8 @@ extension Client: WebSocketEventDelegate {
             
             return true
             
-        case .notificationMutesUpdated(let user, _, _):
+        case .notificationChannelMutesUpdated(let user, _),
+             .notificationMutesUpdated(let user, _, _):
             userAtomic.set(user)
             return true
             

--- a/Sources/Client/Client/Endpoint.swift
+++ b/Sources/Client/Client/Endpoint.swift
@@ -54,6 +54,10 @@ public enum Endpoint {
     case hideChannel(Channel, User, _ clearHistory: Bool)
     /// Show a channel if it was hidden.
     case showChannel(Channel, User)
+    /// Mute a channel.
+    case muteChannel(Channel)
+    /// Unmute a channel.
+    case unmuteChannel(Channel)
     /// Send a message to a channel.
     case sendMessage(Message, Channel)
     /// Upload an image to a channel.
@@ -102,7 +106,7 @@ public enum Endpoint {
     case users(UsersQuery)
     /// Update a user.
     case updateUsers([User])
-    /// Mute a use.
+    /// Mute a user.
     case muteUser(User)
     /// Unmute a user.
     case unmuteUser(User)
@@ -165,6 +169,10 @@ extension Endpoint {
             return path(to: channel, "show")
         case .hideChannel(let channel, _, _):
             return path(to: channel, "hide")
+        case .muteChannel:
+            return "moderation/mute/channel"
+        case .unmuteChannel:
+            return "moderation/unmute/channel"
         case .replies(let message, _):
             return path(to: message.id, "replies")
             
@@ -285,11 +293,14 @@ extension Endpoint {
         case .channel(let query):
             return query
             
+        case .hideChannel(_, let user, let clearHistory):
+            return HiddenChannelRequest(userId: user.id, clearHistory: clearHistory)
+            
         case .showChannel(_, let user):
             return ["user_id": user.id]
             
-        case .hideChannel(_, let user, let clearHistory):
-            return HiddenChannelRequest(userId: user.id, clearHistory: clearHistory)
+        case .muteChannel(let channel), .unmuteChannel(let channel):
+            return ["channel_cid": channel.cid]
             
         case .sendMessage(let message, _):
             return ["message": message]
@@ -360,7 +371,9 @@ extension Endpoint {
         case .channel(let query):
             return query.options.contains(.presence) || query.options.contains(.state)
         case .updateUsers,
-             .stopWatching:
+             .stopWatching,
+             .muteChannel,
+             .unmuteChannel:
             return true
         case .heatUpTCPConnection,
              .guestToken,

--- a/Sources/Client/Model/Channel/Channel+Requests.swift
+++ b/Sources/Client/Model/Channel/Channel+Requests.swift
@@ -79,6 +79,20 @@ public extension Channel {
         Client.shared.show(channel: self, completion)
     }
     
+    /// Mutes a channel.
+    /// - Parameter completion: an empty completion block.
+    @discardableResult
+    func mute(_ completion: @escaping Client.Completion<MutedChannelResponse> = { _ in }) -> Cancellable {
+        Client.shared.mute(channel: self, completion)
+    }
+    
+    /// Unmutes a channel.
+    /// - Parameter completion: an empty completion block.
+    @discardableResult
+    func unmute(_ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> Cancellable {
+        Client.shared.unmute(channel: self, completion)
+    }
+    
     /// Update channel data.
     /// - Parameters:
     ///   - name: a channel name.

--- a/Sources/Client/Model/Channel/MutedChannel.swift
+++ b/Sources/Client/Model/Channel/MutedChannel.swift
@@ -1,0 +1,49 @@
+//
+//  MutedChannel.swift
+//  StreamChatClient
+//
+//  Created by Alexey Bukhtin on 24/08/2020.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A muted channel.
+public struct MutedChannel: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case channel
+        case created = "created_at"
+        case updated = "updated_at"
+    }
+    
+    /// A channel.
+    public let channel: Channel
+    /// A created date.
+    public let created: Date
+    /// A updated date.
+    public let updated: Date
+    
+    /// Creates a muted channel.
+    /// - Parameters:
+    ///   - user: a user.
+    ///   - created: a created date.
+    ///   - updated: an updated date.
+    init(channel: Channel, created: Date, updated: Date) {
+        self.channel = channel
+        self.created = created
+        self.updated = updated
+    }
+}
+
+/// A response for the muted channel.
+public struct MutedChannelResponse: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case currentUser = "own_user"
+        case mutedChannel = "channel_mute"
+    }
+    
+    /// An own user.
+    public let currentUser: User
+    /// A muted channel.
+    public let mutedChannel: Channel
+}

--- a/Sources/Client/Model/Event.swift
+++ b/Sources/Client/Model/Event.swift
@@ -95,6 +95,8 @@ public enum Event: Decodable, Equatable {
     /// When the total count of unread messages (across all channels the user is a member) changed
     /// (when clients from the user affected by the change).
     case notificationMarkAllRead(MessageRead, EventType)
+    /// When the user mutes a channel.
+    case notificationChannelMutesUpdated(User, EventType)
     /// When the user mutes someone.
     case notificationMutesUpdated(User, ChannelId?, EventType)
     
@@ -150,6 +152,7 @@ public enum Event: Decodable, Equatable {
              .notificationMessageNew(_, _, _, _, let type),
              .notificationMarkRead(_, _, _, let type),
              .notificationMarkAllRead(_, let type),
+             .notificationChannelMutesUpdated(_, let type),
              .notificationMutesUpdated(_, _, let type),
              
              .notificationAddedToChannel(_, _, let type),
@@ -168,6 +171,7 @@ public enum Event: Decodable, Equatable {
         case .connectionChanged,
              .healthCheck,
              .pong,
+             .notificationChannelMutesUpdated,
              .notificationMarkAllRead:
             return nil
             
@@ -227,6 +231,7 @@ public enum Event: Decodable, Equatable {
              .reactionDeleted(_, _, let user, _, _),
              .typingStart(let user, _, _),
              .typingStop(let user, _, _),
+             .notificationChannelMutesUpdated(let user, _),
              .notificationMutesUpdated(let user, _, _):
             return user
         case .memberAdded(let member, _, _),
@@ -235,7 +240,22 @@ public enum Event: Decodable, Equatable {
         case .messageNew(let message, _, _, _, _),
              .notificationMessageNew(let message, _, _, _, _):
             return message.user
-        default:
+        case .connectionChanged,
+             .pong,
+             .userBanned,
+             .channelUpdated,
+             .channelDeleted,
+             .channelHidden,
+             .messageUpdated,
+             .messageDeleted,
+             .messageRead,
+             .notificationMarkRead,
+             .notificationMarkAllRead,
+             .notificationAddedToChannel,
+             .notificationRemovedFromChannel,
+             .notificationInvited,
+             .notificationInviteAccepted,
+             .notificationInviteRejected:
             return nil
         }
     }
@@ -245,6 +265,7 @@ public enum Event: Decodable, Equatable {
         case .notificationMarkAllRead,
              .notificationMarkRead,
              .notificationMessageNew,
+             .notificationChannelMutesUpdated,
              .notificationMutesUpdated,
              .notificationAddedToChannel,
              .notificationRemovedFromChannel,
@@ -396,6 +417,8 @@ public enum Event: Decodable, Equatable {
             self = try .reactionDeleted(reaction(), message(), user(), cid(), type)
             
         // Notifications
+        case .notificationChannelMutesUpdated:
+            self = try .notificationChannelMutesUpdated(container.decode(User.self, forKey: .me), type)
         case .notificationMutesUpdated:
             self = try .notificationMutesUpdated(container.decode(User.self, forKey: .me), cid(), type)
         case .notificationMarkRead:

--- a/Sources/Client/Model/EventType.swift
+++ b/Sources/Client/Model/EventType.swift
@@ -73,6 +73,8 @@ public enum EventType: String, Codable, CaseIterable {
     /// When the total count of unread messages (across all channels the user is a member) changes
     /// (when clients from the user affected by the change).
     case notificationMarkRead = "notification.mark_read"
+    /// When the user mutes a channel.
+    case notificationChannelMutesUpdated = "notification.channel_mutes_updated"
     /// When the user mutes someone.
     case notificationMutesUpdated = "notification.mutes_updated"
     

--- a/Sources/Client/Model/User/User.swift
+++ b/Sources/Client/Model/User/User.swift
@@ -22,6 +22,7 @@ public struct User: Codable {
         case lastActiveDate = "last_active"
         case isInvisible = "invisible"
         case devices
+        case mutedChannels = "channel_mutes"
         case mutedUsers = "mutes"
         case unreadMessagesCount = "unread_count"
         case unreadChannelsCount = "unread_channels"
@@ -87,6 +88,8 @@ public struct User: Codable {
     public internal(set) var devices: [Device]
     /// A list of devices.
     public internal(set) var currentDevice: Device?
+    /// Muted channels.
+    public internal(set) var mutedChannels: [MutedChannel]
     /// Muted users.
     public internal(set) var mutedUsers: [MutedUser]
     /// Teams the user belongs to. You need to enable multi-tenancy if you want to use this, else it'll be empty.
@@ -127,6 +130,7 @@ public struct User: Codable {
                 lastActiveDate: Date? = nil,
                 isInvisible: Bool = false,
                 isBanned: Bool = false,
+                mutedChannels: [MutedChannel] = [],
                 mutedUsers: [MutedUser] = [],
                 teams: [String] = []) {
         self.id = id
@@ -137,6 +141,7 @@ public struct User: Codable {
         self.lastActiveDate = lastActiveDate
         self.isInvisible = isInvisible
         self.isBanned = isBanned
+        self.mutedChannels = mutedChannels
         self.mutedUsers = mutedUsers
         self.teams = teams
         isOnline = false
@@ -161,6 +166,7 @@ public struct User: Codable {
         isInvisible = try container.decodeIfPresent(Bool.self, forKey: .isInvisible) ?? false
         isBanned = try container.decodeIfPresent(Bool.self, forKey: .isBanned) ?? false
         devices = try container.decodeIfPresent([Device].self, forKey: .devices) ?? []
+        mutedChannels = try container.decodeIfPresent([MutedChannel].self, forKey: .mutedChannels) ?? []
         mutedUsers = try container.decodeIfPresent([MutedUser].self, forKey: .mutedUsers) ?? []
         teams = try container.decodeIfPresent([String].self, forKey: .teams) ?? []
         extraData = User.decodeUserExtraData(from: decoder)

--- a/Sources/Core/Client/Channel/Channel+RxRequests.swift
+++ b/Sources/Core/Client/Channel/Channel+RxRequests.swift
@@ -67,6 +67,16 @@ public extension Reactive where Base == Channel {
         Client.shared.rx.show(channel: base)
     }
     
+    /// Mutes a channel.
+    func mute() -> Observable<MutedChannelResponse> {
+        Client.shared.rx.mute(channel: base)
+    }
+    
+    /// Unmutes a channel.
+    func unmute() -> Observable<EmptyData> {
+        Client.shared.rx.unmute(channel: base)
+    }
+    
     /// Update channel data.
     /// - Parameters:
     ///   - name: a channel name.

--- a/Sources/Core/Client/Channel/Channel+RxRequests.swift
+++ b/Sources/Core/Client/Channel/Channel+RxRequests.swift
@@ -17,7 +17,6 @@ extension Channel: ReactiveCompatible {}
 public extension Reactive where Base == Channel {
     
     /// Create a channel.
-    /// - Parameter completion: a completion block with `ChannelResponse`.
     @discardableResult
     func create() -> Observable<ChannelResponse> {
         Client.shared.rx.create(channel: base)
@@ -63,7 +62,7 @@ public extension Reactive where Base == Channel {
     /// Removes the hidden status for a channel.
     /// - Parameters:
     ///   - user: the current user.
-    func show(_ completion: @escaping Client.Completion<EmptyData> = { _ in }) -> Observable<EmptyData> {
+    func show() -> Observable<EmptyData> {
         Client.shared.rx.show(channel: base)
     }
     

--- a/Sources/Core/Client/Client+RxChannel.swift
+++ b/Sources/Core/Client/Client+RxChannel.swift
@@ -90,6 +90,24 @@ public extension Reactive where Base == Client {
         }))
     }
     
+    /// Mutes a channel.
+    /// - Parameter channel: a channel.
+    @discardableResult
+    func mute(channel: Channel) -> Observable<MutedChannelResponse> {
+        connected(request({ [unowned base] completion in
+            base.mute(channel: channel, completion)
+        }))
+    }
+    
+    /// Unmutes a channel.
+    /// - Parameter channel: a channel.
+    @discardableResult
+    func unmute(channel: Channel) -> Observable<EmptyData> {
+        connected(request({ [unowned base] completion in
+            base.unmute(channel: channel, completion)
+        }))
+    }
+    
     /// Update channel data.
     /// - Parameters:
     ///   - channel: a channel.

--- a/Sources/Core/Presenter/Channels/ChannelsPresenter+Rx.swift
+++ b/Sources/Core/Presenter/Channels/ChannelsPresenter+Rx.swift
@@ -44,6 +44,18 @@ public extension Reactive where Base == ChannelsPresenter {
             .asDriver(onErrorJustReturn: .empty)
     }
     
+    /// Mutes a channel from a given `ChannelPresenter`.
+    /// - Parameter channelPresenter: a channel presenter.
+    func mute(_ channelPresenter: ChannelPresenter) -> Observable<MutedChannelResponse> {
+        channelPresenter.channel.rx.mute()
+    }
+    
+    /// Unmutes a channel from a given `ChannelPresenter`.
+    /// - Parameter channelPresenter: a channel presenter.
+    func unmute(_ channelPresenter: ChannelPresenter) -> Observable<EmptyData> {
+        channelPresenter.channel.rx.unmute()
+    }
+    
     /// Delete a channel and remove a channel presenter from items.
     ///
     /// - Parameters:

--- a/Sources/Core/Presenter/Channels/ChannelsPresenter.swift
+++ b/Sources/Core/Presenter/Channels/ChannelsPresenter.swift
@@ -89,6 +89,20 @@ public extension ChannelsPresenter {
         rx.hide(channelPresenter, clearHistory: clearHistory).asObservable().bindOnce(to: completion)
     }
     
+    /// Mutes a channel from a given `ChannelPresenter`.
+    /// - Parameter channelPresenter: a channel presenter.
+    func mute(_ channelPresenter: ChannelPresenter,
+              _ completion: @escaping Client.Completion<MutedChannelResponse> = { _ in }) {
+        rx.mute(channelPresenter).bindOnce(to: completion)
+    }
+    
+    /// Unmutes a channel from a given `ChannelPresenter`.
+    /// - Parameter channelPresenter: a channel presenter.
+    func unmute(_ channelPresenter: ChannelPresenter,
+                _ completion: @escaping Client.Completion<EmptyData> = { _ in }) {
+        rx.unmute(channelPresenter).bindOnce(to: completion)
+    }
+    
     /// Delete a channel and remove the channel presenter from items.
     ///
     /// - Parameters:

--- a/Sources/UI/Channels/ChannelsViewController.swift
+++ b/Sources/UI/Channels/ChannelsViewController.swift
@@ -369,6 +369,9 @@ extension ChannelsViewController: UITableViewDataSource, UITableViewDelegate {
             return
         }
         
-        channelPresenter.channel.rx.stopWatching().flatMap { _ in self.presenter.rx.delete(channelPresenter) }.subscribe().disposed(by: disposeBag)
+        channelPresenter.channel.rx.stopWatching()
+            .flatMap { _ in self.presenter.rx.delete(channelPresenter) }
+            .subscribe()
+            .disposed(by: disposeBag)
     }
 }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		8A9ECEF6242A573700206E7D /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACC7C4E241924B5000750E4 /* Application.swift */; };
 		8A9ECEF7242A57B900206E7D /* AssociatedValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACC7C4F241924B5000750E4 /* AssociatedValue.swift */; };
 		8A9ECEF9242A5C3A00206E7D /* UIApplication+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9ECEF8242A5C3A00206E7D /* UIApplication+Rx.swift */; };
+		8AA0884824F413400002F8D6 /* MutedChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0884724F413400002F8D6 /* MutedChannel.swift */; };
 		8AA8F13D241FD2BD008FD89C /* Reaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACC7BD0241924AD000750E4 /* Reaction.swift */; };
 		8AA8F13E2420FFE0008FD89C /* Int+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACC7BBB241924AD000750E4 /* Int+Extensions.swift */; };
 		8AAE2337245B00480080EB00 /* WebSocketProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAE2336245B00480080EB00 /* WebSocketProvider.swift */; };
@@ -370,6 +371,7 @@
 		8A9BC2EB2487D9F5004C5E69 /* WebSocketEventsMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketEventsMock.swift; sourceTree = "<group>"; };
 		8A9D2C7224487E0E007BD497 /* ChatViewStyle+Presets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatViewStyle+Presets.swift"; sourceTree = "<group>"; };
 		8A9ECEF8242A5C3A00206E7D /* UIApplication+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+Rx.swift"; sourceTree = "<group>"; };
+		8AA0884724F413400002F8D6 /* MutedChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedChannel.swift; sourceTree = "<group>"; };
 		8AAE2336245B00480080EB00 /* WebSocketProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketProvider.swift; sourceTree = "<group>"; };
 		8AAE2338245B00B20080EB00 /* URLSessionWebSocketProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionWebSocketProvider.swift; sourceTree = "<group>"; };
 		8AAE233A245B00CF0080EB00 /* StarscreamWebSocketProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarscreamWebSocketProvider.swift; sourceTree = "<group>"; };
@@ -883,6 +885,7 @@
 				8ACC7BE2241924AD000750E4 /* ChannelResponse.swift */,
 				8ACC7BE3241924AD000750E4 /* Channel+WatcherCount.swift */,
 				8ADA1EEA2472C2E500C4FC82 /* ChannelNamingStrategy.swift */,
+				8AA0884724F413400002F8D6 /* MutedChannel.swift */,
 			);
 			path = Channel;
 			sourceTree = "<group>";
@@ -1666,6 +1669,7 @@
 				8ACC7C0A241924AD000750E4 /* UnreadCount.swift in Sources */,
 				8ACC7C10241924AD000750E4 /* AttachmentFile.swift in Sources */,
 				8ACC7BFB241924AD000750E4 /* ConnectionState.swift in Sources */,
+				8AA0884824F413400002F8D6 /* MutedChannel.swift in Sources */,
 				8ACC7C2B241924AD000750E4 /* Token.swift in Sources */,
 				8ACC7C25241924AD000750E4 /* Channel+WatcherCount.swift in Sources */,
 				8A9ECEF7242A57B900206E7D /* AssociatedValue.swift in Sources */,

--- a/Tests/Client/Unit Tests/EventTests.swift
+++ b/Tests/Client/Unit Tests/EventTests.swift
@@ -96,6 +96,7 @@ final class EventTests: XCTestCase {
              .notificationMessageNew,
              .notificationMarkRead,
              .notificationMarkAllRead,
+             .notificationChannelMutesUpdated,
              .notificationMutesUpdated,
              .notificationAddedToChannel,
              .notificationRemovedFromChannel,


### PR DESCRIPTION
- added mute/unmute a channel
  - `Client.shared.mute(channel: channel) {}` or `channel.mute {}`
  - `Client.shared.rx.mute(channel: channel)` or `channel.rx.mute()`
- added `.notificationChannelMutesUpdated` event type to get the current user updated when a channel was muted or unmuted