### PR TITLE
[CIS-346] Background workers ownership

### DIFF
--- a/Sources_v3/Workers/Background/ChannelWatchStateUpdater.swift
+++ b/Sources_v3/Workers/Background/ChannelWatchStateUpdater.swift
@@ -30,7 +30,7 @@ final class ChannelWatchStateUpdater<ExtraData: ExtraDataTypes>: Worker {
         webSocketConnectedObserver = WebSocketConnectedObserver(
             notificationCenter: webSocketClient.eventNotificationCenter,
             filter: { $0.connectionStatus == .connected },
-            callback: { [weak self] in self?.watchChannels() }
+            callback: { [unowned self] in self.watchChannels() }
         )
     }
     

--- a/Sources_v3/Workers/Background/ChannelWatchStateUpdater_Tests.swift
+++ b/Sources_v3/Workers/Background/ChannelWatchStateUpdater_Tests.swift
@@ -85,4 +85,18 @@ class ChannelWatchStateUpdater_Tests: StressTestCase {
         // Assert APIClient is called with the correct endpoint
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(endpoint))
     }
+    
+    func test_channelWatchStateUpdater_doesNotRetainItself() throws {
+        // Create channel in the database
+        try database.createChannel()
+        
+        // Simulate `.connected` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        
+        // Assert api-client is called
+        XCTAssertNotNil(apiClient.request_endpoint)
+        
+        // Assert `channelWatchStateUpdater` can be released before network response comes
+        AssertAsync.canBeReleased(&channelWatchStateUpdater)
+    }
 }

--- a/Sources_v3/Workers/Background/ChannelWatchStateUpdater_Tests.swift
+++ b/Sources_v3/Workers/Background/ChannelWatchStateUpdater_Tests.swift
@@ -48,9 +48,9 @@ class ChannelWatchStateUpdater_Tests: StressTestCase {
         try database.createChannel(cid: cid1, withMessages: false)
         try database.createChannel(cid: cid2, withMessages: false)
         
-        simulateWebSocket(state: .connecting)
-        simulateWebSocket(state: .disconnected(error: .none))
-        simulateWebSocket(state: .waitingForConnectionId)
+        webSocketClient.simulateConnectionStatus(.connecting)
+        webSocketClient.simulateConnectionStatus(.disconnected(error: .none))
+        webSocketClient.simulateConnectionStatus(.waitingForConnectionId)
         
         // Assert APIClient is not called for other events
         XCTAssertNil(apiClient.request_endpoint)
@@ -58,7 +58,7 @@ class ChannelWatchStateUpdater_Tests: StressTestCase {
     
     func test_apiClient_is_not_called_on_empty_channels() {
         // Simulate WebSocket successfully connected
-        simulateWebSocket(state: .connected(connectionId: .unique))
+        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
         
         // Assert APIClient is not called for empty channels
         XCTAssertNil(apiClient.request_endpoint)
@@ -72,7 +72,7 @@ class ChannelWatchStateUpdater_Tests: StressTestCase {
         XCTAssertNil(apiClient.request_endpoint)
         
         // Simulate WebSocket successfully connected
-        simulateWebSocket(state: .connected(connectionId: .unique))
+        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
         
         let query: ChannelListQuery = .init(
             filter: .in("cid", [cid].map(\.rawValue)),
@@ -84,11 +84,5 @@ class ChannelWatchStateUpdater_Tests: StressTestCase {
         
         // Assert APIClient is called with the correct endpoint
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(endpoint))
-    }
-    
-    func simulateWebSocket(state: WebSocketConnectionState) {
-        let event = ConnectionStatusUpdated(webSocketConnectionState: state)
-        let notification = Notification(newEventReceived: event, sender: self)
-        webSocketClient.eventNotificationCenter.post(notification)
     }
 }

--- a/Sources_v3/Workers/Background/MessageSender_Tests.swift
+++ b/Sources_v3/Workers/Background/MessageSender_Tests.swift
@@ -307,4 +307,19 @@ class MessageSender_Tests: StressTestCase {
             $0.endpoint == AnyEndpoint(.sendMessage(cid: cidB, messagePayload: channelB_message2Payload))
         }))
     }
+    
+    // MARK: - Life cycle tests
+    
+    func test_sender_doesNotRetainItself() throws {
+        let messageId: MessageId = .unique
+        
+        // Create a message with pending state
+        try database.createMessage(id: messageId, cid: cid, text: "Message pending send", localState: .pendingSend)
+        
+        // Wait for the API call to be initiated
+        AssertAsync.willBeTrue(apiClient.request_endpoint != nil)
+        
+        // Assert sender can be released even though network response hasn't come yet
+        AssertAsync.canBeReleased(&sender)
+    }
 }

--- a/Sources_v3/Workers/Background/MissingEventsPublisher_Tests.swift
+++ b/Sources_v3/Workers/Background/MissingEventsPublisher_Tests.swift
@@ -5,7 +5,7 @@
 @testable import StreamChatClient
 import XCTest
 
-final class MissingEventsReplayer_Tests: StressTestCase {
+final class MissingEventsPublisher_Tests: StressTestCase {
     typealias ExtraData = DefaultDataTypes
     
     var database: DatabaseContainerMock!

--- a/Sources_v3/Workers/Background/NewChannelQueryUpdater_Tests.swift
+++ b/Sources_v3/Workers/Background/NewChannelQueryUpdater_Tests.swift
@@ -97,6 +97,18 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
             Assert.willBeEqual(self.env!.channelQueryUpdater?.update_query?.filter.description, expectedFilter.description)
         }
     }
+    
+    func test_newChannelQueryUpdater_doesNotRetainItself() throws {
+        let filter: Filter = .contains(.unique, String.unique)
+        try database.createChannelListQuery(filter: filter)
+        try database.createChannel()
+        
+        // Assert `update(channelListQuery` is called
+        AssertAsync.willBeEqual(env!.channelQueryUpdater?.update_calls_counter, 1)
+        
+        // Assert `newChannelQueryUpdater` can be released even though network response hasn't come yet
+        AssertAsync.canBeReleased(&newChannelQueryUpdater)
+    }
 }
 
 private class TestEnvironment {


### PR DESCRIPTION
**This PR:**

- updates each background worker **not to retain** itself via database/api-client completion;
- adds tests that check workers can be released if completions haven't called yet;