### PR TITLE
[CIS-319] [CIS-332] Expose typing channel members

### DIFF
--- a/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChatViewController.swift
+++ b/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChatViewController.swift
@@ -86,13 +86,13 @@ final class CombineSimpleChatViewController: UITableViewController {
         
         /// The subscription  below receives a `TypingEvent` and updates the view controller's `navigationItem.prompt` to show that an user is currently typing.
         channelController
-            .typingEventPublisher
-            /// Map user with the typing event.
-            .map { [weak self] in (self?.channelController.dataStore.user(id: $0.userId), $0) }
-            /// Skip if user was not fetched succesfully from DB.
-            .filter { $0.0 != nil }
+            .typingMembersPublisher
             /// Create or reset prompt depending on `isTyping` event type.
-            .map { $0.1.isTyping ? "\($0.0?.name ?? $0.1.userId) is typing..." : "" }
+            .map { typingMembers in
+                guard !typingMembers.isEmpty else { return "" }
+                let names = typingMembers.map { $0.name ?? $0.id }.sorted()
+                return names.joined(separator: ",") + " \(names.count == 1 ? "is" : "are") typing..."
+            }
             .receive(on: RunLoop.main)
             /// Assign it to `navigationItem.prompt`.
             .assign(to: \.navigationItem.prompt, on: self)

--- a/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
@@ -68,15 +68,14 @@ final class SimpleChatViewController: UITableViewController, ChannelControllerDe
     }
     
     ///
-    /// # didReceiveTypingEvent
+    /// # didChangeTypingMembers
     ///
-    /// The method below receives a `TypingEvent` and updates the view controller's `navigationItem.prompt` to show that an user is currently typing.
+    /// The method below receives a set of `Member` that are currently typing.
     ///
