### PR TITLE
[CIS-288] Calculate channel unread count based on latest channel read

### DIFF
--- a/Sources_v3/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO_Tests.swift
@@ -120,6 +120,109 @@ class ChannelDTO_Tests: XCTestCase {
         }
     }
     
+    func test_channelPayload_withNoExtraData_isStoredAndLoadedFromDB() {
+        let channelId: ChannelId = .unique
+        
+        let payload = dummyPayloadWithNoExtraData(with: channelId)
+        
+        // Asynchronously save the payload to the db
+        database.write { session in
+            try! session.saveChannel(payload: payload)
+        }
+        
+        // Load the channel from the db and check the fields are correct
+        var loadedChannel: ChannelModel<DefaultDataTypes>? {
+            database.viewContext.loadChannel(cid: channelId)
+        }
+        
+        AssertAsync {
+            // Channel details
+            Assert.willBeEqual(channelId, loadedChannel?.cid)
+            
+            Assert.willBeEqual(payload.channel.typeRawValue, loadedChannel?.type.rawValue)
+            Assert.willBeEqual(payload.channel.lastMessageAt, loadedChannel?.lastMessageAt)
+            Assert.willBeEqual(payload.channel.createdAt, loadedChannel?.createdAt)
+            Assert.willBeEqual(payload.channel.updatedAt, loadedChannel?.updatedAt)
+            Assert.willBeEqual(payload.channel.deletedAt, loadedChannel?.deletedAt)
+            
+            // Config
+            Assert.willBeEqual(payload.channel.config.reactionsEnabled, loadedChannel?.config.reactionsEnabled)
+            Assert.willBeEqual(payload.channel.config.typingEventsEnabled, loadedChannel?.config.typingEventsEnabled)
+            Assert.willBeEqual(payload.channel.config.readEventsEnabled, loadedChannel?.config.readEventsEnabled)
+            Assert.willBeEqual(payload.channel.config.connectEventsEnabled, loadedChannel?.config.connectEventsEnabled)
+            Assert.willBeEqual(payload.channel.config.uploadsEnabled, loadedChannel?.config.uploadsEnabled)
+            Assert.willBeEqual(payload.channel.config.repliesEnabled, loadedChannel?.config.repliesEnabled)
+            Assert.willBeEqual(payload.channel.config.searchEnabled, loadedChannel?.config.searchEnabled)
+            Assert.willBeEqual(payload.channel.config.mutesEnabled, loadedChannel?.config.mutesEnabled)
+            Assert.willBeEqual(payload.channel.config.urlEnrichmentEnabled, loadedChannel?.config.urlEnrichmentEnabled)
+            Assert.willBeEqual(payload.channel.config.messageRetention, loadedChannel?.config.messageRetention)
+            Assert.willBeEqual(payload.channel.config.maxMessageLength, loadedChannel?.config.maxMessageLength)
+            Assert.willBeEqual(payload.channel.config.commands, loadedChannel?.config.commands)
+            Assert.willBeEqual(payload.channel.config.createdAt, loadedChannel?.config.createdAt)
+            Assert.willBeEqual(payload.channel.config.updatedAt, loadedChannel?.config.updatedAt)
+            
+            // Creator
+            Assert.willBeEqual(payload.channel.createdBy!.id, loadedChannel?.createdBy?.id)
+            Assert.willBeEqual(payload.channel.createdBy!.createdAt, loadedChannel?.createdBy?.userCreatedAt)
+            Assert.willBeEqual(payload.channel.createdBy!.updatedAt, loadedChannel?.createdBy?.userUpdatedAt)
+            Assert.willBeEqual(payload.channel.createdBy!.lastActiveAt, loadedChannel?.createdBy?.lastActiveAt)
+            Assert.willBeEqual(payload.channel.createdBy!.isOnline, loadedChannel?.createdBy?.isOnline)
+            Assert.willBeEqual(payload.channel.createdBy!.isBanned, loadedChannel?.createdBy?.isBanned)
+            Assert.willBeEqual(payload.channel.createdBy!.role, loadedChannel?.createdBy?.userRole)
+            Assert.willBeEqual(payload.channel.createdBy!.teams, loadedChannel?.createdBy?.teams)
+            
+            // Members
+            Assert.willBeEqual(payload.members[0].role, loadedChannel?.members.first?.memberRole)
+            Assert.willBeEqual(payload.members[0].createdAt, loadedChannel?.members.first?.memberCreatedAt)
+            Assert.willBeEqual(payload.members[0].updatedAt, loadedChannel?.members.first?.memberUpdatedAt)
+            
+            Assert.willBeEqual(payload.members[0].user.id, loadedChannel?.members.first?.id)
+            Assert.willBeEqual(payload.members[0].user.createdAt, loadedChannel?.members.first?.userCreatedAt)
+            Assert.willBeEqual(payload.members[0].user.updatedAt, loadedChannel?.members.first?.userUpdatedAt)
+            Assert.willBeEqual(payload.members[0].user.lastActiveAt, loadedChannel?.members.first?.lastActiveAt)
+            Assert.willBeEqual(payload.members[0].user.isOnline, loadedChannel?.members.first?.isOnline)
+            Assert.willBeEqual(payload.members[0].user.isBanned, loadedChannel?.members.first?.isBanned)
+            Assert.willBeEqual(payload.members[0].user.role, loadedChannel?.members.first?.userRole)
+            Assert.willBeEqual(payload.members[0].user.teams, loadedChannel?.members.first?.teams)
+            // Assert.willBeEqual(payload.members[0].user.isInvisible, loadedChannel?.members.first?.isInvisible)
+            // Assert.willBeEqual(payload.members[0].user.devices, loadedChannel?.members.first?.devices)
+            // Assert.willBeEqual(payload.members[0].user.mutedUsers, loadedChannel?.members.first?.mutedUsers)
+            // Assert.willBeEqual(payload.members[0].user.unreadChannelsCount, loadedChannel?.members.first?.unreadChannelsCount)
+            // Assert.willBeEqual(payload.members[0].user.unreadMessagesCount, loadedChannel?.members.first?.unreadMessagesCount)
+            
+            // Messages
+            Assert.willBeEqual(payload.messages[0].id, loadedChannel?.latestMessages.first?.id)
+            Assert.willBeEqual(payload.messages[0].type.rawValue, loadedChannel?.latestMessages.first?.type.rawValue)
+            Assert.willBeEqual(payload.messages[0].text, loadedChannel?.latestMessages.first?.text)
+            Assert.willBeEqual(payload.messages[0].updatedAt, loadedChannel?.latestMessages.first?.updatedAt)
+            Assert.willBeEqual(payload.messages[0].createdAt, loadedChannel?.latestMessages.first?.createdAt)
+            Assert.willBeEqual(payload.messages[0].deletedAt, loadedChannel?.latestMessages.first?.deletedAt)
+            Assert.willBeEqual(payload.messages[0].args, loadedChannel?.latestMessages.first?.arguments)
+            Assert.willBeEqual(payload.messages[0].command, loadedChannel?.latestMessages.first?.command)
+            Assert.willBeEqual(payload.messages[0].extraData, loadedChannel?.latestMessages.first?.extraData)
+            Assert.willBeEqual(payload.messages[0].isSilent, loadedChannel?.latestMessages.first?.isSilent)
+            Assert.willBeEqual(payload.messages[0].mentionedUsers.count, loadedChannel?.latestMessages.first?.mentionedUsers.count)
+            Assert.willBeEqual(payload.messages[0].parentId, loadedChannel?.latestMessages.first?.parentMessageId)
+            Assert.willBeEqual(payload.messages[0].reactionScores, loadedChannel?.latestMessages.first?.reactionScores)
+            Assert.willBeEqual(payload.messages[0].replyCount, loadedChannel?.latestMessages.first?.replyCount)
+            
+            // Message user
+            Assert.willBeEqual(payload.messages[0].user.id, loadedChannel?.latestMessages.first?.author.id)
+            Assert.willBeEqual(payload.messages[0].user.createdAt, loadedChannel?.latestMessages.first?.author.userCreatedAt)
+            Assert.willBeEqual(payload.messages[0].user.updatedAt, loadedChannel?.latestMessages.first?.author.userUpdatedAt)
+            Assert.willBeEqual(payload.messages[0].user.lastActiveAt, loadedChannel?.latestMessages.first?.author.lastActiveAt)
+            Assert.willBeEqual(payload.messages[0].user.isOnline, loadedChannel?.latestMessages.first?.author.isOnline)
+            Assert.willBeEqual(payload.messages[0].user.isBanned, loadedChannel?.latestMessages.first?.author.isBanned)
+            Assert.willBeEqual(payload.messages[0].user.role, loadedChannel?.latestMessages.first?.author.userRole)
+            Assert.willBeEqual(payload.messages[0].user.teams, loadedChannel?.latestMessages.first?.author.teams)
+            
+            // Read
+            Assert.willBeEqual(payload.channelReads[0].lastReadAt, loadedChannel?.reads.first?.lastReadAt)
+            Assert.willBeEqual(payload.channelReads[0].unreadMessagesCount, loadedChannel?.reads.first?.unreadMessagesCount)
+            Assert.willBeEqual(payload.channelReads[0].user.id, loadedChannel?.reads.first?.user.id)
+        }
+    }
+    
     func test_channelWithChannelListQuery_isSavedAndLoaded() {
         let query = ChannelListQuery(filter: .equal("name", to: "Luke Skywalker") & .less("age", than: 50))
         
@@ -254,116 +357,15 @@ class ChannelDTO_Tests: XCTestCase {
             return json["key"] as! String
         }
     }
