### PR TITLE
[CIS-249] Replay missing events

### DIFF
--- a/Sources_v3/APIClient/Endpoints/Payloads/MissingEventsPayload.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/MissingEventsPayload.swift
@@ -1,0 +1,14 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The type describes the incoming JSON from `/sync` endpoint
+struct MissingEventsPayload<ExtraData: ExtraDataTypes>: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case eventPayloads = "events"
+    }
+    
+    let eventPayloads: [EventPayload<ExtraData>]
+}

--- a/Sources_v3/APIClient/Endpoints/Payloads/MissingEventsPayload_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/MissingEventsPayload_Tests.swift
@@ -1,0 +1,69 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class MissingEventsPayload_Tests: XCTestCase {
+    func test_missingEventsPayload_isDeserialized() throws {
+        let json = XCTestCase.mockData(fromFile: "MissingEventsPayload")
+        let payload = try JSONDecoder.default.decode(MissingEventsPayload<DefaultDataTypes>.self, from: json)
+        XCTAssertEqual(payload.eventPayloads.count, 1)
+        
+        let expectedUser = UserPayload(
+            id: "broken-waterfall-5",
+            role: .user,
+            createdAt: "2019-12-12T15:33:46.488935Z".toDate(),
+            updatedAt: "2020-09-07T12:27:43.096437Z".toDate(),
+            lastActiveAt: "2020-09-07T12:25:41.501574Z".toDate(),
+            isOnline: true,
+            isInvisible: false,
+            isBanned: false,
+            extraData: NameAndImageExtraData(
+                name: "Broken Waterfall",
+                imageURL: URL(string: "https://api.adorable.io/avatars/285/broken-waterfall-5.png")
+            )
+        )
+        
+        let event = try XCTUnwrap(payload.eventPayloads.first)
+        XCTAssertEqual(event.eventType, .messageNew)
+        XCTAssertEqual(event.cid?.rawValue, "messaging:A2F4393C-D656-46B8-9A43-6148E9E62D7F")
+        XCTAssertEqual(event.createdAt, "2020-09-07T12:25:50.702323Z".toDate())
+
+        let message = try XCTUnwrap(event.message)
+        XCTAssertEqual(message.id, "AD6B64F8-1A12-48AF-B246-09774FD1B748")
+        XCTAssertEqual(message.text, "How are you?")
+        XCTAssertEqual(message.type, .regular)
+        XCTAssertTrue(message.latestReactions.isEmpty)
+        XCTAssertTrue(message.ownReactions.isEmpty)
+        XCTAssertTrue(message.reactionScores.isEmpty)
+        XCTAssertEqual(message.replyCount, 0)
+        XCTAssertEqual(message.createdAt, "2020-09-07T12:25:50.702323Z".toDate())
+        XCTAssertEqual(message.updatedAt, "2020-09-07T12:25:50.702324Z".toDate())
+        XCTAssertTrue(message.mentionedUsers.isEmpty)
+        XCTAssertFalse(message.isSilent)
+
+        let messageUser = try XCTUnwrap(message.user)
+        XCTAssertEqual(messageUser.id, expectedUser.id)
+        XCTAssertEqual(messageUser.role, expectedUser.role)
+        XCTAssertEqual(messageUser.createdAt, expectedUser.createdAt)
+        XCTAssertEqual(messageUser.updatedAt, expectedUser.updatedAt)
+        XCTAssertEqual(messageUser.lastActiveAt, expectedUser.lastActiveAt)
+        XCTAssertEqual(messageUser.isBanned, expectedUser.isBanned)
+        XCTAssertEqual(messageUser.isOnline, expectedUser.isOnline)
+        XCTAssertEqual(messageUser.isInvisible, expectedUser.isInvisible)
+        XCTAssertEqual(messageUser.extraData, expectedUser.extraData)
+        
+        let eventUser = try XCTUnwrap(event.user)
+        XCTAssertEqual(eventUser.id, expectedUser.id)
+        XCTAssertEqual(eventUser.role, expectedUser.role)
+        XCTAssertEqual(eventUser.createdAt, expectedUser.createdAt)
+        XCTAssertEqual(eventUser.updatedAt, expectedUser.updatedAt)
+        XCTAssertEqual(eventUser.lastActiveAt, expectedUser.lastActiveAt)
+        XCTAssertEqual(eventUser.isBanned, expectedUser.isBanned)
+        XCTAssertEqual(eventUser.isOnline, expectedUser.isOnline)
+        XCTAssertEqual(eventUser.isInvisible, expectedUser.isInvisible)
+        XCTAssertEqual(eventUser.extraData, expectedUser.extraData)
+    }
+}

--- a/Sources_v3/APIClient/Endpoints/Requests/MissingEventsRequestBody.swift
+++ b/Sources_v3/APIClient/Endpoints/Requests/MissingEventsRequestBody.swift
@@ -1,0 +1,16 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The type describes the outgoing JSON to `/sync` endpoint
+struct MissingEventsRequestBody: Encodable {
+    private enum CodingKeys: String, CodingKey {
+        case lastSyncedAt = "last_sync_at"
+        case cids = "channel_cids"
+    }
+    
+    let lastSyncedAt: Date
+    let cids: [ChannelId]
+}

--- a/Sources_v3/APIClient/Endpoints/Requests/MissingEventsRequestBody_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/Requests/MissingEventsRequestBody_Tests.swift
@@ -1,0 +1,23 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class MissingEventsRequestBody_Tests: XCTestCase {
+    func test_missingEventsRequestBody_isEncodedCorrectly() throws {
+        let lastSyncedAt: Date = .unique
+        let cids: [ChannelId] = [.unique, .unique, .unique]
+        let payload = MissingEventsRequestBody(lastSyncedAt: lastSyncedAt, cids: cids)
+        
+        // Encode the user
+        let json = try JSONEncoder.default.encode(payload)
+        
+        // Assert encoding is correct
+        AssertJSONEqual(json, [
+            "last_sync_at": DateFormatter.Stream.iso8601DateString(from: lastSyncedAt)!,
+            "channel_cids": cids as NSArray
+        ])
+    }
+}

--- a/Sources_v3/APIClient/Endpoints/SyncEndpoint.swift
+++ b/Sources_v3/APIClient/Endpoints/SyncEndpoint.swift
@@ -1,0 +1,20 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension Endpoint {
+    static func missingEvents<ExtraData: ExtraDataTypes>(
+        since: Date,
+        cids: [ChannelId]
+    ) -> Endpoint<MissingEventsPayload<ExtraData>> {
+        .init(
+            path: "sync",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: MissingEventsRequestBody(lastSyncedAt: since, cids: cids)
+        )
+    }
+}