-    func channelController(_ channelController: ChannelController, didReceiveTypingEvent event: TypingEvent) {
-        guard let user = channelController.dataStore.user(id: event.userId) else { return }
-        
-        if event.isTyping {
-            navigationItem.prompt = "\(user.name ?? event.userId) is typing..."
+    func channelController(_ channelController: ChannelController, didChangeTypingMembers typingMembers: Set<Member>) {
+        if !typingMembers.isEmpty {
+            let names = typingMembers.map { $0.name ?? $0.id }.sorted()
+            navigationItem.prompt = names.joined(separator: ",") + " \(names.count == 1 ? "is" : "are") typing..."
         } else {
             navigationItem.prompt = ""
         }

--- a/Sources_v3/ChatClient.swift
+++ b/Sources_v3/ChatClient.swift
@@ -67,7 +67,8 @@ public class Client<ExtraData: ExtraDataTypes> {
         TypingStartCleanupMiddleware<ExtraData>(
             excludedUserIds: { [weak self] in Set([self?.currentUserId].compactMap { $0 }) }
         ),
-        ChannelReadUpdaterMiddleware<ExtraData>(database: databaseContainer)
+        ChannelReadUpdaterMiddleware<ExtraData>(database: databaseContainer),
+        ChannelMemberTypingStateUpdaterMiddleware<ExtraData>(database: databaseContainer)
     ])
     
     /// The `APIClient` instance `Client` uses to communicate with Stream REST API.

--- a/Sources_v3/ChatClient_Tests.swift
+++ b/Sources_v3/ChatClient_Tests.swift
@@ -158,9 +158,16 @@ class ChatClient_Tests: StressTestCase {
         // Assert `EventDataProcessorMiddleware` exists
         XCTAssert(middlewares.contains(where: { $0 is EventDataProcessorMiddleware<DefaultDataTypes> }))
         // Assert `TypingStartCleanupMiddleware` exists
-        XCTAssert(middlewares.contains(where: { $0 is TypingStartCleanupMiddleware<DefaultDataTypes> }))
+        let typingStartCleanupMiddlewareIndex = middlewares.firstIndex { $0 is TypingStartCleanupMiddleware<DefaultDataTypes> }
+        XCTAssertNotNil(typingStartCleanupMiddlewareIndex)
         // Assert `ChannelReadUpdaterMiddleware` exists
         XCTAssert(middlewares.contains(where: { $0 is ChannelReadUpdaterMiddleware<DefaultDataTypes> }))
+        // Assert `ChannelMemberTypingStateUpdaterMiddleware` exists
+        let typingStateUpdaterMiddlewareIndex = middlewares
+            .firstIndex { $0 is ChannelMemberTypingStateUpdaterMiddleware<DefaultDataTypes> }
+        XCTAssertNotNil(typingStateUpdaterMiddlewareIndex)
+        // Assert `ChannelMemberTypingStateUpdaterMiddleware` goes after `TypingStartCleanupMiddleware`
+        XCTAssertTrue(typingStateUpdaterMiddlewareIndex! > typingStartCleanupMiddlewareIndex!)
     }
     
     func test_connectionStatus_isExposed() {

--- a/Sources_v3/Controllers/ChannelController/ChannelController+Combine.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+Combine.swift
@@ -27,9 +27,9 @@ extension ChannelControllerGeneric {
         basePublishers.memberEvent.keepAlive(self)
     }
     
-    /// A publisher emitting a new value every time typing event received.
-    public var typingEventPublisher: AnyPublisher<TypingEvent, Never> {
-        basePublishers.typingEvent.keepAlive(self)
+    /// A publisher emitting a new value every time typing members change.
+    public var typingMembersPublisher: AnyPublisher<Set<MemberModel<ExtraData.User>>, Never> {
+        basePublishers.typingMembers.keepAlive(self)
     }
 
     /// An internal backing object for all publicly available Combine publishers. We use it to simplify the way we expose
@@ -51,8 +51,8 @@ extension ChannelControllerGeneric {
         /// A backing subject for `memberEventPublisher`.
         let memberEvent: PassthroughSubject<MemberEvent, Never> = .init()
         
-        /// A backing subject for `typingEventPublisher`.
-        let typingEvent: PassthroughSubject<TypingEvent, Never> = .init()
+        /// A backing subject for `typingMembersPublisher`.
+        let typingMembers: PassthroughSubject<Set<MemberModel<ExtraData.User>>, Never> = .init()
                 
         init(controller: ChannelControllerGeneric<ExtraData>) {
             self.controller = controller
@@ -86,8 +86,11 @@ extension ChannelControllerGeneric.BasePublishers: ChannelControllerDelegateGene
     func channelController(_ channelController: ChannelControllerGeneric<ExtraData>, didReceiveMemberEvent event: MemberEvent) {
         memberEvent.send(event)
     }
-
-    func channelController(_ channelController: ChannelControllerGeneric<ExtraData>, didReceiveTypingEvent event: TypingEvent) {
-        typingEvent.send(event)
+    
+    func channelController(
+        _ channelController: ChannelControllerGeneric<ExtraData>,
+        didChangeTypingMembers typingMembers: Set<MemberModel<ExtraData.User>>
+    ) {
+        self.typingMembers.send(typingMembers)
     }
 }

--- a/Sources_v3/Controllers/ChannelController/ChannelController+Combine_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+Combine_Tests.swift
@@ -112,13 +112,13 @@ class ChannelController_Combine_Tests: iOS13TestCase {
         XCTAssertEqual(recording.output as! [TestMemberEvent], [memberEvent])
     }
     
-    func test_typingEventPublisher() {
+    func test_typingMembersPublisher() {
         // Setup Recording publishers
-        var recording = Record<TypingEvent, Never>.Recording()
+        var recording = Record<Set<Member>, Never>.Recording()
         
         // Setup the chain
         channelController
-            .typingEventPublisher
+            .typingMembersPublisher
             .sink(receiveValue: { recording.receive($0) })
             .store(in: &cancellables)
         
@@ -126,11 +126,27 @@ class ChannelController_Combine_Tests: iOS13TestCase {
         weak var controller: ChannelControllerMock? = channelController
         channelController = nil
 
-        let typingEvent: TypingEvent = .unique
+        let typingMember = Member(
+            id: .unique,
+            isOnline: true,
+            isBanned: false,
+            userRole: .user,
+            userCreatedAt: .unique,
+            userUpdatedAt: .unique,
+            lastActiveAt: .unique,
+            extraData: .defaultValue,
+            memberRole: .member,
+            memberCreatedAt: .unique,
+            memberUpdatedAt: .unique,
+            isInvited: false,
+            inviteAcceptedAt: nil,
+            inviteRejectedAt: nil
+        )
+        
         controller?.delegateCallback {
-            $0.channelController(controller!, didReceiveTypingEvent: typingEvent)
+            $0.channelController(controller!, didChangeTypingMembers: [typingMember])
         }
         
-        XCTAssertEqual(recording.output, [typingEvent])
+        XCTAssertEqual(recording.output, [[typingMember]])
     }
 }

--- a/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI.swift
@@ -24,6 +24,9 @@ extension ChannelControllerGeneric {
         /// The current state of the Controller.
         @Published public private(set) var state: DataController.State
         
+        /// The typing members related to the channel.
+        @Published public private(set) var typingMembers: Set<MemberModel<ExtraData.User>> = []
+        
         /// Creates a new `ObservableObject` wrapper with the provided controller instance.
         init(controller: ChannelControllerGeneric<ExtraData>) {
             self.controller = controller
@@ -33,6 +36,7 @@ extension ChannelControllerGeneric {
             
             channel = controller.channel
             messages = controller.messages
+            typingMembers = controller.channel?.currentlyTypingMembers ?? []
         }
     }
 }
@@ -55,5 +59,12 @@ extension ChannelControllerGeneric.ObservableObject: ChannelControllerDelegateGe
     
     public func controller(_ controller: DataController, didChangeState state: DataController.State) {
         self.state = state
+    }
+    
+    public func channelController(
+        _ channelController: ChannelControllerGeneric<ExtraData>,
+        didChangeTypingMembers typingMembers: Set<MemberModel<ExtraData.User>>
+    ) {
+        self.typingMembers = typingMembers
     }
 }

--- a/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -73,6 +73,37 @@ class ChannelController_SwiftUI_Tests: iOS13TestCase {
         
         AssertAsync.willBeEqual(observableObject.state, newState)
     }
+    
+    func test_observableObject_reactsToDelegateTypingMembersChangeCallback() {
+        let observableObject = channelController.observableObject
+        
+        let typingMember = Member(
+            id: .unique,
+            isOnline: true,
+            isBanned: false,
+            userRole: .user,
+            userCreatedAt: .unique,
+            userUpdatedAt: .unique,
+            lastActiveAt: .unique,
+            extraData: .defaultValue,
+            memberRole: .member,
+            memberCreatedAt: .unique,
+            memberUpdatedAt: .unique,
+            isInvited: false,
+            inviteAcceptedAt: nil,
+            inviteRejectedAt: nil
+        )
+        
+        // Simulate typing members change
+        channelController.delegateCallback {
+            $0.channelController(
+                self.channelController,
+                didChangeTypingMembers: [typingMember]
+            )
+        }
+        
+        AssertAsync.willBeEqual(observableObject.typingMembers, [typingMember])
+    }
 }
 
 class ChannelControllerMock: ChannelController {

--- a/Sources_v3/Controllers/ChannelController/ChannelController.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController.swift
@@ -216,7 +216,7 @@ public class ChannelControllerGeneric<ExtraData: ExtraDataTypes>: DataController
             let observer = EntityDatabaseObserver(
                 context: self.client.databaseContainer.viewContext,
                 fetchRequest: ChannelDTO.fetchRequest(for: self.channelQuery.cid),
-                itemCreator: ChannelModel<ExtraData>.create
+                itemCreator: { $0.asModel() as ChannelModel<ExtraData> }
             )
             observer.onChange { change in
                 self.delegateCallback { $0.channelController(self, didUpdateChannel: change) }

--- a/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
@@ -348,7 +348,7 @@ class ChannelController_Tests: StressTestCase {
             }, completion: $0)
         }
         XCTAssertNil(error)
-        let channel: Channel = client.databaseContainer.viewContext.loadChannel(cid: channelId)!
+        let channel: Channel = client.databaseContainer.viewContext.channel(cid: channelId)!.asModel()
         assert(channel.latestMessages.count == 1)
         let message: Message = channel.latestMessages.first!
 
@@ -370,7 +370,7 @@ class ChannelController_Tests: StressTestCase {
             }, completion: $0)
         }
         XCTAssertNil(error)
-        let newChannel: Channel = client.databaseContainer.viewContext.loadChannel(cid: newCid)!
+        let newChannel: Channel = client.databaseContainer.viewContext.channel(cid: newCid)!.asModel()
         assert(channel.latestMessages.count == 1)
         let newMessage: Message = newChannel.latestMessages.first!
 
@@ -478,7 +478,7 @@ class ChannelController_Tests: StressTestCase {
             }, completion: $0)
         }
         XCTAssertNil(error)
-        let channel: Channel = client.databaseContainer.viewContext.loadChannel(cid: channelId)!
+        let channel: Channel = client.databaseContainer.viewContext.channel(cid: channelId)!.asModel()
         assert(channel.latestMessages.count == 1)
         let message: Message = channel.latestMessages.first!
         
@@ -504,7 +504,7 @@ class ChannelController_Tests: StressTestCase {
                 try session.saveChannel(payload: self.dummyPayload(with: self.channelId), query: nil)
             }, completion: $0)
         }
