### PR TITLE
[CIS-317] Give users access to any object by its id

### DIFF
--- a/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
@@ -140,7 +140,8 @@ extension SimpleChatViewController: ChannelControllerDelegate {
     }
     
     func channelController(_ channelController: ChannelController, didReceiveTypingEvent event: TypingEvent) {
-        log.debug("\(event.userId) \(event.isTyping ? "started" : "stopped") typing.")
+        guard let user = channelController.dataStore.user(id: event.userId) else { return }
+        log.debug("\(user.name ?? "_missing name_") \(event.isTyping ? "started" : "stopped") typing.")
     }
 }
 

--- a/Sources_v3/Controllers/ChannelController.swift
+++ b/Sources_v3/Controllers/ChannelController.swift
@@ -82,7 +82,7 @@ public typealias ChannelController = ChannelControllerGeneric<DefaultDataTypes>
 ///
 ///  ... you can do this and that
 ///
-public class ChannelControllerGeneric<ExtraData: ExtraDataTypes>: Controller, DelegateCallable {
+public class ChannelControllerGeneric<ExtraData: ExtraDataTypes>: Controller, DelegateCallable, DataStoreProvider {
     /// The ChannelQuery this controller observes.
     @Atomic public private(set) var channelQuery: ChannelQuery<ExtraData>
 

--- a/Sources_v3/Controllers/ChannelListController.swift
+++ b/Sources_v3/Controllers/ChannelListController.swift
@@ -23,7 +23,7 @@ public typealias ChannelListController = ChannelListControllerGeneric<DefaultDat
 ///
 ///  ... you can do this and that
 ///
-public class ChannelListControllerGeneric<ExtraData: ExtraDataTypes>: Controller, DelegateCallable {
+public class ChannelListControllerGeneric<ExtraData: ExtraDataTypes>: Controller, DelegateCallable, DataStoreProvider {
     /// The query specifying and filtering the list of channels.
     public let query: ChannelListQuery
     

--- a/Sources_v3/Controllers/CurrentUserController.swift
+++ b/Sources_v3/Controllers/CurrentUserController.swift
@@ -17,7 +17,7 @@ public extension Client {
 public typealias CurrentUserController = CurrentUserControllerGeneric<DefaultDataTypes>
 
 /// `CurrentUserControllerGeneric` allows to observer current user updates
-public final class CurrentUserControllerGeneric<ExtraData: ExtraDataTypes>: Controller, DelegateCallable {
+public final class CurrentUserControllerGeneric<ExtraData: ExtraDataTypes>: Controller, DelegateCallable, DataStoreProvider {
     /// The `ChatClient` instance this controller belongs to.
     public let client: Client<ExtraData>
     

--- a/Sources_v3/Database/DataStore.swift
+++ b/Sources_v3/Database/DataStore.swift
@@ -1,0 +1,72 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Types conforming to this protocol automatically exposes public `dataStore` variable.
+public protocol DataStoreProvider {
+    associatedtype ExtraData: ExtraDataTypes
+    var client: Client<ExtraData> { get }
+}
+
+extension DataStoreProvider {
+    /// `DataStore` provide access to all locally available model objects based on their id.
+    public var dataStore: DataStore<ExtraData> { .init(client: client) }
+}
+
+/// `DataStore` provide access to all locally available model objects based on their id.
+public struct DataStore<ExtraData: ExtraDataTypes> {
+    let database: DatabaseContainer
+    
+    // Technically, we need only `database` but we use a `Client` instance to get the extra data types from it.
+    init(client: Client<ExtraData>) {
+        database = client.databaseContainer
+    }
+    
+    /// Loads a user model with a matching `id` from the **local data store**.
+    ///
+    /// If the data doesn't exist locally, it's recommended to use controllers to fetch data from remote servers.
+    ///
+    /// - Returns: If there's a user object in the locally cached data matching the provided `id`, returns the matching
+    /// model object. If a user object doesn't exist locally, returns `nil`.
+    ///
+    /// - Parameter id: An id of a user.
+    public func user(id: UserId) -> UserModel<ExtraData.User>? {
+        database.viewContext.user(id: id)?.asModel()
+    }
+    
+    /// Loads a current user model with a matching `id` from the **local data store**.
+    ///
+    /// If the data doesn't exist locally, it's recommended to use controllers to fetch data from remote servers.
+    ///
+    /// - Returns: If there's a current user object in the locally cached data, returns the matching
+    /// model object. If a user object doesn't exist locally, returns `nil`.
+    public func currentUser() -> CurrentUserModel<ExtraData.User>? {
+        database.viewContext.currentUser()?.asModel()
+    }
+
+    /// Loads a channel model with a matching `cid` from the **local data store**.
+    ///
+    /// If the data doesn't exist locally, it's recommended to use controllers to fetch data from remote servers.
+    ///
+    /// - Returns: If there's a channel object in the locally cached data matching the provided `cid`, returns the matching
+    /// model object. If a channel object doesn't exist locally, returns `nil`.
+    ///
+    /// - Parameter cid: An cid of a channel.
+    public func channel(cid: ChannelId) -> ChannelModel<ExtraData>? {
+        database.viewContext.loadChannel(cid: cid)
+    }
+    
+    /// Loads a message model with a matching `id` from the **local data store**.
+    ///
+    /// If the data doesn't exist locally, it's recommended to use controllers to fetch data from remote servers.
+    ///
+    /// - Returns: If there's a message object in the locally cached data matching the provided `id`, returns the matching
+    /// model object. If a user object doesn't exist locally, returns `nil`.
+    ///
+    /// - Parameter id: An id of a message.
+    public func message(id: MessageId) -> MessageModel<ExtraData>? {
+        database.viewContext.message(id: id)?.asModel()
+    }
+}

--- a/Sources_v3/Database/DataStore_Tests.swift
+++ b/Sources_v3/Database/DataStore_Tests.swift
@@ -1,0 +1,48 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+class DataStore_Tests: StressTestCase {
+    // We use `_` because `Client<ExtraData>!` doesn't conform to `DataStoreProvider`
+    var _client: Client<DefaultDataTypes>!
+    
+    override func setUp() {
+        super.setUp()
+        _client = Client.mock
+    }
+    
+    func test_userIsLoaded() throws {
+        let userId: UserId = .unique
+        XCTAssertNil(dataStore.user(id: userId))
+        try _client.databaseContainer.createUser(id: userId)
+        XCTAssertNotNil(dataStore.user(id: userId))
+    }
+    
+    func test_currentUserIsLoaded() throws {
+        XCTAssertNil(dataStore.currentUser())
+        try _client.databaseContainer.createCurrentUser()
+        XCTAssertNotNil(dataStore.currentUser())
+    }
+
+    func test_channelIsLoaded() throws {
+        let cid: ChannelId = .unique
+        XCTAssertNil(dataStore.channel(cid: cid))
+        try _client.databaseContainer.createChannel(cid: cid)
+        XCTAssertNotNil(dataStore.channel(cid: cid))
+    }
+    
+    func test_messageIsLoaded() throws {
+        let id: MessageId = .unique
+        XCTAssertNil(dataStore.message(id: id))
+        try _client.databaseContainer.createMessage(id: id)
+        XCTAssertNotNil(dataStore.message(id: id))
+    }
+}
+
+// Make `DataStore_Tests` to test is the same way we will use it.
+extension DataStore_Tests: DataStoreProvider {
+    var client: Client<DefaultDataTypes> { _client }
+}

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -47,8 +47,15 @@ extension DatabaseContainer {
             throw error
         }
     }
-    
-    /// Synchrnously creates a new CurrentUserDTO in the DB with the given id.
+
+    /// Synchronously creates a new UserDTO in the DB with the given id.
+    func createUser(id: UserId = .unique) throws {
+        try writeSynchronously { session in
+            try session.saveUser(payload: .dummy(userId: id))
+        }
+    }
+
+    /// Synchronously creates a new CurrentUserDTO in the DB with the given id.
     func createCurrentUser(id: UserId = .unique) throws {
         try writeSynchronously { session in
             try session.saveCurrentUser(payload: .dummy(
@@ -59,7 +66,7 @@ extension DatabaseContainer {
         }
     }
     
-    /// Synchrnously creates a new ChannelDTO in the DB with the given cid.
+    /// Synchronously creates a new ChannelDTO in the DB with the given cid.
     func createChannel(cid: ChannelId = .unique) throws {
         try writeSynchronously { session in
             try session.saveChannel(payload: XCTestCase().dummyPayload(with: cid))
@@ -75,6 +82,16 @@ extension DatabaseContainer {
                 ) as! ChannelListQueryDTO
             dto.filterHash = filter.filterHash
             dto.filterJSONData = try JSONEncoder.default.encode(filter)
+        }
+    }
+    
+    /// Synchronously creates a new MessageDTO in the DB with the given id.
+    func createMessage(id: MessageId = .unique, authorId: UserId = .unique, cid: ChannelId = .unique) throws {
+        try writeSynchronously { session in
+            try session.saveChannel(payload: XCTestCase().dummyPayload(with: cid))
+            
+            let message: MessagePayload<DefaultDataTypes> = .dummy(messageId: id, authorUserId: authorId)
+            try session.saveMessage(payload: message, for: cid)
         }
     }
 }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -90,6 +90,8 @@
 		797A756624814EF8003CF16D /* SystemEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797A756524814EF8003CF16D /* SystemEnvironment.swift */; };
 		797A756824814F0D003CF16D /* BundleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797A756724814F0D003CF16D /* BundleExtensions.swift */; };
 		797E10A824EAF6DE00353791 /* UniqueId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797E10A724EAF6DE00353791 /* UniqueId.swift */; };
+		797EEA4624FFAF4F00C81203 /* DataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797EEA4524FFAF4F00C81203 /* DataStore.swift */; };
+		797EEA4824FFB4C200C81203 /* DataStore_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797EEA4724FFB4C200C81203 /* DataStore_Tests.swift */; };
 		798779FB2498E47700015F8B /* Member.json in Resources */ = {isa = PBXBuildFile; fileRef = 798779F62498E47700015F8B /* Member.json */; };
 		798779FC2498E47700015F8B /* Channel.json in Resources */ = {isa = PBXBuildFile; fileRef = 798779F72498E47700015F8B /* Channel.json */; };
 		798779FD2498E47700015F8B /* OtherUser.json in Resources */ = {isa = PBXBuildFile; fileRef = 798779F82498E47700015F8B /* OtherUser.json */; };
@@ -391,6 +393,8 @@
 		797A756524814EF8003CF16D /* SystemEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemEnvironment.swift; sourceTree = "<group>"; };
 		797A756724814F0D003CF16D /* BundleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleExtensions.swift; sourceTree = "<group>"; };
 		797E10A724EAF6DE00353791 /* UniqueId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniqueId.swift; sourceTree = "<group>"; };
+		797EEA4524FFAF4F00C81203 /* DataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStore.swift; sourceTree = "<group>"; };
+		797EEA4724FFB4C200C81203 /* DataStore_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStore_Tests.swift; sourceTree = "<group>"; };
 		798779F62498E47700015F8B /* Member.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Member.json; sourceTree = "<group>"; };
 		798779F72498E47700015F8B /* Channel.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Channel.json; sourceTree = "<group>"; };
 		798779F82498E47700015F8B /* OtherUser.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = OtherUser.json; sourceTree = "<group>"; };
@@ -946,6 +950,8 @@
 				F61ED5A024F3F58400874777 /* DatabaseContainer_Mock.swift */,
 				792FCB4A24A3D52A000290C7 /* DatabaseSession.swift */,
 				792FCB4C24A3D56D000290C7 /* DatabaseSession_Tests.swift */,
+				797EEA4524FFAF4F00C81203 /* DataStore.swift */,
+				797EEA4724FFB4C200C81203 /* DataStore_Tests.swift */,
 				792A4F18247EA97000EAF71D /* DTOs */,
 			);
 			path = Database;
@@ -1582,6 +1588,7 @@
 				79CD959224F9380B00E87377 /* MulticastDelegate.swift in Sources */,
 				7964F3BC249A5E60002A09EC /* RequestEncoder.swift in Sources */,
 				79280F712487CD2B00CDEB89 /* Atomic.swift in Sources */,
+				797EEA4624FFAF4F00C81203 /* DataStore.swift in Sources */,
 				79CDE1DD24B321FE0003BD1D /* CurrentUserDTO.swift in Sources */,
 				797A756824814F0D003CF16D /* BundleExtensions.swift in Sources */,
 				792B805024D95B5D00C2963E /* Cached.swift in Sources */,
@@ -1660,6 +1667,7 @@
 				F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */,
 				79DDF81B249CE38B002F4412 /* AssertNetworkRequest.swift in Sources */,
 				791C0B6324EEBDF40013CA2F /* MessageSender_Tests.swift in Sources */,
+				797EEA4824FFB4C200C81203 /* DataStore_Tests.swift in Sources */,
 				79877A2A2498E51500015F8B /* MemberModelDTO_Tests.swift in Sources */,
 				799C947D247E6114001F1104 /* TestError.swift in Sources */,
 				799C946A247D791A001F1104 /* AssertAsync.swift in Sources */,


### PR DESCRIPTION
We should allow users to load any arbitrary object from the DB based on its id.

I solved this by introducing a `DataStoreProvider` protocol. Every object conforming to this protocol automatically exposes a `dataStore` variable, that acts like a proxy to the db.

Currently, only controllers expose `dataStore`, but any other object having access to `Client` (like the client itself) can adopt this protocol, too.

---

@cardoso This should fix the issue you have with not having access to the user model from typing events.