### PR TITLE
[CIS-259] Channels pagination

### DIFF
--- a/Sample_v3/Samples/SimpleChat/MasterViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/MasterViewController.swift
@@ -17,7 +17,10 @@ class MasterViewController: UITableViewController {
     )
 
     lazy var channelListController: ChannelListController = chatClient
-        .channelListController(query: ChannelListQuery(filter: .in("members", ["broken-waterfall-5"]), options: [.watch]))
+        .channelListController(query: ChannelListQuery(
+            filter: .in("members", ["broken-waterfall-5"]),
+            pagination: [.limit(25)],
+            options: [.watch]))
     
     var detailViewController: DetailViewController? = nil
 
@@ -108,6 +111,12 @@ class MasterViewController: UITableViewController {
         }
     }
 
+    override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if indexPath.section == tableView.numberOfSections - 1 &&
+            indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1 {
+            channelListController.loadNextChannels()
+        }
+    }
 }
 
 // MARK: - Private

--- a/Sources_v3/Controllers/ChannelListController.swift
+++ b/Sources_v3/Controllers/ChannelListController.swift
@@ -129,6 +129,26 @@ public class ChannelListControllerGeneric<ExtraData: ExtraDataTypes>: Controller
     }
 }
 
+// MARK: - Actions
+
+public extension ChannelListControllerGeneric {
+    /// Loads next channels from backend.
+    /// - Parameters:
+    ///   - limit: Limit for page size.
+    ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    ///                 If request fails, the completion will be called with an error.
+    func loadNextChannels(
+        limit: Int = 25,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        var updatedQuery = query
+        updatedQuery.pagination = [.limit(limit), .offset(channels.count)]
+        worker.update(channelListQuery: updatedQuery) { [weak self] error in
+            self?.callback { completion?(error) }
+        }
+    }
+}
+
 extension ChannelListControllerGeneric {
     struct Environment {
         var channelQueryUpdaterBuilder: (

--- a/Sources_v3/Controllers/ChannelListController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController_Tests.swift
@@ -14,6 +14,9 @@ class ChannelListController_Tests: StressTestCase {
     var query: ChannelListQuery!
     
     var controller: ChannelListController!
+    var controllerCallbackQueueID: UUID!
+    /// Workaround for uwrapping **controllerCallbackQueueID!** in each closure that captures it
+    private var callbackQueueID: UUID { controllerCallbackQueueID }
     
     override func setUp() {
         super.setUp()
@@ -22,6 +25,8 @@ class ChannelListController_Tests: StressTestCase {
         client = Client(config: ChatClientConfig(apiKey: .init(.unique)))
         query = .init(filter: .in("members", ["Luke"]))
         controller = ChannelListController(query: query, client: client, environment: env.environment)
+        controllerCallbackQueueID = UUID()
+        controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)
     }
     
     override func tearDown() {
@@ -230,6 +235,46 @@ class ChannelListController_Tests: StressTestCase {
         let channel: Channel = client.databaseContainer.viewContext.loadChannel(cid: cid)!
         
         AssertAsync.willBeEqual(delegate.didChangeChannels_changes, [.insert(channel, index: [0, 0])])
+    }
+    
+    // MARK: - Channels pagination
+    
+    func test_loadNextChannels_callsChannelListQueryUpdater() {
+        var completionCalled = false
+        let limit = 42
+        controller.loadNextChannels(limit: limit) { [callbackQueueID] error in
+            AssertTestQueue(withId: callbackQueueID)
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+        
+        // Completion shouldn't be called yet
+        XCTAssertFalse(completionCalled)
+        
+        // Simulate successfull udpate
+        env!.channelQueryUpdater?.update_completion?(nil)
+        
+        // Completion should be called
+        AssertAsync.willBeTrue(completionCalled)
+        
+        // Assert correct `Pagination` is created
+        XCTAssertEqual(env!.channelQueryUpdater?.update_query?.pagination, [.limit(limit), .offset(controller.channels.count)])
+    }
+    
+    func test_loadNextChannels_callsChannelUpdaterWithError() {
+        // Simulate `loadNextChannels` call and catch the completion
+        var completionCalledError: Error?
+        controller.loadNextChannels { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionCalledError = $0
+        }
+        
+        // Simulate failed udpate
+        let testError = TestError()
+        env.channelQueryUpdater!.update_completion?(testError)
+        
+        // Completion should be called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
     }
 }
 

--- a/Sources_v3/Query/ChannelListQuery.swift
+++ b/Sources_v3/Query/ChannelListQuery.swift
@@ -22,7 +22,7 @@ public struct ChannelListQuery: Encodable {
     /// A sorting for the query (see `Sorting`).
     public let sort: [Sorting<ChannelListSortingKey>]
     /// A pagination.
-    public let pagination: Pagination
+    public var pagination: Pagination
     /// A number of messages inside each channel.
     public let messagesLimit: Pagination
     /// Query options.


### PR DESCRIPTION
**In this PR:**

- Implement channels pagination in `ChannelListController`
- Make use of pagination in `SampleApp`

_**Q**: I’m not doing any checks for empty `channels` in `loadNextChannels` function cause it’s not an issue to have 0 offset. But there is a possibility that this function will be called successfully before `startUpdating` call. (`channels` has empty array as fallback value) If we want to restrict this we can check for controller `state` but I’m not sure if we should do that._ 