### PR TITLE
[CIS-341] [CIS-342] V3 Sample: allow specifying id in member actions & show alert on login error

### DIFF
--- a/Sample_v3/AppDelegate.swift
+++ b/Sample_v3/AppDelegate.swift
@@ -12,6 +12,7 @@ var chatClient: ChatClient = {
 
 func logIn(apiKey: String, userId: String, userName: String, token: Token?) {
     let extraData = NameAndImageExtraData(name: userName, imageURL: nil)
+    chatClient = ChatClient(config: ChatClientConfig(apiKey: APIKey(apiKey)))
     
     if let token = token {
         chatClient.setUser(userId: userId, userExtraData: extraData, token: token)

--- a/Sample_v3/AppDelegate.swift
+++ b/Sample_v3/AppDelegate.swift
@@ -10,17 +10,6 @@ var chatClient: ChatClient = {
     return ChatClient(config: config)
 }()
 
-func logIn(apiKey: String, userId: String, userName: String, token: Token?) {
-    let extraData = NameAndImageExtraData(name: userName, imageURL: nil)
-    chatClient = ChatClient(config: ChatClientConfig(apiKey: APIKey(apiKey)))
-    
-    if let token = token {
-        chatClient.setUser(userId: userId, userExtraData: extraData, token: token)
-    } else {
-        chatClient.setGuestUser(userId: userId, extraData: extraData)
-    }
-}
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?

--- a/Sample_v3/Extensions/UITableViewController+KeyboardAvoidance.swift
+++ b/Sample_v3/Extensions/UITableViewController+KeyboardAvoidance.swift
@@ -23,6 +23,10 @@ extension UITableViewController {
     }
     
     func adjustContentInsetsIfNeeded() {
+        guard presentedViewController == nil else {
+            return
+        }
+        
         var contentInset = tableView.contentInset
         contentInset.bottom = topHeight
         contentInset.top = bottomHeight
@@ -68,7 +72,7 @@ extension UITableViewController {
 
     @objc private func _onKeyboardFrameWillChangeNotificationReceived(_ notification: Notification) {
         guard
-            presentedViewController?.isBeingDismissed != false,
+            presentedViewController == nil,
             let userInfo = notification.userInfo,
             let keyboardFrame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
         else {

--- a/Sample_v3/Extensions/UIViewController+Alert.swift
+++ b/Sample_v3/Extensions/UIViewController+Alert.swift
@@ -1,0 +1,25 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController {
+    func alert(title: String, message: String) {
+        let controller = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        controller.addAction(.init(title: "OK", style: .default))
+        present(controller, animated: true)
+    }
+    
+    func alertTextField(title: String, placeholder: String, completion: @escaping (String) -> Void) {
+        let controller = UIAlertController(title: title, message: "", preferredStyle: .alert)
+        controller.addAction(UIAlertAction(title: "Confirm", style: .default, handler: { _ in
+            let input = controller.textFields?.first?.text ?? ""
+            completion(input.isEmpty ? placeholder : input)
+        }))
+        controller.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        controller.addTextField(configurationHandler: nil)
+        controller.textFields?.first?.placeholder = placeholder
+        present(controller, animated: true)
+    }
+}

--- a/Sample_v3/LoginViewController.swift
+++ b/Sample_v3/LoginViewController.swift
@@ -15,6 +15,23 @@ class LoginViewController: UITableViewController {
     @IBOutlet var userNameTextField: UITextField!
     @IBOutlet var jwtTextField: UITextField!
     
+    func logIn() {
+        let extraData = NameAndImageExtraData(name: userName, imageURL: nil)
+        chatClient = ChatClient(config: ChatClientConfig(apiKey: APIKey(apiKey)))
+        
+        func setUserCompletion(_ error: Error?) {
+            guard let error = error else { return }
+            alert(title: "Error", message: "Error logging in: \(error)")
+            navigationController?.popToRootViewController(animated: true)
+        }
+        
+        if let token = token {
+            chatClient.setUser(userId: userId, userExtraData: extraData, token: token, completion: setUserCompletion)
+        } else {
+            chatClient.setGuestUser(userId: userId, extraData: extraData, completion: setUserCompletion)
+        }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -53,20 +70,17 @@ extension LoginViewController {
 
 extension LoginViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        logIn()
+        
         switch indexPath {
         case .simpleChatIndexPath:
-            logIn(apiKey: apiKey, userId: userId, userName: userName, token: token)
-            
             let storyboard = UIStoryboard(name: "SimpleChat", bundle: nil)
             let initial = storyboard.instantiateInitialViewController()
             UIView.transition(with: view.window!, duration: 0.5, options: .transitionFlipFromLeft, animations: {
                 self.view.window?.rootViewController = initial
             })
-            
         case .swiftUISimpleChatIndexPath:
             if #available(iOS 13, *) {
-                logIn(apiKey: apiKey, userId: userId, userName: userName, token: token)
-                
                 // Ideally, we'd pass the `Client` instance as the environment object and create the list controller later.
                 let listController = chatClient.channelListController(
                     query: .init(filter: .in("members", ["broken-waterfall-5"]))

--- a/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
@@ -243,23 +243,29 @@ final class SimpleChatViewController: UITableViewController, ChannelControllerDe
     @objc func showChannelActionsAlert() {
         let alert = UIAlertController(title: "Member Actions", message: "", preferredStyle: .actionSheet)
         
-        let userIds = Set(["steep-moon-9"])
+        let defaultUserId = "steep-moon-9"
         
-        alert.addAction(.init(title: "Add a member", style: .default, handler: { [unowned self] _ in
-            self.channelController?.addMembers(userIds: userIds) {
-                guard let error = $0 else {
-                    return print("Members \(userIds) added successfully")
+        alert.addAction(.init(title: "Add a member", style: .default, handler: { [weak self] _ in
+            guard let self = self else { return }
+            
+            self.alertTextField(title: "Add member", placeholder: defaultUserId) { userId in
+                self.channelController?.addMembers(userIds: [userId]) {
+                    guard let error = $0 else {
+                        return print("Members \(userId) added successfully")
+                    }
+                    self.alert(title: "Error", message: "Error adding member \(userId): \(error)")
                 }
-                print("Error adding members \(userIds): \(error)")
             }
         }))
         
         alert.addAction(.init(title: "Remove a member", style: .default, handler: { [unowned self] _ in
-            self.channelController?.removeMembers(userIds: userIds) {
-                guard let error = $0 else {
-                    return print("Members \(userIds) removed successfully")
+            self.alertTextField(title: "Remove member", placeholder: defaultUserId) { userId in
+                self.channelController?.removeMembers(userIds: [userId]) {
+                    guard let error = $0 else {
+                        return print("Member \(userId) removed successfully")
+                    }
+                    self.alert(title: "Error", message: "Error removing member \(userId): \(error)")
                 }
-                print("Error removing members \(userIds): \(error)")
             }
         }))
         
@@ -268,7 +274,7 @@ final class SimpleChatViewController: UITableViewController, ChannelControllerDe
                 guard let error = $0 else {
                     return print("Channel deleted successfully")
                 }
-                print("Error deleting channel: \(error)")
+                self.alert(title: "Error", message: "Error deleting channel: \(error)")
             }
         }))
         

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		804B127724ED59FE002B00EA /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 804B127624ED59FE002B00EA /* Settings.storyboard */; };
 		8A0175F02501174000570345 /* EventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175EF2501174000570345 /* EventSender.swift */; };
 		8A0175F425013B6400570345 /* EventSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175F325013B6400570345 /* EventSender_Tests.swift */; };
+		805A11492506FBBD0089DFC4 /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805A11472506FBB30089DFC4 /* UIViewController+Alert.swift */; };
 		8A08C6A624D437DF00DEF995 /* WebSocketPingController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */; };
 		8A0C3BBC24C0947400CAFD19 /* UserEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0C3BBB24C0947400CAFD19 /* UserEvents.swift */; };
 		8A0C3BBF24C0ACAB00CAFD19 /* UserPresence.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A0C3BBD24C0AC6400CAFD19 /* UserPresence.json */; };
@@ -548,6 +549,7 @@
 		804B127624ED59FE002B00EA /* Settings.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Settings.storyboard; sourceTree = "<group>"; };
 		8A0175EF2501174000570345 /* EventSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender.swift; sourceTree = "<group>"; };
 		8A0175F325013B6400570345 /* EventSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender_Tests.swift; sourceTree = "<group>"; };
+		805A11472506FBB30089DFC4 /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketPingController_Tests.swift; sourceTree = "<group>"; };
 		8A0C3BBB24C0947400CAFD19 /* UserEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEvents.swift; sourceTree = "<group>"; };
 		8A0C3BBD24C0AC6400CAFD19 /* UserPresence.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = UserPresence.json; sourceTree = "<group>"; };
@@ -1187,6 +1189,7 @@
 			isa = PBXGroup;
 			children = (
 				8008C17F24ED64C000F5BCCE /* UIViewController+MoveToStoryboard.swift */,
+				805A11472506FBB30089DFC4 /* UIViewController+Alert.swift */,
 				8008C18224ED65A500F5BCCE /* UIStoryboard+Definitions.swift */,
 				8008C19024F44DF600F5BCCE /* UIView+InstantiateFromNib.swift */,
 				8008C19E24F84DB600F5BCCE /* UITableViewController+KeyboardAvoidance.swift */,
@@ -1702,6 +1705,7 @@
 				8008C19224F44DF900F5BCCE /* UIView+InstantiateFromNib.swift in Sources */,
 				8040BC5E24FDAB1E00DE369F /* UIColor+ForUsername.swift in Sources */,
 				8008C18124ED64D300F5BCCE /* UIViewController+MoveToStoryboard.swift in Sources */,
+				805A11492506FBBD0089DFC4 /* UIViewController+Alert.swift in Sources */,
 				792A4F27247FF01800EAF71D /* SceneDelegate.swift in Sources */,
 				8AE8950D24D8660800E852EC /* PingPongEmojiFormatter.swift in Sources */,
 			);


### PR DESCRIPTION
Decided to do these two tasks in one PR because both could use the alert extension. The alert for the login error is pretty much never called since, for now, the setUser method keeps retrying forever.

Also fixes:
- a glitch when the member actions alert shows up the tableview offset can go wrong
- chatClient not receiving the API key specified in the login screen
