### PR TITLE
[CIS-238] Message actions

### DIFF
--- a/Sources_v3/APIClient/Endpoints/MessageEndpoints.swift
+++ b/Sources_v3/APIClient/Endpoints/MessageEndpoints.swift
@@ -1,0 +1,44 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension Endpoint {
+    static func getMessage<ExtraData: ExtraDataTypes>(messageId: MessageId) -> Endpoint<MessagePayload<ExtraData>> {
+        .init(
+            path: messageId.path,
+            method: .get,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: nil
+        )
+    }
+    
+    static func deleteMessage(messageId: MessageId) -> Endpoint<EmptyResponse> {
+        .init(
+            path: messageId.path,
+            method: .delete,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: nil
+        )
+    }
+    
+    static func editMessage<ExtraData: ExtraDataTypes>(payload: MessageRequestBody<ExtraData>)
+        -> Endpoint<EmptyResponse> {
+        .init(
+            path: payload.id.path,
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["message": payload]
+        )
+    }
+}
+
+private extension MessageId {
+    var path: String {
+        "messages/\(self)"
+    }
+}

--- a/Sources_v3/APIClient/Endpoints/MessageEndpoints_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/MessageEndpoints_Tests.swift
@@ -1,0 +1,67 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class MessageEndpoints_Tests: XCTestCase {
+    func test_getMessage_buildsCorrectly() {
+        let messageId: MessageId = .unique
+        
+        let expectedEndpoint = Endpoint<MessagePayload<DefaultDataTypes>>(
+            path: "messages/\(messageId)",
+            method: .get,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: nil
+        )
+        
+        // Build endpoint
+        let endpoint: Endpoint<MessagePayload<DefaultDataTypes>> = .getMessage(messageId: messageId)
+        
+        // Assert endpoint is built correctly
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
+    
+    func test_deleteMessage_buildsCorrectly() {
+        let messageId: MessageId = .unique
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: "messages/\(messageId)",
+            method: .delete,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: nil
+        )
+        
+        // Build endpoint
+        let endpoint: Endpoint<EmptyResponse> = .deleteMessage(messageId: messageId)
+        
+        // Assert endpoint is built correctly
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
+    
+    func test_editMessage_buildsCorrectly() {
+        let payload = MessageRequestBody<DefaultDataTypes>(
+            id: .unique,
+            user: .init(id: .unique, extraData: .init()),
+            text: .unique,
+            extraData: .init()
+        )
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: "messages/\(payload.id)",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["message": payload]
+        )
+        
+        // Build endpoint
+        let endpoint: Endpoint<EmptyResponse> = .editMessage(payload: payload)
+        
+        // Assert endpoint is built correctly
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
+}

--- a/Sources_v3/ChatClient.swift
+++ b/Sources_v3/ChatClient.swift
@@ -174,7 +174,8 @@ public class Client<ExtraData: ExtraDataTypes> {
         let workerBuilders: [WorkerBuilder] = [
             MessageSender<ExtraData>.init,
             NewChannelQueryUpdater<ExtraData>.init,
-            ChannelWatchStateUpdater<ExtraData>.init
+            ChannelWatchStateUpdater<ExtraData>.init,
+            MessageEditor<ExtraData>.init
         ]
         
         self.init(

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -311,7 +311,7 @@ private class TestDelegateGeneric: QueueAwareDelegate, CurrentUserControllerDele
 }
 
 private class TestEnvironment {
-    var currentUserObserver: MockEntityObserver<CurrentUser, CurrentUserDTO>!
+    var currentUserObserver: EntityDatabaseObserverMock<CurrentUser, CurrentUserDTO>!
     var currentUserObserverStartUpdatingError: Error?
 
     lazy var currentUserControllerEnvironment: CurrentUserController
@@ -327,16 +327,4 @@ private class TestEnvironment {
         self.databaseContainer = try! DatabaseContainerMock(kind: $0)
         return self.databaseContainer
     })
-}
-
-private class MockEntityObserver<Item, DTO: NSManagedObject>: EntityDatabaseObserver<Item, DTO> {
-    var startUpdatingError: Error?
-    
-    override func startObserving() throws {
-        if let error = startUpdatingError {
-            throw error
-        } else {
-            try super.startObserving()
-        }
-    }
 }

--- a/Sources_v3/Controllers/EntityDatabaseObserver_Mock.swift
+++ b/Sources_v3/Controllers/EntityDatabaseObserver_Mock.swift
@@ -1,0 +1,19 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChatClient
+import XCTest
+
+class EntityDatabaseObserverMock<Item, DTO: NSManagedObject>: EntityDatabaseObserver<Item, DTO> {
+    var startUpdatingError: Error?
+    
+    override func startObserving() throws {
+        if let error = startUpdatingError {
+            throw error
+        } else {
+            try super.startObserving()
+        }
+    }
+}

--- a/Sources_v3/Controllers/MessageController/MessageController.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController.swift
@@ -1,0 +1,282 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+public extension Client {
+    /// Creates a new `MessageController` for the message with the provided id.
+    /// - Parameter cid: The channel identifer the message relates to.
+    /// - Parameter messageId: The message identifier.
+    /// - Returns: A new instance of `MessageController`.
+    func messageController(cid: ChannelId, messageId: MessageId) -> MessageControllerGeneric<ExtraData> {
+        .init(client: self, cid: cid, messageId: messageId)
+    }
+}
+
+/// A convenience typealias for `MessageControllerGeneric` with `DefaultDataTypes`.
+public typealias MessageController = MessageControllerGeneric<DefaultDataTypes>
+
+/// The `MessageControllerGeneric` is designed to edit the message it was created with.
+public final class MessageControllerGeneric<ExtraData: ExtraDataTypes>: Controller, DelegateCallable {
+    /// The `ChatClient` instance this controller belongs to.
+    public let client: Client<ExtraData>
+    
+    /// The channel identifier the message is related to.
+    public let cid: ChannelId
+    
+    /// The message identifier this controller manages.
+    public let messageId: MessageId
+    
+    /// The message data
+    /// Always returns `nil` if `startUpdating` was not called
+    /// To observe the updates of this value, set your class as a delegate of this controller and call `startUpdating`.
+    public var message: MessageModel<ExtraData>? {
+        guard state != .inactive else {
+            log.warning("Accessing `message` before calling `startUpdating()` always results in `nil`.")
+            return nil
+        }
+        
+        return messageObserver.item
+    }
+    
+    private let environment: Environment
+    
+    /// A type-erased multicast delegate.
+    var multicastDelegate: MulticastDelegate<AnyMessageControllerDelegate<ExtraData>> = .init() {
+        didSet {
+            stateMulticastDelegate.mainDelegate = multicastDelegate.mainDelegate
+            stateMulticastDelegate.additionalDelegates = multicastDelegate.additionalDelegates
+        }
+    }
+    
+    /// The observer used to listen to message updates
+    private lazy var messageObserver = createMessageObserver()
+        .onChange { [unowned self] change in
+            self.delegateCallback {
+                $0.messageController(self, didChangeMessage: change)
+            }
+        }
+    
+    /// The worker used to fetch the remote data and communicate with servers.
+    private lazy var messageUpdater: MessageUpdater<ExtraData> = environment.messageUpdaterBuilder(
+        client.databaseContainer,
+        client.webSocketClient,
+        client.apiClient
+    )
+
+    /// Creates a new `MessageControllerGeneric`.
+    /// - Parameters:
+    ///   - client: The `Client` instance this controller belongs to.
+    ///   - cid: The channel identifier the message belongs to.
+    ///   - messageId: The message identifier.
+    ///   - environment: The source of internal dependencies.
+    init(client: Client<ExtraData>, cid: ChannelId, messageId: MessageId, environment: Environment = .init()) {
+        self.client = client
+        self.cid = cid
+        self.messageId = messageId
+        self.environment = environment
+    }
+    
+    /// Starts updating the results.
+    ///
+    /// 1. **Synchronously** loads the data for the referenced objects from the local cache. These data are immediately available in
+    /// the `message` property of the controller once this method returns. Any further changes to the data are communicated
+    /// using `delegate`.
+    ///
+    /// 2. It also **asynchronously** fetches the latest version of the data from the servers. Once the remote fetch is completed,
+    /// the completion block is called. If the updated data differ from the locally cached ones, the controller uses the `delegate`
+    /// methods to inform about the changes.
+    ///
+    /// - Parameter completion: Called when the controller has finished fetching remote data.
+    ///                         If the data fetching fails, the `error` variable contains more details about the problem.
+    public func startUpdating(_ completion: ((Error?) -> Void)? = nil) {
+        do {
+            try messageObserver.startObserving()
+        } catch {
+            callback { completion?(ClientError(with: error)) }
+            return
+        }
+        
+        state = .localDataFetched
+        
+        messageUpdater.getMessage(cid: cid, messageId: messageId) { [weak self] error in
+            guard let self = self else { return }
+            self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
+            self.callback { completion?(error) }
+        }
+    }
+}
+
+// MARK: - Actions
+
+public extension MessageControllerGeneric {
+    /// Edits the message this controller manages with the provided values.
+    /// - Parameters:
+    ///   - text: The updated message text.
+    ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    ///                 If request fails, the completion will be called with an error.
+    func editMessage(text: String, completion: ((Error?) -> Void)? = nil) {
+        messageUpdater.editMessage(messageId: messageId, text: text) { [weak self] error in
+            self?.callback {
+                completion?(error)
+            }
+        }
+    }
+    
+    /// Delete the message this controller manages.
+    /// - Parameters:
+    ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    ///                 If request fails, the completion will be called with an error.
+    func deleteMessage(completion: ((Error?) -> Void)? = nil) {
+        messageUpdater.deleteMessage(messageId: messageId) { [weak self] error in
+            self?.callback {
+                completion?(error)
+            }
+        }
+    }
+}
+
+// MARK: - Environment
+
+extension MessageControllerGeneric {
+    struct Environment {
+        var messageObserverBuilder: (
+            _ context: NSManagedObjectContext,
+            _ fetchRequest: NSFetchRequest<MessageDTO>,
+            _ itemCreator: @escaping (MessageDTO) -> MessageModel<ExtraData>,
+            _ fetchedResultsControllerType: NSFetchedResultsController<MessageDTO>.Type
+        ) -> EntityDatabaseObserver<MessageModel<ExtraData>, MessageDTO> = EntityDatabaseObserver.init
+        
+        var messageUpdaterBuilder: (
+            _ database: DatabaseContainer,
+            _ webSocketClient: WebSocketClient,
+            _ apiClient: APIClient
+        ) -> MessageUpdater<ExtraData> = MessageUpdater.init
+    }
+}
+
+// MARK: - Private
+
+private extension MessageControllerGeneric {
+    func createMessageObserver() -> EntityDatabaseObserver<MessageModel<ExtraData>, MessageDTO> {
+        environment.messageObserverBuilder(
+            client.databaseContainer.viewContext,
+            MessageDTO.message(withID: messageId),
+            { $0.asModel() }, // swiftlint:disable:this opening_brace
+            NSFetchedResultsController<MessageDTO>.self
+        )
+    }
+}
+
+// MARK: - Delegate
+
+/// `MessageController` uses this protocol to communicate changes to its delegate.
+///
+/// This protocol can be used only when no custom extra data are specified.
+/// If you're using custom extra data types, please use `MessageControllerDelegateGeneric` instead.
+public protocol MessageControllerDelegate: ControllerStateDelegate {
+    /// The controller observed a change in the `Message`.
+    func messageController(_ controller: MessageController, didChangeMessage change: EntityChange<Message>)
+}
+
+public extension MessageControllerDelegate {
+    func messageController(_ controller: MessageController, didChangeMessage change: EntityChange<Message>) {}
+}
+
+/// `MessageControllerDelegateGeneric` uses this protocol to communicate changes to its delegate.
+///
+/// If you're **not** using custom extra data types, you can use a convenience version of this protocol
+/// named `MessageControllerDelegate`, which hides the generic types, and make the usage easier.
+public protocol MessageControllerDelegateGeneric: ControllerStateDelegate {
+    associatedtype ExtraData: ExtraDataTypes
+    
+    /// The controller observed a change in the `MessageModel<ExtraData>`.
+    func messageController(
+        _ controller: MessageControllerGeneric<ExtraData>,
+        didChangeMessage change: EntityChange<MessageModel<ExtraData>>
+    )
+}
+
+public extension MessageControllerDelegateGeneric {
+    func messageController(
+        _ controller: MessageControllerGeneric<ExtraData>,
+        didChangeMessage change: EntityChange<MessageModel<ExtraData>>
+    ) {}
+}
+
+final class AnyMessageControllerDelegate<ExtraData: ExtraDataTypes>: MessageControllerDelegateGeneric {
+    weak var wrappedDelegate: AnyObject?
+    private var _controllerDidChangeState: (Controller, Controller.State) -> Void
+    private var _messageControllerDidChangeMessage: (MessageControllerGeneric<ExtraData>, EntityChange<MessageModel<ExtraData>>)
+        -> Void
+    
+    init(
+        wrappedDelegate: AnyObject?,
+        controllerDidChangeState: @escaping (Controller, Controller.State) -> Void,
+        messageControllerDidChangeMessage: @escaping (MessageControllerGeneric<ExtraData>, EntityChange<MessageModel<ExtraData>>)
+            -> Void
+    ) {
+        self.wrappedDelegate = wrappedDelegate
+        _controllerDidChangeState = controllerDidChangeState
+        _messageControllerDidChangeMessage = messageControllerDidChangeMessage
+    }
+
+    func controller(_ controller: Controller, didChangeState state: Controller.State) {
+        _controllerDidChangeState(controller, state)
+    }
+
+    func messageController(
+        _ controller: MessageControllerGeneric<ExtraData>,
+        didChangeMessage change: EntityChange<MessageModel<ExtraData>>
+    ) {
+        _messageControllerDidChangeMessage(controller, change)
+    }
+}
+
+extension AnyMessageControllerDelegate {
+    convenience init<Delegate: MessageControllerDelegateGeneric>(_ delegate: Delegate) where Delegate.ExtraData == ExtraData {
+        self.init(
+            wrappedDelegate: delegate,
+            controllerDidChangeState: { [weak delegate] in delegate?.controller($0, didChangeState: $1) },
+            messageControllerDidChangeMessage: { [weak delegate] in delegate?.messageController($0, didChangeMessage: $1) }
+        )
+    }
+}
+
+extension AnyMessageControllerDelegate where ExtraData == DefaultDataTypes {
+    convenience init(_ delegate: MessageControllerDelegate?) {
+        self.init(
+            wrappedDelegate: delegate,
+            controllerDidChangeState: { [weak delegate] in delegate?.controller($0, didChangeState: $1) },
+            messageControllerDidChangeMessage: { [weak delegate] in delegate?.messageController($0, didChangeMessage: $1) }
+        )
+    }
+}
+ 
+public extension MessageControllerGeneric {
+    /// Sets the provided object as a delegate of this controller.
+    ///
+    /// - Note: If you don't use custom extra data types, you can set the delegate directly using `controller.delegate = self`.
+    /// Due to the current limits of Swift and the way it handles protocols with associated types, it's required to use this
+    /// method to set the delegate, if you're using custom extra data types.
+    ///
+    /// - Parameter delegate: The object used as a delegate. It's referenced weakly, so you need to keep the object
+    /// alive if you want keep receiving updates.
+    func setDelegate<Delegate: MessageControllerDelegateGeneric>(_ delegate: Delegate?) where Delegate.ExtraData == ExtraData {
+        multicastDelegate.mainDelegate = delegate.flatMap(AnyMessageControllerDelegate.init)
+    }
+}
+
+public extension MessageController {
+    /// Set the delegate of `MessageController` to observe the changes in the system.
+    ///
+    /// - Note: The delegate can be set directly only if you're **not** using custom extra data types. Due to the current
+    /// limits of Swift and the way it handles protocols with associated types, it's required to use `setDelegate` method
+    /// instead to set the delegate, if you're using custom extra data types.
+    var delegate: MessageControllerDelegate? {
+        set { multicastDelegate.mainDelegate = AnyMessageControllerDelegate(newValue) }
+        get { multicastDelegate.mainDelegate?.wrappedDelegate as? MessageControllerDelegate }
+    }
+}

--- a/Sources_v3/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController_Tests.swift
@@ -1,0 +1,443 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChatClient
+import XCTest
+
+final class MessageController_Tests: StressTestCase {
+    private var env: TestEnvironment!
+    private var client: ChatClient!
+    
+    private var currentUserId: UserId!
+    private var messageId: MessageId!
+    private var cid: ChannelId!
+    
+    private var controller: MessageController!
+    private var controllerCallbackQueueID: UUID!
+    private var callbackQueueID: UUID { controllerCallbackQueueID }
+    
+    // MARK: - Setup
+    
+    override func setUp() {
+        super.setUp()
+        
+        env = TestEnvironment()
+        client = Client.mock
+        
+        currentUserId = .unique
+        messageId = .unique
+        cid = .unique
+        
+        controllerCallbackQueueID = UUID()
+        controller = MessageController(client: client, cid: cid, messageId: messageId, environment: env.controllerEnvironment)
+        controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)
+    }
+    
+    override func tearDown() {
+        controllerCallbackQueueID = nil
+        currentUserId = nil
+        messageId = nil
+        cid = nil
+        
+        AssertAsync {
+            Assert.canBeReleased(&controller)
+            Assert.canBeReleased(&client)
+            Assert.canBeReleased(&env)
+        }
+
+        super.tearDown()
+    }
+    
+    // MARK: - Controller
+    
+    func test_controllerIsCreatedCorrectly() {
+        // Create a controller with specific `cid` and `messageId`
+        let controller = client.messageController(cid: cid, messageId: messageId)
+        
+        // Assert controller has correct `cid`
+        XCTAssertEqual(controller.cid, cid)
+        // Assert controller has correct `messageId`
+        XCTAssertEqual(controller.messageId, messageId)
+    }
+
+    func test_initialState() {
+        // Assert client is assigned correctly
+        XCTAssertTrue(controller.client === client)
+        
+        // Assert initial state is correct
+        XCTAssertEqual(controller.state, .inactive)
+        
+        // Assert message is nil
+        XCTAssertNil(controller.message)
+    }
+    
+    // MARK: - Start updating
+    
+    func test_startUpdating_forwardsObserverError() throws {
+        // Update observer to throw the error
+        let observerError = TestError()
+        env.messageObserver_startUpdatingError = observerError
+        
+        // Simulate `startUpdating` call
+        let completionError = try await(controller.startUpdating)
+        
+        // Assert correct error is received
+        XCTAssertEqual(completionError as? ClientError, ClientError(with: observerError))
+        // Assert controller stays in `.inactive` state
+        XCTAssertEqual(controller.state, .inactive)
+    }
+    
+    func test_startUpdating_forwardsUpdaterError() throws {
+        // Simulate `startUpdating` call
+        var completionError: Error?
+        controller.startUpdating {
+            completionError = $0
+        }
+        
+        // Simulate netrwork response with the error
+        let networkError = TestError()
+        env.messageUpdater.getMessage_completion?(networkError)
+        
+        AssertAsync {
+            // Assert netrwork error is propogated
+            Assert.willBeEqual(completionError as? TestError, networkError)
+            // Assert netrwork error is propogated
+            Assert.willBeEqual(self.controller.state, .remoteDataFetchFailed(ClientError(with: networkError)))
+        }
+    }
+    
+    func test_startUpdating_changesStateCorrectly_ifNoErrorsHappen() throws {
+        // Simulate `startUpdating` call
+        var completionError: Error?
+        var completionCalled = false
+        controller.startUpdating {
+            completionError = $0
+            completionCalled = true
+        }
+        
+        // Assert controller is in `localDataFetched` state
+        XCTAssertEqual(controller.state, .localDataFetched)
+        
+        // Simulate netrwork response with the error
+        env.messageUpdater.getMessage_completion?(nil)
+        
+        AssertAsync {
+            // Assert completion is called
+            Assert.willBeTrue(completionCalled)
+            // Assert completion is called without any error
+            Assert.staysTrue(completionError == nil)
+            // Assert controller is in `remoteDataFetched` state
+            Assert.willBeEqual(self.controller.state, .remoteDataFetched)
+        }
+    }
+    
+    // MARK: - Updates
+
+    func test_messageIsUpToDate_onAllStartUpdatingStages() throws {
+        let messageLocalText: MessageId = .unique
+        
+        // Assert message is `nil` initially
+        XCTAssertNil(controller.message)
+        
+        // Create current user in the database
+        try client.databaseContainer.createCurrentUser(id: currentUserId)
+        
+        // Create message in that matches controller's `messageId`
+        try client.databaseContainer.createMessage(id: messageId, authorId: currentUserId, cid: cid, text: messageLocalText)
+        
+        // Simulate `startUpdating` call
+        var completionCalled = false
+        controller.startUpdating {
+            XCTAssertNil($0)
+            completionCalled = true
+        }
+        
+        // Assert message is fetched from the database and has correct field values
+        var message = try XCTUnwrap(controller.message)
+        XCTAssertEqual(message.id, messageId)
+        XCTAssertEqual(message.text, messageLocalText)
+        
+        // Simulate response from the backend with updated `text`, update the local message in the databse
+        let messagePayload: MessagePayload<DefaultDataTypes> = .dummy(
+            messageId: messageId,
+            authorUserId: currentUserId,
+            text: .unique
+        )
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveMessage(payload: messagePayload, for: self.cid)
+        }
+        env.messageUpdater.getMessage_completion?(nil)
+        
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+        
+        // Assert the controller's `message` is up-to-date
+        message = try XCTUnwrap(controller.message)
+        XCTAssertEqual(message.id, messageId)
+        XCTAssertEqual(message.text, messagePayload.text)
+    }
+
+    // MARK: - Delegate
+
+    func test_delegate_isAssignedCorrectly() {
+        let delegate = TestDelegate()
+
+        // Set the delegate
+        controller.delegate = delegate
+
+        // Assert the delegate is assigned correctly
+        XCTAssert(controller.delegate === delegate)
+    }
+
+    func test_delegate_isNotifiedAboutStateChanges() throws {
+        // Set the delegate
+        let delegate = TestDelegate()
+        delegate.expectedQueueId = controllerCallbackQueueID
+        controller.delegate = delegate
+
+        // Assert no state changes received so far
+        XCTAssertNil(delegate.state)
+
+        // Start updating
+        controller.startUpdating()
+        
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .localDataFetched)
+        
+        // Simulate network call response
+        env.messageUpdater.getMessage_completion?(nil)
+        
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)
+    }
+
+    func test_genericDelegate_isNotifiedAboutStateChanges() throws {
+        // Set the generic delegate
+        let delegate = TestDelegateGeneric()
+        delegate.expectedQueueId = controllerCallbackQueueID
+        controller.setDelegate(delegate)
+
+        // Assert no state changes received so far
+        XCTAssertNil(delegate.state)
+        
+        // Start updating
+        controller.startUpdating()
+        
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .localDataFetched)
+        
+        // Simulate network call response
+        env.messageUpdater.getMessage_completion?(nil)
+        
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)
+    }
+
+    func test_delegate_isNotifiedAboutCreatedMessage() throws {
+        // Create current user in the database
+        try client.databaseContainer.createCurrentUser(id: currentUserId)
+        
+        // Create channel in the database
+        try client.databaseContainer.createChannel(cid: cid)
+        
+        // Set the delegate
+        let delegate = TestDelegate()
+        delegate.expectedQueueId = controllerCallbackQueueID
+        controller.delegate = delegate
+        
+        // Simulate `startUpdating` call
+        controller.startUpdating()
+
+        // Simulate response from a backend with a message that doesn't exist locally
+        let messagePayload: MessagePayload<DefaultDataTypes> = .dummy(
+            messageId: messageId,
+            authorUserId: currentUserId
+        )
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveMessage(payload: messagePayload, for: self.cid)
+        }
+        env.messageUpdater.getMessage_completion?(nil)
+        
+        // Assert `create` entity change is received by the delegate
+        AssertAsync {
+            Assert.willBeEqual(delegate.didChangeMessage_change?.fieldChange(\.id), .create(messagePayload.id))
+            Assert.willBeEqual(delegate.didChangeMessage_change?.fieldChange(\.text), .create(messagePayload.text))
+        }
+    }
+    
+    func test_delegate_isNotifiedAboutUpdatedMessage() throws {
+        let initialMessageText: String = .unique
+
+        // Create current user in the database
+        try client.databaseContainer.createCurrentUser(id: currentUserId)
+        
+        // Create channel in the database
+        try client.databaseContainer.createChannel(cid: cid)
+        
+        // Create message in the database with `initialMessageText`
+        try client.databaseContainer.createMessage(id: messageId, authorId: currentUserId, cid: cid, text: initialMessageText)
+        
+        // Set the delegate
+        let delegate = TestDelegate()
+        delegate.expectedQueueId = controllerCallbackQueueID
+        controller.delegate = delegate
+        
+        // Simulate `startUpdating` call
+        controller.startUpdating()
+        
+        // Simulate response from a backend with a message that exists locally but has out-dated text
+        let messagePayload: MessagePayload<DefaultDataTypes> = .dummy(
+            messageId: messageId,
+            authorUserId: currentUserId,
+            text: "new text"
+        )
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveMessage(payload: messagePayload, for: self.cid)
+        }
+        env.messageUpdater.getMessage_completion?(nil)
+        
+        // Assert `update` entity change is received by the delegate
+        AssertAsync {
+            Assert.willBeEqual(delegate.didChangeMessage_change?.fieldChange(\.id), .update(messagePayload.id))
+            Assert.willBeEqual(delegate.didChangeMessage_change?.fieldChange(\.text), .update(messagePayload.text))
+        }
+    }
+    
+    // MARK: - Delete message
+    
+    func test_deleteMessage_propogatesError() {
+        // Simulate `deleteMessage` call and catch the completion
+        var completionError: Error?
+        controller.deleteMessage { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionError = $0
+        }
+        
+        // Simulate network response with the error
+        let networkError = TestError()
+        env.messageUpdater.deleteMessage_completion?(networkError)
+        
+        // Assert error is propogated
+        AssertAsync.willBeEqual(completionError as? TestError, networkError)
+    }
+    
+    func test_deleteMessage_propogatesNilError() {
+        // Simulate `deleteMessage` call and catch the completion
+        var completionCalled = false
+        controller.deleteMessage { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            XCTAssertNil($0)
+            completionCalled = true
+        }
+        
+        // Simulate successful network response
+        env.messageUpdater.deleteMessage_completion?(nil)
+        
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+    }
+    
+    func test_deleteMessage_callsMessageUpdater_withCorrectValues() {
+        // Simulate `deleteMessage` call
+        controller.deleteMessage()
+        
+        // Assert messageUpdater is called with correct `messageId`
+        XCTAssertEqual(env.messageUpdater.deleteMessage_messageId, controller.messageId)
+    }
+    
+    // MARK: - Edit message
+    
+    func test_editMessage_propogatesError() {
+        // Simulate `editMessage` call and catch the completion
+        var completionError: Error?
+        controller.editMessage(text: .unique) { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionError = $0
+        }
+        
+        // Simulate network response with the error
+        let networkError = TestError()
+        env.messageUpdater.editMessage_completion?(networkError)
+        
+        // Assert error is propogated
+        AssertAsync.willBeEqual(completionError as? TestError, networkError)
+    }
+    
+    func test_editMessage_propogatesNilError() {
+        // Simulate `editMessage` call and catch the completion
+        var completionCalled = false
+        controller.editMessage(text: .unique) { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            XCTAssertNil($0)
+            completionCalled = true
+        }
+        
+        // Simulate successful network response
+        env.messageUpdater.editMessage_completion?(nil)
+        
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+    }
+    
+    func test_editMessage_callsMessageUpdater_withCorrectValues() {
+        let updatedText: String = .unique
+        
+        // Simulate `editMessage` call and catch the completion
+        controller.editMessage(text: updatedText)
+        
+        // Assert message updater is called with correct `messageId` and `text`
+        XCTAssertEqual(env.messageUpdater.editMessage_messageId, controller.messageId)
+        XCTAssertEqual(env.messageUpdater.editMessage_text, updatedText)
+    }
+}
+
+private class TestDelegate: QueueAwareDelegate, MessageControllerDelegate {
+    @Atomic var state: Controller.State?
+    @Atomic var didChangeMessage_change: EntityChange<Message>?
+    
+    func controller(_ controller: Controller, didChangeState state: Controller.State) {
+        self.state = state
+        validateQueue()
+    }
+    
+    func messageController(_ controller: MessageController, didChangeMessage change: EntityChange<Message>) {
+        didChangeMessage_change = change
+        validateQueue()
+    }
+}
+
+private class TestDelegateGeneric: QueueAwareDelegate, MessageControllerDelegateGeneric {
+    @Atomic var state: Controller.State?
+    @Atomic var didChangeMessage_change: EntityChange<Message>?
+   
+    func controller(_ controller: Controller, didChangeState state: Controller.State) {
+        self.state = state
+        validateQueue()
+    }
+    
+    func messageController(_ controller: MessageController, didChangeMessage change: EntityChange<Message>) {
+        didChangeMessage_change = change
+        validateQueue()
+    }
+}
+
+private class TestEnvironment {
+    var messageUpdater: MessageUpdaterMock<DefaultDataTypes>!
+    var messageObserver: EntityDatabaseObserverMock<MessageModel<DefaultDataTypes>, MessageDTO>!
+    var messageObserver_startUpdatingError: Error?
+    
+    lazy var controllerEnvironment: MessageController
+        .Environment = .init(
+            messageObserverBuilder: { [unowned self] in
+                self.messageObserver = .init(context: $0, fetchRequest: $1, itemCreator: $2, fetchedResultsControllerType: $3)
+                self.messageObserver.startUpdatingError = self.messageObserver_startUpdatingError
+                return self.messageObserver!
+            },
+            messageUpdaterBuilder: { [unowned self] in
+                self.messageUpdater = MessageUpdaterMock(database: $0, webSocketClient: $1, apiClient: $2)
+                return self.messageUpdater!
+            }
+        )
+}

