### PR TITLE
[CIS-202] Combine wrapper for `ChannelListController`

### DIFF
--- a/Sample_v3/Samples/SimpleChat/MasterViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/MasterViewController.swift
@@ -2,10 +2,14 @@
 // Copyright © 2020 Stream.io Inc. All rights reserved.
 //
 
+import Combine
 import StreamChatClient
 import UIKit
 
 class MasterViewController: UITableViewController {
+    @available(iOS 13, *)
+    private lazy var cancellables: Set<AnyCancellable> = []
+    
     private lazy var longPressRecognizer = UILongPressGestureRecognizer(
         target: self,
         action: #selector(handleLongPress)
@@ -43,6 +47,12 @@ class MasterViewController: UITableViewController {
         }
 
         tableView.addGestureRecognizer(longPressRecognizer)
+        
+        if #available(iOS 13, *) {
+            channelListController.statePublisher.sink { (state) in
+                print("State changed: \(state)")
+            }.store(in: &cancellables)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Sources_v3/Controllers/ChannelListController+Combine.swift
+++ b/Sources_v3/Controllers/ChannelListController+Combine.swift
@@ -1,0 +1,71 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import UIKit
+
+@available(iOS 13, *)
+extension ChannelListControllerGeneric {
+    /// A publisher emitting a new value every time the state of the controller changes.
+    public var statePublisher: AnyPublisher<Controller.State, Never> {
+        basePublishers.state.keepAlive(self)
+    }
+    
+    /// A publisher emitting a new value every time the list of the channels mathicn the query changes.
+    public var channelsChangesPublisher: AnyPublisher<[ListChange<ChannelModel<ExtraData>>], Never> {
+        basePublishers.channelsChanges.keepAlive(self)
+    }
+
+    /// An internal backing object for all publicly available Combine publishers. We use it to simplify the way we expose
+    /// publishers. Instead of creating custom `Publisher` types, we use `CurrentValueSubject` and `PassthroughSubject` internally,
+    /// and expose the published values by mapping them to a read-only `AnyPublisher` type.
+    class BasePublishers {
+        /// The wrapper controller
+        unowned let controller: ChannelListControllerGeneric
+        
+        /// A backing subject for `remoteActivityPublisher`.
+        let state: CurrentValueSubject<Controller.State, Never>
+        
+        /// A backing subject for `channelChangesPublisher`.
+        let channelsChanges: PassthroughSubject<[ListChange<ChannelModel<ExtraData>>], Never> = .init()
+                
+        init(controller: ChannelListControllerGeneric<ExtraData>) {
+            self.controller = controller
+            state = .init(controller.state)
+            
+            controller.multicastDelegate.additionalDelegates.append(AnyChannelListControllerDelegate(self))
+            
+            if controller.state == .inactive {
+                // Start updating and load the current data
+                controller.startUpdating()
+            }
+        }
+    }
+}
+
+@available(iOS 13, *)
+extension ChannelListControllerGeneric.BasePublishers: ChannelListControllerDelegateGeneric {
+    func controller(_ controller: Controller, didChangeState state: Controller.State) {
+        self.state.send(state)
+    }
+    
+    func controller(
+        _ controller: ChannelListControllerGeneric<ExtraData>,
+        didChangeChannels changes: [ListChange<ChannelModel<ExtraData>>]
+    ) {
+        channelsChanges.send(changes)
+    }
+}
+
+@available(iOS 13.0, *)
+extension Publisher {
+    /// A helper function which attaches the provided object to the publisher chain and keeps it alive as long
+    /// as the publisher chain is alive.
+    func keepAlive(_ object: AnyObject) -> AnyPublisher<Output, Failure> {
+        map {
+            _ = object
+            return $0
+        }.eraseToAnyPublisher()
+    }
+}

--- a/Sources_v3/Controllers/ChannelListController+Combine_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController+Combine_Tests.swift
@@ -1,0 +1,76 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+import CoreData
+@testable import StreamChatClient
+import XCTest
+
+@available(iOS 13, *)
+class ChannelListController_Combine_Tests: XCTestCase {
+    var channelListController: ChannelListControllerMock!
+    var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+        channelListController = ChannelListControllerMock()
+        cancellables = []
+    }
+    
+    override func tearDown() {
+        // Release existing subscriptions and make sure the controller gets released, too
+        cancellables = nil
+        AssertAsync.canBeReleased(&channelListController)
+        super.tearDown()
+    }
+    
+    func test_startUpdatingIsCalled_whenPublisherIsAccessed() {
+        assert(channelListController.startUpdating_called == false)
+        _ = channelListController.statePublisher
+        XCTAssertTrue(channelListController.startUpdating_called)
+    }
+    
+    func test_statePublisher() {
+        // Setup Recording publishers
+        var recording = Record<Controller.State, Never>.Recording()
+        
+        // Setup the chain
+        channelListController
+            .statePublisher
+            .sink(receiveValue: { recording.receive($0) })
+            .store(in: &cancellables)
+        
+        // Keep only the weak reference to the controller. The existing publisher should keep it alive.
+        weak var controller: ChannelListControllerMock? = channelListController
+        channelListController = nil
+        
+        controller?.delegateCallback { $0.controller(controller!, didChangeState: .localDataFetched) }
+        controller?.delegateCallback { $0.controller(controller!, didChangeState: .remoteDataFetched) }
+        
+        XCTAssertEqual(recording.output, [.inactive, .localDataFetched, .remoteDataFetched])
+    }
+
+    func test_channelsChangesPublisher() {
+        // Setup Recording publishers
+        var recording = Record<[ListChange<Channel>], Never>.Recording()
+        
+        // Setup the chain
+        channelListController
+            .channelsChangesPublisher
+            .sink(receiveValue: { recording.receive($0) })
+            .store(in: &cancellables)
+        
+        // Keep only the weak reference to the controller. The existing publisher should keep it alive.
+        weak var controller: ChannelListControllerMock? = channelListController
+        channelListController = nil
+
+        let newChannel: Channel = .init(cid: .unique, extraData: .defaultValue)
+        controller?.channels_simulated = [newChannel]
+        controller?.delegateCallback {
+            $0.controller(controller!, didChangeChannels: [.insert(newChannel, index: [0, 1])])
+        }
+        
+        XCTAssertEqual(recording.output, [[.insert(newChannel, index: [0, 1])]])
+    }
+}

--- a/Sources_v3/Controllers/ChannelListController.swift
+++ b/Sources_v3/Controllers/ChannelListController.swift
@@ -75,6 +75,12 @@ public class ChannelListControllerGeneric<ExtraData: ExtraDataTypes>: Controller
         return observer
     }()
     
