### PR TITLE
[CIS-291] ObservableObject for controllers (part 1: `ChannelListController`)

### DIFF
--- a/Sample_v3/LoginViewController.swift
+++ b/Sample_v3/LoginViewController.swift
@@ -67,12 +67,17 @@ extension LoginViewController {
         case .swiftUISimpleChatIndexPath:
             if #available(iOS 13, *) {
                 logIn(apiKey: apiKey, userId: userId, userName: userName, token: token) {
+                    // Ideally, we'd pass the `Client` instance as the environment object and create the list controller later.
+                    let listController = chatClient.channelListController(
+                        query: .init(filter: .in("members", ["broken-waterfall-5"]))
+                    )
+                    
                     DispatchQueue.main.async {
                         UIView.transition(with: self.view.window!, duration: 0.5, options: .transitionFlipFromLeft, animations: {
                             self.view.window?.rootViewController = UIHostingController(
                                 rootView:
                                 NavigationView {
-                                    ChannelListView()
+                                    ChannelListView(channelList: listController.observableObject)
                                 }
                             )
                         })

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
@@ -2,23 +2,21 @@
 // Copyright © 2020 Stream.io Inc. All rights reserved.
 //
 
+import StreamChatClient
 import SwiftUI
 
 @available(iOS 13, *)
 struct ChannelListView: View {
-    @State var channels = [String]()
+    // TODO: It's safer to use `@StateObject` here because `@ObservedObject` can sometimes release the
+    // reference and this will crash.
+    @ObservedObject var channelList: ChannelListController.ObservableObject
 
     var body: some View {
         VStack {
-            List(channels, id: \.self) { channelId in
-                NavigationLink(destination: ChatView(channelId: channelId)) {
-                    Text(channelId)
-                }
-            }.onAppear(perform: loadChannels)
-        }.navigationBarTitle("Channels")
-    }
-    
-    func loadChannels() {
-        channels = ["# StreamChat", "# Foobar", "# Appleseed"]
+            List(channelList.channels, id: \.self) { channel in
+                Text(channel.extraData.name ?? "missing channel name")
+            }
+        }
+        .navigationBarTitle("Channels")
     }
 }

--- a/Sources_v3/ChatClient_Mock.swift
+++ b/Sources_v3/ChatClient_Mock.swift
@@ -1,0 +1,30 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChatClient
+
+extension ChatClient {
+    static var mock: ChatClient {
+        ChatClient(
+            config: .init(apiKey: .init(.unique)),
+            workerBuilders: [],
+            environment: .mock
+        )
+    }
+}
+
+extension Client.Environment where ExtraData == DefaultDataTypes {
+    static var mock: ChatClient.Environment {
+        .init(
+            apiClientBuilder: { _, _, _ in APIClientMock() },
+            webSocketClientBuilder: { _, _, _, _, _ in WebSocketClientMock() },
+            databaseContainerBuilder: { _ in DatabaseContainerMock() },
+            requestEncoderBuilder: { _, _ in DefaultRequestEncoder(baseURL: .unique(), apiKey: .init(.unique)) },
+            requestDecoderBuilder: { DefaultRequestDecoder() },
+            eventDecoderBuilder: { EventDecoder() },
+            notificationCenterBuilder: { _ in EventNotificationCenter() }
+        )
+    }
+}

--- a/Sources_v3/Controllers/ChannelListController+SwiftUI.swift
+++ b/Sources_v3/Controllers/ChannelListController+SwiftUI.swift
@@ -1,0 +1,55 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+@available(iOS 13, *)
+extension ChannelListControllerGeneric {
+    /// A wrapper object that exposes the controller variables in the form of `ObservableObject` to be used in SwiftUI.
+    public var observableObject: ObservableObject { .init(controller: self) }
+    
+    /// A wrapper object for `ChannelListController` type which makes it possible to use the controller comfortably in SwiftUI.
+    public class ObservableObject: SwiftUI.ObservableObject {
+        /// The underlying controller. You can still access it and call methods on it.
+        public let controller: ChannelListControllerGeneric
+        
+        /// The channels matching the query.
+        @Published public private(set) var channels: [ChannelModel<ExtraData>] = []
+        
+        /// The current state of the Controller.
+        @Published public private(set) var state: Controller.State
+        
+        /// Creates a new `ObservableObject` wrapper with the provided controller instance.
+        init(controller: ChannelListControllerGeneric<ExtraData>) {
+            self.controller = controller
+            state = controller.state
+            
+            controller.multicastDelegate.additionalDelegates.append(AnyChannelListControllerDelegate(self))
+            
+            if controller.state == .inactive {
+                // Start updating and load the current data
+                controller.startUpdating()
+            }
+            
+            channels = controller.channels
+        }
+    }
+}
+
+@available(iOS 13, *)
+extension ChannelListControllerGeneric.ObservableObject: ChannelListControllerDelegateGeneric {
+    public func controller(
+        _ controller: ChannelListControllerGeneric<ExtraData>,
+        didChangeChannels changes: [ListChange<ChannelModel<ExtraData>>]
+    ) {
+        // We don't care about detailed changes. We just need to update the `channels` property and keep SwiftUI
+        // deal with the rest.
+        channels = controller.channels
+    }
+    
+    public func controller(_ controller: Controller, didChangeState state: Controller.State) {
+        self.state = state
+    }
+}

--- a/Sources_v3/Controllers/ChannelListController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController+SwiftUI_Tests.swift
@@ -1,0 +1,88 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChatClient
+import XCTest
+
+@available(iOS 13, *)
+class ChannelListController_SwiftUI_Tests: XCTestCase {
+    var channelListController: ChannelListControllerMock!
+    
+    override func setUp() {
+        super.setUp()
+        channelListController = ChannelListControllerMock()
+    }
+    
+    func test_startUpdatingIsCalled_whenObservableObjectCreated() {
+        assert(channelListController.startUpdating_called == false)
+        _ = channelListController.observableObject
+        XCTAssertTrue(channelListController.startUpdating_called)
+    }
+    
+    func test_controllerInitialValuesAreLoaded() {
+        channelListController.state_simulated = .localDataFetched
+        channelListController.channels_simulated = [.init(cid: .unique, extraData: .defaultValue)]
+        
+        let observableObject = channelListController.observableObject
+        
+        XCTAssertEqual(observableObject.state, channelListController.state)
+        XCTAssertEqual(observableObject.channels, channelListController.channels)
+    }
+    
+    func test_observableObject_reactsToDelegateChannelChangesCallback() {
+        let observableObject = channelListController.observableObject
+        
+        // Simulate channel change
+        let newChannel: Channel = .init(cid: .unique, extraData: .defaultValue)
+        channelListController.channels_simulated = [newChannel]
+        channelListController.delegateCallback {
+            $0.controller(
+                self.channelListController,
+                didChangeChannels: [.insert(newChannel, index: [0, 1])]
+            )
+        }
+        
+        AssertAsync.willBeEqual(observableObject.channels, [newChannel])
+    }
+    
+    func test_observableObject_reactsToDelegateStateChangesCallback() {
+        let observableObject = channelListController.observableObject
+        
+        // Simulate state change
+        let newState: Controller.State = .remoteDataFetchFailed(ClientError(with: TestError()))
+        channelListController.state_simulated = newState
+        channelListController.delegateCallback {
+            $0.controller(
+                self.channelListController,
+                didChangeState: newState
+            )
+        }
+        
+        AssertAsync.willBeEqual(observableObject.state, newState)
+    }
+}
+
+class ChannelListControllerMock: ChannelListController {
+    @Atomic var startUpdating_called = false
+    
+    var channels_simulated: [ChannelModel<DefaultDataTypes>]?
+    override var channels: [ChannelModel<DefaultDataTypes>] {
+        channels_simulated ?? super.channels
+    }
+
+    var state_simulated: Controller.State?
+    override var state: Controller.State {
+        get { state_simulated ?? super.state }
+        set { super.state = newValue }
+    }
+    
+    init() {
+        super.init(query: .init(filter: .none), client: .mock)
+    }
+
+    override func startUpdating(_ completion: ((Error?) -> Void)? = nil) {
+        startUpdating_called = true
+    }
+}

--- a/Sources_v3/Controllers/ChannelListController.swift
+++ b/Sources_v3/Controllers/ChannelListController.swift
@@ -75,10 +75,6 @@ public class ChannelListControllerGeneric<ExtraData: ExtraDataTypes>: Controller
         return observer
     }()
     
-    /// An wrapper object that exposes the controller variables in the form of `ObservableObject` to be used in SwiftUI.
-    @available(iOS 13, *)
-    public private(set) lazy var observableObject: ObservableObject = ObservableObject(controller: self)
-    
     private let environment: Environment
     
     /// Creates a new `ChannelListController`.

--- a/Sources_v3/Controllers/Controller_Tests.swift
+++ b/Sources_v3/Controllers/Controller_Tests.swift
@@ -12,7 +12,7 @@ class Controller_Tests: XCTestCase {
         let delegate = TestDelegate()
         
         delegate.expectedQueueId = delegateQueueId
-        controller.stateDelegate = delegate
+        controller.stateMulticastDelegate.mainDelegate = delegate
         controller.callbackQueue = DispatchQueue.testQueue(withId: delegateQueueId)
         
         // Check if state is `inactive` initially.

--- a/Sources_v3/Models/ChannelModel.swift
+++ b/Sources_v3/Models/ChannelModel.swift
@@ -141,9 +141,13 @@ public protocol ChannelExtraData: ExtraData {}
 public protocol AnyChannel {}
 extension ChannelModel: AnyChannel {}
 
-extension ChannelModel: Equatable {
+extension ChannelModel: Hashable {
     public static func == (lhs: ChannelModel<ExtraData>, rhs: ChannelModel<ExtraData>) -> Bool {
         lhs.cid == rhs.cid
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(cid)
     }
 }
 

--- a/Sources_v3/Utils/MulticastDelegate.swift
+++ b/Sources_v3/Utils/MulticastDelegate.swift
@@ -1,0 +1,27 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A wrapper object that allows attaching additional delegates and call the callbacks on all of them.
+///
+/// - Warning: ⚠️ Because `MulticastDelegate` keeps strong references to the delegates, it's strongly recommended to use
+/// an additional wrapper which will make sure the delegate instance is referenced only weakly.
+struct MulticastDelegate<WrappedDelegate> {
+    /// Invokes the delegate callback on all delegates.
+    func invoke(_ action: (WrappedDelegate) -> Void) {
+        if let main = mainDelegate {
+            action(main)
+        }
+        additionalDelegates.forEach { action($0) }
+    }
+    
+    /// The is usually the delegate instance you want to expose to your users as _the_ delegate.
+    // swiftlint:disable:next weak_delegate
+    var mainDelegate: WrappedDelegate?
+    
+    /// Aditional delegates that receive the same callback as the main one. These delegates receive callbacks also when
+    /// the main delegate is not set.
+    var additionalDelegates: [WrappedDelegate] = []
+}

--- a/Sources_v3/Utils/MulticastDelegateTests.swift
+++ b/Sources_v3/Utils/MulticastDelegateTests.swift
@@ -1,0 +1,69 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+class MulticastDelegate_Tests: XCTestCase {
+    // swiftlint:disable:next weak_delegate
+    fileprivate var multicastDelegate: MulticastDelegate<TestDelegate>!
+    
+    override func setUp() {
+        super.setUp()
+        
+        multicastDelegate = .init()
+    }
+
+    func test_mainDelegate_isCalled() {
+        let mainDelegate = TestDelegate()
+        assert(mainDelegate.called == false)
+        
+        multicastDelegate.mainDelegate = mainDelegate
+        multicastDelegate.invoke {
+            $0.called = true
+        }
+        
+        XCTAssertTrue(mainDelegate.called)
+    }
+
+    func test_mainDelegate_isRessetable() {
+        let mainDelegate = TestDelegate()
+        
+        multicastDelegate.mainDelegate = mainDelegate
+        XCTAssert(multicastDelegate.mainDelegate === mainDelegate)
+        
+        multicastDelegate.mainDelegate = nil
+        XCTAssertNil(multicastDelegate.mainDelegate)
+    }
+    
+    func test_additionalDelegate_isCalled_whenNoMainDelegateIsSet() {
+        let additionalDelegate = TestDelegate()
+        
+        multicastDelegate.additionalDelegates.append(additionalDelegate)
+        multicastDelegate.invoke {
+            $0.called = true
+        }
+        
+        XCTAssertTrue(additionalDelegate.called)
+    }
+
+    func test_allDelegates_areCalled() {
+        let mainDelegate = TestDelegate()
+        let additionalDelegate = TestDelegate()
+        
+        multicastDelegate.mainDelegate = mainDelegate
+        multicastDelegate.additionalDelegates.append(additionalDelegate)
+
+        multicastDelegate.invoke {
+            $0.called = true
+        }
+        
+        XCTAssertTrue(mainDelegate.called)
+        XCTAssertTrue(additionalDelegate.called)
+    }
+}
+
+private class TestDelegate {
+    var called = false
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		7988F6B724D15F100004219B /* StressTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7988F6B624D15F100004219B /* StressTestCase.swift */; };
 		7990503224CEEAA600689CDC /* MessageDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */; };
 		7991D83B24F5427E00D21BA3 /* EphemeralValuesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7991D83A24F5427E00D21BA3 /* EphemeralValuesContainer.swift */; };
+		7991D83F24F8F1BF00D21BA3 /* ChatClient_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7991D83E24F8F1BF00D21BA3 /* ChatClient_Mock.swift */; };
 		799BE2EA248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799BE2E9248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift */; };
 		799BE2EC248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799BE2EB248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift */; };
 		799C941F247D2F80001F1104 /* Sources_v3.h in Headers */ = {isa = PBXBuildFile; fileRef = 799C941D247D2F80001F1104 /* Sources_v3.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -405,6 +406,7 @@
 		7988F6B624D15F100004219B /* StressTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StressTestCase.swift; sourceTree = "<group>"; };
 		7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDTO_Tests.swift; sourceTree = "<group>"; };
 		7991D83A24F5427E00D21BA3 /* EphemeralValuesContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EphemeralValuesContainer.swift; sourceTree = "<group>"; };
+		7991D83E24F8F1BF00D21BA3 /* ChatClient_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatClient_Mock.swift; sourceTree = "<group>"; };
 		799BE2E9248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketReconnectionStrategy.swift; sourceTree = "<group>"; };
 		799BE2EB248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketReconnectionStrategy_Tests.swift; sourceTree = "<group>"; };
 		799C941B247D2F80001F1104 /* StreamChatClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -866,6 +868,7 @@
 			children = (
 				79A0E9AC2498BD0C00E9BD50 /* ChatClient.swift */,
 				799C942F247D2FB9001F1104 /* ChatClient_Tests.swift */,
+				7991D83E24F8F1BF00D21BA3 /* ChatClient_Mock.swift */,
 				7962958A2481473A0078EB53 /* Config */,
 				799C9426247D2FB9001F1104 /* WebSocketClient */,
 				799C9435247D2FB9001F1104 /* APIClient */,
@@ -1635,6 +1638,7 @@
 				799C947D247E6114001F1104 /* TestError.swift in Sources */,
 				799C946A247D791A001F1104 /* AssertAsync.swift in Sources */,
 				F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */,
+				7991D83F24F8F1BF00D21BA3 /* ChatClient_Mock.swift in Sources */,
 				792921CB24C077B400116BBB /* TestDispatchQueue.swift in Sources */,
 				79B5517724E595DA00CE9FEC /* CurrentUserPayloads_Tests.swift in Sources */,
 				79280F8324891C6A00CDEB89 /* VirtualTime_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		7990503224CEEAA600689CDC /* MessageDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */; };
 		7991D83B24F5427E00D21BA3 /* EphemeralValuesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7991D83A24F5427E00D21BA3 /* EphemeralValuesContainer.swift */; };
 		7991D83F24F8F1BF00D21BA3 /* ChatClient_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7991D83E24F8F1BF00D21BA3 /* ChatClient_Mock.swift */; };