-    
-    func test_channelPayload_withNoExtraData_isStoredAndLoadedFromDB() {
-        let channelId: ChannelId = .unique
-        
-        let payload = dummyPayloadWithNoExtraData(with: channelId)
-        
-        // Asynchronously save the payload to the db
-        database.write { session in
-            try! session.saveChannel(payload: payload)
-        }
-        
-        // Load the channel from the db and check the fields are correct
-        var loadedChannel: ChannelModel<DefaultDataTypes>? {
-            database.viewContext.loadChannel(cid: channelId)
-        }
-        
-        AssertAsync {
-            // Channel details
-            Assert.willBeEqual(channelId, loadedChannel?.cid)
-            
-            Assert.willBeEqual(payload.channel.typeRawValue, loadedChannel?.type.rawValue)
-            Assert.willBeEqual(payload.channel.lastMessageAt, loadedChannel?.lastMessageAt)
-            Assert.willBeEqual(payload.channel.createdAt, loadedChannel?.createdAt)
-            Assert.willBeEqual(payload.channel.updatedAt, loadedChannel?.updatedAt)
-            Assert.willBeEqual(payload.channel.deletedAt, loadedChannel?.deletedAt)
-            
-            // Config
-            Assert.willBeEqual(payload.channel.config.reactionsEnabled, loadedChannel?.config.reactionsEnabled)
-            Assert.willBeEqual(payload.channel.config.typingEventsEnabled, loadedChannel?.config.typingEventsEnabled)
-            Assert.willBeEqual(payload.channel.config.readEventsEnabled, loadedChannel?.config.readEventsEnabled)
-            Assert.willBeEqual(payload.channel.config.connectEventsEnabled, loadedChannel?.config.connectEventsEnabled)
-            Assert.willBeEqual(payload.channel.config.uploadsEnabled, loadedChannel?.config.uploadsEnabled)
-            Assert.willBeEqual(payload.channel.config.repliesEnabled, loadedChannel?.config.repliesEnabled)
-            Assert.willBeEqual(payload.channel.config.searchEnabled, loadedChannel?.config.searchEnabled)
-            Assert.willBeEqual(payload.channel.config.mutesEnabled, loadedChannel?.config.mutesEnabled)
-            Assert.willBeEqual(payload.channel.config.urlEnrichmentEnabled, loadedChannel?.config.urlEnrichmentEnabled)
-            Assert.willBeEqual(payload.channel.config.messageRetention, loadedChannel?.config.messageRetention)
-            Assert.willBeEqual(payload.channel.config.maxMessageLength, loadedChannel?.config.maxMessageLength)
-            Assert.willBeEqual(payload.channel.config.commands, loadedChannel?.config.commands)
-            Assert.willBeEqual(payload.channel.config.createdAt, loadedChannel?.config.createdAt)
-            Assert.willBeEqual(payload.channel.config.updatedAt, loadedChannel?.config.updatedAt)
-            
-            // Creator
-            Assert.willBeEqual(payload.channel.createdBy!.id, loadedChannel?.createdBy?.id)
-            Assert.willBeEqual(payload.channel.createdBy!.createdAt, loadedChannel?.createdBy?.userCreatedAt)
-            Assert.willBeEqual(payload.channel.createdBy!.updatedAt, loadedChannel?.createdBy?.userUpdatedAt)
-            Assert.willBeEqual(payload.channel.createdBy!.lastActiveAt, loadedChannel?.createdBy?.lastActiveAt)
-            Assert.willBeEqual(payload.channel.createdBy!.isOnline, loadedChannel?.createdBy?.isOnline)
-            Assert.willBeEqual(payload.channel.createdBy!.isBanned, loadedChannel?.createdBy?.isBanned)
-            Assert.willBeEqual(payload.channel.createdBy!.role, loadedChannel?.createdBy?.userRole)
-            Assert.willBeEqual(payload.channel.createdBy!.teams, loadedChannel?.createdBy?.teams)
-            
-            // Members
-            Assert.willBeEqual(payload.members[0].role, loadedChannel?.members.first?.memberRole)
-            Assert.willBeEqual(payload.members[0].createdAt, loadedChannel?.members.first?.memberCreatedAt)
-            Assert.willBeEqual(payload.members[0].updatedAt, loadedChannel?.members.first?.memberUpdatedAt)
-            
-            Assert.willBeEqual(payload.members[0].user.id, loadedChannel?.members.first?.id)
-            Assert.willBeEqual(payload.members[0].user.createdAt, loadedChannel?.members.first?.userCreatedAt)
-            Assert.willBeEqual(payload.members[0].user.updatedAt, loadedChannel?.members.first?.userUpdatedAt)
-            Assert.willBeEqual(payload.members[0].user.lastActiveAt, loadedChannel?.members.first?.lastActiveAt)
-            Assert.willBeEqual(payload.members[0].user.isOnline, loadedChannel?.members.first?.isOnline)
-            Assert.willBeEqual(payload.members[0].user.isBanned, loadedChannel?.members.first?.isBanned)
-            Assert.willBeEqual(payload.members[0].user.role, loadedChannel?.members.first?.userRole)
-            Assert.willBeEqual(payload.members[0].user.teams, loadedChannel?.members.first?.teams)
-            // Assert.willBeEqual(payload.members[0].user.isInvisible, loadedChannel?.members.first?.isInvisible)
-            // Assert.willBeEqual(payload.members[0].user.devices, loadedChannel?.members.first?.devices)
-            // Assert.willBeEqual(payload.members[0].user.mutedUsers, loadedChannel?.members.first?.mutedUsers)
-            // Assert.willBeEqual(payload.members[0].user.unreadChannelsCount, loadedChannel?.members.first?.unreadChannelsCount)
-            // Assert.willBeEqual(payload.members[0].user.unreadMessagesCount, loadedChannel?.members.first?.unreadMessagesCount)
-            
-            // Messages
-            Assert.willBeEqual(payload.messages[0].id, loadedChannel?.latestMessages.first?.id)
-            Assert.willBeEqual(payload.messages[0].type.rawValue, loadedChannel?.latestMessages.first?.type.rawValue)
-            Assert.willBeEqual(payload.messages[0].text, loadedChannel?.latestMessages.first?.text)
-            Assert.willBeEqual(payload.messages[0].updatedAt, loadedChannel?.latestMessages.first?.updatedAt)
-            Assert.willBeEqual(payload.messages[0].createdAt, loadedChannel?.latestMessages.first?.createdAt)
-            Assert.willBeEqual(payload.messages[0].deletedAt, loadedChannel?.latestMessages.first?.deletedAt)
-            Assert.willBeEqual(payload.messages[0].args, loadedChannel?.latestMessages.first?.arguments)
-            Assert.willBeEqual(payload.messages[0].command, loadedChannel?.latestMessages.first?.command)
-            Assert.willBeEqual(payload.messages[0].extraData, loadedChannel?.latestMessages.first?.extraData)
-            Assert.willBeEqual(payload.messages[0].isSilent, loadedChannel?.latestMessages.first?.isSilent)
-            Assert.willBeEqual(payload.messages[0].mentionedUsers.count, loadedChannel?.latestMessages.first?.mentionedUsers.count)
-            Assert.willBeEqual(payload.messages[0].parentId, loadedChannel?.latestMessages.first?.parentMessageId)
-            Assert.willBeEqual(payload.messages[0].reactionScores, loadedChannel?.latestMessages.first?.reactionScores)
-            Assert.willBeEqual(payload.messages[0].replyCount, loadedChannel?.latestMessages.first?.replyCount)
-            
-            // Message user
-            Assert.willBeEqual(payload.messages[0].user.id, loadedChannel?.latestMessages.first?.author.id)
-            Assert.willBeEqual(payload.messages[0].user.createdAt, loadedChannel?.latestMessages.first?.author.userCreatedAt)
-            Assert.willBeEqual(payload.messages[0].user.updatedAt, loadedChannel?.latestMessages.first?.author.userUpdatedAt)
-            Assert.willBeEqual(payload.messages[0].user.lastActiveAt, loadedChannel?.latestMessages.first?.author.lastActiveAt)
-            Assert.willBeEqual(payload.messages[0].user.isOnline, loadedChannel?.latestMessages.first?.author.isOnline)
-            Assert.willBeEqual(payload.messages[0].user.isBanned, loadedChannel?.latestMessages.first?.author.isBanned)
-            Assert.willBeEqual(payload.messages[0].user.role, loadedChannel?.latestMessages.first?.author.userRole)
-            Assert.willBeEqual(payload.messages[0].user.teams, loadedChannel?.latestMessages.first?.author.teams)
-            
-            // Read
-            Assert.willBeEqual(payload.channelReads[0].lastReadAt, loadedChannel?.reads.first?.lastReadAt)
-            Assert.willBeEqual(payload.channelReads[0].unreadMessagesCount, loadedChannel?.reads.first?.unreadMessagesCount)
-            Assert.willBeEqual(payload.channelReads[0].user.id, loadedChannel?.reads.first?.user.id)
-        }
-    }
 }
 
 extension XCTestCase {
+    // MARK: - Dummy data with extra data
+    
+    var lukeExtraData: NameAndImageExtraData { NameAndImageExtraData(name: "Luke", imageURL: URL(string: UUID().uuidString)) }
+    
     var dummyUser: UserPayload<NameAndImageExtraData> {
-        let lukeExtraData = NameAndImageExtraData(name: "Luke", imageURL: URL(string: UUID().uuidString))
-        
-        return .init(
+        UserPayload(
             id: .unique,
             role: .user,
             createdAt: .unique,
@@ -403,8 +405,6 @@ extension XCTestCase {
     }
     
     func dummyPayload(with channelId: ChannelId) -> ChannelPayload<DefaultDataTypes> {
-        let lukeExtraData = NameAndImageExtraData(name: "Luke", imageURL: URL(string: UUID().uuidString))
-        
         let member: MemberPayload<NameAndImageExtraData> =
             .init(
                 user: .init(
@@ -474,6 +474,8 @@ extension XCTestCase {
         
         return payload
     }
+    
+    // MARK: - Dummy data with no extra data
     
     enum NoExtraDataTypes: ExtraDataTypes {
         typealias Channel = NoExtraData

--- a/Sources_v3/Database/DTOs/ChannelReadDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelReadDTO.swift
@@ -17,10 +17,21 @@ class ChannelReadDTO: NSManagedObject {
     @NSManaged var channel: ChannelDTO
     @NSManaged var user: UserDTO
     
+    static func fetchRequest(userId: String) -> NSFetchRequest<ChannelReadDTO> {
+        let request = NSFetchRequest<ChannelReadDTO>(entityName: ChannelReadDTO.entityName)
+        request.predicate = NSPredicate(format: "user.id == %@", userId)
+        return request
+    }
+    
     static func fetchRequest(for cid: ChannelId, userId: String) -> NSFetchRequest<ChannelReadDTO> {
         let request = NSFetchRequest<ChannelReadDTO>(entityName: ChannelReadDTO.entityName)
         request.predicate = NSPredicate(format: "channel.cid == %@ && user.id == %@", cid.rawValue, userId)
         return request
+    }
+    
+    static func load(userId: String, context: NSManagedObjectContext) -> [ChannelReadDTO] {
+        let request = fetchRequest(userId: userId)
+        return try! context.fetch(request)
     }
     
     static func load(cid: ChannelId, userId: String, context: NSManagedObjectContext) -> ChannelReadDTO? {
@@ -58,6 +69,14 @@ extension NSManagedObjectContext {
         dto.unreadMessageCount = payload.unreadMessagesCount
         
         return dto
+    }
+    
+    func loadChannelRead(cid: ChannelId, userId: String) -> ChannelReadDTO? {
+        ChannelReadDTO.load(cid: cid, userId: userId, context: self)
+    }
+    
+    func loadChannelReads(for userId: UserId) -> [ChannelReadDTO] {
+        ChannelReadDTO.load(userId: userId, context: self)
     }
 }
 

--- a/Sources_v3/Database/DatabaseSession.swift
+++ b/Sources_v3/Database/DatabaseSession.swift
@@ -79,7 +79,23 @@ extension MessageDatabaseSession {
     }
 }
 
-protocol DatabaseSession: UserDatabaseSession, CurrentUserDatabaseSession, MessageDatabaseSession {
+protocol ChannelReadDatabaseSession {
+    /// Creates a new `ChannelReadDTO` object in the database. Throws an error if the ChannelRead fails to be created.
+    @discardableResult
+    func saveChannelRead<ExtraData: ExtraDataTypes>(
+        payload: ChannelReadPayload<ExtraData>,
+        for cid: ChannelId
+    ) throws -> ChannelReadDTO
+    
+    /// Fetchtes `ChannelReadDTO` with the given `cid` and `userId` from the DB.
+    /// Returns `nil` if no `ChannelReadDTO` matching the `cid` and `userId`  exists.
+    func loadChannelRead(cid: ChannelId, userId: String) -> ChannelReadDTO?
+    
+    /// Fetchtes `ChannelReadDTO`entities for the given `userId` from the DB.
+    func loadChannelReads(for userId: UserId) -> [ChannelReadDTO]
+}
+
+protocol DatabaseSession: UserDatabaseSession, CurrentUserDatabaseSession, MessageDatabaseSession, ChannelReadDatabaseSession {
     // MARK: - Member
     
     @discardableResult

--- a/Sources_v3/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware.swift
@@ -1,0 +1,51 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A middleware which updates a channel's read events as websocket events arrive.
+struct ChannelReadUpdaterMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
+    let database: DatabaseContainer
+    
+    func handle(event: Event, completion: @escaping (Event?) -> Void) {
+        if let event = event as? MessageReadEvent<ExtraData> {
+            updateReadEvent(for: event.cid, userId: event.userId, lastReadAt: event.readAt) { completion(event) }
+            return
+        }
+        
+        if let event = event as? NotificationMarkReadEvent<ExtraData> {
+            updateReadEvent(for: event.cid, userId: event.userId, lastReadAt: event.readAt) { completion(event) }
+            return
+        }
+        
+        if let event = event as? NotificationMarkAllReadEvent<ExtraData> {
+            database.write({ session in
+                session.loadChannelReads(for: event.userId).forEach { read in
+                    read.lastReadAt = event.readAt
+                    read.unreadMessageCount = 0
+                }
+            }, completion: { error in
+                if let error = error {
+                    log.error("Failed to update channel reads for userId \(event.userId), error: \(error)")
+                }
+                completion(event)
+            })
+            return
+        }
+    }
+    
+    private func updateReadEvent(for cid: ChannelId, userId: UserId, lastReadAt: Date, completion: @escaping () -> Void) {
+        database.write({ session in
+            if let read = session.loadChannelRead(cid: cid, userId: userId) {
+                read.lastReadAt = lastReadAt
+                read.unreadMessageCount = 0
+            }
+        }, completion: { error in
+            if let error = error {
+                log.error("Failed to update channel read for cid \(cid) and userId \(userId), error: \(error)")
+            }
+            completion()
+        })
+    }
+}

--- a/Sources_v3/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
@@ -1,0 +1,159 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
+    var middleware: ChannelReadUpdaterMiddleware<DefaultDataTypes>!
+    fileprivate var database: DatabaseContainerMock!
+    
+    override func setUp() {
+        super.setUp()
+        database = try! DatabaseContainerMock(kind: .inMemory)
+        middleware = ChannelReadUpdaterMiddleware(database: database)
+    }
+    
+    func test_messageReadEvent_handledCorrectly() throws {
+        // Save a channel with a channel read
+        let channelId = ChannelId.unique
+        let payload = dummyPayload(with: channelId)
+        
+        assert(payload.channelReads.count == 1)
+        
+        // Save dummy payload to database
+        try database.writeSynchronously { (session) in
+            try session.saveChannel(payload: payload)
+        }
+        
+        // Load the channel from the db and check the if fields are correct
+        var loadedChannel: ChannelModel<DefaultDataTypes>? {
+            database.viewContext.loadChannel(cid: channelId)
+        }
+        
+        XCTAssertEqual(loadedChannel?.reads.first?.unreadMessagesCount, 10)
+        XCTAssertEqual(loadedChannel?.reads.first?.lastReadAt, Date(timeIntervalSince1970: 1))
+        
+        // Create a MessageReadEvent
+        // with a read date later than original read
+        let newReadDate = Date(timeIntervalSince1970: 2)
+        // Create EventPayload for MessageReadEvent
+        let eventPayload = EventPayload<DefaultDataTypes>(
+            eventType: .messageRead,
+            cid: channelId,
+            user: dummyCurrentUser,
+            unreadCount: .noUnread,
+            createdAt: newReadDate
+        )
+        let messageReadEvent = try MessageReadEvent<DefaultDataTypes>(from: eventPayload)
+        
+        // Let the middleware handle the event
+        // Middleware should mutate the loadedChannel's read
+        let handledEvent = try await { middleware.handle(event: messageReadEvent, completion: $0) }
+        
+        // Assert that the read event entity is updated
+        XCTAssertEqual(handledEvent?.asEquatable, messageReadEvent.asEquatable)
+        XCTAssertEqual(loadedChannel?.reads.first?.unreadMessagesCount, 0)
+        XCTAssertEqual(loadedChannel?.reads.first?.lastReadAt, newReadDate)
+    }
+    
+    func test_notificationMarkReadEvent_handledCorrectly() throws {
+        // Save a channel with a channel read
+        let channelId = ChannelId.unique
+        let payload = dummyPayload(with: channelId)
+        
+        assert(payload.channelReads.count == 1)
+        
+        // Save dummy payload to database
+        try database.writeSynchronously { (session) in
+            try session.saveChannel(payload: payload)
+        }
+
+        // Load the channel from the db and check the if fields are correct
+        var loadedChannel: ChannelModel<DefaultDataTypes>? {
+            database.viewContext.loadChannel(cid: channelId)
+        }
+        
+        XCTAssertEqual(loadedChannel?.reads.first?.unreadMessagesCount, 10)
+        XCTAssertEqual(loadedChannel?.reads.first?.lastReadAt, Date(timeIntervalSince1970: 1))
+        
+        // Create a NotificationMarkReadEvent
+        // with a read date later than original read
+        let newReadDate = Date(timeIntervalSince1970: 2)
+        // Unfortunately, ChannelDetailPayload is needed for NotificationMarkReadEvent...
+        let channelDetailPayload = ChannelDetailPayload<DefaultDataTypes>(
+            cid: channelId,
+            extraData: lukeExtraData,
+            typeRawValue: "",
+            lastMessageAt: nil,
+            createdAt: .unique,
+            deletedAt: nil,
+            updatedAt: .unique,
+            createdBy: nil,
+            config: .init(),
+            isFrozen: false,
+            memberCount: 0,
+            team: "",
+            members: nil
+        )
+        // Create EventPayload for NotificationMarkReadEvent
+        let eventPayload = EventPayload<DefaultDataTypes>(
+            eventType: .notificationMarkRead,
+            user: dummyCurrentUser,
+            channel: channelDetailPayload,
+            unreadCount: .noUnread,
+            createdAt: newReadDate
+        )
+        let notificationMarkReadEvent = try NotificationMarkReadEvent<DefaultDataTypes>(from: eventPayload)
+        
+        // Let the middleware handle the event
+        let handledEvent = try await { middleware.handle(event: notificationMarkReadEvent, completion: $0) }
+        
+        // Assert that the read event entity is updated
+        XCTAssertEqual(handledEvent?.asEquatable, notificationMarkReadEvent.asEquatable)
+        XCTAssertEqual(loadedChannel?.reads.first?.unreadMessagesCount, 0)
+        XCTAssertEqual(loadedChannel?.reads.first?.lastReadAt, newReadDate)
+    }
+    
+    func test_notificationMarkAllReadEvent_handledCorrectly() throws {
+        // Save a channel with a channel read
+        let channelId = ChannelId.unique
+        let payload = dummyPayload(with: channelId)
+        
+        assert(payload.channelReads.count == 1)
+        
+        // Save dummy payload to database
+        try database.writeSynchronously { (session) in
+            try session.saveChannel(payload: payload)
+        }
+        
+        // Load the channel from the db and check the if fields are correct
+        var loadedChannel: ChannelModel<DefaultDataTypes>? {
+            database.viewContext.loadChannel(cid: channelId)
+        }
+        
+        // Assert that the read event entity is updated
+        XCTAssertEqual(loadedChannel?.reads.first?.unreadMessagesCount, 10)
+        XCTAssertEqual(loadedChannel?.reads.first?.lastReadAt, Date(timeIntervalSince1970: 1))
+        
+        // Create a NotificationMarkAllReadEvent
+        // with a read date later than original read
+        let newReadDate = Date(timeIntervalSince1970: 2)
+        // Create EventPayload for NotificationMarkAllReadEvent
+        let eventPayload = EventPayload<DefaultDataTypes>(
+            eventType: .notificationMarkRead,
+            user: dummyCurrentUser,
+            createdAt: newReadDate
+        )
+        let notificationMarkAllReadEvent = try NotificationMarkAllReadEvent(from: eventPayload)
+        
+        // Let the middleware handle the event
+        let handledEvent = try await { middleware.handle(event: notificationMarkAllReadEvent, completion: $0) }
+        
+        // Assert that the read event entity is updated
+        XCTAssertEqual(handledEvent?.asEquatable, notificationMarkAllReadEvent.asEquatable)
+        XCTAssertEqual(loadedChannel?.reads.first?.unreadMessagesCount, 0)
+        XCTAssertEqual(loadedChannel?.reads.first?.lastReadAt, newReadDate)
+    }
+}

--- a/Sources_v3/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
@@ -5,7 +5,7 @@
 @testable import StreamChatClient
 import XCTest
 
-class EventDataProcessorMiddlewaree_Tests: XCTestCase {
+class EventDataProcessorMiddleware_Tests: XCTestCase {
     var middleware: EventDataProcessorMiddleware<DefaultDataTypes>!
     fileprivate var database: DatabaseContainerMock!
     

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -122,6 +122,8 @@
 		79896D5C2506593E00BA8F1C /* ChannelReadDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796FD215250654940076C99B /* ChannelReadDTO.swift */; };
 		79896D5E25065ECD00BA8F1C /* ChannelReadModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79896D5D25065E6900BA8F1C /* ChannelReadModel.swift */; };
 		79896D622507B16000BA8F1C /* ChannelListUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79896D602507B0DD00BA8F1C /* ChannelListUpdater_Mock.swift */; };
+		79896D64250A63A200BA8F1C /* ChannelReadUpdaterMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79896D63250A62EE00BA8F1C /* ChannelReadUpdaterMiddleware.swift */; };
+		79896D66250A6D1800BA8F1C /* ChannelReadUpdaterMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79896D65250A6D1500BA8F1C /* ChannelReadUpdaterMiddleware_Tests.swift */; };
 		7990503224CEEAA600689CDC /* MessageDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */; };
 		7991D83B24F5427E00D21BA3 /* EphemeralValuesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7991D83A24F5427E00D21BA3 /* EphemeralValuesContainer.swift */; };
 		7991D83D24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7991D83C24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift */; };
@@ -487,6 +489,8 @@
 		7988F6B624D15F100004219B /* StressTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StressTestCase.swift; sourceTree = "<group>"; };
 		79896D5D25065E6900BA8F1C /* ChannelReadModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelReadModel.swift; sourceTree = "<group>"; };
 		79896D602507B0DD00BA8F1C /* ChannelListUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListUpdater_Mock.swift; sourceTree = "<group>"; };
+		79896D63250A62EE00BA8F1C /* ChannelReadUpdaterMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelReadUpdaterMiddleware.swift; sourceTree = "<group>"; };
+		79896D65250A6D1500BA8F1C /* ChannelReadUpdaterMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelReadUpdaterMiddleware_Tests.swift; sourceTree = "<group>"; };
 		7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDTO_Tests.swift; sourceTree = "<group>"; };
 		7991D83A24F5427E00D21BA3 /* EphemeralValuesContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EphemeralValuesContainer.swift; sourceTree = "<group>"; };
 		7991D83C24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelListController+SwiftUI.swift"; sourceTree = "<group>"; };
@@ -950,6 +954,8 @@
 				79A0E9B82498C31300E9BD50 /* TypingStartCleanupMiddleware_Tests.swift */,
 				792FCB4424A33B5B000290C7 /* EventDataProcessorMiddleware.swift */,
 				792FCB4624A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift */,
+				79896D63250A62EE00BA8F1C /* ChannelReadUpdaterMiddleware.swift */,
+				79896D65250A6D1500BA8F1C /* ChannelReadUpdaterMiddleware_Tests.swift */,
 			);
 			path = EventMiddlewares;
 			sourceTree = "<group>";
@@ -1826,6 +1832,7 @@
 				8A0C3BD424C1DF2100CAFD19 /* MessageEvents.swift in Sources */,
 				79CD959224F9380B00E87377 /* MulticastDelegate.swift in Sources */,
 				7964F3BC249A5E60002A09EC /* RequestEncoder.swift in Sources */,
+				79896D64250A63A200BA8F1C /* ChannelReadUpdaterMiddleware.swift in Sources */,
 				DA4AA3B8250271BD00FAAF6E /* CurrentUserController+Combine.swift in Sources */,
 				79280F712487CD2B00CDEB89 /* Atomic.swift in Sources */,
 				797EEA4624FFAF4F00C81203 /* DataStore.swift in Sources */,
@@ -1963,6 +1970,7 @@
 				F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */,
 				79280F7D24891B1300CDEB89 /* WebSocketEngine_Mock.swift in Sources */,
 				79B5517C24E6A1CA00CE9FEC /* MessagePayloads_Tests.swift in Sources */,
+				79896D66250A6D1800BA8F1C /* ChannelReadUpdaterMiddleware_Tests.swift in Sources */,
 				790B9E3224DC221A005455AA /* UserPayload.swift in Sources */,
 				792921CD24C07A9000116BBB /* QueueAwareDelegate.swift in Sources */,
 				79DDF812249CD5AC002F4412 /* APIClient_Tests.swift in Sources */,


### PR DESCRIPTION
The missing piece is, parsing `messageRead` events and updating DB's `ChannelRead` objects accordingly. I believe an event observer will be used for this purpose. Should it be done in this PR?