+    /// An internal backing object for all publicly available Combine publishers. We use it to simplify the way we expose
+    /// publishers. Instead of creating custom `Publisher` types, we use `CurrentValueSubject` and `PassthroughSubject` internally,
+    /// and expose the published values by mapping them to a read-only `AnyPublisher` type.
+    @available(iOS 13, *)
+    lazy var basePublishers: BasePublishers = .init(controller: self)
+    
     private let environment: Environment
     
     /// Creates a new `ChannelListController`.

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */; };
 		792FCB4B24A3D52A000290C7 /* DatabaseSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4A24A3D52A000290C7 /* DatabaseSession.swift */; };
 		792FCB4D24A3D56D000290C7 /* DatabaseSession_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4C24A3D56D000290C7 /* DatabaseSession_Tests.swift */; };
+		7931818C24FD2660002F8C84 /* ChannelListController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7931818B24FD2660002F8C84 /* ChannelListController+Combine.swift */; };
+		7931818E24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7931818D24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift */; };
 		7937282A2498FFD300E13FE5 /* MemberPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793728292498FFD300E13FE5 /* MemberPayload.swift */; };
 		7937282C249900CB00E13FE5 /* MemberPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7937282B249900CB00E13FE5 /* MemberPayload_Tests.swift */; };
 		793C14DC24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793C14DB24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift */; };
@@ -112,8 +114,8 @@
 		7988F6B724D15F100004219B /* StressTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7988F6B624D15F100004219B /* StressTestCase.swift */; };
 		7990503224CEEAA600689CDC /* MessageDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */; };
 		7991D83B24F5427E00D21BA3 /* EphemeralValuesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7991D83A24F5427E00D21BA3 /* EphemeralValuesContainer.swift */; };
-		7991D83F24F8F1BF00D21BA3 /* ChatClient_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7991D83E24F8F1BF00D21BA3 /* ChatClient_Mock.swift */; };
 		7991D83D24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7991D83C24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift */; };