+		7991D83D24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7991D83C24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift */; };
 		799BE2EA248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799BE2E9248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift */; };
 		799BE2EC248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799BE2EB248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift */; };
 		799C941F247D2F80001F1104 /* Sources_v3.h in Headers */ = {isa = PBXBuildFile; fileRef = 799C941D247D2F80001F1104 /* Sources_v3.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -153,6 +154,7 @@
 		79C8C6F524AE291C002E64D7 /* StreamChatClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 799C941B247D2F80001F1104 /* StreamChatClient.framework */; };
 		79CD959224F9380B00E87377 /* MulticastDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CD959124F9380B00E87377 /* MulticastDelegate.swift */; };
 		79CD959424F9381700E87377 /* MulticastDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CD959324F9381700E87377 /* MulticastDelegateTests.swift */; };
+		79CD959624F9414700E87377 /* ChannelListController+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CD959524F9414700E87377 /* ChannelListController+SwiftUI_Tests.swift */; };
 		79CDE1DD24B321FE0003BD1D /* CurrentUserDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CDE1DC24B321FE0003BD1D /* CurrentUserDTO.swift */; };
 		79DDF80E249CB920002F4412 /* RequestDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF80D249CB920002F4412 /* RequestDecoder.swift */; };
 		79DDF810249CB92E002F4412 /* RequestDecoder_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF80F249CB92E002F4412 /* RequestDecoder_Tests.swift */; };