--- a/Sources_v3/Database/DTOs/MessageDTO.swift
+++ b/Sources_v3/Database/DTOs/MessageDTO.swift
@@ -171,6 +171,10 @@ extension NSManagedObjectContext: MessageDatabaseSession {
     }
     
     func message(id: MessageId) -> MessageDTO? { .load(id: id, context: self) }
+    
+    func delete(message: MessageDTO) {
+        delete(message)
+    }
 }
 
 extension MessageDTO {

--- a/Sources_v3/Database/DTOs/MessageDTO.swift
+++ b/Sources_v3/Database/DTOs/MessageDTO.swift
@@ -58,11 +58,27 @@ class MessageDTO: NSManagedObject {
         return request
     }
     
+    /// Returns a fetch request for messages pending sync.
+    static func messagesPendingSyncFetchRequest() -> NSFetchRequest<MessageDTO> {
+        let request = NSFetchRequest<MessageDTO>(entityName: MessageDTO.entityName)
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \MessageDTO.locallyCreatedAt, ascending: true)]
+        request.predicate = NSPredicate(format: "localMessageStateRaw == %@", LocalMessageState.pendingSync.rawValue)
+        return request
+    }
+    
     /// Returns a fetch request for messages from the channel with the provided `cid`.
     static func messagesFetchRequest(for cid: ChannelId, sortAscending: Bool = false) -> NSFetchRequest<MessageDTO> {
         let request = NSFetchRequest<MessageDTO>(entityName: MessageDTO.entityName)
         request.sortDescriptors = [NSSortDescriptor(keyPath: \MessageDTO.defaultSortingKey, ascending: sortAscending)]
         request.predicate = NSPredicate(format: "channel.cid == %@", cid.rawValue)
+        return request
+    }
+    
+    /// Returns a fetch request for the dto with a specific `messageId`.
+    static func message(withID messageId: MessageId) -> NSFetchRequest<MessageDTO> {
+        let request = NSFetchRequest<MessageDTO>(entityName: MessageDTO.entityName)
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \MessageDTO.defaultSortingKey, ascending: false)]
+        request.predicate = NSPredicate(format: "id == %@", messageId)
         return request
     }
     

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -92,12 +92,20 @@ extension DatabaseContainer {
     }
     
     /// Synchronously creates a new MessageDTO in the DB with the given id.