-        let channel: Channel = client.databaseContainer.viewContext.loadChannel(cid: channelId)!
+        let channel: Channel = client.databaseContainer.viewContext.channel(cid: channelId)!.asModel()
         assert(channel.latestMessages.count == 1)
         let message: Message = channel.latestMessages.first!
         

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController.swift
@@ -59,7 +59,7 @@ public class ChannelListControllerGeneric<ExtraData: ExtraDataTypes>: DataContro
         let observer = self.environment.createChannelListDabaseObserver(
             client.databaseContainer.viewContext,
             request,
-            ChannelModel<ExtraData>.create
+            { $0.asModel() }
         )
         
         observer.onChange = { [unowned self] changes in

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -254,7 +254,7 @@ class ChannelListController_Tests: StressTestCase {
             }, completion: $0)
         }
         XCTAssertNil(error)
-        let channel: Channel = client.databaseContainer.viewContext.loadChannel(cid: cid)!
+        let channel: Channel = client.databaseContainer.viewContext.channel(cid: cid)!.asModel()
         
         AssertAsync.willBeEqual(delegate.didChangeChannels_changes, [.insert(channel, index: [0, 0])])
     }
@@ -277,7 +277,7 @@ class ChannelListController_Tests: StressTestCase {
                 try session.saveChannel(payload: self.dummyPayload(with: cid), query: self.query)
             }, completion: $0)
         }
-        let channel: Channel = client.databaseContainer.viewContext.loadChannel(cid: cid)!
+        let channel: Channel = client.databaseContainer.viewContext.channel(cid: cid)!.asModel()
         
         AssertAsync.willBeEqual(delegate.didChangeChannels_changes, [.insert(channel, index: [0, 0])])
     }

--- a/Sources_v3/Database/DTOs/ChannelDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO.swift
@@ -125,8 +125,8 @@ extension NSManagedObjectContext {
         return dto
     }
     
-    func loadChannel<ExtraData: ExtraDataTypes>(cid: ChannelId) -> ChannelModel<ExtraData>? {
-        ChannelDTO.load(cid: cid, context: self).map(ChannelModel.create(fromDTO:))
+    func channel(cid: ChannelId) -> ChannelDTO? {
+        ChannelDTO.load(cid: cid, context: self)
     }
 }
 
@@ -155,11 +155,16 @@ extension ChannelDTO {
     }
 }
 