@@ -407,6 +409,7 @@
 		7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDTO_Tests.swift; sourceTree = "<group>"; };
 		7991D83A24F5427E00D21BA3 /* EphemeralValuesContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EphemeralValuesContainer.swift; sourceTree = "<group>"; };
 		7991D83E24F8F1BF00D21BA3 /* ChatClient_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatClient_Mock.swift; sourceTree = "<group>"; };
+		7991D83C24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelListController+SwiftUI.swift"; sourceTree = "<group>"; };
 		799BE2E9248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketReconnectionStrategy.swift; sourceTree = "<group>"; };
 		799BE2EB248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketReconnectionStrategy_Tests.swift; sourceTree = "<group>"; };
 		799C941B247D2F80001F1104 /* StreamChatClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -449,6 +452,7 @@
 		79C750BD2490D0130023F0B7 /* ConnectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionState.swift; sourceTree = "<group>"; };
 		79CD959124F9380B00E87377 /* MulticastDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MulticastDelegate.swift; sourceTree = "<group>"; };
 		79CD959324F9381700E87377 /* MulticastDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MulticastDelegateTests.swift; sourceTree = "<group>"; };
+		79CD959524F9414700E87377 /* ChannelListController+SwiftUI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelListController+SwiftUI_Tests.swift"; sourceTree = "<group>"; };
 		79CDE1DC24B321FE0003BD1D /* CurrentUserDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserDTO.swift; sourceTree = "<group>"; };
 		79DDF80D249CB920002F4412 /* RequestDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestDecoder.swift; sourceTree = "<group>"; };
 		79DDF80F249CB92E002F4412 /* RequestDecoder_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestDecoder_Tests.swift; sourceTree = "<group>"; };
@@ -981,6 +985,8 @@
 				7952B3B224D314B100AC53D4 /* ChannelController_Tests.swift */,
 				792A4F1C247FEA2200EAF71D /* ChannelListController.swift */,
 				792921C824C056F400116BBB /* ChannelListController_Tests.swift */,