-    func createMessage(id: MessageId = .unique, authorId: UserId = .unique, cid: ChannelId = .unique) throws {
+    func createMessage(
+        id: MessageId = .unique,
+        authorId: UserId = .unique,
+        cid: ChannelId = .unique,
+        text: String = .unique,
+        localState: LocalMessageState? = nil
+    ) throws {
         try writeSynchronously { session in
             try session.saveChannel(payload: XCTestCase().dummyPayload(with: cid))
             
-            let message: MessagePayload<DefaultDataTypes> = .dummy(messageId: id, authorUserId: authorId)
-            try session.saveMessage(payload: message, for: cid)
+            let message: MessagePayload<DefaultDataTypes> = .dummy(messageId: id, authorUserId: authorId, text: text)
+            
+            let messageDTO = try session.saveMessage(payload: message, for: cid)
+            messageDTO.localMessageState = localState
         }
     }
 }

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -38,6 +38,13 @@ class DatabaseContainerMock: DatabaseContainer {
 }
 
 extension DatabaseContainer {
+    /// Deletes all data synchronously
+    func flush() throws {
+        if let error = try await({ self.removeAllData(force: true, completion: $0) }) {
+            throw error
+        }
+    }
+    
     /// Writes changes to the DB synchronously. Only for test purposes!
     func writeSynchronously(_ actions: @escaping (DatabaseSession) throws -> Void) throws {
         let error = try await { completion in

--- a/Sources_v3/Database/DatabaseSession.swift
+++ b/Sources_v3/Database/DatabaseSession.swift
@@ -53,6 +53,10 @@ protocol MessageDatabaseSession {
     
     /// Fetchtes `MessageDTO` with the given `id` from the DB. Returns `nil` if no `MessageDTO` matching the `id` exists.
     func message(id: MessageId) -> MessageDTO?
+    
+    /// Deletes the provided dto from a database
+    /// - Parameter message: The DTO to be deleted
+    func delete(message: MessageDTO)
 }
 
 extension MessageDatabaseSession {

--- a/Sources_v3/Database/DatabaseSession_Tests.swift
+++ b/Sources_v3/Database/DatabaseSession_Tests.swift
@@ -129,6 +129,29 @@ class DatabaseSession_Tests: StressTestCase {
         XCTAssert(loadedChannel.latestMessages.contains(message))
     }
     
+    func test_deleteMessage() throws {
+        let channelId: ChannelId = .unique
+        let messageId: MessageId = .unique
+
+        // Create current user in the DB
+        try database.createCurrentUser()
+        
+        // Create channel in the DB
+        try database.createChannel(cid: channelId)
+        
+        // Save the message to the DB and remember the messageId
+        try database.createMessage(id: messageId, cid: channelId)
+        
+        // Delete the message from the DB
+        try database.writeSynchronously { session in
+            let dto = try XCTUnwrap(session.message(id: messageId))
+            session.delete(message: dto)
+        }
+        
+        // Assert message is deleted
+        XCTAssertNil(database.viewContext.message(id: messageId))
+    }
+    
     func test_saveEvent_unreadCountFromEventPayloadIsApplied() throws {
         let eventPayload = EventPayload<DefaultDataTypes>(
             eventType: .messageNew,

--- a/Sources_v3/Models/Message.swift
+++ b/Sources_v3/Models/Message.swift
@@ -33,6 +33,13 @@ public enum MessageType: String, Codable {
 
 /// A possible additional local state of the message. Applies only for the messages of the current user.
 public enum LocalMessageState: String {
+    /// The message is waiting to be synced.
+    case pendingSync
+    /// The message is currently being synced
+    case syncing
+    /// Syncing of the message failed after multiple of tries. The system is not trying to sync this message anymore.
+    case syncingFailed
+    
     /// The message is waiting to be sent.
     case pendingSend
     /// The message is currently being sent to the servers.

--- a/Sources_v3/Workers/Background/MessageEditor.swift
+++ b/Sources_v3/Workers/Background/MessageEditor.swift
@@ -1,0 +1,122 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+/// Observers the storage for messages in a `pendingSync` state and updates them on the backend.
+///
+/// Sending of the message has the following phases:
+///     1. When a message with `pendingSync` state local state appears in the db, the editor enques it in the sending queue.
+///     2. The pending messages are edited one by one, the order doesn't matter here.
+///     3. When the message is being sent, its local state is changed to `syncing`
+///     4. If the operation is successfull, the local state of the message is changed to `nil`. If the operation fails, the local
+///     state of is changed to `syncingFailed`.
+///
+// TODO:
+/// - Message edit retry
+/// - Start editing messages when connection status changes (offline -> online)
+///
+class MessageEditor<ExtraData: ExtraDataTypes>: Worker {
+    @Atomic private var pendingMessageIDs: Set<MessageId> = []
+    private let observer: ListDatabaseObserver<MessageDTO, MessageDTO>
+    private let sendingQueue: DispatchQueue
+
+    override init(database: DatabaseContainer, webSocketClient: WebSocketClient, apiClient: APIClient) {
+        observer = .init(
+            context: database.backgroundReadOnlyContext,
+            fetchRequest: MessageDTO.messagesPendingSyncFetchRequest(),
+            itemCreator: { $0 }
+        )
+        
+        sendingQueue = .init(
+            label: "co.getStream.ChatClient.MessageEditorQueue",
+            qos: .userInitiated
+        )
+        
+        super.init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        
+        startObserving()
+    }
+    
+    // MARK: - Private
+
+    private func startObserving() {
+        do {
+            try observer.startObserving()
+            observer.onChange = { [weak self] in self?.handleChanges(changes: $0) }
+            let changes = observer.items.map { ListChange.insert($0, index: .init(row: 0, section: 0)) }
+            handleChanges(changes: changes)
+        } catch {
+            log.error("Failed to start MessageEditor worker. \(error)")
+        }
+    }
+    
+    private func handleChanges(changes: [ListChange<MessageDTO>]) {
+        let wasEmpty = pendingMessageIDs.isEmpty
+        changes.pendingEditMessageIDs.forEach { pendingMessageIDs.insert($0) }
+        if wasEmpty {
+            processNextMessage()
+        }
+    }
+
+    private func processNextMessage() {
+        guard let messageId = pendingMessageIDs.first else { return }
+        
+        guard let dto = database.backgroundReadOnlyContext.message(id: messageId) else {
+            removeMessageIDAndContinue(messageId)
+            return
+        }
+        
+        guard dto.localMessageState == .pendingSync else {
+            removeMessageIDAndContinue(messageId)
+            return
+        }
+        
+        markMessage(withID: messageId, as: .syncing) {
+            let requestBody = dto.asRequestBody() as MessageRequestBody<ExtraData>
+            self.apiClient.request(endpoint: .editMessage(payload: requestBody)) {
+                switch $0 {
+                case .success:
+                    self.markMessage(withID: messageId, as: nil) {
+                        self.removeMessageIDAndContinue(messageId)
+                    }
+                case .failure:
+                    self.markMessage(withID: messageId, as: .syncingFailed) {
+                        self.removeMessageIDAndContinue(messageId)
+                    }
+                }
+            }
+        }
+    }
+    
+    private func removeMessageIDAndContinue(_ messageId: MessageId) {
+        pendingMessageIDs.remove(messageId)
+        sendingQueue.async { self.processNextMessage() }
+    }
+    
+    private func markMessage(withID id: MessageId, as state: LocalMessageState?, completion: @escaping () -> Void) {
+        database.write({
+            $0.message(id: id)?.localMessageState = state
+        }, completion: {
+            if let error = $0 {
+                log.error("Error changing localMessageState for message with id \(id) to `\(String(describing: state))`: \(error)")
+            }
+            completion()
+        })
+    }
+}
+
+private extension Array where Element == ListChange<MessageDTO> {
+    var pendingEditMessageIDs: [MessageId] {
+        compactMap {
+            switch $0 {
+            case let .insert(dto, _), let .update(dto, _):
+                return dto.id
+            case .move, .remove:
+                return nil
+            }
+        }
+    }
+}

--- a/Sources_v3/Workers/Background/MessageEditor_Tests.swift
+++ b/Sources_v3/Workers/Background/MessageEditor_Tests.swift
@@ -1,0 +1,130 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class MessageEditor_Tests: StressTestCase {
+    typealias ExtraData = DefaultDataTypes
+    
+    var webSocketClient: WebSocketClientMock!
+    var apiClient: APIClientMock!
+    var database: DatabaseContainerMock!
+    var editor: MessageEditor<ExtraData>!
+    
+    // MARK: - Setup
+    
+    override func setUp() {
+        super.setUp()
+        
+        webSocketClient = WebSocketClientMock()
+        apiClient = APIClientMock()
+        database = try! DatabaseContainerMock(kind: .inMemory)
+        editor = MessageEditor(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+    }
+    
+    override func tearDown() {
+        apiClient.cleanUp()
+                
+        AssertAsync {
+            Assert.canBeReleased(&editor)
+            Assert.canBeReleased(&webSocketClient)
+            Assert.canBeReleased(&apiClient)
+            Assert.canBeReleased(&database)
+        }
+
+        super.tearDown()
+    }
+    
+    // MARK: - Tests
+    
+    func test_editorSyncsMessage_withPendingSyncLocalState() throws {
+        let currentUserId: UserId = .unique
+        let message1Id: MessageId = .unique
+        let message2Id: MessageId = .unique
+        
+        // Create current user in the database
+        try database.createCurrentUser(id: currentUserId)
+        
+        // Create 2 messages in the DB, only message 1 has `.pendingSync` local state
+        try database.createMessage(id: message1Id, authorId: currentUserId, localState: .pendingSync)
+        try database.createMessage(id: message2Id, authorId: currentUserId, localState: nil)
+        
+        let message1Payload: MessageRequestBody<ExtraData> = try XCTUnwrap(
+            database.viewContext.message(id: message1Id)?
+                .asRequestBody()
+        )
+        let message2Payload: MessageRequestBody<ExtraData> = try XCTUnwrap(
+            database.viewContext.message(id: message2Id)?
+                .asRequestBody()
+        )
+
+        // Check only the message1 was synced
+        AssertAsync {
+            Assert.willBeTrue(self.apiClient.request_allRecordedCalls.contains(where: {
+                $0.endpoint == AnyEndpoint(.editMessage(payload: message1Payload))
+            }))
+            Assert.staysFalse(self.apiClient.request_allRecordedCalls.contains(where: {
+                $0.endpoint == AnyEndpoint(.editMessage(payload: message2Payload))
+            }))
+        }
+    }
+    
+    func test_editor_changesMessageStates_whenSyncingSucceeds() throws {
+        let currentUserId: UserId = .unique
+        let messageId: MessageId = .unique
+       
+        // Create current user in the database
+        try database.createCurrentUser(id: currentUserId)
+        
+        // Create a messages in the DB in `.pendingSync` state
+        try database.createMessage(id: messageId, authorId: currentUserId, localState: .pendingSync)
+        
+        // Load the message
+        var message: MessageDTO? {
+            database.viewContext.message(id: messageId)
+        }
+        
+        // Check the state is eventually changed to `syncing`
+        AssertAsync.willBeEqual(message?.localMessageState, .syncing)
+                
+        // Wait for the API call to be initiated
+        AssertAsync.willBeTrue(apiClient.request_endpoint != nil)
+        
+        // Simulate successfull API response
+        let callback = apiClient.request_completion as! (Result<EmptyResponse, Error>) -> Void
+        callback(.success(.init()))
+        
+        // Check the state is eventually changed to `nil`
+        AssertAsync.willBeEqual(message?.localMessageState, nil)
+    }
+    
+    func test_editor_changesMessageStates_whenSyncingFails() throws {
+        let currentUserId: UserId = .unique
+        let messageId: MessageId = .unique
+        
+        // Create current user in the database
+        try database.createCurrentUser(id: currentUserId)
+        
+        // Create a messages in the DB in `.pendingSync` state
+        try database.createMessage(id: messageId, authorId: currentUserId, localState: .pendingSync)
+        
+        // Load the message
+        var message: MessageDTO? {
+            database.viewContext.message(id: messageId)
+        }
+        
+        // Check the state is eventually changed to `syncing`
+        AssertAsync.willBeEqual(message?.localMessageState, .syncing)
+                
+        // Wait for the API call to be initiated
+        AssertAsync.willBeTrue(apiClient.request_endpoint != nil)
+        
+        // Simulate API response with the error
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(TestError()))
+        
+        // Check the state is eventually changed to `syncingFailed`
+        AssertAsync.willBeEqual(message?.localMessageState, .syncingFailed)
+    }
+}

--- a/Sources_v3/Workers/MessageUpdater.swift
+++ b/Sources_v3/Workers/MessageUpdater.swift
@@ -1,0 +1,153 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+/// The type provides the API for getting/editing/deleting a message
+class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
+    /// Fetches the message from the backend and saves it into the database
+    /// - Parameters:
+    ///   - cid: The channel identifier the message relates to.
+    ///   - messageId: The message identifier.
+    ///   - completion: The completion. Will be called with an error if smth goes wrong, otherwise - will be called with `nil`.
+    func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Error?) -> Void)? = nil) {
+        let endpoint: Endpoint<MessagePayload<ExtraData>> = .getMessage(messageId: messageId)
+        apiClient.request(endpoint: endpoint) {
+            switch $0 {
+            case let .success(message):
+                // TODO: CIS-235 (make a channel-query call from `getMessage` if channel doesn't exist locally)
+                self.database.write({ session in
+                    try session.saveMessage(payload: message, for: cid)
+                }, completion: { error in
+                    completion?(error)
+                })
+            case let .failure(error):
+                completion?(error)
+            }
+        }
+    }
+    
+    /// Deletes the message.
+    ///
+    /// If the message with a provided `messageId` has `pendingSend` or `sendingFailed` state
+    /// it will be removed locally as it hasn't been sent yet.
+    ///
+    /// If the messsage a provided `messageId` has some other local state it should be removed on the backend.
+    /// Before the `delete` network call happens the local state is set to `deleting` and based on
+    /// the response it becomes either `nil` if request succeeds or `deletingFailed` if request fails.
+    ///
+    /// - Parameters:
+    ///   - messageId: The message identifier.
+    ///   - completion: The completion. Will be called with an error if smth goes wrong, otherwise - will be called with `nil`.
+    func deleteMessage(messageId: MessageId, completion: ((Error?) -> Void)? = nil) {
+        var shouldDeleteOnBackend = true
+        
+        database.write({ session in
+            guard let currentUserDTO = session.currentUser() else {
+                throw ClientError.CurrentUserDoesNotExist()
+            }
+            
+            guard let messageDTO = session.message(id: messageId) else {
+                // Even though the message does not exist locally
+                // we don't throw any error becauase we still want
+                // to try to delete the message on the backend.
+                return
+            }
+            
+            guard messageDTO.user.id == currentUserDTO.user.id else {
+                throw ClientError.MessageCannotBeUpdatedByCurrentUser(messageId: messageId)
+            }
+            
+            if messageDTO.existsOnlyLocally {
+                session.delete(message: messageDTO)
+                shouldDeleteOnBackend = false
+            } else {
+                messageDTO.localMessageState = .deleting
+            }
+        }, completion: { error in
+            guard shouldDeleteOnBackend, error == nil else {
+                completion?(error)
+                return
+            }
+            
+            self.apiClient.request(endpoint: .deleteMessage(messageId: messageId)) { result in
+                self.database.write({ session in
+                    let messageDTO = session.message(id: messageId)
+                    switch result {
+                    case .success:
+                        messageDTO?.localMessageState = nil
+                    case .failure:
+                        messageDTO?.localMessageState = .deletingFailed
+                    }
+                }, completion: { error in
+                    completion?(result.error ?? error)
+                })
+            }
+        })
+    }
+    
+    /// Edits a new message in the local DB and sets its local state to `.pendingSync`
+    /// The message should exist locally and have current user as a sender
+    ///  - Parameters:
+    ///   - messageId: The message identifier.
+    ///   - text: The updated message text.
+    ///   - completion: The completion. Will be called with an error if smth goes wrong, otherwise - will be called with `nil`.
+    func editMessage(messageId: MessageId, text: String, completion: ((Error?) -> Void)? = nil) {
+        database.write({ session in
+            guard let currentUserDTO = session.currentUser() else {
+                throw ClientError.CurrentUserDoesNotExist()
+            }
+            
+            guard let messageDTO = session.message(id: messageId) else {
+                throw ClientError.MessageDoesNotExist(messageId: messageId)
+            }
+            
+            guard messageDTO.user.id == currentUserDTO.user.id else {
+                throw ClientError.MessageCannotBeUpdatedByCurrentUser(messageId: messageId)
+            }
+
+            switch messageDTO.localMessageState {
+            case nil:
+                messageDTO.text = text
+                messageDTO.localMessageState = .pendingSync
+            case .pendingSync, .pendingSend:
+                messageDTO.text = text
+            default:
+                throw ClientError.MessageEditing(
+                    messageId: messageId,
+                    reason: "message is in `\(messageDTO.localMessageState!)` state"
+                )
+            }
+        }, completion: {
+            completion?($0)
+        })
+    }
+}
+
+extension ClientError {
+    class MessageDoesNotExist: ClientError {
+        init(messageId: MessageId) {
+            super.init("There is no `MessageDTO` instance in the DB matching id: \(messageId).")
+        }
+    }
+    
+    class MessageCannotBeUpdatedByCurrentUser: ClientError {
+        init(messageId: MessageId) {
+            super.init("Current user can not perform actions on the message with id: \(messageId)")
+        }
+    }
+    
+    class MessageEditing: ClientError {
+        init(messageId: String, reason: String) {
+            super.init("Message with id: \(messageId) can't be edited (\(reason)")
+        }
+    }
+}
+
+private extension MessageDTO {
+    var existsOnlyLocally: Bool {
+        localMessageState == .pendingSend || localMessageState == .sendingFailed
+    }
+}

--- a/Sources_v3/Workers/MessageUpdater_Mock.swift
+++ b/Sources_v3/Workers/MessageUpdater_Mock.swift
@@ -1,0 +1,37 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+/// Mock implementation of MessageUpdater
+final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraData> {
+    @Atomic var getMessage_cid: ChannelId?
+    @Atomic var getMessage_messageId: MessageId?
+    @Atomic var getMessage_completion: ((Error?) -> Void)?
+
+    @Atomic var deleteMessage_messageId: MessageId?
+    @Atomic var deleteMessage_completion: ((Error?) -> Void)?
+
+    @Atomic var editMessage_messageId: MessageId?
+    @Atomic var editMessage_text: String?
+    @Atomic var editMessage_completion: ((Error?) -> Void)?
+    
+    override func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Error?) -> Void)? = nil) {
+        getMessage_cid = cid
+        getMessage_messageId = messageId
+        getMessage_completion = completion
+    }
+    
+    override func deleteMessage(messageId: MessageId, completion: ((Error?) -> Void)? = nil) {
+        deleteMessage_messageId = messageId
+        deleteMessage_completion = completion
+    }
+    
+    override func editMessage(messageId: MessageId, text: String, completion: ((Error?) -> Void)? = nil) {
+        editMessage_messageId = messageId
+        editMessage_text = text
+        editMessage_completion = completion
+    }
+}

--- a/Sources_v3/Workers/MessageUpdater_Tests.swift
+++ b/Sources_v3/Workers/MessageUpdater_Tests.swift
@@ -1,0 +1,422 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class MessageUpdater_Tests: StressTestCase {
+    typealias ExtraData = DefaultDataTypes
+    
+    var webSocketClient: WebSocketClientMock!
+    var apiClient: APIClientMock!
+    var database: DatabaseContainerMock!
+    var messageUpdater: MessageUpdater<ExtraData>!
+    
+    // MARK: Setup
+    
+    override func setUp() {
+        super.setUp()
+        
+        webSocketClient = WebSocketClientMock()
+        apiClient = APIClientMock()
+        database = try! DatabaseContainerMock(kind: .inMemory)
+        messageUpdater = MessageUpdater(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+    }
+    
+    override func tearDown() {
+        apiClient.cleanUp()
+        
+        AssertAsync {
+            Assert.canBeReleased(&messageUpdater)
+            Assert.canBeReleased(&webSocketClient)
+            Assert.canBeReleased(&apiClient)
+            Assert.canBeReleased(&database)
+        }
+        
+        super.tearDown()
+    }
+    
+    // MARK: Edit message
+    
+    func test_editMessage_propogates_CurrentUserDoesNotExist_Error() throws {
+        // Simulate `editMessage(messageId:, text:)` call
+        let completionError = try await {
+            messageUpdater.editMessage(messageId: .unique, text: .unique, completion: $0)
+        }
+        
+        // Assert `CurrentUserDoesNotExist` is received
+        XCTAssertTrue(completionError is ClientError.CurrentUserDoesNotExist)
+    }
+    
+    func test_editMessage_propogates_MessageDoesNotExist_Error() throws {
+        // Create current user is the database
+        try database.createCurrentUser()
+        
+        // Simulate `editMessage(messageId:, text:)` call
+        let completionError = try await {
+            messageUpdater.editMessage(messageId: .unique, text: .unique, completion: $0)
+        }
+        
+        // Assert `MessageDoesNotExist` is received
+        XCTAssertTrue(completionError is ClientError.MessageDoesNotExist)
+    }
+    
+    func test_editMessage_propogates_MessageCanNotBeUpdatedByCurrentUser_Error() throws {
+        let anotherUserId: UserId = .unique
+        let anotherUserMessageId: MessageId = .unique
+
+        // Create current user is the database
+        try database.createCurrentUser()
+    
+        // Create message authored by another user in the database
+        try database.createMessage(id: anotherUserMessageId, authorId: anotherUserId)
+
+        // Try to edit another user's message
+        let completionError = try await {
+            messageUpdater.editMessage(messageId: anotherUserMessageId, text: .unique, completion: $0)
+        }
+        
+        // Assert `MessageCannotBeUpdatedByCurrentUser` is received
+        XCTAssertTrue(completionError is ClientError.MessageCannotBeUpdatedByCurrentUser)
+    }
+
+    func test_editMessage_updatesLocalMessageCorrectly() throws {
+        let pairs: [(LocalMessageState?, LocalMessageState?)] = [
+            (nil, .pendingSync),
+            (.pendingSync, .pendingSync),
+            (.pendingSend, .pendingSend)
+        ]
+        
+        for (initialState, expectedState) in pairs {
+            let currentUserId: UserId = .unique
+            let messageId: MessageId = .unique
+            let updatedText: String = .unique
+            
+            // Flush the database
+            try database.flush()
+            
+            // Create current user is the database
+            try database.createCurrentUser(id: currentUserId)
+            
+            // Create a new message in the database
+            try database.createMessage(id: messageId, authorId: currentUserId, localState: initialState)
+            
+            // Edit created message with new text
+            let completionError = try await {
+                messageUpdater.editMessage(messageId: messageId, text: updatedText, completion: $0)
+            }
+            
+            // Load the message
+            let message = try XCTUnwrap(database.viewContext.message(id: messageId))
+            
+            // Assert completion is called without any error
+            XCTAssertNil(completionError)
+            // Assert message still has expected local state
+            XCTAssertEqual(message.localMessageState, expectedState)
+            // Assert message text is updated correctly
+            XCTAssertEqual(message.text, updatedText)
+        }
+    }
+    
+    func test_editMessage_propogatesMessageEditingError_ifLocalStateIsInvalidForEditing() throws {
+        let invalidStates: [LocalMessageState] = [
+            .deleting,
+            .deletingFailed,
+            .sending,
+            .sendingFailed,
+            .syncing,
+            .syncingFailed
+        ]
+        
+        for state in invalidStates {
+            let currentUserId: UserId = .unique
+            let messageId: MessageId = .unique
+            let initialText: String = .unique
+            let updatedText: String = .unique
+            
+            // Flush the database
+            try database.flush()
+            
+            // Create current user is the database
+            try database.createCurrentUser(id: currentUserId)
+            
+            // Create a new message in the database
+            try database.createMessage(id: messageId, authorId: currentUserId, text: initialText, localState: state)
+            
+            // Edit created message with new text
+            let completionError = try await {
+                messageUpdater.editMessage(messageId: messageId, text: updatedText, completion: $0)
+            }
+            
+            // Load the message
+            let message = try XCTUnwrap(database.viewContext.message(id: messageId))
+            
+            // Assert `MessageEditing` error is received
+            XCTAssertTrue(completionError is ClientError.MessageEditing)
+            // Assert message stays in the same state
+            XCTAssertEqual(message.localMessageState, state)
+            // Assert message's text stays the same
+            XCTAssertEqual(message.text, initialText)
+        }
+    }
+    
+    // MARK: Delete message
+    
+    func test_deleteMessage_propogates_CurrentUserDoesNotExist_Error() throws {
+        // Simulate `deleteMessage(messageId:)` call
+        let completionError = try await {
+            messageUpdater.deleteMessage(messageId: .unique, completion: $0)
+        }
+        
+        // Assert `CurrentUserDoesNotExist` is received
+        XCTAssertTrue(completionError is ClientError.CurrentUserDoesNotExist)
+    }
+    
+    func test_deleteMessage_propogates_MessageCanNotBeUpdatedByCurrentUser_Error() throws {
+        let anotherUserId: UserId = .unique
+        let anotherUserMessageId: MessageId = .unique
+        
+        // Create current user is the database
+        try database.createCurrentUser()
+        
+        // Create message authored by another user in the database
+        try database.createMessage(id: anotherUserMessageId, authorId: anotherUserId)
+        
+        // Simulate `deleteMessage(messageId:)` call
+        let completionError = try await {
+            messageUpdater.deleteMessage(messageId: anotherUserMessageId, completion: $0)
+        }
+        
+        // Assert `MessageCannotBeUpdatedByCurrentUser` is received
+        XCTAssertTrue(completionError is ClientError.MessageCannotBeUpdatedByCurrentUser)
+    }
+    
+    func test_deleteMessage_sendsCorrectAPICall_ifMessageDoesNotExistLocally() throws {
+        let messageId: MessageId = .unique
+        
+        // Create current user in the database
+        try database.createCurrentUser()
+        
+        // Simulate `deleteMessage(messageId:)` call
+        messageUpdater.deleteMessage(messageId: messageId)
+        
+        // Assert correct endpoint is called
+        let expectedEndpoint: Endpoint<EmptyResponse> = .deleteMessage(messageId: messageId)
+        AssertAsync.willBeEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
+    }
+    
+    func test_deleteMessage_propogatesRequestError() throws {
+        let messageId: MessageId = .unique
+        
+        // Create current user in the database
+        try database.createCurrentUser()
+        
+        // Simulate `deleteMessage(messageId:)` call
+        var completionCalledError: Error?
+        messageUpdater.deleteMessage(messageId: messageId) {
+            completionCalledError = $0
+        }
+        
+        // Assert correct endpoint is called
+        let expectedEndpoint: Endpoint<EmptyResponse> = .deleteMessage(messageId: messageId)
+        AssertAsync.willBeEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
+        
+        // Simulate API response with success
+        let testError = TestError()
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(testError))
+                
+        // Assert completion is called without any error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
+    }
+    
+    func test_deleteMessage_propogatesDatabaseError_beforeAPICall() throws {
+        // Update database container to throw the error on write
+        let databaseError = TestError()
+        database.write_errorResponse = databaseError
+        
+        // Simulate `deleteMessage(messageId:)` call
+        let completionError = try await {
+            messageUpdater.deleteMessage(messageId: .unique, completion: $0)
+        }
+        
+        // Assert database error is propogated
+        XCTAssertEqual(completionError as? TestError, databaseError)
+    }
+    
+    func test_deleteMessage_propogatesDatabaseError_afterAPICall() throws {
+        let messageId: MessageId = .unique
+
+        // Create current user in the database
+        try database.createCurrentUser()
+
+        // Simulate `deleteMessage(messageId:)` call
+        var completionCalledError: Error?
+        messageUpdater.deleteMessage(messageId: messageId) {
+            completionCalledError = $0
+        }
+        
+        // Assert correct endpoint is called
+        let expectedEndpoint: Endpoint<EmptyResponse> = .deleteMessage(messageId: messageId)
+        AssertAsync.willBeEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
+        
+        // Update database container to throw the error on write
+        let databaseError = TestError()
+        database.write_errorResponse = databaseError
+        
+        // Simulate API response with success
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.success(.init()))
+                
+        // Assert database error is propogated
+        AssertAsync.willBeEqual(completionCalledError as? TestError, databaseError)
+    }
+
+    func test_deleteMessage_removesMessageThatExistOnlyLocally() throws {
+        for state in [LocalMessageState.pendingSend, .sendingFailed] {
+            let currentUserId: UserId = .unique
+            let messageId: MessageId = .unique
+
+            // Flush the database
+            try database.flush()
+            
+            // Create current user in the database
+            try database.createCurrentUser(id: currentUserId)
+                   
+            // Create a new message in the database
+            try database.createMessage(id: messageId, authorId: currentUserId, localState: state)
+
+            // Simulate `deleteMessage(messageId:)` call
+            var completionCalled = false
+            messageUpdater.deleteMessage(messageId: messageId) { error in
+                XCTAssertNil(error)
+                completionCalled = true
+            }
+            
+            var message: MessageDTO? {
+                database.viewContext.message(id: messageId)
+            }
+            
+            AssertAsync {
+                // Assert completion is called
+                Assert.willBeTrue(completionCalled)
+                // Assert message is deleted locally
+                Assert.willBeTrue(message == nil)
+                // Assert API is not called
+                Assert.staysTrue(self.apiClient.request_endpoint == nil)
+            }
+        }
+    }
+    
+    func test_deleteMessage_updatesMessageStateCorrectly() throws {
+        let pairs: [(Result<EmptyResponse, Error>, LocalMessageState?)] = [
+            (.success(.init()), nil),
+            (.failure(TestError()), .deletingFailed)
+        ]
+        
+        for (networkResult, expectedState) in pairs {
+            let currentUserId: UserId = .unique
+            let messageId: MessageId = .unique
+            
+            // Flush the database
+            try database.flush()
+            
+            // Create current user in the database
+            try database.createCurrentUser(id: currentUserId)
+            
+            // Create message authored by current user in the database
+            try database.createMessage(id: messageId, authorId: currentUserId)
+            
+            // Simulate `deleteMessage(messageId:)` call
+            messageUpdater.deleteMessage(messageId: messageId)
+            
+            // Load the message
+            let message = try XCTUnwrap(database.viewContext.message(id: messageId))
+            
+            // Assert message's local state becomes `deleting`
+            AssertAsync.willBeEqual(message.localMessageState, .deleting)
+            
+            // Simulate API response
+            apiClient.test_simulateResponse(networkResult)
+            
+            // Assert message's local state becomes expected
+            AssertAsync.willBeEqual(message.localMessageState, expectedState)
+        }
+    }
+    
+    // MARK: Get message
+    
+    func test_getMessage_makesCorrectAPICall() {
+        let cid: ChannelId = .unique
+        let messageId: MessageId = .unique
+        
+        // Simulate `getMessage(cid:, messageId:)` call
+        messageUpdater.getMessage(cid: cid, messageId: messageId)
+                
+        // Assert correct endpoint is called
+        let expectedEndpoint: Endpoint<MessagePayload<ExtraData>> = .getMessage(messageId: messageId)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
+    }
+    
+    func test_getMessage_propogatesRequestError() {
+        // Simulate `getMessage(cid:, messageId:)` call
+        var completionCalledError: Error?
+        messageUpdater.getMessage(cid: .unique, messageId: .unique) {
+            completionCalledError = $0
+        }
+        
+        // Simulate API response with failure
+        let error = TestError()
+        apiClient.test_simulateResponse(Result<MessagePayload<ExtraData>, Error>.failure(error))
+                
+        // Assert the completion is called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, error)
+    }
+    
+    func test_getMessage_propogatesDatabaseError() {
+        let messagePayload: MessagePayload<ExtraData> = .dummy(messageId: .unique, authorUserId: .unique)
+        
+        // Update database container to throw the error on write
+        let testError = TestError()
+        database.write_errorResponse = testError
+        
+        // Simulate `getMessage(cid:, messageId:)` call
+        var completionCalledError: Error?
+        messageUpdater.getMessage(cid: .unique, messageId: messagePayload.id) {
+            completionCalledError = $0
+        }
+        
+        // Simulate API response with success
+        apiClient.test_simulateResponse(Result<MessagePayload<ExtraData>, Error>.success(messagePayload))
+                
+        // Assert database error is propogated
+        AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
+    }
+    
+    func test_getMessage_savesMessageToDatabase() throws {
+        let currentUserId: UserId = .unique
+        let messageId: MessageId = .unique
+        let cid: ChannelId = .unique
+
+        // Create current user in the database
+        try database.createCurrentUser(id: currentUserId)
+        
+        // Create channel in the database
+        try database.createChannel(cid: cid)
+        
+        // Simulate `getMessage(cid:, messageId:)` call
+        var completionCalled = false
+        messageUpdater.getMessage(cid: cid, messageId: messageId) { _ in
+            completionCalled = true
+        }
+        
+        // Simulate API response with success
+        let messagePayload: MessagePayload<ExtraData> = .dummy(messageId: messageId, authorUserId: currentUserId)
+        apiClient.test_simulateResponse(Result<MessagePayload<ExtraData>, Error>.success(messagePayload))
+        
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+        
+        // Assert fetched message is saved to the database
+        XCTAssertNotNil(database.viewContext.message(id: messageId))
+    }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -279,6 +279,7 @@
 		DAFAD6A124DC476A0043ED06 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFAD6A024DC476A0043ED06 /* Result+Extensions.swift */; };
 		DAFAD6A324DD8E1A0043ED06 /* ChannelEditDetailPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFAD6A224DD8E1A0043ED06 /* ChannelEditDetailPayload.swift */; };
 		DAFC1D4724F50C5C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFC1D4524F50C2C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift */; };
