### PR TITLE
[CIS-337] Move connect/disconnect to ConnectionController

### DIFF
--- a/Sample_v3/Samples/SettingsViewController.swift
+++ b/Sample_v3/Samples/SettingsViewController.swift
@@ -57,7 +57,7 @@ extension SettingsViewController {
     }
     
     func logout() {
-        currentUserController.client.disconnect()
+        currentUserController.client.connectionController().disconnect()
         moveToStoryboard(.main, options: .transitionFlipFromRight)
     }
 }
@@ -74,14 +74,14 @@ extension SettingsViewController {
     func webSocketsConnectionSwitchValueChanged(_ sender: Any) {
         if webSocketsConnectionSwitch.isOn {
             webSocketsConnectionSwitch.isEnabled = false
-            currentUserController.client.connect { [weak self] error in
+            currentUserController.client.connectionController().connect { [weak self] error in
                 DispatchQueue.main.async {
                     self?.webSocketsConnectionSwitch.isEnabled = true
                     self?.webSocketsConnectionSwitch.setOn(error == nil, animated: true)
                 }
             }
         } else {
-            currentUserController.client.disconnect()
+            currentUserController.client.connectionController().disconnect()
         }
     }
 }

--- a/Sources_v3/ChatClient_Tests.swift
+++ b/Sources_v3/ChatClient_Tests.swift
@@ -456,7 +456,7 @@ class ChatClient_Tests: StressTestCase {
         testEnv.databaseContainer?.flush_called = false
        
         // Disconnect
-        client.disconnect()
+        client.connectionController().disconnect()
 
         // Set the same user again
         client.setUser(userId: newUserId, token: newUserToken)
@@ -585,7 +585,7 @@ class ChatClient_Tests: StressTestCase {
         testEnv.webSocketClient?.disconnect_calledCounter = 0
         
         // Disconnect and assert WS is disconnected
-        client.disconnect()
+        client.connectionController().disconnect()
         XCTAssertEqual(testEnv.webSocketClient?.disconnect_calledCounter, 1)
         
         // Simulate WS disconnecting
@@ -594,7 +594,7 @@ class ChatClient_Tests: StressTestCase {
         
         // Call connect again and assert WS connect is called
         var connectCompletionCalled = false
-        client.connect(completion: { _ in connectCompletionCalled = true })
+        client.connectionController().connect(completion: { _ in connectCompletionCalled = true })
         XCTAssertEqual(testEnv.webSocketClient!.connect_calledCounter, 1)
         
         // Simulate successful connection


### PR DESCRIPTION
Moved `Client.connect()` and `Client.disconnect()` to `ConnectionController`.