### PR TITLE
[CIS-264] Delegate type erasers auto-generation

### DIFF
--- a/Sources_v3/.swiftlint.yml
+++ b/Sources_v3/.swiftlint.yml
@@ -60,3 +60,6 @@ cyclomatic_complexity:
   ignores_case_statements: true
   warning: 25
   error: 30
+
+excluded:
+  - Generated

--- a/Sources_v3/Generated/TypeErasure.generated.swift
+++ b/Sources_v3/Generated/TypeErasure.generated.swift
@@ -1,0 +1,85 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - CurrentUserControllerDelegateGeneric
+
+final class AnyCurrentUserControllerDelegate<ExtraData: ExtraDataTypes>: CurrentUserControllerDelegateGeneric {
+    weak var wrappedDelegate: AnyObject?
+    private let _currentUserControllerDidChangeCurrentUserUnreadCount: (CurrentUserControllerGeneric<ExtraData>, UnreadCount)
+        -> Void
+    private let _currentUserControllerDidChangeCurrentUser: (
+        CurrentUserControllerGeneric<ExtraData>,
+        EntityChange<CurrentUserModel<ExtraData.User>>
+    ) -> Void
+    private let _controllerDidChangeState: (Controller, Controller.State) -> Void
+
+    init(
+        wrappedDelegate: AnyObject?,
+        currentUserControllerDidChangeCurrentUserUnreadCount: @escaping (CurrentUserControllerGeneric<ExtraData>, UnreadCount)
+            -> Void,
+        currentUserControllerDidChangeCurrentUser: @escaping (
+            CurrentUserControllerGeneric<ExtraData>,
+            EntityChange<CurrentUserModel<ExtraData.User>>
+        ) -> Void,
+        controllerDidChangeState: @escaping (Controller, Controller.State) -> Void
+    ) {
+        self.wrappedDelegate = wrappedDelegate
+        _currentUserControllerDidChangeCurrentUserUnreadCount = currentUserControllerDidChangeCurrentUserUnreadCount
+        _currentUserControllerDidChangeCurrentUser = currentUserControllerDidChangeCurrentUser
+        _controllerDidChangeState = controllerDidChangeState
+    }
+
+    func currentUserController(
+        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        didChangeCurrentUserUnreadCount count: UnreadCount
+    ) {
+        _currentUserControllerDidChangeCurrentUserUnreadCount(controller, count)
+    }
+
+    func currentUserController(
+        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        didChangeCurrentUser change: EntityChange<CurrentUserModel<ExtraData.User>>
+    ) {
+        _currentUserControllerDidChangeCurrentUser(controller, change)
+    }
+
+    func controller(_ controller: Controller, didChangeState state: Controller.State) {
+        _controllerDidChangeState(controller, state)
+    }
+}
+
+extension AnyCurrentUserControllerDelegate {
+    convenience init<Delegate: CurrentUserControllerDelegateGeneric>(_ delegate: Delegate) where Delegate.ExtraData == ExtraData {
+        self.init(
+            wrappedDelegate: delegate,
+            currentUserControllerDidChangeCurrentUserUnreadCount: { [weak delegate] (controller, count) in
+                guard let delegate = delegate else { return }
+
+                let function = delegate.currentUserController(_:didChangeCurrentUserUnreadCount:)
+                let args = (controller, count)
+                call(function, with: args)
+            },
+            currentUserControllerDidChangeCurrentUser: { [weak delegate] (controller, change) in
+                guard let delegate = delegate else { return }
+
+                let function = delegate.currentUserController(_:didChangeCurrentUser:)
+                let args = (controller, change)
+                call(function, with: args)
+            },
+            controllerDidChangeState: { [weak delegate] (controller, state) in
+                guard let delegate = delegate else { return }
+
+                let function = delegate.controller(_:didChangeState:)
+                let args = (controller, state)
+                call(function, with: args)
+            }
+        )
+    }
+}
+
+private func call<T, U>(_ closure: (T) -> U, with args: T) -> U {
+    closure(args)
+}