+		F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */; };
 		F61ED5A124F3F58400874777 /* DatabaseContainer_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61ED5A024F3F58400874777 /* DatabaseContainer_Mock.swift */; };
 		F62D143E24DD70190081D241 /* ChannelUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */; };
 		F63CC36F24E591840052844D /* EventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC36E24E591840052844D /* EventObserver.swift */; };
@@ -292,6 +293,7 @@
 		F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69C4BC524F66CC200A3D740 /* EventLogger.swift */; };
 		F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */; };
 		F6C56D1424F7B89D0012BB1F /* EventMiddleware_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */; };
+		F6FF1DAA24FD23D300151735 /* MessageEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -612,6 +614,7 @@
 		DAFAD6A024DC476A0043ED06 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		DAFAD6A224DD8E1A0043ED06 /* ChannelEditDetailPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelEditDetailPayload.swift; sourceTree = "<group>"; };
 		DAFC1D4524F50C2C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewChannelQueryUpdater_Tests.swift; sourceTree = "<group>"; };
+		F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints_Tests.swift; sourceTree = "<group>"; };
 		F61ED5A024F3F58400874777 /* DatabaseContainer_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseContainer_Mock.swift; sourceTree = "<group>"; };
 		F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelUpdater_Mock.swift; sourceTree = "<group>"; };
 		F63CC36E24E591840052844D /* EventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver.swift; sourceTree = "<group>"; };
@@ -625,6 +628,7 @@
 		F69C4BC524F66CC200A3D740 /* EventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogger.swift; sourceTree = "<group>"; };
 		F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserController_Tests.swift; sourceTree = "<group>"; };
 		F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware_Mock.swift; sourceTree = "<group>"; };
+		F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -904,6 +908,8 @@
 				7937282B249900CB00E13FE5 /* MemberPayload_Tests.swift */,
 				79877A132498E4EE00015F8B /* ChannelEndpoints.swift */,
 				DAEAF4B724DC026C0015FB28 /* ChannelEndpoints_Tests.swift */,
