### PR TITLE
[CIS-301] Internet Connection

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -2,6 +2,8 @@
 --header "\nCopyright © {year} Stream.io Inc. All rights reserved.\n"
 --swiftversion 5.2
 
+--exclude **/*_Vendor.swift
+
 # Rules inferred from Swift Standard Library:
 --disable anyObjectProtocol, wrapMultilineStatementBraces
 --indent 4

--- a/Sources_v3/.swiftlint.yml
+++ b/Sources_v3/.swiftlint.yml
@@ -1,3 +1,6 @@
+excluded:
+  - "Utils/Internet Connection/Reachability_Vendor.swift"
+  
 disabled_rules:
   - large_tuple
   - multiple_closures_with_trailing_closure

--- a/Sources_v3/ChatClient.swift
+++ b/Sources_v3/ChatClient.swift
@@ -129,6 +129,8 @@ public class Client<ExtraData: ExtraDataTypes> {
         }
     }()
     
+    private(set) lazy var internetConnection = environment.internetConnection()
+    
     /// The environment object containing all dependencies of this `Client` instance.
     private let environment: Environment
     
@@ -438,6 +440,8 @@ extension Client {
         var eventDecoderBuilder: () -> EventDecoder<ExtraData> = EventDecoder<ExtraData>.init
         
         var notificationCenterBuilder: ([EventMiddleware]) -> EventNotificationCenter = EventNotificationCenter.init
+        
+        var internetConnection: () -> InternetConnection = { InternetConnection() }
     }
 }
 

--- a/Sources_v3/Utils/Internet Connection/InternetConnection.swift
+++ b/Sources_v3/Utils/Internet Connection/InternetConnection.swift
@@ -1,0 +1,268 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import Network
+
+extension Notification.Name {
+    static let internetConnectionStatusDidChange = Notification.Name("io.getstream.StreamChatClient.internetConnectionStatus")
+}
+
+extension InternetConnection {
+    static let statusUserInfoKey = "statusUserInfoKey"
+}
+
+/// An Internet Connection monitor.
+///
+/// Basically, it's a wrapper over legacy monitor based on `Reachability` (iOS 11 only)
+/// and default monitor based on `Network`.`NWPathMonitor` (iOS 12+).
+class InternetConnection {
+    /// The current Internet connection status.
+    var status: InternetConnection.Status { monitor.status }
+    
+    private var notificationCenter: NotificationCenter
+    
+    /// A specific Internet connection monitor.
+    private var monitor: InternetConnectionMonitor
+    
+    /// Creates a `InternetConnection` with a given monitor.
+    /// - Parameter monitor: an Internet connection monitor. Use nil for a default `InternetConnectionMonitor`.
+    init(
+        notificationCenter: NotificationCenter = .default,
+        monitor: InternetConnectionMonitor? = nil
+    ) {
+        self.notificationCenter = notificationCenter
+        
+        if let monitor = monitor {
+            self.monitor = monitor
+        } else if #available(iOS 12, *) {
+            self.monitor = Monitor()
+        } else {
+            self.monitor = LegacyMonitor()
+        }
+        
+        self.monitor.delegate = self
+    }
+    
+    func start() {
+        monitor.start()
+    }
+    
+    func stop() {
+        monitor.stop()
+    }
+}
+
+extension InternetConnection: InternetConnectionDelegate {
+    func internetConnectionStatusDidChange(status: Status) {
+        notificationCenter.post(
+            name: .internetConnectionStatusDidChange,
+            object: self,
+            userInfo: [InternetConnection.statusUserInfoKey: status]
+        )
+    }
+}
+
+// MARK: - Internet Connection Monitors
+
+/// A delegate to receive Internet connection events.
+protocol InternetConnectionDelegate: class {
+    /// Calls when the Internet connection status did change.
+    /// - Parameter status: an Internet connection status.
+    func internetConnectionStatusDidChange(status: InternetConnection.Status)
+}
+
+/// A protocol for Internet connection monitors.
+protocol InternetConnectionMonitor {
+    /// A delegate for receiving Internet connection events.
+    var delegate: InternetConnectionDelegate? { get set }
+    
+    /// The current status of Internet connection.
+    var status: InternetConnection.Status { get }
+    
+    /// Start Internet connection monitoring.
+    func start()
+    /// Stop Internet connection monitoring.
+    func stop()
+}
+
+// MARK: Internet Connection Subtypes
+
+extension InternetConnection {
+    /// The Internet connectivity status.
+    enum Status: Equatable {
+        /// Notification of an Internet connection has not begun.
+        case unknown
+        
+        /// The Internet is available with a specific `Quality` level.
+        case available(Quality)
+        
+        /// The Internet is unavailable.
+        case unavailable
+    }
+    
+    /// The Internet connectivity status quality.
+    enum Quality: Equatable {
+        /// The Internet connection is great (like Wi-Fi).
+        case great
+        
+        /// Internet connection uses an interface that is considered expensive, such as Cellular or a Personal Hotspot.
+        case expensive
+        
+        /// Internet connection uses Low Data Mode.
+        /// Recommendations for Low Data Mode: don't autoplay video, music (high-quality) or gifs (big files).
+        /// Supports only by iOS 13+
+        case constrained
+    }
+}
+
+// MARK: - Internet Connection Monitor
+
+private extension InternetConnection {
+    /// The default Internet connection monitor for iOS 12+.
+    /// It uses Apple Network API.
+    @available(iOS 12, *)
+    class Monitor: InternetConnectionMonitor {
+        private var monitor: NWPathMonitor?
+        
+        weak var delegate: InternetConnectionDelegate?
+        
+        var status: InternetConnection.Status {
+            if let path = monitor?.currentPath {
+                return status(from: path)
+            }
+            
+            return .unknown
+        }
+        
+        func start() {
+            guard monitor == nil else { return }
+            
+            monitor = createMonitor()
+            monitor?.start(queue: .global())
+        }
+        
+        func stop() {
+            monitor?.cancel()
+            monitor = nil
+            delegate?.internetConnectionStatusDidChange(status: .unknown)
+        }
+        
+        private func createMonitor() -> NWPathMonitor {
+            let monitor = NWPathMonitor()
+            monitor.pathUpdateHandler = { [unowned self] in self.updateStatus(with: $0) }
+            return monitor
+        }
+        
+        private func updateStatus(with path: NWPath) {
+            log.info("Internet Connection info: \(path.debugDescription)")
+            delegate?.internetConnectionStatusDidChange(status: status(from: path))
+        }
+        
+        private func status(from path: NWPath) -> InternetConnection.Status {
+            guard path.status == .satisfied else {
+                return .unavailable
+            }
+            
+            let quality: InternetConnection.Quality
+            
+            if #available(iOS 13.0, *) {
+                quality = path.isConstrained ? .constrained : (path.isExpensive ? .expensive : .great)
+            } else {
+                quality = path.isExpensive ? .expensive : .great
+            }
+            
+            return .available(quality)
+        }
+    }
+}
+
+// MARK: Legacy Internet Connection Monitor for iOS 11 only
+
+private extension InternetConnection {
+    class LegacyMonitor: InternetConnectionMonitor {
+        /// A Reachability instance for Internet connection monitoring.
+        private lazy var reachability = createReachability()
+        
+        weak var delegate: InternetConnectionDelegate?
+        
+        var status: InternetConnection.Status {
+            if let reachability = reachability {
+                return status(from: reachability)
+            }
+            
+            return .unknown
+        }
+        
+        func start() {
+            DispatchQueue.main.async {
+                guard let reachability = self.reachability else {
+                    return
+                }
+                
+                do {
+                    try reachability.startNotifier()
+                } catch {
+                    log.error(error)
+                }
+            }
+        }
+        
+        func stop() {
+            DispatchQueue.main.async {
+                self.reachability?.stopNotifier()
+                self.delegate?.internetConnectionStatusDidChange(status: .unknown)
+            }
+        }
+        
+        private func createReachability() -> Reachability? {
+            var reachability: Reachability?
+            
+            do {
+                reachability = try Reachability()
+                reachability?.whenReachable = { [unowned self] in self.updateStatus(with: $0) }
+                reachability?.whenUnreachable = { [unowned self] in self.updateStatus(with: $0) }
+            } catch {
+                log.error(error)
+            }
+            
+            return reachability
+        }
+        
+        private func updateStatus(with reachability: Reachability) {
+            log.info("Internet Connection info: \(reachability.description)")
+            
+            if case .unavailable = reachability.connection {
+                delegate?.internetConnectionStatusDidChange(status: .unavailable)
+                return
+            }
+            
+            let quality: InternetConnection.Quality
+            
+            if case .cellular = reachability.connection {
+                quality = .expensive
+            } else {
+                quality = .great
+            }
+            
+            delegate?.internetConnectionStatusDidChange(status: .available(quality))
+        }
+        
+        private func status(from reachability: Reachability) -> InternetConnection.Status {
+            if case .unavailable = reachability.connection {
+                return .unavailable
+            }
+            
+            let quality: InternetConnection.Quality
+            
+            if case .cellular = reachability.connection {
+                quality = .expensive
+            } else {
+                quality = .great
+            }
+            
+            return .available(quality)
+        }
+    }
+}

--- a/Sources_v3/Utils/Internet Connection/InternetConnection_Tests.swift
+++ b/Sources_v3/Utils/Internet Connection/InternetConnection_Tests.swift
@@ -1,0 +1,71 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+class InternetConnection_Tests: XCTestCase {
+    var monitor: InternetConnectionMonitorMock!
+    var internetConnection: InternetConnection!
+    
+    override func setUp() {
+        super.setUp()
+        monitor = InternetConnectionMonitorMock()
+        internetConnection = InternetConnection(monitor: monitor)
+    }
+
+    func test_internetConnection_start() throws {
+        let notificationExpectation = expectation(forNotification: .internetConnectionStatusDidChange, object: nil) {
+            $0.userInfo?[InternetConnection.statusUserInfoKey] as? InternetConnection.Status == .available(.great)
+        }
+        
+        XCTAssertEqual(internetConnection.status, .unknown)
+        internetConnection.start()
+        XCTAssertTrue(monitor.isStarted)
+        XCTAssertEqual(internetConnection.status, .available(.great))
+        wait(for: [notificationExpectation], timeout: 5)
+    }
+
+    func test_internetConnection_stop() throws {
+        var notificationStatuses = [InternetConnection.Status]()
+        
+        let notificationExpectation = expectation(forNotification: .internetConnectionStatusDidChange, object: nil) {
+            if let status = $0.userInfo?[InternetConnection.statusUserInfoKey] as? InternetConnection.Status {
+                notificationStatuses.append(status)
+            }
+            
+            return true
+        }
+        
+        internetConnection.start()
+        XCTAssertTrue(monitor.isStarted)
+        internetConnection.stop()
+        XCTAssertFalse(monitor.isStarted)
+        XCTAssertEqual(internetConnection.status, .unknown)
+        wait(for: [notificationExpectation], timeout: 5)
+        XCTAssertEqual(notificationStatuses, [.available(.great), .unknown])
+    }
+}
+
+class InternetConnectionMonitorMock: InternetConnectionMonitor {
+    weak var delegate: InternetConnectionDelegate?
+    
+    var status: InternetConnection.Status = .unknown {
+        didSet {
+            delegate?.internetConnectionStatusDidChange(status: status)
+        }
+    }
+    
+    var isStarted = false
+    
+    func start() {
+        isStarted = true
+        status = .available(.great)
+    }
+    
+    func stop() {
+        isStarted = false
+        status = .unknown
+    }
+}

--- a/Sources_v3/Utils/Internet Connection/Reachability_Vendor.swift
+++ b/Sources_v3/Utils/Internet Connection/Reachability_Vendor.swift
@@ -1,0 +1,351 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import SystemConfiguration
+
+enum ReachabilityError: Error {
+    case failedToCreateWithAddress(sockaddr, Int32)
+    case failedToCreateWithHostname(String, Int32)
+    case unableToSetCallback(Int32)
+    case unableToSetDispatchQueue(Int32)
+    case unableToGetFlags(Int32)
+}
+
+class Reachability {
+    typealias NetworkReachable = (Reachability) -> Void
+    typealias NetworkUnreachable = (Reachability) -> Void
+    
+    enum Connection: CustomStringConvertible {
+        case unavailable, wifi, cellular
+        
+        var description: String {
+            switch self {
+            case .cellular: return "Cellular"
+            case .wifi: return "WiFi"
+            case .unavailable: return "No Connection"
+            }
+        }
+    }
+    
+    var whenReachable: NetworkReachable?
+    var whenUnreachable: NetworkUnreachable?
+    
+    /// Set to `false` to force Reachability.connection to .none when on cellular connection (default value `true`)
+    var allowsCellularConnection: Bool
+    
+    var connection: Connection {
+        if flags == nil {
+            try? setReachabilityFlags()
+        }
+        
+        switch flags?.connection {
+        case .unavailable?, nil: return .unavailable
+        case .cellular?: return allowsCellularConnection ? .cellular : .unavailable
+        case .wifi?: return .wifi
+        }
+    }
+    
+    private var isRunningOnDevice: Bool = {
+        #if targetEnvironment(simulator)
+            return false
+        #else
+            return true
+        #endif
+    }()
+    
+    private(set) var notifierRunning = false
+    private let reachabilityRef: SCNetworkReachability
+    private let reachabilitySerialQueue: DispatchQueue
+    private let notificationQueue: DispatchQueue?
+    
+    private(set) var flags: SCNetworkReachabilityFlags? {
+        didSet {
+            guard flags != oldValue else { return }
+            notifyReachabilityChanged()
+        }
+    }
+    
+    required init(
+        reachabilityRef: SCNetworkReachability,
+        queueQoS: DispatchQoS = .default,
+        targetQueue: DispatchQueue? = nil,
+        notificationQueue: DispatchQueue? = .main
+    ) {
+        allowsCellularConnection = true
+        self.reachabilityRef = reachabilityRef
+        reachabilitySerialQueue = DispatchQueue(
+            label: "io.getstream.StreamChatClient.reachability",
+            qos: queueQoS,
+            target: targetQueue
+        )
+        self.notificationQueue = notificationQueue
+    }
+    
+    convenience init(
+        hostname: String,
+        queueQoS: DispatchQoS = .default,
+        targetQueue: DispatchQueue? = nil,
+        notificationQueue: DispatchQueue? = .main
+    ) throws {
+        guard let ref = SCNetworkReachabilityCreateWithName(nil, hostname) else {
+            throw ReachabilityError.failedToCreateWithHostname(hostname, SCError())
+        }
+        
+        self.init(reachabilityRef: ref, queueQoS: queueQoS, targetQueue: targetQueue, notificationQueue: notificationQueue)
+    }
+    
+    convenience init(
+        queueQoS: DispatchQoS = .default,
+        targetQueue: DispatchQueue? = nil,
+        notificationQueue: DispatchQueue? = .main
+    ) throws {
+        var zeroAddress = sockaddr()
+        zeroAddress.sa_len = UInt8(MemoryLayout<sockaddr>.size)
+        zeroAddress.sa_family = sa_family_t(AF_INET)
+        
+        guard let ref = SCNetworkReachabilityCreateWithAddress(nil, &zeroAddress) else {
+            throw ReachabilityError.failedToCreateWithAddress(zeroAddress, SCError())
+        }
+        
+        self.init(reachabilityRef: ref, queueQoS: queueQoS, targetQueue: targetQueue, notificationQueue: notificationQueue)
+    }
+    
+    deinit {
+        stopNotifier()
+    }
+}
+
+extension Reachability {
+    // MARK: - *** Notifier methods ***
+    
+    func startNotifier() throws {
+        guard !notifierRunning else { return }
+        
+        let callback: SCNetworkReachabilityCallBack = { (_, flags, info) in
+            guard let info = info else { return }
+            
+            // `weakifiedReachability` is guaranteed to exist by virtue of our
+            // retain/release callbacks which we provided to the `SCNetworkReachabilityContext`.
+            let weakifiedReachability = Unmanaged<ReachabilityWeakifier>.fromOpaque(info).takeUnretainedValue()
+            
+            // The weak `reachability` _may_ no longer exist if the `Reachability`
+            // object has since been deallocated but a callback was already in flight.
+            weakifiedReachability.reachability?.flags = flags
+        }
+        
+        let weakifiedReachability = ReachabilityWeakifier(reachability: self)
+        let opaqueWeakifiedReachability = Unmanaged<ReachabilityWeakifier>.passUnretained(weakifiedReachability).toOpaque()
+        
+        var context = SCNetworkReachabilityContext(
+            version: 0,
+            info: UnsafeMutableRawPointer(opaqueWeakifiedReachability),
+            retain: { (info: UnsafeRawPointer) -> UnsafeRawPointer in
+                let unmanagedWeakifiedReachability = Unmanaged<ReachabilityWeakifier>
+                    .fromOpaque(info)
+                _ = unmanagedWeakifiedReachability.retain()
+                return UnsafeRawPointer(unmanagedWeakifiedReachability.toOpaque())
+            },
+            release: { (info: UnsafeRawPointer) -> Void in
+                let unmanagedWeakifiedReachability = Unmanaged<ReachabilityWeakifier>
+                    .fromOpaque(info)
+                unmanagedWeakifiedReachability.release()
+            },
+            copyDescription: { (info: UnsafeRawPointer) -> Unmanaged<CFString> in
+                let unmanagedWeakifiedReachability = Unmanaged<ReachabilityWeakifier>
+                    .fromOpaque(info)
+                let weakifiedReachability = unmanagedWeakifiedReachability
+                    .takeUnretainedValue()
+                let description = weakifiedReachability.reachability?.description ?? "nil"
+                return Unmanaged.passRetained(description as CFString)
+            }
+        )
+        
+        if !SCNetworkReachabilitySetCallback(reachabilityRef, callback, &context) {
+            stopNotifier()
+            throw ReachabilityError.unableToSetCallback(SCError())
+        }
+        
+        if !SCNetworkReachabilitySetDispatchQueue(reachabilityRef, reachabilitySerialQueue) {
+            stopNotifier()
+            throw ReachabilityError.unableToSetDispatchQueue(SCError())
+        }
+        
+        // Perform an initial check
+        try setReachabilityFlags()
+        
+        notifierRunning = true
+    }
+    
+    func stopNotifier() {
+        defer { notifierRunning = false }
+        
+        SCNetworkReachabilitySetCallback(reachabilityRef, nil, nil)
+        SCNetworkReachabilitySetDispatchQueue(reachabilityRef, nil)
+    }
+    
+    var description: String {
+        flags?.description ?? "unavailable flags"
+    }
+}
+
+private extension Reachability {
+    func setReachabilityFlags() throws {
+        try reachabilitySerialQueue.sync { [unowned self] in
+            var flags = SCNetworkReachabilityFlags()
+            if !SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags) {
+                self.stopNotifier()
+                throw ReachabilityError.unableToGetFlags(SCError())
+            }
+            
+            self.flags = flags
+        }
+    }
+    
+    func notifyReachabilityChanged() {
+        let notify = { [weak self] in
+            guard let self = self else { return }
+            self.connection != .unavailable ? self.whenReachable?(self) : self.whenUnreachable?(self)
+        }
+        
+        // notify on the configured `notificationQueue`, or the caller's (i.e. `reachabilitySerialQueue`)
+        notificationQueue?.async(execute: notify) ?? notify()
+    }
+}
+
+private extension SCNetworkReachabilityFlags {
+    typealias Connection = Reachability.Connection
+    
+    var connection: Connection {
+        guard isReachableFlagSet else { return .unavailable }
+        
+        // If we're reachable, but not on an iOS device (i.e. simulator), we must be on WiFi
+        #if targetEnvironment(simulator)
+            return .wifi
+        #else
+        
+            var connection = Connection.unavailable
+        
+            if !isConnectionRequiredFlagSet {
+                connection = .wifi
+            }
+        
+            if isConnectionOnTrafficOrDemandFlagSet {
+                if !isInterventionRequiredFlagSet {
+                    connection = .wifi
+                }
+            }
+        
+            if isOnWWANFlagSet {
+                connection = .cellular
+            }
+        
+            return connection
+        #endif
+    }
+    
+    var isOnWWANFlagSet: Bool {
+        #if os(iOS)
+            return contains(.isWWAN)
+        #else
+            return false
+        #endif
+    }
+    
+    var isReachableFlagSet: Bool {
+        contains(.reachable)
+    }
+    
+    var isConnectionRequiredFlagSet: Bool {
+        contains(.connectionRequired)
+    }
+    
+    var isInterventionRequiredFlagSet: Bool {
+        contains(.interventionRequired)
+    }
+    
+    var isConnectionOnTrafficFlagSet: Bool {
+        contains(.connectionOnTraffic)
+    }
+    
+    var isConnectionOnDemandFlagSet: Bool {
+        contains(.connectionOnDemand)
+    }
+    
+    var isConnectionOnTrafficOrDemandFlagSet: Bool {
+        !intersection([.connectionOnTraffic, .connectionOnDemand]).isEmpty
+    }
+    
+    var isTransientConnectionFlagSet: Bool {
+        contains(.transientConnection)
+    }
+    
+    var isLocalAddressFlagSet: Bool {
+        contains(.isLocalAddress)
+    }
+    
+    var isDirectFlagSet: Bool {
+        contains(.isDirect)
+    }
+    
+    var isConnectionRequiredAndTransientFlagSet: Bool {
+        intersection([.connectionRequired, .transientConnection]) == [.connectionRequired, .transientConnection]
+    }
+    
+    var description: String {
+        var info = [String]()
+        isOnWWANFlagSet ? info.append("WWAN") : ()
+        isReachableFlagSet ? info.append("Reachable") : ()
+        isConnectionRequiredFlagSet ? info.append("Required") : ()
+        isTransientConnectionFlagSet ? info.append("Transient") : ()
+        isInterventionRequiredFlagSet ? info.append("InterventionRequired") : ()
+        isConnectionOnTrafficFlagSet ? info.append("ConnectionOnTraffic") : ()
+        isConnectionOnDemandFlagSet ? info.append("ConnectionOnDemand") : ()
+        isLocalAddressFlagSet ? info.append("LocalAddress") : ()
+        isDirectFlagSet ? info.append("Direct") : ()
+        
+        return info.joined(separator: " ")
+    }
+}
+
+/**
+ `ReachabilityWeakifier` weakly wraps the `Reachability` class
+ in order to break retain cycles when interacting with CoreFoundation.
+ 
+ CoreFoundation callbacks expect a pair of retain/release whenever an
+ opaque `info` parameter is provided. These callbacks exist to guard
+ against memory management race conditions when invoking the callbacks.
+ 
+ #### Race Condition
+ 
+ If we passed `SCNetworkReachabilitySetCallback` a direct reference to our
+ `Reachability` class without also providing corresponding retain/release
+ callbacks, then a race condition can lead to crashes when:
+ - `Reachability` is deallocated on thread X
+ - A `SCNetworkReachability` callback(s) is already in flight on thread Y
+ 
+ #### Retain Cycle
+ 
+ If we pass `Reachability` to CoreFoundtion while also providing retain/
+ release callbacks, we would create a retain cycle once CoreFoundation
+ retains our `Reachability` class. This fixes the crashes and his how
+ CoreFoundation expects the API to be used, but doesn't play nicely with
+ Swift/ARC. This cycle would only be broken after manually calling
+ `stopNotifier()` — `deinit` would never be called.
+ 
+ #### ReachabilityWeakifier
+ 
+ By providing both retain/release callbacks and wrapping `Reachability` in
+ a weak wrapper, we:
+ - interact correctly with CoreFoundation, thereby avoiding a crash.
+ See "Memory Management Programming Guide for Core Foundation".
+ - don't alter the API of `Reachability.swift` in any way
+ - still allow for automatic stopping of the notifier on `deinit`.
+ */
+private class ReachabilityWeakifier {
+    weak var reachability: Reachability?
+    init(reachability: Reachability) {
+        self.reachability = reachability
+    }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -239,6 +239,9 @@
 		8AC9CBE224C74DD0006E236C /* NotificationInviteRejected.json in Resources */ = {isa = PBXBuildFile; fileRef = 8AC9CBDB24C74704006E236C /* NotificationInviteRejected.json */; };
 		8AC9CBE424C74ECB006E236C /* NotificationEvents_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC9CBE324C74E54006E236C /* NotificationEvents_Tests.swift */; };
 		8AC9CBE624C7500E006E236C /* NotificationMarkAllRead.json in Resources */ = {isa = PBXBuildFile; fileRef = 8AC9CBE524C74FFE006E236C /* NotificationMarkAllRead.json */; };
