### PR TITLE
[CIS-318] Fix failing tests on iOS11&12

### DIFF
--- a/Sources_v3/APIClient/APIClient_Tests.swift
+++ b/Sources_v3/APIClient/APIClient_Tests.swift
@@ -51,7 +51,7 @@ class APIClient_Tests: StressTestCase {
     func test_isInitializedWithCorrectValues() {
         XCTAssert(apiClient.encoder as AnyObject === encoder)
         XCTAssert(apiClient.decoder as AnyObject === decoder)
-        XCTAssertEqual(apiClient.session.configuration, sessionConfiguration)
+        XCTAssertTrue(apiClient.session.configuration.isTestEqual(to: sessionConfiguration))
     }
     
     func test_requestEncoderIsCalledWithEndpoint() {
@@ -269,5 +269,40 @@ private class TestWebSocketClient: WebSocketClient {
             eventNotificationCenter: EventNotificationCenter(),
             reconnectionStrategy: DefaultReconnectionStrategy()
         )
+    }
+}
+
+extension URLSessionConfiguration {
+    // Because on < iOS13 the configuration class gets copied and we can't simply compare it's the same instance, we need to
+    // provide custom implementation for comparing. The default `Equatable` implementation of `URLSessionConfiguration`
+    // simply compares the pointers.
+    @available(iOS, deprecated: 12.0, message: "Remove this workaround when dropping iOS 12 support.")
+    func isTestEqual(to otherConfiguration: URLSessionConfiguration) -> Bool {
+        identifier == otherConfiguration.identifier
+            && requestCachePolicy == otherConfiguration.requestCachePolicy
+            && timeoutIntervalForRequest == otherConfiguration.timeoutIntervalForRequest
+            && timeoutIntervalForResource == otherConfiguration.timeoutIntervalForResource
+            && networkServiceType == otherConfiguration.networkServiceType
+            && allowsCellularAccess == otherConfiguration.allowsCellularAccess
+            && httpShouldUsePipelining == otherConfiguration.httpShouldUsePipelining
+            && httpShouldSetCookies == otherConfiguration.httpShouldSetCookies
+            && httpCookieAcceptPolicy == otherConfiguration.httpCookieAcceptPolicy
+            && httpAdditionalHeaders as? [String: String] == otherConfiguration.httpAdditionalHeaders as? [String: String]
+            && httpMaximumConnectionsPerHost == otherConfiguration.httpMaximumConnectionsPerHost
+            && httpCookieStorage == otherConfiguration.httpCookieStorage
+            && urlCredentialStorage == otherConfiguration.urlCredentialStorage
+            && urlCache == otherConfiguration.urlCache
+            && shouldUseExtendedBackgroundIdleMode == otherConfiguration.shouldUseExtendedBackgroundIdleMode
+//            && protocolClasses == otherConfiguration.protocolClasses
+            && multipathServiceType == otherConfiguration.multipathServiceType
+            && waitsForConnectivity == otherConfiguration.waitsForConnectivity
+            && isDiscretionary == otherConfiguration.isDiscretionary
+            && sharedContainerIdentifier == otherConfiguration.sharedContainerIdentifier
+            && sessionSendsLaunchEvents == otherConfiguration.sessionSendsLaunchEvents
+//            && connectionProxyDictionary == otherConfiguration.connectionProxyDictionary
+            && waitsForConnectivity == otherConfiguration.waitsForConnectivity
+            && isDiscretionary == otherConfiguration.isDiscretionary
+            && sharedContainerIdentifier == otherConfiguration.sharedContainerIdentifier
+            && sessionSendsLaunchEvents == otherConfiguration.sessionSendsLaunchEvents
     }
 }