--- a/Sources_v3/APIClient/Endpoints/SyncEndpoint_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/SyncEndpoint_Tests.swift
@@ -1,0 +1,27 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class SyncEndpoint_Tests: XCTestCase {
+    func test_missingEvents_buildsCorrectly() {
+        let lastSyncedAt: Date = .unique
+        let cids: [ChannelId] = [.unique, .unique, .unique]
+
+        let expectedEndpoint = Endpoint<MissingEventsPayload<DefaultDataTypes>>(
+            path: "sync",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: MissingEventsRequestBody(lastSyncedAt: lastSyncedAt, cids: cids)
+        )
+        
+        // Build endpoint
+        let endpoint: Endpoint<MissingEventsPayload<DefaultDataTypes>> = .missingEvents(since: lastSyncedAt, cids: cids)
+        
+        // Assert endpoint is built correctly
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
+}

--- a/Sources_v3/ChatClient.swift
+++ b/Sources_v3/ChatClient.swift
@@ -176,7 +176,8 @@ public class Client<ExtraData: ExtraDataTypes> {
             MessageSender<ExtraData>.init,
             NewChannelQueryUpdater<ExtraData>.init,
             ChannelWatchStateUpdater<ExtraData>.init,
-            MessageEditor<ExtraData>.init
+            MessageEditor<ExtraData>.init,
+            MissingEventsPublisher<ExtraData>.init
         ]
         
         self.init(

--- a/Sources_v3/ChatClient_Tests.swift
+++ b/Sources_v3/ChatClient_Tests.swift
@@ -273,6 +273,9 @@ class ChatClient_Tests: StressTestCase {
         // Check all the mandatory background workers are initialized
         XCTAssert(client.backgroundWorkers.contains { $0 is MessageSender<DefaultDataTypes> })
         XCTAssert(client.backgroundWorkers.contains { $0 is NewChannelQueryUpdater<DefaultDataTypes> })
+        XCTAssert(client.backgroundWorkers.contains { $0 is ChannelWatchStateUpdater<DefaultDataTypes> })
+        XCTAssert(client.backgroundWorkers.contains { $0 is MessageEditor<DefaultDataTypes> })
+        XCTAssert(client.backgroundWorkers.contains { $0 is MissingEventsPublisher<DefaultDataTypes> })
     }
     
     func test_backgroundWorkersAreInitialized() {

--- a/Sources_v3/Database/DTOs/ChannelDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO.swift
@@ -29,6 +29,13 @@ class ChannelDTO: NSManagedObject {
     @NSManaged var members: Set<MemberDTO>
     @NSManaged var messages: Set<MessageDTO>
     
+    /// The fetch request that returns all existed channels from the database
+    static var allChannelsFetchRequest: NSFetchRequest<ChannelDTO> {
+        let request = NSFetchRequest<ChannelDTO>(entityName: ChannelDTO.entityName)
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \ChannelDTO.updatedAt, ascending: false)]
+        return request
+    }
+    
     static func fetchRequest(for cid: ChannelId) -> NSFetchRequest<ChannelDTO> {
         let request = NSFetchRequest<ChannelDTO>(entityName: ChannelDTO.entityName)
         request.sortDescriptors = [NSSortDescriptor(keyPath: \ChannelDTO.updatedAt, ascending: false)]

--- a/Sources_v3/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO.swift
@@ -12,6 +12,11 @@ class CurrentUserDTO: NSManagedObject {
     @NSManaged var unreadChannelsCount: Int16
     @NSManaged var unreadMessagesCount: Int16
     
+    /// Into this field the creation date of last locally received event is saved.
+    /// The date later serves as reference date for `/sync` endpoint
+    /// that returns all events that happen after the given date
+    @NSManaged var lastReceivedEventDate: Date?
+
     @NSManaged var mutedUsers: Set<UserDTO>
     @NSManaged var user: UserDTO
     

--- a/Sources_v3/Database/DatabaseSession.swift
+++ b/Sources_v3/Database/DatabaseSession.swift
@@ -133,6 +133,10 @@ extension DatabaseSession {
             try saveCurrentUserUnreadCount(count: unreadCount)
         }
         
+        if let currentUser = currentUser(), let date = payload.createdAt {
+            currentUser.lastReceivedEventDate = date
+        }
+        
         // Save message data (must be always done after the channel data!)
         if let message = payload.message {
             if let cid = payload.cid {

--- a/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19E266" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19C57" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ChannelDTO" representedClassName="ChannelDTO" syncable="YES">
         <attribute name="cid" attributeType="String"/>
         <attribute name="config" attributeType="Binary"/>
@@ -49,6 +49,7 @@
         </uniquenessConstraints>
     </entity>
     <entity name="CurrentUserDTO" representedClassName="CurrentUserDTO" syncable="YES">
+        <attribute name="lastReceivedEventDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="uniquenessKey" attributeType="String" defaultValueString="this is an immmutable arbitrary key which makes sure we have only once instance of CurrentUserDTO in the db"/>
         <attribute name="unreadChannelsCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="unreadMessagesCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
@@ -151,7 +152,7 @@
     <elements>
         <element name="ChannelDTO" positionX="0" positionY="0" width="128" height="283"/>
         <element name="ChannelListQueryDTO" positionX="0" positionY="0" width="128" height="88"/>
-        <element name="CurrentUserDTO" positionX="0" positionY="0" width="128" height="118"/>
+        <element name="CurrentUserDTO" positionX="0" positionY="0" width="128" height="133"/>
         <element name="MemberDTO" positionX="0" positionY="0" width="128" height="178"/>
         <element name="MessageDTO" positionX="0" positionY="0" width="128" height="343"/>
         <element name="TeamDTO" positionX="0" positionY="0" width="128" height="88"/>

--- a/Sources_v3/WebSocketClient/Events/MessageEvents.swift
+++ b/Sources_v3/WebSocketClient/Events/MessageEvents.swift
@@ -9,8 +9,8 @@ public struct MessageNewEvent<ExtraData: ExtraDataTypes>: EventWithUserPayload, 
     public let cid: ChannelId
     public let messageId: MessageId
     public let createdAt: Date
-    public let watcherCount: Int
-    public let unreadCount: UnreadCount
+    public let watcherCount: Int?
+    public let unreadCount: UnreadCount?
     
     let payload: Any
     
@@ -19,8 +19,8 @@ public struct MessageNewEvent<ExtraData: ExtraDataTypes>: EventWithUserPayload, 
         cid = try response.value(at: \.cid)
         messageId = try response.value(at: \.message?.id)
         createdAt = try response.value(at: \.message?.createdAt)
-        watcherCount = try response.value(at: \.watcherCount)
-        unreadCount = try response.value(at: \.unreadCount)
+        watcherCount = try? response.value(at: \.watcherCount)
+        unreadCount = try? response.value(at: \.unreadCount)
         payload = response
     }
 }

--- a/Sources_v3/WebSocketClient/Events/MessageEvents_Tests.swift
+++ b/Sources_v3/WebSocketClient/Events/MessageEvents_Tests.swift
@@ -20,6 +20,17 @@ class MessageEvents_Tests: XCTestCase {
         XCTAssertEqual(event?.unreadCount, .init(channels: 1, messages: 1))
     }
     
+    func test_new_withMissingFields() throws {
+        let json = XCTestCase.mockData(fromFile: "MessageNew+MissingFields")
+        let event = try eventDecoder.decode(from: json) as? MessageNewEvent<DefaultDataTypes>
+        XCTAssertEqual(event?.userId, "broken-waterfall-5")
+        XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "general"))
+        XCTAssertEqual(event?.messageId, messageId)
+        XCTAssertEqual(event?.createdAt.description, "2020-07-17 13:42:21 +0000")
+        XCTAssertNil(event?.watcherCount)
+        XCTAssertNil(event?.unreadCount)
+    }
+    
     func test_updated() throws {
         let json = XCTestCase.mockData(fromFile: "MessageUpdated")
         let event = try eventDecoder.decode(from: json) as? MessageUpdatedEvent<DefaultDataTypes>

--- a/Sources_v3/Workers/Background/MissingEventsPublisher.swift
+++ b/Sources_v3/Workers/Background/MissingEventsPublisher.swift
@@ -1,0 +1,102 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+/// The type is designed to obtain missing events that happened in watched channels while user
+/// was not connected to the web-socket.
+///
+/// The object listenes for `ConnectionStatusUpdated` events
+/// and remembers the `CurrentUserDTO.lastReceivedEventDate` when status becomes `connecting`.
+///
+/// When the status becomes `connected` the `/sync` endpoint is called
+/// with `lastReceivedEventDate` and `cids` of watched channels.
+///
+/// We remember `lastReceivedEventDate` when state becomes `connecting` to catch the last event date
+/// before the `HealthCheck` override the `lastReceivedEventDate` with the recent date.
+///
+class MissingEventsPublisher<ExtraData: ExtraDataTypes>: Worker {
+    // MARK: - Properties
+    
+    private var connectionObserver: EventObserver?
+    @Atomic private var lastSyncedAt: Date?
+    
+    // MARK: - Init
+
+    override init(database: DatabaseContainer, webSocketClient: WebSocketClient, apiClient: APIClient) {
+        super.init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        startObserving()
+    }
+    
+    // MARK: - Private
+    
+    private func startObserving() {
+        connectionObserver = EventObserver(
+            notificationCenter: webSocketClient.eventNotificationCenter,
+            tranform: { $0 as? ConnectionStatusUpdated },
+            callback: { [unowned self] in
+                switch $0.webSocketConnectionState {
+                case .connecting:
+                    self.obtainLastSyncDate()
+                case .connected:
+                    self.fetchAndReplayMissingEvents()
+                default:
+                    break
+                }
+            }
+        )
+    }
+    
+    private func obtainLastSyncDate() {
+        lastSyncedAt = database.backgroundReadOnlyContext.currentUser()?.lastReceivedEventDate
+    }
+    
+    private func fetchAndReplayMissingEvents() {
+        guard let lastSyncedAt = lastSyncedAt else { return }
+        
+        let watchedChannelIDs = allChannels.filter { $0.isWatched }.map(\.cid)
+        
+        let endpoint: Endpoint<MissingEventsPayload<ExtraData>> = .missingEvents(
+            since: lastSyncedAt,
+            cids: watchedChannelIDs
+        )
+        
+        apiClient.request(endpoint: endpoint) { [weak self] in
+            switch $0 {
+            case let .success(payload):
+                self?.webSocketClient.eventNotificationCenter.process(payload.eventPayloads)
+            case let .failure(error):
+                log.error("Internal error: Failed to fetch and reply missing events: \(error)")
+            }
+        }
+    }
+    
+    private var allChannels: [ChannelModel<ExtraData>] {
+        do {
+            return try database.backgroundReadOnlyContext.fetch(ChannelDTO.allChannelsFetchRequest).map(ChannelModel.create)
+        } catch {
+            log.error("Internal error: Failed to fetch [ChannelDTO]: \(error)")
+            return []
+        }
+    }
+}
+
+// MARK: - Extensions
+
+private extension EventNotificationCenter {
+    /// The method is used to convert incoming event payloads into events and calls `process(_:)` for each event
+    /// that was successfully decoded.
+    ///
+    /// - Parameter payloads: The event payloads
+    func process<ExtraData: ExtraDataTypes>(_ payloads: [EventPayload<ExtraData>]) {
+        payloads.forEach {
+            do {
+                process(try $0.event())
+            } catch {
+                log.error("Failed to transform a payload into an event: \($0)")
+            }
+        }
+    }
+}

--- a/Sources_v3/Workers/Background/MissingEventsPublisher_Tests.swift
+++ b/Sources_v3/Workers/Background/MissingEventsPublisher_Tests.swift
@@ -1,0 +1,147 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class MissingEventsReplayer_Tests: StressTestCase {
+    typealias ExtraData = DefaultDataTypes
+    
+    var database: DatabaseContainerMock!
+    var webSocketClient: WebSocketClientMock!
+    var apiClient: APIClientMock!
+    var publisher: MissingEventsPublisher<ExtraData>?
+    
+    // MARK: - Setup
+    
+    override func setUp() {
+        super.setUp()
+        
+        database = try! DatabaseContainerMock(kind: .inMemory)
+        webSocketClient = WebSocketClientMock()
+        apiClient = APIClientMock()
+        
+        publisher = MissingEventsPublisher(
+            database: database,
+            webSocketClient: webSocketClient,
+            apiClient: apiClient
+        )
+    }
+    
+    override func tearDown() {
+        apiClient.cleanUp()
+        
+        AssertAsync {
+            Assert.canBeReleased(&publisher)
+            Assert.canBeReleased(&database)
+            Assert.canBeReleased(&webSocketClient)
+            Assert.canBeReleased(&apiClient)
+        }
+        
+        super.tearDown()
+    }
+    
+    // MARK: - Tests
+    
+    func test_endpointIsNotCalled_ifThereIsNoCurrentUser() throws {
+        // Simulate `.connecting` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connecting)
+        
+        // Simulate `.connected` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        
+        // Assert endpoint is not called as `lastSyncAt` is unknown
+        XCTAssertNil(apiClient.request_endpoint)
+    }
+    
+    func test_endpointIsCalled_whenStatusBecomesConnected() throws {
+        let cid: ChannelId = .unique
+        let lastReceivedEventDate: Date = .unique
+        
+        // Create current user in the database
+        try database.createCurrentUser()
+        
+        // Create channel in the database
+        try database.createChannel(cid: cid)
+
+        // Set `lastReceivedEventDate`
+        try database.writeSynchronously { session in
+            let currentUser = try XCTUnwrap(session.currentUser())
+            currentUser.lastReceivedEventDate = lastReceivedEventDate
+        }
+        
+        // Simulate `.connecting` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connecting)
+        
+        // Simulate `.connected` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        
+        // Assert endpoint is called with correct values
+        let endpoint: Endpoint<MissingEventsPayload<ExtraData>> = .missingEvents(
+            since: lastReceivedEventDate,
+            cids: [cid]
+        )
+        XCTAssertEqual(try XCTUnwrap(apiClient.request_endpoint), AnyEndpoint(endpoint))
+    }
+    
+    func test_noEventsArePublished_ifErrorResponseComes() throws {
+        let cid: ChannelId = .unique
+
+        // Create current user in the database
+        try database.createCurrentUser()
+        
+        // Create channel in the database
+        try database.createChannel(cid: cid)
+        
+        // Set `lastReceivedEventDate`
+        try database.writeSynchronously { session in
+            let currentUser = try XCTUnwrap(session.currentUser())
+            currentUser.lastReceivedEventDate = Date()
+        }
+        
+        // Simulate `.connecting` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connecting)
+        
+        // Simulate `.connected` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        
+        // Create event logger to check published events
+        let eventLogger = EventLogger(webSocketClient.init_eventNotificationCenter)
+        
+        // Simulate error response
+        apiClient.test_simulateResponse(Result<MissingEventsPayload<ExtraData>, Error>.failure(TestError()))
+        
+        // Assert no events are published
+        AssertAsync.willBeTrue(eventLogger.equatableEvents.isEmpty)
+    }
+    
+    func test_eventsFromPayloadArePublished_ifSuccessfulResponseComes() throws {
+        let json = XCTestCase.mockData(fromFile: "MissingEventsPayload")
+        let payload = try JSONDecoder.default.decode(MissingEventsPayload<ExtraData>.self, from: json)
+        let events = payload.eventPayloads.compactMap { try? $0.event() }
+        
+        // Create current user in the database
+        try database.createCurrentUser()
+        
+        // Create channel in the database
+        try database.createChannel(cid: (events.first as! EventWithChannelId).cid)
+        
+        try database.writeSynchronously { session in
+            let currentUser = try XCTUnwrap(session.currentUser())
+            currentUser.lastReceivedEventDate = .unique
+        }
+        
+        webSocketClient.simulateConnectionStatus(.connecting)
+        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        
+        // Create event logger to check published events
+        let eventLogger = EventLogger(webSocketClient.init_eventNotificationCenter)
+        
+        // Simulate successful response
+        apiClient.test_simulateResponse(Result<MissingEventsPayload<ExtraData>, Error>.success(payload))
+        
+        // Assert events from payload are published
+        AssertAsync.willBeEqual(eventLogger.equatableEvents, events.map(\.asEquatable))
+    }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -290,6 +290,7 @@
 		F61D7C3524FFA6FD00188A0E /* MessageUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3424FFA6FD00188A0E /* MessageUpdater_Tests.swift */; };
 		F61D7C3724FFE17200188A0E /* MessageEditor_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3624FFE17200188A0E /* MessageEditor_Tests.swift */; };
 		F61ED5A124F3F58400874777 /* DatabaseContainer_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61ED5A024F3F58400874777 /* DatabaseContainer_Mock.swift */; };
+		F62BE78325062FC400D13B86 /* SyncEndpoint_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62BE78225062FC400D13B86 /* SyncEndpoint_Tests.swift */; };
 		F62D143E24DD70190081D241 /* ChannelUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */; };
 		F63CC36F24E591840052844D /* EventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC36E24E591840052844D /* EventObserver.swift */; };
 		F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37024E591990052844D /* EventObserver_Tests.swift */; };