+				7991D83C24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift */,
+				79CD959524F9414700E87377 /* ChannelListController+SwiftUI_Tests.swift */,
 				79E2B83F24CAC8D60024752F /* ListDatabaseObserver.swift */,
 				793C14DB24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift */,
 				792AF91524D812440010097B /* EntityDatabaseObserver.swift */,
@@ -1604,6 +1610,7 @@
 				797A756424814E7A003CF16D /* WebSocketConnectPayload.swift in Sources */,
 				797E10A824EAF6DE00353791 /* UniqueId.swift in Sources */,
 				79877A0B2498E4BC00015F8B /* MemberModel.swift in Sources */,
+				7991D83D24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift in Sources */,
 				8A0D64A724E57A520017A3C0 /* GuestUserTokenRequestPayload.swift in Sources */,
 				792FCB4524A33B5B000290C7 /* EventDataProcessorMiddleware.swift in Sources */,
 				79A0E9BE2498C33100E9BD50 /* TypingEvent.swift in Sources */,
@@ -1696,6 +1703,7 @@
 				79A0E9BC2498C31A00E9BD50 /* TypingStartCleanupMiddleware_Tests.swift in Sources */,
 				796610BB248E687000761629 /* EventMiddleware_Tests.swift in Sources */,
 				DA15A20424DF257500BE2423 /* ChannelQuery_Tests.swift in Sources */,