+				F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */,
+				F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */,
 			);
 			path = Endpoints;
 			sourceTree = "<group>";
@@ -1712,6 +1718,7 @@
 				79877A092498E4BC00015F8B /* UserModel.swift in Sources */,
 				79B5517324E593C200CE9FEC /* UserPayloads.swift in Sources */,
 				DA99D0D024ED63C600AD5354 /* NewChannelQueryUpdater.swift in Sources */,
+				F6FF1DAA24FD23D300151735 /* MessageEndpoints.swift in Sources */,
 				799C943E247D2FB9001F1104 /* Message.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1722,6 +1729,7 @@
 			files = (
 				793C14DC24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift in Sources */,
 				79A0E9AF2498BFD800E9BD50 /* WebSocketClient_Tests.swift in Sources */,
+				F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */,
 				DAFC1D4724F50C5C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift in Sources */,
 				7964F3AA249A19EA002A09EC /* Filter_Tests.swift in Sources */,
 				F67415C024F0129800C3222F /* UnreadCount.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -282,12 +282,14 @@
 		F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */; };
 		F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */; };
 		F61D7C3524FFA6FD00188A0E /* MessageUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3424FFA6FD00188A0E /* MessageUpdater_Tests.swift */; };
+		F61D7C3724FFE17200188A0E /* MessageEditor_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3624FFE17200188A0E /* MessageEditor_Tests.swift */; };
 		F61ED5A124F3F58400874777 /* DatabaseContainer_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61ED5A024F3F58400874777 /* DatabaseContainer_Mock.swift */; };
 		F62D143E24DD70190081D241 /* ChannelUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */; };
 		F63CC36F24E591840052844D /* EventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC36E24E591840052844D /* EventObserver.swift */; };
 		F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37024E591990052844D /* EventObserver_Tests.swift */; };
 		F63CC37324E592D30052844D /* MemberEventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37224E592D30052844D /* MemberEventObserver.swift */; };
 		F63CC37524E592DD0052844D /* MemberEventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */; };