+		8AE335A824FCF999002B6677 /* Reachability_Vendor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE335A524FCF999002B6677 /* Reachability_Vendor.swift */; };
+		8AE335A924FCF999002B6677 /* InternetConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE335A624FCF999002B6677 /* InternetConnection.swift */; };
+		8AE335AA24FCF99E002B6677 /* InternetConnection_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE335A424FCF999002B6677 /* InternetConnection_Tests.swift */; };
 		8AE8950D24D8660800E852EC /* PingPongEmojiFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */; };
 		DA15A20424DF257500BE2423 /* ChannelQuery_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA15A20224DF256F00BE2423 /* ChannelQuery_Tests.swift */; };
 		DA7229E424E140600074503A /* ChannelEditDetailPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7229E224E140260074503A /* ChannelEditDetailPayload_Tests.swift */; };
@@ -545,6 +548,9 @@
 		8AD5EDD022E9BB0C005CFAC9 /* RxGesture.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxGesture.framework; path = Carthage/Build/iOS/RxGesture.framework; sourceTree = "<group>"; };
 		8AD5EDD122E9BB0C005CFAC9 /* Nuke.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nuke.framework; path = Carthage/Build/iOS/Nuke.framework; sourceTree = "<group>"; };
 		8AD5EDD222E9BB0C005CFAC9 /* SwiftyGif.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyGif.framework; path = Carthage/Build/iOS/SwiftyGif.framework; sourceTree = "<group>"; };
+		8AE335A424FCF999002B6677 /* InternetConnection_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternetConnection_Tests.swift; sourceTree = "<group>"; };
+		8AE335A524FCF999002B6677 /* Reachability_Vendor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability_Vendor.swift; sourceTree = "<group>"; };
+		8AE335A624FCF999002B6677 /* InternetConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternetConnection.swift; sourceTree = "<group>"; };
 		8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingPongEmojiFormatter.swift; sourceTree = "<group>"; };
 		DA15A20224DF256F00BE2423 /* ChannelQuery_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelQuery_Tests.swift; sourceTree = "<group>"; };
 		DA7229E224E140260074503A /* ChannelEditDetailPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelEditDetailPayload_Tests.swift; sourceTree = "<group>"; };
@@ -721,6 +727,7 @@
 		792A4F3A247FFB7600EAF71D /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				8AE335A324FCF95D002B6677 /* Internet Connection */,
 				79BF83EA248F8EC0007611A1 /* Logger */,
 				79280F6F2487CD2B00CDEB89 /* Atomic.swift */,
 				79280F702487CD2B00CDEB89 /* Atomic_Tests.swift */,
