### PR TITLE
Failing `ChannelWatchStateUpdater` test

### DIFF
--- a/Sources_v3/Workers/Background/ChannelWatchStateUpdater_Tests.swift
+++ b/Sources_v3/Workers/Background/ChannelWatchStateUpdater_Tests.swift
@@ -65,11 +65,9 @@ class ChannelWatchStateUpdater_Tests: StressTestCase {
     }
     
     func test_apiClient_called_on_websocket_connected() throws {
-        let cid1: ChannelId = .unique
-        let cid2: ChannelId = .unique
+        let cid: ChannelId = .unique
         
-        try database.createChannel(cid: cid1, withMessages: false)
-        try database.createChannel(cid: cid2, withMessages: false)
+        try database.createChannel(cid: cid, withMessages: false)
         
         XCTAssertNil(apiClient.request_endpoint)
         
@@ -77,7 +75,7 @@ class ChannelWatchStateUpdater_Tests: StressTestCase {
         simulateWebSocket(state: .connected(connectionId: .unique))
         
         let query: ChannelListQuery = .init(
-            filter: .in("cid", [cid1, cid2].map(\.rawValue)),
+            filter: .in("cid", [cid].map(\.rawValue)),
             pagination: [.limit(1)],
             options: [.watch]
         )


### PR DESCRIPTION
**In this PR:**

- Fix failing `ChannelWatchStateUpdater` test

_The test fails because we are comparing endpoints and in `==` method of `AnyEndpoint` 2 arrays with different elements order are treated as not equal. It's hard to make any sorting cause we are dealing with String(describing: `Encodable`) comparing. I decided that test modification doesn't affect test goal so it's the best way to fix error rather than modifying client code for test._