@@ -305,6 +306,7 @@
 		F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69C4BC524F66CC200A3D740 /* EventLogger.swift */; };
 		F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */; };
 		F6C56D1424F7B89D0012BB1F /* EventMiddleware_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */; };
+		F6ED5F76250278D7005D7327 /* SyncEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6ED5F75250278D7005D7327 /* SyncEndpoint.swift */; };
 		F6FF1DA624FD17B400151735 /* MessageController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA524FD17B400151735 /* MessageController.swift */; };
 		F6FF1DA824FD232C00151735 /* MessageUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA724FD232C00151735 /* MessageUpdater.swift */; };
 		F6FF1DAA24FD23D300151735 /* MessageEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */; };
@@ -649,6 +651,7 @@
 		F61D7C3424FFA6FD00188A0E /* MessageUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Tests.swift; sourceTree = "<group>"; };
 		F61D7C3624FFE17200188A0E /* MessageEditor_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEditor_Tests.swift; sourceTree = "<group>"; };
 		F61ED5A024F3F58400874777 /* DatabaseContainer_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseContainer_Mock.swift; sourceTree = "<group>"; };
+		F62BE78225062FC400D13B86 /* SyncEndpoint_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEndpoint_Tests.swift; sourceTree = "<group>"; };
 		F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelUpdater_Mock.swift; sourceTree = "<group>"; };
 		F63CC36E24E591840052844D /* EventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver.swift; sourceTree = "<group>"; };
 		F63CC37024E591990052844D /* EventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver_Tests.swift; sourceTree = "<group>"; };
@@ -664,6 +667,7 @@
 		F69C4BC524F66CC200A3D740 /* EventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogger.swift; sourceTree = "<group>"; };
 		F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserController_Tests.swift; sourceTree = "<group>"; };
 		F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware_Mock.swift; sourceTree = "<group>"; };
+		F6ED5F75250278D7005D7327 /* SyncEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEndpoint.swift; sourceTree = "<group>"; };
 		F6FF1DA524FD17B400151735 /* MessageController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageController.swift; sourceTree = "<group>"; };
 		F6FF1DA724FD232C00151735 /* MessageUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater.swift; sourceTree = "<group>"; };
 		F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints.swift; sourceTree = "<group>"; };
@@ -930,6 +934,7 @@
 				798779F82498E47700015F8B /* OtherUser.json */,
 				798779F92498E47700015F8B /* CurrentUser.json */,
 				798779FA2498E47700015F8B /* ChannelsQuery.json */,
