### PR TITLE
Fixes ChannelController.startUpdating completion called multiple times

### DIFF
--- a/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
@@ -310,6 +310,9 @@ class ChannelController_Tests: StressTestCase {
 
         // Simulate `startUpdating` call
         controller.startUpdating()
+        
+        // Simulate updater's channelCreatedCallback call
+        env.channelUpdater!.update_channelCreatedCallback!(channelId)
 
         // Simulate DB update
         var error = try await {

--- a/Sources_v3/Controllers/Controller.swift
+++ b/Sources_v3/Controllers/Controller.swift
@@ -12,6 +12,8 @@ public class Controller {
         case inactive
         /// The controllers already fetched local data if any. Remote data fetch is in progress.
         case localDataFetched
+        /// The controller failed to fetch local data.
+        case localDataFetchFailed(ClientError)
         /// The controller fetched remote data.
         case remoteDataFetched
         /// The controller failed to fetch remote data.


### PR DESCRIPTION
As it is, ChannelController.startUpdating passes its completion param to multiple places:
- to setupDatabaseObservers
- to channelCreatedCallback
so, if an error occurs in multiple places, it'll be reported in multiple places. If this is what we want, then it's correct.
Another issue is that `startDatabaseObservers` should not be called before channel is actually created (so `isChannelAlreadyCreated` should be true) but it's not checked. I've also refactored it so `startDatabaseObservers` and `setupEventObservers` are called once, in the correct place: if channel exists, called in `startUpdating` otherwise called in `channelCreatedCallback` (hence in set(channelQuery:))