### PR TITLE
[CIS-185] Connect the web socket when connection restored

### DIFF
--- a/Sample_v3/LogStore.swift
+++ b/Sample_v3/LogStore.swift
@@ -6,7 +6,7 @@ import Foundation
 import StreamChatClient
 
 class LogStore: BaseLogDestination {
-    var logs = ""
+    @Atomic var logs = ""
     
     static let shared = LogStore()
     
@@ -15,6 +15,6 @@ class LogStore: BaseLogDestination {
     }
     
     override func write(message: String) {
-        logs += message
+        _logs { $0 += message }
     }
 }

--- a/Sources_v3/APIClient/APIClient_Tests.swift
+++ b/Sources_v3/APIClient/APIClient_Tests.swift
@@ -267,6 +267,7 @@ private class TestWebSocketClient: WebSocketClient {
             requestEncoder: DefaultRequestEncoder(baseURL: .unique(), apiKey: .init(.unique)),
             eventDecoder: EventDecoder<DefaultDataTypes>(),
             eventNotificationCenter: EventNotificationCenter(),
+            internetConnection: InternetConnection(),
             reconnectionStrategy: DefaultReconnectionStrategy()
         )
     }

--- a/Sources_v3/ChatClient.swift
+++ b/Sources_v3/ChatClient.swift
@@ -93,7 +93,8 @@ public class Client<ExtraData: ExtraDataTypes> {
             urlSessionConfiguration,
             encoder,
             EventDecoder<ExtraData>(),
-            eventNotificationCenter
+            eventNotificationCenter,
+            internetConnection
         )
         
         webSocketClient.connectionStateDelegate = self
@@ -426,14 +427,16 @@ extension Client {
             _ sessionConfiguration: URLSessionConfiguration,
             _ requestEncoder: RequestEncoder,
             _ eventDecoder: AnyEventDecoder,
-            _ notificationCenter: EventNotificationCenter
+            _ notificationCenter: EventNotificationCenter,
+            _ internetConnection: InternetConnection
         ) -> WebSocketClient = {
             WebSocketClient(
                 connectEndpoint: $0,
                 sessionConfiguration: $1,
                 requestEncoder: $2,
                 eventDecoder: $3,
-                eventNotificationCenter: $4
+                eventNotificationCenter: $4,
+                internetConnection: $5
             )
         }
         

