### PR TITLE
[CIS-185] Internet connection for WebSocketClient

### DIFF
--- a/Sources_v3/APIClient/APIClient_Tests.swift
+++ b/Sources_v3/APIClient/APIClient_Tests.swift
@@ -261,13 +261,16 @@ struct AnyEndpoint: Equatable {
 
 private class TestWebSocketClient: WebSocketClient {
     init() {
+        let internetConnection = InternetConnectionMock()
+        
         super.init(
             connectEndpoint: .init(path: "", method: .get, queryItems: nil, requiresConnectionId: false, body: nil),
             sessionConfiguration: .default,
             requestEncoder: DefaultRequestEncoder(baseURL: .unique(), apiKey: .init(.unique)),
             eventDecoder: EventDecoder<DefaultDataTypes>(),
             eventNotificationCenter: EventNotificationCenter(),
-            reconnectionStrategy: DefaultReconnectionStrategy()
+            internetConnection: internetConnection,
+            reconnectionStrategy: DefaultReconnectionStrategy(inernetConnection: internetConnection)
         )
     }
 }

--- a/Sources_v3/ChatClient.swift
+++ b/Sources_v3/ChatClient.swift
@@ -88,7 +88,9 @@ public class Client<ExtraData: ExtraDataTypes> {
             urlSessionConfiguration,
             encoder,
             EventDecoder<ExtraData>(),
-            eventNotificationCenter
+            eventNotificationCenter,
+            internetConnection,
+            DefaultReconnectionStrategy(inernetConnection: internetConnection)
         )
         
         webSocketClient.connectionStateDelegate = self
@@ -338,10 +340,14 @@ public class Client<ExtraData: ExtraDataTypes> {
         }
         
         webSocketClient.connect()
+        internetConnection.start()
     }
     
     /// Disconnects `Client` from the chat servers. No further updates from the servers are received.
     public func disconnect() {
+        // Stop recieving Internet connection status updates.
+        internetConnection.stop()
+        
         // Disconnect the web socket
         webSocketClient.disconnect(source: .userInitiated)
         
@@ -419,14 +425,18 @@ extension Client {
             _ sessionConfiguration: URLSessionConfiguration,
             _ requestEncoder: RequestEncoder,
             _ eventDecoder: AnyEventDecoder,
-            _ notificationCenter: EventNotificationCenter
+            _ notificationCenter: EventNotificationCenter,
+            _ internetConnection: InternetConnection,
+            _ reconnectionStrategy: WebSocketClientReconnectionStrategy
         ) -> WebSocketClient = {
             WebSocketClient(
                 connectEndpoint: $0,
                 sessionConfiguration: $1,
                 requestEncoder: $2,
                 eventDecoder: $3,
-                eventNotificationCenter: $4
+                eventNotificationCenter: $4,
+                internetConnection: $5,
+                reconnectionStrategy: $6
             )
         }
         

--- a/Sources_v3/ChatClient_Mock.swift
+++ b/Sources_v3/ChatClient_Mock.swift
@@ -19,7 +19,7 @@ extension Client.Environment where ExtraData == DefaultDataTypes {
     static var mock: ChatClient.Environment {
         .init(
             apiClientBuilder: { _, _, _ in APIClientMock() },
-            webSocketClientBuilder: { _, _, _, _, _ in WebSocketClientMock() },
+            webSocketClientBuilder: { _, _, _, _, _, _, _ in WebSocketClientMock() },
             databaseContainerBuilder: { _ in DatabaseContainerMock() },
             requestEncoderBuilder: { _, _ in DefaultRequestEncoder(baseURL: .unique(), apiKey: .init(.unique)) },
             requestDecoderBuilder: { DefaultRequestDecoder() },

--- a/Sources_v3/ChatClient_Tests.swift
+++ b/Sources_v3/ChatClient_Tests.swift
@@ -584,7 +584,9 @@ private class TestEnvironment<ExtraData: ExtraDataTypes> {
                     sessionConfiguration: $1,
                     requestEncoder: $2,
                     eventDecoder: $3,
-                    eventNotificationCenter: $4
+                    eventNotificationCenter: $4,
+                    internetConnection: $5,
+                    reconnectionStrategy: $6
                 )
                 return self.webSocketClient!
             },
@@ -703,6 +705,7 @@ class WebSocketClientMock: WebSocketClient {
     let init_requestEncoder: RequestEncoder
     let init_eventDecoder: AnyEventDecoder
     let init_eventNotificationCenter: EventNotificationCenter
+    let init_internetConnection: InternetConnection
     let init_reconnectionStrategy: WebSocketClientReconnectionStrategy
     let init_environment: WebSocketClient.Environment
     
@@ -715,7 +718,8 @@ class WebSocketClientMock: WebSocketClient {
         requestEncoder: RequestEncoder,
         eventDecoder: AnyEventDecoder,
         eventNotificationCenter: EventNotificationCenter,
-        reconnectionStrategy: WebSocketClientReconnectionStrategy = DefaultReconnectionStrategy(),
+        internetConnection: InternetConnection,
+        reconnectionStrategy: WebSocketClientReconnectionStrategy,
         environment: WebSocketClient.Environment = .init()
     ) {
         init_connectEndpoint = connectEndpoint
@@ -723,6 +727,7 @@ class WebSocketClientMock: WebSocketClient {
         init_requestEncoder = requestEncoder
         init_eventDecoder = eventDecoder
         init_eventNotificationCenter = eventNotificationCenter
+        init_internetConnection = internetConnection
         init_reconnectionStrategy = reconnectionStrategy
         init_environment = environment
         
@@ -732,6 +737,7 @@ class WebSocketClientMock: WebSocketClient {
             requestEncoder: requestEncoder,
             eventDecoder: eventDecoder,
             eventNotificationCenter: eventNotificationCenter,
+            internetConnection: internetConnection,
             reconnectionStrategy: reconnectionStrategy,
             environment: environment
         )
@@ -748,12 +754,16 @@ class WebSocketClientMock: WebSocketClient {
 
 extension WebSocketClientMock {
     convenience init() {
+        let internetConnection = InternetConnectionMock()
+        
         self.init(
             connectEndpoint: .init(path: "", method: .get, queryItems: nil, requiresConnectionId: false, body: nil),
             sessionConfiguration: .default,
             requestEncoder: DefaultRequestEncoder(baseURL: .unique(), apiKey: .init(.unique)),
             eventDecoder: EventDecoder<DefaultDataTypes>(),
-            eventNotificationCenter: .init()
+            eventNotificationCenter: .init(),
+            internetConnection: internetConnection,
+            reconnectionStrategy: DefaultReconnectionStrategy(inernetConnection: internetConnection)
         )
     }
 }

--- a/Sources_v3/Utils/Internet Connection/InternetConnection_Tests.swift
+++ b/Sources_v3/Utils/Internet Connection/InternetConnection_Tests.swift
@@ -17,7 +17,7 @@ class InternetConnection_Tests: XCTestCase {
 
     func test_internetConnection_start() throws {
         let notificationExpectation = expectation(forNotification: .internetConnectionStatusDidChange, object: nil) {
-            $0.userInfo?[InternetConnection.statusUserInfoKey] as? InternetConnection.Status == .available(.great)
+            $0.internetConnectionStatus == .available(.great)
         }
         
         XCTAssertEqual(internetConnection.status, .unknown)
@@ -31,7 +31,7 @@ class InternetConnection_Tests: XCTestCase {
         var notificationStatuses = [InternetConnection.Status]()
         
         let notificationExpectation = expectation(forNotification: .internetConnectionStatusDidChange, object: nil) {
-            if let status = $0.userInfo?[InternetConnection.statusUserInfoKey] as? InternetConnection.Status {
+            if let status = $0.internetConnectionStatus {
                 notificationStatuses.append(status)
             }
             
@@ -45,6 +45,16 @@ class InternetConnection_Tests: XCTestCase {
         XCTAssertEqual(internetConnection.status, .unknown)
         wait(for: [notificationExpectation], timeout: 5)
         XCTAssertEqual(notificationStatuses, [.available(.great), .unknown])
+    }
+}
+
+class InternetConnectionMock: InternetConnection {
+    private(set) var monitorMock: InternetConnectionMonitorMock!
+    
+    init(notificationCenter: NotificationCenter = .default) {
+        let monitor = InternetConnectionMonitorMock()
+        super.init(notificationCenter: notificationCenter, monitor: monitor)
+        monitorMock = monitor
     }
 }
 

--- a/Sources_v3/WebSocketClient/ConnectionState.swift
+++ b/Sources_v3/WebSocketClient/ConnectionState.swift
@@ -21,6 +21,9 @@ public enum ConnectionState: Equatable {
         
         /// `WebSocketPingController` didn't get a pong response.
         case noPongReceived
+        
+        /// The Internet connection is unavailable.
+        case internetConnectionUnavailable
     }
     
     /// The web socket is not connected. Optionally contains an error, if the connection was disconnected due to an error.

--- a/Sources_v3/WebSocketClient/WebSocketReconnectionStrategy_Tests.swift
+++ b/Sources_v3/WebSocketClient/WebSocketReconnectionStrategy_Tests.swift
@@ -7,10 +7,12 @@ import XCTest
 
 class DefaultReconnectionStrategy_Tests: XCTestCase {
     var strategy: DefaultReconnectionStrategy!
+    var internetConnection: InternetConnectionMock!
     
     override func setUp() {
         super.setUp()
-        strategy = DefaultReconnectionStrategy()
+        internetConnection = InternetConnectionMock()
+        strategy = DefaultReconnectionStrategy(inernetConnection: internetConnection)
     }
     
     func test_delaysAreIncreasing() throws {


### PR DESCRIPTION
In the PR:
- fixed InternetConnection crash and refactor the status notification userInfo key
- added: `ConnectionState.DisconnectionSource.internetConnectionUnavailable`
- added `InternetConnection` as a dependency for `WebSocketClient` and `DefaultReconnectionStrategy`
- added subscription for `InternetConnection` notifications in `WebSocketClient`
- fixed: removed `WebSocketClient` as an observer for App State notifications on `deinit()`
- changed: `WebSocketClient.disconnect()` will check if `connectionState.isActive` before changing the state to `.disconnecting`
- changed: when app did enter background and `WebSocketClient` doesn't allowed to keep connected, then if `connectionState.isActive` it do `disconnect()`
- added: `DefaultWebSocketReconnectionStrategy` will skip reconnecting if Internet connection unavailable
- added: `Client` will start `InternetConnection` monitoring on `connect()` and will stop on `disconnect()`
- added tests for `WebSocketClient` when Internet connection available and unavailable

The flow:
![image](https://user-images.githubusercontent.com/284922/91989426-cd7dac80-ed30-11ea-95dd-91052e79ba25.jpeg)

⚠️ Note: I didn't test it on a device because we don't have yet configured signing certificates for Sample v3 app.