### PR TITLE
Sample v3: Upgrade SwiftUI sample to iOS 14

### DIFF
--- a/Sample_v3/Extensions/View+AlertTextField.swift
+++ b/Sample_v3/Extensions/View+AlertTextField.swift
@@ -54,18 +54,5 @@ struct AlertWrapper<Content: View>: UIViewControllerRepresentable {
         if !isPresented, uiViewController.presentedViewController == context.coordinator.alertController {
             uiViewController.dismiss(animated: true)
         }
-        /* uiViewController.rootView = content
-         if isPresented && uiViewController.presentedViewController == nil {
-             var alert = self.alert
-             alert.action = {
-                 self.isPresented = false
-                 self.alert.action($0)
-             }
-             context.coordinator.alertController = UIAlertController(
-             uiViewController.present(context.coordinator.alertController!, animated: true)
-         }
-         if !isPresented && uiViewController.presentedViewController == context.coordinator.alertController {
-             uiViewController.dismiss(animated: true)
-         } */
     }
 }

--- a/Sample_v3/Extensions/View+AlertTextField.swift
+++ b/Sample_v3/Extensions/View+AlertTextField.swift
@@ -1,0 +1,71 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 14, *)
+extension View {
+    func alert(isPresented: Binding<Bool>, _ alert: TextAlert) -> some View {
+        AlertWrapper(isPresented: isPresented, alert: alert, content: self)
+    }
+}
+
+@available(iOS 14, *)
+struct TextAlert {
+    var title: String
+    var placeholder: String = ""
+    var action: (String?) -> Void
+}
+
+@available(iOS 14, *)
+struct AlertWrapper<Content: View>: UIViewControllerRepresentable {
+    @Binding var isPresented: Bool
+    let alert: TextAlert
+    let content: Content
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<AlertWrapper>) -> UIHostingController<Content> {
+        UIHostingController(rootView: content)
+    }
+
+    final class Coordinator {
+        var alertController: UIAlertController?
+        init(_ controller: UIAlertController? = nil) {
+            alertController = controller
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func updateUIViewController(
+        _ uiViewController: UIHostingController<Content>,
+        context: UIViewControllerRepresentableContext<AlertWrapper>
+    ) {
+        uiViewController.rootView = content
+        if isPresented, uiViewController.presentedViewController == nil {
+            uiViewController.alertTextField(title: alert.title, placeholder: alert.placeholder) {
+                self.isPresented = false
+                self.alert.action($0)
+            }
+        }
+        
+        if !isPresented, uiViewController.presentedViewController == context.coordinator.alertController {
+            uiViewController.dismiss(animated: true)
+        }
+        /* uiViewController.rootView = content
+         if isPresented && uiViewController.presentedViewController == nil {
+             var alert = self.alert
+             alert.action = {
+                 self.isPresented = false
+                 self.alert.action($0)
+             }
+             context.coordinator.alertController = UIAlertController(
+             uiViewController.present(context.coordinator.alertController!, animated: true)
+         }
+         if !isPresented && uiViewController.presentedViewController == context.coordinator.alertController {
+             uiViewController.dismiss(animated: true)
+         } */
+    }
+}

--- a/Sample_v3/LoginViewController.swift
+++ b/Sample_v3/LoginViewController.swift
@@ -136,7 +136,7 @@ extension LoginViewController {
                 self.view.window?.rootViewController = initial
             })
         case .swiftUISimpleChatIndexPath:
-            if #available(iOS 13, *) {
+            if #available(iOS 14, *) {
                 // Ideally, we'd pass the `Client` instance as the environment object and create the list controller later.
                 UIView.transition(with: self.view.window!, duration: 0.5, options: .transitionFlipFromLeft, animations: {
                     self.view.window?.rootViewController = UIHostingController(
@@ -146,6 +146,8 @@ extension LoginViewController {
                         }
                     )
                 })
+            } else {
+                alert(title: "iOS 14 required", message: "You need iOS 14 to run this sample.")
             }
         case .combineUIKitSimpleChatIndexPath:
             if #available(iOS 13, *) {