--- a/Sources_v3/ChatClient_Mock.swift
+++ b/Sources_v3/ChatClient_Mock.swift
@@ -19,7 +19,7 @@ extension Client.Environment where ExtraData == DefaultDataTypes {
     static var mock: ChatClient.Environment {
         .init(
             apiClientBuilder: { _, _, _ in APIClientMock() },
-            webSocketClientBuilder: { _, _, _, _, _ in WebSocketClientMock() },
+            webSocketClientBuilder: { _, _, _, _, _, _ in WebSocketClientMock() },
             databaseContainerBuilder: { _ in DatabaseContainerMock() },
             requestEncoderBuilder: { _, _ in DefaultRequestEncoder(baseURL: .unique(), apiKey: .init(.unique)) },
             requestDecoderBuilder: { DefaultRequestDecoder() },

--- a/Sources_v3/ChatClient_Tests.swift
+++ b/Sources_v3/ChatClient_Tests.swift
@@ -601,7 +601,8 @@ private class TestEnvironment<ExtraData: ExtraDataTypes> {
                     sessionConfiguration: $1,
                     requestEncoder: $2,
                     eventDecoder: $3,
-                    eventNotificationCenter: $4
+                    eventNotificationCenter: $4,
+                    internetConnection: $5
                 )
                 return self.webSocketClient!
             },
@@ -720,6 +721,7 @@ class WebSocketClientMock: WebSocketClient {
     let init_requestEncoder: RequestEncoder
     let init_eventDecoder: AnyEventDecoder
     let init_eventNotificationCenter: EventNotificationCenter
+    let init_internetConnection: InternetConnection
     let init_reconnectionStrategy: WebSocketClientReconnectionStrategy
     let init_environment: WebSocketClient.Environment
     
@@ -732,6 +734,7 @@ class WebSocketClientMock: WebSocketClient {
         requestEncoder: RequestEncoder,
         eventDecoder: AnyEventDecoder,
         eventNotificationCenter: EventNotificationCenter,
+        internetConnection: InternetConnection,
         reconnectionStrategy: WebSocketClientReconnectionStrategy = DefaultReconnectionStrategy(),
         environment: WebSocketClient.Environment = .init()
     ) {
@@ -740,6 +743,7 @@ class WebSocketClientMock: WebSocketClient {
         init_requestEncoder = requestEncoder
         init_eventDecoder = eventDecoder
         init_eventNotificationCenter = eventNotificationCenter
+        init_internetConnection = internetConnection
         init_reconnectionStrategy = reconnectionStrategy
         init_environment = environment
         
@@ -749,6 +753,7 @@ class WebSocketClientMock: WebSocketClient {
             requestEncoder: requestEncoder,
             eventDecoder: eventDecoder,
             eventNotificationCenter: eventNotificationCenter,
+            internetConnection: internetConnection,
             reconnectionStrategy: reconnectionStrategy,
             environment: environment
         )
@@ -770,7 +775,8 @@ extension WebSocketClientMock {
             sessionConfiguration: .default,
             requestEncoder: DefaultRequestEncoder(baseURL: .unique(), apiKey: .init(.unique)),
             eventDecoder: EventDecoder<DefaultDataTypes>(),
-            eventNotificationCenter: .init()
+            eventNotificationCenter: .init(),
+            internetConnection: InternetConnection()
         )
     }
 }

--- a/Sources_v3/ChatClient_Tests.swift
+++ b/Sources_v3/ChatClient_Tests.swift
@@ -407,7 +407,7 @@ class ChatClient_Tests: StressTestCase {
         
         // Simulate a health check event with the current user data
         // This should trigger the middlewares and save the current user data to DB
-        testEnv.webSocketClient?.websocketDidReceiveMessage(healthCheckEventJSON(userId: newUserId))
+        testEnv.webSocketClient?.webSocketDidReceiveMessage(healthCheckEventJSON(userId: newUserId))
         
         // Simulate successful connection
         testEnv.webSocketClient!.connectionStateDelegate?
@@ -504,7 +504,7 @@ class ChatClient_Tests: StressTestCase {
         
         // Simulate a health check event with the current user data
         // This should trigger the middlewares and save the current user data to DB
-        testEnv.webSocketClient?.websocketDidReceiveMessage(healthCheckEventJSON(userId: newUser.userId))
+        testEnv.webSocketClient?.webSocketDidReceiveMessage(healthCheckEventJSON(userId: newUser.userId))
         
         // Simulate successful connection
         testEnv.webSocketClient!.connectionStateDelegate?

--- a/Sources_v3/Utils/Internet Connection/Error+InternetNotAvailable.swift
+++ b/Sources_v3/Utils/Internet Connection/Error+InternetNotAvailable.swift
@@ -1,0 +1,20 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The list of know n"internet connection is not available" errors. This list is hardly completely and it's meant
+/// to be extended as needed.
+private let offlineErrors: [(domain: String, errorCode: Int)] = [
+    (NSURLErrorDomain, NSURLErrorNotConnectedToInternet),
+    (NSPOSIXErrorDomain, 50)
+]
+
+extension Error {
+    /// Returns `true` if the error is one of the known errors for internet connection not being available.
+    var isInternetOfflineError: Bool {
+        let error = self as NSError
+        return offlineErrors.contains { $0.domain == error.domain && $0.errorCode == error.code }
+    }
+}

--- a/Sources_v3/Utils/Internet Connection/InternetConnection.swift
+++ b/Sources_v3/Utils/Internet Connection/InternetConnection.swift
@@ -67,6 +67,26 @@ extension InternetConnection: InternetConnectionDelegate {
     }
 }
 
+extension InternetConnection {
+    /// Sets up a one-time observer which is called when the status chnages to the desired status.
+    func notifyOnce(when: @escaping (Status) -> Bool, callback: @escaping () -> Void) {
+        var token: NSObjectProtocol?
+        token = notificationCenter.addObserver(
+            forName: .internetConnectionStatusDidChange,
+            object: self,
+            queue: nil,
+            using: { [weak notificationCenter] in
+                if let status = $0.internetConnectionStatus, when(status) {
+                    callback()
+                    if let token = token {
+                        notificationCenter?.removeObserver(token)
+                    }
+                }
+            }
+        )
+    }
+}
+
 // MARK: - Internet Connection Monitors
 
 /// A delegate to receive Internet connection events.
@@ -117,6 +137,17 @@ extension InternetConnection {
         /// Recommendations for Low Data Mode: don't autoplay video, music (high-quality) or gifs (big files).
         /// Supports only by iOS 13+
         case constrained
+    }
+}
+
+extension InternetConnection.Status {
+    /// Returns `true` if the internet connection is available, ignoring the quality of the connection.
+    var isAvailable: Bool {
+        if case .available = self {
+            return true
+        } else {
+            return false
+        }
     }
 }
 

--- a/Sources_v3/Utils/Internet Connection/InternetConnection_Tests.swift
+++ b/Sources_v3/Utils/Internet Connection/InternetConnection_Tests.swift
@@ -39,6 +39,26 @@ class InternetConnection_Tests: XCTestCase {
         internetConnection = nil
         XCTAssertFalse(monitor.isStarted)
     }
+    
+    func test_notifyOnce() throws {
+        var calledCounter = 0
+        internetConnection.notifyOnce(when: { $0 == .available(.great) }) {
+            calledCounter += 1
+        }
+        
+        // Simulate status change to some other value
+        monitor.status = .unavailable
+        XCTAssertEqual(calledCounter, 0)
+        
+        // Simulate status change to the target value
+        monitor.status = .available(.great)
+        XCTAssertEqual(calledCounter, 1)
+        
+        // Simulate more changes and verify callback is no longer called
+        monitor.status = .unavailable
+        monitor.status = .available(.great)
+        XCTAssertEqual(calledCounter, 1)
+    }
 }
 
 class InternetConnectionMock: InternetConnection {

--- a/Sources_v3/WebSocketClient/Engine/StarscreamWebSocketEngine.swift
+++ b/Sources_v3/WebSocketClient/Engine/StarscreamWebSocketEngine.swift
@@ -10,7 +10,6 @@ import Foundation
     class StarscreamWebSocketProvider: WebSocketEngine {
         private let webSocket: Starscream.WebSocket
         var request: URLRequest { webSocket.request }
-        var isConnected: Bool { webSocket.isConnected }
         var callbackQueue: DispatchQueue { webSocket.callbackQueue }
         weak var delegate: WebSocketEngineDelegate?
         
@@ -48,25 +47,15 @@ import Foundation
     
     extension StarscreamWebSocketProvider: Starscream.WebSocketDelegate {
         func websocketDidConnect(socket: Starscream.WebSocketClient) {
-            delegate?.websocketDidConnect()
+            delegate?.webSocketDidConnect()
         }
         
         func websocketDidDisconnect(socket: Starscream.WebSocketClient, error: Error?) {
-            var engineError: WebSocketEngineError?
-            
-            if let error = error {
-                engineError = .init(
-                    reason: error.localizedDescription,
-                    code: (error as? WSError)?.code ?? 0,
-                    engineError: error
-                )
-            }
-            
-            delegate?.websocketDidDisconnect(error: engineError)
+            delegate?.webSocketDidDisconnect(error: error.map(WebSocketEngineError.init))
         }
         
         func websocketDidReceiveMessage(socket: Starscream.WebSocketClient, text: String) {
-            delegate?.websocketDidReceiveMessage(text)
+            delegate?.webSocketDidReceiveMessage(text)
         }
         
         func websocketDidReceiveData(socket: Starscream.WebSocketClient, data: Data) {}

--- a/Sources_v3/WebSocketClient/Engine/WebSocketEngine.swift
+++ b/Sources_v3/WebSocketClient/Engine/WebSocketEngine.swift
@@ -6,20 +6,20 @@ import Foundation
 
 protocol WebSocketEngine: AnyObject {
     var request: URLRequest { get }
-    var isConnected: Bool { get }
     var callbackQueue: DispatchQueue { get }
     var delegate: WebSocketEngineDelegate? { get set }
     
     init(request: URLRequest, sessionConfiguration: URLSessionConfiguration, callbackQueue: DispatchQueue)
+    
     func connect()
     func disconnect()
     func sendPing()
 }
 
 protocol WebSocketEngineDelegate: AnyObject {
-    func websocketDidConnect()
-    func websocketDidDisconnect(error: WebSocketEngineError?)
-    func websocketDidReceiveMessage(_ message: String)
+    func webSocketDidConnect()
+    func webSocketDidDisconnect(error: WebSocketEngineError?)
+    func webSocketDidReceiveMessage(_ message: String)
 }
 
 struct WebSocketEngineError: Error {
@@ -30,4 +30,22 @@ struct WebSocketEngineError: Error {
     let engineError: Error?
     
     var localizedDescription: String { reason }
+}
+
+extension WebSocketEngineError {
+    init(error: Error?) {
+        if let error = error {
+            self.init(
+                reason: error.localizedDescription,
+                code: (error as NSError).code,
+                engineError: error
+            )
+        } else {
+            self.init(
+                reason: "Unknown",
+                code: 0,
+                engineError: nil
+            )
+        }
+    }
 }

--- a/Sources_v3/WebSocketClient/Engine/WebSocketEngine_Mock.swift
+++ b/Sources_v3/WebSocketClient/Engine/WebSocketEngine_Mock.swift
@@ -47,7 +47,7 @@ class WebSocketEngineMock: WebSocketEngine {
     
     func simulateConnectionSuccess() {
         isConnected = true
-        delegate?.websocketDidConnect()
+        delegate?.webSocketDidConnect()
     }
     
     func simulateMessageReceived(_ json: [String: Any] = [:]) {
@@ -56,7 +56,7 @@ class WebSocketEngineMock: WebSocketEngine {
     }
     
     func simulateMessageReceived(_ data: Data) {
-        delegate?.websocketDidReceiveMessage(String(data: data, encoding: .utf8)!)
+        delegate?.webSocketDidReceiveMessage(String(data: data, encoding: .utf8)!)
     }
     
     func simulatePong() {
@@ -65,7 +65,7 @@ class WebSocketEngineMock: WebSocketEngine {
     
     func simulateDisconnect(_ error: WebSocketEngineError? = nil) {
         isConnected = false
-        delegate?.websocketDidDisconnect(error: error)
+        delegate?.webSocketDidDisconnect(error: error)
     }
 }
 

--- a/Sources_v3/WebSocketClient/WebSocketClient.swift
+++ b/Sources_v3/WebSocketClient/WebSocketClient.swift
@@ -246,11 +246,11 @@ extension WebSocketClient {
 // MARK: - Web Socket Delegate
 
 extension WebSocketClient: WebSocketEngineDelegate {
-    func websocketDidConnect() {
+    func webSocketDidConnect() {
         connectionState = .waitingForConnectionId
     }
     
-    func websocketDidReceiveMessage(_ message: String) {
+    func webSocketDidReceiveMessage(_ message: String) {
         do {
             let messageData = Data(message.utf8)
             let event = try eventDecoder.decode(from: messageData)
@@ -272,7 +272,7 @@ extension WebSocketClient: WebSocketEngineDelegate {
         }
     }
     
-    func websocketDidDisconnect(error engineError: WebSocketEngineError?) {
+    func webSocketDidDisconnect(error engineError: WebSocketEngineError?) {
         // Reconnection shouldn't happen for manually initiated disconnect
         let shouldReconnect = connectionState != .disconnecting(source: .userInitiated)
         

--- a/Sources_v3/WebSocketClient/WebSocketClient.swift
+++ b/Sources_v3/WebSocketClient/WebSocketClient.swift
@@ -80,6 +80,9 @@ class WebSocketClient {
     /// The identifier of the currently running background task. `nil` of no background task is running.
     private var activeBackgroundTask: UIBackgroundTaskIdentifier?
     
+    /// The internet connection observer we use for recovering when the connection was offline for some time.
+    private let internetConnection: InternetConnection
+    
     /// An object containing external dependencies of `WebSocketClient`
     private let environment: Environment
     
@@ -109,6 +112,7 @@ class WebSocketClient {
         requestEncoder: RequestEncoder,
         eventDecoder: AnyEventDecoder,
         eventNotificationCenter: EventNotificationCenter,
+        internetConnection: InternetConnection,
         reconnectionStrategy: WebSocketClientReconnectionStrategy = DefaultReconnectionStrategy(),
         environment: Environment = .init()
     ) {
@@ -118,6 +122,8 @@ class WebSocketClient {
         self.sessionConfiguration = sessionConfiguration
         self.reconnectionStrategy = reconnectionStrategy
         self.eventDecoder = eventDecoder
+        self.internetConnection = internetConnection
+
         self.eventNotificationCenter = eventNotificationCenter
         self.eventNotificationCenter.add(middleware: HealthCheckMiddleware(webSocketClient: self))
         

--- a/Sources_v3/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Sources_v3/WebSocketClient/WebSocketClient_Tests.swift
@@ -25,6 +25,7 @@ class WebSocketClient_Tests: StressTestCase {
     var backgroundTaskScheduler: MockBackgroundTaskScheduler!
     var requestEncoder: TestRequestEncoder!
     var pingController: WebSocketPingControllerMock { webSocketClient.pingController as! WebSocketPingControllerMock }
+    var internetConnectionMonitor: InternetConnectionMonitorMock!
     
     var eventNotificationCenter: EventNotificationCenter!
     private var eventNotificationCenterMiddleware: EventMiddlewareMock!
@@ -53,6 +54,8 @@ class WebSocketClient_Tests: StressTestCase {
         eventNotificationCenterMiddleware = EventMiddlewareMock()
         eventNotificationCenter.add(middleware: eventNotificationCenterMiddleware)
         
+        internetConnectionMonitor = InternetConnectionMonitorMock()
+        
         var environment = WebSocketClient.Environment()
         environment.timerType = VirtualTimeTimer.self
         environment.createPingController = WebSocketPingControllerMock.init
@@ -65,6 +68,7 @@ class WebSocketClient_Tests: StressTestCase {
             requestEncoder: requestEncoder,
             eventDecoder: decoder,
             eventNotificationCenter: eventNotificationCenter,
+            internetConnection: InternetConnection(monitor: internetConnectionMonitor),
             reconnectionStrategy: reconnectionStrategy,
             environment: environment
         )

--- a/Sources_v3/WebSocketClient/WebSocketReconnectionStrategy.swift
+++ b/Sources_v3/WebSocketClient/WebSocketReconnectionStrategy.swift
@@ -25,11 +25,16 @@ class DefaultReconnectionStrategy: WebSocketClientReconnectionStrategy {
     }
     
     func reconnectionDelay(forConnectionError error: Error?) -> TimeInterval? {
-        if
-            let engineError = error as? WebSocketEngineError,
-            engineError.code == WebSocketEngineError.stopErrorCode {
-            // Don't reconnect on `stop` errors
-            return nil
+        if let wsEngineError = error as? WebSocketEngineError {
+            if wsEngineError.code == WebSocketEngineError.stopErrorCode {
+                // Don't reconnect on `stop` errors
+                return nil
+            }
+            
+            if wsEngineError.engineError?.isInternetOfflineError == true {
+                // Don't try to reconnect when internet is not available
+                return nil
+            }
         }
         
         if

--- a/Sources_v3/WebSocketClient/WebSocketReconnectionStrategy_Tests.swift
+++ b/Sources_v3/WebSocketClient/WebSocketReconnectionStrategy_Tests.swift
@@ -65,4 +65,17 @@ class DefaultReconnectionStrategy_Tests: XCTestCase {
         let delay = strategy.reconnectionDelay(forConnectionError: error)
         XCTAssertNotNil(delay)
     }
+    
+    func test_returnsNilForInternetIsOfflineError() {
+        let error = WebSocketEngineError(
+            error:
+            NSError(
+                domain: NSURLErrorDomain,
+                code: NSURLErrorNotConnectedToInternet,
+                userInfo: nil
+            )
+        )
+        let delay = strategy.reconnectionDelay(forConnectionError: error)
+        XCTAssertNil(delay)
+    }
 }

--- a/Sources_v3/Workers/Background/MessageEditor.swift
+++ b/Sources_v3/Workers/Background/MessageEditor.swift
@@ -57,7 +57,9 @@ class MessageEditor<ExtraData: ExtraDataTypes>: Worker {
         let wasEmpty = pendingMessageIDs.isEmpty
         changes.pendingEditMessageIDs.forEach { pendingMessageIDs.insert($0) }
         if wasEmpty {
-            processNextMessage()
+            database.backgroundReadOnlyContext.perform { [weak self] in
+                self?.processNextMessage()
+            }
         }
     }
 
@@ -103,7 +105,9 @@ class MessageEditor<ExtraData: ExtraDataTypes>: Worker {
             if let error = $0 {
                 log.error("Error changing localMessageState for message with id \(id) to `\(String(describing: state))`: \(error)")
             }
-            completion()
+            self.database.backgroundReadOnlyContext.perform {
+                completion()
+            }
         })
     }
 }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		79177A2D248A6A2600F053A2 /* AssertAsync+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79177A2C248A6A2600F053A2 /* AssertAsync+Events.swift */; };
 		791C0B6324EEBDF40013CA2F /* MessageSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */; };
 		791C0B6524EFBD260013CA2F /* UnwrapAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */; };
+		79200D46250140BB002F4EB1 /* StreamChatClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 799C941B247D2F80001F1104 /* StreamChatClient.framework */; };
+		79200D47250140BB002F4EB1 /* StreamChatClient.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 799C941B247D2F80001F1104 /* StreamChatClient.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		79200D4C25025B81002F4EB1 /* Error+InternetNotAvailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79200D4B25025B81002F4EB1 /* Error+InternetNotAvailable.swift */; };
 		79200D42250118A1002F4EB1 /* iOS13TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79200D41250118A1002F4EB1 /* iOS13TestCase.swift */; };
 		7922F30624DACEF100C364BC /* TestDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 7922F30424DACEF100C364BC /* TestDataModel.xcdatamodeld */; };
@@ -158,7 +160,6 @@
 		79BA19F324B3386B00E11FC2 /* CurrentUserDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BA19F224B3386B00E11FC2 /* CurrentUserDTO_Tests.swift */; };
 		79BF83F2248F8F60007611A1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BF83F1248F8F60007611A1 /* Logger.swift */; };
 		79C750BB248FC4100023F0B7 /* ErrorPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C750BA248FC4100023F0B7 /* ErrorPayload.swift */; };
-		79C8C6F524AE291C002E64D7 /* StreamChatClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 799C941B247D2F80001F1104 /* StreamChatClient.framework */; };
 		79CD959224F9380B00E87377 /* MulticastDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CD959124F9380B00E87377 /* MulticastDelegate.swift */; };
 		79CD959424F9381700E87377 /* MulticastDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CD959324F9381700E87377 /* MulticastDelegateTests.swift */; };
 		79CD959624F9414700E87377 /* ChannelListController+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CD959524F9414700E87377 /* ChannelListController+SwiftUI_Tests.swift */; };
@@ -320,6 +321,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		79200D48250140BB002F4EB1 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				79200D47250140BB002F4EB1 /* StreamChatClient.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		796610B6248E518D00761629 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -662,7 +674,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				79C8C6F524AE291C002E64D7 /* StreamChatClient.framework in Frameworks */,
+				79200D46250140BB002F4EB1 /* StreamChatClient.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1439,6 +1451,7 @@
 				792A4F1E247FF01800EAF71D /* Sources */,
 				792A4F1F247FF01800EAF71D /* Frameworks */,
 				792A4F20247FF01800EAF71D /* Resources */,
+				79200D48250140BB002F4EB1 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		79177A2D248A6A2600F053A2 /* AssertAsync+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79177A2C248A6A2600F053A2 /* AssertAsync+Events.swift */; };
 		791C0B6324EEBDF40013CA2F /* MessageSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */; };
 		791C0B6524EFBD260013CA2F /* UnwrapAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */; };
+		79200D4C25025B81002F4EB1 /* Error+InternetNotAvailable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79200D4B25025B81002F4EB1 /* Error+InternetNotAvailable.swift */; };
 		79200D42250118A1002F4EB1 /* iOS13TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79200D41250118A1002F4EB1 /* iOS13TestCase.swift */; };
 		7922F30624DACEF100C364BC /* TestDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 7922F30424DACEF100C364BC /* TestDataModel.xcdatamodeld */; };
 		7922F30824DACF1F00C364BC /* TestManagedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7922F30724DACF1F00C364BC /* TestManagedObject.swift */; };
