### PR TITLE
[CIS-325] Tap on attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
+### ✅ Added
+- A a new method for `ChatViewController` to customize behaviour for a tap on an attachment:
+`tapOnAttachment(_ attachment: Attachment, at index: Int, in cell: MessageTableViewCell, message: Message)` [#466](https://github.com/GetStream/stream-chat-swift/pull/466)
+
 ### 🐞 Fixed
 - Carthage building incorrect (v3-alpha) version instead of 2.3.0 and 2.3.1. If you're using Carthage, please skip these versions. [#468](https://github.com/GetStream/stream-chat-swift/issues/468)
 

--- a/Sources/.swiftlint.yml
+++ b/Sources/.swiftlint.yml
@@ -5,6 +5,7 @@ disabled_rules:
   - attributes
   - function_parameter_count
   - file_length
+  - type_body_length
 
 opt_in_rules:
   - empty_count
@@ -57,5 +58,3 @@ cyclomatic_complexity:
   ignores_case_statements: true
   warning: 25
   error: 30
-
-type_body_length: 300

--- a/Sources/UI/Chat/Cells/MessageTableViewCell+Attachments.swift
+++ b/Sources/UI/Chat/Cells/MessageTableViewCell+Attachments.swift
@@ -34,7 +34,7 @@ extension MessageTableViewCell {
             }
             
             (preview as UIView).rx.anyGesture(TapControlEvent.default)
-                .subscribe(onNext: { _ in tap(attachment, index, message.attachments) })
+                .subscribe(onNext: { _ in tap(attachment, index, message) })
                 .disposed(by: disposeBag)
         }
         

--- a/Sources/UI/Chat/Cells/MessageTableViewCell.swift
+++ b/Sources/UI/Chat/Cells/MessageTableViewCell.swift
@@ -18,7 +18,7 @@ open class MessageTableViewCell: UITableViewCell, Reusable {
     
     typealias ReactionAction = (_ cell: UITableViewCell, _ locationInView: CGPoint) -> Void
     typealias TapAction = (_ cell: MessageTableViewCell, _ message: Message) -> Void
-    typealias AttachmentTapAction = (_ attachment: Attachment, _ at: Int, _ attachments: [Attachment]) -> Void
+    typealias AttachmentTapAction = (_ attachment: Attachment, _ at: Int, _ message: Message) -> Void
     typealias LongPressAction = (_ cell: MessageTableViewCell, _ message: Message) -> Void
     typealias AttachmentActionTapAction = (_ message: Message, _ button: UIButton) -> Void
     

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Cells.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Cells.swift
@@ -184,7 +184,7 @@ extension ChatViewController {
             .subscribe(onNext: { [weak self, weak cell] gesture in
                 if let self = self, let cell = cell {
                     if let tapGesture = gesture as? UITapGestureRecognizer {
-                        self.handleMessageCellTap(from: cell, in: message, tapGesture: tapGesture)
+                        self.tapOnMessageCell(from: cell, in: message, tapGesture: tapGesture)
                     } else {
                         self.showActions(from: cell, for: message, locationInView: gesture.location(in: cell))
                     }
@@ -193,9 +193,9 @@ extension ChatViewController {
             .disposed(by: cell.disposeBag)
     }
     
-    func handleMessageCellTap(from cell: MessageTableViewCell,
-                              in message: Message,
-                              tapGesture: UITapGestureRecognizer) {
+    func tapOnMessageCell(from cell: MessageTableViewCell,
+                          in message: Message,
+                          tapGesture: UITapGestureRecognizer) {
         if let messageTextEnrichment = cell.messageTextEnrichment, !messageTextEnrichment.detectedURLs.isEmpty {
             for detectedURL in messageTextEnrichment.detectedURLs {
                 if tapGesture.didTapAttributedTextInLabel(label: cell.messageLabel, inRange: detectedURL.range) {

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Cells.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Cells.swift
@@ -122,16 +122,22 @@ extension ChatViewController {
         // Show attachments.
         if !message.attachments.isEmpty {
             message.attachments.enumerated().forEach { index, attachment in
-                cell.addAttachment(attachment,
-                                   at: index,
-                                   from: message,
-                                   tap: { [weak self] in self?.show(attachment: $0, at: $1, from: $2) },
-                                   actionTap: { [weak self] in self?.sendActionForEphemeralMessage($0, button: $1) },
-                                   reload: { [weak self] in
-                                    if let self = self {
-                                        self.tableView.reloadRows(at: [indexPath], with: .none)
-                                    }
-                })
+                cell.addAttachment(
+                    attachment,
+                    at: index,
+                    from: message,
+                    tap: { [weak self, weak cell] in
+                        if let self = self, let cell = cell {
+                            self.tapOnAttachment($0, at: $1, in: cell, message: $2)
+                        }
+                    },
+                    actionTap: { [weak self] in self?.sendActionForEphemeralMessage($0, button: $1) },
+                    reload: { [weak self] in
+                        if let self = self {
+                            self.tableView.reloadRows(at: [indexPath], with: .none)
+                        }
+                    }
+                )
             }
             
             cell.isContinueMessage = !message.isEphemeral
@@ -208,19 +214,6 @@ extension ChatViewController {
         if let presenter = presenter, presenter.channel.config.reactionsEnabled {
             showReactions(from: cell, in: message, locationInView: tapGesture.location(in: cell))
         }
-    }
-    
-    private func show(attachment: Attachment, at index: Int, from attachments: [Attachment]) {
-        if attachment.isImage {
-            showMediaGallery(with: attachments.compactMap {
-                let logoImage = $0.type == .giphy ? UIImage.Logo.giphy : nil
-                return MediaGalleryItem(title: $0.title, url: $0.imageURL, logoImage: logoImage)
-            }, selectedIndex: index)
-            
-            return
-        }
-        
-        showWebView(url: attachment.url, title: attachment.title)
     }
     
     func showReplies(parentMessage: Message) {

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -269,6 +269,30 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
         cell.avatarView.update(with: message.user.avatarURL, name: message.user.name)
     }
     
+    /// Handles a tap on the attachment.
+    /// - Parameters:
+    ///   - attachment: an attachment.
+    ///   - index: an index of the attachment in a list of message attachments.
+    ///   - attachments: a list of message attachments.
+    ///   - cell: a message cell with attachments.
+    ///   - message: a message with attachments.
+    open func tapOnAttachment(_ attachment: Attachment,
+                              at index: Int,
+                              in cell: MessageTableViewCell,
+                              message: Message) {
+        guard attachment.isImage else {
+            showWebView(url: attachment.url, title: attachment.title)
+            return
+        }
+        
+        let items: [MediaGalleryItem] = message.attachments.compactMap {
+            let logoImage = $0.type == .giphy ? UIImage.Logo.giphy : nil
+            return MediaGalleryItem(title: $0.title, url: $0.imageURL, logoImage: logoImage)
+        }
+        
+        showMediaGallery(with: items, selectedIndex: index)
+    }
+    
     /// Updates typing user avatar in the footer view.
     /// - Parameters:
     ///   - footerView: a footer view.


### PR DESCRIPTION
Added a new method for `ChatViewController` to customize behaviour for a tap on an attachment:
```swift
    open func tapOnAttachment(_ attachment: Attachment,
                              at index: Int,
                              in cell: MessageTableViewCell,
                              message: Message) {
```