+		F670B50F24FE6EA900003B1A /* MessageEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F670B50E24FE6EA900003B1A /* MessageEditor.swift */; };
 		F67415C024F0129800C3222F /* UnreadCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67415BF24F0129800C3222F /* UnreadCount.swift */; };
 		F6778F9A24F5144F005E7D22 /* EventNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6778F9924F5144F005E7D22 /* EventNotificationCenter.swift */; };
 		F688643624E6DA8700A71361 /* CurrentUserController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F688643524E6DA8700A71361 /* CurrentUserController.swift */; };
@@ -620,12 +622,14 @@
 		F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints_Tests.swift; sourceTree = "<group>"; };
 		F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Mock.swift; sourceTree = "<group>"; };
 		F61D7C3424FFA6FD00188A0E /* MessageUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Tests.swift; sourceTree = "<group>"; };
+		F61D7C3624FFE17200188A0E /* MessageEditor_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEditor_Tests.swift; sourceTree = "<group>"; };
 		F61ED5A024F3F58400874777 /* DatabaseContainer_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseContainer_Mock.swift; sourceTree = "<group>"; };
 		F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelUpdater_Mock.swift; sourceTree = "<group>"; };
 		F63CC36E24E591840052844D /* EventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver.swift; sourceTree = "<group>"; };
 		F63CC37024E591990052844D /* EventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver_Tests.swift; sourceTree = "<group>"; };
 		F63CC37224E592D30052844D /* MemberEventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventObserver.swift; sourceTree = "<group>"; };
 		F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventObserver_Tests.swift; sourceTree = "<group>"; };
+		F670B50E24FE6EA900003B1A /* MessageEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEditor.swift; sourceTree = "<group>"; };
 		F67415BF24F0129800C3222F /* UnreadCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadCount.swift; sourceTree = "<group>"; };
 		F6778F9924F5144F005E7D22 /* EventNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventNotificationCenter.swift; sourceTree = "<group>"; };
 		F688643524E6DA8700A71361 /* CurrentUserController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserController.swift; sourceTree = "<group>"; };
@@ -720,6 +724,8 @@
 				791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */,
 				DA99D0CF24ED63C600AD5354 /* NewChannelQueryUpdater.swift */,
 				DAFC1D4524F50C2C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift */,