--- a/Sources_v3/Templates/TypeErasure.stencil
+++ b/Sources_v3/Templates/TypeErasure.stencil
@@ -1,0 +1,55 @@
+import Foundation
+{% macro swiftifyMethodName method %}{{ method.selectorName | replace:"(","_" | replace:")","" | replace:":","_" | replace:"`","" | snakeToCamelCase | lowerFirstWord }}{% endmacro %}
+{% macro methodClosure method %}({% for param in method.parameters %}{{ param.typeName }}{{ ', ' if not forloop.last }}{% endfor %}){{ ' throws' if method.throws }} -> {{ method.returnTypeName }}{% endmacro %}
+{% macro getAssosiatedTypes p %}{% for key in p.associatedTypes %}{{ p.associatedTypes[key].name }}: {{ p.associatedTypes[key].typeName }}{{ ', ' if not forloop.last }}{% endfor %}{% endmacro %}
+{% macro typeErasureName type %}Any{{ type.name|replace:"Generic","" }}{% endmacro %}
+
+{% for type in types.protocols|annotated:"TypeErase" %}
+// MARK: - {{type.name}}
+
+final class {% call typeErasureName type %}<{% call getAssosiatedTypes type %}>: {{ type.name }} {
+    weak var wrappedDelegate: AnyObject?
+    {% for method in type.allMethods|!definedInExtension %}
+    private let _{% call swiftifyMethodName method %}: {% call methodClosure method %}
+    {% endfor %}
+
+    init(
+        wrappedDelegate: AnyObject?,
+        {% for method in type.allMethods|!definedInExtension %}
+        {% call swiftifyMethodName method %}: @escaping {% call methodClosure method %}{{ ',' if not forloop.last }}
+        {% endfor %}
+    ) {
+        self.wrappedDelegate = wrappedDelegate
+        {% for method in type.allMethods|!definedInExtension %}
+        _{% call swiftifyMethodName method %} = {% call swiftifyMethodName method %}
+        {% endfor %}
+    }
+
+    {% for method in type.allMethods|!definedInExtension %}
+    func {{ method.name }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
+        {{ 'try ' if method.throws }}_{% call swiftifyMethodName method %}({% for param in method.parameters %}{{ param.name }}{{ ', ' if not forloop.last }}{% endfor %})
+    }
+    {% endfor %}
+}
+
+extension {% call typeErasureName type %} {
+    convenience init<Delegate: {{ type.name }}>(_ delegate: Delegate) where {% for key in type.associatedTypes %}Delegate.{{ type.associatedTypes[key].name }} == {{ type.associatedTypes[key].name }}{{ ', ' if not forloop.last }}{% endfor %} {
+        self.init(
+            wrappedDelegate: delegate,
+            {% for method in type.allMethods|!definedInExtension %}
+            {% call swiftifyMethodName method %}: { [weak delegate] ({% for p in method.parameters %}{{ p.name }}{{ ', ' if not forloop.last }}{% endfor %}) in
+                guard let delegate = delegate else { return }
+
+                let function = delegate.{{method.selectorName}}
+                let args = ({% for p in method.parameters %}{{ p.name }}{{ ', ' if not forloop.last }}{% endfor %})
+                call(function, with: args)
+            }{{ ',' if not forloop.last }}
+            {% endfor %}
+        )
+    }
+}
+
+{% endfor %}
+private func call<T, U>(_ closure: (T) -> U, with args: T) -> U {
+    closure(args)
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -261,6 +261,7 @@
 		F69C4BC424F664A700A3D740 /* EventNotificationCenter_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69C4BC324F664A700A3D740 /* EventNotificationCenter_Tests.swift */; };
 		F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69C4BC524F66CC200A3D740 /* EventLogger.swift */; };
 		F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */; };
+		F6E9B48A24F9166800AB5B86 /* TypeErasure.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E9B48924F9166800AB5B86 /* TypeErasure.generated.swift */; };
 		F6C56D1424F7B89D0012BB1F /* EventMiddleware_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */; };
 		F6C56D1624F7BCFF0012BB1F /* HealthCheckMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56D1524F7BCFF0012BB1F /* HealthCheckMiddleware_Tests.swift */; };
 /* End PBXBuildFile section */