+				F62BE7882506616900D13B86 /* Sync */,
 				8A0D649E24E57A260017A3C0 /* GuestUser */,
 				8A62705F24BE31B20040BFD6 /* Events */,
 			);
@@ -948,6 +953,8 @@
 				7937282B249900CB00E13FE5 /* MemberPayload_Tests.swift */,
 				79877A132498E4EE00015F8B /* ChannelEndpoints.swift */,
 				DAEAF4B724DC026C0015FB28 /* ChannelEndpoints_Tests.swift */,
+				F6ED5F75250278D7005D7327 /* SyncEndpoint.swift */,
+				F62BE78225062FC400D13B86 /* SyncEndpoint_Tests.swift */,
 				F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */,
 				F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */,
 			);
@@ -1722,6 +1729,7 @@
 				79280F712487CD2B00CDEB89 /* Atomic.swift in Sources */,
 				797EEA4624FFAF4F00C81203 /* DataStore.swift in Sources */,
 				79CDE1DD24B321FE0003BD1D /* CurrentUserDTO.swift in Sources */,
+				F6ED5F76250278D7005D7327 /* SyncEndpoint.swift in Sources */,
 				797A756824814F0D003CF16D /* BundleExtensions.swift in Sources */,
 				792B805024D95B5D00C2963E /* Cached.swift in Sources */,
 				799C9479247E3DEA001F1104 /* StreamChatModel.xcdatamodeld in Sources */,