+				F670B50E24FE6EA900003B1A /* MessageEditor.swift */,
+				F61D7C3624FFE17200188A0E /* MessageEditor_Tests.swift */,
 				DAE566F625010CA100E39431 /* ChannelWatchStateUpdater.swift */,
 				DAE566F8250119E800E39431 /* ChannelWatchStateUpdater_Tests.swift */,
 			);
@@ -1717,6 +1723,7 @@
 				797A756424814E7A003CF16D /* WebSocketConnectPayload.swift in Sources */,
 				797E10A824EAF6DE00353791 /* UniqueId.swift in Sources */,
 				79877A0B2498E4BC00015F8B /* MemberModel.swift in Sources */,
+				F670B50F24FE6EA900003B1A /* MessageEditor.swift in Sources */,
 				7991D83D24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift in Sources */,
 				8A0D64A724E57A520017A3C0 /* GuestUserTokenRequestPayload.swift in Sources */,
 				792FCB4524A33B5B000290C7 /* EventDataProcessorMiddleware.swift in Sources */,
@@ -1744,6 +1751,7 @@
 				7964F3AA249A19EA002A09EC /* Filter_Tests.swift in Sources */,
 				F67415C024F0129800C3222F /* UnreadCount.swift in Sources */,
 				79DDF819249CE38B002F4412 /* MockNetworkURLProtocol.swift in Sources */,
+				F61D7C3724FFE17200188A0E /* MessageEditor_Tests.swift in Sources */,
 				8AE335AA24FCF99E002B6677 /* InternetConnection_Tests.swift in Sources */,
 				F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */,
 				7922F30A24DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37024E591990052844D /* EventObserver_Tests.swift */; };
 		F63CC37324E592D30052844D /* MemberEventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37224E592D30052844D /* MemberEventObserver.swift */; };
 		F63CC37524E592DD0052844D /* MemberEventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */; };
+		F649B2372500F785008F98C8 /* MessageController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F649B2362500F785008F98C8 /* MessageController_Tests.swift */; };
 		F649B2392500FD56008F98C8 /* EntityDatabaseObserver_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F649B2382500FD56008F98C8 /* EntityDatabaseObserver_Mock.swift */; };
 		F670B50F24FE6EA900003B1A /* MessageEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F670B50E24FE6EA900003B1A /* MessageEditor.swift */; };
 		F67415C024F0129800C3222F /* UnreadCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67415BF24F0129800C3222F /* UnreadCount.swift */; };
@@ -298,6 +299,7 @@
 		F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69C4BC524F66CC200A3D740 /* EventLogger.swift */; };
 		F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */; };
 		F6C56D1424F7B89D0012BB1F /* EventMiddleware_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */; };
+		F6FF1DA624FD17B400151735 /* MessageController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA524FD17B400151735 /* MessageController.swift */; };
 		F6FF1DA824FD232C00151735 /* MessageUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA724FD232C00151735 /* MessageUpdater.swift */; };
 		F6FF1DAA24FD23D300151735 /* MessageEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */; };
 /* End PBXBuildFile section */
@@ -630,6 +632,7 @@
 		F63CC37024E591990052844D /* EventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver_Tests.swift; sourceTree = "<group>"; };
 		F63CC37224E592D30052844D /* MemberEventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventObserver.swift; sourceTree = "<group>"; };
 		F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventObserver_Tests.swift; sourceTree = "<group>"; };
+		F649B2362500F785008F98C8 /* MessageController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageController_Tests.swift; sourceTree = "<group>"; };
 		F649B2382500FD56008F98C8 /* EntityDatabaseObserver_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDatabaseObserver_Mock.swift; sourceTree = "<group>"; };
 		F670B50E24FE6EA900003B1A /* MessageEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEditor.swift; sourceTree = "<group>"; };
 		F67415BF24F0129800C3222F /* UnreadCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadCount.swift; sourceTree = "<group>"; };
@@ -639,6 +642,7 @@
 		F69C4BC524F66CC200A3D740 /* EventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogger.swift; sourceTree = "<group>"; };
 		F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserController_Tests.swift; sourceTree = "<group>"; };
 		F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware_Mock.swift; sourceTree = "<group>"; };
+		F6FF1DA524FD17B400151735 /* MessageController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageController.swift; sourceTree = "<group>"; };
 		F6FF1DA724FD232C00151735 /* MessageUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater.swift; sourceTree = "<group>"; };
 		F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1050,6 +1054,7 @@
 				DAE566F22500F97E00E39431 /* ChannelController */,
 				DAE566F32500F98D00E39431 /* ChannelListController */,
 				DAE566F42500F99900E39431 /* CurrentUserController */,