--- a/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 @available(iOS 13, *)
-class ChannelController_SwiftUI_Tests: XCTestCase {
+class ChannelController_SwiftUI_Tests: iOS13TestCase {
     var channelController: ChannelControllerMock!
     
     override func setUp() {

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController+Combine_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController+Combine_Tests.swift
@@ -8,7 +8,7 @@ import CoreData
 import XCTest
 
 @available(iOS 13, *)
-class ChannelListController_Combine_Tests: XCTestCase {
+class ChannelListController_Combine_Tests: iOS13TestCase {
     var channelListController: ChannelListControllerMock!
     var cancellables: Set<AnyCancellable>!
 

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController+SwiftUI_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 @available(iOS 13, *)
-class ChannelListController_SwiftUI_Tests: XCTestCase {
+class ChannelListController_SwiftUI_Tests: iOS13TestCase {
     var channelListController: ChannelListControllerMock!
     
     override func setUp() {

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 @available(iOS 13, *)
-class CurrentUserController_SwiftUI_Tests: XCTestCase {
+class CurrentUserController_SwiftUI_Tests: iOS13TestCase {
     var currentUserController: CurrentUserControllerMock!
     
     override func setUp() {

--- a/Sources_v3/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO_Tests.swift
@@ -237,9 +237,17 @@ class ChannelDTO_Tests: XCTestCase {
     }
     
     private func encodedChannelListSortingKey(_ sortingKey: ChannelListSortingKey) -> String {
-        let encodedData = try! JSONEncoder.stream.encode(sortingKey)
-        return String(data: encodedData, encoding: .utf8)!
-            .trimmingCharacters(in: .init(charactersIn: "\""))
+        if #available(iOS 13, *) {
+            let encodedData = try! JSONEncoder.stream.encode(sortingKey)
+            return String(data: encodedData, encoding: .utf8)!.trimmingCharacters(in: .init(charactersIn: "\""))
+        
+        } else {
+            @available(iOS, deprecated: 12.0, message: "Remove this workaround when dropping iOS 12 support.")
+            // Workaround for a bug https://bugs.swift.org/browse/SR-6163 fixed in iOS 13
+            let data = try! JSONEncoder.stream.encode(["key": sortingKey])
+            let json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+            return json["key"] as! String
+        }
     }
     
     func test_channelPayload_withNoExtraData_isStoredAndLoadedFromDB() {

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		79177A2D248A6A2600F053A2 /* AssertAsync+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79177A2C248A6A2600F053A2 /* AssertAsync+Events.swift */; };
 		791C0B6324EEBDF40013CA2F /* MessageSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */; };
 		791C0B6524EFBD260013CA2F /* UnwrapAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */; };
+		79200D42250118A1002F4EB1 /* iOS13TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79200D41250118A1002F4EB1 /* iOS13TestCase.swift */; };
 		7922F30624DACEF100C364BC /* TestDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 7922F30424DACEF100C364BC /* TestDataModel.xcdatamodeld */; };
 		7922F30824DACF1F00C364BC /* TestManagedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7922F30724DACF1F00C364BC /* TestManagedObject.swift */; };
 		7922F30A24DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7922F30924DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift */; };
@@ -316,6 +317,7 @@
 		79177A2C248A6A2600F053A2 /* AssertAsync+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AssertAsync+Events.swift"; sourceTree = "<group>"; };
 		791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSender_Tests.swift; sourceTree = "<group>"; };
 		791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnwrapAsync.swift; sourceTree = "<group>"; };
+		79200D41250118A1002F4EB1 /* iOS13TestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOS13TestCase.swift; sourceTree = "<group>"; };
 		7922F30524DACEF100C364BC /* TestDataModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TestDataModel.xcdatamodel; sourceTree = "<group>"; };
 		7922F30724DACF1F00C364BC /* TestManagedObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestManagedObject.swift; sourceTree = "<group>"; };
 		7922F30924DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDatabaseObserver_Tests.swift; sourceTree = "<group>"; };
@@ -1039,6 +1041,7 @@
 				7922F30724DACF1F00C364BC /* TestManagedObject.swift */,
 				792B805324D95FC700C2963E /* RandomDispatchQueue.swift */,
 				F69C4BC524F66CC200A3D740 /* EventLogger.swift */,
+				79200D41250118A1002F4EB1 /* iOS13TestCase.swift */,
 			);
 			indentWidth = 4;
 			path = Tests_v3;
@@ -1748,6 +1751,7 @@
 				79DDF810249CB92E002F4412 /* RequestDecoder_Tests.swift in Sources */,
 				8A62706A24BF02D80040BFD6 /* XCTAssertEqual+Difference.swift in Sources */,
 				7931818E24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift in Sources */,
+				79200D42250118A1002F4EB1 /* iOS13TestCase.swift in Sources */,
 				79877A292498E51500015F8B /* ChannelDTO_Tests.swift in Sources */,
 				DAEAF4B824DC026C0015FB28 /* ChannelEndpoints_Tests.swift in Sources */,
 				792FCB4D24A3D56D000290C7 /* DatabaseSession_Tests.swift in Sources */,

--- a/Tests_v3/iOS13TestCase.swift
+++ b/Tests_v3/iOS13TestCase.swift
@@ -1,0 +1,22 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import XCTest
+
+/// This is a workaround for a bug when Xcode ignores `@available()` marks at XCTestCase classes and runs them anyway. This causes
+/// version-specific tests to crash on older iOS versions.
+///
+/// If you make you tests class a subclass of this class, it will still be visible to Xcode but the test won't be executed.
+///
+/// Stack overflow: https://stackoverflow.com/questions/59645536/available-attribute-does-not-work-with-xctest-classes-or-methods
+class iOS13TestCase: XCTestCase {
+    override func invokeTest() {
+        if #available(iOS 13, *) {
+            return super.invokeTest()
+        } else {
+            print("Skipping test because it's iOS13+ only.")
+            return
+        }
+    }
+}


### PR DESCRIPTION
The failing tests were caused by 3 different bugs in Xcode and/or Swift.

### Bug 1: 
**`JSONEncoder`/`Decoder` don't support JSON framents on iOS11&12**
Prior iOS13, trying to encode a JSON fragment fails with an error. I worked around this by always boxing the value into a JSON object.

### Bug 2: 
**`NSInMemoryStore` doesn't work properly on iOS13**
**`NSSQLiteStoreType` with `/dev/null` URL doesn't work correctly on iOS 11&12**

So it means, we have to use `NSInMemoryStore` for older versions, and `NSSQLiteStoreType` for iOS13.

### Bug 3: 
**Xcode ignores `@available()` directives on `XCTestCase` classes and run them anyway.**
I created a custom `XCTestCase` subclass that skips test invocations when running on iOS 13. It's ugly but it works. 