@@ -1824,6 +1832,7 @@
 				8A0D649324E5794C0017A3C0 /* CurrentUserPayload.swift in Sources */,
 				8A0D64AE24E5853F0017A3C0 /* Controller_Tests.swift in Sources */,
 				8A0C3BC924C0BBAB00CAFD19 /* UserEvents_Tests.swift in Sources */,
+				F62BE78325062FC400D13B86 /* SyncEndpoint_Tests.swift in Sources */,
 				F63CC37524E592DD0052844D /* MemberEventObserver_Tests.swift in Sources */,
 				792FCB4724A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift in Sources */,
 				797EEA4A24FFC37600C81203 /* ConnectionStatus_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -294,6 +294,7 @@
 		F62BE7852506309B00D13B86 /* MissingEventsPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62BE7842506309B00D13B86 /* MissingEventsPayload_Tests.swift */; };
 		F62BE7872506525700D13B86 /* MissingEventsRequestBody_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62BE7862506525700D13B86 /* MissingEventsRequestBody_Tests.swift */; };
 		F62BE7902506620000D13B86 /* MissingEventsPayload.json in Resources */ = {isa = PBXBuildFile; fileRef = F62BE78D2506620000D13B86 /* MissingEventsPayload.json */; };
+		F62BE7922506692700D13B86 /* MissingEventsPublisher_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62BE7912506692700D13B86 /* MissingEventsPublisher_Tests.swift */; };
 		F62D143E24DD70190081D241 /* ChannelUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */; };
 		F63CC36F24E591840052844D /* EventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC36E24E591840052844D /* EventObserver.swift */; };
 		F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37024E591990052844D /* EventObserver_Tests.swift */; };
@@ -309,6 +310,7 @@
 		F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69C4BC524F66CC200A3D740 /* EventLogger.swift */; };
 		F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */; };
 		F6C56D1424F7B89D0012BB1F /* EventMiddleware_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */; };
+		F6ED5F7425023EB4005D7327 /* MissingEventsPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6ED5F7325023EB4005D7327 /* MissingEventsPublisher.swift */; };
 		F6ED5F76250278D7005D7327 /* SyncEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6ED5F75250278D7005D7327 /* SyncEndpoint.swift */; };
 		F6FF1DA624FD17B400151735 /* MessageController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA524FD17B400151735 /* MessageController.swift */; };
 		F6FF1DA824FD232C00151735 /* MessageUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA724FD232C00151735 /* MessageUpdater.swift */; };
@@ -660,6 +662,7 @@
 		F62BE7842506309B00D13B86 /* MissingEventsPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingEventsPayload_Tests.swift; sourceTree = "<group>"; };
 		F62BE7862506525700D13B86 /* MissingEventsRequestBody_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingEventsRequestBody_Tests.swift; sourceTree = "<group>"; };
 		F62BE78D2506620000D13B86 /* MissingEventsPayload.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MissingEventsPayload.json; sourceTree = "<group>"; };
+		F62BE7912506692700D13B86 /* MissingEventsPublisher_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingEventsPublisher_Tests.swift; sourceTree = "<group>"; };
 		F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelUpdater_Mock.swift; sourceTree = "<group>"; };
 		F63CC36E24E591840052844D /* EventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver.swift; sourceTree = "<group>"; };
 		F63CC37024E591990052844D /* EventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver_Tests.swift; sourceTree = "<group>"; };
@@ -675,6 +678,7 @@
 		F69C4BC524F66CC200A3D740 /* EventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogger.swift; sourceTree = "<group>"; };
 		F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserController_Tests.swift; sourceTree = "<group>"; };
 		F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware_Mock.swift; sourceTree = "<group>"; };
+		F6ED5F7325023EB4005D7327 /* MissingEventsPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingEventsPublisher.swift; sourceTree = "<group>"; };
 		F6ED5F75250278D7005D7327 /* SyncEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEndpoint.swift; sourceTree = "<group>"; };
 		F6FF1DA524FD17B400151735 /* MessageController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageController.swift; sourceTree = "<group>"; };
 		F6FF1DA724FD232C00151735 /* MessageUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater.swift; sourceTree = "<group>"; };
@@ -770,6 +774,8 @@
 				F61D7C3624FFE17200188A0E /* MessageEditor_Tests.swift */,
 				DAE566F625010CA100E39431 /* ChannelWatchStateUpdater.swift */,
 				DAE566F8250119E800E39431 /* ChannelWatchStateUpdater_Tests.swift */,
+				F6ED5F7325023EB4005D7327 /* MissingEventsPublisher.swift */,
+				F62BE7912506692700D13B86 /* MissingEventsPublisher_Tests.swift */,
 			);
 			path = Background;
 			sourceTree = "<group>";
@@ -1804,6 +1810,7 @@
 				797A756424814E7A003CF16D /* WebSocketConnectPayload.swift in Sources */,
 				F6FF1DA624FD17B400151735 /* MessageController.swift in Sources */,
 				797E10A824EAF6DE00353791 /* UniqueId.swift in Sources */,
+				F6ED5F7425023EB4005D7327 /* MissingEventsPublisher.swift in Sources */,
 				79877A0B2498E4BC00015F8B /* MemberModel.swift in Sources */,
 				F670B50F24FE6EA900003B1A /* MessageEditor.swift in Sources */,
 				7991D83D24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift in Sources */,