@@ -164,10 +166,14 @@ extension LoginViewController {
                 UIView.transition(with: view.window!, duration: 0.5, options: .transitionFlipFromLeft, animations: {
                     self.view.window?.rootViewController = initial
                 })
+            } else {
+                alert(title: "iOS 13 required", message: "You need iOS 13 to run this sample.")
             }
         default:
             return
         }
+        
+        tableView.deselectRow(at: indexPath, animated: true)
     }
 }
 

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
@@ -6,7 +6,7 @@ import Combine
 import StreamChatClient
 import SwiftUI
 
-@available(iOS 13, *)
+@available(iOS 14, *)
 struct ChannelListView: View {
     // TODO: It's safer to use `@StateObject` here because `@ObservedObject` can sometimes release the
     // reference and this will crash.

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
@@ -93,10 +93,24 @@ struct ChatView: View {
         )
         
         return HStack {
-            // ZStack TextEditor with Text for autoexpanding behavior
             ZStack {
-                TextEditor(text: textBinding)
-                Text(text).fixedSize(horizontal: false, vertical: true).padding(.all, 8)
+                if text.isEmpty {
+                    Text("Type a message")
+                        .foregroundColor(.secondary)
+                        .padding(.all, 8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .allowsHitTesting(false)
+                } else {
+                    Text(text) // hack to auto expand the composer (TextEditor alone won't do it)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.all, 8)
+                        .opacity(0)
+                        .allowsHitTesting(false)
+                }
+                
+                TextEditor(text: textBinding).background(Color.clear).onAppear {
+                    UITextView.appearance().backgroundColor = .clear
+                }
             }
             Button(action: self.send) {
                 Image(systemName: "arrow.up.circle.fill")

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
@@ -99,13 +99,11 @@ struct ChatView: View {
                         .foregroundColor(.secondary)
                         .padding(.all, 8)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .allowsHitTesting(false)
                 } else {
                     Text(text) // hack to auto expand the composer (TextEditor alone won't do it)
                         .fixedSize(horizontal: false, vertical: true)
                         .padding(.all, 8)
                         .opacity(0)
-                        .allowsHitTesting(false)
                 }
                 
                 TextEditor(text: textBinding).background(Color.clear).onAppear {

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
@@ -5,10 +5,11 @@
 import StreamChatClient
 import SwiftUI
 
-@available(iOS 13, *)
+@available(iOS 14, *)
 struct ChatView: View {
     /// The `ChannelController` used to interact with this channel. Will be synchornized in `onAppear`.
     @State var channel: ChannelController.ObservableObject
+    
     /// The `text` written in the message composer
     @State var text: String = ""
     /// Binding for message actions ActionSheet
@@ -16,13 +17,22 @@ struct ChatView: View {
     /// Message being edited
     @State var editingMessage: Message?
 
+    /// User action
+    @State var userActionTrigger: Bool = false
+    @State var userAction: ((String) -> Void)?
+
     var body: some View {
         VStack {
-            self.messageList()
+            self.messageList().layoutPriority(1)
             self.composerView()
         }
         /// Channel ActionSheet presenter.
         .actionSheet(isPresented: $actionSheetTrigger, content: self.actionSheet)
+        /// User action alert
+        .alert(isPresented: $userActionTrigger, TextAlert(title: "User Id", placeholder: "steep-moon-9", action: {
+            self.userAction?($0 ?? "steep-moon-9")
+            self.userAction = nil
+        }))
         /// Set title to channel's name
         .navigationBarTitle(
             Text(channel.channel.flatMap(createTypingMemberString) ?? channel.channel?.extraData.name ?? "Unnamed Channel"),
@@ -74,11 +84,20 @@ struct ChatView: View {
     func composerView() -> some View {
         let textBinding = Binding(
             get: { self.text },
-            set: { self.text = $0; self.didKeystroke() }
+            set: { newValue in
+                DispatchQueue.main.async {
+                    self.text = newValue
+                    self.didKeystroke()
+                }
+            }
         )
         
         return HStack {
-            TextField("Type a message", text: textBinding, onCommit: didStopTyping)
+            // ZStack TextEditor with Text for autoexpanding behavior
+            ZStack {
+                TextEditor(text: textBinding)
+                Text(text).fixedSize(horizontal: false, vertical: true).padding(.all, 8)
+            }
             Button(action: self.send) {
                 Image(systemName: "arrow.up.circle.fill")
             }
@@ -111,10 +130,19 @@ struct ChatView: View {
                 .cancel { self.editingMessage = nil }
             ])
         } else {
-            let userIds = Set(["steep-moon-9"])
             return ActionSheet(title: Text("Channel Actions"), message: Text(""), buttons: [
-                .default(Text("Add Member"), action: { self.channel.controller.addMembers(userIds: userIds) }),
-                .default(Text("Remove Member"), action: { self.channel.controller.removeMembers(userIds: userIds) }),
+                .default(
+                    Text("Add Member"), action: {
+                        self.userAction = { self.channel.controller.addMembers(userIds: [$0]) }
+                        self.userActionTrigger = true
+                    }
+                ),
+                .default(
+                    Text("Remove Member"), action: {
+                        self.userAction = { self.channel.controller.removeMembers(userIds: [$0]) }
+                        self.userActionTrigger = true
+                    }
+                ),
                 .cancel()
             ])
         }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		804B127724ED59FE002B00EA /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 804B127624ED59FE002B00EA /* Settings.storyboard */; };
 		805A11492506FBBD0089DFC4 /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805A11472506FBB30089DFC4 /* UIViewController+Alert.swift */; };
 		80C6026F2514281000A6B714 /* UITableViewController+Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */; };
+		80C6027B25157E4D00A6B714 /* View+AlertTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */; };
 		8A0175F02501174000570345 /* EventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175EF2501174000570345 /* EventSender.swift */; };
 		8A0175F425013B6400570345 /* EventSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175F325013B6400570345 /* EventSender_Tests.swift */; };
 		8A08C6A624D437DF00DEF995 /* WebSocketPingController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */; };
@@ -572,6 +573,7 @@
 		804B127624ED59FE002B00EA /* Settings.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Settings.storyboard; sourceTree = "<group>"; };
 		805A11472506FBB30089DFC4 /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewController+Cells.swift"; sourceTree = "<group>"; };
+		80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AlertTextField.swift"; sourceTree = "<group>"; };
 		8A0175EF2501174000570345 /* EventSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender.swift; sourceTree = "<group>"; };
 		8A0175F325013B6400570345 /* EventSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender_Tests.swift; sourceTree = "<group>"; };
 		8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketPingController_Tests.swift; sourceTree = "<group>"; };
@@ -1238,6 +1240,7 @@
 			children = (
 				8008C17F24ED64C000F5BCCE /* UIViewController+MoveToStoryboard.swift */,
 				805A11472506FBB30089DFC4 /* UIViewController+Alert.swift */,
+				80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */,
 				8008C18224ED65A500F5BCCE /* UIStoryboard+Definitions.swift */,
 				8008C19024F44DF600F5BCCE /* UIView+InstantiateFromNib.swift */,
 				8008C19E24F84DB600F5BCCE /* UITableViewController+KeyboardAvoidance.swift */,
@@ -1777,6 +1780,7 @@
 				DAD8A8A52507E1C800D05282 /* CombineSimpleChatViewController.swift in Sources */,
 				80C6026F2514281000A6B714 /* UITableViewController+Cells.swift in Sources */,
 				8008C19224F44DF900F5BCCE /* UIView+InstantiateFromNib.swift in Sources */,
+				80C6027B25157E4D00A6B714 /* View+AlertTextField.swift in Sources */,
 				8040BC5E24FDAB1E00DE369F /* UIColor+ForUsername.swift in Sources */,
 				F6CA70932513A1450024ED5D /* Channel+MembersInfo.swift in Sources */,
 				8008C18124ED64D300F5BCCE /* UIViewController+MoveToStoryboard.swift in Sources */,


### PR DESCRIPTION
Additional changes:
- Chat and composer will now adjust for keyboard (iOS 14 does this by default)
- Composer is now multiline and autoexpands (using TextEditor + Text ZStack workaround)
- Can now specify user id to add / remove in a channel (wrapping the existing UIKit alert extension)
