### PR TITLE
[CIS-339] V3 Sample: Send keystroke events

### DIFF
--- a/Sample_v3/AppDelegate.swift
+++ b/Sample_v3/AppDelegate.swift
@@ -5,11 +5,6 @@
 @testable import StreamChatClient
 import UIKit
 
-var chatClient: ChatClient = {
-    var config = ChatClientConfig(apiKey: APIKey("qk4nn7rpcn75"))
-    return ChatClient(config: config)
-}()
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?

--- a/Sample_v3/Samples/SettingsViewController.swift
+++ b/Sample_v3/Samples/SettingsViewController.swift
@@ -11,15 +11,14 @@ class SettingsViewController: UITableViewController {
     @IBOutlet var clearLocalDatabaseCell: UITableViewCell!
     @IBOutlet var enablePushNotificationsSwitch: UISwitch!
     @IBOutlet var webSocketsConnectionSwitch: UISwitch!
-    
     @IBOutlet var userNameLabel: UILabel!
     @IBOutlet var userSecondaryLabel: UILabel!
     
-    private lazy var currentUserController: CurrentUserController = {
-        let controller = chatClient.currentUserController()
-        controller.delegate = self
-        return controller
-    }()
+    var currentUserController: CurrentUserController! {
+        didSet {
+            currentUserController.delegate = self
+        }
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -58,7 +57,7 @@ extension SettingsViewController {
     }
     
     func logout() {
-        chatClient.disconnect()
+        currentUserController.client.disconnect()
         moveToStoryboard(.main, options: .transitionFlipFromRight)
     }
 }
@@ -75,14 +74,14 @@ extension SettingsViewController {
     func webSocketsConnectionSwitchValueChanged(_ sender: Any) {
         if webSocketsConnectionSwitch.isOn {
             webSocketsConnectionSwitch.isEnabled = false
-            chatClient.connect { [weak self] error in
+            currentUserController.client.connect { [weak self] error in
                 DispatchQueue.main.async {
                     self?.webSocketsConnectionSwitch.isEnabled = true
                     self?.webSocketsConnectionSwitch.setOn(error == nil, animated: true)
                 }
             }
         } else {
-            chatClient.disconnect()
+            currentUserController.client.disconnect()
         }
     }
 }

--- a/Sample_v3/Samples/SimpleChat/SimpleChannelsViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChannelsViewController.swift
@@ -6,57 +6,156 @@ import Combine
 import StreamChatClient
 import UIKit
 
-class SimpleChannelsViewController: UITableViewController {
-    @available(iOS 13, *)
-    private lazy var cancellables: Set<AnyCancellable> = []
-
-    private lazy var longPressRecognizer = UILongPressGestureRecognizer(
-        target: self,
-        action: #selector(handleLongPress)
-    )
-
-    var channelListController: ChannelListController!
+///
+/// # SimpleChannelsViewController
+///
+/// A `UITableViewController` subclass that displays and manages the list of channels.  It uses the `ChannelListController`  class to make calls to the Stream Chat API
+/// and listens to events by conforming to `ChannelListControllerDelegate`.
+///
+class SimpleChannelsViewController: UITableViewController, ChannelListControllerDelegate {
+    // MARK: - Properties
     
-    var detailViewController: SimpleChatViewController?
+    ///
+    /// # channelListController
+    ///
+    ///  The property below holds the `ChannelListController` object.  It is used to make calls to the Stream Chat API and to listen to the events related to the channels list.
+    ///  After it is set, `channelController.delegate` needs to receive a reference to a `ChannelListControllerDelegate`, which, in this case, is `self`. After the
+    ///  delegate is set,`channelListController.startUpdating()` must be called to start listening to events related to the channel list. Additionally,
+    ///  `channelListController.client` holds a reference to the `ChatClient` which created this instance. It can be used to create other controllers.
+    ///
+    var channelListController: ChannelListController! {
+        didSet {
+            channelListController.delegate = self
+            channelListController.startUpdating()
+        }
+    }
+    
+    // MARK: - ChannelControllerDelegate
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        channelListController.delegate = self
-        channelListController.startUpdating()
+    ///
+    /// The methods below are part of the `ChannelListControllerDelegate` protocol and will be called when events happen in the channel list. In order for these updates to
+    /// happen, `channelController.delegate` must be equal `self` and `channelController.startUpdating()` must be called.
+    ///
+    
+    ///
+    /// # didChangeChannels
+    ///
+    /// The method below receives the `changes` that happen in the list of messages and updates the `UITableView` accordingly.
+    ///
+    func controller(
+        _ controller: ChannelListControllerGeneric<DefaultDataTypes>,
+        didChangeChannels changes: [ListChange<Channel>]
+    ) {
+        tableView.beginUpdates()
         
-        // Do any additional setup after loading the view.
-        navigationItem.leftBarButtonItem = UIBarButtonItem(
-            title: "Settings",
-            style: .plain,
-            target: self,
-            action: #selector(handleSettingsButton)
+        for change in changes {
+            switch change {
+            case let .insert(_, index: index):
+                tableView.insertRows(at: [index], with: .automatic)
+            case let .move(_, fromIndex: fromIndex, toIndex: toIndex):
+                tableView.moveRow(at: fromIndex, to: toIndex)
+            case let .update(_, index: index):
+                tableView.reloadRows(at: [index], with: .automatic)
+            case let .remove(_, index: index):
+                tableView.deleteRows(at: [index], with: .automatic)
+            }
+        }
+        
+        tableView.endUpdates()
+    }
+    
+    // MARK: - UITableViewDataSource
+
+    ///
+    /// The methods below are part of the `UITableViewDataSource` protocol and will be called when the `UITableView` needs information which will be given by the
+    /// `channelListController` object.
+    ///
+    
+    ///
+    /// # numberOfRowsInSection
+    ///
+    /// The method below returns the current loaded channels count `channelListController.channels.count`. It will increase as more channels are loaded or decrease as
+    /// channels are deleted.
+    ///
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        channelListController.channels.count
+    }
+    
+    ///
+    /// # cellForRowAt
+    ///
+    /// The method below returns a cell configured based on the channel in position `indexPath.row` of `channelListController.channels`.
+    ///
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let channel = channelListController.channels[indexPath.row]
+        
+        let subtitle: String
+        if let latestMessage = channel.latestMessages.first {
+            let author = latestMessage.author.name ?? latestMessage.author.id.description
+            subtitle = "\(author): \(latestMessage.text)"
+        } else {
+            subtitle = "No messages"
+        }
+        
+        return cellWithChannelName(
+            channel.extraData.name ?? channel.cid.description,
+            subtitle: subtitle,
+            unreadCount: channel.unreadCount.messages
         )
-
-        let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(insertNewObject(_:)))
-        navigationItem.rightBarButtonItem = addButton
-        if let split = splitViewController {
-            let controllers = split.viewControllers
-            detailViewController = (controllers[controllers.count - 1] as! UINavigationController)
-                .topViewController as? SimpleChatViewController
-        }
-
-        tableView.addGestureRecognizer(longPressRecognizer)
-        
-        if #available(iOS 13, *) {
-            channelListController.statePublisher.sink { (state) in
-                print("State changed: \(state)")
-            }.store(in: &cancellables)
-        }
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        clearsSelectionOnViewWillAppear = splitViewController!.isCollapsed
-        super.viewWillAppear(animated)
     }
     
-    @objc
-    func handleSettingsButton(_ sender: Any) {
+    // MARK: - UITableViewDelegate
+
+    ///
+    /// The methods below are part of the `UITableViewDelegate` protocol and will be called when some event happened in the `UITableView`  which will cause some action
+    /// done by the `channelController` object.
+    ///
+    
+    ///
+    /// # willDisplay
+    ///
+    /// The method below handles the case when the last cell in the channels list is displayed by calling `channelListController.loadNextChannels()` to fetch more
+    /// channels.
+    ///
+    override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if indexPath.section == tableView.numberOfSections - 1,
+            indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1 {
+            channelListController.loadNextChannels()
+        }
+    }
+    
+    ///
+    /// # commit editingStyle
+    ///
+    /// The method below pressing the delete button after swiping a channel cell by calling `channelController.deleteChannel()`
+    ///
+    override func tableView(
+        _ tableView: UITableView,
+        commit editingStyle: UITableViewCell.EditingStyle,
+        forRowAt indexPath: IndexPath
+    ) {
+        switch editingStyle {
+        case .delete:
+            let channelId = channelListController.channels[indexPath.row].cid
+            channelListController.client.channelController(for: channelId).deleteChannel()
+        default:
+            return
+        }
+    }
+    
+    // MARK: - Actions
+
+    ///
+    /// The methods below are called when the user presses some button to open the settings screen or create a channel, or long presses a channel cell in the table view.
+    ///
+    
+    ///
+    /// # handleSettingsButton
+    ///
+    /// The method below is called when the user taps the settings button. Before presenting the view controller, `settingsViewController.currentUserController` is set
+    /// so that view controller can get information and take actions that affect the current user.
+    ///
+    @objc func handleSettingsButton(_ sender: Any) {
         guard
             let navigationViewController = UIStoryboard.settings.instantiateInitialViewController(),
             let settingsViewController = navigationViewController.children.first as? SettingsViewController
@@ -68,8 +167,12 @@ class SimpleChannelsViewController: UITableViewController {
         present(navigationViewController, animated: true)
     }
 
-    @objc
-    func insertNewObject(_ sender: Any) {
+    ///
+    /// # handleAddChannelButton
+    ///
+    /// The method below is called when the user taps the add channel button. It creates the channel by calling `client.channelController(createChannelWithId: ...)`
+    ///
+    @objc func handleAddChannelButton(_ sender: Any) {
         let id = UUID().uuidString
         let controller = channelListController.client.channelController(
             createChannelWithId: .init(type: .messaging, id: id),
@@ -78,108 +181,30 @@ class SimpleChannelsViewController: UITableViewController {
         )
         controller.startUpdating()
     }
-
-    // MARK: - Segues
-
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "showDetail" {
-            if let indexPath = tableView.indexPathForSelectedRow {
-                let channel = channelListController.channels[indexPath.row]
-                let controller = (segue.destination as! UINavigationController).topViewController as! SimpleChatViewController
-                controller.channelController = channelListController.client.channelController(for: channel.cid)
-                controller.navigationItem.leftBarButtonItem = splitViewController?.displayModeButtonItem
-                controller.navigationItem.leftItemsSupplementBackButton = true
-                detailViewController = controller
-            }
-        }
-    }
-
-    // MARK: - Table View
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        1
-    }
-
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        channelListController.channels.count
-    }
-
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
-        let channel = channelListController.channels[indexPath.row]
-        cell.textLabel?.text = channel.extraData.name ?? channel.cid.description
-        
-        // set channel cell subtitle to latest message
-        if let latestMessage = channel.latestMessages.first {
-            let author = latestMessage.author.name ?? latestMessage.author.id.description
-            cell.detailTextLabel?.text = "\(author): \(latestMessage.text)"
-        } else {
-            cell.detailTextLabel?.text = "No messages"
-        }
-        
-        if channel.isUnread {
-            // set channel name font to bold
-            cell.textLabel?.font = UIFont.boldSystemFont(ofSize: cell.textLabel?.font.pointSize ?? UIFont.labelFontSize)
-            
-            // set accessory view to number of unread messages
-            let unreadLabel = UILabel()
-            unreadLabel.text = "\(channel.unreadCount.messages)"
-            cell.accessoryView = unreadLabel
-        }
-        
-        return cell
-    }
-
-    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the specified item to be editable.
-        true
-    }
-
-    override func tableView(
-        _ tableView: UITableView,
-        commit editingStyle: UITableViewCell.EditingStyle,
-        forRowAt indexPath: IndexPath
-    ) {
-        switch editingStyle {
-        case .delete:
-            let channelId = channelListController.channels[indexPath.row].cid
-            channelListController.client.channelController(for: channelId).deleteChannel()
-        default: return
-        }
-    }
-
-    override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        if indexPath.section == tableView.numberOfSections - 1,
-            indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1 {
-            channelListController.loadNextChannels()
-        }
-    }
-}
-
-// MARK: - Private
-
-private extension SimpleChannelsViewController {
-    @objc
-    func handleLongPress(_ gestureRecognizer: UILongPressGestureRecognizer) {
+    
+    ///
+    /// # handleLongPress
+    ///
+    /// The method below handles long press on channel cells by displaying a `UIAlertController` with many actions that can be taken on the `channelController` such
+    /// as `updateChannel`, `muteChannel`, `unmuteChannel`, ``showChannel`, and `hideChannel`.
+    ///
+    @objc func handleLongPress(_ gestureRecognizer: UILongPressGestureRecognizer) {
         guard
             let indexPath = tableView.indexPathForRow(at: gestureRecognizer.location(in: tableView)),
             gestureRecognizer.state == .began
-        else { return }
+        else {
+            return
+        }
 
-        let channelController = channelListController.client
-            .channelController(for: channelListController.channels[indexPath.row].cid)
+        let channelId = channelListController.channels[indexPath.row].cid
+        let channelController = channelListController.client.channelController(for: channelId)
 
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let actions = [
             UIAlertAction(title: "Change name", style: .default) { _ in
-                let alert = UIAlertController(title: "Change channel name", message: "", preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "Confirm", style: .default, handler: { _ in
-                    guard let newName = alert.textFields?.first?.text else { return }
+                self.alertTextField(title: "Change channel name", placeholder: "New name") { newName in
                     channelController.updateChannel(team: nil, extraData: .init(name: newName, imageURL: nil))
-                }))
-                alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-                alert.addTextField(configurationHandler: nil)
-                self.present(alert, animated: true, completion: nil)
+                }
             },
             UIAlertAction(title: "Mute", style: .default) { _ in
                 channelController.muteChannel()
@@ -199,44 +224,102 @@ private extension SimpleChannelsViewController {
 
         present(actionSheet, animated: true)
     }
-}
-
-extension SimpleChannelsViewController: ChannelListControllerDelegate {
-    func controller(
-        _ controller: ChannelListControllerGeneric<DefaultDataTypes>,
-        didChangeChannels changes: [ListChange<Channel>]
-    ) {
-        // Animate changes
-        
-        /*
-         TODO: It could be nice to provide this boilerplate as an extension of UITableView. Something like:
-         
-            tableView.apply(changes: changes)
-         
-         and similarly for:
-         
-            collectionView.apply(changes: changes)
-         */
-        
-        tableView.beginUpdates()
-        
-        for change in changes {
-            switch change {
-            case let .insert(_, index: index):
-                tableView.insertRows(at: [index], with: .automatic)
-            case let .move(_, fromIndex: fromIndex, toIndex: toIndex):
-                tableView.moveRow(at: fromIndex, to: toIndex)
-            case let .update(_, index: index):
-                tableView.reloadRows(at: [index], with: .automatic)
-            case let .remove(_, index: index):
-                tableView.deleteRows(at: [index], with: .automatic)
+    
+    // MARK: - Segues
+    
+    ///
+    /// # prepareForSegue
+    ///
+    /// The method below handles the segue to `SimpleChatViewController`. It passes down to it a reference to a `ChannelController` for the respective channel so it
+    /// can display and manage it.
+    ///
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "showDetail" {
+            if let indexPath = tableView.indexPathForSelectedRow {
+                let channel = channelListController.channels[indexPath.row]
+                let controller = (segue.destination as! UINavigationController).topViewController as! SimpleChatViewController
+                
+                /// pass down reference to `ChannelController`.
+                controller.channelController = channelListController.client.channelController(for: channel.cid)
+                
+                controller.navigationItem.leftBarButtonItem = splitViewController?.displayModeButtonItem
+                controller.navigationItem.leftItemsSupplementBackButton = true
+                detailViewController = controller
             }
         }
+    }
+    
+    // MARK: - UI code
+
+    ///
+    /// From here on, you'll see mostly UI code that's not related to the `ChannelListController` usage.
+    ///
+    var detailViewController: SimpleChatViewController?
+    
+    private lazy var longPressRecognizer = UILongPressGestureRecognizer(
+        target: self,
+        action: #selector(handleLongPress)
+    )
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
         
-        tableView.endUpdates()
+        // Do any additional setup after loading the view.
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            title: "Settings",
+            style: .plain,
+            target: self,
+            action: #selector(handleSettingsButton)
+        )
+
+        let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(handleAddChannelButton(_:)))
+        navigationItem.rightBarButtonItem = addButton
+        if let split = splitViewController {
+            let controllers = split.viewControllers
+            detailViewController = (controllers[controllers.count - 1] as! UINavigationController)
+                .topViewController as? SimpleChatViewController
+        }
+
+        tableView.addGestureRecognizer(longPressRecognizer)
     }
 
-    func controller(_ controller: Controller, didChangeState state: Controller.State) {
-        log.debug("didChangeState: \(state)")
+    override func viewWillAppear(_ animated: Bool) {
+        clearsSelectionOnViewWillAppear = splitViewController!.isCollapsed
+        super.viewWillAppear(animated)
+    }
+
+    // MARK: - Table View
+
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        true
+    }
+}
+
+// MARK: - Private
+
+private extension SimpleChannelsViewController {
+    func cellWithChannelName(_ channelName: String?, subtitle: String, unreadCount: Int) -> UITableViewCell {
+        let cell: UITableViewCell
+        if let _cell = tableView.dequeueReusableCell(withIdentifier: "Cell") {
+            cell = _cell
+        } else {
+            cell = UITableViewCell(style: .subtitle, reuseIdentifier: "Cell")
+        }
+        
+        cell.textLabel?.text = channelName
+        cell.detailTextLabel?.text = subtitle
+        
+        if unreadCount > 0 {
+            // set channel name font to bold
+            cell.textLabel?.font = UIFont.boldSystemFont(ofSize: cell.textLabel?.font.pointSize ?? UIFont.labelFontSize)
+            
+            // set accessory view to number of unread messages
+            let unreadLabel = UILabel()
+            unreadLabel.text = "\(unreadCount)"
+            cell.accessoryView = unreadLabel
+        }
+        
+        return cell
     }
 }

--- a/Sources_v3/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources_v3/APIClient/Endpoints/ChannelEndpoints.swift
@@ -128,9 +128,9 @@ extension Endpoint {
         )
     }
     
-    static func sendEvent<ExtraData: ExtraDataTypes>(cid: ChannelId, eventType: EventType) -> Endpoint<EventPayload<ExtraData>> {
+    static func sendEvent(cid: ChannelId, eventType: EventType) -> Endpoint<EmptyResponse> {
         .init(
-            path: "channels/\(cid.type)/\(cid.id)",
+            path: "channels/\(cid.type)/\(cid.id)/event",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,

--- a/Sources_v3/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -262,6 +262,23 @@ final class ChannelEndpoints_Tests: XCTestCase {
         
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
     }
+    
+    func test_sendEvent_buildsCorrectly() {
+        let cid = ChannelId.unique
+        let eventType = EventType.userStartTyping
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: "channels/\(cid.type)/\(cid.id)/event",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["event": ["type": eventType]]
+        )
+        
+        let endpoint = Endpoint<EmptyResponse>.sendEvent(cid: cid, eventType: eventType)
+        
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
 }
 
 extension ChannelEditDetailPayload where ExtraData == DefaultDataTypes {

--- a/Sources_v3/Workers/EventSender.swift
+++ b/Sources_v3/Workers/EventSender.swift
@@ -46,8 +46,8 @@ class EventSender<ExtraData: ExtraDataTypes>: Worker {
     func startTyping(in cid: ChannelId, completion: ((Error?) -> Void)? = nil) {
         apiClient.request(
             endpoint: .sendEvent(cid: cid, eventType: .userStartTyping)
-        ) { (result: Result<EventPayload<ExtraData>, Error>) in
-            completion?(result.error)
+        ) {
+            completion?($0.error)
         }
     }
     
@@ -62,8 +62,8 @@ class EventSender<ExtraData: ExtraDataTypes>: Worker {
         
         apiClient.request(
             endpoint: .sendEvent(cid: cid, eventType: .userStopTyping)
-        ) { (result: Result<EventPayload<ExtraData>, Error>) in
-            completion?(result.error)
+        ) {
+            completion?($0.error)
         }
     }
     

--- a/Sources_v3/Workers/EventSender_Tests.swift
+++ b/Sources_v3/Workers/EventSender_Tests.swift
@@ -38,7 +38,7 @@ class EventSender_Tests: StressTestCase {
         let cid = ChannelId.unique
         eventSender.keystroke(in: cid)
         
-        let startTypingEndpoint: Endpoint<EventPayload<ExtraData>> = .sendEvent(cid: cid, eventType: .userStartTyping)
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStartTyping)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(startTypingEndpoint))
         apiClient.request_endpoint = nil
         
@@ -46,7 +46,7 @@ class EventSender_Tests: StressTestCase {
         time.run(numberOfSeconds: .startTypingEventTimeout)
         
         // Make sure the stop typing event has been sent.
-        let stopTypingEndpoint: Endpoint<EventPayload<ExtraData>> = .sendEvent(cid: cid, eventType: .userStopTyping)
+        let stopTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStopTyping)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(stopTypingEndpoint))
     }
     
@@ -55,7 +55,7 @@ class EventSender_Tests: StressTestCase {
         let cid = ChannelId.unique
         eventSender.keystroke(in: cid)
         
-        let startTypingEndpoint: Endpoint<EventPayload<ExtraData>> = .sendEvent(cid: cid, eventType: .userStartTyping)
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStartTyping)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(startTypingEndpoint))
         
         // Before typing timeout send keystroke after `.startTypingEventTimeout` - 1 to avoid sending the stop typing event.
@@ -84,7 +84,7 @@ class EventSender_Tests: StressTestCase {
         } while time.currentTime < .startTypingResendInterval
         
         // Another start typing event should be sent.
-        let startTypingEndpoint: Endpoint<EventPayload<ExtraData>> = .sendEvent(cid: cid, eventType: .userStartTyping)
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStartTyping)
         let calls: [AnyEndpoint] = apiClient.request_allRecordedCalls.map(\.endpoint)
         XCTAssertEqual(calls, [AnyEndpoint(startTypingEndpoint), AnyEndpoint(startTypingEndpoint)])
     }
@@ -95,14 +95,14 @@ class EventSender_Tests: StressTestCase {
         eventSender.keystroke(in: cid)
         
         // Check the start typing event has been sent.
-        let startTypingEndpoint: Endpoint<EventPayload<ExtraData>> = .sendEvent(cid: cid, eventType: .userStartTyping)
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStartTyping)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(startTypingEndpoint))
         
         time.run(numberOfSeconds: .startTypingEventTimeout - 1)
         
         // Force to stop typing and it should reset scheduled stop typing timer.
         eventSender.stopTyping(in: cid)
-        let stopTypingEndpoint: Endpoint<EventPayload<ExtraData>> = .sendEvent(cid: cid, eventType: .userStopTyping)
+        let stopTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStopTyping)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(stopTypingEndpoint))
         
         // Check the scheduled stop typing timer was cancelled.


### PR DESCRIPTION
List of changes:
- SimpleChatViewController.swift: Send keystroke events
- Multiple files: Remove global reference to chat client (it's now passed down via the controllers)
- SimpleChannelsViewController.swift: Comment & refactor to focus on `ChannelListController` usage.