@@ -1891,6 +1898,7 @@
 				DAE566FA25011A4E00E39431 /* ChannelWatchStateUpdater_Tests.swift in Sources */,
 				8A62706A24BF02D80040BFD6 /* XCTAssertEqual+Difference.swift in Sources */,
 				7931818E24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift in Sources */,
+				F62BE7922506692700D13B86 /* MissingEventsPublisher_Tests.swift in Sources */,
 				79200D42250118A1002F4EB1 /* iOS13TestCase.swift in Sources */,
 				79877A292498E51500015F8B /* ChannelDTO_Tests.swift in Sources */,
 				DAEAF4B824DC026C0015FB28 /* ChannelEndpoints_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -291,6 +291,7 @@
 		F61D7C3724FFE17200188A0E /* MessageEditor_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3624FFE17200188A0E /* MessageEditor_Tests.swift */; };
 		F61ED5A124F3F58400874777 /* DatabaseContainer_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61ED5A024F3F58400874777 /* DatabaseContainer_Mock.swift */; };
 		F62BE78325062FC400D13B86 /* SyncEndpoint_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62BE78225062FC400D13B86 /* SyncEndpoint_Tests.swift */; };
+		F62BE7872506525700D13B86 /* MissingEventsRequestBody_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62BE7862506525700D13B86 /* MissingEventsRequestBody_Tests.swift */; };
 		F62D143E24DD70190081D241 /* ChannelUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */; };
 		F63CC36F24E591840052844D /* EventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC36E24E591840052844D /* EventObserver.swift */; };
 		F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37024E591990052844D /* EventObserver_Tests.swift */; };
@@ -310,6 +311,7 @@
 		F6FF1DA624FD17B400151735 /* MessageController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA524FD17B400151735 /* MessageController.swift */; };
 		F6FF1DA824FD232C00151735 /* MessageUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA724FD232C00151735 /* MessageUpdater.swift */; };
 		F6FF1DAA24FD23D300151735 /* MessageEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */; };
+		F6ED5F7825027907005D7327 /* MissingEventsRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6ED5F7725027907005D7327 /* MissingEventsRequestBody.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -652,6 +654,7 @@
 		F61D7C3624FFE17200188A0E /* MessageEditor_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEditor_Tests.swift; sourceTree = "<group>"; };
 		F61ED5A024F3F58400874777 /* DatabaseContainer_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseContainer_Mock.swift; sourceTree = "<group>"; };
 		F62BE78225062FC400D13B86 /* SyncEndpoint_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEndpoint_Tests.swift; sourceTree = "<group>"; };
+		F62BE7862506525700D13B86 /* MissingEventsRequestBody_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingEventsRequestBody_Tests.swift; sourceTree = "<group>"; };
 		F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelUpdater_Mock.swift; sourceTree = "<group>"; };
 		F63CC36E24E591840052844D /* EventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver.swift; sourceTree = "<group>"; };
 		F63CC37024E591990052844D /* EventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver_Tests.swift; sourceTree = "<group>"; };
@@ -671,6 +674,7 @@
 		F6FF1DA524FD17B400151735 /* MessageController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageController.swift; sourceTree = "<group>"; };
 		F6FF1DA724FD232C00151735 /* MessageUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater.swift; sourceTree = "<group>"; };
 		F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints.swift; sourceTree = "<group>"; };
+		F6ED5F7725027907005D7327 /* MissingEventsRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingEventsRequestBody.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1407,6 +1411,8 @@
 				8A0D64A524E57A520017A3C0 /* GuestUserTokenRequestPayload.swift */,
 				8A0D64A624E57A520017A3C0 /* GuestUserTokenRequestPayload_Tests.swift */,
 				DAEAF4B224DAD99E0015FB28 /* HideChannelRequest.swift */,
+				F6ED5F7725027907005D7327 /* MissingEventsRequestBody.swift */,
+				F62BE7862506525700D13B86 /* MissingEventsRequestBody_Tests.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -1679,6 +1685,7 @@
 				8A62706E24BF45360040BFD6 /* BanEnabling.swift in Sources */,
 				79877A0A2498E4BC00015F8B /* Device.swift in Sources */,
 				79280F4F2485308100CDEB89 /* Controller.swift in Sources */,
+				F6ED5F7825027907005D7327 /* MissingEventsRequestBody.swift in Sources */,
 				79877A252498E50D00015F8B /* TeamDTO.swift in Sources */,
 				7964F3B7249A314D002A09EC /* LogFormatter.swift in Sources */,
 				F63CC36F24E591840052844D /* EventObserver.swift in Sources */,
@@ -1814,6 +1821,7 @@
 				7922F30A24DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift in Sources */,
 				8A62705E24BE2CD70040BFD6 /* XCTestCase+MockJSON.swift in Sources */,
 				F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */,
+				F62BE7872506525700D13B86 /* MissingEventsRequestBody_Tests.swift in Sources */,
 				79DDF81B249CE38B002F4412 /* AssertNetworkRequest.swift in Sources */,
 				791C0B6324EEBDF40013CA2F /* MessageSender_Tests.swift in Sources */,
 				797EEA4824FFB4C200C81203 /* DataStore_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		F63CC37524E592DD0052844D /* MemberEventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */; };
 		F649B2372500F785008F98C8 /* MessageController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F649B2362500F785008F98C8 /* MessageController_Tests.swift */; };
 		F649B2392500FD56008F98C8 /* EntityDatabaseObserver_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F649B2382500FD56008F98C8 /* EntityDatabaseObserver_Mock.swift */; };
+		F64F9B6225077CF600834F55 /* MessageNew+MissingFields.json in Resources */ = {isa = PBXBuildFile; fileRef = F64F9B6125077CF600834F55 /* MessageNew+MissingFields.json */; };
 		F670B50F24FE6EA900003B1A /* MessageEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F670B50E24FE6EA900003B1A /* MessageEditor.swift */; };
 		F67415C024F0129800C3222F /* UnreadCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67415BF24F0129800C3222F /* UnreadCount.swift */; };
 		F6778F9A24F5144F005E7D22 /* EventNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6778F9924F5144F005E7D22 /* EventNotificationCenter.swift */; };