+		7991D83F24F8F1BF00D21BA3 /* ChatClient_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7991D83E24F8F1BF00D21BA3 /* ChatClient_Mock.swift */; };
 		799BE2EA248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799BE2E9248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift */; };
 		799BE2EC248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799BE2EB248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift */; };
 		799C941F247D2F80001F1104 /* Sources_v3.h in Headers */ = {isa = PBXBuildFile; fileRef = 799C941D247D2F80001F1104 /* Sources_v3.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -357,6 +359,8 @@
 		792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OptionSet+Extensions.swift"; sourceTree = "<group>"; };
 		792FCB4A24A3D52A000290C7 /* DatabaseSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSession.swift; sourceTree = "<group>"; };
 		792FCB4C24A3D56D000290C7 /* DatabaseSession_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSession_Tests.swift; sourceTree = "<group>"; };
+		7931818B24FD2660002F8C84 /* ChannelListController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelListController+Combine.swift"; sourceTree = "<group>"; };
+		7931818D24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelListController+Combine_Tests.swift"; sourceTree = "<group>"; };
 		793728292498FFD300E13FE5 /* MemberPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberPayload.swift; sourceTree = "<group>"; };
 		7937282B249900CB00E13FE5 /* MemberPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberPayload_Tests.swift; sourceTree = "<group>"; };
 		793C14DB24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListDatabaseObserver_Tests.swift; sourceTree = "<group>"; };
@@ -408,8 +412,8 @@
 		7988F6B624D15F100004219B /* StressTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StressTestCase.swift; sourceTree = "<group>"; };
 		7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDTO_Tests.swift; sourceTree = "<group>"; };
 		7991D83A24F5427E00D21BA3 /* EphemeralValuesContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EphemeralValuesContainer.swift; sourceTree = "<group>"; };
-		7991D83E24F8F1BF00D21BA3 /* ChatClient_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatClient_Mock.swift; sourceTree = "<group>"; };
 		7991D83C24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelListController+SwiftUI.swift"; sourceTree = "<group>"; };
+		7991D83E24F8F1BF00D21BA3 /* ChatClient_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatClient_Mock.swift; sourceTree = "<group>"; };
 		799BE2E9248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketReconnectionStrategy.swift; sourceTree = "<group>"; };
 		799BE2EB248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketReconnectionStrategy_Tests.swift; sourceTree = "<group>"; };
 		799C941B247D2F80001F1104 /* StreamChatClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -987,6 +991,8 @@
 				792921C824C056F400116BBB /* ChannelListController_Tests.swift */,
 				7991D83C24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift */,
 				79CD959524F9414700E87377 /* ChannelListController+SwiftUI_Tests.swift */,
+				7931818B24FD2660002F8C84 /* ChannelListController+Combine.swift */,
+				7931818D24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift */,
 				79E2B83F24CAC8D60024752F /* ListDatabaseObserver.swift */,
 				793C14DB24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift */,
 				792AF91524D812440010097B /* EntityDatabaseObserver.swift */,
@@ -1515,6 +1521,7 @@
 				792CA62624CEE93700D70A5E /* ChannelListQueryUpdater.swift in Sources */,
 				79DDF80E249CB920002F4412 /* RequestDecoder.swift in Sources */,
 				8AC9CBD624C73689006E236C /* NotificationEvents.swift in Sources */,
+				7931818C24FD2660002F8C84 /* ChannelListController+Combine.swift in Sources */,
 				8A62706E24BF45360040BFD6 /* BanEnabling.swift in Sources */,
 				79877A0A2498E4BC00015F8B /* Device.swift in Sources */,
 				79280F4F2485308100CDEB89 /* Controller.swift in Sources */,
@@ -1681,6 +1688,7 @@
 				7964F3BE249A5E6E002A09EC /* RequestEncoder_Tests.swift in Sources */,
 				79DDF810249CB92E002F4412 /* RequestDecoder_Tests.swift in Sources */,
 				8A62706A24BF02D80040BFD6 /* XCTAssertEqual+Difference.swift in Sources */,
+				7931818E24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift in Sources */,
 				F6C56D1624F7BCFF0012BB1F /* HealthCheckMiddleware_Tests.swift in Sources */,
 				79877A292498E51500015F8B /* ChannelDTO_Tests.swift in Sources */,
 				DAEAF4B824DC026C0015FB28 /* ChannelEndpoints_Tests.swift in Sources */,

--- a/Tests_v3/Custom Assertions/AssertAsync.swift
+++ b/Tests_v3/Custom Assertions/AssertAsync.swift
@@ -509,7 +509,7 @@ extension AssertAsync {
         line: UInt = #line
     ) {
         AssertAsync {
-            Assert.canBeReleased(&object, timeout: timeout, message: message())
+            Assert.canBeReleased(&object, timeout: timeout, message: message(), file: file, line: line)
         }
     }
 }


### PR DESCRIPTION
This PR follows the same pattern we use for the **SwiftUI** wrapper.

Two interesting bits:
- We use the internal `BasePublishers` object which is shared for all exposed publishers. It simplifies the implementation a lot because we don't need to implement custom `Publisher` types, and we just expose them as `AnyPublisher`.

- We have a `keepAlive(_: AnyObject)` helper on the `Publisher` type. It allows "attaching" any object's lifetime to the lifetime of the publisher chain. Without this helper, the following construct won't work, because the result of the `client.channelListController()`call - the actual controller - would get deallocated and wouldn't listen for database updates:

```swift
client.channelListController(query: ...)
   .channelsChangesPublisher
   .map { ... } 
   .assign(to: ...)
   .store(in: &cancellables)
``` 
