### PR TITLE
[CIS-350] Move `entityName` to extension

### DIFF
--- a/Sources_v3/Database/DTOs/ChannelDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO.swift
@@ -7,8 +7,6 @@ import Foundation
 
 @objc(ChannelDTO)
 class ChannelDTO: NSManagedObject {
-    static let entityName = "ChannelDTO"
-    
     @NSManaged var cid: String
     @NSManaged var typeRawValue: String
     @NSManaged var extraData: Data

--- a/Sources_v3/Database/DTOs/ChannelListQueryDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelListQueryDTO.swift
@@ -6,8 +6,6 @@ import CoreData
 
 @objc(ChannelListQueryDTO)
 class ChannelListQueryDTO: NSManagedObject {
-    static let entityName = "ChannelListQueryDTO"
-    
     /// Unique identifier of the query/
     @NSManaged var filterHash: String
     

--- a/Sources_v3/Database/DTOs/ChannelReadDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelReadDTO.swift
@@ -7,8 +7,6 @@ import Foundation
 
 @objc(ChannelReadDTO)
 class ChannelReadDTO: NSManagedObject {
-    static let entityName = "ChannelReadDTO"
-    
     @NSManaged var lastReadAt: Date
     @NSManaged var unreadMessageCount: Int
     

--- a/Sources_v3/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO.swift
@@ -7,8 +7,6 @@ import Foundation
 
 @objc(CurrentUserDTO)
 class CurrentUserDTO: NSManagedObject {
-    static let entityName: String = "CurrentUserDTO"
-    
     @NSManaged var unreadChannelsCount: Int16
     @NSManaged var unreadMessagesCount: Int16
     

--- a/Sources_v3/Database/DTOs/MemberModelDTO.swift
+++ b/Sources_v3/Database/DTOs/MemberModelDTO.swift
@@ -6,8 +6,6 @@ import CoreData
 
 @objc(MemberDTO)
 class MemberDTO: NSManagedObject {
-    static let entityName: String = "MemberDTO"
-    
     // Because we need to have a unique identifier of a member in the db, we use the combination of the related
     // user' id and the channel the member belongs to.
     @NSManaged fileprivate var id: String

--- a/Sources_v3/Database/DTOs/MessageDTO.swift
+++ b/Sources_v3/Database/DTOs/MessageDTO.swift
@@ -7,8 +7,6 @@ import Foundation
 
 @objc(MessageDTO)
 class MessageDTO: NSManagedObject {
-    static let entityName = "MessageDTO"
-    
     @NSManaged fileprivate var localMessageStateRaw: String?
     
     @NSManaged var id: String

--- a/Sources_v3/Database/DTOs/UserDTO.swift
+++ b/Sources_v3/Database/DTOs/UserDTO.swift
@@ -7,8 +7,6 @@ import Foundation
 
 @objc(UserDTO)
 class UserDTO: NSManagedObject {
-    static let entityName: String = "UserDTO"
-    
     @NSManaged var extraData: Data
     @NSManaged var id: String
     @NSManaged var isBanned: Bool

--- a/Sources_v3/Utils/Database/NSManagedObject+Extensions.swift
+++ b/Sources_v3/Utils/Database/NSManagedObject+Extensions.swift
@@ -1,0 +1,11 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+
+extension NSManagedObject {
+    @objc class var entityName: String {
+        "\(self)"
+    }
+}

--- a/Sources_v3/Utils/Database/NSManagedObject_Tests.swift
+++ b/Sources_v3/Utils/Database/NSManagedObject_Tests.swift
@@ -1,0 +1,21 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChatClient
+import XCTest
+
+final class NSManagedObject_Tests: XCTestCase {
+    func test_entityName_default() {
+        class EntityWithDefaultName: NSManagedObject {}
+        XCTAssertEqual(EntityWithDefaultName.entityName, "EntityWithDefaultName")
+    }
+    
+    func test_entityName_custom() {
+        class EntityWithCustomName: NSManagedObject {
+            override class var entityName: String { "CustomName" }
+        }
+        XCTAssertEqual(EntityWithCustomName.entityName, "CustomName")
+    }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -324,6 +324,8 @@
 		F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69C4BC524F66CC200A3D740 /* EventLogger.swift */; };
 		F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */; };
 		F6C56D1424F7B89D0012BB1F /* EventMiddleware_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */; };
+		F6D61D9B2510B3FC00EB0624 /* NSManagedObject+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D61D9A2510B3FC00EB0624 /* NSManagedObject+Extensions.swift */; };
+		F6D61D9D2510B57F00EB0624 /* NSManagedObject_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D61D9C2510B57F00EB0624 /* NSManagedObject_Tests.swift */; };
 		F6ED5F7425023EB4005D7327 /* MissingEventsPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6ED5F7325023EB4005D7327 /* MissingEventsPublisher.swift */; };
 		F6ED5F76250278D7005D7327 /* SyncEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6ED5F75250278D7005D7327 /* SyncEndpoint.swift */; };
 		F6ED5F7825027907005D7327 /* MissingEventsRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6ED5F7725027907005D7327 /* MissingEventsRequestBody.swift */; };