@@ -670,6 +671,7 @@
 		F63CC37424E592DD0052844D /* MemberEventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventObserver_Tests.swift; sourceTree = "<group>"; };
 		F649B2362500F785008F98C8 /* MessageController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageController_Tests.swift; sourceTree = "<group>"; };
 		F649B2382500FD56008F98C8 /* EntityDatabaseObserver_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDatabaseObserver_Mock.swift; sourceTree = "<group>"; };
+		F64F9B6125077CF600834F55 /* MessageNew+MissingFields.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "MessageNew+MissingFields.json"; sourceTree = "<group>"; };
 		F670B50E24FE6EA900003B1A /* MessageEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEditor.swift; sourceTree = "<group>"; };
 		F67415BF24F0129800C3222F /* UnreadCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadCount.swift; sourceTree = "<group>"; };
 		F6778F9924F5144F005E7D22 /* EventNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventNotificationCenter.swift; sourceTree = "<group>"; };
@@ -1255,6 +1257,7 @@
 			isa = PBXGroup;
 			children = (
 				8A0C3BD724C1E26C00CAFD19 /* MessageNew.json */,
+				F64F9B6125077CF600834F55 /* MessageNew+MissingFields.json */,
 				8A0C3BD824C1E33100CAFD19 /* MessageUpdated.json */,
 				8A0C3BDB24C1E5AE00CAFD19 /* MessageDeleted.json */,
 				8A0C3BD924C1E40E00CAFD19 /* MessageRead.json */,
@@ -1616,6 +1619,7 @@
 				8AC9CBE124C74DD0006E236C /* NotificationInviteAccepted.json in Resources */,
 				8A0C3BCC24C1CA9900CAFD19 /* ChannelUpdated.json in Resources */,
 				798779FD2498E47700015F8B /* OtherUser.json in Resources */,
+				F64F9B6225077CF600834F55 /* MessageNew+MissingFields.json in Resources */,
 				8A0C3BE024C1F18700CAFD19 /* NotificationMarkRead.json in Resources */,
 				8A0CC9EF24C604E000705CF9 /* MemberUpdated.json in Resources */,
 				8A0C3BCE24C1CB0500CAFD19 /* ChannelDeleted.json in Resources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -291,7 +291,9 @@
 		F61D7C3724FFE17200188A0E /* MessageEditor_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3624FFE17200188A0E /* MessageEditor_Tests.swift */; };
 		F61ED5A124F3F58400874777 /* DatabaseContainer_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61ED5A024F3F58400874777 /* DatabaseContainer_Mock.swift */; };
 		F62BE78325062FC400D13B86 /* SyncEndpoint_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62BE78225062FC400D13B86 /* SyncEndpoint_Tests.swift */; };
+		F62BE7852506309B00D13B86 /* MissingEventsPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62BE7842506309B00D13B86 /* MissingEventsPayload_Tests.swift */; };
 		F62BE7872506525700D13B86 /* MissingEventsRequestBody_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62BE7862506525700D13B86 /* MissingEventsRequestBody_Tests.swift */; };
+		F62BE7902506620000D13B86 /* MissingEventsPayload.json in Resources */ = {isa = PBXBuildFile; fileRef = F62BE78D2506620000D13B86 /* MissingEventsPayload.json */; };
 		F62D143E24DD70190081D241 /* ChannelUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */; };
 		F63CC36F24E591840052844D /* EventObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC36E24E591840052844D /* EventObserver.swift */; };
 		F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63CC37024E591990052844D /* EventObserver_Tests.swift */; };
@@ -312,6 +314,7 @@
 		F6FF1DA824FD232C00151735 /* MessageUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA724FD232C00151735 /* MessageUpdater.swift */; };
 		F6FF1DAA24FD23D300151735 /* MessageEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */; };
 		F6ED5F7825027907005D7327 /* MissingEventsRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6ED5F7725027907005D7327 /* MissingEventsRequestBody.swift */; };
+		F6ED5F7A2502791F005D7327 /* MissingEventsPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6ED5F792502791F005D7327 /* MissingEventsPayload.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -654,7 +657,9 @@
 		F61D7C3624FFE17200188A0E /* MessageEditor_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEditor_Tests.swift; sourceTree = "<group>"; };
 		F61ED5A024F3F58400874777 /* DatabaseContainer_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseContainer_Mock.swift; sourceTree = "<group>"; };
 		F62BE78225062FC400D13B86 /* SyncEndpoint_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEndpoint_Tests.swift; sourceTree = "<group>"; };
+		F62BE7842506309B00D13B86 /* MissingEventsPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingEventsPayload_Tests.swift; sourceTree = "<group>"; };
 		F62BE7862506525700D13B86 /* MissingEventsRequestBody_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingEventsRequestBody_Tests.swift; sourceTree = "<group>"; };
+		F62BE78D2506620000D13B86 /* MissingEventsPayload.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MissingEventsPayload.json; sourceTree = "<group>"; };
 		F62D143D24DD70190081D241 /* ChannelUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelUpdater_Mock.swift; sourceTree = "<group>"; };
 		F63CC36E24E591840052844D /* EventObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver.swift; sourceTree = "<group>"; };
 		F63CC37024E591990052844D /* EventObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObserver_Tests.swift; sourceTree = "<group>"; };
@@ -675,6 +680,7 @@
 		F6FF1DA724FD232C00151735 /* MessageUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater.swift; sourceTree = "<group>"; };
 		F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints.swift; sourceTree = "<group>"; };
 		F6ED5F7725027907005D7327 /* MissingEventsRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingEventsRequestBody.swift; sourceTree = "<group>"; };
+		F6ED5F792502791F005D7327 /* MissingEventsPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingEventsPayload.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -925,6 +931,8 @@
 				8A0D649A24E579E90017A3C0 /* GuestUserTokenPayload_Tests.swift */,
 				79682C4824BF37650071578E /* MessagePayloads.swift */,
 				79B5517B24E6A1CA00CE9FEC /* MessagePayloads_Tests.swift */,
+				F6ED5F792502791F005D7327 /* MissingEventsPayload.swift */,
+				F62BE7842506309B00D13B86 /* MissingEventsPayload_Tests.swift */,
 			);
 			path = Payloads;
 			sourceTree = "<group>";
@@ -1417,6 +1425,14 @@
 			path = Requests;
 			sourceTree = "<group>";
 		};