@@ -565,6 +566,7 @@
 		F69C4BC324F664A700A3D740 /* EventNotificationCenter_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventNotificationCenter_Tests.swift; sourceTree = "<group>"; };
 		F69C4BC524F66CC200A3D740 /* EventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogger.swift; sourceTree = "<group>"; };
 		F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserController_Tests.swift; sourceTree = "<group>"; };
+		F6E9B48924F9166800AB5B86 /* TypeErasure.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeErasure.generated.swift; sourceTree = "<group>"; };
 		F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware_Mock.swift; sourceTree = "<group>"; };
 		F6C56D1524F7BCFF0012BB1F /* HealthCheckMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthCheckMiddleware_Tests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -859,6 +861,7 @@
 				792A4F412480103A00EAF71D /* Query */,
 				79280F3D2484E33C00CDEB89 /* Errors */,
 				792A4F3A247FFB7600EAF71D /* Utils */,
+				F61ED59B24F3E98D00874777 /* Generated */,
 				799C941D247D2F80001F1104 /* Sources_v3.h */,
 				799C941E247D2F80001F1104 /* Info.plist */,
 			);
@@ -1235,6 +1238,14 @@
 			path = Requests;
 			sourceTree = "<group>";
 		};
+		F61ED59B24F3E98D00874777 /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				F6E9B48924F9166800AB5B86 /* TypeErasure.generated.swift */,
+			);
+			path = Generated;
+			sourceTree = "<group>";
+		};
 		F63CC36D24E591690052844D /* EventObservers */ = {
 			isa = PBXGroup;
 			children = (
@@ -1282,6 +1293,7 @@
 			buildConfigurationList = 799C9420247D2F80001F1104 /* Build configuration list for PBXNativeTarget "StreamChatClient" */;
 			buildPhases = (
 				799C9416247D2F80001F1104 /* Headers */,
+				F61ED59824F3DE0800874777 /* Sourcery */,
 				799C9417247D2F80001F1104 /* Sources */,
 				799C9418247D2F80001F1104 /* Frameworks */,
 				799C9419247D2F80001F1104 /* Resources */,
@@ -1445,6 +1457,24 @@
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint lint ./Sources_v3/\nelse\n  echo \"warning: SwiftLint not installed, (homebrew install swiftlint)\"\nfi\n";
 		};
+		F61ED59824F3DE0800874777 /* Sourcery */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = Sourcery;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which sourcery >/dev/null; then\n  sourcery --sources ./Sources_v3 --templates ./Sources_v3/Templates --output ./Sources_v3/Generated\nelse\n  echo \"warning: Sourcery not installed, (homebrew install sourcery)\"\nfi\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -1505,6 +1535,7 @@
 				7964F3B8249A314D002A09EC /* ConsoleLogDestination.swift in Sources */,
 				799C9445247D3DD2001F1104 /* WebSocketClient.swift in Sources */,
 				797A756624814EF8003CF16D /* SystemEnvironment.swift in Sources */,
+				F6E9B48A24F9166800AB5B86 /* TypeErasure.generated.swift in Sources */,
 				799C9438247D2FB9001F1104 /* ChatClientConfig.swift in Sources */,
 				7964F3B6249A314D002A09EC /* PrefixLogFormatter.swift in Sources */,
 				79A0E9B02498C09900E9BD50 /* ConnectionState.swift in Sources */,

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,6 +10,9 @@ brew install https://raw.githubusercontent.com/nicklockwood/homebrew-core/026935
 brew link swiftformat
 brew switch swiftformat 0.45.6
 
+# Install the latest released sourcery
+brew reinstall sourcery
+
 # Set bash to Strict Mode (http://redsymbol.net/articles/unofficial-bash-strict-mode/)
 set -euo pipefail
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 ignore:
+  - "Sources_v3/Generated"
   - "Tests_v3/"
   - "**/*_Tests.swift"
   - "**/*_Mock.swift"


### PR DESCRIPTION
This PR adds `Sourcery` tool to the project that automatically generates type-erasers for all protocols with `/// sourcery: TypeErase` annotation. The code-generation is added as a build-phase that goes right before the `Compile Sources` phase.

**TBD**
- do we need generated files to be formated by `swiftformat` (currently they are)
- didn't find the way to freeze `Sourcery` package version
- what else we'd like to have generated automatically