### PR TITLE
[CIS-347] Re-create background workers on `prepareEnvironmentForNewUser`

### DIFF
--- a/Sources_v3/ChatClient.swift
+++ b/Sources_v3/ChatClient.swift
@@ -399,11 +399,12 @@ public class Client<ExtraData: ExtraDataTypes> {
         // Set a new WebSocketClient connect endpoint
         webSocketClient.connectEndpoint = webSocketConnectEndpoint(userId: userId, role: role, extraData: extraData)
         
-        // Re-create backgroundWorker's so their ongoing requests won't affect database state
-        createBackgroundWorkers()
-        
-        // Reset all existing data if the new user is not the same as the last logged-in one
+        // If the new user is not the same as the last logged-in one....
         if databaseContainer.viewContext.currentUser()?.user.id != userId {
+            // Re-create backgroundWorker's so their ongoing requests won't affect database state
+            createBackgroundWorkers()
+            
+            // Reset all existing local data
             databaseContainer.removeAllData(force: true) { completion($0) }
         } else {
             // Otherwise we're done


### PR DESCRIPTION
For quite some time, I've been thinking about test cases for this... But I'm not able to!

This PR aims to prevent the case, where if there's an ongoing API request during a user change, the result of API request shouldn't affect the new user's DB instance. [1]
But it shouldn't be possible anyway!
When a new user is set, we flush the database. The workers only update the DTO's based on their id/cid. If we flushed the DB, the entity won't exist anymore, therefore it won't get updated.

I've checked the workers but none of them seem to insert new entities to the DB, in which [1] would cause an inconsistency.
But this should be tested regardless, so I'm opening the PR as draft for discussions.