+				79CD959624F9414700E87377 /* ChannelListController+SwiftUI_Tests.swift in Sources */,
 				7988F6B124D010890004219B /* TestRunnerEnvironment.swift in Sources */,
 				799C9469247D791A001F1104 /* AssertResult.swift in Sources */,
 				7952B3B524D45DA300AC53D4 /* ChannelUpdater_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -150,6 +150,8 @@
 		79BF83F2248F8F60007611A1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BF83F1248F8F60007611A1 /* Logger.swift */; };
 		79C750BB248FC4100023F0B7 /* ErrorPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C750BA248FC4100023F0B7 /* ErrorPayload.swift */; };
 		79C8C6F524AE291C002E64D7 /* StreamChatClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 799C941B247D2F80001F1104 /* StreamChatClient.framework */; };
+		79CD959224F9380B00E87377 /* MulticastDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CD959124F9380B00E87377 /* MulticastDelegate.swift */; };
+		79CD959424F9381700E87377 /* MulticastDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CD959324F9381700E87377 /* MulticastDelegateTests.swift */; };
 		79CDE1DD24B321FE0003BD1D /* CurrentUserDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CDE1DC24B321FE0003BD1D /* CurrentUserDTO.swift */; };
 		79DDF80E249CB920002F4412 /* RequestDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF80D249CB920002F4412 /* RequestDecoder.swift */; };
 		79DDF810249CB92E002F4412 /* RequestDecoder_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF80F249CB92E002F4412 /* RequestDecoder_Tests.swift */; };