+extension ChannelDTO {
+    /// Snapshots the current state of `ChannelDTO` and returns an immutable model object from it.
+    func asModel<ExtraData: ExtraDataTypes>() -> ChannelModel<ExtraData> { .create(fromDTO: self) }
+}
+
 extension ChannelModel {
     /// Create a ChannelModel struct from its DTO
-    static func create(fromDTO dto: ChannelDTO) -> ChannelModel {
-        let members = dto.members.map { MemberModel<ExtraData.User>.create(fromDTO: $0) }
-        let typingMembers = dto.currentlyTypingMembers.map { MemberModel<ExtraData.User>.create(fromDTO: $0) }
+    fileprivate static func create(fromDTO dto: ChannelDTO) -> ChannelModel {
+        let members: [MemberModel<ExtraData.User>] = dto.members.map { $0.asModel() }
+        let typingMembers: [MemberModel<ExtraData.User>] = dto.currentlyTypingMembers.map { $0.asModel() }
 
         // It's safe to use `try!` here, because the extra data payload comes from the DB, so we know it must
         // be a valid JSON payload, otherwise it wouldn't be possible to save it there.

--- a/Sources_v3/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO_Tests.swift
@@ -25,7 +25,7 @@ class ChannelDTO_Tests: XCTestCase {
         
         // Load the channel from the db and check the fields are correct
         var loadedChannel: ChannelModel<DefaultDataTypes>? {
-            database.viewContext.loadChannel(cid: channelId)
+            database.viewContext.channel(cid: channelId)?.asModel()
         }
         
         AssertAsync {
@@ -132,7 +132,7 @@ class ChannelDTO_Tests: XCTestCase {
         
         // Load the channel from the db and check the fields are correct
         var loadedChannel: ChannelModel<DefaultDataTypes>? {
-            database.viewContext.loadChannel(cid: channelId)
+            database.viewContext.channel(cid: channelId)?.asModel()
         }
         
         AssertAsync {
@@ -359,7 +359,7 @@ class ChannelDTO_Tests: XCTestCase {
         
         // Load the channel from the db and check the if fields are correct
         var loadedChannel: ChannelModel<DefaultDataTypes>? {
-            database.viewContext.loadChannel(cid: channelId)
+            database.viewContext.channel(cid: channelId)?.asModel()
         }
         
         AssertAsync {

--- a/Sources_v3/Database/DTOs/MemberModelDTO.swift
+++ b/Sources_v3/Database/DTOs/MemberModelDTO.swift
@@ -72,14 +72,17 @@ extension NSManagedObjectContext {
         return dto
     }
     
-    func loadMember<ExtraData: UserExtraData>(id: String, channelId: ChannelId) -> MemberModel<ExtraData>? {
-        guard let dto = MemberDTO.load(id: id, channelId: channelId, context: self) else { return nil }
-        return MemberModel.create(fromDTO: dto)
+    func member(userId: UserId, cid: ChannelId) -> MemberDTO? {
+        MemberDTO.load(id: userId, channelId: cid, context: self)
     }
 }
 
+extension MemberDTO {
+    func asModel<ExtraData: UserExtraData>() -> MemberModel<ExtraData> { .create(fromDTO: self) }
+}
+
 extension MemberModel {
-    static func create(fromDTO dto: MemberDTO) -> MemberModel {
+    fileprivate static func create(fromDTO dto: MemberDTO) -> MemberModel {
         let extraData: ExtraData
         do {
             extraData = try JSONDecoder.default.decode(ExtraData.self, from: dto.user.extraData)

--- a/Sources_v3/Database/DTOs/MemberModelDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/MemberModelDTO_Tests.swift
@@ -49,7 +49,7 @@ class MemberModelDTO_Tests: XCTestCase {
         
         // Load the member from the db and check it's the same member
         var loadedMember: MemberModel<NameAndImageExtraData>? {
-            database.viewContext.loadMember(id: userId, channelId: channelId)
+            database.viewContext.member(userId: userId, cid: channelId)?.asModel()
         }
         
         AssertAsync {
@@ -97,7 +97,7 @@ class MemberModelDTO_Tests: XCTestCase {
         
         // Load the member from the db and check it's the same member
         var loadedMember: MemberModel<NameAndImageExtraData>? {
-            database.viewContext.loadMember(id: userId, channelId: channelId)
+            database.viewContext.member(userId: userId, cid: channelId)?.asModel()
         }
         
         AssertAsync {

--- a/Sources_v3/Database/DataStore.swift
+++ b/Sources_v3/Database/DataStore.swift
@@ -55,7 +55,7 @@ public struct DataStore<ExtraData: ExtraDataTypes> {
     ///
     /// - Parameter cid: An cid of a channel.
     public func channel(cid: ChannelId) -> ChannelModel<ExtraData>? {
-        database.viewContext.loadChannel(cid: cid)
+        database.viewContext.channel(cid: cid)?.asModel()
     }
     
     /// Loads a message model with a matching `id` from the **local data store**.

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -115,4 +115,10 @@ extension DatabaseContainer {
             messageDTO.localMessageState = localState
         }
     }
+    
+    func createMember(userId: UserId = .unique, role: MemberRole = .member, cid: ChannelId) throws {
+        try writeSynchronously { session in
+            try session.saveMember(payload: .dummy(userId: userId, role: role), channelId: cid)
+        }
+    }
 }

--- a/Sources_v3/Database/DatabaseSession.swift
+++ b/Sources_v3/Database/DatabaseSession.swift
@@ -79,6 +79,22 @@ extension MessageDatabaseSession {
     }
 }
 
+protocol ChannelDatabaseSession {
+    /// Creates a new `ChannelDTO` object in the database with the given `payload` and `query`.
+    @discardableResult
+    func saveChannel<ExtraData: ExtraDataTypes>(payload: ChannelPayload<ExtraData>, query: ChannelListQuery?) throws -> ChannelDTO
+    
+    /// Creates a new `ChannelDTO` object in the database with the given `payload` and `query`.
+    @discardableResult
+    func saveChannel<ExtraData: ExtraDataTypes>(
+        payload: ChannelDetailPayload<ExtraData>,
+        query: ChannelListQuery?
+    ) throws -> ChannelDTO
+    
+    /// Fetches `ChannelDTO` with the given `cid` from the database.
+    func channel(cid: ChannelId) -> ChannelDTO?
+}
+
 protocol ChannelReadDatabaseSession {
     /// Creates a new `ChannelReadDTO` object in the database. Throws an error if the ChannelRead fails to be created.
     @discardableResult
@@ -95,26 +111,13 @@ protocol ChannelReadDatabaseSession {
     func loadChannelReads(for userId: UserId) -> [ChannelReadDTO]
 }
 
-protocol DatabaseSession: UserDatabaseSession, CurrentUserDatabaseSession, MessageDatabaseSession, ChannelReadDatabaseSession {
+protocol DatabaseSession: UserDatabaseSession, CurrentUserDatabaseSession, MessageDatabaseSession, ChannelReadDatabaseSession, ChannelDatabaseSession {
     // MARK: - Member
     
     @discardableResult
     func saveMember<ExtraData: UserExtraData>(payload: MemberPayload<ExtraData>, channelId: ChannelId) throws -> MemberDTO
     
     func loadMember<ExtraData: UserExtraData>(id: UserId, channelId: ChannelId) -> MemberModel<ExtraData>?
-    
-    // MARK: - Channel
-    
-    @discardableResult
-    func saveChannel<ExtraData: ExtraDataTypes>(payload: ChannelPayload<ExtraData>, query: ChannelListQuery?) throws -> ChannelDTO
-    
-    @discardableResult
-    func saveChannel<ExtraData: ExtraDataTypes>(
-        payload: ChannelDetailPayload<ExtraData>,
-        query: ChannelListQuery?
-    ) throws -> ChannelDTO
-    
-    func loadChannel<ExtraData: ExtraDataTypes>(cid: ChannelId) -> ChannelModel<ExtraData>?
 }
 
 extension DatabaseSession {

--- a/Sources_v3/Database/DatabaseSession.swift
+++ b/Sources_v3/Database/DatabaseSession.swift
@@ -111,14 +111,21 @@ protocol ChannelReadDatabaseSession {
     func loadChannelReads(for userId: UserId) -> [ChannelReadDTO]
 }
 
-protocol DatabaseSession: UserDatabaseSession, CurrentUserDatabaseSession, MessageDatabaseSession, ChannelReadDatabaseSession, ChannelDatabaseSession {
-    // MARK: - Member
-    
+protocol MemberDatabaseSession {
+    /// Creates a new `MemberDTO` object in the database with the given `payload` in the channel with `channelId`.
     @discardableResult
     func saveMember<ExtraData: UserExtraData>(payload: MemberPayload<ExtraData>, channelId: ChannelId) throws -> MemberDTO
     
-    func loadMember<ExtraData: UserExtraData>(id: UserId, channelId: ChannelId) -> MemberModel<ExtraData>?
+    /// Fetchtes `MemberDTO`entity for the given `userId` and `cid`.
+    func member(userId: UserId, cid: ChannelId) -> MemberDTO?
 }
+
+protocol DatabaseSession: UserDatabaseSession,
+    CurrentUserDatabaseSession,
+    MessageDatabaseSession,
+    ChannelReadDatabaseSession,
+    ChannelDatabaseSession,
+    MemberDatabaseSession {}
 
 extension DatabaseSession {
     @discardableResult

--- a/Sources_v3/Database/DatabaseSession_Tests.swift
+++ b/Sources_v3/Database/DatabaseSession_Tests.swift
@@ -32,7 +32,7 @@ class DatabaseSession_Tests: StressTestCase {
         
         // Try to load the saved channel from DB
         var loadedChannel: ChannelModel<DefaultDataTypes>? {
-            database.viewContext.loadChannel(cid: channelId)
+            database.viewContext.channel(cid: channelId)?.asModel()
         }
         
         AssertAsync.willBeEqual(loadedChannel?.cid, channelId)
@@ -124,7 +124,7 @@ class DatabaseSession_Tests: StressTestCase {
         AssertAsync.willBeTrue(loadedMessage != nil)
         
         // Verify the channel has the message
-        let loadedChannel: ChannelModel<DefaultDataTypes> = try XCTUnwrap(database.viewContext.loadChannel(cid: channelId))
+        let loadedChannel: ChannelModel<DefaultDataTypes> = try XCTUnwrap(database.viewContext.channel(cid: channelId)?.asModel())
         let message = try XCTUnwrap(loadedMessage)
         XCTAssert(loadedChannel.latestMessages.contains(message))
     }

--- a/Sources_v3/Database/DatabaseSession_Tests.swift
+++ b/Sources_v3/Database/DatabaseSession_Tests.swift
@@ -49,7 +49,7 @@ class DatabaseSession_Tests: StressTestCase {
         // Try to load the saved member from DB
         if let member = channelPayload.channel.members?.first {
             var loadedMember: UserModel<DefaultDataTypes.User>? {
-                database.viewContext.loadMember(id: member.user.id, channelId: channelId)
+                database.viewContext.member(userId: member.user.id, cid: channelId)?.asModel()
             }
             
             AssertAsync.willBeEqual(loadedMember?.id, member.user.id)

--- a/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19C57" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19G2021" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ChannelDTO" representedClassName="ChannelDTO" syncable="YES">
         <attribute name="cid" attributeType="String"/>
         <attribute name="config" attributeType="Binary"/>
@@ -12,6 +12,7 @@
         <attribute name="typeRawValue" optional="YES" attributeType="String"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="createdBy" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="createdChannels" inverseEntity="UserDTO"/>
+        <relationship name="currentlyTypingMembers" toMany="YES" deletionRule="Nullify" destinationEntity="MemberDTO" inverseName="typingIn" inverseEntity="MemberDTO"/>
         <relationship name="members" toMany="YES" deletionRule="Nullify" destinationEntity="MemberDTO" inverseName="channel" inverseEntity="MemberDTO"/>
         <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="channel" inverseEntity="MessageDTO"/>
         <relationship name="queries" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelListQueryDTO" inverseName="channels" inverseEntity="ChannelListQueryDTO"/>
@@ -77,6 +78,7 @@
         <attribute name="memberCreatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="memberUpdatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="members" inverseEntity="ChannelDTO"/>
+        <relationship name="typingIn" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="currentlyTypingMembers" inverseEntity="ChannelDTO"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="members" inverseEntity="UserDTO"/>
         <fetchIndex name="id">
             <fetchIndexElement property="id" type="Binary" order="ascending"/>
@@ -158,11 +160,11 @@
         </uniquenessConstraints>
     </entity>
     <elements>
-        <element name="ChannelDTO" positionX="0" positionY="0" width="128" height="298"/>
+        <element name="ChannelDTO" positionX="0" positionY="0" width="128" height="313"/>
         <element name="ChannelListQueryDTO" positionX="0" positionY="0" width="128" height="88"/>
         <element name="ChannelReadDTO" positionX="9" positionY="153" width="128" height="103"/>
         <element name="CurrentUserDTO" positionX="0" positionY="0" width="128" height="118"/>
-        <element name="MemberDTO" positionX="0" positionY="0" width="128" height="178"/>
+        <element name="MemberDTO" positionX="0" positionY="0" width="128" height="193"/>
         <element name="MessageDTO" positionX="0" positionY="0" width="128" height="343"/>
         <element name="TeamDTO" positionX="0" positionY="0" width="128" height="88"/>
         <element name="UserDTO" positionX="0" positionY="0" width="128" height="298"/>

--- a/Sources_v3/Models/ChannelModel.swift
+++ b/Sources_v3/Models/ChannelModel.swift
@@ -32,6 +32,9 @@ public struct ChannelModel<ExtraData: ExtraDataTypes> {
     /// A list of channel members.
     public let members: Set<MemberModel<ExtraData.User>>
     
+    /// A list of typing channel members.
+    public let currentlyTypingMembers: Set<MemberModel<ExtraData.User>>
+    
     /// A list of channel watchers.
     public let watchers: Set<UserModel<ExtraData.User>>
     
@@ -78,6 +81,7 @@ public struct ChannelModel<ExtraData: ExtraDataTypes> {
         config: ChannelConfig = .init(),
         isFrozen: Bool = false,
         members: Set<MemberModel<ExtraData.User>> = [],
+        currentlyTypingMembers: Set<MemberModel<ExtraData.User>> = [],
         watchers: Set<UserModel<ExtraData.User>> = [],
         team: String = "",
         unreadCount: ChannelUnreadCount = .noUnread,
@@ -98,6 +102,7 @@ public struct ChannelModel<ExtraData: ExtraDataTypes> {
         self.config = config
         self.isFrozen = isFrozen
         self.members = members
+        self.currentlyTypingMembers = currentlyTypingMembers
         self.watchers = watchers
         self.team = team
         self.unreadCount = unreadCount

--- a/Sources_v3/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware.swift
@@ -1,0 +1,36 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+
+/// A middleware which updates `currentlyTypingMembers` for a specific channel based on received `TypingEvent`.
+struct ChannelMemberTypingStateUpdaterMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
+    let database: DatabaseContainer
+    
+    func handle(event: Event, completion: @escaping (Event?) -> Void) {
+        guard let typingEvent = event as? TypingEvent else {
+            completion(event)
+            return
+        }
+        
+        database.write({ session in
+            guard
+                let channelDTO = session.channel(cid: typingEvent.cid),
+                let memberDTO = session.member(userId: typingEvent.userId, cid: typingEvent.cid)
+            else { return }
+            
+            if typingEvent.isTyping {
+                channelDTO.currentlyTypingMembers.insert(memberDTO)
+            } else {
+                channelDTO.currentlyTypingMembers.remove(memberDTO)
+            }
+        }, completion: { error in
+            if let error = error {
+                log.error("Failed saving incoming `TypingEvent` data to DB. Error: \(error)")
+            }
+            
+            completion(event)
+        })
+    }
+}

--- a/Sources_v3/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware_Tests.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware_Tests.swift
@@ -19,9 +19,9 @@ final class ChannelMemberTypingStateUpdaterMiddleware_Tests: XCTestCase {
     }
     
     override func tearDown() {
-        database = nil
         middleware = nil
-        
+        AssertAsync.canBeReleased(&database)
+
         super.tearDown()
     }
     

--- a/Sources_v3/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware_Tests.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware_Tests.swift
@@ -1,0 +1,132 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class ChannelMemberTypingStateUpdaterMiddleware_Tests: XCTestCase {
+    var database: DatabaseContainerMock!
+    var middleware: ChannelMemberTypingStateUpdaterMiddleware<DefaultDataTypes>!
+    
+    // MARK: - Set up
+    
+    override func setUp() {
+        super.setUp()
+        
+        database = try! DatabaseContainerMock(kind: .inMemory)
+        middleware = ChannelMemberTypingStateUpdaterMiddleware(database: database)
+    }
+    
+    override func tearDown() {
+        database = nil
+        middleware = nil
+        
+        super.tearDown()
+    }
+    
+    // MARK: - Tests
+    
+    func tests_middleware_forwardsNonTypingEvents() throws {
+        let event = TestEvent()
+        
+        // Handle non-typing event
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Assert event is forwarded as it is
+        XCTAssertEqual(forwardedEvent as! TestEvent, event)
+    }
+    
+    func tests_middleware_forwardsTypingEvent_ifDatabaseWriteGeneratesError() throws {
+        let cid: ChannelId = .unique
+        let memberId: UserId = .unique
+        
+        // Create channel in the database
+        try database.createChannel(cid: cid)
+        
+        // Create member in the database
+        try database.createMember(userId: memberId, cid: cid)
+        
+        // Set error to be thrown on write
+        let error = TestError()
+        database.write_errorResponse = error
+        
+        // Simulate typing event
+        let event = TypingEvent(isTyping: true, cid: cid, userId: memberId)
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Assert `TypingEvent` is forwarded even though database error happened
+        XCTAssertEqual(forwardedEvent as! TypingEvent, event)
+    }
+    
+    func tests_middleware_handlesTypingStartedEventCorrectly() throws {
+        let cid: ChannelId = .unique
+        let memberId: UserId = .unique
+        
+        // Create channel in the database
+        try database.createChannel(cid: cid)
+        
+        // Create member in the database
+        try database.createMember(userId: memberId, cid: cid)
+        
+        // Load the channel
+        var channel: Channel {
+            database.viewContext.channel(cid: cid)!.asModel()
+        }
+        
+        // Assert there is no typing members so far
+        XCTAssertTrue(channel.currentlyTypingMembers.isEmpty)
+        
+        // Simulate start typing event
+        let event = TypingEvent(isTyping: true, cid: cid, userId: memberId)
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Assert `TypingEvent` is forwarded as it is
+        XCTAssertEqual(forwardedEvent as! TypingEvent, event)
+        // Assert channel's currentlyTypingMembers are updated correctly
+        XCTAssertEqual(channel.currentlyTypingMembers.first?.id, memberId)
+        XCTAssertEqual(channel.currentlyTypingMembers.count, 1)
+    }
+    
+    func tests_middleware_handlesTypingFinishedEventCorrectly() throws {
+        let cid: ChannelId = .unique
+        let memberId: UserId = .unique
+        
+        // Create channel in the database
+        try database.createChannel(cid: cid)
+        // Create member in the database
+        try database.createMember(userId: memberId, cid: cid)
+        // Set created member as a typing member
+        try database.writeSynchronously { session in
+            let channel = try XCTUnwrap(session.channel(cid: cid))
+            let member = try XCTUnwrap(session.member(userId: memberId, cid: cid))
+            channel.currentlyTypingMembers.insert(member)
+        }
+        
+        // Load the channel
+        var channel: Channel {
+            database.viewContext.channel(cid: cid)!.asModel()
+        }
+        
+        // Simulate stop typing events
+        let event = TypingEvent(isTyping: false, cid: cid, userId: memberId)
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Assert `TypingEvent` is forwarded as it is
+        XCTAssertEqual(forwardedEvent as! TypingEvent, event)
+        // Assert channel's currentlyTypingMembers are updated correctly
+        XCTAssertTrue(channel.currentlyTypingMembers.isEmpty)
+    }
+}
+
+private struct TestEvent: Event, Equatable {
+    let id = UUID()
+}

--- a/Sources_v3/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
@@ -29,7 +29,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         
         // Load the channel from the db and check the if fields are correct
         var loadedChannel: ChannelModel<DefaultDataTypes>? {
-            database.viewContext.loadChannel(cid: channelId)
+            database.viewContext.channel(cid: channelId)?.asModel()
         }
         
         XCTAssertEqual(loadedChannel?.reads.first?.unreadMessagesCount, 10)
@@ -75,7 +75,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
 
         // Load the channel from the db and check the if fields are correct
         var loadedChannel: ChannelModel<DefaultDataTypes>? {
-            database.viewContext.loadChannel(cid: channelId)
+            database.viewContext.channel(cid: channelId)?.asModel()
         }
         
         XCTAssertEqual(loadedChannel?.reads.first?.unreadMessagesCount, 10)
@@ -136,7 +136,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         
         // Load the channel from the db and check the if fields are correct
         var loadedChannel: ChannelModel<DefaultDataTypes>? {
-            database.viewContext.loadChannel(cid: channelId)
+            database.viewContext.channel(cid: channelId)?.asModel()
         }
         
         // Assert that the read event entity is updated

--- a/Sources_v3/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
@@ -38,7 +38,7 @@ class EventDataProcessorMiddleware_Tests: XCTestCase {
         
         // Assert the channel data is saved and the event is forwarded
         var loadedChannel: ChannelModel<DefaultDataTypes>? {
-            database.viewContext.loadChannel(cid: channelId)
+            database.viewContext.channel(cid: channelId)!.asModel()
         }
         XCTAssertEqual(loadedChannel?.cid, channelId)
         XCTAssertEqual(completion?.asEquatable, testEvent.asEquatable)

--- a/Sources_v3/Workers/Background/MissingEventsPublisher.swift
+++ b/Sources_v3/Workers/Background/MissingEventsPublisher.swift
@@ -80,7 +80,7 @@ class MissingEventsPublisher<ExtraData: ExtraDataTypes>: Worker {
     
     private var allChannels: [ChannelModel<ExtraData>] {
         do {
-            return try database.backgroundReadOnlyContext.fetch(ChannelDTO.allChannelsFetchRequest).map(ChannelModel.create)
+            return try database.backgroundReadOnlyContext.fetch(ChannelDTO.allChannelsFetchRequest).map { $0.asModel() }
         } catch {
             log.error("Internal error: Failed to fetch [ChannelDTO]: \(error)")
             return []

--- a/Sources_v3/Workers/ChannelListUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelListUpdater_Tests.swift
@@ -55,7 +55,7 @@ class ChannelListUpdater_Tests: StressTestCase {
         
         // Assert the data is stored in the DB
         var channel: Channel? {
-            database.viewContext.loadChannel(cid: cid)
+            database.viewContext.channel(cid: cid)?.asModel()
         }
         AssertAsync {
             Assert.willBeTrue(channel != nil)

--- a/Sources_v3/Workers/ChannelUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelUpdater_Tests.swift
@@ -57,7 +57,7 @@ class ChannelUpdater_Tests: StressTestCase {
         
         // Assert the data is stored in the DB
         var channel: Channel? {
-            database.viewContext.loadChannel(cid: cid)
+            database.viewContext.channel(cid: cid)?.asModel()
         }
         AssertAsync {
             Assert.willBeTrue(channel != nil)
@@ -85,7 +85,7 @@ class ChannelUpdater_Tests: StressTestCase {
         var cid: ChannelId = .unique
 
         var channel: Channel? {
-            database.viewContext.loadChannel(cid: cid)
+            database.viewContext.channel(cid: cid)?.asModel()
         }
 
         let callback: (ChannelId) -> Void = {

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -325,6 +325,7 @@
 		F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69C4BC524F66CC200A3D740 /* EventLogger.swift */; };
 		F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */; };
 		F6C56D1424F7B89D0012BB1F /* EventMiddleware_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */; };
+		F6CCA25125124BA9004C1859 /* MemberPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CCA25025124BA9004C1859 /* MemberPayload.swift */; };
 		F6D61D9B2510B3FC00EB0624 /* NSManagedObject+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D61D9A2510B3FC00EB0624 /* NSManagedObject+Extensions.swift */; };
 		F6D61D9D2510B57F00EB0624 /* NSManagedObject_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D61D9C2510B57F00EB0624 /* NSManagedObject_Tests.swift */; };
 		F6ED5F7425023EB4005D7327 /* MissingEventsPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6ED5F7325023EB4005D7327 /* MissingEventsPublisher.swift */; };
@@ -710,6 +711,7 @@
 		F69C4BC524F66CC200A3D740 /* EventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogger.swift; sourceTree = "<group>"; };
 		F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserController_Tests.swift; sourceTree = "<group>"; };
 		F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware_Mock.swift; sourceTree = "<group>"; };
+		F6CCA25025124BA9004C1859 /* MemberPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberPayload.swift; sourceTree = "<group>"; };
 		F6D61D9A2510B3FC00EB0624 /* NSManagedObject+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Extensions.swift"; sourceTree = "<group>"; };
 		F6D61D9C2510B57F00EB0624 /* NSManagedObject_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSManagedObject_Tests.swift; sourceTree = "<group>"; };
 		F6ED5F7325023EB4005D7327 /* MissingEventsPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingEventsPublisher.swift; sourceTree = "<group>"; };
@@ -757,6 +759,7 @@
 				79F3ABEB24EAE0B900AB9505 /* UserRequestBody.swift */,
 				8A0D649224E5794C0017A3C0 /* CurrentUserPayload.swift */,
 				F67415BF24F0129800C3222F /* UnreadCount.swift */,
+				F6CCA25025124BA9004C1859 /* MemberPayload.swift */,
 			);
 			path = "Dummy data";
 			sourceTree = "<group>";
@@ -1935,6 +1938,7 @@
 				F649B2372500F785008F98C8 /* MessageController_Tests.swift in Sources */,
 				799C947D247E6114001F1104 /* TestError.swift in Sources */,
 				799C946A247D791A001F1104 /* AssertAsync.swift in Sources */,
+				F6CCA25125124BA9004C1859 /* MemberPayload.swift in Sources */,
 				F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */,
 				7991D83F24F8F1BF00D21BA3 /* ChatClient_Mock.swift in Sources */,
 				792921CB24C077B400116BBB /* TestDispatchQueue.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -325,6 +325,8 @@
 		F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69C4BC524F66CC200A3D740 /* EventLogger.swift */; };
 		F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */; };
 		F6C56D1424F7B89D0012BB1F /* EventMiddleware_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */; };
+		F6CCA24D251235F7004C1859 /* ChannelMemberTypingStateUpdaterMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CCA24C251235F7004C1859 /* ChannelMemberTypingStateUpdaterMiddleware.swift */; };
+		F6CCA24F2512491B004C1859 /* ChannelMemberTypingStateUpdaterMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CCA24E2512491B004C1859 /* ChannelMemberTypingStateUpdaterMiddleware_Tests.swift */; };
 		F6CCA25125124BA9004C1859 /* MemberPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CCA25025124BA9004C1859 /* MemberPayload.swift */; };
 		F6D61D9B2510B3FC00EB0624 /* NSManagedObject+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D61D9A2510B3FC00EB0624 /* NSManagedObject+Extensions.swift */; };
 		F6D61D9D2510B57F00EB0624 /* NSManagedObject_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D61D9C2510B57F00EB0624 /* NSManagedObject_Tests.swift */; };
@@ -711,6 +713,8 @@
 		F69C4BC524F66CC200A3D740 /* EventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogger.swift; sourceTree = "<group>"; };
 		F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserController_Tests.swift; sourceTree = "<group>"; };
 		F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware_Mock.swift; sourceTree = "<group>"; };
+		F6CCA24C251235F7004C1859 /* ChannelMemberTypingStateUpdaterMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberTypingStateUpdaterMiddleware.swift; sourceTree = "<group>"; };
+		F6CCA24E2512491B004C1859 /* ChannelMemberTypingStateUpdaterMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberTypingStateUpdaterMiddleware_Tests.swift; sourceTree = "<group>"; };
 		F6CCA25025124BA9004C1859 /* MemberPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberPayload.swift; sourceTree = "<group>"; };
 		F6D61D9A2510B3FC00EB0624 /* NSManagedObject+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Extensions.swift"; sourceTree = "<group>"; };
 		F6D61D9C2510B57F00EB0624 /* NSManagedObject_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSManagedObject_Tests.swift; sourceTree = "<group>"; };
@@ -958,6 +962,8 @@
 				792FCB4624A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift */,
 				79896D63250A62EE00BA8F1C /* ChannelReadUpdaterMiddleware.swift */,
 				79896D65250A6D1500BA8F1C /* ChannelReadUpdaterMiddleware_Tests.swift */,
+				F6CCA24C251235F7004C1859 /* ChannelMemberTypingStateUpdaterMiddleware.swift */,
+				F6CCA24E2512491B004C1859 /* ChannelMemberTypingStateUpdaterMiddleware_Tests.swift */,
 			);
 			path = EventMiddlewares;
 			sourceTree = "<group>";
@@ -1897,6 +1903,7 @@
 				792FCB4524A33B5B000290C7 /* EventDataProcessorMiddleware.swift in Sources */,
 				79A0E9BE2498C33100E9BD50 /* TypingEvent.swift in Sources */,
 				79896D5C2506593E00BA8F1C /* ChannelReadDTO.swift in Sources */,
+				F6CCA24D251235F7004C1859 /* ChannelMemberTypingStateUpdaterMiddleware.swift in Sources */,
 				8A618E4524D19D510003D83C /* WebSocketPingController.swift in Sources */,
 				8A62704E24B8660A0040BFD6 /* EventType.swift in Sources */,
 				F65D9091250A5989000B8CEB /* WebSocketConnectEndpoint.swift in Sources */,
@@ -1925,6 +1932,7 @@
 				79DDF819249CE38B002F4412 /* MockNetworkURLProtocol.swift in Sources */,
 				F61D7C3724FFE17200188A0E /* MessageEditor_Tests.swift in Sources */,
 				8AE335AA24FCF99E002B6677 /* InternetConnection_Tests.swift in Sources */,
+				F6CCA24F2512491B004C1859 /* ChannelMemberTypingStateUpdaterMiddleware_Tests.swift in Sources */,
 				F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */,
 				7922F30A24DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift in Sources */,
 				8A62705E24BE2CD70040BFD6 /* XCTestCase+MockJSON.swift in Sources */,

--- a/Tests_v3/Dummy data/MemberPayload.swift
+++ b/Tests_v3/Dummy data/MemberPayload.swift
@@ -1,0 +1,18 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChatClient
+
+extension MemberPayload where ExtraData == NameAndImageExtraData {
+    /// Returns a dummy member payload with the given `userId` and `role`
+    static func dummy(userId: UserId = .unique, role: MemberRole = .member) -> MemberPayload {
+        .init(
+            user: .dummy(userId: userId),
+            role: role,
+            createdAt: .unique,
+            updatedAt: .unique
+        )
+    }
+}


### PR DESCRIPTION
**This PR:**
- adds `typingMembers` to `ChannelDTO/ChannelModel`
- updates `ChannelControllerDelegate` to expose typing events via `didChangeTypingMembers`
- introduces and makes use of `ChannelMemberTypingStateUpdaterMiddleware`
- introduces `MemberDatabaseSession` and `ChannelDatabaseSession`