+				F649B23F250125C9008F98C8 /* MessageController */,
 				79E2B83F24CAC8D60024752F /* ListDatabaseObserver.swift */,
 				793C14DB24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift */,
 				792AF91524D812440010097B /* EntityDatabaseObserver.swift */,
@@ -1389,6 +1394,15 @@
 			path = EventObservers;
 			sourceTree = "<group>";
 		};
+		F649B23F250125C9008F98C8 /* MessageController */ = {
+			isa = PBXGroup;
+			children = (
+				F6FF1DA524FD17B400151735 /* MessageController.swift */,
+				F649B2362500F785008F98C8 /* MessageController_Tests.swift */,
+			);
+			path = MessageController;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -1724,6 +1738,7 @@
 				DA4AA3B22502718600FAAF6E /* ChannelController+Combine.swift in Sources */,
 				79A0E9BB2498C31300E9BD50 /* TypingStartCleanupMiddleware.swift in Sources */,
 				797A756424814E7A003CF16D /* WebSocketConnectPayload.swift in Sources */,
+				F6FF1DA624FD17B400151735 /* MessageController.swift in Sources */,
 				797E10A824EAF6DE00353791 /* UniqueId.swift in Sources */,
 				79877A0B2498E4BC00015F8B /* MemberModel.swift in Sources */,
 				F670B50F24FE6EA900003B1A /* MessageEditor.swift in Sources */,
@@ -1764,6 +1779,7 @@
 				791C0B6324EEBDF40013CA2F /* MessageSender_Tests.swift in Sources */,
 				797EEA4824FFB4C200C81203 /* DataStore_Tests.swift in Sources */,
 				79877A2A2498E51500015F8B /* MemberModelDTO_Tests.swift in Sources */,
+				F649B2372500F785008F98C8 /* MessageController_Tests.swift in Sources */,
 				799C947D247E6114001F1104 /* TestError.swift in Sources */,
 				799C946A247D791A001F1104 /* AssertAsync.swift in Sources */,
 				F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37024E591990052844D /* EventObserver_Tests.swift */; };
 		F63CC37324E592D30052844D /* MemberEventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37224E592D30052844D /* MemberEventObserver.swift */; };
 		F63CC37524E592DD0052844D /* MemberEventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */; };
+		F649B2392500FD56008F98C8 /* EntityDatabaseObserver_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F649B2382500FD56008F98C8 /* EntityDatabaseObserver_Mock.swift */; };
 		F670B50F24FE6EA900003B1A /* MessageEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F670B50E24FE6EA900003B1A /* MessageEditor.swift */; };
 		F67415C024F0129800C3222F /* UnreadCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67415BF24F0129800C3222F /* UnreadCount.swift */; };
 		F6778F9A24F5144F005E7D22 /* EventNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6778F9924F5144F005E7D22 /* EventNotificationCenter.swift */; };
@@ -629,6 +630,7 @@
 		F63CC37024E591990052844D /* EventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver_Tests.swift; sourceTree = "<group>"; };
 		F63CC37224E592D30052844D /* MemberEventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventObserver.swift; sourceTree = "<group>"; };
 		F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventObserver_Tests.swift; sourceTree = "<group>"; };
+		F649B2382500FD56008F98C8 /* EntityDatabaseObserver_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDatabaseObserver_Mock.swift; sourceTree = "<group>"; };
 		F670B50E24FE6EA900003B1A /* MessageEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEditor.swift; sourceTree = "<group>"; };
 		F67415BF24F0129800C3222F /* UnreadCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadCount.swift; sourceTree = "<group>"; };
 		F6778F9924F5144F005E7D22 /* EventNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventNotificationCenter.swift; sourceTree = "<group>"; };
@@ -1052,6 +1054,7 @@
 				793C14DB24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift */,
 				792AF91524D812440010097B /* EntityDatabaseObserver.swift */,
 				7922F30924DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift */,
+				F649B2382500FD56008F98C8 /* EntityDatabaseObserver_Mock.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -1822,6 +1825,7 @@
 				8A62706C24BF3DBC0040BFD6 /* ChannelEvents_Tests.swift in Sources */,
 				79280F8424891C6A00CDEB89 /* VirtualTime.swift in Sources */,
 				799C9476247D7E94001F1104 /* TemporaryData.swift in Sources */,
+				F649B2392500FD56008F98C8 /* EntityDatabaseObserver_Mock.swift in Sources */,
 				79CD959424F9381700E87377 /* MulticastDelegateTests.swift in Sources */,
 				792921C724C047DD00116BBB /* APIClient_Mock.swift in Sources */,
 				DAD5C836250278AD0045117A /* ChannelController+Combine_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -280,6 +280,8 @@
 		DAFAD6A324DD8E1A0043ED06 /* ChannelEditDetailPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFAD6A224DD8E1A0043ED06 /* ChannelEditDetailPayload.swift */; };
 		DAFC1D4724F50C5C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFC1D4524F50C2C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift */; };
 		F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */; };
+		F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */; };
+		F61D7C3524FFA6FD00188A0E /* MessageUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3424FFA6FD00188A0E /* MessageUpdater_Tests.swift */; };
 		F61ED5A124F3F58400874777 /* DatabaseContainer_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61ED5A024F3F58400874777 /* DatabaseContainer_Mock.swift */; };
 		F62D143E24DD70190081D241 /* ChannelUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */; };
 		F63CC36F24E591840052844D /* EventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC36E24E591840052844D /* EventObserver.swift */; };
@@ -293,6 +295,7 @@
 		F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69C4BC524F66CC200A3D740 /* EventLogger.swift */; };
 		F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */; };
 		F6C56D1424F7B89D0012BB1F /* EventMiddleware_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */; };
+		F6FF1DA824FD232C00151735 /* MessageUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA724FD232C00151735 /* MessageUpdater.swift */; };
 		F6FF1DAA24FD23D300151735 /* MessageEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */; };
 /* End PBXBuildFile section */
 
@@ -615,6 +618,8 @@
 		DAFAD6A224DD8E1A0043ED06 /* ChannelEditDetailPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelEditDetailPayload.swift; sourceTree = "<group>"; };
 		DAFC1D4524F50C2C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewChannelQueryUpdater_Tests.swift; sourceTree = "<group>"; };
 		F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints_Tests.swift; sourceTree = "<group>"; };
+		F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Mock.swift; sourceTree = "<group>"; };
+		F61D7C3424FFA6FD00188A0E /* MessageUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Tests.swift; sourceTree = "<group>"; };
 		F61ED5A024F3F58400874777 /* DatabaseContainer_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseContainer_Mock.swift; sourceTree = "<group>"; };
 		F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelUpdater_Mock.swift; sourceTree = "<group>"; };
 		F63CC36E24E591840052844D /* EventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver.swift; sourceTree = "<group>"; };
@@ -628,6 +633,7 @@
 		F69C4BC524F66CC200A3D740 /* EventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogger.swift; sourceTree = "<group>"; };
 		F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserController_Tests.swift; sourceTree = "<group>"; };
 		F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware_Mock.swift; sourceTree = "<group>"; };
+		F6FF1DA724FD232C00151735 /* MessageUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater.swift; sourceTree = "<group>"; };
 		F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -968,6 +974,9 @@
 				7952B3B424D45D9400AC53D4 /* ChannelUpdater_Tests.swift */,
 				F6778F9924F5144F005E7D22 /* EventNotificationCenter.swift */,
 				F69C4BC324F664A700A3D740 /* EventNotificationCenter_Tests.swift */,
+				F6FF1DA724FD232C00151735 /* MessageUpdater.swift */,
+				F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */,
+				F61D7C3424FFA6FD00188A0E /* MessageUpdater_Tests.swift */,
 				F63CC36D24E591690052844D /* EventObservers */,
 				79280F4524850ECC00CDEB89 /* Background */,
 			);
@@ -1606,6 +1615,7 @@
 				792CA62624CEE93700D70A5E /* ChannelListQueryUpdater.swift in Sources */,
 				79DDF80E249CB920002F4412 /* RequestDecoder.swift in Sources */,
 				8AC9CBD624C73689006E236C /* NotificationEvents.swift in Sources */,
+				F6FF1DA824FD232C00151735 /* MessageUpdater.swift in Sources */,
 				7931818C24FD2660002F8C84 /* ChannelListController+Combine.swift in Sources */,
 				8A62706E24BF45360040BFD6 /* BanEnabling.swift in Sources */,
 				79877A0A2498E4BC00015F8B /* Device.swift in Sources */,
@@ -1762,6 +1772,7 @@
 				792921C524C0479700116BBB /* ChannelListQueryUpdater_Tests.swift in Sources */,
 				79177A2D248A6A2600F053A2 /* AssertAsync+Events.swift in Sources */,
 				F6C56D1424F7B89D0012BB1F /* EventMiddleware_Mock.swift in Sources */,
+				F61D7C3524FFA6FD00188A0E /* MessageUpdater_Tests.swift in Sources */,
 				79B5517824E5969700CE9FEC /* UserPayloads_Tests.swift in Sources */,
 				792921C924C056F400116BBB /* ChannelListController_Tests.swift in Sources */,
 				8A0D64AB24E57BF20017A3C0 /* ChannelListPayload_Tests.swift in Sources */,
@@ -1771,6 +1782,7 @@
 				8A5D3EF924AF749200E2FE35 /* ChannelId_Tests.swift in Sources */,
 				799C945C247D59D8001F1104 /* ChatClient_Tests.swift in Sources */,
 				79BA19F324B3386B00E11FC2 /* CurrentUserDTO_Tests.swift in Sources */,
+				F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */,
 				79280F7D24891B1300CDEB89 /* WebSocketEngine_Mock.swift in Sources */,
 				79B5517C24E6A1CA00CE9FEC /* MessagePayloads_Tests.swift in Sources */,
 				790B9E3224DC221A005455AA /* UserPayload.swift in Sources */,

--- a/Tests_v3/Dummy data/MessagePayload.swift
+++ b/Tests_v3/Dummy data/MessagePayload.swift
@@ -10,6 +10,7 @@ extension MessagePayload {
     static func dummy<T: ExtraDataTypes>(
         messageId: MessageId,
         authorUserId: UserId,
+        text: String = .unique,
         extraData: T.Message = .defaultValue
     ) -> MessagePayload<T> where T.User == NameAndImageExtraData {
         .init(
@@ -19,7 +20,7 @@ extension MessagePayload {
             createdAt: .unique,
             updatedAt: .unique,
             deletedAt: .unique,
-            text: .unique,
+            text: text,
             command: .unique,
             args: .unique,
             parentId: .unique,


### PR DESCRIPTION
**This PR:**
- introduces `MessageController` that can be used to take **edit/delete** actions a specific message
- introduces `MessageEditor` - background worker that listens for messages in a `pendingSync` state and syncs them with the backend
- introduces `MessageUpdater` that acts as an API wrapper for message related endpoints
- adds new `pendingSync/syncing/syncingFailed` local message states that allows `MessageEditor` to do it's job