@@ -706,6 +708,8 @@
 		F69C4BC524F66CC200A3D740 /* EventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogger.swift; sourceTree = "<group>"; };
 		F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserController_Tests.swift; sourceTree = "<group>"; };
 		F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware_Mock.swift; sourceTree = "<group>"; };
+		F6D61D9A2510B3FC00EB0624 /* NSManagedObject+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Extensions.swift"; sourceTree = "<group>"; };
+		F6D61D9C2510B57F00EB0624 /* NSManagedObject_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSManagedObject_Tests.swift; sourceTree = "<group>"; };
 		F6ED5F7325023EB4005D7327 /* MissingEventsPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingEventsPublisher.swift; sourceTree = "<group>"; };
 		F6ED5F75250278D7005D7327 /* SyncEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncEndpoint.swift; sourceTree = "<group>"; };
 		F6ED5F7725027907005D7327 /* MissingEventsRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingEventsRequestBody.swift; sourceTree = "<group>"; };
@@ -870,6 +874,7 @@
 		792A4F3A247FFB7600EAF71D /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				F6D61D992510B3E300EB0624 /* Database */,
 				8AE335A324FCF95D002B6677 /* Internet Connection */,
 				79BF83EA248F8EC0007611A1 /* Logger */,
 				79280F6F2487CD2B00CDEB89 /* Atomic.swift */,
@@ -1515,6 +1520,15 @@
 			path = MessageController;
 			sourceTree = "<group>";
 		};
+		F6D61D992510B3E300EB0624 /* Database */ = {
+			isa = PBXGroup;
+			children = (
+				F6D61D9A2510B3FC00EB0624 /* NSManagedObject+Extensions.swift */,
+				F6D61D9C2510B57F00EB0624 /* NSManagedObject_Tests.swift */,
+			);
+			path = Database;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -1812,6 +1826,7 @@
 				79CD959224F9380B00E87377 /* MulticastDelegate.swift in Sources */,
 				7964F3BC249A5E60002A09EC /* RequestEncoder.swift in Sources */,
 				79896D64250A63A200BA8F1C /* ChannelReadUpdaterMiddleware.swift in Sources */,
+				F6D61D9B2510B3FC00EB0624 /* NSManagedObject+Extensions.swift in Sources */,
 				DA4AA3B8250271BD00FAAF6E /* CurrentUserController+Combine.swift in Sources */,
 				79280F712487CD2B00CDEB89 /* Atomic.swift in Sources */,
 				797EEA4624FFAF4F00C81203 /* DataStore.swift in Sources */,
@@ -1947,6 +1962,7 @@
 				F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */,
 				79280F7D24891B1300CDEB89 /* WebSocketEngine_Mock.swift in Sources */,
 				79B5517C24E6A1CA00CE9FEC /* MessagePayloads_Tests.swift in Sources */,
+				F6D61D9D2510B57F00EB0624 /* NSManagedObject_Tests.swift in Sources */,
 				79896D66250A6D1800BA8F1C /* ChannelReadUpdaterMiddleware_Tests.swift in Sources */,
 				790B9E3224DC221A005455AA /* UserPayload.swift in Sources */,
 				792921CD24C07A9000116BBB /* QueueAwareDelegate.swift in Sources */,


### PR DESCRIPTION
**This PR:** moves `entityName` to extension and reduces the boilerplate code we have to write when we declare a new DTO.