@@ -443,6 +445,8 @@
 		79BF83F1248F8F60007611A1 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		79C750BA248FC4100023F0B7 /* ErrorPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorPayload.swift; sourceTree = "<group>"; };
 		79C750BD2490D0130023F0B7 /* ConnectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionState.swift; sourceTree = "<group>"; };
+		79CD959124F9380B00E87377 /* MulticastDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MulticastDelegate.swift; sourceTree = "<group>"; };
+		79CD959324F9381700E87377 /* MulticastDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MulticastDelegateTests.swift; sourceTree = "<group>"; };
 		79CDE1DC24B321FE0003BD1D /* CurrentUserDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserDTO.swift; sourceTree = "<group>"; };
 		79DDF80D249CB920002F4412 /* RequestDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestDecoder.swift; sourceTree = "<group>"; };
 		79DDF80F249CB92E002F4412 /* RequestDecoder_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestDecoder_Tests.swift; sourceTree = "<group>"; };
@@ -741,6 +745,8 @@
 				792B805124D95D4300C2963E /* Cached_Tests.swift */,
 				DAFAD6A024DC476A0043ED06 /* Result+Extensions.swift */,
 				797E10A724EAF6DE00353791 /* UniqueId.swift */,
+				79CD959124F9380B00E87377 /* MulticastDelegate.swift */,
+				79CD959324F9381700E87377 /* MulticastDelegateTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1545,6 +1551,7 @@
 				79877A272498E50D00015F8B /* MemberModelDTO.swift in Sources */,
 				7962958C248147430078EB53 /* BaseURL.swift in Sources */,
 				8A0C3BD424C1DF2100CAFD19 /* MessageEvents.swift in Sources */,
+				79CD959224F9380B00E87377 /* MulticastDelegate.swift in Sources */,
 				7964F3BC249A5E60002A09EC /* RequestEncoder.swift in Sources */,
 				79280F712487CD2B00CDEB89 /* Atomic.swift in Sources */,
 				79CDE1DD24B321FE0003BD1D /* CurrentUserDTO.swift in Sources */,
@@ -1680,6 +1687,7 @@
 				8A62706C24BF3DBC0040BFD6 /* ChannelEvents_Tests.swift in Sources */,
 				79280F8424891C6A00CDEB89 /* VirtualTime.swift in Sources */,
 				799C9476247D7E94001F1104 /* TemporaryData.swift in Sources */,
+				79CD959424F9381700E87377 /* MulticastDelegateTests.swift in Sources */,
 				792921C724C047DD00116BBB /* APIClient_Mock.swift in Sources */,
 				79A0E9BC2498C31A00E9BD50 /* TypingStartCleanupMiddleware_Tests.swift in Sources */,
 				796610BB248E687000761629 /* EventMiddleware_Tests.swift in Sources */,


### PR DESCRIPTION
This PR adds and `ObservableObject` wrapper for `ChannelListController` to be used in SwiftUI.

#### Changes:

- We use `MulticastDelegate` to make it possible to attach additional delegates for the wrappers, while keeping the underlying controller fully functional. This is a much better experience than originally designed in #356 , where the wrapped controller wasn't accessible. 
_Note_: Refactoring this was a piece of cake thanks to our existing test coverage 😎 

- The `ObservableObject` wrapper is just a simple object that aggregates the changes reported by the delegate.

- Notice the simplicity of the tests. We don't need to test the actual functionality. We just test that the wrapper listens to the delegate callbacks.