@@ -338,6 +339,7 @@
 		79177A2C248A6A2600F053A2 /* AssertAsync+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AssertAsync+Events.swift"; sourceTree = "<group>"; };
 		791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSender_Tests.swift; sourceTree = "<group>"; };
 		791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnwrapAsync.swift; sourceTree = "<group>"; };
+		79200D4B25025B81002F4EB1 /* Error+InternetNotAvailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+InternetNotAvailable.swift"; sourceTree = "<group>"; };
 		79200D41250118A1002F4EB1 /* iOS13TestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOS13TestCase.swift; sourceTree = "<group>"; };
 		7922F30524DACEF100C364BC /* TestDataModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TestDataModel.xcdatamodel; sourceTree = "<group>"; };
 		7922F30724DACF1F00C364BC /* TestManagedObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestManagedObject.swift; sourceTree = "<group>"; };
@@ -1336,6 +1338,7 @@
 				8AE335A624FCF999002B6677 /* InternetConnection.swift */,
 				8AE335A424FCF999002B6677 /* InternetConnection_Tests.swift */,
 				8AE335A524FCF999002B6677 /* Reachability_Vendor.swift */,
+				79200D4B25025B81002F4EB1 /* Error+InternetNotAvailable.swift */,
 			);
 			path = "Internet Connection";
 			sourceTree = "<group>";
@@ -1688,6 +1691,7 @@
 				79A0E9B02498C09900E9BD50 /* ConnectionStatus.swift in Sources */,
 				799C9439247D2FB9001F1104 /* ChannelDTO.swift in Sources */,
 				799C9443247D3DA7001F1104 /* APIClient.swift in Sources */,
+				79200D4C25025B81002F4EB1 /* Error+InternetNotAvailable.swift in Sources */,
 				8A0CC9F124C606EF00705CF9 /* ReactionEvents.swift in Sources */,
 				79877A0F2498E4BC00015F8B /* ChannelId.swift in Sources */,
 				792A4F492480107A00EAF71D /* Sorting.swift in Sources */,


### PR DESCRIPTION
This is an alternative approach to #457. I tried to come up with a different and more straightforward solution that relies more on the existing infrastructure.

#### A typical scenario looks like:
- The engine returns "no internet" error
- `ReconnectionStrategy` returns `nil` and no reconnection is scheduled
- An `InternetConnection` waiter is scheduled
- Once the connection is back online, WS tries to reconnect

It seems we don't need any special handling for the foreground/background app state. As far as I understand, the existing implementation covers that situation properly.

---

@buh Please take a look and let me know if I missed something. It seems to me this is all we need to do.