+		F62BE7882506616900D13B86 /* Sync */ = {
+			isa = PBXGroup;
+			children = (
+				F62BE78D2506620000D13B86 /* MissingEventsPayload.json */,
+			);
+			path = Sync;
+			sourceTree = "<group>";
+		};
 		F63CC36D24E591690052844D /* EventObservers */ = {
 			isa = PBXGroup;
 			children = (
@@ -1618,6 +1634,7 @@
 				8AC9CBDD24C74DD0006E236C /* NotificationMessageNew.json in Resources */,
 				8AC9CBE224C74DD0006E236C /* NotificationInviteRejected.json in Resources */,
 				8A0CC9EC24C602B600705CF9 /* MemberAdded.json in Resources */,
+				F62BE7902506620000D13B86 /* MissingEventsPayload.json in Resources */,
 				8A0CC9F624C608C500705CF9 /* ReactionNew.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1693,6 +1710,7 @@
 				8A62705024B867190040BFD6 /* EventPayload.swift in Sources */,
 				F6778F9A24F5144F005E7D22 /* EventNotificationCenter.swift in Sources */,
 				8AE335A924FCF999002B6677 /* InternetConnection.swift in Sources */,
+				F6ED5F7A2502791F005D7327 /* MissingEventsPayload.swift in Sources */,
 				792A4F40247FFDE700EAF71D /* Data+Gzip.swift in Sources */,
 				79E2B84024CAC8D60024752F /* ListDatabaseObserver.swift in Sources */,
 				796610B9248E651800761629 /* EventMiddleware.swift in Sources */,
@@ -1877,6 +1895,7 @@
 				79877A292498E51500015F8B /* ChannelDTO_Tests.swift in Sources */,
 				DAEAF4B824DC026C0015FB28 /* ChannelEndpoints_Tests.swift in Sources */,
 				792FCB4D24A3D56D000290C7 /* DatabaseSession_Tests.swift in Sources */,
+				F62BE7852506309B00D13B86 /* MissingEventsPayload_Tests.swift in Sources */,
 				7922F30824DACF1F00C364BC /* TestManagedObject.swift in Sources */,
 				792B805424D95FC700C2963E /* RandomDispatchQueue.swift in Sources */,
 				7952B3B324D4560E00AC53D4 /* ChannelController_Tests.swift in Sources */,

--- a/Tests_v3/MockEnpointResponses/Events/Message/MessageNew+MissingFields.json
+++ b/Tests_v3/MockEnpointResponses/Events/Message/MessageNew+MissingFields.json
@@ -1,0 +1,53 @@
+{
+    "user" : {
+        "id" : "broken-waterfall-5",
+        "banned" : false,
+        "extraData" : {
+            "name" : "Tester"
+        },
+        "last_active" : "2020-07-17T13:38:43.540206Z",
+        "created_at" : "2019-12-12T15:33:46.488935Z",
+        "invisible" : false,
+        "image" : "https:\/\/api.adorable.io\/avatars\/285\/broken-waterfall-5.png",
+        "updated_at" : "2020-07-17T13:42:01.565446Z",
+        "role" : "user",
+        "online" : true,
+        "name" : "broken-waterfall-5"
+    },
+    "channel_type" : "messaging",
+    "channel_id" : "general",
+    "created_at" : "2020-07-17T13:42:21.539429604Z",
+    "message" : {
+        "id" : "1ff9f6d0-df70-4703-aef0-379f95ad7366",
+        "reaction_counts" : null,
+        "silent" : false,
+        "created_at" : "2020-07-17T13:42:21.531523Z",
+        "reaction_scores" : {},
+        "type" : "regular",
+        "latest_reactions" : [],
+        "text" : "Hi",
+        "attachments" : [],
+        "own_reactions" : [],
+        "updated_at" : "2020-07-17T13:42:21.531523Z",
+        "reply_count" : 0,
+        "user" : {
+            "id" : "broken-waterfall-5",
+            "banned" : false,
+            "extraData" : {
+                "name" : "Tester"
+            },
+            "last_active" : "2020-07-17T13:38:43.540206Z",
+            "created_at" : "2019-12-12T15:33:46.488935Z",
+            "invisible" : false,
+            "image" : "https:\/\/api.adorable.io\/avatars\/285\/broken-waterfall-5.png",
+            "updated_at" : "2020-07-17T13:42:01.565446Z",
+            "role" : "user",
+            "online" : true,
+            "name" : "broken-waterfall-5"
+        },
+        "mentioned_users" : [],
+        "html" : "<p>Hi<\/p>\n"
+    },
+    "type" : "message.new",
+    "cid" : "messaging:general"
+}

--- a/Tests_v3/MockEnpointResponses/Sync/MissingEventsPayload.json
+++ b/Tests_v3/MockEnpointResponses/Sync/MissingEventsPayload.json
@@ -1,0 +1,55 @@
+{
+  "events": [
+    {
+      "type": "message.new",
+      "cid": "messaging:A2F4393C-D656-46B8-9A43-6148E9E62D7F",
+      "channel_id": "A2F4393C-D656-46B8-9A43-6148E9E62D7F",
+      "channel_type": "messaging",
+      "message": {
+        "id": "AD6B64F8-1A12-48AF-B246-09774FD1B748",
+        "text": "How are you?",
+        "html": "<p>How are you?</p>\n",
+        "type": "regular",
+        "user": {
+          "id": "broken-waterfall-5",
+          "role": "user",
+          "created_at": "2019-12-12T15:33:46.488935Z",
+          "updated_at": "2020-09-07T12:27:43.096437Z",
+          "last_active": "2020-09-07T12:25:41.501574Z",
+          "banned": false,
+          "online": true,
+          "invisible": false,
+          "name": "Broken Waterfall",
+          "channel_mutes": null,
+          "devices": null,
+          "image": "https://api.adorable.io/avatars/285/broken-waterfall-5.png"
+        },
+        "attachments": [],
+        "latest_reactions": [],
+        "own_reactions": [],
+        "reaction_counts": null,
+        "reaction_scores": {},
+        "reply_count": 0,
+        "created_at": "2020-09-07T12:25:50.702323Z",
+        "updated_at": "2020-09-07T12:25:50.702324Z",
+        "mentioned_users": [],
+        "silent": false
+      },
+      "user": {
+        "id": "broken-waterfall-5",
+        "role": "user",
+        "created_at": "2019-12-12T15:33:46.488935Z",
+        "updated_at": "2020-09-07T12:27:43.096437Z",
+        "last_active": "2020-09-07T12:25:41.501574Z",
+        "banned": false,
+        "online": true,
+        "invisible": false,
+        "name": "Broken Waterfall",
+        "channel_mutes": null,
+        "devices": null,
+        "image": "https://api.adorable.io/avatars/285/broken-waterfall-5.png"
+      },
+      "created_at": "2020-09-07T12:25:50.702323Z"
+    }
+  ]
+}


### PR DESCRIPTION
**This PR:**

- introduces `MissingEventsPublisher` that replays missing events that happened when the user was not connected to a web-socket, sets`MissingEventsPublisher` as a background worker;
- introduces `/sync` endpoint and types for incoming/outgoing JSONs;
- adjusts `MessageNewEvent` so it can be parsed from `/sync` endpoint response.
 