@@ -1229,6 +1236,16 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		8AE335A324FCF95D002B6677 /* Internet Connection */ = {
+			isa = PBXGroup;
+			children = (
+				8AE335A624FCF999002B6677 /* InternetConnection.swift */,
+				8AE335A424FCF999002B6677 /* InternetConnection_Tests.swift */,
+				8AE335A524FCF999002B6677 /* Reachability_Vendor.swift */,
+			);
+			path = "Internet Connection";
+			sourceTree = "<group>";
+		};
 		DAEAF4B624DADA990015FB28 /* Requests */ = {
 			isa = PBXGroup;
 			children = (
@@ -1492,6 +1509,7 @@
 				8A0D649724E579A50017A3C0 /* GuestEndpoints.swift in Sources */,
 				8A62705024B867190040BFD6 /* EventPayload.swift in Sources */,
 				F6778F9A24F5144F005E7D22 /* EventNotificationCenter.swift in Sources */,
+				8AE335A924FCF999002B6677 /* InternetConnection.swift in Sources */,
 				792A4F40247FFDE700EAF71D /* Data+Gzip.swift in Sources */,
 				79E2B84024CAC8D60024752F /* ListDatabaseObserver.swift in Sources */,
 				796610B9248E651800761629 /* EventMiddleware.swift in Sources */,
@@ -1547,6 +1565,7 @@
 				79877A182498E4EE00015F8B /* ChannelEndpoints.swift in Sources */,
 				7964F3BA249A314D002A09EC /* LogDestination.swift in Sources */,
 				F63CC37324E592D30052844D /* MemberEventObserver.swift in Sources */,
+				8AE335A824FCF999002B6677 /* Reachability_Vendor.swift in Sources */,
 				79877A0C2498E4BC00015F8B /* ChannelType.swift in Sources */,
 				79280F4B248523C000CDEB89 /* ConnectionEvents.swift in Sources */,
 				DAFAD6A324DD8E1A0043ED06 /* ChannelEditDetailPayload.swift in Sources */,
@@ -1598,6 +1617,7 @@
 				7964F3AA249A19EA002A09EC /* Filter_Tests.swift in Sources */,
 				F67415C024F0129800C3222F /* UnreadCount.swift in Sources */,
 				79DDF819249CE38B002F4412 /* MockNetworkURLProtocol.swift in Sources */,
+				8AE335AA24FCF99E002B6677 /* InternetConnection_Tests.swift in Sources */,
 				F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */,
 				7922F30A24DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift in Sources */,
 				8A62705E24BE2CD70040BFD6 /* XCTestCase+MockJSON.swift in Sources */,

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,4 @@ ignore:
   - "Tests_v3/"
   - "**/*_Tests.swift"
   - "**/*_Mock.swift"
+  - "**/*_Vendor.swift"


### PR DESCRIPTION
Added `InternetConnection` to monitor the Internet connection.
Basically, it's a wrapper over legacy monitor based on `Reachability` (iOS 11 only) and default monitor based on `Network`.`NWPathMonitor` (iOS 12+).