### PR TITLE
[CIS-284] The Big Renaming

### DIFF
--- a/Sample_v3/Extensions/Channel+MembersInfo.swift
+++ b/Sample_v3/Extensions/Channel+MembersInfo.swift
@@ -4,11 +4,11 @@
 
 import StreamChatClient
 
-func createMemberInfoString(for channel: Channel) -> String {
+func createMemberInfoString(for channel: ChatChannel) -> String {
     "\(channel.members.count) members, \(channel.members.filter(\.isOnline).count) online"
 }
 
-func createTypingMemberString(for channel: Channel) -> String? {
+func createTypingMemberString(for channel: ChatChannel) -> String? {
     guard !channel.currentlyTypingMembers.isEmpty else { return nil }
     let names = channel.currentlyTypingMembers.map { $0.name ?? $0.id }.sorted()
     return names.joined(separator: ",") + " \(names.count == 1 ? "is" : "are") typing..."

--- a/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChannelsViewController.swift
+++ b/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChannelsViewController.swift
@@ -25,7 +25,7 @@ class CombineSimpleChannelsViewController: UITableViewController {
     ///  Also we need to call `channelController.synchronize()` to update local data with remote one.
     ///  Additionally, `channelListController.client` holds a reference to the `ChatClient` which created this instance.
     ///  It can be used to create other controllers.
-    var channelListController: ChannelListController! {
+    var channelListController: ChatChannelListController! {
         didSet {
             subscribeToCombinePublishers()
             channelListController.synchronize()

--- a/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChatViewController.swift
+++ b/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChatViewController.swift
@@ -53,7 +53,7 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
         ///
         let initialChannel = Just(channelController.channel)
             .compactMap { $0 }
-            .map { EntityChange<Channel>.update($0) }
+            .map { EntityChange<ChatChannel>.update($0) }
         
         ///
         /// This subscription updates the view controller's `title` and its `navigationItem.prompt` to display the count of channel
@@ -65,7 +65,7 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
             .prepend(initialChannel)
             /// Dismiss VC and break the sequence if channel got deleted.
             /// Map `EntityChange` to `Channel` and continue executing sequence if it is `update` change.
-            .compactMap { [weak self] change -> Channel? in
+            .compactMap { [weak self] change -> ChatChannel? in
                 switch change {
                 case .create:
                     return nil

--- a/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChatViewController.swift
+++ b/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChatViewController.swift
@@ -25,7 +25,7 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
     ///  `Publishers` functionality is identical to methods of `ChannelControllerDelegate`.
     ///  Also we need to call `channelController.synchronize()` to update local data with remote one.
     ///
-    var channelController: ChannelController! {
+    var channelController: ChatChannelController! {
         didSet {
             channelController.synchronize()
             subscribeToCombinePublishers()

--- a/Sample_v3/Samples/SettingsViewController.swift
+++ b/Sample_v3/Samples/SettingsViewController.swift
@@ -15,7 +15,7 @@ class SettingsViewController: UITableViewController {
     @IBOutlet var userNameLabel: UILabel!
     @IBOutlet var userSecondaryLabel: UILabel!
     
-    var currentUserController: CurrentUserController! {
+    var currentUserController: CurrentChatUserController! {
         didSet {
             currentUserController.delegate = self
         }
@@ -97,8 +97,11 @@ extension SettingsViewController {
 
 // MARK: - CurrentUserControllerDelegate
 
-extension SettingsViewController: CurrentUserControllerDelegate {
-    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser change: EntityChange<CurrentChatUser>) {
+extension SettingsViewController: CurrentChatUserControllerDelegate {
+    func currentUserController(
+        _ controller: CurrentChatUserController,
+        didChangeCurrentUser change: EntityChange<CurrentChatUser>
+    ) {
         updateUserCell(with: change.item)
     }
 }
@@ -106,7 +109,7 @@ extension SettingsViewController: CurrentUserControllerDelegate {
 @available(iOS 13.0, *)
 struct SettingsView: UIViewControllerRepresentable {
     typealias UIViewControllerType = SettingsViewController
-    let currentUserController: CurrentUserController
+    let currentUserController: CurrentChatUserController
     
     func makeUIViewController(context: Context) -> SettingsViewController {
         let navigationViewController = UIStoryboard.settings.instantiateInitialViewController()!

--- a/Sample_v3/Samples/SettingsViewController.swift
+++ b/Sample_v3/Samples/SettingsViewController.swift
@@ -47,7 +47,7 @@ class SettingsViewController: UITableViewController {
 // MARK: - Current User
 
 extension SettingsViewController {
-    func updateUserCell(with user: CurrentUser?) {
+    func updateUserCell(with user: CurrentChatUser?) {
         if let user = user {
             userNameLabel.text = user.name ?? ""
             userNameLabel.text! += " (\(user.id))"
@@ -98,7 +98,7 @@ extension SettingsViewController {
 // MARK: - CurrentUserControllerDelegate
 
 extension SettingsViewController: CurrentUserControllerDelegate {
-    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser change: EntityChange<CurrentUser>) {
+    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser change: EntityChange<CurrentChatUser>) {
         updateUserCell(with: change.item)
     }
 }

--- a/Sample_v3/Samples/SimpleChat/SimpleChannelsViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChannelsViewController.swift
@@ -52,7 +52,7 @@ class SimpleChannelsViewController: UITableViewController, ChannelListController
     /// The method below receives the `changes` that happen in the list of messages and updates the `UITableView` accordingly.
     ///
     func controller(
-        _ controller: ChannelListControllerGeneric<DefaultDataTypes>,
+        _ controller: ChannelListControllerGeneric<DefaultExtraData>,
         didChangeChannels changes: [ListChange<Channel>]
     ) {
         tableView.beginUpdates()

--- a/Sample_v3/Samples/SimpleChat/SimpleChannelsViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChannelsViewController.swift
@@ -53,7 +53,7 @@ class SimpleChannelsViewController: UITableViewController, ChannelListController
     ///
     func controller(
         _ controller: ChannelListControllerGeneric<DefaultExtraData>,
-        didChangeChannels changes: [ListChange<Channel>]
+        didChangeChannels changes: [ListChange<ChatChannel>]
     ) {
         tableView.beginUpdates()
         

--- a/Sample_v3/Samples/SimpleChat/SimpleChannelsViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChannelsViewController.swift
@@ -12,7 +12,7 @@ import UIKit
 /// A `UITableViewController` subclass that displays and manages the list of channels.  It uses the `ChannelListController`  class to make calls to the Stream Chat API
 /// and listens to events by conforming to `ChannelListControllerDelegate`.
 ///
-class SimpleChannelsViewController: UITableViewController, ChannelListControllerDelegate {
+class SimpleChannelsViewController: UITableViewController, ChatChannelListControllerDelegate {
     // MARK: - Properties
     
     ///
@@ -23,7 +23,7 @@ class SimpleChannelsViewController: UITableViewController, ChannelListController
     ///  delegate is set,`channelListController.synchronize()` must be called to start listening to events related to the channel list. Additionally,
     ///  `channelListController.client` holds a reference to the `ChatClient` which created this instance. It can be used to create other controllers.
     ///
-    var channelListController: ChannelListController! {
+    var channelListController: ChatChannelListController! {
         didSet {
             channelListController.delegate = self
             channelListController.synchronize()
@@ -52,7 +52,7 @@ class SimpleChannelsViewController: UITableViewController, ChannelListController
     /// The method below receives the `changes` that happen in the list of messages and updates the `UITableView` accordingly.
     ///
     func controller(
-        _ controller: ChannelListControllerGeneric<DefaultExtraData>,
+        _ controller: _ChannelListController<DefaultExtraData>,
         didChangeChannels changes: [ListChange<ChatChannel>]
     ) {
         tableView.beginUpdates()

--- a/Sample_v3/Samples/SimpleChat/SimpleChannelsViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChannelsViewController.swift
@@ -52,7 +52,7 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
     /// The method below receives the `changes` that happen in the list of messages and updates the `UITableView` accordingly.
     ///
     func controller(
-        _ controller: _ChannelListController<DefaultExtraData>,
+        _ controller: ChatChannelListController,
         didChangeChannels changes: [ListChange<ChatChannel>]
     ) {
         tableView.beginUpdates()

--- a/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
@@ -70,7 +70,7 @@ final class SimpleChatViewController: UITableViewController, ChannelControllerDe
     /// The method below reacts to changes in the `Channel` entity. It updates the view controller's `title` and its `navigationItem.prompt` to display the count of channel
     /// members and the count of online members. When the channel is deleted, this view controller is dismissed.
     ///
-    func channelController(_ channelController: ChannelController, didUpdateChannel channel: EntityChange<Channel>) {
+    func channelController(_ channelController: ChannelController, didUpdateChannel channel: EntityChange<ChatChannel>) {
         switch channel {
         case .create:
             break

--- a/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 /// A `UITableViewController` subclass that displays and manages a channel.  It uses the `ChannelController`  class to make calls to the Stream Chat API and listens to
 /// events by conforming to `ChannelControllerDelegate`.
 ///
-final class SimpleChatViewController: UITableViewController, ChannelControllerDelegate, UITextViewDelegate {
+final class SimpleChatViewController: UITableViewController, ChatChannelControllerDelegate, UITextViewDelegate {
     // MARK: - Properties
     
     ///
@@ -22,7 +22,7 @@ final class SimpleChatViewController: UITableViewController, ChannelControllerDe
     ///  `channelController.synchronize()` must be called to start listening to events related to the channel. Additionally, `channelController.client` holds a
     ///  reference to the `ChatClient` which created this instance. It can be used to create other controllers.
     ///
-    var channelController: ChannelController! {
+    var channelController: ChatChannelController! {
         didSet {
             channelController.delegate = self
             channelController.synchronize()
@@ -45,7 +45,8 @@ final class SimpleChatViewController: UITableViewController, ChannelControllerDe
     ///
     /// The method below receives the `changes` that happen in the list of messages and updates the `UITableView` accordingly.
     ///
-    func channelController(_ channelController: ChannelController, didUpdateMessages changes: [ListChange<ChatMessage>]) {
+    func channelController(_ channelController: ChatChannelController, didUpdateMessages changes: [ListChange<ChatMessage>]) {
+        tableView.beginUpdates()
         
         for change in changes {
             switch change {
@@ -69,7 +70,7 @@ final class SimpleChatViewController: UITableViewController, ChannelControllerDe
     /// The method below reacts to changes in the `Channel` entity. It updates the view controller's `title` and its `navigationItem.prompt` to display the count of channel
     /// members and the count of online members. When the channel is deleted, this view controller is dismissed.
     ///
-    func channelController(_ channelController: ChannelController, didUpdateChannel channel: EntityChange<ChatChannel>) {
+    func channelController(_ channelController: ChatChannelController, didUpdateChannel channel: EntityChange<ChatChannel>) {
         switch channel {
         case .create:
             break
@@ -85,7 +86,10 @@ final class SimpleChatViewController: UITableViewController, ChannelControllerDe
     ///
     /// The method below receives a set of `Member` that are currently typing.
     ///
-    func channelController(_ channelController: ChannelController, didChangeTypingMembers typingMembers: Set<ChatChannelMember>) {
+    func channelController(
+        _ channelController: ChatChannelController,
+        didChangeTypingMembers typingMembers: Set<ChatChannelMember>
+    ) {
         updateNavigationTitleAndPrompt()
     }
     

--- a/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
@@ -85,7 +85,7 @@ final class SimpleChatViewController: UITableViewController, ChannelControllerDe
     ///
     /// The method below receives a set of `Member` that are currently typing.
     ///
-    func channelController(_ channelController: ChannelController, didChangeTypingMembers: Set<Member>) {
+    func channelController(_ channelController: ChannelController, didChangeTypingMembers typingMembers: Set<ChatChannelMember>) {
         updateNavigationTitleAndPrompt()
     }
     

--- a/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
@@ -45,8 +45,7 @@ final class SimpleChatViewController: UITableViewController, ChannelControllerDe
     ///
     /// The method below receives the `changes` that happen in the list of messages and updates the `UITableView` accordingly.
     ///
-    func channelController(_ channelController: ChannelController, didUpdateMessages changes: [ListChange<Message>]) {
-        tableView.beginUpdates()
+    func channelController(_ channelController: ChannelController, didUpdateMessages changes: [ListChange<ChatMessage>]) {
         
         for change in changes {
             switch change {

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
@@ -142,7 +142,7 @@ struct ChannelListView: View {
     }
     
     /// Unread count number in circle.
-    func unreadCountCircle(for channel: Channel) -> AnyView {
+    func unreadCountCircle(for channel: ChatChannel) -> AnyView {
         if channel.isUnread {
             return AnyView(
                 Text("\(channel.unreadCount.messages)")
@@ -188,7 +188,7 @@ struct ChannelListView: View {
     
     // MARK: - Helpers
     
-    private func channel(_ index: Int) -> Channel {
+    private func channel(_ index: Int) -> ChatChannel {
         channelList.channels[index]
     }
     
@@ -205,6 +205,6 @@ struct ChannelListView: View {
 /// ChannelId already conforms to protocol cause it has `id` property.
 extension ChannelId: Identifiable {}
 
-private extension Channel {
+private extension ChatChannel {
     var name: String { extraData.name ?? cid.description }
 }

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ChannelListView: View {
     // TODO: It's safer to use `@StateObject` here because `@ObservedObject` can sometimes release the
     // reference and this will crash.
-    @ObservedObject var channelList: ChannelListController.ObservableObject
+    @ObservedObject var channelList: ChatChannelListController.ObservableObject
     /// Binding for channel actions ActionSheet
     @State private var showActionSheet: ChannelId?
     /// Binding for ChatView navigation
@@ -20,7 +20,7 @@ struct ChannelListView: View {
         
     private lazy var cancellables: Set<AnyCancellable> = []
     
-    init(channelList: ChannelListController.ObservableObject) {
+    init(channelList: ChatChannelListController.ObservableObject) {
         self.channelList = channelList
         
         /// Dummy binding for State changes.

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
@@ -8,8 +8,7 @@ import SwiftUI
 @available(iOS 14, *)
 struct ChatView: View {
     /// The `ChannelController` used to interact with this channel. Will be synchornized in `onAppear`.
-    @State var channel: ChannelController.ObservableObject
-    
+    @State var channel: ChatChannelController.ObservableObject
     /// The `text` written in the message composer
     @State var text: String = ""
     /// Binding for message actions ActionSheet

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
@@ -15,7 +15,7 @@ struct ChatView: View {
     /// Binding for message actions ActionSheet
     @State var actionSheetTrigger: Bool = false
     /// Message being edited
-    @State var editingMessage: Message?
+    @State var editingMessage: ChatMessage?
 
     /// User action
     @State var userActionTrigger: Bool = false
@@ -57,7 +57,7 @@ struct ChatView: View {
         .offset(x: 0, y: 2)
     }
     
-    func messageView(for message: Message) -> some View {
+    func messageView(for message: ChatMessage) -> some View {
         let username = message.author.extraData.name ?? message.author.id
         let text: Text
         

--- a/Sources_v3/APIClient/APIClient_Tests.swift
+++ b/Sources_v3/APIClient/APIClient_Tests.swift
@@ -265,7 +265,7 @@ private class TestWebSocketClient: WebSocketClient {
             connectEndpoint: .init(path: "", method: .get, queryItems: nil, requiresConnectionId: false, body: nil),
             sessionConfiguration: .default,
             requestEncoder: DefaultRequestEncoder(baseURL: .unique(), apiKey: .init(.unique)),
-            eventDecoder: EventDecoder<DefaultDataTypes>(),
+            eventDecoder: EventDecoder<DefaultExtraData>(),
             eventNotificationCenter: EventNotificationCenter(),
             internetConnection: InternetConnection(),
             reconnectionStrategy: DefaultReconnectionStrategy()

--- a/Sources_v3/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -18,7 +18,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
         ]
         
         for (query, requiresConnectionId) in testCases {
-            let expectedEndpoint = Endpoint<ChannelListPayload<DefaultDataTypes>>(
+            let expectedEndpoint = Endpoint<ChannelListPayload<DefaultExtraData>>(
                 path: "channels",
                 method: .get,
                 queryItems: nil,
@@ -27,7 +27,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
             )
             
             // Build endpoint
-            let endpoint: Endpoint<ChannelListPayload<DefaultDataTypes>> = .channels(query: query)
+            let endpoint: Endpoint<ChannelListPayload<DefaultExtraData>> = .channels(query: query)
             
             // Assert endpoint is built correctly
             XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
@@ -37,7 +37,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
     func test_channel_buildsCorrectly() {
         let channelID = ChannelId(type: .livestream, id: "qwerty")
         
-        let testCases: [(ChannelQuery<DefaultDataTypes>, Bool)] = [
+        let testCases: [(ChannelQuery<DefaultExtraData>, Bool)] = [
             (.init(cid: channelID, options: .state), true),
             (.init(cid: channelID, options: .presence), true),
             (.init(cid: channelID, options: .watch), true),
@@ -47,7 +47,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
         
         for (query, requiresConnectionId) in testCases {
             let expectedEndpoint =
-                Endpoint<ChannelPayload<DefaultDataTypes>>(
+                Endpoint<ChannelPayload<DefaultExtraData>>(
                     path: "channels/\(query.cid.type.rawValue)/\(query.cid.id)/query",
                     method: .post,
                     queryItems: nil,
@@ -56,7 +56,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
                 )
             
             // Build endpoint
-            let endpoint: Endpoint<ChannelPayload<DefaultDataTypes>> = .channel(query: query)
+            let endpoint: Endpoint<ChannelPayload<DefaultExtraData>> = .channel(query: query)
             
             // Assert endpoint is built correctly
             XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
@@ -64,7 +64,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
     }
     
     func test_updateChannel_buildsCorrectly() {
-        let channelPayload: ChannelEditDetailPayload<DefaultDataTypes> = .unique
+        let channelPayload: ChannelEditDetailPayload<DefaultExtraData> = .unique
         
         let expectedEndpoint = Endpoint<EmptyResponse>(
             path: "channels/\(channelPayload.cid.type)/\(channelPayload.cid.id)",
@@ -169,7 +169,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
     func test_sendMessage_buildsCorrectly() {
         let cid = ChannelId.unique
         
-        let messageBody = MessageRequestBody<DefaultDataTypes>(
+        let messageBody = MessageRequestBody<DefaultExtraData>(
             id: .unique,
             user: .dummy(userId: .unique),
             text: .unique,
@@ -281,7 +281,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
     }
 }
 
-extension ChannelEditDetailPayload where ExtraData == DefaultDataTypes {
+extension ChannelEditDetailPayload where ExtraData == DefaultExtraData {
     static var unique: Self {
         Self(
             cid: .unique,

--- a/Sources_v3/APIClient/Endpoints/MessageEndpoints_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/MessageEndpoints_Tests.swift
@@ -9,7 +9,7 @@ final class MessageEndpoints_Tests: XCTestCase {
     func test_getMessage_buildsCorrectly() {
         let messageId: MessageId = .unique
         
-        let expectedEndpoint = Endpoint<MessagePayload<DefaultDataTypes>>(
+        let expectedEndpoint = Endpoint<MessagePayload<DefaultExtraData>>(
             path: "messages/\(messageId)",
             method: .get,
             queryItems: nil,
@@ -18,7 +18,7 @@ final class MessageEndpoints_Tests: XCTestCase {
         )
         
         // Build endpoint
-        let endpoint: Endpoint<MessagePayload<DefaultDataTypes>> = .getMessage(messageId: messageId)
+        let endpoint: Endpoint<MessagePayload<DefaultExtraData>> = .getMessage(messageId: messageId)
         
         // Assert endpoint is built correctly
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
@@ -43,7 +43,7 @@ final class MessageEndpoints_Tests: XCTestCase {
     }
     
     func test_editMessage_buildsCorrectly() {
-        let payload = MessageRequestBody<DefaultDataTypes>(
+        let payload = MessageRequestBody<DefaultExtraData>(
             id: .unique,
             user: .init(id: .unique, extraData: .init()),
             text: .unique,

--- a/Sources_v3/APIClient/Endpoints/Payloads/ChannelEditDetailPayload_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/ChannelEditDetailPayload_Tests.swift
@@ -16,7 +16,7 @@ class ChannelEditDetailPayload_Tests: XCTestCase {
         let extraData: NameAndImageExtraData = .init(name: name, imageURL: imageURL)
 
         // Create ChannelEditDetailPayload
-        let payload = ChannelEditDetailPayload<DefaultDataTypes>(
+        let payload = ChannelEditDetailPayload<DefaultExtraData>(
             cid: cid,
             team: team,
             members: [invite],

--- a/Sources_v3/APIClient/Endpoints/Payloads/ChannelListPayload_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/ChannelListPayload_Tests.swift
@@ -12,7 +12,7 @@ class ChannelListPayload_Tests: XCTestCase {
     }()
     
     func test_channelQueryJSON_isSerialized_withDefaultExtraData() throws {
-        let payload = try JSONDecoder.default.decode(ChannelListPayload<DefaultDataTypes>.self, from: channelJSON)
+        let payload = try JSONDecoder.default.decode(ChannelListPayload<DefaultExtraData>.self, from: channelJSON)
         XCTAssertEqual(payload.channels.count, 20)
     }
 }
@@ -24,7 +24,7 @@ class ChannelPayload_Tests: XCTestCase {
     }()
     
     func test_channelJSON_isSerialized_withDefaultExtraData() throws {
-        let payload = try JSONDecoder.default.decode(ChannelPayload<DefaultDataTypes>.self, from: channelJSON)
+        let payload = try JSONDecoder.default.decode(ChannelPayload<DefaultExtraData>.self, from: channelJSON)
         
         XCTAssertEqual(payload.watcherCount, 7)
         XCTAssertEqual(payload.members.count, 4)

--- a/Sources_v3/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
@@ -9,7 +9,7 @@ class MessagePayload_Tests: XCTestCase {
     let messageJSON = XCTestCase.mockData(fromFile: "Message")
     
     func test_messagePayload_isSerialized_withDefaultExtraData() throws {
-        let payload = try JSONDecoder.default.decode(MessagePayload<DefaultDataTypes>.self, from: messageJSON)
+        let payload = try JSONDecoder.default.decode(MessagePayload<DefaultExtraData>.self, from: messageJSON)
         
         XCTAssertEqual(payload.id, "7baa1533-3294-4c0c-9a62-c9d0928bf733")
         XCTAssertEqual(payload.type.rawValue, "regular")

--- a/Sources_v3/APIClient/Endpoints/Payloads/MissingEventsPayload_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/MissingEventsPayload_Tests.swift
@@ -8,7 +8,7 @@ import XCTest
 final class MissingEventsPayload_Tests: XCTestCase {
     func test_missingEventsPayload_isDeserialized() throws {
         let json = XCTestCase.mockData(fromFile: "MissingEventsPayload")
-        let payload = try JSONDecoder.default.decode(MissingEventsPayload<DefaultDataTypes>.self, from: json)
+        let payload = try JSONDecoder.default.decode(MissingEventsPayload<DefaultExtraData>.self, from: json)
         XCTAssertEqual(payload.eventPayloads.count, 1)
         
         let expectedUser = UserPayload(

--- a/Sources_v3/APIClient/Endpoints/SyncEndpoint_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/SyncEndpoint_Tests.swift
@@ -10,7 +10,7 @@ final class SyncEndpoint_Tests: XCTestCase {
         let lastSyncedAt: Date = .unique
         let cids: [ChannelId] = [.unique, .unique, .unique]
 
-        let expectedEndpoint = Endpoint<MissingEventsPayload<DefaultDataTypes>>(
+        let expectedEndpoint = Endpoint<MissingEventsPayload<DefaultExtraData>>(
             path: "sync",
             method: .post,
             queryItems: nil,
@@ -19,7 +19,7 @@ final class SyncEndpoint_Tests: XCTestCase {
         )
         
         // Build endpoint
-        let endpoint: Endpoint<MissingEventsPayload<DefaultDataTypes>> = .missingEvents(since: lastSyncedAt, cids: cids)
+        let endpoint: Endpoint<MissingEventsPayload<DefaultExtraData>> = .missingEvents(since: lastSyncedAt, cids: cids)
         
         // Assert endpoint is built correctly
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))

--- a/Sources_v3/ChatClient.swift
+++ b/Sources_v3/ChatClient.swift
@@ -34,14 +34,14 @@ public protocol ExtraDataTypes {
 /// A concrete implementation of `ExtraDataTypes` with the default values.
 public struct DefaultExtraData: ExtraDataTypes {}
 
-/// A convenience typealias for `Client` with the default data types.
-public typealias ChatClient = Client<DefaultExtraData>
+/// A convenience typealias for `_ChatClient` with the default data types.
+public typealias ChatClient = _ChatClient<DefaultExtraData>
 
 /// The root object representing a Stream Chat.
 ///
 /// If you don't need to specify your custom extra data types for `User`, `Channel`, or `Message`, use the convenient non-generic
 /// typealias `ChatClient` which specifies the default extra data types.
-public class Client<ExtraData: ExtraDataTypes> {
+public class _ChatClient<ExtraData: ExtraDataTypes> {
     /// The id of the currently logged in user.
     @Atomic public var currentUserId: UserId = .anonymous
     
@@ -238,7 +238,7 @@ public class Client<ExtraData: ExtraDataTypes> {
     }
 }
 
-extension Client {
+extension _ChatClient {
     /// An object containing all dependencies of `Client`
     struct Environment {
         var apiClientBuilder: (
@@ -297,7 +297,7 @@ extension ClientError {
 
 /// `APIClient` listens for `WebSocketClient` connection updates so it can forward the current connection id to
 /// its `RequestEncoder`.
-extension Client: ConnectionStateDelegate {
+extension _ChatClient: ConnectionStateDelegate {
     func webSocketClient(_ client: WebSocketClient, didUpdateConectionState state: WebSocketConnectionState) {
         if case let .connected(connectionId) = state {
             self.connectionId = connectionId
@@ -310,7 +310,7 @@ extension Client: ConnectionStateDelegate {
 }
 
 /// `Client` provides connection details for the `RequestEncoder`s it creates.
-extension Client: ConnectionDetailsProviderDelegate {
+extension _ChatClient: ConnectionDetailsProviderDelegate {
     func provideToken() -> Token? {
         currentToken
     }

--- a/Sources_v3/ChatClient.swift
+++ b/Sources_v3/ChatClient.swift
@@ -32,10 +32,10 @@ public protocol ExtraDataTypes {
 }
 
 /// A concrete implementation of `ExtraDataTypes` with the default values.
-public struct DefaultDataTypes: ExtraDataTypes {}
+public struct DefaultExtraData: ExtraDataTypes {}
 
 /// A convenience typealias for `Client` with the default data types.
-public typealias ChatClient = Client<DefaultDataTypes>
+public typealias ChatClient = Client<DefaultExtraData>
 
 /// The root object representing a Stream Chat.
 ///

--- a/Sources_v3/ChatClient_Mock.swift
+++ b/Sources_v3/ChatClient_Mock.swift
@@ -27,7 +27,7 @@ extension ChatClient {
     }
 }
 
-extension Client.Environment where ExtraData == DefaultExtraData {
+extension _ChatClient.Environment where ExtraData == DefaultExtraData {
     static var mock: ChatClient.Environment {
         .init(
             apiClientBuilder: APIClientMock.init,

--- a/Sources_v3/ChatClient_Mock.swift
+++ b/Sources_v3/ChatClient_Mock.swift
@@ -27,7 +27,7 @@ extension ChatClient {
     }
 }
 
-extension Client.Environment where ExtraData == DefaultDataTypes {
+extension Client.Environment where ExtraData == DefaultExtraData {
     static var mock: ChatClient.Environment {
         .init(
             apiClientBuilder: APIClientMock.init,

--- a/Sources_v3/ChatClient_Tests.swift
+++ b/Sources_v3/ChatClient_Tests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 class ChatClient_Tests: StressTestCase {
     var userId: UserId!
-    private var testEnv: TestEnvironment<DefaultDataTypes>!
+    private var testEnv: TestEnvironment<DefaultExtraData>!
     
     // A helper providing ChatClientConfic with in-memory DB option
     var inMemoryStorageConfig: ChatClientConfig {
@@ -31,9 +31,9 @@ class ChatClient_Tests: StressTestCase {
     }
     
     var workerBuilders: [WorkerBuilder] = [
-        MessageSender<DefaultDataTypes>.init,
-        NewChannelQueryUpdater<DefaultDataTypes>.init,
-        ChannelWatchStateUpdater<DefaultDataTypes>.init
+        MessageSender<DefaultExtraData>.init,
+        NewChannelQueryUpdater<DefaultExtraData>.init,
+        ChannelWatchStateUpdater<DefaultExtraData>.init
     ]
     
     // MARK: - Database stack tests
@@ -137,7 +137,7 @@ class ChatClient_Tests: StressTestCase {
         XCTAssertNotNil(webSocket?.init_eventDecoder)
         
         // EventDataProcessorMiddleware must be always first
-        XCTAssert(webSocket?.init_eventNotificationCenter.middlewares[0] is EventDataProcessorMiddleware<DefaultDataTypes>)
+        XCTAssert(webSocket?.init_eventNotificationCenter.middlewares[0] is EventDataProcessorMiddleware<DefaultExtraData>)
         
         // Assert Client sets itself as delegate for the request encoder
         XCTAssert(webSocket?.init_requestEncoder.connectionDetailsProviderDelegate === client)
@@ -156,15 +156,15 @@ class ChatClient_Tests: StressTestCase {
         let middlewares = try XCTUnwrap(testEnv.webSocketClient?.init_eventNotificationCenter.middlewares)
         
         // Assert `EventDataProcessorMiddleware` exists
-        XCTAssert(middlewares.contains(where: { $0 is EventDataProcessorMiddleware<DefaultDataTypes> }))
+        XCTAssert(middlewares.contains(where: { $0 is EventDataProcessorMiddleware<DefaultExtraData> }))
         // Assert `TypingStartCleanupMiddleware` exists
-        let typingStartCleanupMiddlewareIndex = middlewares.firstIndex { $0 is TypingStartCleanupMiddleware<DefaultDataTypes> }
+        let typingStartCleanupMiddlewareIndex = middlewares.firstIndex { $0 is TypingStartCleanupMiddleware<DefaultExtraData> }
         XCTAssertNotNil(typingStartCleanupMiddlewareIndex)
         // Assert `ChannelReadUpdaterMiddleware` exists
-        XCTAssert(middlewares.contains(where: { $0 is ChannelReadUpdaterMiddleware<DefaultDataTypes> }))
+        XCTAssert(middlewares.contains(where: { $0 is ChannelReadUpdaterMiddleware<DefaultExtraData> }))
         // Assert `ChannelMemberTypingStateUpdaterMiddleware` exists
         let typingStateUpdaterMiddlewareIndex = middlewares
-            .firstIndex { $0 is ChannelMemberTypingStateUpdaterMiddleware<DefaultDataTypes> }
+            .firstIndex { $0 is ChannelMemberTypingStateUpdaterMiddleware<DefaultExtraData> }
         XCTAssertNotNil(typingStateUpdaterMiddlewareIndex)
         // Assert `ChannelMemberTypingStateUpdaterMiddleware` goes after `TypingStartCleanupMiddleware`
         XCTAssertTrue(typingStateUpdaterMiddlewareIndex! > typingStartCleanupMiddlewareIndex!)
@@ -277,14 +277,14 @@ class ChatClient_Tests: StressTestCase {
     func test_productionClientIsInitalizedWithAllMandatoryBackgroundWorkers() {
         // Create a new Client with production configuration
         let config = ChatClientConfig(apiKey: .init(.unique))
-        let client = Client<DefaultDataTypes>(config: config)
+        let client = Client<DefaultExtraData>(config: config)
         
         // Check all the mandatory background workers are initialized
-        XCTAssert(client.backgroundWorkers.contains { $0 is MessageSender<DefaultDataTypes> })
-        XCTAssert(client.backgroundWorkers.contains { $0 is NewChannelQueryUpdater<DefaultDataTypes> })
-        XCTAssert(client.backgroundWorkers.contains { $0 is ChannelWatchStateUpdater<DefaultDataTypes> })
-        XCTAssert(client.backgroundWorkers.contains { $0 is MessageEditor<DefaultDataTypes> })
-        XCTAssert(client.backgroundWorkers.contains { $0 is MissingEventsPublisher<DefaultDataTypes> })
+        XCTAssert(client.backgroundWorkers.contains { $0 is MessageSender<DefaultExtraData> })
+        XCTAssert(client.backgroundWorkers.contains { $0 is NewChannelQueryUpdater<DefaultExtraData> })
+        XCTAssert(client.backgroundWorkers.contains { $0 is ChannelWatchStateUpdater<DefaultExtraData> })
+        XCTAssert(client.backgroundWorkers.contains { $0 is MessageEditor<DefaultExtraData> })
+        XCTAssert(client.backgroundWorkers.contains { $0 is MissingEventsPublisher<DefaultExtraData> })
     }
     
     func test_backgroundWorkersAreInitialized() {
@@ -332,7 +332,7 @@ class ChatClient_Tests: StressTestCase {
     func test_settingUser_resetsBackgroundWorkers() {
         // TestWorker to be used for checking if workers are re-created
         class TestWorker: Worker {
-            let id: UUID = UUID()
+            let id = UUID()
         }
         
         // Custom workerBuilders for ChatClient, including only TestWorker
@@ -533,7 +533,7 @@ extension WebSocketClientMock {
             connectEndpoint: .init(path: "", method: .get, queryItems: nil, requiresConnectionId: false, body: nil),
             sessionConfiguration: .default,
             requestEncoder: DefaultRequestEncoder(baseURL: .unique(), apiKey: .init(.unique)),
-            eventDecoder: EventDecoder<DefaultDataTypes>(),
+            eventDecoder: EventDecoder<DefaultExtraData>(),
             eventNotificationCenter: .init(),
             internetConnection: InternetConnection()
         )

--- a/Sources_v3/ChatClient_Tests.swift
+++ b/Sources_v3/ChatClient_Tests.swift
@@ -277,7 +277,7 @@ class ChatClient_Tests: StressTestCase {
     func test_productionClientIsInitalizedWithAllMandatoryBackgroundWorkers() {
         // Create a new Client with production configuration
         let config = ChatClientConfig(apiKey: .init(.unique))
-        let client = Client<DefaultExtraData>(config: config)
+        let client = _ChatClient<DefaultExtraData>(config: config)
         
         // Check all the mandatory background workers are initialized
         XCTAssert(client.backgroundWorkers.contains { $0 is MessageSender<DefaultExtraData> })
@@ -307,7 +307,7 @@ class ChatClient_Tests: StressTestCase {
         }
         
         // Create a Client instance and check the TestWorker is initialized properly
-        let client = Client(
+        let client = _ChatClient(
             config: config,
             workerBuilders: [TestWorker.init],
             environment: testEnv.environment
@@ -339,7 +339,7 @@ class ChatClient_Tests: StressTestCase {
         let workerBuilders: [WorkerBuilder] = [TestWorker.init]
         
         // Create ChatClient
-        let client = Client(
+        let client = _ChatClient(
             config: inMemoryStorageConfig,
             workerBuilders: workerBuilders,
             environment: testEnv.environment
@@ -386,7 +386,7 @@ private class TestEnvironment<ExtraData: ExtraDataTypes> {
     
     @Atomic var eventDecoder: EventDecoder<ExtraData>?
     
-    lazy var environment: Client<ExtraData>.Environment = { [unowned self] in
+    lazy var environment: _ChatClient<ExtraData>.Environment = { [unowned self] in
         .init(
             apiClientBuilder: {
                 self.apiClient = APIClientMock(sessionConfiguration: $0, requestEncoder: $1, requestDecoder: $2)

--- a/Sources_v3/Controllers/ChannelController/ChannelController+Combine.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+Combine.swift
@@ -13,7 +13,7 @@ extension ChannelControllerGeneric {
     }
     
     /// A publisher emitting a new value every time the channel changes.
-    public var channelChangePublisher: AnyPublisher<EntityChange<ChannelModel<ExtraData>>, Never> {
+    public var channelChangePublisher: AnyPublisher<EntityChange<_ChatChannel<ExtraData>>, Never> {
         basePublishers.channelChange.keepAlive(self)
     }
     
@@ -43,7 +43,7 @@ extension ChannelControllerGeneric {
         let state: CurrentValueSubject<DataController.State, Never>
         
         /// A backing subject for `channelChangePublisher`.
-        let channelChange: PassthroughSubject<EntityChange<ChannelModel<ExtraData>>, Never> = .init()
+        let channelChange: PassthroughSubject<EntityChange<_ChatChannel<ExtraData>>, Never> = .init()
         
         /// A backing subject for `messagesChangesPublisher`.
         let messagesChanges: PassthroughSubject<[ListChange<MessageModel<ExtraData>>], Never> = .init()
@@ -71,7 +71,7 @@ extension ChannelControllerGeneric.BasePublishers: ChannelControllerDelegateGene
 
     func channelController(
         _ channelController: ChannelControllerGeneric<ExtraData>,
-        didUpdateChannel channel: EntityChange<ChannelModel<ExtraData>>
+        didUpdateChannel channel: EntityChange<_ChatChannel<ExtraData>>
     ) {
         channelChange.send(channel)
     }

--- a/Sources_v3/Controllers/ChannelController/ChannelController+Combine.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+Combine.swift
@@ -28,7 +28,7 @@ extension ChannelControllerGeneric {
     }
     
     /// A publisher emitting a new value every time typing members change.
-    public var typingMembersPublisher: AnyPublisher<Set<MemberModel<ExtraData.User>>, Never> {
+    public var typingMembersPublisher: AnyPublisher<Set<_ChatChannelMember<ExtraData.User>>, Never> {
         basePublishers.typingMembers.keepAlive(self)
     }
 
@@ -52,7 +52,7 @@ extension ChannelControllerGeneric {
         let memberEvent: PassthroughSubject<MemberEvent, Never> = .init()
         
         /// A backing subject for `typingMembersPublisher`.
-        let typingMembers: PassthroughSubject<Set<MemberModel<ExtraData.User>>, Never> = .init()
+        let typingMembers: PassthroughSubject<Set<_ChatChannelMember<ExtraData.User>>, Never> = .init()
                 
         init(controller: ChannelControllerGeneric<ExtraData>) {
             self.controller = controller
@@ -89,7 +89,7 @@ extension ChannelControllerGeneric.BasePublishers: ChannelControllerDelegateGene
     
     func channelController(
         _ channelController: ChannelControllerGeneric<ExtraData>,
-        didChangeTypingMembers typingMembers: Set<MemberModel<ExtraData.User>>
+        didChangeTypingMembers typingMembers: Set<_ChatChannelMember<ExtraData.User>>
     ) {
         self.typingMembers.send(typingMembers)
     }

--- a/Sources_v3/Controllers/ChannelController/ChannelController+Combine.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+Combine.swift
@@ -6,7 +6,7 @@ import Combine
 import UIKit
 
 @available(iOS 13, *)
-extension ChannelControllerGeneric {
+extension _ChatChannelController {
     /// A publisher emitting a new value every time the state of the controller changes.
     public var statePublisher: AnyPublisher<DataController.State, Never> {
         basePublishers.state.keepAlive(self)
@@ -37,7 +37,7 @@ extension ChannelControllerGeneric {
     /// and expose the published values by mapping them to a read-only `AnyPublisher` type.
     class BasePublishers {
         /// The wrapper controller
-        unowned let controller: ChannelControllerGeneric
+        unowned let controller: _ChatChannelController
         
         /// A backing subject for `statePublisher`.
         let state: CurrentValueSubject<DataController.State, Never>
@@ -54,7 +54,7 @@ extension ChannelControllerGeneric {
         /// A backing subject for `typingMembersPublisher`.
         let typingMembers: PassthroughSubject<Set<_ChatChannelMember<ExtraData.User>>, Never> = .init()
                 
-        init(controller: ChannelControllerGeneric<ExtraData>) {
+        init(controller: _ChatChannelController<ExtraData>) {
             self.controller = controller
             state = .init(controller.state)
             
@@ -64,31 +64,31 @@ extension ChannelControllerGeneric {
 }
 
 @available(iOS 13, *)
-extension ChannelControllerGeneric.BasePublishers: ChannelControllerDelegateGeneric {
+extension _ChatChannelController.BasePublishers: _ChatChannelControllerDelegate {
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
         self.state.send(state)
     }
 
     func channelController(
-        _ channelController: ChannelControllerGeneric<ExtraData>,
+        _ channelController: _ChatChannelController<ExtraData>,
         didUpdateChannel channel: EntityChange<_ChatChannel<ExtraData>>
     ) {
         channelChange.send(channel)
     }
 
     func channelController(
-        _ channelController: ChannelControllerGeneric<ExtraData>,
+        _ channelController: _ChatChannelController<ExtraData>,
         didUpdateMessages changes: [ListChange<_ChatMessage<ExtraData>>]
     ) {
         messagesChanges.send(changes)
     }
 
-    func channelController(_ channelController: ChannelControllerGeneric<ExtraData>, didReceiveMemberEvent event: MemberEvent) {
+    func channelController(_ channelController: _ChatChannelController<ExtraData>, didReceiveMemberEvent event: MemberEvent) {
         memberEvent.send(event)
     }
     
     func channelController(
-        _ channelController: ChannelControllerGeneric<ExtraData>,
+        _ channelController: _ChatChannelController<ExtraData>,
         didChangeTypingMembers typingMembers: Set<_ChatChannelMember<ExtraData.User>>
     ) {
         self.typingMembers.send(typingMembers)

--- a/Sources_v3/Controllers/ChannelController/ChannelController+Combine.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+Combine.swift
@@ -18,7 +18,7 @@ extension ChannelControllerGeneric {
     }
     
     /// A publisher emitting a new value every time the list of the messages matching the query changes.
-    public var messagesChangesPublisher: AnyPublisher<[ListChange<MessageModel<ExtraData>>], Never> {
+    public var messagesChangesPublisher: AnyPublisher<[ListChange<_ChatMessage<ExtraData>>], Never> {
         basePublishers.messagesChanges.keepAlive(self)
     }
     
@@ -46,7 +46,7 @@ extension ChannelControllerGeneric {
         let channelChange: PassthroughSubject<EntityChange<_ChatChannel<ExtraData>>, Never> = .init()
         
         /// A backing subject for `messagesChangesPublisher`.
-        let messagesChanges: PassthroughSubject<[ListChange<MessageModel<ExtraData>>], Never> = .init()
+        let messagesChanges: PassthroughSubject<[ListChange<_ChatMessage<ExtraData>>], Never> = .init()
         
         /// A backing subject for `memberEventPublisher`.
         let memberEvent: PassthroughSubject<MemberEvent, Never> = .init()
@@ -78,7 +78,7 @@ extension ChannelControllerGeneric.BasePublishers: ChannelControllerDelegateGene
 
     func channelController(
         _ channelController: ChannelControllerGeneric<ExtraData>,
-        didUpdateMessages changes: [ListChange<MessageModel<ExtraData>>]
+        didUpdateMessages changes: [ListChange<_ChatMessage<ExtraData>>]
     ) {
         messagesChanges.send(changes)
     }

--- a/Sources_v3/Controllers/ChannelController/ChannelController+Combine_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+Combine_Tests.swift
@@ -46,7 +46,7 @@ class ChannelController_Combine_Tests: iOS13TestCase {
 
     func test_channelChangePublisher() {
         // Setup Recording publishers
-        var recording = Record<EntityChange<Channel>, Never>.Recording()
+        var recording = Record<EntityChange<ChatChannel>, Never>.Recording()
         
         // Setup the chain
         channelController
@@ -58,7 +58,7 @@ class ChannelController_Combine_Tests: iOS13TestCase {
         weak var controller: ChannelControllerMock? = channelController
         channelController = nil
 
-        let newChannel: Channel = .init(cid: .unique, extraData: .defaultValue)
+        let newChannel: ChatChannel = .init(cid: .unique, extraData: .defaultValue)
         controller?.channel_simulated = newChannel
         controller?.delegateCallback {
             $0.channelController(controller!, didUpdateChannel: .create(newChannel))

--- a/Sources_v3/Controllers/ChannelController/ChannelController+Combine_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+Combine_Tests.swift
@@ -69,7 +69,7 @@ class ChannelController_Combine_Tests: iOS13TestCase {
     
     func test_messagesChangesPublisher() {
         // Setup Recording publishers
-        var recording = Record<[ListChange<MessageModel<DefaultDataTypes>>], Never>.Recording()
+        var recording = Record<[ListChange<MessageModel<DefaultExtraData>>], Never>.Recording()
         
         // Setup the chain
         channelController

--- a/Sources_v3/Controllers/ChannelController/ChannelController+Combine_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+Combine_Tests.swift
@@ -114,7 +114,7 @@ class ChannelController_Combine_Tests: iOS13TestCase {
     
     func test_typingMembersPublisher() {
         // Setup Recording publishers
-        var recording = Record<Set<Member>, Never>.Recording()
+        var recording = Record<Set<ChatChannelMember>, Never>.Recording()
         
         // Setup the chain
         channelController
@@ -126,7 +126,7 @@ class ChannelController_Combine_Tests: iOS13TestCase {
         weak var controller: ChannelControllerMock? = channelController
         channelController = nil
 
-        let typingMember = Member(
+        let typingMember = ChatChannelMember(
             id: .unique,
             isOnline: true,
             isBanned: false,

--- a/Sources_v3/Controllers/ChannelController/ChannelController+Combine_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+Combine_Tests.swift
@@ -69,7 +69,7 @@ class ChannelController_Combine_Tests: iOS13TestCase {
     
     func test_messagesChangesPublisher() {
         // Setup Recording publishers
-        var recording = Record<[ListChange<MessageModel<DefaultExtraData>>], Never>.Recording()
+        var recording = Record<[ListChange<_ChatMessage<DefaultExtraData>>], Never>.Recording()
         
         // Setup the chain
         channelController
@@ -81,7 +81,7 @@ class ChannelController_Combine_Tests: iOS13TestCase {
         weak var controller: ChannelControllerMock? = channelController
         channelController = nil
 
-        let newMessage: MessageModel = .unique
+        let newMessage: _ChatMessage = .unique
         controller?.messages_simulated = [newMessage]
         controller?.delegateCallback {
             $0.channelController(controller!, didUpdateMessages: [.insert(newMessage, index: .init())])

--- a/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI.swift
@@ -16,7 +16,7 @@ extension ChannelControllerGeneric {
         public let controller: ChannelControllerGeneric
         
         /// The channel matching the ChannelId.
-        @Published public private(set) var channel: ChannelModel<ExtraData>?
+        @Published public private(set) var channel: _ChatChannel<ExtraData>?
         
         /// The messages related to the channel.
         @Published public private(set) var messages: [MessageModel<ExtraData>] = []
@@ -45,7 +45,7 @@ extension ChannelControllerGeneric {
 extension ChannelControllerGeneric.ObservableObject: ChannelControllerDelegateGeneric {
     public func channelController(
         _ channelController: ChannelControllerGeneric<ExtraData>,
-        didUpdateChannel channel: EntityChange<ChannelModel<ExtraData>>
+        didUpdateChannel channel: EntityChange<_ChatChannel<ExtraData>>
     ) {
         self.channel = channelController.channel
     }

--- a/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI.swift
@@ -19,7 +19,7 @@ extension ChannelControllerGeneric {
         @Published public private(set) var channel: _ChatChannel<ExtraData>?
         
         /// The messages related to the channel.
-        @Published public private(set) var messages: [MessageModel<ExtraData>] = []
+        @Published public private(set) var messages: [_ChatMessage<ExtraData>] = []
         
         /// The current state of the Controller.
         @Published public private(set) var state: DataController.State
@@ -52,7 +52,7 @@ extension ChannelControllerGeneric.ObservableObject: ChannelControllerDelegateGe
    
     public func channelController(
         _ channelController: ChannelControllerGeneric<ExtraData>,
-        didUpdateMessages changes: [ListChange<MessageModel<ExtraData>>]
+        didUpdateMessages changes: [ListChange<_ChatMessage<ExtraData>>]
     ) {
         messages = channelController.messages
     }

--- a/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI.swift
@@ -6,14 +6,14 @@ import Foundation
 import SwiftUI
 
 @available(iOS 13, *)
-extension ChannelControllerGeneric {
+extension _ChatChannelController {
     /// A wrapper object that exposes the controller variables in the form of `ObservableObject` to be used in SwiftUI.
     public var observableObject: ObservableObject { .init(controller: self) }
     
     /// A wrapper object for `ChannelListController` type which makes it possible to use the controller comfortably in SwiftUI.
     public class ObservableObject: SwiftUI.ObservableObject {
         /// The underlying controller. You can still access it and call methods on it.
-        public let controller: ChannelControllerGeneric
+        public let controller: _ChatChannelController
         
         /// The channel matching the ChannelId.
         @Published public private(set) var channel: _ChatChannel<ExtraData>?
@@ -28,7 +28,7 @@ extension ChannelControllerGeneric {
         @Published public private(set) var typingMembers: Set<_ChatChannelMember<ExtraData.User>> = []
         
         /// Creates a new `ObservableObject` wrapper with the provided controller instance.
-        init(controller: ChannelControllerGeneric<ExtraData>) {
+        init(controller: _ChatChannelController<ExtraData>) {
             self.controller = controller
             state = controller.state
             
@@ -42,16 +42,16 @@ extension ChannelControllerGeneric {
 }
 
 @available(iOS 13, *)
-extension ChannelControllerGeneric.ObservableObject: ChannelControllerDelegateGeneric {
+extension _ChatChannelController.ObservableObject: _ChatChannelControllerDelegate {
     public func channelController(
-        _ channelController: ChannelControllerGeneric<ExtraData>,
+        _ channelController: _ChatChannelController<ExtraData>,
         didUpdateChannel channel: EntityChange<_ChatChannel<ExtraData>>
     ) {
         self.channel = channelController.channel
     }
    
     public func channelController(
-        _ channelController: ChannelControllerGeneric<ExtraData>,
+        _ channelController: _ChatChannelController<ExtraData>,
         didUpdateMessages changes: [ListChange<_ChatMessage<ExtraData>>]
     ) {
         messages = channelController.messages
@@ -62,7 +62,7 @@ extension ChannelControllerGeneric.ObservableObject: ChannelControllerDelegateGe
     }
     
     public func channelController(
-        _ channelController: ChannelControllerGeneric<ExtraData>,
+        _ channelController: _ChatChannelController<ExtraData>,
         didChangeTypingMembers typingMembers: Set<_ChatChannelMember<ExtraData.User>>
     ) {
         self.typingMembers = typingMembers

--- a/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI.swift
@@ -25,7 +25,7 @@ extension ChannelControllerGeneric {
         @Published public private(set) var state: DataController.State
         
         /// The typing members related to the channel.
-        @Published public private(set) var typingMembers: Set<MemberModel<ExtraData.User>> = []
+        @Published public private(set) var typingMembers: Set<_ChatChannelMember<ExtraData.User>> = []
         
         /// Creates a new `ObservableObject` wrapper with the provided controller instance.
         init(controller: ChannelControllerGeneric<ExtraData>) {
@@ -63,7 +63,7 @@ extension ChannelControllerGeneric.ObservableObject: ChannelControllerDelegateGe
     
     public func channelController(
         _ channelController: ChannelControllerGeneric<ExtraData>,
-        didChangeTypingMembers typingMembers: Set<MemberModel<ExtraData.User>>
+        didChangeTypingMembers typingMembers: Set<_ChatChannelMember<ExtraData.User>>
     ) {
         self.typingMembers = typingMembers
     }

--- a/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -46,7 +46,7 @@ class ChannelController_SwiftUI_Tests: iOS13TestCase {
         let observableObject = channelController.observableObject
         
         // Simulate messages change
-        let newMessage: Message = .unique
+        let newMessage: ChatMessage = .unique
         channelController.messages_simulated = [newMessage]
         channelController.delegateCallback {
             $0.channelController(
@@ -114,8 +114,8 @@ class ChannelControllerMock: ChannelController {
         channel_simulated
     }
     
-    var messages_simulated: [MessageModel<DefaultExtraData>]?
-    override var messages: [MessageModel<DefaultExtraData>] {
+    var messages_simulated: [_ChatMessage<DefaultExtraData>]?
+    override var messages: [_ChatMessage<DefaultExtraData>] {
         messages_simulated ?? super.messages
     }
 
@@ -134,8 +134,8 @@ class ChannelControllerMock: ChannelController {
     }
 }
 
-extension MessageModel {
-    static var unique: Message {
+extension _ChatMessage {
+    static var unique: ChatMessage {
         .init(
             id: .unique,
             text: "",

--- a/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -109,13 +109,13 @@ class ChannelController_SwiftUI_Tests: iOS13TestCase {
 class ChannelControllerMock: ChannelController {
     @Atomic var synchronize_called = false
     
-    var channel_simulated: ChannelModel<DefaultDataTypes>?
-    override var channel: ChannelModel<DefaultDataTypes>? {
+    var channel_simulated: ChannelModel<DefaultExtraData>?
+    override var channel: ChannelModel<DefaultExtraData>? {
         channel_simulated
     }
     
-    var messages_simulated: [MessageModel<DefaultDataTypes>]?
-    override var messages: [MessageModel<DefaultDataTypes>] {
+    var messages_simulated: [MessageModel<DefaultExtraData>]?
+    override var messages: [MessageModel<DefaultExtraData>] {
         messages_simulated ?? super.messages
     }
 

--- a/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -77,7 +77,7 @@ class ChannelController_SwiftUI_Tests: iOS13TestCase {
     func test_observableObject_reactsToDelegateTypingMembersChangeCallback() {
         let observableObject = channelController.observableObject
         
-        let typingMember = Member(
+        let typingMember = ChatChannelMember(
             id: .unique,
             isOnline: true,
             isBanned: false,

--- a/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -30,7 +30,7 @@ class ChannelController_SwiftUI_Tests: iOS13TestCase {
         let observableObject = channelController.observableObject
         
         // Simulate channel change
-        let newChannel: Channel = .init(cid: .unique, extraData: .defaultValue)
+        let newChannel: ChatChannel = .init(cid: .unique, extraData: .defaultValue)
         channelController.channel_simulated = newChannel
         channelController.delegateCallback {
             $0.channelController(
@@ -109,8 +109,8 @@ class ChannelController_SwiftUI_Tests: iOS13TestCase {
 class ChannelControllerMock: ChannelController {
     @Atomic var synchronize_called = false
     
-    var channel_simulated: ChannelModel<DefaultExtraData>?
-    override var channel: ChannelModel<DefaultExtraData>? {
+    var channel_simulated: _ChatChannel<DefaultExtraData>?
+    override var channel: _ChatChannel<DefaultExtraData>? {
         channel_simulated
     }
     

--- a/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -106,7 +106,7 @@ class ChannelController_SwiftUI_Tests: iOS13TestCase {
     }
 }
 
-class ChannelControllerMock: ChannelController {
+class ChannelControllerMock: ChatChannelController {
     @Atomic var synchronize_called = false
     
     var channel_simulated: _ChatChannel<DefaultExtraData>?

--- a/Sources_v3/Controllers/ChannelController/ChannelController.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController.swift
@@ -112,7 +112,7 @@ public class ChannelControllerGeneric<ExtraData: ExtraDataTypes>: DataController
     
     /// The messages related to the channel. To observe updates to the channel,
     /// set your class as a delegate of this controller or use `Combine` wrapper.
-    public var messages: [MessageModel<ExtraData>] {
+    public var messages: [_ChatMessage<ExtraData>] {
         if state == .initialized {
             setLocalStateBasedOnError(startDatabaseObservers())
         }
@@ -156,7 +156,7 @@ public class ChannelControllerGeneric<ExtraData: ExtraDataTypes>: DataController
     }
 
     @Cached private var channelObserver: EntityDatabaseObserver<_ChatChannel<ExtraData>, ChannelDTO>
-    @Cached private var messagesObserver: ListDatabaseObserver<MessageModel<ExtraData>, MessageDTO>
+    @Cached private var messagesObserver: ListDatabaseObserver<_ChatMessage<ExtraData>, MessageDTO>
     
     private var eventObservers: [EventObserver] = []
     private let environment: Environment
@@ -236,7 +236,7 @@ public class ChannelControllerGeneric<ExtraData: ExtraDataTypes>: DataController
             let observer = ListDatabaseObserver(
                 context: self.client.databaseContainer.viewContext,
                 fetchRequest: MessageDTO.messagesFetchRequest(for: self.channelQuery.cid, sortAscending: sortAscending),
-                itemCreator: { $0.asModel() as MessageModel<ExtraData> }
+                itemCreator: { $0.asModel() as _ChatMessage<ExtraData> }
             )
             observer.onChange = { changes in
                 self.delegateCallback {
@@ -711,7 +711,7 @@ public protocol ChannelControllerDelegate: DataControllerStateDelegate {
     /// The controller observed changes in the `Messages` of the observed channel.
     func channelController(
         _ channelController: ChannelController,
-        didUpdateMessages changes: [ListChange<Message>]
+        didUpdateMessages changes: [ListChange<ChatMessage>]
     )
 
     /// The controller received a `MemberEvent` related to the channel it observes.
@@ -729,7 +729,7 @@ public extension ChannelControllerDelegate {
     
     func channelController(
         _ channelController: ChannelController,
-        didUpdateMessages changes: [ListChange<Message>]
+        didUpdateMessages changes: [ListChange<ChatMessage>]
     ) {}
 
     func channelController(_ channelController: ChannelController, didReceiveMemberEvent: MemberEvent) {}
@@ -755,7 +755,7 @@ public protocol ChannelControllerDelegateGeneric: DataControllerStateDelegate {
     /// The controller observed changes in the `Messages` of the observed channel.
     func channelController(
         _ channelController: ChannelControllerGeneric<ExtraData>,
-        didUpdateMessages changes: [ListChange<MessageModel<ExtraData>>]
+        didUpdateMessages changes: [ListChange<_ChatMessage<ExtraData>>]
     )
 
     /// The controller received a `MemberEvent` related to the channel it observes.
@@ -776,7 +776,7 @@ public extension ChannelControllerDelegateGeneric {
     
     func channelController(
         _ channelController: ChannelController,
-        didUpdateMessages changes: [ListChange<MessageModel<ExtraData>>]
+        didUpdateMessages changes: [ListChange<_ChatMessage<ExtraData>>]
     ) {}
 
     func channelController(_ channelController: ChannelControllerGeneric<ExtraData>, didReceiveMemberEvent: MemberEvent) {}
@@ -792,7 +792,7 @@ public extension ChannelControllerDelegateGeneric {
 class AnyChannelControllerDelegate<ExtraData: ExtraDataTypes>: ChannelControllerDelegateGeneric {
     private var _controllerdidUpdateMessages: (
         ChannelControllerGeneric<ExtraData>,
-        [ListChange<MessageModel<ExtraData>>]
+        [ListChange<_ChatMessage<ExtraData>>]
     ) -> Void
     
     private var _controllerDidUpdateChannel: (
@@ -823,7 +823,7 @@ class AnyChannelControllerDelegate<ExtraData: ExtraDataTypes>: ChannelController
         ) -> Void,
         controllerdidUpdateMessages: @escaping (
             ChannelControllerGeneric<ExtraData>,
-            [ListChange<MessageModel<ExtraData>>]
+            [ListChange<_ChatMessage<ExtraData>>]
         ) -> Void,
         controllerDidReceiveMemberEvent: @escaping (
             ChannelControllerGeneric<ExtraData>,
@@ -855,7 +855,7 @@ class AnyChannelControllerDelegate<ExtraData: ExtraDataTypes>: ChannelController
     
     func channelController(
         _ controller: ChannelControllerGeneric<ExtraData>,
-        didUpdateMessages changes: [ListChange<MessageModel<ExtraData>>]
+        didUpdateMessages changes: [ListChange<_ChatMessage<ExtraData>>]
     ) {
         _controllerdidUpdateMessages(controller, changes)
     }

--- a/Sources_v3/Controllers/ChannelController/ChannelController.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController.swift
@@ -5,7 +5,7 @@
 import CoreData
 import Foundation
 
-extension Client {
+extension _ChatClient {
     /// Creates a new `ChannelController` for the channel with the provided id and options.
     ///
     /// - Parameter channelId: The id of the channel this controller represents.
@@ -99,7 +99,7 @@ public class ChannelControllerGeneric<ExtraData: ExtraDataTypes>: DataController
     private var channelId: ChannelId { channelQuery.cid }
     
     /// The `ChatClient` instance this controller belongs to.
-    public let client: Client<ExtraData>
+    public let client: _ChatClient<ExtraData>
     
     /// The channel matching the channelId. To observe updates to the channel,
     /// set your class as a delegate of this controller or use `Combine` wrapper.
@@ -197,7 +197,7 @@ public class ChannelControllerGeneric<ExtraData: ExtraDataTypes>: DataController
     ///   - isChannelAlreadyCreated: Flag indicating whether channel is created on backend.
     init(
         channelQuery: ChannelQuery<ExtraData>,
-        client: Client<ExtraData>,
+        client: _ChatClient<ExtraData>,
         environment: Environment = .init(),
         isChannelAlreadyCreated: Bool = true
     ) {

--- a/Sources_v3/Controllers/ChannelController/ChannelController.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController.swift
@@ -103,7 +103,7 @@ public class ChannelControllerGeneric<ExtraData: ExtraDataTypes>: DataController
     
     /// The channel matching the channelId. To observe updates to the channel,
     /// set your class as a delegate of this controller or use `Combine` wrapper.
-    public var channel: ChannelModel<ExtraData>? {
+    public var channel: _ChatChannel<ExtraData>? {
         if state == .initialized {
             setLocalStateBasedOnError(startDatabaseObservers())
         }
@@ -155,7 +155,7 @@ public class ChannelControllerGeneric<ExtraData: ExtraDataTypes>: DataController
         }
     }
 
-    @Cached private var channelObserver: EntityDatabaseObserver<ChannelModel<ExtraData>, ChannelDTO>
+    @Cached private var channelObserver: EntityDatabaseObserver<_ChatChannel<ExtraData>, ChannelDTO>
     @Cached private var messagesObserver: ListDatabaseObserver<MessageModel<ExtraData>, MessageDTO>
     
     private var eventObservers: [EventObserver] = []
@@ -216,7 +216,7 @@ public class ChannelControllerGeneric<ExtraData: ExtraDataTypes>: DataController
             let observer = EntityDatabaseObserver(
                 context: self.client.databaseContainer.viewContext,
                 fetchRequest: ChannelDTO.fetchRequest(for: self.channelQuery.cid),
-                itemCreator: { $0.asModel() as ChannelModel<ExtraData> }
+                itemCreator: { $0.asModel() as _ChatChannel<ExtraData> }
             ).onChange { change in
                 self.delegateCallback { $0.channelController(self, didUpdateChannel: change) }
             }
@@ -705,7 +705,7 @@ public protocol ChannelControllerDelegate: DataControllerStateDelegate {
     /// The controller observed a change in the `Channel` entity.
     func channelController(
         _ channelController: ChannelController,
-        didUpdateChannel channel: EntityChange<Channel>
+        didUpdateChannel channel: EntityChange<ChatChannel>
     )
     
     /// The controller observed changes in the `Messages` of the observed channel.
@@ -724,7 +724,7 @@ public protocol ChannelControllerDelegate: DataControllerStateDelegate {
 public extension ChannelControllerDelegate {
     func channelController(
         _ channelController: ChannelController,
-        didUpdateChannel channel: EntityChange<Channel>
+        didUpdateChannel channel: EntityChange<ChatChannel>
     ) {}
     
     func channelController(
@@ -749,7 +749,7 @@ public protocol ChannelControllerDelegateGeneric: DataControllerStateDelegate {
     /// The controller observed a change in the `Channel` entity.
     func channelController(
         _ channelController: ChannelControllerGeneric<ExtraData>,
-        didUpdateChannel channel: EntityChange<ChannelModel<ExtraData>>
+        didUpdateChannel channel: EntityChange<_ChatChannel<ExtraData>>
     )
     
     /// The controller observed changes in the `Messages` of the observed channel.
@@ -771,7 +771,7 @@ public protocol ChannelControllerDelegateGeneric: DataControllerStateDelegate {
 public extension ChannelControllerDelegateGeneric {
     func channelController(
         _ channelController: ChannelControllerGeneric<ExtraData>,
-        didUpdateChannel channel: EntityChange<ChannelModel<ExtraData>>
+        didUpdateChannel channel: EntityChange<_ChatChannel<ExtraData>>
     ) {}
     
     func channelController(
@@ -797,7 +797,7 @@ class AnyChannelControllerDelegate<ExtraData: ExtraDataTypes>: ChannelController
     
     private var _controllerDidUpdateChannel: (
         ChannelControllerGeneric<ExtraData>,
-        EntityChange<ChannelModel<ExtraData>>
+        EntityChange<_ChatChannel<ExtraData>>
     ) -> Void
 
     private var _controllerDidChangeState: (DataController, DataController.State) -> Void
@@ -819,7 +819,7 @@ class AnyChannelControllerDelegate<ExtraData: ExtraDataTypes>: ChannelController
         controllerDidChangeState: @escaping (DataController, DataController.State) -> Void,
         controllerDidUpdateChannel: @escaping (
             ChannelControllerGeneric<ExtraData>,
-            EntityChange<ChannelModel<ExtraData>>
+            EntityChange<_ChatChannel<ExtraData>>
         ) -> Void,
         controllerdidUpdateMessages: @escaping (
             ChannelControllerGeneric<ExtraData>,
@@ -848,7 +848,7 @@ class AnyChannelControllerDelegate<ExtraData: ExtraDataTypes>: ChannelController
     
     func channelController(
         _ controller: ChannelControllerGeneric<ExtraData>,
-        didUpdateChannel channel: EntityChange<ChannelModel<ExtraData>>
+        didUpdateChannel channel: EntityChange<_ChatChannel<ExtraData>>
     ) {
         _controllerDidUpdateChannel(controller, channel)
     }

--- a/Sources_v3/Controllers/ChannelController/ChannelController.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController.swift
@@ -718,7 +718,7 @@ public protocol ChannelControllerDelegate: DataControllerStateDelegate {
     func channelController(_ channelController: ChannelController, didReceiveMemberEvent: MemberEvent)
     
     /// The controller received a change related to memebers typing in the channel it observes.
-    func channelController(_ channelController: ChannelController, didChangeTypingMembers typingMembers: Set<Member>)
+    func channelController(_ channelController: ChannelController, didChangeTypingMembers typingMembers: Set<ChatChannelMember>)
 }
 
 public extension ChannelControllerDelegate {
@@ -734,7 +734,7 @@ public extension ChannelControllerDelegate {
 
     func channelController(_ channelController: ChannelController, didReceiveMemberEvent: MemberEvent) {}
     
-    func channelController(_ channelController: ChannelController, didChangeTypingMembers typingMembers: Set<Member>) {}
+    func channelController(_ channelController: ChannelController, didChangeTypingMembers typingMembers: Set<ChatChannelMember>) {}
 }
 
 // MARK: Generic Delegates
@@ -764,7 +764,7 @@ public protocol ChannelControllerDelegateGeneric: DataControllerStateDelegate {
     /// The controller received a change related to memebers typing in the channel it observes.
     func channelController(
         _ channelController: ChannelControllerGeneric<ExtraData>,
-        didChangeTypingMembers typingMembers: Set<MemberModel<ExtraData.User>>
+        didChangeTypingMembers typingMembers: Set<_ChatChannelMember<ExtraData.User>>
     )
 }
 
@@ -783,7 +783,7 @@ public extension ChannelControllerDelegateGeneric {
     
     func channelController(
         _ channelController: ChannelControllerGeneric<ExtraData>,
-        didChangeTypingMembers: Set<MemberModel<ExtraData.User>>
+        didChangeTypingMembers: Set<_ChatChannelMember<ExtraData.User>>
     ) {}
 }
 
@@ -809,7 +809,7 @@ class AnyChannelControllerDelegate<ExtraData: ExtraDataTypes>: ChannelController
     
     private var _controllerDidChangeTypingMembers: (
         ChannelControllerGeneric<ExtraData>,
-        Set<MemberModel<ExtraData.User>>
+        Set<_ChatChannelMember<ExtraData.User>>
     ) -> Void
 
     weak var wrappedDelegate: AnyObject?
@@ -831,7 +831,7 @@ class AnyChannelControllerDelegate<ExtraData: ExtraDataTypes>: ChannelController
         ) -> Void,
         controllerDidChangeTypingMembers: @escaping (
             ChannelControllerGeneric<ExtraData>,
-            Set<MemberModel<ExtraData.User>>
+            Set<_ChatChannelMember<ExtraData.User>>
         ) -> Void
     ) {
         self.wrappedDelegate = wrappedDelegate
@@ -869,7 +869,7 @@ class AnyChannelControllerDelegate<ExtraData: ExtraDataTypes>: ChannelController
     
     func channelController(
         _ channelController: ChannelControllerGeneric<ExtraData>,
-        didChangeTypingMembers typingMembers: Set<MemberModel<ExtraData.User>>
+        didChangeTypingMembers typingMembers: Set<_ChatChannelMember<ExtraData.User>>
     ) {
         _controllerDidChangeTypingMembers(channelController, typingMembers)
     }

--- a/Sources_v3/Controllers/ChannelController/ChannelController.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController.swift
@@ -75,8 +75,8 @@ extension Client {
     }
 }
 
-/// A convenience typealias for `ChannelControllerGeneric` with `DefaultDataTypes`
-public typealias ChannelController = ChannelControllerGeneric<DefaultDataTypes>
+/// A convenience typealias for `ChannelControllerGeneric` with `DefaultExtraData`
+public typealias ChannelController = ChannelControllerGeneric<DefaultExtraData>
 
 /// Describes the flow of the items in the list
 public enum ListOrdering {
@@ -683,7 +683,7 @@ extension ChannelControllerGeneric {
     }
 }
 
-public extension ChannelControllerGeneric where ExtraData == DefaultDataTypes {
+public extension ChannelControllerGeneric where ExtraData == DefaultExtraData {
     /// Set the delegate of `ChannelController` to observe the changes in the system.
     ///
     /// - Note: The delegate can be set directly only if you're **not** using custom extra data types. Due to the current
@@ -892,7 +892,7 @@ extension AnyChannelControllerDelegate {
     }
 }
 
-extension AnyChannelControllerDelegate where ExtraData == DefaultDataTypes {
+extension AnyChannelControllerDelegate where ExtraData == DefaultExtraData {
     convenience init(_ delegate: ChannelControllerDelegate?) {
         self.init(
             wrappedDelegate: delegate,

--- a/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
@@ -224,7 +224,7 @@ class ChannelController_Tests: StressTestCase {
         
         // Simulate an incoming message
         let newMesageId: MessageId = .unique
-        let newMessagePayload: MessagePayload<DefaultDataTypes> = .dummy(messageId: newMesageId, authorUserId: .unique)
+        let newMessagePayload: MessagePayload<DefaultExtraData> = .dummy(messageId: newMesageId, authorUserId: .unique)
         _ = try await {
             client.databaseContainer.write({ session in
                 try session.saveMessage(payload: newMessagePayload, for: self.channelId)
@@ -240,8 +240,8 @@ class ChannelController_Tests: StressTestCase {
         try client.databaseContainer.createChannel(cid: channelId, withMessages: false)
         
         // Insert two messages
-        let message1: MessagePayload<DefaultDataTypes> = .dummy(messageId: .unique, authorUserId: .unique)
-        let message2: MessagePayload<DefaultDataTypes> = .dummy(messageId: .unique, authorUserId: .unique)
+        let message1: MessagePayload<DefaultExtraData> = .dummy(messageId: .unique, authorUserId: .unique)
+        let message2: MessagePayload<DefaultExtraData> = .dummy(messageId: .unique, authorUserId: .unique)
         
         try client.databaseContainer.writeSynchronously {
             try $0.saveMessage(payload: message1, for: self.channelId)
@@ -540,7 +540,7 @@ class ChannelController_Tests: StressTestCase {
     
     // MARK: - Channel actions propagation tests
 
-    func setupControllerForNewChannel(query: ChannelQuery<DefaultDataTypes>) {
+    func setupControllerForNewChannel(query: ChannelQuery<DefaultExtraData>) {
         controller = ChannelController(
             channelQuery: query,
             client: client,
@@ -963,13 +963,13 @@ class ChannelController_Tests: StressTestCase {
     
     // Helper function that creates channel with message
     func setupChannelWithMessage(_ session: DatabaseSession) throws -> MessageId {
-        let dummyUserPayload: CurrentUserPayload<DefaultDataTypes.User> = .dummy(userId: .unique, role: .user)
+        let dummyUserPayload: CurrentUserPayload<DefaultExtraData.User> = .dummy(userId: .unique, role: .user)
         try session.saveCurrentUser(payload: dummyUserPayload)
         try session.saveChannel(payload: dummyPayload(with: channelId))
         let message = try session.createNewMessage(
             in: channelId,
             text: "Message",
-            extraData: DefaultDataTypes.Message.defaultValue
+            extraData: DefaultExtraData.Message.defaultValue
         )
         return message.id
     }
@@ -1191,7 +1191,7 @@ class ChannelController_Tests: StressTestCase {
         let arguments: String = .unique
         let parentMessageId: MessageId = .unique
         let showReplyInChannel = true
-        let extraData: DefaultDataTypes.Message = .defaultValue
+        let extraData: DefaultExtraData.Message = .defaultValue
         
         // Simulate `createNewMessage` calls and catch the completion
         var completionCalled = false
@@ -1468,8 +1468,8 @@ class ChannelController_Tests: StressTestCase {
 }
 
 private class TestEnvironment {
-    var channelUpdater: ChannelUpdaterMock<DefaultDataTypes>?
-    var eventSender: EventSenderMock<DefaultDataTypes>?
+    var channelUpdater: ChannelUpdaterMock<DefaultExtraData>?
+    var eventSender: EventSenderMock<DefaultExtraData>?
     
     lazy var environment: ChannelController.Environment = .init(
         channelUpdaterBuilder: { [unowned self] in

--- a/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
@@ -22,7 +22,7 @@ class ChannelController_Tests: StressTestCase {
         super.setUp()
         
         env = TestEnvironment()
-        client = Client.mock
+        client = _ChatClient.mock
         channelId = ChannelId.unique
         controller = ChannelController(channelQuery: .init(cid: channelId), client: client, environment: env.environment)
         controllerCallbackQueueID = UUID()

--- a/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
@@ -350,7 +350,7 @@ class ChannelController_Tests: StressTestCase {
         XCTAssertNil(error)
         let channel: ChatChannel = client.databaseContainer.viewContext.channel(cid: channelId)!.asModel()
         assert(channel.latestMessages.count == 1)
-        let message: Message = channel.latestMessages.first!
+        let message: ChatMessage = channel.latestMessages.first!
 
         // Assert DB observers call delegate updates
         AssertAsync {
@@ -372,7 +372,7 @@ class ChannelController_Tests: StressTestCase {
         XCTAssertNil(error)
         let newChannel: ChatChannel = client.databaseContainer.viewContext.channel(cid: newCid)!.asModel()
         assert(channel.latestMessages.count == 1)
-        let newMessage: Message = newChannel.latestMessages.first!
+        let newMessage: ChatMessage = newChannel.latestMessages.first!
 
         // Assert DB observers call delegate updates for new `cid`
         AssertAsync {
@@ -504,7 +504,7 @@ class ChannelController_Tests: StressTestCase {
         XCTAssertNil(error)
         let channel: ChatChannel = client.databaseContainer.viewContext.channel(cid: channelId)!.asModel()
         assert(channel.latestMessages.count == 1)
-        let message: Message = channel.latestMessages.first!
+        let message: ChatMessage = channel.latestMessages.first!
         
         AssertAsync {
             Assert.willBeEqual(delegate.didUpdateChannel_channel, .create(channel))
@@ -530,7 +530,7 @@ class ChannelController_Tests: StressTestCase {
         }
         let channel: ChatChannel = client.databaseContainer.viewContext.channel(cid: channelId)!.asModel()
         assert(channel.latestMessages.count == 1)
-        let message: Message = channel.latestMessages.first!
+        let message: ChatMessage = channel.latestMessages.first!
         
         AssertAsync {
             Assert.willBeEqual(delegate.didUpdateChannel_channel, .create(channel))
@@ -1489,7 +1489,7 @@ private class TestDelegate: QueueAwareDelegate, ChannelControllerDelegate {
     @Atomic var willStartFetchingRemoteDataCalledCounter = 0
     @Atomic var didStopFetchingRemoteDataCalledCounter = 0
     @Atomic var didUpdateChannel_channel: EntityChange<ChatChannel>?
-    @Atomic var didUpdateMessages_messages: [ListChange<Message>]?
+    @Atomic var didUpdateMessages_messages: [ListChange<ChatMessage>]?
     @Atomic var didReceiveMemberEvent_event: MemberEvent?
     @Atomic var didChangeTypingMembers_typingMembers: Set<Member>?
     
@@ -1508,7 +1508,7 @@ private class TestDelegate: QueueAwareDelegate, ChannelControllerDelegate {
         validateQueue()
     }
     
-    func channelController(_ channelController: ChannelController, didUpdateMessages changes: [ListChange<Message>]) {
+    func channelController(_ channelController: ChannelController, didUpdateMessages changes: [ListChange<ChatMessage>]) {
         didUpdateMessages_messages = changes
         validateQueue()
     }
@@ -1533,7 +1533,7 @@ private class TestDelegate: QueueAwareDelegate, ChannelControllerDelegate {
 private class TestDelegateGeneric: QueueAwareDelegate, ChannelControllerDelegateGeneric {
     @Atomic var state: DataController.State?
     @Atomic var didUpdateChannel_channel: EntityChange<ChatChannel>?
-    @Atomic var didUpdateMessages_messages: [ListChange<Message>]?
+    @Atomic var didUpdateMessages_messages: [ListChange<ChatMessage>]?
     @Atomic var didReceiveMemberEvent_event: MemberEvent?
     @Atomic var didChangeTypingMembers_typingMembers: Set<Member>?
     
@@ -1542,7 +1542,7 @@ private class TestDelegateGeneric: QueueAwareDelegate, ChannelControllerDelegate
         validateQueue()
     }
     
-    func channelController(_ channelController: ChannelController, didUpdateMessages changes: [ListChange<Message>]) {
+    func channelController(_ channelController: ChannelController, didUpdateMessages changes: [ListChange<ChatMessage>]) {
         didUpdateMessages_messages = changes
         validateQueue()
     }

--- a/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
@@ -442,7 +442,7 @@ class ChannelController_Tests: StressTestCase {
         }
         
         // Load the channel member
-        var typingMember: Member {
+        var typingMember: ChatChannelMember {
             client.databaseContainer.viewContext.member(userId: memberId, cid: channelId)!.asModel()
         }
         
@@ -473,7 +473,7 @@ class ChannelController_Tests: StressTestCase {
         }
         
         // Load the channel member
-        var typingMember: Member {
+        var typingMember: ChatChannelMember {
             client.databaseContainer.viewContext.member(userId: memberId, cid: channelId)!.asModel()
         }
         
@@ -1491,7 +1491,7 @@ private class TestDelegate: QueueAwareDelegate, ChannelControllerDelegate {
     @Atomic var didUpdateChannel_channel: EntityChange<ChatChannel>?
     @Atomic var didUpdateMessages_messages: [ListChange<ChatMessage>]?
     @Atomic var didReceiveMemberEvent_event: MemberEvent?
-    @Atomic var didChangeTypingMembers_typingMembers: Set<Member>?
+    @Atomic var didChangeTypingMembers_typingMembers: Set<ChatChannelMember>?
     
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
         self.state = state
@@ -1523,7 +1523,7 @@ private class TestDelegate: QueueAwareDelegate, ChannelControllerDelegate {
         validateQueue()
     }
     
-    func channelController(_ channelController: ChannelController, didChangeTypingMembers typingMembers: Set<Member>) {
+    func channelController(_ channelController: ChannelController, didChangeTypingMembers typingMembers: Set<ChatChannelMember>) {
         didChangeTypingMembers_typingMembers = typingMembers
         validateQueue()
     }
@@ -1535,7 +1535,7 @@ private class TestDelegateGeneric: QueueAwareDelegate, ChannelControllerDelegate
     @Atomic var didUpdateChannel_channel: EntityChange<ChatChannel>?
     @Atomic var didUpdateMessages_messages: [ListChange<ChatMessage>]?
     @Atomic var didReceiveMemberEvent_event: MemberEvent?
-    @Atomic var didChangeTypingMembers_typingMembers: Set<Member>?
+    @Atomic var didChangeTypingMembers_typingMembers: Set<ChatChannelMember>?
     
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
         self.state = state
@@ -1557,7 +1557,7 @@ private class TestDelegateGeneric: QueueAwareDelegate, ChannelControllerDelegate
         validateQueue()
     }
     
-    func channelController(_ channelController: ChannelController, didChangeTypingMembers typingMembers: Set<Member>) {
+    func channelController(_ channelController: ChannelController, didChangeTypingMembers typingMembers: Set<ChatChannelMember>) {
         didChangeTypingMembers_typingMembers = typingMembers
         validateQueue()
     }

--- a/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
@@ -348,7 +348,7 @@ class ChannelController_Tests: StressTestCase {
             }, completion: $0)
         }
         XCTAssertNil(error)
-        let channel: Channel = client.databaseContainer.viewContext.channel(cid: channelId)!.asModel()
+        let channel: ChatChannel = client.databaseContainer.viewContext.channel(cid: channelId)!.asModel()
         assert(channel.latestMessages.count == 1)
         let message: Message = channel.latestMessages.first!
 
@@ -370,7 +370,7 @@ class ChannelController_Tests: StressTestCase {
             }, completion: $0)
         }
         XCTAssertNil(error)
-        let newChannel: Channel = client.databaseContainer.viewContext.channel(cid: newCid)!.asModel()
+        let newChannel: ChatChannel = client.databaseContainer.viewContext.channel(cid: newCid)!.asModel()
         assert(channel.latestMessages.count == 1)
         let newMessage: Message = newChannel.latestMessages.first!
 
@@ -502,7 +502,7 @@ class ChannelController_Tests: StressTestCase {
             }, completion: $0)
         }
         XCTAssertNil(error)
-        let channel: Channel = client.databaseContainer.viewContext.channel(cid: channelId)!.asModel()
+        let channel: ChatChannel = client.databaseContainer.viewContext.channel(cid: channelId)!.asModel()
         assert(channel.latestMessages.count == 1)
         let message: Message = channel.latestMessages.first!
         
@@ -528,7 +528,7 @@ class ChannelController_Tests: StressTestCase {
                 try session.saveChannel(payload: self.dummyPayload(with: self.channelId), query: nil)
             }, completion: $0)
         }
-        let channel: Channel = client.databaseContainer.viewContext.channel(cid: channelId)!.asModel()
+        let channel: ChatChannel = client.databaseContainer.viewContext.channel(cid: channelId)!.asModel()
         assert(channel.latestMessages.count == 1)
         let message: Message = channel.latestMessages.first!
         
@@ -1488,7 +1488,7 @@ private class TestDelegate: QueueAwareDelegate, ChannelControllerDelegate {
     @Atomic var state: DataController.State?
     @Atomic var willStartFetchingRemoteDataCalledCounter = 0
     @Atomic var didStopFetchingRemoteDataCalledCounter = 0
-    @Atomic var didUpdateChannel_channel: EntityChange<Channel>?
+    @Atomic var didUpdateChannel_channel: EntityChange<ChatChannel>?
     @Atomic var didUpdateMessages_messages: [ListChange<Message>]?
     @Atomic var didReceiveMemberEvent_event: MemberEvent?
     @Atomic var didChangeTypingMembers_typingMembers: Set<Member>?
@@ -1513,7 +1513,7 @@ private class TestDelegate: QueueAwareDelegate, ChannelControllerDelegate {
         validateQueue()
     }
     
-    func channelController(_ channelController: ChannelController, didUpdateChannel channel: EntityChange<Channel>) {
+    func channelController(_ channelController: ChannelController, didUpdateChannel channel: EntityChange<ChatChannel>) {
         didUpdateChannel_channel = channel
         validateQueue()
     }
@@ -1532,7 +1532,7 @@ private class TestDelegate: QueueAwareDelegate, ChannelControllerDelegate {
 /// A concrete `ChannelControllerDelegateGeneric` implementation allowing capturing the delegate calls.
 private class TestDelegateGeneric: QueueAwareDelegate, ChannelControllerDelegateGeneric {
     @Atomic var state: DataController.State?
-    @Atomic var didUpdateChannel_channel: EntityChange<Channel>?
+    @Atomic var didUpdateChannel_channel: EntityChange<ChatChannel>?
     @Atomic var didUpdateMessages_messages: [ListChange<Message>]?
     @Atomic var didReceiveMemberEvent_event: MemberEvent?
     @Atomic var didChangeTypingMembers_typingMembers: Set<Member>?
@@ -1547,7 +1547,7 @@ private class TestDelegateGeneric: QueueAwareDelegate, ChannelControllerDelegate
         validateQueue()
     }
     
-    func channelController(_ channelController: ChannelController, didUpdateChannel channel: EntityChange<Channel>) {
+    func channelController(_ channelController: ChannelController, didUpdateChannel channel: EntityChange<ChatChannel>) {
         didUpdateChannel_channel = channel
         validateQueue()
     }

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController+Combine.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController+Combine.swift
@@ -13,7 +13,7 @@ extension ChannelListControllerGeneric {
     }
     
     /// A publisher emitting a new value every time the list of the channels matching the query changes.
-    public var channelsChangesPublisher: AnyPublisher<[ListChange<ChannelModel<ExtraData>>], Never> {
+    public var channelsChangesPublisher: AnyPublisher<[ListChange<_ChatChannel<ExtraData>>], Never> {
         basePublishers.channelsChanges.keepAlive(self)
     }
 
@@ -28,7 +28,7 @@ extension ChannelListControllerGeneric {
         let state: CurrentValueSubject<DataController.State, Never>
         
         /// A backing subject for `channelsChangesPublisher`.
-        let channelsChanges: PassthroughSubject<[ListChange<ChannelModel<ExtraData>>], Never> = .init()
+        let channelsChanges: PassthroughSubject<[ListChange<_ChatChannel<ExtraData>>], Never> = .init()
                 
         init(controller: ChannelListControllerGeneric<ExtraData>) {
             self.controller = controller
@@ -47,7 +47,7 @@ extension ChannelListControllerGeneric.BasePublishers: ChannelListControllerDele
     
     func controller(
         _ controller: ChannelListControllerGeneric<ExtraData>,
-        didChangeChannels changes: [ListChange<ChannelModel<ExtraData>>]
+        didChangeChannels changes: [ListChange<_ChatChannel<ExtraData>>]
     ) {
         channelsChanges.send(changes)
     }

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController+Combine.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController+Combine.swift
@@ -6,7 +6,7 @@ import Combine
 import UIKit
 
 @available(iOS 13, *)
-extension ChannelListControllerGeneric {
+extension _ChatChannelListController {
     /// A publisher emitting a new value every time the state of the controller changes.
     public var statePublisher: AnyPublisher<DataController.State, Never> {
         basePublishers.state.keepAlive(self)
@@ -22,7 +22,7 @@ extension ChannelListControllerGeneric {
     /// and expose the published values by mapping them to a read-only `AnyPublisher` type.
     class BasePublishers {
         /// The wrapper controller
-        unowned let controller: ChannelListControllerGeneric
+        unowned let controller: _ChatChannelListController
         
         /// A backing subject for `statePublisher`.
         let state: CurrentValueSubject<DataController.State, Never>
@@ -30,7 +30,7 @@ extension ChannelListControllerGeneric {
         /// A backing subject for `channelsChangesPublisher`.
         let channelsChanges: PassthroughSubject<[ListChange<_ChatChannel<ExtraData>>], Never> = .init()
                 
-        init(controller: ChannelListControllerGeneric<ExtraData>) {
+        init(controller: _ChatChannelListController<ExtraData>) {
             self.controller = controller
             state = .init(controller.state)
             
@@ -40,13 +40,13 @@ extension ChannelListControllerGeneric {
 }
 
 @available(iOS 13, *)
-extension ChannelListControllerGeneric.BasePublishers: ChannelListControllerDelegateGeneric {
+extension _ChatChannelListController.BasePublishers: _ChatChannelListControllerDelegate {
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
         self.state.send(state)
     }
     
     func controller(
-        _ controller: ChannelListControllerGeneric<ExtraData>,
+        _ controller: _ChatChannelListController<ExtraData>,
         didChangeChannels changes: [ListChange<_ChatChannel<ExtraData>>]
     ) {
         channelsChanges.send(changes)

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController+Combine_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController+Combine_Tests.swift
@@ -46,7 +46,7 @@ class ChannelListController_Combine_Tests: iOS13TestCase {
 
     func test_channelsChangesPublisher() {
         // Setup Recording publishers
-        var recording = Record<[ListChange<Channel>], Never>.Recording()
+        var recording = Record<[ListChange<ChatChannel>], Never>.Recording()
         
         // Setup the chain
         channelListController
@@ -58,7 +58,7 @@ class ChannelListController_Combine_Tests: iOS13TestCase {
         weak var controller: ChannelListControllerMock? = channelListController
         channelListController = nil
 
-        let newChannel: Channel = .init(cid: .unique, extraData: .defaultValue)
+        let newChannel: ChatChannel = .init(cid: .unique, extraData: .defaultValue)
         controller?.channels_simulated = [newChannel]
         controller?.delegateCallback {
             $0.controller(controller!, didChangeChannels: [.insert(newChannel, index: [0, 1])])

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController+SwiftUI.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController+SwiftUI.swift
@@ -16,7 +16,7 @@ extension ChannelListControllerGeneric {
         public let controller: ChannelListControllerGeneric
         
         /// The channels matching the query.
-        @Published public private(set) var channels: [ChannelModel<ExtraData>] = []
+        @Published public private(set) var channels: [_ChatChannel<ExtraData>] = []
         
         /// The current state of the Controller.
         @Published public private(set) var state: DataController.State
@@ -36,7 +36,7 @@ extension ChannelListControllerGeneric {
 extension ChannelListControllerGeneric.ObservableObject: ChannelListControllerDelegateGeneric {
     public func controller(
         _ controller: ChannelListControllerGeneric<ExtraData>,
-        didChangeChannels changes: [ListChange<ChannelModel<ExtraData>>]
+        didChangeChannels changes: [ListChange<_ChatChannel<ExtraData>>]
     ) {
         // We don't care about detailed changes. We just need to update the `channels` property and keep SwiftUI
         // deal with the rest.

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController+SwiftUI.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController+SwiftUI.swift
@@ -6,14 +6,14 @@ import Foundation
 import SwiftUI
 
 @available(iOS 13, *)
-extension ChannelListControllerGeneric {
+extension _ChatChannelListController {
     /// A wrapper object that exposes the controller variables in the form of `ObservableObject` to be used in SwiftUI.
     public var observableObject: ObservableObject { .init(controller: self) }
     
     /// A wrapper object for `ChannelListController` type which makes it possible to use the controller comfortably in SwiftUI.
     public class ObservableObject: SwiftUI.ObservableObject {
         /// The underlying controller. You can still access it and call methods on it.
-        public let controller: ChannelListControllerGeneric
+        public let controller: _ChatChannelListController
         
         /// The channels matching the query.
         @Published public private(set) var channels: [_ChatChannel<ExtraData>] = []
@@ -22,7 +22,7 @@ extension ChannelListControllerGeneric {
         @Published public private(set) var state: DataController.State
         
         /// Creates a new `ObservableObject` wrapper with the provided controller instance.
-        init(controller: ChannelListControllerGeneric<ExtraData>) {
+        init(controller: _ChatChannelListController<ExtraData>) {
             self.controller = controller
             state = controller.state
             
@@ -33,9 +33,9 @@ extension ChannelListControllerGeneric {
 }
 
 @available(iOS 13, *)
-extension ChannelListControllerGeneric.ObservableObject: ChannelListControllerDelegateGeneric {
+extension _ChatChannelListController.ObservableObject: _ChatChannelListControllerDelegate {
     public func controller(
-        _ controller: ChannelListControllerGeneric<ExtraData>,
+        _ controller: _ChatChannelListController<ExtraData>,
         didChangeChannels changes: [ListChange<_ChatChannel<ExtraData>>]
     ) {
         // We don't care about detailed changes. We just need to update the `channels` property and keep SwiftUI

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController+SwiftUI_Tests.swift
@@ -28,7 +28,7 @@ class ChannelListController_SwiftUI_Tests: iOS13TestCase {
         let observableObject = channelListController.observableObject
         
         // Simulate channel change
-        let newChannel: Channel = .init(cid: .unique, extraData: .defaultValue)
+        let newChannel: ChatChannel = .init(cid: .unique, extraData: .defaultValue)
         channelListController.channels_simulated = [newChannel]
         channelListController.delegateCallback {
             $0.controller(
@@ -60,8 +60,8 @@ class ChannelListController_SwiftUI_Tests: iOS13TestCase {
 class ChannelListControllerMock: ChannelListController {
     @Atomic var synchronize_called = false
     
-    var channels_simulated: [ChannelModel<DefaultExtraData>]?
-    override var channels: [ChannelModel<DefaultExtraData>] {
+    var channels_simulated: [_ChatChannel<DefaultExtraData>]?
+    override var channels: [_ChatChannel<DefaultExtraData>] {
         channels_simulated ?? super.channels
     }
 

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController+SwiftUI_Tests.swift
@@ -57,7 +57,7 @@ class ChannelListController_SwiftUI_Tests: iOS13TestCase {
     }
 }
 
-class ChannelListControllerMock: ChannelListController {
+class ChannelListControllerMock: ChatChannelListController {
     @Atomic var synchronize_called = false
     
     var channels_simulated: [_ChatChannel<DefaultExtraData>]?

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController+SwiftUI_Tests.swift
@@ -60,8 +60,8 @@ class ChannelListController_SwiftUI_Tests: iOS13TestCase {
 class ChannelListControllerMock: ChannelListController {
     @Atomic var synchronize_called = false
     
-    var channels_simulated: [ChannelModel<DefaultDataTypes>]?
-    override var channels: [ChannelModel<DefaultDataTypes>] {
+    var channels_simulated: [ChannelModel<DefaultExtraData>]?
+    override var channels: [ChannelModel<DefaultExtraData>] {
         channels_simulated ?? super.channels
     }
 

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController.swift
@@ -16,8 +16,8 @@ extension Client {
     }
 }
 
-/// A convenience typealias for `ChannelListControllerGeneric` with `DefaultDataTypes`
-public typealias ChannelListController = ChannelListControllerGeneric<DefaultDataTypes>
+/// A convenience typealias for `ChannelListControllerGeneric` with `DefaultExtraData`
+public typealias ChannelListController = ChannelListControllerGeneric<DefaultExtraData>
 
 /// `ChannelListController` allows observing and mutating the list of channels specified by a channel query.
 ///
@@ -184,7 +184,7 @@ extension ChannelListControllerGeneric {
     }
 }
 
-extension ChannelListControllerGeneric where ExtraData == DefaultDataTypes {
+extension ChannelListControllerGeneric where ExtraData == DefaultExtraData {
     /// Set the delegate of `ChannelListController` to observe the changes in the system.
     ///
     /// - Note: The delegate can be set directly only if you're **not** using custom extra data types. Due to the current
@@ -201,12 +201,12 @@ extension ChannelListControllerGeneric where ExtraData == DefaultDataTypes {
 /// This protocol can be used only when no custom extra data are specified. If you're using custom extra data types,
 /// please use `GenericChannelListController` instead.
 public protocol ChannelListControllerDelegate: DataControllerStateDelegate {
-    func controller(_ controller: ChannelListControllerGeneric<DefaultDataTypes>, didChangeChannels changes: [ListChange<Channel>])
+    func controller(_ controller: ChannelListControllerGeneric<DefaultExtraData>, didChangeChannels changes: [ListChange<Channel>])
 }
 
 public extension ChannelListControllerDelegate {
     func controller(
-        _ controller: ChannelListControllerGeneric<DefaultDataTypes>,
+        _ controller: ChannelListControllerGeneric<DefaultExtraData>,
         didChangeChannels changes: [ListChange<Channel>]
     ) {}
 }
@@ -225,7 +225,7 @@ public protocol ChannelListControllerDelegateGeneric: DataControllerStateDelegat
 
 public extension ChannelListControllerDelegateGeneric {
     func controller(
-        _ controller: ChannelListControllerGeneric<DefaultDataTypes>,
+        _ controller: ChannelListControllerGeneric<DefaultExtraData>,
         didChangeChannels changes: [ListChange<ChannelModel<ExtraData>>]
     ) {}
 }
@@ -278,7 +278,7 @@ extension AnyChannelListControllerDelegate {
     }
 }
 
-extension AnyChannelListControllerDelegate where ExtraData == DefaultDataTypes {
+extension AnyChannelListControllerDelegate where ExtraData == DefaultExtraData {
     convenience init(_ delegate: ChannelListControllerDelegate?) {
         self.init(
             wrappedDelegate: delegate,

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController.swift
@@ -5,7 +5,7 @@
 import CoreData
 import Foundation
 
-extension Client {
+extension _ChatClient {
     /// Creates a new `ChannelListController` with the provided channel query.
     ///
     /// - Parameter query: The query specify the filter and sorting of the channels the controller should fetch.
@@ -28,7 +28,7 @@ public class ChannelListControllerGeneric<ExtraData: ExtraDataTypes>: DataContro
     public let query: ChannelListQuery
     
     /// The `ChatClient` instance this controller belongs to.
-    public let client: Client<ExtraData>
+    public let client: _ChatClient<ExtraData>
     
     /// The channels matching the query. To observe updates in the list, set your class as a delegate of this controller.
     public var channels: [ChannelModel<ExtraData>] { channelListObserver.items }
@@ -92,7 +92,7 @@ public class ChannelListControllerGeneric<ExtraData: ExtraDataTypes>: DataContro
     /// - Parameters:
     ///   - query: The query used for filtering the channels.
     ///   - client: The `Client` instance this controller belongs to.
-    init(query: ChannelListQuery, client: Client<ExtraData>, environment: Environment = .init()) {
+    init(query: ChannelListQuery, client: _ChatClient<ExtraData>, environment: Environment = .init()) {
         self.client = client
         self.query = query
         self.environment = environment

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController.swift
@@ -202,7 +202,7 @@ extension _ChatChannelListController where ExtraData == DefaultExtraData {
 /// please use `GenericChannelListController` instead.
 public protocol ChatChannelListControllerDelegate: DataControllerStateDelegate {
     func controller(
-        _ controller: _ChatChannelListController<DefaultExtraData>,
+        _ controller: ChatChannelListController,
         didChangeChannels changes: [ListChange<ChatChannel>]
     )
 }

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -360,7 +360,7 @@ class ChannelListController_Tests: StressTestCase {
 }
 
 private class TestEnvironment {
-    @Atomic var channelListUpdater: ChannelListUpdaterMock<DefaultDataTypes>?
+    @Atomic var channelListUpdater: ChannelListUpdaterMock<DefaultExtraData>?
     
     lazy var environment: ChannelListController.Environment =
         .init(channelQueryUpdaterBuilder: { [unowned self] in
@@ -384,7 +384,7 @@ private class TestDelegate: QueueAwareDelegate, ChannelListControllerDelegate {
     }
     
     func controller(
-        _ controller: ChannelListControllerGeneric<DefaultDataTypes>,
+        _ controller: ChannelListControllerGeneric<DefaultExtraData>,
         didChangeChannels changes: [ListChange<Channel>]
     ) {
         didChangeChannels_changes = changes
@@ -403,7 +403,7 @@ private class TestDelegateGeneric: QueueAwareDelegate, ChannelListControllerDele
     }
     
     func controller(
-        _ controller: ChannelListControllerGeneric<DefaultDataTypes>,
+        _ controller: ChannelListControllerGeneric<DefaultExtraData>,
         didChangeChannels changes: [ListChange<Channel>]
     ) {
         didChangeChannels_changes = changes

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -22,7 +22,7 @@ class ChannelListController_Tests: StressTestCase {
         super.setUp()
         
         env = TestEnvironment()
-        client = Client.mock
+        client = _ChatClient.mock
         query = .init(filter: .in("members", ["Luke"]))
         controller = ChannelListController(query: query, client: client, environment: env.environment)
         controllerCallbackQueueID = UUID()

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -254,7 +254,7 @@ class ChannelListController_Tests: StressTestCase {
             }, completion: $0)
         }
         XCTAssertNil(error)
-        let channel: Channel = client.databaseContainer.viewContext.channel(cid: cid)!.asModel()
+        let channel: ChatChannel = client.databaseContainer.viewContext.channel(cid: cid)!.asModel()
         
         AssertAsync.willBeEqual(delegate.didChangeChannels_changes, [.insert(channel, index: [0, 0])])
     }
@@ -277,7 +277,7 @@ class ChannelListController_Tests: StressTestCase {
                 try session.saveChannel(payload: self.dummyPayload(with: cid), query: self.query)
             }, completion: $0)
         }
-        let channel: Channel = client.databaseContainer.viewContext.channel(cid: cid)!.asModel()
+        let channel: ChatChannel = client.databaseContainer.viewContext.channel(cid: cid)!.asModel()
         
         AssertAsync.willBeEqual(delegate.didChangeChannels_changes, [.insert(channel, index: [0, 0])])
     }
@@ -376,7 +376,7 @@ private class TestEnvironment {
 // A concrete `ChannelListControllerDelegate` implementation allowing capturing the delegate calls
 private class TestDelegate: QueueAwareDelegate, ChannelListControllerDelegate {
     @Atomic var state: DataController.State?
-    @Atomic var didChangeChannels_changes: [ListChange<Channel>]?
+    @Atomic var didChangeChannels_changes: [ListChange<ChatChannel>]?
     
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
         self.state = state
@@ -385,7 +385,7 @@ private class TestDelegate: QueueAwareDelegate, ChannelListControllerDelegate {
     
     func controller(
         _ controller: ChannelListControllerGeneric<DefaultExtraData>,
-        didChangeChannels changes: [ListChange<Channel>]
+        didChangeChannels changes: [ListChange<ChatChannel>]
     ) {
         didChangeChannels_changes = changes
         validateQueue()
@@ -395,7 +395,7 @@ private class TestDelegate: QueueAwareDelegate, ChannelListControllerDelegate {
 // A concrete `ChannelListControllerDelegateGeneric` implementation allowing capturing the delegate calls.
 private class TestDelegateGeneric: QueueAwareDelegate, ChannelListControllerDelegateGeneric {
     @Atomic var state: DataController.State?
-    @Atomic var didChangeChannels_changes: [ListChange<Channel>]?
+    @Atomic var didChangeChannels_changes: [ListChange<ChatChannel>]?
     
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
         self.state = state
@@ -404,7 +404,7 @@ private class TestDelegateGeneric: QueueAwareDelegate, ChannelListControllerDele
     
     func controller(
         _ controller: ChannelListControllerGeneric<DefaultExtraData>,
-        didChangeChannels changes: [ListChange<Channel>]
+        didChangeChannels changes: [ListChange<ChatChannel>]
     ) {
         didChangeChannels_changes = changes
         validateQueue()

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -13,7 +13,7 @@ class ChannelListController_Tests: StressTestCase {
     
     var query: ChannelListQuery!
     
-    var controller: ChannelListController!
+    var controller: ChatChannelListController!
     var controllerCallbackQueueID: UUID!
     /// Workaround for uwrapping **controllerCallbackQueueID!** in each closure that captures it
     private var callbackQueueID: UUID { controllerCallbackQueueID }
@@ -24,7 +24,7 @@ class ChannelListController_Tests: StressTestCase {
         env = TestEnvironment()
         client = _ChatClient.mock
         query = .init(filter: .in("members", ["Luke"]))
-        controller = ChannelListController(query: query, client: client, environment: env.environment)
+        controller = ChatChannelListController(query: query, client: client, environment: env.environment)
         controllerCallbackQueueID = UUID()
         controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)
     }
@@ -362,7 +362,7 @@ class ChannelListController_Tests: StressTestCase {
 private class TestEnvironment {
     @Atomic var channelListUpdater: ChannelListUpdaterMock<DefaultExtraData>?
     
-    lazy var environment: ChannelListController.Environment =
+    lazy var environment: ChatChannelListController.Environment =
         .init(channelQueryUpdaterBuilder: { [unowned self] in
             self.channelListUpdater = ChannelListUpdaterMock(
                 database: $0,
@@ -374,7 +374,7 @@ private class TestEnvironment {
 }
 
 // A concrete `ChannelListControllerDelegate` implementation allowing capturing the delegate calls
-private class TestDelegate: QueueAwareDelegate, ChannelListControllerDelegate {
+private class TestDelegate: QueueAwareDelegate, ChatChannelListControllerDelegate {
     @Atomic var state: DataController.State?
     @Atomic var didChangeChannels_changes: [ListChange<ChatChannel>]?
     
@@ -384,7 +384,7 @@ private class TestDelegate: QueueAwareDelegate, ChannelListControllerDelegate {
     }
     
     func controller(
-        _ controller: ChannelListControllerGeneric<DefaultExtraData>,
+        _ controller: _ChatChannelListController<DefaultExtraData>,
         didChangeChannels changes: [ListChange<ChatChannel>]
     ) {
         didChangeChannels_changes = changes
@@ -392,8 +392,8 @@ private class TestDelegate: QueueAwareDelegate, ChannelListControllerDelegate {
     }
 }
 
-// A concrete `ChannelListControllerDelegateGeneric` implementation allowing capturing the delegate calls.
-private class TestDelegateGeneric: QueueAwareDelegate, ChannelListControllerDelegateGeneric {
+// A concrete `_ChatChannelListControllerDelegate` implementation allowing capturing the delegate calls.
+private class TestDelegateGeneric: QueueAwareDelegate, _ChatChannelListControllerDelegate {
     @Atomic var state: DataController.State?
     @Atomic var didChangeChannels_changes: [ListChange<ChatChannel>]?
     
@@ -403,7 +403,7 @@ private class TestDelegateGeneric: QueueAwareDelegate, ChannelListControllerDele
     }
     
     func controller(
-        _ controller: ChannelListControllerGeneric<DefaultExtraData>,
+        _ controller: _ChatChannelListController<DefaultExtraData>,
         didChangeChannels changes: [ListChange<ChatChannel>]
     ) {
         didChangeChannels_changes = changes

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+Combine.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+Combine.swift
@@ -13,7 +13,7 @@ extension CurrentUserControllerGeneric {
     }
     
     /// A publisher emitting a new value every time the current user changes.
-    public var currentUserChangePublisher: AnyPublisher<EntityChange<CurrentUserModel<ExtraData.User>>, Never> {
+    public var currentUserChangePublisher: AnyPublisher<EntityChange<_CurrentChatUser<ExtraData.User>>, Never> {
         basePublishers.currentUserChange.keepAlive(self)
     }
     
@@ -38,7 +38,7 @@ extension CurrentUserControllerGeneric {
         let state: CurrentValueSubject<DataController.State, Never>
         
         /// A backing subject for `currentUserChangePublisher`.
-        let currentUserChange: PassthroughSubject<EntityChange<CurrentUserModel<ExtraData.User>>, Never> = .init()
+        let currentUserChange: PassthroughSubject<EntityChange<_CurrentChatUser<ExtraData.User>>, Never> = .init()
         
         /// A backing subject for `unreadCountPublisher`.
         let unreadCount: CurrentValueSubject<UnreadCount, Never>
@@ -77,7 +77,7 @@ extension CurrentUserControllerGeneric.BasePublishers: CurrentUserControllerDele
     
     func currentUserController(
         _ controller: CurrentUserControllerGeneric<ExtraData>,
-        didChangeCurrentUser currentUser: EntityChange<CurrentUserModel<ExtraData.User>>
+        didChangeCurrentUser currentUser: EntityChange<_CurrentChatUser<ExtraData.User>>
     ) {
         currentUserChange.send(currentUser)
     }

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+Combine.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+Combine.swift
@@ -6,7 +6,7 @@ import Combine
 import UIKit
 
 @available(iOS 13, *)
-extension CurrentUserControllerGeneric {
+extension _CurrentChatUserController {
     /// A publisher emitting a new value every time the state of the controller changes.
     public var statePublisher: AnyPublisher<DataController.State, Never> {
         basePublishers.state.keepAlive(self)
@@ -32,7 +32,7 @@ extension CurrentUserControllerGeneric {
     /// and expose the published values by mapping them to a read-only `AnyPublisher` type.
     class BasePublishers {
         /// The wrapper controller
-        unowned let controller: CurrentUserControllerGeneric
+        unowned let controller: _CurrentChatUserController
         
         /// A backing subject for `statePublisher`.
         let state: CurrentValueSubject<DataController.State, Never>
@@ -46,7 +46,7 @@ extension CurrentUserControllerGeneric {
         /// A backing subject for `connectionStatusPublisher`.
         let connectionStatus: CurrentValueSubject<ConnectionStatus, Never>
                 
-        init(controller: CurrentUserControllerGeneric<ExtraData>) {
+        init(controller: _CurrentChatUserController<ExtraData>) {
             self.controller = controller
             state = .init(controller.state)
             unreadCount = .init(.noUnread)
@@ -63,27 +63,27 @@ extension CurrentUserControllerGeneric {
 }
 
 @available(iOS 13, *)
-extension CurrentUserControllerGeneric.BasePublishers: CurrentUserControllerDelegateGeneric {
+extension _CurrentChatUserController.BasePublishers: _CurrentChatUserControllerDelegate {
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
         self.state.send(state)
     }
     
     func currentUserController(
-        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        _ controller: _CurrentChatUserController<ExtraData>,
         didChangeCurrentUserUnreadCount unreadCount: UnreadCount
     ) {
         self.unreadCount.send(unreadCount)
     }
     
     func currentUserController(
-        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        _ controller: _CurrentChatUserController<ExtraData>,
         didChangeCurrentUser currentUser: EntityChange<_CurrentChatUser<ExtraData.User>>
     ) {
         currentUserChange.send(currentUser)
     }
     
     func currentUserController(
-        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        _ controller: _CurrentChatUserController<ExtraData>,
         didUpdateConnectionStatus status: ConnectionStatus
     ) {
         connectionStatus.send(status)

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+Combine_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+Combine_Tests.swift
@@ -53,7 +53,7 @@ class CurrentUserController_Combine_Tests: iOS13TestCase {
 
     func test_currentUserChangePublisher() {
         // Setup Recording publishers
-        var recording = Record<EntityChange<CurrentUser>, Never>.Recording()
+        var recording = Record<EntityChange<CurrentChatUser>, Never>.Recording()
         
         // Setup the chain
         currentUserController
@@ -65,7 +65,7 @@ class CurrentUserController_Combine_Tests: iOS13TestCase {
         weak var controller: CurrentUserControllerMock? = currentUserController
         currentUserController = nil
 
-        let newCurrentUser: CurrentUser = .init(id: .unique)
+        let newCurrentUser: CurrentChatUser = .init(id: .unique)
         controller?.currentUser_simulated = newCurrentUser
         controller?.delegateCallback {
             $0.currentUserController(controller!, didChangeCurrentUser: .create(newCurrentUser))

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI.swift
@@ -6,14 +6,14 @@ import Foundation
 import SwiftUI
 
 @available(iOS 13, *)
-extension CurrentUserControllerGeneric {
+extension _CurrentChatUserController {
     /// A wrapper object that exposes the controller variables in the form of `ObservableObject` to be used in SwiftUI.
     public var observableObject: ObservableObject { .init(controller: self) }
     
     /// A wrapper object for `CurrentUserController` type which makes it possible to use the controller comfortably in SwiftUI.
     public class ObservableObject: SwiftUI.ObservableObject {
         /// The underlying controller. You can still access it and call methods on it.
-        public let controller: CurrentUserControllerGeneric
+        public let controller: _CurrentChatUserController
         
         /// The currently logged-in user.
         @Published public private(set) var currentUser: _CurrentChatUser<ExtraData.User>?
@@ -28,7 +28,7 @@ extension CurrentUserControllerGeneric {
         @Published public private(set) var connectionStatus: ConnectionStatus
         
         /// Creates a new `ObservableObject` wrapper with the provided controller instance.
-        init(controller: CurrentUserControllerGeneric<ExtraData>) {
+        init(controller: _CurrentChatUserController<ExtraData>) {
             self.controller = controller
             state = controller.state
             connectionStatus = controller.connectionStatus
@@ -47,16 +47,16 @@ extension CurrentUserControllerGeneric {
 }
 
 @available(iOS 13, *)
-extension CurrentUserControllerGeneric.ObservableObject: CurrentUserControllerDelegateGeneric {
+extension _CurrentChatUserController.ObservableObject: _CurrentChatUserControllerDelegate {
     public func currentUserController(
-        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        _ controller: _CurrentChatUserController<ExtraData>,
         didChangeCurrentUserUnreadCount unreadCount: UnreadCount
     ) {
         self.unreadCount = controller.unreadCount
     }
     
     public func currentUserController(
-        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        _ controller: _CurrentChatUserController<ExtraData>,
         didChangeCurrentUser currentUser: EntityChange<_CurrentChatUser<ExtraData.User>>
     ) {
         self.currentUser = controller.currentUser
@@ -67,7 +67,7 @@ extension CurrentUserControllerGeneric.ObservableObject: CurrentUserControllerDe
     }
     
     public func currentUserController(
-        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        _ controller: _CurrentChatUserController<ExtraData>,
         didUpdateConnectionStatus status: ConnectionStatus
     ) {
         connectionStatus = status

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI.swift
@@ -16,7 +16,7 @@ extension CurrentUserControllerGeneric {
         public let controller: CurrentUserControllerGeneric
         
         /// The currently logged-in user.
-        @Published public private(set) var currentUser: CurrentUserModel<ExtraData.User>?
+        @Published public private(set) var currentUser: _CurrentChatUser<ExtraData.User>?
         
         /// The unread messages and channels count for the current user.
         @Published public private(set) var unreadCount: UnreadCount = .noUnread
@@ -57,7 +57,7 @@ extension CurrentUserControllerGeneric.ObservableObject: CurrentUserControllerDe
     
     public func currentUserController(
         _ controller: CurrentUserControllerGeneric<ExtraData>,
-        didChangeCurrentUser currentUser: EntityChange<CurrentUserModel<ExtraData.User>>
+        didChangeCurrentUser currentUser: EntityChange<_CurrentChatUser<ExtraData.User>>
     ) {
         self.currentUser = controller.currentUser
     }

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI_Tests.swift
@@ -94,7 +94,7 @@ class CurrentUserController_SwiftUI_Tests: iOS13TestCase {
     }
 }
 
-class CurrentUserControllerMock: CurrentUserController {
+class CurrentUserControllerMock: CurrentChatUserController {
     @Atomic var startUpdating_called = false
     
     var currentUser_simulated: _CurrentChatUser<DefaultExtraData.User>?

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI_Tests.swift
@@ -34,7 +34,7 @@ class CurrentUserController_SwiftUI_Tests: iOS13TestCase {
         let observableObject = currentUserController.observableObject
         
         // Simulate current user change
-        let newCurrentUser: CurrentUser = .init(id: .unique)
+        let newCurrentUser: CurrentChatUser = .init(id: .unique)
         currentUserController.currentUser_simulated = newCurrentUser
         currentUserController.delegateCallback {
             $0.currentUserController(
@@ -97,8 +97,8 @@ class CurrentUserController_SwiftUI_Tests: iOS13TestCase {
 class CurrentUserControllerMock: CurrentUserController {
     @Atomic var startUpdating_called = false
     
-    var currentUser_simulated: CurrentUserModel<DefaultExtraData.User>?
-    override var currentUser: CurrentUserModel<DefaultExtraData.User>? {
+    var currentUser_simulated: _CurrentChatUser<DefaultExtraData.User>?
+    override var currentUser: _CurrentChatUser<DefaultExtraData.User>? {
         currentUser_simulated ?? super.currentUser
     }
     

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI_Tests.swift
@@ -97,8 +97,8 @@ class CurrentUserController_SwiftUI_Tests: iOS13TestCase {
 class CurrentUserControllerMock: CurrentUserController {
     @Atomic var startUpdating_called = false
     
-    var currentUser_simulated: CurrentUserModel<DefaultDataTypes.User>?
-    override var currentUser: CurrentUserModel<DefaultDataTypes.User>? {
+    var currentUser_simulated: CurrentUserModel<DefaultExtraData.User>?
+    override var currentUser: CurrentUserModel<DefaultExtraData.User>? {
         currentUser_simulated ?? super.currentUser
     }
     

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
@@ -8,16 +8,16 @@ import Foundation
 public extension _ChatClient {
     /// Creates a new `CurrentUserControllerGeneric`
     /// - Returns: A new instance of `ChannelController`.
-    func currentUserController() -> CurrentUserControllerGeneric<ExtraData> {
+    func currentUserController() -> _CurrentChatUserController<ExtraData> {
         .init(client: self, environment: .init())
     }
 }
 
 /// A convenience typealias for `CurrentUserControllerGeneric` with `DefaultExtraData`
-public typealias CurrentUserController = CurrentUserControllerGeneric<DefaultExtraData>
+public typealias CurrentChatUserController = _CurrentChatUserController<DefaultExtraData>
 
 /// `CurrentUserControllerGeneric` allows to observer current user updates
-public class CurrentUserControllerGeneric<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
+public class _CurrentChatUserController<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
     /// The `ChatClient` instance this controller belongs to.
     public let client: _ChatClient<ExtraData>
     
@@ -148,7 +148,7 @@ public class CurrentUserControllerGeneric<ExtraData: ExtraDataTypes>: DataContro
 
 // MARK: - Set current user
 
-public extension CurrentUserControllerGeneric {
+public extension _CurrentChatUserController {
     /// Connects a client the controller owns to the chat servers.
     /// When the connection is established, `Client` starts receiving chat updates.
     ///
@@ -299,7 +299,7 @@ public extension CurrentUserControllerGeneric {
 
 // MARK: - Environment
 
-extension CurrentUserControllerGeneric {
+extension _CurrentChatUserController {
     struct Environment {
         var currentUserObserverBuilder: (
             _ context: NSManagedObjectContext,
@@ -325,7 +325,7 @@ private extension EntityChange where Item == UnreadCount {
     }
 }
 
-private extension CurrentUserControllerGeneric {
+private extension _CurrentChatUserController {
     func createUserObserver() -> EntityDatabaseObserver<_CurrentChatUser<ExtraData.User>, CurrentUserDTO> {
         environment.currentUserObserverBuilder(
             client.databaseContainer.viewContext,
@@ -342,66 +342,66 @@ private extension CurrentUserControllerGeneric {
 ///
 /// This protocol can be used only when no custom extra data are specified.
 /// If you're using custom extra data types, please use `CurrentUserControllerDelegateGeneric` instead.
-public protocol CurrentUserControllerDelegate: DataControllerStateDelegate {
+public protocol CurrentChatUserControllerDelegate: DataControllerStateDelegate {
     /// The controller observed a change in the `UnreadCount`.
-    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUserUnreadCount: UnreadCount)
+    func currentUserController(_ controller: CurrentChatUserController, didChangeCurrentUserUnreadCount: UnreadCount)
     
     /// The controller observed a change in the `CurrentUser` entity.
-    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser: EntityChange<CurrentChatUser>)
+    func currentUserController(_ controller: CurrentChatUserController, didChangeCurrentUser: EntityChange<CurrentChatUser>)
     
     /// The controller observed a change in connection status.
-    func currentUserController(_ controller: CurrentUserController, didUpdateConnectionStatus status: ConnectionStatus)
+    func currentUserController(_ controller: CurrentChatUserController, didUpdateConnectionStatus status: ConnectionStatus)
 }
 
-public extension CurrentUserControllerDelegate {
-    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUserUnreadCount: UnreadCount) {}
+public extension CurrentChatUserControllerDelegate {
+    func currentUserController(_ controller: CurrentChatUserController, didChangeCurrentUserUnreadCount: UnreadCount) {}
     
-    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser: EntityChange<CurrentChatUser>) {}
+    func currentUserController(_ controller: CurrentChatUserController, didChangeCurrentUser: EntityChange<CurrentChatUser>) {}
     
-    func currentUserController(_ controller: CurrentUserController, didUpdateConnectionStatus status: ConnectionStatus) {}
+    func currentUserController(_ controller: CurrentChatUserController, didUpdateConnectionStatus status: ConnectionStatus) {}
 }
 
 /// `CurrentUserControllerGeneric` uses this protocol to communicate changes to its delegate.
 ///
 /// If you're **not** using custom extra data types, you can use a convenience version of this protocol
 /// named `CurrentUserControllerDelegate`, which hides the generic types, and make the usage easier.
-public protocol CurrentUserControllerDelegateGeneric: DataControllerStateDelegate {
+public protocol _CurrentChatUserControllerDelegate: DataControllerStateDelegate {
     associatedtype ExtraData: ExtraDataTypes
     
     /// The controller observed a change in the `UnreadCount`.
-    func currentUserController(_ controller: CurrentUserControllerGeneric<ExtraData>, didChangeCurrentUserUnreadCount: UnreadCount)
+    func currentUserController(_ controller: _CurrentChatUserController<ExtraData>, didChangeCurrentUserUnreadCount: UnreadCount)
     
     /// The controller observed a change in the `CurrentUser` entity.
     func currentUserController(
-        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        _ controller: _CurrentChatUserController<ExtraData>,
         didChangeCurrentUser: EntityChange<_CurrentChatUser<ExtraData.User>>
     )
     
     /// The controller observed a change in connection status.
     func currentUserController(
-        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        _ controller: _CurrentChatUserController<ExtraData>,
         didUpdateConnectionStatus status: ConnectionStatus
     )
 }
 
-public extension CurrentUserControllerDelegateGeneric {
+public extension _CurrentChatUserControllerDelegate {
     func currentUserController(
-        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        _ controller: _CurrentChatUserController<ExtraData>,
         didChangeCurrentUserUnreadCount: UnreadCount
     ) {}
     
     func currentUserController(
-        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        _ controller: _CurrentChatUserController<ExtraData>,
         didChangeCurrentUser: EntityChange<_CurrentChatUser<ExtraData.User>>
     ) {}
     
     func currentUserController(
-        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        _ controller: _CurrentChatUserController<ExtraData>,
         didUpdateConnectionStatus status: ConnectionStatus
     ) {}
 }
 
-final class AnyCurrentUserControllerDelegate<ExtraData: ExtraDataTypes>: CurrentUserControllerDelegateGeneric {
+final class AnyCurrentUserControllerDelegate<ExtraData: ExtraDataTypes>: _CurrentChatUserControllerDelegate {
     weak var wrappedDelegate: AnyObject?
     
     private var _controllerDidChangeState: (
@@ -410,17 +410,17 @@ final class AnyCurrentUserControllerDelegate<ExtraData: ExtraDataTypes>: Current
     ) -> Void
     
     private var _controllerDidChangeCurrentUserUnreadCount: (
-        CurrentUserControllerGeneric<ExtraData>,
+        _CurrentChatUserController<ExtraData>,
         UnreadCount
     ) -> Void
     
     private var _controllerDidChangeCurrentUser: (
-        CurrentUserControllerGeneric<ExtraData>,
+        _CurrentChatUserController<ExtraData>,
         EntityChange<_CurrentChatUser<ExtraData.User>>
     ) -> Void
     
     private var _controllerDidChangeConnectionStatus: (
-        CurrentUserControllerGeneric<ExtraData>,
+        _CurrentChatUserController<ExtraData>,
         ConnectionStatus
     ) -> Void
     
@@ -431,15 +431,15 @@ final class AnyCurrentUserControllerDelegate<ExtraData: ExtraDataTypes>: Current
             DataController.State
         ) -> Void,
         controllerDidChangeCurrentUserUnreadCount: @escaping (
-            CurrentUserControllerGeneric<ExtraData>,
+            _CurrentChatUserController<ExtraData>,
             UnreadCount
         ) -> Void,
         controllerDidChangeCurrentUser: @escaping (
-            CurrentUserControllerGeneric<ExtraData>,
+            _CurrentChatUserController<ExtraData>,
             EntityChange<_CurrentChatUser<ExtraData.User>>
         ) -> Void,
         controllerDidChangeConnectionStatus: @escaping (
-            CurrentUserControllerGeneric<ExtraData>,
+            _CurrentChatUserController<ExtraData>,
             ConnectionStatus
         ) -> Void
     ) {
@@ -455,21 +455,21 @@ final class AnyCurrentUserControllerDelegate<ExtraData: ExtraDataTypes>: Current
     }
 
     func currentUserController(
-        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        _ controller: _CurrentChatUserController<ExtraData>,
         didChangeCurrentUserUnreadCount unreadCount: UnreadCount
     ) {
         _controllerDidChangeCurrentUserUnreadCount(controller, unreadCount)
     }
     
     func currentUserController(
-        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        _ controller: _CurrentChatUserController<ExtraData>,
         didChangeCurrentUser user: EntityChange<_CurrentChatUser<ExtraData.User>>
     ) {
         _controllerDidChangeCurrentUser(controller, user)
     }
     
     func currentUserController(
-        _ controller: CurrentUserControllerGeneric<ExtraData>,
+        _ controller: _CurrentChatUserController<ExtraData>,
         didUpdateConnectionStatus status: ConnectionStatus
     ) {
         _controllerDidChangeConnectionStatus(controller, status)
@@ -477,7 +477,7 @@ final class AnyCurrentUserControllerDelegate<ExtraData: ExtraDataTypes>: Current
 }
 
 extension AnyCurrentUserControllerDelegate {
-    convenience init<Delegate: CurrentUserControllerDelegateGeneric>(_ delegate: Delegate) where Delegate.ExtraData == ExtraData {
+    convenience init<Delegate: _CurrentChatUserControllerDelegate>(_ delegate: Delegate) where Delegate.ExtraData == ExtraData {
         self.init(
             wrappedDelegate: delegate,
             controllerDidChangeState: { [weak delegate] in delegate?.controller($0, didChangeState: $1) },
@@ -495,7 +495,7 @@ extension AnyCurrentUserControllerDelegate {
 }
 
 extension AnyCurrentUserControllerDelegate where ExtraData == DefaultExtraData {
-    convenience init(_ delegate: CurrentUserControllerDelegate?) {
+    convenience init(_ delegate: CurrentChatUserControllerDelegate?) {
         self.init(
             wrappedDelegate: delegate,
             controllerDidChangeState: { [weak delegate] in delegate?.controller($0, didChangeState: $1) },
@@ -512,7 +512,7 @@ extension AnyCurrentUserControllerDelegate where ExtraData == DefaultExtraData {
     }
 }
  
-public extension CurrentUserControllerGeneric {
+public extension _CurrentChatUserController {
     /// Sets the provided object as a delegate of this controller.
     ///
     /// - Note: If you don't use custom extra data types, you can set the delegate directly using `controller.delegate = self`.
@@ -521,20 +521,20 @@ public extension CurrentUserControllerGeneric {
     ///
     /// - Parameter delegate: The object used as a delegate. It's referenced weakly, so you need to keep the object
     /// alive if you want keep receiving updates.
-    func setDelegate<Delegate: CurrentUserControllerDelegateGeneric>(_ delegate: Delegate?) where Delegate.ExtraData == ExtraData {
+    func setDelegate<Delegate: _CurrentChatUserControllerDelegate>(_ delegate: Delegate?) where Delegate.ExtraData == ExtraData {
         multicastDelegate.mainDelegate = delegate.flatMap(AnyCurrentUserControllerDelegate.init)
     }
 }
 
-public extension CurrentUserController {
+public extension CurrentChatUserController {
     /// Set the delegate of `CurrentUserController` to observe the changes in the system.
     ///
     /// - Note: The delegate can be set directly only if you're **not** using custom extra data types. Due to the current
     /// limits of Swift and the way it handles protocols with associated types, it's required to use `setDelegate` method
     /// instead to set the delegate, if you're using custom extra data types.
-    var delegate: CurrentUserControllerDelegate? {
+    var delegate: CurrentChatUserControllerDelegate? {
         set { multicastDelegate.mainDelegate = AnyCurrentUserControllerDelegate(newValue) }
-        get { multicastDelegate.mainDelegate?.wrappedDelegate as? CurrentUserControllerDelegate }
+        get { multicastDelegate.mainDelegate?.wrappedDelegate as? CurrentChatUserControllerDelegate }
     }
 }
 

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
@@ -13,8 +13,8 @@ public extension Client {
     }
 }
 
-/// A convenience typealias for `CurrentUserControllerGeneric` with `DefaultDataTypes`
-public typealias CurrentUserController = CurrentUserControllerGeneric<DefaultDataTypes>
+/// A convenience typealias for `CurrentUserControllerGeneric` with `DefaultExtraData`
+public typealias CurrentUserController = CurrentUserControllerGeneric<DefaultExtraData>
 
 /// `CurrentUserControllerGeneric` allows to observer current user updates
 public class CurrentUserControllerGeneric<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
@@ -494,7 +494,7 @@ extension AnyCurrentUserControllerDelegate {
     }
 }
 
-extension AnyCurrentUserControllerDelegate where ExtraData == DefaultDataTypes {
+extension AnyCurrentUserControllerDelegate where ExtraData == DefaultExtraData {
     convenience init(_ delegate: CurrentUserControllerDelegate?) {
         self.init(
             wrappedDelegate: delegate,

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
@@ -5,7 +5,7 @@
 import CoreData
 import Foundation
 
-public extension Client {
+public extension _ChatClient {
     /// Creates a new `CurrentUserControllerGeneric`
     /// - Returns: A new instance of `ChannelController`.
     func currentUserController() -> CurrentUserControllerGeneric<ExtraData> {
@@ -19,7 +19,7 @@ public typealias CurrentUserController = CurrentUserControllerGeneric<DefaultExt
 /// `CurrentUserControllerGeneric` allows to observer current user updates
 public class CurrentUserControllerGeneric<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
     /// The `ChatClient` instance this controller belongs to.
-    public let client: Client<ExtraData>
+    public let client: _ChatClient<ExtraData>
     
     private let environment: Environment
     
@@ -87,7 +87,7 @@ public class CurrentUserControllerGeneric<ExtraData: ExtraDataTypes>: DataContro
     /// - Parameters:
     ///   - client: The `Client` instance this controller belongs to.
     ///   - environment: The source of internal dependencies
-    init(client: Client<ExtraData>, environment: Environment = .init()) {
+    init(client: _ChatClient<ExtraData>, environment: Environment = .init()) {
         self.client = client
         self.environment = environment
         

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
@@ -67,7 +67,7 @@ public class CurrentUserControllerGeneric<ExtraData: ExtraDataTypes>: DataContro
     /// The currently logged-in user.
     /// Always returns `nil` if `startUpdating` was not called
     /// To observe the updates of this value, set your class as a delegate of this controller and call `startUpdating`.
-    public var currentUser: CurrentUserModel<ExtraData.User>? {
+    public var currentUser: _CurrentChatUser<ExtraData.User>? {
         guard state != .initialized else {
             log.warning("Accessing `currentUser` fields before calling `startUpdating()` always results in `nil`.")
             return nil
@@ -304,9 +304,9 @@ extension CurrentUserControllerGeneric {
         var currentUserObserverBuilder: (
             _ context: NSManagedObjectContext,
             _ fetchRequest: NSFetchRequest<CurrentUserDTO>,
-            _ itemCreator: @escaping (CurrentUserDTO) -> CurrentUserModel<ExtraData.User>,
+            _ itemCreator: @escaping (CurrentUserDTO) -> _CurrentChatUser<ExtraData.User>,
             _ fetchedResultsControllerType: NSFetchedResultsController<CurrentUserDTO>.Type
-        ) -> EntityDatabaseObserver<CurrentUserModel<ExtraData.User>, CurrentUserDTO> = EntityDatabaseObserver.init
+        ) -> EntityDatabaseObserver<_CurrentChatUser<ExtraData.User>, CurrentUserDTO> = EntityDatabaseObserver.init
     }
 }
 
@@ -326,7 +326,7 @@ private extension EntityChange where Item == UnreadCount {
 }
 
 private extension CurrentUserControllerGeneric {
-    func createUserObserver() -> EntityDatabaseObserver<CurrentUserModel<ExtraData.User>, CurrentUserDTO> {
+    func createUserObserver() -> EntityDatabaseObserver<_CurrentChatUser<ExtraData.User>, CurrentUserDTO> {
         environment.currentUserObserverBuilder(
             client.databaseContainer.viewContext,
             CurrentUserDTO.defaultFetchRequest,
@@ -347,7 +347,7 @@ public protocol CurrentUserControllerDelegate: DataControllerStateDelegate {
     func currentUserController(_ controller: CurrentUserController, didChangeCurrentUserUnreadCount: UnreadCount)
     
     /// The controller observed a change in the `CurrentUser` entity.
-    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser: EntityChange<CurrentUser>)
+    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser: EntityChange<CurrentChatUser>)
     
     /// The controller observed a change in connection status.
     func currentUserController(_ controller: CurrentUserController, didUpdateConnectionStatus status: ConnectionStatus)
@@ -356,7 +356,7 @@ public protocol CurrentUserControllerDelegate: DataControllerStateDelegate {
 public extension CurrentUserControllerDelegate {
     func currentUserController(_ controller: CurrentUserController, didChangeCurrentUserUnreadCount: UnreadCount) {}
     
-    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser: EntityChange<CurrentUser>) {}
+    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser: EntityChange<CurrentChatUser>) {}
     
     func currentUserController(_ controller: CurrentUserController, didUpdateConnectionStatus status: ConnectionStatus) {}
 }
@@ -374,7 +374,7 @@ public protocol CurrentUserControllerDelegateGeneric: DataControllerStateDelegat
     /// The controller observed a change in the `CurrentUser` entity.
     func currentUserController(
         _ controller: CurrentUserControllerGeneric<ExtraData>,
-        didChangeCurrentUser: EntityChange<CurrentUserModel<ExtraData.User>>
+        didChangeCurrentUser: EntityChange<_CurrentChatUser<ExtraData.User>>
     )
     
     /// The controller observed a change in connection status.
@@ -392,7 +392,7 @@ public extension CurrentUserControllerDelegateGeneric {
     
     func currentUserController(
         _ controller: CurrentUserControllerGeneric<ExtraData>,
-        didChangeCurrentUser: EntityChange<CurrentUserModel<ExtraData.User>>
+        didChangeCurrentUser: EntityChange<_CurrentChatUser<ExtraData.User>>
     ) {}
     
     func currentUserController(
@@ -416,7 +416,7 @@ final class AnyCurrentUserControllerDelegate<ExtraData: ExtraDataTypes>: Current
     
     private var _controllerDidChangeCurrentUser: (
         CurrentUserControllerGeneric<ExtraData>,
-        EntityChange<CurrentUserModel<ExtraData.User>>
+        EntityChange<_CurrentChatUser<ExtraData.User>>
     ) -> Void
     
     private var _controllerDidChangeConnectionStatus: (
@@ -436,7 +436,7 @@ final class AnyCurrentUserControllerDelegate<ExtraData: ExtraDataTypes>: Current
         ) -> Void,
         controllerDidChangeCurrentUser: @escaping (
             CurrentUserControllerGeneric<ExtraData>,
-            EntityChange<CurrentUserModel<ExtraData.User>>
+            EntityChange<_CurrentChatUser<ExtraData.User>>
         ) -> Void,
         controllerDidChangeConnectionStatus: @escaping (
             CurrentUserControllerGeneric<ExtraData>,
@@ -463,7 +463,7 @@ final class AnyCurrentUserControllerDelegate<ExtraData: ExtraDataTypes>: Current
     
     func currentUserController(
         _ controller: CurrentUserControllerGeneric<ExtraData>,
-        didChangeCurrentUser user: EntityChange<CurrentUserModel<ExtraData.User>>
+        didChangeCurrentUser user: EntityChange<_CurrentChatUser<ExtraData.User>>
     ) {
         _controllerDidChangeCurrentUser(controller, user)
     }

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -201,7 +201,7 @@ final class CurrentUserController_Tests: StressTestCase {
     
     func test_delegate_isNotifiedAboutCreatedUser() throws {
         let extraData = NameAndImageExtraData(name: .unique, imageURL: .unique())
-        let currentUserPayload: CurrentUserPayload<DefaultDataTypes.User> = .dummy(
+        let currentUserPayload: CurrentUserPayload<DefaultExtraData.User> = .dummy(
             userId: .unique,
             role: .user,
             extraData: extraData
@@ -232,7 +232,7 @@ final class CurrentUserController_Tests: StressTestCase {
     
     func test_delegate_isNotifiedAboutUpdatedUser() throws {
         var extraData = NameAndImageExtraData(name: .unique, imageURL: .unique())
-        var currentUserPayload: CurrentUserPayload<DefaultDataTypes.User> = .dummy(
+        var currentUserPayload: CurrentUserPayload<DefaultExtraData.User> = .dummy(
             userId: .unique,
             role: .user,
             extraData: extraData
@@ -290,7 +290,7 @@ final class CurrentUserController_Tests: StressTestCase {
 
         // Simulate saving current user to a database
         try client.databaseContainer.writeSynchronously {
-            let currentUserPayload: CurrentUserPayload<DefaultDataTypes.User> = .dummy(
+            let currentUserPayload: CurrentUserPayload<DefaultExtraData.User> = .dummy(
                 userId: .unique,
                 role: .user,
                 unreadCount: unreadCount
@@ -702,8 +702,8 @@ private class TestEnvironment {
 }
 
 private extension WebSocketClient {
-    var typingMiddleware: TypingStartCleanupMiddleware<DefaultDataTypes>? {
-        eventNotificationCenter.middlewares.compactMap { $0 as? TypingStartCleanupMiddleware<DefaultDataTypes> }.first
+    var typingMiddleware: TypingStartCleanupMiddleware<DefaultExtraData>? {
+        eventNotificationCenter.middlewares.compactMap { $0 as? TypingStartCleanupMiddleware<DefaultExtraData> }.first
     }
 }
 

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -637,7 +637,7 @@ final class CurrentUserController_Tests: StressTestCase {
 
 private class TestDelegate: QueueAwareDelegate, CurrentUserControllerDelegate {
     @Atomic var state: DataController.State?
-    @Atomic var didChangeCurrentUser_change: EntityChange<CurrentUser>?
+    @Atomic var didChangeCurrentUser_change: EntityChange<CurrentChatUser>?
     @Atomic var didChangeCurrentUserUnreadCount_count: UnreadCount?
     @Atomic var didUpdateConnectionStatus_statuses = [ConnectionStatus]()
     
@@ -646,7 +646,7 @@ private class TestDelegate: QueueAwareDelegate, CurrentUserControllerDelegate {
         validateQueue()
     }
 
-    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser change: EntityChange<CurrentUser>) {
+    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser change: EntityChange<CurrentChatUser>) {
         didChangeCurrentUser_change = change
         validateQueue()
     }
@@ -664,7 +664,7 @@ private class TestDelegate: QueueAwareDelegate, CurrentUserControllerDelegate {
 
 private class TestDelegateGeneric: QueueAwareDelegate, CurrentUserControllerDelegateGeneric {
     @Atomic var state: DataController.State?
-    @Atomic var didChangeCurrentUser_change: EntityChange<CurrentUser>?
+    @Atomic var didChangeCurrentUser_change: EntityChange<CurrentChatUser>?
     @Atomic var didChangeCurrentUserUnreadCount_count: UnreadCount?
     @Atomic var didUpdateConnectionStatus_statuses = [ConnectionStatus]()
     
@@ -673,7 +673,7 @@ private class TestDelegateGeneric: QueueAwareDelegate, CurrentUserControllerDele
         validateQueue()
     }
     
-    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser change: EntityChange<CurrentUser>) {
+    func currentUserController(_ controller: CurrentUserController, didChangeCurrentUser change: EntityChange<CurrentChatUser>) {
         didChangeCurrentUser_change = change
         validateQueue()
     }
@@ -690,7 +690,7 @@ private class TestDelegateGeneric: QueueAwareDelegate, CurrentUserControllerDele
 }
 
 private class TestEnvironment {
-    var currentUserObserver: EntityDatabaseObserverMock<CurrentUser, CurrentUserDTO>!
+    var currentUserObserver: EntityDatabaseObserverMock<CurrentChatUser, CurrentUserDTO>!
     var currentUserObserverStartUpdatingError: Error?
 
     lazy var currentUserControllerEnvironment: CurrentUserController

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -19,7 +19,7 @@ final class CurrentUserController_Tests: StressTestCase {
         super.setUp()
         
         env = TestEnvironment()
-        client = Client.mock
+        client = _ChatClient.mock
         controller = CurrentUserController(client: client, environment: env.currentUserControllerEnvironment)
         controllerCallbackQueueID = UUID()
         controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)

--- a/Sources_v3/Controllers/MessageController/MessageController+Combine.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController+Combine.swift
@@ -6,7 +6,7 @@ import Combine
 import UIKit
 
 @available(iOS 13, *)
-extension MessageControllerGeneric {
+extension _ChatMessageController {
     /// A publisher emitting a new value every time the state of the controller changes.
     public var statePublisher: AnyPublisher<DataController.State, Never> {
         basePublishers.state.keepAlive(self)
@@ -22,7 +22,7 @@ extension MessageControllerGeneric {
     /// and expose the published values by mapping them to a read-only `AnyPublisher` type.
     class BasePublishers {
         /// The wrapper controller
-        unowned let controller: MessageControllerGeneric
+        unowned let controller: _ChatMessageController
         
         /// A backing subject for `statePublisher`.
         let state: CurrentValueSubject<DataController.State, Never>
@@ -30,7 +30,7 @@ extension MessageControllerGeneric {
         /// A backing subject for `messageChangePublisher`.
         let messageChange: PassthroughSubject<EntityChange<_ChatMessage<ExtraData>>, Never> = .init()
         
-        init(controller: MessageControllerGeneric<ExtraData>) {
+        init(controller: _ChatMessageController<ExtraData>) {
             self.controller = controller
             state = .init(controller.state)
             
@@ -40,13 +40,13 @@ extension MessageControllerGeneric {
 }
 
 @available(iOS 13, *)
-extension MessageControllerGeneric.BasePublishers: MessageControllerDelegateGeneric {
+extension _ChatMessageController.BasePublishers: _MessageControllerDelegate {
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
         self.state.send(state)
     }
     
     func messageController(
-        _ controller: MessageControllerGeneric<ExtraData>,
+        _ controller: _ChatMessageController<ExtraData>,
         didChangeMessage change: EntityChange<_ChatMessage<ExtraData>>
     ) {
         messageChange.send(change)

--- a/Sources_v3/Controllers/MessageController/MessageController+Combine.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController+Combine.swift
@@ -13,7 +13,7 @@ extension MessageControllerGeneric {
     }
     
     /// A publisher emitting a new value every time the message changes.
-    public var messageChangePublisher: AnyPublisher<EntityChange<MessageModel<ExtraData>>, Never> {
+    public var messageChangePublisher: AnyPublisher<EntityChange<_ChatMessage<ExtraData>>, Never> {
         basePublishers.messageChange.keepAlive(self)
     }
     
@@ -28,7 +28,7 @@ extension MessageControllerGeneric {
         let state: CurrentValueSubject<DataController.State, Never>
         
         /// A backing subject for `messageChangePublisher`.
-        let messageChange: PassthroughSubject<EntityChange<MessageModel<ExtraData>>, Never> = .init()
+        let messageChange: PassthroughSubject<EntityChange<_ChatMessage<ExtraData>>, Never> = .init()
         
         init(controller: MessageControllerGeneric<ExtraData>) {
             self.controller = controller
@@ -47,7 +47,7 @@ extension MessageControllerGeneric.BasePublishers: MessageControllerDelegateGene
     
     func messageController(
         _ controller: MessageControllerGeneric<ExtraData>,
-        didChangeMessage change: EntityChange<MessageModel<ExtraData>>
+        didChangeMessage change: EntityChange<_ChatMessage<ExtraData>>
     ) {
         messageChange.send(change)
     }

--- a/Sources_v3/Controllers/MessageController/MessageController+Combine_Tests.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController+Combine_Tests.swift
@@ -46,7 +46,7 @@ class MessageController_Combine_Tests: iOS13TestCase {
 
     func test_messageChangePublisher() {
         // Setup Recording publishers
-        var recording = Record<EntityChange<Message>, Never>.Recording()
+        var recording = Record<EntityChange<ChatMessage>, Never>.Recording()
         
         // Setup the chain
         messageController
@@ -58,7 +58,7 @@ class MessageController_Combine_Tests: iOS13TestCase {
         weak var controller: MessageControllerMock? = messageController
         messageController = nil
 
-        let newMessage: Message = .unique
+        let newMessage: ChatMessage = .unique
         controller?.message_simulated = newMessage
         controller?.delegateCallback {
             $0.messageController(controller!, didChangeMessage: .create(newMessage))

--- a/Sources_v3/Controllers/MessageController/MessageController+SwiftUI.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController+SwiftUI.swift
@@ -16,7 +16,7 @@ extension MessageControllerGeneric {
         public let controller: MessageControllerGeneric
         
         /// The message that current controller observes.
-        @Published public private(set) var message: MessageModel<ExtraData>?
+        @Published public private(set) var message: _ChatMessage<ExtraData>?
         
         /// The current state of the Controller.
         @Published public private(set) var state: DataController.State
@@ -37,7 +37,7 @@ extension MessageControllerGeneric {
 extension MessageControllerGeneric.ObservableObject: MessageControllerDelegateGeneric {
     public func messageController(
         _ controller: MessageControllerGeneric<ExtraData>,
-        didChangeMessage change: EntityChange<MessageModel<ExtraData>>
+        didChangeMessage change: EntityChange<_ChatMessage<ExtraData>>
     ) {
         message = controller.message
     }

--- a/Sources_v3/Controllers/MessageController/MessageController+SwiftUI.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController+SwiftUI.swift
@@ -6,14 +6,14 @@ import Foundation
 import SwiftUI
 
 @available(iOS 13, *)
-extension MessageControllerGeneric {
+extension _ChatMessageController {
     /// A wrapper object that exposes the controller variables in the form of `ObservableObject` to be used in SwiftUI.
     public var observableObject: ObservableObject { .init(controller: self) }
     
     /// A wrapper object for `CurrentUserController` type which makes it possible to use the controller comfortably in SwiftUI.
     public class ObservableObject: SwiftUI.ObservableObject {
         /// The underlying controller. You can still access it and call methods on it.
-        public let controller: MessageControllerGeneric
+        public let controller: _ChatMessageController
         
         /// The message that current controller observes.
         @Published public private(set) var message: _ChatMessage<ExtraData>?
@@ -22,7 +22,7 @@ extension MessageControllerGeneric {
         @Published public private(set) var state: DataController.State
         
         /// Creates a new `ObservableObject` wrapper with the provided controller instance.
-        init(controller: MessageControllerGeneric<ExtraData>) {
+        init(controller: _ChatMessageController<ExtraData>) {
             self.controller = controller
             state = controller.state
             
@@ -34,9 +34,9 @@ extension MessageControllerGeneric {
 }
 
 @available(iOS 13, *)
-extension MessageControllerGeneric.ObservableObject: MessageControllerDelegateGeneric {
+extension _ChatMessageController.ObservableObject: _MessageControllerDelegate {
     public func messageController(
-        _ controller: MessageControllerGeneric<ExtraData>,
+        _ controller: _ChatMessageController<ExtraData>,
         didChangeMessage change: EntityChange<_ChatMessage<ExtraData>>
     ) {
         message = controller.message

--- a/Sources_v3/Controllers/MessageController/MessageController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController+SwiftUI_Tests.swift
@@ -56,7 +56,7 @@ class MessageController_SwiftUI_Tests: iOS13TestCase {
     }
 }
 
-class MessageControllerMock: MessageController {
+class MessageControllerMock: ChatMessageController {
     @Atomic var synchronize_called = false
     
     var message_simulated: ChatMessage?

--- a/Sources_v3/Controllers/MessageController/MessageController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController+SwiftUI_Tests.swift
@@ -28,7 +28,7 @@ class MessageController_SwiftUI_Tests: iOS13TestCase {
         let observableObject = messageController.observableObject
         
         // Simulate message change
-        let newMessage: Message = .unique
+        let newMessage: ChatMessage = .unique
         messageController.message_simulated = newMessage
         messageController.delegateCallback {
             $0.messageController(
@@ -59,8 +59,8 @@ class MessageController_SwiftUI_Tests: iOS13TestCase {
 class MessageControllerMock: MessageController {
     @Atomic var synchronize_called = false
     
-    var message_simulated: Message?
-    override var message: Message? {
+    var message_simulated: ChatMessage?
+    override var message: ChatMessage? {
         message_simulated ?? super.message
     }
 

--- a/Sources_v3/Controllers/MessageController/MessageController.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController.swift
@@ -5,7 +5,7 @@
 import CoreData
 import Foundation
 
-public extension Client {
+public extension _ChatClient {
     /// Creates a new `MessageController` for the message with the provided id.
     /// - Parameter cid: The channel identifer the message relates to.
     /// - Parameter messageId: The message identifier.
@@ -21,7 +21,7 @@ public typealias MessageController = MessageControllerGeneric<DefaultExtraData>
 /// The `MessageControllerGeneric` is designed to edit the message it was created with.
 public class MessageControllerGeneric<ExtraData: ExtraDataTypes>: DataController, DelegateCallable {
     /// The `ChatClient` instance this controller belongs to.
-    public let client: Client<ExtraData>
+    public let client: _ChatClient<ExtraData>
     
     /// The channel identifier the message is related to.
     public let cid: ChannelId
@@ -71,7 +71,7 @@ public class MessageControllerGeneric<ExtraData: ExtraDataTypes>: DataController
     ///   - cid: The channel identifier the message belongs to.
     ///   - messageId: The message identifier.
     ///   - environment: The source of internal dependencies.
-    init(client: Client<ExtraData>, cid: ChannelId, messageId: MessageId, environment: Environment = .init()) {
+    init(client: _ChatClient<ExtraData>, cid: ChannelId, messageId: MessageId, environment: Environment = .init()) {
         self.client = client
         self.cid = cid
         self.messageId = messageId

--- a/Sources_v3/Controllers/MessageController/MessageController.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController.swift
@@ -15,8 +15,8 @@ public extension Client {
     }
 }
 
-/// A convenience typealias for `MessageControllerGeneric` with `DefaultDataTypes`.
-public typealias MessageController = MessageControllerGeneric<DefaultDataTypes>
+/// A convenience typealias for `MessageControllerGeneric` with `DefaultExtraData`.
+public typealias MessageController = MessageControllerGeneric<DefaultExtraData>
 
 /// The `MessageControllerGeneric` is designed to edit the message it was created with.
 public class MessageControllerGeneric<ExtraData: ExtraDataTypes>: DataController, DelegateCallable {
@@ -253,7 +253,7 @@ extension AnyMessageControllerDelegate {
     }
 }
 
-extension AnyMessageControllerDelegate where ExtraData == DefaultDataTypes {
+extension AnyMessageControllerDelegate where ExtraData == DefaultExtraData {
     convenience init(_ delegate: MessageControllerDelegate?) {
         self.init(
             wrappedDelegate: delegate,

--- a/Sources_v3/Controllers/MessageController/MessageController.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController.swift
@@ -31,7 +31,7 @@ public class MessageControllerGeneric<ExtraData: ExtraDataTypes>: DataController
     
     /// The message data
     /// To observe the updates of this value, set your class as a delegate of this controller or use `Combine` wrapper.
-    public var message: MessageModel<ExtraData>? { messageObserver.item }
+    public var message: _ChatMessage<ExtraData>? { messageObserver.item }
     
     private let environment: Environment
     
@@ -143,9 +143,9 @@ extension MessageControllerGeneric {
         var messageObserverBuilder: (
             _ context: NSManagedObjectContext,
             _ fetchRequest: NSFetchRequest<MessageDTO>,
-            _ itemCreator: @escaping (MessageDTO) -> MessageModel<ExtraData>,
+            _ itemCreator: @escaping (MessageDTO) -> _ChatMessage<ExtraData>,
             _ fetchedResultsControllerType: NSFetchedResultsController<MessageDTO>.Type
-        ) -> EntityDatabaseObserver<MessageModel<ExtraData>, MessageDTO> = EntityDatabaseObserver.init
+        ) -> EntityDatabaseObserver<_ChatMessage<ExtraData>, MessageDTO> = EntityDatabaseObserver.init
         
         var messageUpdaterBuilder: (
             _ database: DatabaseContainer,
@@ -158,7 +158,7 @@ extension MessageControllerGeneric {
 // MARK: - Private
 
 private extension MessageControllerGeneric {
-    func createMessageObserver() -> EntityDatabaseObserver<MessageModel<ExtraData>, MessageDTO> {
+    func createMessageObserver() -> EntityDatabaseObserver<_ChatMessage<ExtraData>, MessageDTO> {
         let observer = environment.messageObserverBuilder(
             client.databaseContainer.viewContext,
             MessageDTO.message(withID: messageId),
@@ -186,11 +186,11 @@ private extension MessageControllerGeneric {
 /// If you're using custom extra data types, please use `MessageControllerDelegateGeneric` instead.
 public protocol MessageControllerDelegate: DataControllerStateDelegate {
     /// The controller observed a change in the `Message`.
-    func messageController(_ controller: MessageController, didChangeMessage change: EntityChange<Message>)
+    func messageController(_ controller: MessageController, didChangeMessage change: EntityChange<ChatMessage>)
 }
 
 public extension MessageControllerDelegate {
-    func messageController(_ controller: MessageController, didChangeMessage change: EntityChange<Message>) {}
+    func messageController(_ controller: MessageController, didChangeMessage change: EntityChange<ChatMessage>) {}
 }
 
 /// `MessageControllerDelegateGeneric` uses this protocol to communicate changes to its delegate.
@@ -203,27 +203,27 @@ public protocol MessageControllerDelegateGeneric: DataControllerStateDelegate {
     /// The controller observed a change in the `MessageModel<ExtraData>`.
     func messageController(
         _ controller: MessageControllerGeneric<ExtraData>,
-        didChangeMessage change: EntityChange<MessageModel<ExtraData>>
+        didChangeMessage change: EntityChange<_ChatMessage<ExtraData>>
     )
 }
 
 public extension MessageControllerDelegateGeneric {
     func messageController(
         _ controller: MessageControllerGeneric<ExtraData>,
-        didChangeMessage change: EntityChange<MessageModel<ExtraData>>
+        didChangeMessage change: EntityChange<_ChatMessage<ExtraData>>
     ) {}
 }
 
 final class AnyMessageControllerDelegate<ExtraData: ExtraDataTypes>: MessageControllerDelegateGeneric {
     weak var wrappedDelegate: AnyObject?
     private var _controllerDidChangeState: (DataController, DataController.State) -> Void
-    private var _messageControllerDidChangeMessage: (MessageControllerGeneric<ExtraData>, EntityChange<MessageModel<ExtraData>>)
+    private var _messageControllerDidChangeMessage: (MessageControllerGeneric<ExtraData>, EntityChange<_ChatMessage<ExtraData>>)
         -> Void
     
     init(
         wrappedDelegate: AnyObject?,
         controllerDidChangeState: @escaping (DataController, DataController.State) -> Void,
-        messageControllerDidChangeMessage: @escaping (MessageControllerGeneric<ExtraData>, EntityChange<MessageModel<ExtraData>>)
+        messageControllerDidChangeMessage: @escaping (MessageControllerGeneric<ExtraData>, EntityChange<_ChatMessage<ExtraData>>)
             -> Void
     ) {
         self.wrappedDelegate = wrappedDelegate
@@ -237,7 +237,7 @@ final class AnyMessageControllerDelegate<ExtraData: ExtraDataTypes>: MessageCont
 
     func messageController(
         _ controller: MessageControllerGeneric<ExtraData>,
-        didChangeMessage change: EntityChange<MessageModel<ExtraData>>
+        didChangeMessage change: EntityChange<_ChatMessage<ExtraData>>
     ) {
         _messageControllerDidChangeMessage(controller, change)
     }

--- a/Sources_v3/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController_Tests.swift
@@ -377,14 +377,14 @@ final class MessageController_Tests: StressTestCase {
 
 private class TestDelegate: QueueAwareDelegate, MessageControllerDelegate {
     @Atomic var state: DataController.State?
-    @Atomic var didChangeMessage_change: EntityChange<Message>?
+    @Atomic var didChangeMessage_change: EntityChange<ChatMessage>?
     
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
         self.state = state
         validateQueue()
     }
     
-    func messageController(_ controller: MessageController, didChangeMessage change: EntityChange<Message>) {
+    func messageController(_ controller: MessageController, didChangeMessage change: EntityChange<ChatMessage>) {
         didChangeMessage_change = change
         validateQueue()
     }
@@ -392,14 +392,14 @@ private class TestDelegate: QueueAwareDelegate, MessageControllerDelegate {
 
 private class TestDelegateGeneric: QueueAwareDelegate, MessageControllerDelegateGeneric {
     @Atomic var state: DataController.State?
-    @Atomic var didChangeMessage_change: EntityChange<Message>?
+    @Atomic var didChangeMessage_change: EntityChange<ChatMessage>?
    
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
         self.state = state
         validateQueue()
     }
     
-    func messageController(_ controller: MessageController, didChangeMessage change: EntityChange<Message>) {
+    func messageController(_ controller: MessageController, didChangeMessage change: EntityChange<ChatMessage>) {
         didChangeMessage_change = change
         validateQueue()
     }
@@ -407,7 +407,7 @@ private class TestDelegateGeneric: QueueAwareDelegate, MessageControllerDelegate
 
 private class TestEnvironment {
     var messageUpdater: MessageUpdaterMock<DefaultExtraData>!
-    var messageObserver: EntityDatabaseObserverMock<MessageModel<DefaultExtraData>, MessageDTO>!
+    var messageObserver: EntityDatabaseObserverMock<_ChatMessage<DefaultExtraData>, MessageDTO>!
     var messageObserver_synchronizeError: Error?
     
     lazy var controllerEnvironment: MessageController

--- a/Sources_v3/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController_Tests.swift
@@ -14,7 +14,7 @@ final class MessageController_Tests: StressTestCase {
     private var messageId: MessageId!
     private var cid: ChannelId!
     
-    private var controller: MessageController!
+    private var controller: ChatMessageController!
     private var controllerCallbackQueueID: UUID!
     private var callbackQueueID: UUID { controllerCallbackQueueID }
     
@@ -31,7 +31,7 @@ final class MessageController_Tests: StressTestCase {
         cid = .unique
         
         controllerCallbackQueueID = UUID()
-        controller = MessageController(client: client, cid: cid, messageId: messageId, environment: env.controllerEnvironment)
+        controller = ChatMessageController(client: client, cid: cid, messageId: messageId, environment: env.controllerEnvironment)
         controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)
     }
     
@@ -375,7 +375,7 @@ final class MessageController_Tests: StressTestCase {
     }
 }
 
-private class TestDelegate: QueueAwareDelegate, MessageControllerDelegate {
+private class TestDelegate: QueueAwareDelegate, ChatMessageControllerDelegate {
     @Atomic var state: DataController.State?
     @Atomic var didChangeMessage_change: EntityChange<ChatMessage>?
     
@@ -384,13 +384,13 @@ private class TestDelegate: QueueAwareDelegate, MessageControllerDelegate {
         validateQueue()
     }
     
-    func messageController(_ controller: MessageController, didChangeMessage change: EntityChange<ChatMessage>) {
+    func messageController(_ controller: ChatMessageController, didChangeMessage change: EntityChange<ChatMessage>) {
         didChangeMessage_change = change
         validateQueue()
     }
 }
 
-private class TestDelegateGeneric: QueueAwareDelegate, MessageControllerDelegateGeneric {
+private class TestDelegateGeneric: QueueAwareDelegate, _MessageControllerDelegate {
     @Atomic var state: DataController.State?
     @Atomic var didChangeMessage_change: EntityChange<ChatMessage>?
    
@@ -399,7 +399,7 @@ private class TestDelegateGeneric: QueueAwareDelegate, MessageControllerDelegate
         validateQueue()
     }
     
-    func messageController(_ controller: MessageController, didChangeMessage change: EntityChange<ChatMessage>) {
+    func messageController(_ controller: ChatMessageController, didChangeMessage change: EntityChange<ChatMessage>) {
         didChangeMessage_change = change
         validateQueue()
     }
@@ -410,7 +410,7 @@ private class TestEnvironment {
     var messageObserver: EntityDatabaseObserverMock<_ChatMessage<DefaultExtraData>, MessageDTO>!
     var messageObserver_synchronizeError: Error?
     
-    lazy var controllerEnvironment: MessageController
+    lazy var controllerEnvironment: ChatMessageController
         .Environment = .init(
             messageObserverBuilder: { [unowned self] in
                 self.messageObserver = .init(context: $0, fetchRequest: $1, itemCreator: $2, fetchedResultsControllerType: $3)

--- a/Sources_v3/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController_Tests.swift
@@ -24,7 +24,7 @@ final class MessageController_Tests: StressTestCase {
         super.setUp()
         
         env = TestEnvironment()
-        client = Client.mock
+        client = _ChatClient.mock
         
         currentUserId = .unique
         messageId = .unique

--- a/Sources_v3/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController_Tests.swift
@@ -139,7 +139,7 @@ final class MessageController_Tests: StressTestCase {
         XCTAssertEqual(message.text, messageLocalText)
         
         // Simulate response from the backend with updated `text`, update the local message in the databse
-        let messagePayload: MessagePayload<DefaultDataTypes> = .dummy(
+        let messagePayload: MessagePayload<DefaultExtraData> = .dummy(
             messageId: messageId,
             authorUserId: currentUserId,
             text: .unique
@@ -233,7 +233,7 @@ final class MessageController_Tests: StressTestCase {
         controller.synchronize()
 
         // Simulate response from a backend with a message that doesn't exist locally
-        let messagePayload: MessagePayload<DefaultDataTypes> = .dummy(
+        let messagePayload: MessagePayload<DefaultExtraData> = .dummy(
             messageId: messageId,
             authorUserId: currentUserId
         )
@@ -270,7 +270,7 @@ final class MessageController_Tests: StressTestCase {
         controller.synchronize()
         
         // Simulate response from a backend with a message that exists locally but has out-dated text
-        let messagePayload: MessagePayload<DefaultDataTypes> = .dummy(
+        let messagePayload: MessagePayload<DefaultExtraData> = .dummy(
             messageId: messageId,
             authorUserId: currentUserId,
             text: "new text"
@@ -406,8 +406,8 @@ private class TestDelegateGeneric: QueueAwareDelegate, MessageControllerDelegate
 }
 
 private class TestEnvironment {
-    var messageUpdater: MessageUpdaterMock<DefaultDataTypes>!
-    var messageObserver: EntityDatabaseObserverMock<MessageModel<DefaultDataTypes>, MessageDTO>!
+    var messageUpdater: MessageUpdaterMock<DefaultExtraData>!
+    var messageObserver: EntityDatabaseObserverMock<MessageModel<DefaultExtraData>, MessageDTO>!
     var messageObserver_synchronizeError: Error?
     
     lazy var controllerEnvironment: MessageController

--- a/Sources_v3/Database/DTOs/ChannelDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO.swift
@@ -157,12 +157,12 @@ extension ChannelDTO {
 
 extension ChannelDTO {
     /// Snapshots the current state of `ChannelDTO` and returns an immutable model object from it.
-    func asModel<ExtraData: ExtraDataTypes>() -> ChannelModel<ExtraData> { .create(fromDTO: self) }
+    func asModel<ExtraData: ExtraDataTypes>() -> _ChatChannel<ExtraData> { .create(fromDTO: self) }
 }
 
-extension ChannelModel {
+extension _ChatChannel {
     /// Create a ChannelModel struct from its DTO
-    fileprivate static func create(fromDTO dto: ChannelDTO) -> ChannelModel {
+    fileprivate static func create(fromDTO dto: ChannelDTO) -> _ChatChannel {
         let members: [MemberModel<ExtraData.User>] = dto.members.map { $0.asModel() }
         let typingMembers: [MemberModel<ExtraData.User>] = dto.currentlyTypingMembers.map { $0.asModel() }
 
@@ -199,7 +199,7 @@ extension ChannelModel {
             )
         }
         
-        return ChannelModel(
+        return _ChatChannel(
             cid: cid,
             lastMessageAt: dto.lastMessageAt,
             createdAt: dto.createdAt,

--- a/Sources_v3/Database/DTOs/ChannelDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO.swift
@@ -174,7 +174,7 @@ extension _ChatChannel {
         let context = dto.managedObjectContext!
         
         // TODO: make messagesLimit a param
-        let latestMessages: [MessageModel<ExtraData>] = MessageDTO
+        let latestMessages: [_ChatMessage<ExtraData>] = MessageDTO
             .load(for: dto.cid, limit: 25, context: context)
             .map { $0.asModel() }
         

--- a/Sources_v3/Database/DTOs/ChannelDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO.swift
@@ -163,8 +163,8 @@ extension ChannelDTO {
 extension _ChatChannel {
     /// Create a ChannelModel struct from its DTO
     fileprivate static func create(fromDTO dto: ChannelDTO) -> _ChatChannel {
-        let members: [MemberModel<ExtraData.User>] = dto.members.map { $0.asModel() }
-        let typingMembers: [MemberModel<ExtraData.User>] = dto.currentlyTypingMembers.map { $0.asModel() }
+        let members: [_ChatChannelMember<ExtraData.User>] = dto.members.map { $0.asModel() }
+        let typingMembers: [_ChatChannelMember<ExtraData.User>] = dto.currentlyTypingMembers.map { $0.asModel() }
 
         // It's safe to use `try!` here, because the extra data payload comes from the DB, so we know it must
         // be a valid JSON payload, otherwise it wouldn't be possible to save it there.

--- a/Sources_v3/Database/DTOs/ChannelDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO.swift
@@ -178,7 +178,7 @@ extension ChannelModel {
             .load(for: dto.cid, limit: 25, context: context)
             .map { $0.asModel() }
         
-        let reads: [ChannelReadModel<ExtraData>] = dto.reads.map { $0.asModel() }
+        let reads: [_ChatChannelRead<ExtraData>] = dto.reads.map { $0.asModel() }
         
         var unreadCount = ChannelUnreadCount.noUnread
         if let currentUser = context.currentUser(),

--- a/Sources_v3/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO_Tests.swift
@@ -24,7 +24,7 @@ class ChannelDTO_Tests: XCTestCase {
         }
         
         // Load the channel from the db and check the fields are correct
-        var loadedChannel: ChannelModel<DefaultDataTypes>? {
+        var loadedChannel: ChannelModel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)?.asModel()
         }
         
@@ -131,7 +131,7 @@ class ChannelDTO_Tests: XCTestCase {
         }
         
         // Load the channel from the db and check the fields are correct
-        var loadedChannel: ChannelModel<DefaultDataTypes>? {
+        var loadedChannel: ChannelModel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)?.asModel()
         }
         
@@ -358,7 +358,7 @@ class ChannelDTO_Tests: XCTestCase {
         }
         
         // Load the channel from the db and check the if fields are correct
-        var loadedChannel: ChannelModel<DefaultDataTypes>? {
+        var loadedChannel: ChannelModel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)?.asModel()
         }
         
@@ -447,7 +447,7 @@ extension XCTestCase {
         )
     }
     
-    var dummyMessage: MessagePayload<DefaultDataTypes> {
+    var dummyMessage: MessagePayload<DefaultExtraData> {
         MessagePayload(
             id: .unique,
             type: .regular,
@@ -468,11 +468,11 @@ extension XCTestCase {
         )
     }
     
-    var dummyChannelRead: ChannelReadPayload<DefaultDataTypes> {
+    var dummyChannelRead: ChannelReadPayload<DefaultExtraData> {
         ChannelReadPayload(user: dummyCurrentUser, lastReadAt: Date(timeIntervalSince1970: 1), unreadMessagesCount: 10)
     }
     
-    func dummyPayload(with channelId: ChannelId) -> ChannelPayload<DefaultDataTypes> {
+    func dummyPayload(with channelId: ChannelId) -> ChannelPayload<DefaultExtraData> {
         let member: MemberPayload<NameAndImageExtraData> =
             .init(
                 user: .init(
@@ -495,7 +495,7 @@ extension XCTestCase {
         let channelCreatedDate = Date.unique
         let lastMessageAt: Date? = Bool.random() ? channelCreatedDate.addingTimeInterval(.random(in: 100_000...900_000)) : nil
         
-        let payload: ChannelPayload<DefaultDataTypes> =
+        let payload: ChannelPayload<DefaultExtraData> =
             .init(
                 channel: .init(
                     cid: channelId,

--- a/Sources_v3/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO_Tests.swift
@@ -24,7 +24,7 @@ class ChannelDTO_Tests: XCTestCase {
         }
         
         // Load the channel from the db and check the fields are correct
-        var loadedChannel: ChannelModel<DefaultExtraData>? {
+        var loadedChannel: _ChatChannel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)?.asModel()
         }
         
@@ -131,7 +131,7 @@ class ChannelDTO_Tests: XCTestCase {
         }
         
         // Load the channel from the db and check the fields are correct
-        var loadedChannel: ChannelModel<DefaultExtraData>? {
+        var loadedChannel: _ChatChannel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)?.asModel()
         }
         
@@ -358,7 +358,7 @@ class ChannelDTO_Tests: XCTestCase {
         }
         
         // Load the channel from the db and check the if fields are correct
-        var loadedChannel: ChannelModel<DefaultExtraData>? {
+        var loadedChannel: _ChatChannel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)?.asModel()
         }
         
@@ -384,7 +384,7 @@ class ChannelDTO_Tests: XCTestCase {
         }
         
         // Load the channel
-        var channel: Channel {
+        var channel: ChatChannel {
             database.viewContext.channel(cid: cid)!.asModel()
         }
         

--- a/Sources_v3/Database/DTOs/ChannelReadDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelReadDTO.swift
@@ -49,7 +49,7 @@ class ChannelReadDTO: NSManagedObject {
     }
     
     /// Snapshots the current state of `ChannelReadDTO` and returns an immutable model object from it.
-    func asModel<ExtraData: ExtraDataTypes>() -> ChannelReadModel<ExtraData> { .create(fromDTO: self) }
+    func asModel<ExtraData: ExtraDataTypes>() -> _ChatChannelRead<ExtraData> { .create(fromDTO: self) }
 }
 
 // MARK: Saving and loading the data
@@ -78,8 +78,8 @@ extension NSManagedObjectContext {
     }
 }
 
-extension ChannelReadModel {
-    fileprivate static func create(fromDTO dto: ChannelReadDTO) -> ChannelReadModel {
+extension _ChatChannelRead {
+    fileprivate static func create(fromDTO dto: ChannelReadDTO) -> _ChatChannelRead {
         .init(lastReadAt: dto.lastReadAt, unreadMessagesCount: dto.unreadMessageCount, user: dto.user.asModel())
     }
 }

--- a/Sources_v3/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO.swift
@@ -86,7 +86,7 @@ extension NSManagedObjectContext: CurrentUserDatabaseSession {
 
 extension CurrentUserDTO {
     /// Snapshots the current state of `CurrentUserDTO` and returns an immutable model object from it.
-    func asModel<ExtraData: UserExtraData>() -> CurrentUserModel<ExtraData> { .create(fromDTO: self) }
+    func asModel<ExtraData: UserExtraData>() -> _CurrentChatUser<ExtraData> { .create(fromDTO: self) }
     
     /// Snapshots the current state of `CurrentUserDTO` and returns its representation for used in API calls.
     func asRequestBody<ExtraData: UserExtraData>() -> CurrentUserRequestBody<ExtraData> {
@@ -95,8 +95,8 @@ extension CurrentUserDTO {
     }
 }
 
-extension CurrentUserModel {
-    fileprivate static func create(fromDTO dto: CurrentUserDTO) -> CurrentUserModel {
+extension _CurrentChatUser {
+    fileprivate static func create(fromDTO dto: CurrentUserDTO) -> _CurrentChatUser {
         let user = dto.user
         
         let extraData: ExtraData
@@ -111,7 +111,7 @@ extension CurrentUserModel {
         
         let mutedUsers: [_ChatUser<ExtraData>] = dto.mutedUsers.map { $0.asModel() }
         
-        return CurrentUserModel(
+        return _CurrentChatUser(
             id: user.id,
             isOnline: user.isOnline,
             isBanned: user.isBanned,

--- a/Sources_v3/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO.swift
@@ -109,7 +109,7 @@ extension CurrentUserModel {
             )
         }
         
-        let mutedUsers: [UserModel<ExtraData>] = dto.mutedUsers.map { $0.asModel() }
+        let mutedUsers: [_ChatUser<ExtraData>] = dto.mutedUsers.map { $0.asModel() }
         
         return CurrentUserModel(
             id: user.id,

--- a/Sources_v3/Database/DTOs/MemberModelDTO.swift
+++ b/Sources_v3/Database/DTOs/MemberModelDTO.swift
@@ -78,11 +78,11 @@ extension NSManagedObjectContext {
 }
 
 extension MemberDTO {
-    func asModel<ExtraData: UserExtraData>() -> MemberModel<ExtraData> { .create(fromDTO: self) }
+    func asModel<ExtraData: UserExtraData>() -> _ChatChannelMember<ExtraData> { .create(fromDTO: self) }
 }
 
-extension MemberModel {
-    fileprivate static func create(fromDTO dto: MemberDTO) -> MemberModel {
+extension _ChatChannelMember {
+    fileprivate static func create(fromDTO dto: MemberDTO) -> _ChatChannelMember {
         let extraData: ExtraData
         do {
             extraData = try JSONDecoder.default.decode(ExtraData.self, from: dto.user.extraData)
@@ -95,7 +95,7 @@ extension MemberModel {
         
         let role = dto.channelRoleRaw.flatMap { MemberRole(rawValue: $0) } ?? .member
         
-        return MemberModel(
+        return _ChatChannelMember(
             id: dto.user.id,
             isOnline: dto.user.isOnline,
             isBanned: dto.user.isBanned,

--- a/Sources_v3/Database/DTOs/MemberModelDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/MemberModelDTO_Tests.swift
@@ -48,7 +48,7 @@ class MemberModelDTO_Tests: XCTestCase {
         }
         
         // Load the member from the db and check it's the same member
-        var loadedMember: MemberModel<NameAndImageExtraData>? {
+        var loadedMember: _ChatChannelMember<NameAndImageExtraData>? {
             database.viewContext.member(userId: userId, cid: channelId)?.asModel()
         }
         
@@ -96,7 +96,7 @@ class MemberModelDTO_Tests: XCTestCase {
         }
         
         // Load the member from the db and check it's the same member
-        var loadedMember: MemberModel<NameAndImageExtraData>? {
+        var loadedMember: _ChatChannelMember<NameAndImageExtraData>? {
             database.viewContext.member(userId: userId, cid: channelId)?.asModel()
         }
         

--- a/Sources_v3/Database/DTOs/MessageDTO.swift
+++ b/Sources_v3/Database/DTOs/MessageDTO.swift
@@ -193,7 +193,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
 
 extension MessageDTO {
     /// Snapshots the current state of `MessageDTO` and returns an immutable model object from it.
-    func asModel<ExtraData: ExtraDataTypes>() -> MessageModel<ExtraData> { .init(fromDTO: self) }
+    func asModel<ExtraData: ExtraDataTypes>() -> _ChatMessage<ExtraData> { .init(fromDTO: self) }
     
     /// Snapshots the current state of `MessageDTO` and returns its representation for the use in API calls.
     func asRequestBody<ExtraData: ExtraDataTypes>() -> MessageRequestBody<ExtraData> {
@@ -220,7 +220,7 @@ extension MessageDTO {
     }
 }
 
-extension MessageModel {
+extension _ChatMessage {
     fileprivate init(fromDTO dto: MessageDTO) {
         id = dto.id
         text = dto.text

--- a/Sources_v3/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/MessageDTO_Tests.swift
@@ -142,7 +142,7 @@ class MessageDTO_Tests: XCTestCase {
         }
         
         // Load the message from the db and check the fields are correct
-        var loadedMessage: MessageModel<DefaultExtraData>? {
+        var loadedMessage: _ChatMessage<DefaultExtraData>? {
             database.viewContext.message(id: messageId)?.asModel()
         }
         
@@ -225,7 +225,7 @@ class MessageDTO_Tests: XCTestCase {
         }
         
         // Load the message from the db
-        var loadedMessage: MessageModel<DefaultExtraData>? {
+        var loadedMessage: _ChatMessage<DefaultExtraData>? {
             database.viewContext.message(id: messageId)?.asModel()
         }
         
@@ -359,7 +359,7 @@ class MessageDTO_Tests: XCTestCase {
             }, completion: completion)
         }
         
-        let loadedMessage: MessageModel<DefaultExtraData> = try unwrapAsync(
+        let loadedMessage: _ChatMessage<DefaultExtraData> = try unwrapAsync(
             database.viewContext.message(id: newMessageId)?
                 .asModel()
         )

--- a/Sources_v3/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/MessageDTO_Tests.swift
@@ -18,9 +18,9 @@ class MessageDTO_Tests: XCTestCase {
         let messageId: MessageId = .unique
         let channelId: ChannelId = .unique
         
-        let channelPayload: ChannelPayload<DefaultDataTypes> = dummyPayload(with: channelId)
+        let channelPayload: ChannelPayload<DefaultExtraData> = dummyPayload(with: channelId)
         
-        let messagePayload: MessagePayload<DefaultDataTypes> = .dummy(messageId: messageId, authorUserId: userId)
+        let messagePayload: MessagePayload<DefaultExtraData> = .dummy(messageId: messageId, authorUserId: userId)
         
         // Asynchronously save the payload to the db
         database.write { session in
@@ -76,7 +76,7 @@ class MessageDTO_Tests: XCTestCase {
         let messageId: MessageId = .unique
         let channelId: ChannelId = .unique
         
-        let channelPayload: ChannelPayload<DefaultDataTypes> = dummyPayload(with: channelId)
+        let channelPayload: ChannelPayload<DefaultExtraData> = dummyPayload(with: channelId)
         
         let messagePayload: MessagePayload<SecretExtraData> = .dummy(
             messageId: messageId,
@@ -128,9 +128,9 @@ class MessageDTO_Tests: XCTestCase {
         let messageId: MessageId = .unique
         let channelId: ChannelId = .unique
         
-        let channelPayload: ChannelPayload<DefaultDataTypes> = dummyPayload(with: channelId)
+        let channelPayload: ChannelPayload<DefaultExtraData> = dummyPayload(with: channelId)
         
-        let messagePayload: MessagePayload<DefaultDataTypes> = .dummy(messageId: messageId, authorUserId: userId)
+        let messagePayload: MessagePayload<DefaultExtraData> = .dummy(messageId: messageId, authorUserId: userId)
         
         // Asynchronously save the payload to the db
         database.write { session in
@@ -142,7 +142,7 @@ class MessageDTO_Tests: XCTestCase {
         }
         
         // Load the message from the db and check the fields are correct
-        var loadedMessage: MessageModel<DefaultDataTypes>? {
+        var loadedMessage: MessageModel<DefaultExtraData>? {
             database.viewContext.message(id: messageId)?.asModel()
         }
         
@@ -171,9 +171,9 @@ class MessageDTO_Tests: XCTestCase {
         let messageId: MessageId = .unique
         let channelId: ChannelId = .unique
         
-        let channelPayload: ChannelPayload<DefaultDataTypes> = dummyPayload(with: channelId)
+        let channelPayload: ChannelPayload<DefaultExtraData> = dummyPayload(with: channelId)
         
-        let messagePayload: MessagePayload<DefaultDataTypes> = .dummy(messageId: messageId, authorUserId: userId)
+        let messagePayload: MessagePayload<DefaultExtraData> = .dummy(messageId: messageId, authorUserId: userId)
         
         // Asynchronously save the payload to the db
         database.write { session in
@@ -185,7 +185,7 @@ class MessageDTO_Tests: XCTestCase {
         }
         
         // Load the message from the db and check the fields are correct
-        var loadedMessage: MessageRequestBody<DefaultDataTypes>? {
+        var loadedMessage: MessageRequestBody<DefaultExtraData>? {
             database.viewContext.message(id: messageId)?.asRequestBody()
         }
         
@@ -207,8 +207,8 @@ class MessageDTO_Tests: XCTestCase {
         let messageId: MessageId = .unique
         let channelId: ChannelId = .unique
         
-        let channelPayload: ChannelPayload<DefaultDataTypes> = dummyPayload(with: channelId)
-        let messagePayload: MessagePayload<DefaultDataTypes> = .dummy(messageId: messageId, authorUserId: userId)
+        let channelPayload: ChannelPayload<DefaultExtraData> = dummyPayload(with: channelId)
+        let messagePayload: MessagePayload<DefaultExtraData> = .dummy(messageId: messageId, authorUserId: userId)
         
         // Asynchronously save the payload to the db
         database.write { session in
@@ -225,7 +225,7 @@ class MessageDTO_Tests: XCTestCase {
         }
         
         // Load the message from the db
-        var loadedMessage: MessageModel<DefaultDataTypes>? {
+        var loadedMessage: MessageModel<DefaultExtraData>? {
             database.viewContext.message(id: messageId)?.asModel()
         }
         
@@ -359,7 +359,7 @@ class MessageDTO_Tests: XCTestCase {
             }, completion: completion)
         }
         
-        let loadedMessage: MessageModel<DefaultDataTypes> = try unwrapAsync(
+        let loadedMessage: MessageModel<DefaultExtraData> = try unwrapAsync(
             database.viewContext.message(id: newMessageId)?
                 .asModel()
         )

--- a/Sources_v3/Database/DTOs/UserDTO.swift
+++ b/Sources_v3/Database/DTOs/UserDTO.swift
@@ -80,7 +80,7 @@ extension NSManagedObjectContext: UserDatabaseSession {
 
 extension UserDTO {
     /// Snapshots the current state of `UserDTO` and returns an immutable model object from it.
-    func asModel<ExtraData: UserExtraData>() -> UserModel<ExtraData> { .create(fromDTO: self) }
+    func asModel<ExtraData: UserExtraData>() -> _ChatUser<ExtraData> { .create(fromDTO: self) }
     
     /// Snapshots the current state of `UserDTO` and returns its representation for used in API calls.
     func asRequestBody<ExtraData: UserExtraData>() -> UserRequestBody<ExtraData> {
@@ -98,8 +98,8 @@ extension UserDTO {
     }
 }
 
-extension UserModel {
-    fileprivate static func create(fromDTO dto: UserDTO) -> UserModel {
+extension _ChatUser {
+    fileprivate static func create(fromDTO dto: UserDTO) -> _ChatUser {
         let extraData: ExtraData
         do {
             extraData = try JSONDecoder.default.decode(ExtraData.self, from: dto.extraData)
@@ -110,7 +110,7 @@ extension UserModel {
             )
         }
         
-        return UserModel(
+        return _ChatUser(
             id: dto.id,
             isOnline: dto.isOnline,
             isBanned: dto.isBanned,

--- a/Sources_v3/Database/DTOs/UserDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/UserDTO_Tests.swift
@@ -93,7 +93,7 @@ class UserDTO_Tests: XCTestCase {
         }
         
         // Load the user from the db and check the fields are correct
-        var loadedUserModel: UserModel<NameAndImageExtraData>? {
+        var loadedUserModel: _ChatUser<NameAndImageExtraData>? {
             database.viewContext.user(id: userId)?.asModel()
         }
         

--- a/Sources_v3/Database/DataStore.swift
+++ b/Sources_v3/Database/DataStore.swift
@@ -7,7 +7,7 @@ import Foundation
 /// Types conforming to this protocol automatically exposes public `dataStore` variable.
 public protocol DataStoreProvider {
     associatedtype ExtraData: ExtraDataTypes
-    var client: Client<ExtraData> { get }
+    var client: _ChatClient<ExtraData> { get }
 }
 
 extension DataStoreProvider {
@@ -20,7 +20,7 @@ public struct DataStore<ExtraData: ExtraDataTypes> {
     let database: DatabaseContainer
     
     // Technically, we need only `database` but we use a `Client` instance to get the extra data types from it.
-    init(client: Client<ExtraData>) {
+    init(client: _ChatClient<ExtraData>) {
         database = client.databaseContainer
     }
     

--- a/Sources_v3/Database/DataStore.swift
+++ b/Sources_v3/Database/DataStore.swift
@@ -54,7 +54,7 @@ public struct DataStore<ExtraData: ExtraDataTypes> {
     /// model object. If a channel object doesn't exist locally, returns `nil`.
     ///
     /// - Parameter cid: An cid of a channel.
-    public func channel(cid: ChannelId) -> ChannelModel<ExtraData>? {
+    public func channel(cid: ChannelId) -> _ChatChannel<ExtraData>? {
         database.viewContext.channel(cid: cid)?.asModel()
     }
     

--- a/Sources_v3/Database/DataStore.swift
+++ b/Sources_v3/Database/DataStore.swift
@@ -42,7 +42,7 @@ public struct DataStore<ExtraData: ExtraDataTypes> {
     ///
     /// - Returns: If there's a current user object in the locally cached data, returns the matching
     /// model object. If a user object doesn't exist locally, returns `nil`.
-    public func currentUser() -> CurrentUserModel<ExtraData.User>? {
+    public func currentUser() -> _CurrentChatUser<ExtraData.User>? {
         database.viewContext.currentUser()?.asModel()
     }
 

--- a/Sources_v3/Database/DataStore.swift
+++ b/Sources_v3/Database/DataStore.swift
@@ -32,7 +32,7 @@ public struct DataStore<ExtraData: ExtraDataTypes> {
     /// model object. If a user object doesn't exist locally, returns `nil`.
     ///
     /// - Parameter id: An id of a user.
-    public func user(id: UserId) -> UserModel<ExtraData.User>? {
+    public func user(id: UserId) -> _ChatUser<ExtraData.User>? {
         database.viewContext.user(id: id)?.asModel()
     }
     

--- a/Sources_v3/Database/DataStore.swift
+++ b/Sources_v3/Database/DataStore.swift
@@ -66,7 +66,7 @@ public struct DataStore<ExtraData: ExtraDataTypes> {
     /// model object. If a user object doesn't exist locally, returns `nil`.
     ///
     /// - Parameter id: An id of a message.
-    public func message(id: MessageId) -> MessageModel<ExtraData>? {
+    public func message(id: MessageId) -> _ChatMessage<ExtraData>? {
         database.viewContext.message(id: id)?.asModel()
     }
 }

--- a/Sources_v3/Database/DataStore_Tests.swift
+++ b/Sources_v3/Database/DataStore_Tests.swift
@@ -7,11 +7,11 @@ import XCTest
 
 class DataStore_Tests: StressTestCase {
     // We use `_` because `Client<ExtraData>!` doesn't conform to `DataStoreProvider`
-    var _client: Client<DefaultExtraData>!
+    var _client: _ChatClient<DefaultExtraData>!
     
     override func setUp() {
         super.setUp()
-        _client = Client.mock
+        _client = _ChatClient.mock
     }
     
     func test_userIsLoaded() throws {
@@ -44,5 +44,5 @@ class DataStore_Tests: StressTestCase {
 
 // Make `DataStore_Tests` to test is the same way we will use it.
 extension DataStore_Tests: DataStoreProvider {
-    var client: Client<DefaultExtraData> { _client }
+    var client: _ChatClient<DefaultExtraData> { _client }
 }

--- a/Sources_v3/Database/DataStore_Tests.swift
+++ b/Sources_v3/Database/DataStore_Tests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 class DataStore_Tests: StressTestCase {
     // We use `_` because `Client<ExtraData>!` doesn't conform to `DataStoreProvider`
-    var _client: Client<DefaultDataTypes>!
+    var _client: Client<DefaultExtraData>!
     
     override func setUp() {
         super.setUp()
@@ -44,5 +44,5 @@ class DataStore_Tests: StressTestCase {
 
 // Make `DataStore_Tests` to test is the same way we will use it.
 extension DataStore_Tests: DataStoreProvider {
-    var client: Client<DefaultDataTypes> { _client }
+    var client: Client<DefaultExtraData> { _client }
 }

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -109,7 +109,7 @@ extension DatabaseContainer {
         try writeSynchronously { session in
             try session.saveChannel(payload: XCTestCase().dummyPayload(with: cid))
             
-            let message: MessagePayload<DefaultDataTypes> = .dummy(messageId: id, authorUserId: authorId, text: text)
+            let message: MessagePayload<DefaultExtraData> = .dummy(messageId: id, authorUserId: authorId, text: text)
             
             let messageDTO = try session.saveMessage(payload: message, for: cid)
             messageDTO.localMessageState = localState

--- a/Sources_v3/Database/DatabaseSession_Tests.swift
+++ b/Sources_v3/Database/DatabaseSession_Tests.swift
@@ -31,7 +31,7 @@ class DatabaseSession_Tests: StressTestCase {
         }
         
         // Try to load the saved channel from DB
-        var loadedChannel: ChannelModel<DefaultExtraData>? {
+        var loadedChannel: _ChatChannel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)?.asModel()
         }
         
@@ -124,7 +124,7 @@ class DatabaseSession_Tests: StressTestCase {
         AssertAsync.willBeTrue(loadedMessage != nil)
         
         // Verify the channel has the message
-        let loadedChannel: ChannelModel<DefaultExtraData> = try XCTUnwrap(database.viewContext.channel(cid: channelId)?.asModel())
+        let loadedChannel: _ChatChannel<DefaultExtraData> = try XCTUnwrap(database.viewContext.channel(cid: channelId)?.asModel())
         let message = try XCTUnwrap(loadedMessage)
         XCTAssert(loadedChannel.latestMessages.contains(message))
     }

--- a/Sources_v3/Database/DatabaseSession_Tests.swift
+++ b/Sources_v3/Database/DatabaseSession_Tests.swift
@@ -118,7 +118,7 @@ class DatabaseSession_Tests: StressTestCase {
         }
         
         // Try to load the saved message from DB
-        var loadedMessage: MessageModel<DefaultExtraData>? {
+        var loadedMessage: _ChatMessage<DefaultExtraData>? {
             database.viewContext.message(id: messageId)?.asModel()
         }
         AssertAsync.willBeTrue(loadedMessage != nil)

--- a/Sources_v3/Database/DatabaseSession_Tests.swift
+++ b/Sources_v3/Database/DatabaseSession_Tests.swift
@@ -31,7 +31,7 @@ class DatabaseSession_Tests: StressTestCase {
         }
         
         // Try to load the saved channel from DB
-        var loadedChannel: ChannelModel<DefaultDataTypes>? {
+        var loadedChannel: ChannelModel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)?.asModel()
         }
         
@@ -39,7 +39,7 @@ class DatabaseSession_Tests: StressTestCase {
         
         // Try to load a saved channel owner from DB
         if let userId = channelPayload.channel.createdBy?.id {
-            var loadedUser: UserModel<DefaultDataTypes.User>? {
+            var loadedUser: UserModel<DefaultExtraData.User>? {
                 database.viewContext.user(id: userId)?.asModel()
             }
             
@@ -48,7 +48,7 @@ class DatabaseSession_Tests: StressTestCase {
         
         // Try to load the saved member from DB
         if let member = channelPayload.channel.members?.first {
-            var loadedMember: UserModel<DefaultDataTypes.User>? {
+            var loadedMember: UserModel<DefaultExtraData.User>? {
                 database.viewContext.member(userId: member.user.id, cid: channelId)?.asModel()
             }
             
@@ -61,7 +61,7 @@ class DatabaseSession_Tests: StressTestCase {
         let channelId: ChannelId = .unique
         let messageId: MessageId = .unique
         
-        let channelPayload: ChannelDetailPayload<DefaultDataTypes> = dummyPayload(with: channelId).channel
+        let channelPayload: ChannelDetailPayload<DefaultExtraData> = dummyPayload(with: channelId).channel
         
         let userPayload: UserPayload<NameAndImageExtraData> = .init(
             id: .unique,
@@ -78,7 +78,7 @@ class DatabaseSession_Tests: StressTestCase {
             )
         )
         
-        let messagePayload = MessagePayload<DefaultDataTypes>(
+        let messagePayload = MessagePayload<DefaultExtraData>(
             id: messageId,
             type: .regular,
             user: userPayload,
@@ -93,7 +93,7 @@ class DatabaseSession_Tests: StressTestCase {
             isSilent: false
         )
         
-        let eventPayload: EventPayload<DefaultDataTypes> = .init(
+        let eventPayload: EventPayload<DefaultExtraData> = .init(
             eventType: .messageNew,
             connectionId: .unique,
             cid: channelId,
@@ -118,13 +118,13 @@ class DatabaseSession_Tests: StressTestCase {
         }
         
         // Try to load the saved message from DB
-        var loadedMessage: MessageModel<DefaultDataTypes>? {
+        var loadedMessage: MessageModel<DefaultExtraData>? {
             database.viewContext.message(id: messageId)?.asModel()
         }
         AssertAsync.willBeTrue(loadedMessage != nil)
         
         // Verify the channel has the message
-        let loadedChannel: ChannelModel<DefaultDataTypes> = try XCTUnwrap(database.viewContext.channel(cid: channelId)?.asModel())
+        let loadedChannel: ChannelModel<DefaultExtraData> = try XCTUnwrap(database.viewContext.channel(cid: channelId)?.asModel())
         let message = try XCTUnwrap(loadedMessage)
         XCTAssert(loadedChannel.latestMessages.contains(message))
     }
@@ -153,7 +153,7 @@ class DatabaseSession_Tests: StressTestCase {
     }
     
     func test_saveEvent_unreadCountFromEventPayloadIsApplied() throws {
-        let eventPayload = EventPayload<DefaultDataTypes>(
+        let eventPayload = EventPayload<DefaultExtraData>(
             eventType: .messageNew,
             connectionId: .unique,
             cid: .unique,
@@ -191,7 +191,7 @@ class DatabaseSession_Tests: StressTestCase {
     
     func test_saveEvent_resetsLastReceivedEventDate_withEventCreatedAtValue() throws {
         // Create event payload with specific `createdAt` date
-        let eventPayload = EventPayload<DefaultDataTypes>(
+        let eventPayload = EventPayload<DefaultExtraData>(
             eventType: .messageNew,
             connectionId: .unique,
             cid: .unique,
@@ -218,7 +218,7 @@ class DatabaseSession_Tests: StressTestCase {
     
     func test_saveEvent_doesntResetLastReceivedEventDate_whenEventCreatedAtValueIsNil() throws {
         // Create event payload with missing `createdAt`
-        let eventPayload = EventPayload<DefaultDataTypes>(
+        let eventPayload = EventPayload<DefaultExtraData>(
             eventType: .messageNew,
             connectionId: .unique,
             cid: .unique,

--- a/Sources_v3/Database/DatabaseSession_Tests.swift
+++ b/Sources_v3/Database/DatabaseSession_Tests.swift
@@ -39,7 +39,7 @@ class DatabaseSession_Tests: StressTestCase {
         
         // Try to load a saved channel owner from DB
         if let userId = channelPayload.channel.createdBy?.id {
-            var loadedUser: UserModel<DefaultExtraData.User>? {
+            var loadedUser: _ChatUser<DefaultExtraData.User>? {
                 database.viewContext.user(id: userId)?.asModel()
             }
             
@@ -48,7 +48,7 @@ class DatabaseSession_Tests: StressTestCase {
         
         // Try to load the saved member from DB
         if let member = channelPayload.channel.members?.first {
-            var loadedMember: UserModel<DefaultExtraData.User>? {
+            var loadedMember: _ChatUser<DefaultExtraData.User>? {
                 database.viewContext.member(userId: member.user.id, cid: channelId)?.asModel()
             }
             

--- a/Sources_v3/Models/BanEnabling.swift
+++ b/Sources_v3/Models/BanEnabling.swift
@@ -43,7 +43,7 @@ public enum BanEnabling {
     
     /// Returns true is the ban is enabled for the channel.
     /// - Parameter channel: a channel.
-    public func isEnabled(for channel: Channel) -> Bool {
+    public func isEnabled(for channel: ChatChannel) -> Bool {
         switch self {
         case .disabled:
             return false

--- a/Sources_v3/Models/ChannelModel.swift
+++ b/Sources_v3/Models/ChannelModel.swift
@@ -59,7 +59,7 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
     
     // TODO: refactor comment and add latestMessages limit mention
     /// Latest messages present on the channel.
-    public let latestMessages: [MessageModel<ExtraData>]
+    public let latestMessages: [_ChatMessage<ExtraData>]
     
     /// Read states of the users for this channel.
     public let reads: [_ChatChannelRead<ExtraData>]
@@ -94,7 +94,7 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
         reads: [_ChatChannelRead<ExtraData>] = [],
         extraData: ExtraData.Channel,
         invitedMembers: Set<MemberModel<ExtraData.User>> = [],
-        latestMessages: [MessageModel<ExtraData>] = []
+        latestMessages: [_ChatMessage<ExtraData>] = []
     ) {
         self.cid = cid
         self.lastMessageAt = lastMessageAt

--- a/Sources_v3/Models/ChannelModel.swift
+++ b/Sources_v3/Models/ChannelModel.swift
@@ -137,7 +137,7 @@ extension ChannelModel {
 }
 
 /// A convenience `ChannelModel` typealias with no additional channel data.
-public typealias Channel = ChannelModel<DefaultDataTypes>
+public typealias Channel = ChannelModel<DefaultExtraData>
 
 /// Additional data fields `ChannelModel` can be extended with. You can use it to store your custom data related to a channel.
 public protocol ChannelExtraData: ExtraData {}

--- a/Sources_v3/Models/ChannelModel.swift
+++ b/Sources_v3/Models/ChannelModel.swift
@@ -33,10 +33,10 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
     public let isFrozen: Bool
     
     /// A list of channel members.
-    public let members: Set<MemberModel<ExtraData.User>>
+    public let members: Set<_ChatChannelMember<ExtraData.User>>
     
     /// A list of typing channel members.
-    public let currentlyTypingMembers: Set<MemberModel<ExtraData.User>>
+    public let currentlyTypingMembers: Set<_ChatChannelMember<ExtraData.User>>
     
     /// A list of channel watchers.
     public let watchers: Set<_ChatUser<ExtraData.User>>
@@ -69,10 +69,10 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
     // MARK: - Internal
     
     /// A helper variable to cache the result of the filter for only banned members.
-    //  lazy var bannedMembers: Set<MemberModel<ExtraData.User>> = Set(self.members.filter { $0.isBanned })
+    //  lazy var bannedMembers: Set<_ChatChannelMember<ExtraData.User>> = Set(self.members.filter { $0.isBanned })
     
     /// A list of users to invite in the channel.
-    let invitedMembers: Set<MemberModel<ExtraData.User>> // TODO: Why is this not public?
+    let invitedMembers: Set<_ChatChannelMember<ExtraData.User>> // TODO: Why is this not public?
     
     init(
         cid: ChannelId,
@@ -83,8 +83,8 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
         createdBy: _ChatUser<ExtraData.User>? = nil,
         config: ChannelConfig = .init(),
         isFrozen: Bool = false,
-        members: Set<MemberModel<ExtraData.User>> = [],
-        currentlyTypingMembers: Set<MemberModel<ExtraData.User>> = [],
+        members: Set<_ChatChannelMember<ExtraData.User>> = [],
+        currentlyTypingMembers: Set<_ChatChannelMember<ExtraData.User>> = [],
         watchers: Set<_ChatUser<ExtraData.User>> = [],
         team: String = "",
         unreadCount: ChannelUnreadCount = .noUnread,
@@ -93,7 +93,7 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
         isWatched: Bool = false,
         reads: [_ChatChannelRead<ExtraData>] = [],
         extraData: ExtraData.Channel,
-        invitedMembers: Set<MemberModel<ExtraData.User>> = [],
+        invitedMembers: Set<_ChatChannelMember<ExtraData.User>> = [],
         latestMessages: [_ChatMessage<ExtraData>] = []
     ) {
         self.cid = cid

--- a/Sources_v3/Models/ChannelModel.swift
+++ b/Sources_v3/Models/ChannelModel.swift
@@ -59,7 +59,7 @@ public struct ChannelModel<ExtraData: ExtraDataTypes> {
     public let latestMessages: [MessageModel<ExtraData>]
     
     /// Read states of the users for this channel.
-    public let reads: [ChannelReadModel<ExtraData>]
+    public let reads: [_ChatChannelRead<ExtraData>]
     
     public let extraData: ExtraData.Channel
     
@@ -88,7 +88,7 @@ public struct ChannelModel<ExtraData: ExtraDataTypes> {
         watcherCount: Int = 0,
         banEnabling: BanEnabling = .disabled,
         isWatched: Bool = false,
-        reads: [ChannelReadModel<ExtraData>] = [],
+        reads: [_ChatChannelRead<ExtraData>] = [],
         extraData: ExtraData.Channel,
         invitedMembers: Set<MemberModel<ExtraData.User>> = [],
         latestMessages: [MessageModel<ExtraData>] = []

--- a/Sources_v3/Models/ChannelModel.swift
+++ b/Sources_v3/Models/ChannelModel.swift
@@ -4,7 +4,10 @@
 
 import Foundation
 
-public struct ChannelModel<ExtraData: ExtraDataTypes> {
+/// A convenience `_ChatChannel` typealias with no additional channel data.
+public typealias ChatChannel = _ChatChannel<DefaultExtraData>
+
+public struct _ChatChannel<ExtraData: ExtraDataTypes> {
     /// A channel type + id.
     public let cid: ChannelId
     
@@ -116,7 +119,7 @@ public struct ChannelModel<ExtraData: ExtraDataTypes> {
     }
 }
 
-extension ChannelModel {
+extension _ChatChannel {
     /// A channel type.
     public var type: ChannelType { cid.type }
     
@@ -136,18 +139,15 @@ extension ChannelModel {
     var isEmpty: Bool { /* extraData == nil && members.isEmpty && invitedMembers.isEmpty */ fatalError() }
 }
 
-/// A convenience `ChannelModel` typealias with no additional channel data.
-public typealias Channel = ChannelModel<DefaultExtraData>
-
 /// Additional data fields `ChannelModel` can be extended with. You can use it to store your custom data related to a channel.
 public protocol ChannelExtraData: ExtraData {}
 
 /// A type-erased version of `ChannelModel<CustomData>`. Not intended to be used directly.
 public protocol AnyChannel {}
-extension ChannelModel: AnyChannel {}
+extension _ChatChannel: AnyChannel {}
 
-extension ChannelModel: Hashable {
-    public static func == (lhs: ChannelModel<ExtraData>, rhs: ChannelModel<ExtraData>) -> Bool {
+extension _ChatChannel: Hashable {
+    public static func == (lhs: _ChatChannel<ExtraData>, rhs: _ChatChannel<ExtraData>) -> Bool {
         lhs.cid == rhs.cid
     }
     

--- a/Sources_v3/Models/ChannelModel.swift
+++ b/Sources_v3/Models/ChannelModel.swift
@@ -24,7 +24,7 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
     public let deletedAt: Date?
     
     /// The user which created the channel.
-    public let createdBy: UserModel<ExtraData.User>?
+    public let createdBy: _ChatUser<ExtraData.User>?
     
     /// A config.
     public let config: ChannelConfig
@@ -39,7 +39,7 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
     public let currentlyTypingMembers: Set<MemberModel<ExtraData.User>>
     
     /// A list of channel watchers.
-    public let watchers: Set<UserModel<ExtraData.User>>
+    public let watchers: Set<_ChatUser<ExtraData.User>>
     
     /// The team the channel belongs to. You need to enable multi-tenancy if you want to use this, else it'll be nil.
     /// Refer to [docs](https://getstream.io/chat/docs/multi_tenant_chat/?language=swift) for more info.
@@ -80,12 +80,12 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
         createdAt: Date = .init(),
         updatedAt: Date = .init(),
         deletedAt: Date? = nil,
-        createdBy: UserModel<ExtraData.User>? = nil,
+        createdBy: _ChatUser<ExtraData.User>? = nil,
         config: ChannelConfig = .init(),
         isFrozen: Bool = false,
         members: Set<MemberModel<ExtraData.User>> = [],
         currentlyTypingMembers: Set<MemberModel<ExtraData.User>> = [],
-        watchers: Set<UserModel<ExtraData.User>> = [],
+        watchers: Set<_ChatUser<ExtraData.User>> = [],
         team: String = "",
         unreadCount: ChannelUnreadCount = .noUnread,
         watcherCount: Int = 0,

--- a/Sources_v3/Models/ChannelRead.swift
+++ b/Sources_v3/Models/ChannelRead.swift
@@ -4,8 +4,10 @@
 
 import Foundation
 
-/// A type reprsenting a user's last read action on a channel.
-public struct ChannelReadModel<ExtraData: ExtraDataTypes> {
+public typealias ChatChannelRead = _ChatChannelRead<DefaultExtraData>
+
+/// A type represnting a user's last read action on a channel.
+public struct _ChatChannelRead<ExtraData: ExtraDataTypes> {
     /// The last time the user has read the channel.
     public let lastReadAt: Date
     
@@ -25,5 +27,3 @@ public struct ChannelReadModel<ExtraData: ExtraDataTypes> {
         self.user = user
     }
 }
-
-public typealias ChannelRead = ChannelReadModel<DefaultExtraData>

--- a/Sources_v3/Models/ChannelRead.swift
+++ b/Sources_v3/Models/ChannelRead.swift
@@ -15,12 +15,12 @@ public struct _ChatChannelRead<ExtraData: ExtraDataTypes> {
     public let unreadMessagesCount: Int
     
     /// The user who read the channel.
-    public let user: UserModel<ExtraData.User>
+    public let user: _ChatUser<ExtraData.User>
     
     init(
         lastReadAt: Date,
         unreadMessagesCount: Int,
-        user: UserModel<ExtraData.User>
+        user: _ChatUser<ExtraData.User>
     ) {
         self.lastReadAt = lastReadAt
         self.unreadMessagesCount = unreadMessagesCount

--- a/Sources_v3/Models/ChannelReadModel.swift
+++ b/Sources_v3/Models/ChannelReadModel.swift
@@ -26,4 +26,4 @@ public struct ChannelReadModel<ExtraData: ExtraDataTypes> {
     }
 }
 
-public typealias ChannelRead = ChannelReadModel<DefaultDataTypes>
+public typealias ChannelRead = ChannelReadModel<DefaultExtraData>

--- a/Sources_v3/Models/CurrentUser.swift
+++ b/Sources_v3/Models/CurrentUser.swift
@@ -19,7 +19,7 @@ extension UserId {
 }
 
 /// A convenience typealias for `CurrentUserModel` with the default data type.
-public typealias CurrentUser = CurrentUserModel<DefaultDataTypes.User>
+public typealias CurrentUser = CurrentUserModel<DefaultExtraData.User>
 
 public class CurrentUserModel<ExtraData: UserExtraData>: UserModel<ExtraData> {
     // MARK: - Public

--- a/Sources_v3/Models/CurrentUser.swift
+++ b/Sources_v3/Models/CurrentUser.swift
@@ -19,9 +19,9 @@ extension UserId {
 }
 
 /// A convenience typealias for `CurrentUserModel` with the default data type.
-public typealias CurrentUser = CurrentUserModel<DefaultExtraData.User>
+public typealias CurrentChatUser = _CurrentChatUser<DefaultExtraData.User>
 
-public class CurrentUserModel<ExtraData: UserExtraData>: _ChatUser<ExtraData> {
+public class _CurrentChatUser<ExtraData: UserExtraData>: _ChatUser<ExtraData> {
     // MARK: - Public
     
     /// A list of devices.

--- a/Sources_v3/Models/CurrentUser.swift
+++ b/Sources_v3/Models/CurrentUser.swift
@@ -21,7 +21,7 @@ extension UserId {
 /// A convenience typealias for `CurrentUserModel` with the default data type.
 public typealias CurrentUser = CurrentUserModel<DefaultExtraData.User>
 
-public class CurrentUserModel<ExtraData: UserExtraData>: UserModel<ExtraData> {
+public class CurrentUserModel<ExtraData: UserExtraData>: _ChatUser<ExtraData> {
     // MARK: - Public
     
     /// A list of devices.
@@ -31,7 +31,7 @@ public class CurrentUserModel<ExtraData: UserExtraData>: UserModel<ExtraData> {
     public let currentDevice: Device?
     
     /// Muted users.
-    public let mutedUsers: Set<UserModel<ExtraData>>
+    public let mutedUsers: Set<_ChatUser<ExtraData>>
     
     /// The counts of unread channels and messages.
     public let unreadCount: UnreadCount
@@ -47,7 +47,7 @@ public class CurrentUserModel<ExtraData: UserExtraData>: UserModel<ExtraData> {
         extraData: ExtraData = .defaultValue,
         devices: [Device] = [],
         currentDevice: Device? = nil,
-        mutedUsers: Set<UserModel<ExtraData>> = [],
+        mutedUsers: Set<_ChatUser<ExtraData>> = [],
         unreadCount: UnreadCount = .noUnread
     ) {
         self.devices = devices

--- a/Sources_v3/Models/Member.swift
+++ b/Sources_v3/Models/Member.swift
@@ -4,9 +4,9 @@
 
 import Foundation
 
-public typealias Member = MemberModel<NameAndImageExtraData>
+public typealias ChatChannelMember = _ChatChannelMember<NameAndImageExtraData>
 
-public class MemberModel<ExtraData: UserExtraData>: _ChatUser<ExtraData> {
+public class _ChatChannelMember<ExtraData: UserExtraData>: _ChatUser<ExtraData> {
     // MARK: - Public
     
     /// The role of the user within the channel.

--- a/Sources_v3/Models/MemberModel.swift
+++ b/Sources_v3/Models/MemberModel.swift
@@ -6,7 +6,7 @@ import Foundation
 
 public typealias Member = MemberModel<NameAndImageExtraData>
 
-public class MemberModel<ExtraData: UserExtraData>: UserModel<ExtraData> {
+public class MemberModel<ExtraData: UserExtraData>: _ChatUser<ExtraData> {
     // MARK: - Public
     
     /// The role of the user within the channel.

--- a/Sources_v3/Models/Message.swift
+++ b/Sources_v3/Models/Message.swift
@@ -53,13 +53,13 @@ public enum LocalMessageState: String {
     case deletingFailed
 }
 
-/// A convenient type alias for `MessageModel` with `DefaultExtraData`.
-public typealias Message = MessageModel<DefaultExtraData>
+/// A convenient type alias for `_ChatMessage` with `DefaultExtraData`.
+public typealias ChatMessage = _ChatMessage<DefaultExtraData>
 
 /// Additional data fields `MessageModel` can be extended with. You can use it to store your custom data related to a message.
 public protocol MessageExtraData: ExtraData {}
 
-public struct MessageModel<ExtraData: ExtraDataTypes> {
+public struct _ChatMessage<ExtraData: ExtraDataTypes> {
     public let id: MessageId
     public let text: String
     public let type: MessageType
@@ -88,7 +88,7 @@ public struct MessageModel<ExtraData: ExtraDataTypes> {
     public let localState: LocalMessageState?
 }
 
-extension MessageModel: Hashable {
+extension _ChatMessage: Hashable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id
     }

--- a/Sources_v3/Models/Message.swift
+++ b/Sources_v3/Models/Message.swift
@@ -54,7 +54,7 @@ public enum LocalMessageState: String {
 }
 
 /// A convenient type alias for `MessageModel` with `DefaultExtraData`.
-public typealias Message = MessageModel<DefaultDataTypes>
+public typealias Message = MessageModel<DefaultExtraData>
 
 /// Additional data fields `MessageModel` can be extended with. You can use it to store your custom data related to a message.
 public protocol MessageExtraData: ExtraData {}

--- a/Sources_v3/Models/Message.swift
+++ b/Sources_v3/Models/Message.swift
@@ -78,8 +78,8 @@ public struct _ChatMessage<ExtraData: ExtraDataTypes> {
     public let isSilent: Bool
     public let reactionScores: [String: Int]
     
-    public let author: UserModel<ExtraData.User>
-    public let mentionedUsers: Set<UserModel<ExtraData.User>>
+    public let author: _ChatUser<ExtraData.User>
+    public let mentionedUsers: Set<_ChatUser<ExtraData.User>>
     
     /// A possible additional local state of the message. Applies only for the messages of the current user.
     ///

--- a/Sources_v3/Models/User.swift
+++ b/Sources_v3/Models/User.swift
@@ -11,7 +11,7 @@ public typealias UserId = String
 
 /// A type representing user in chat.
 @dynamicMemberLookup
-public class UserModel<ExtraData: UserExtraData> {
+public class _ChatUser<ExtraData: UserExtraData> {
     // MARK: - Public
     
     /// The id of the user.
@@ -70,8 +70,8 @@ public class UserModel<ExtraData: UserExtraData> {
     }
 }
 
-extension UserModel: Hashable {
-    public static func == (lhs: UserModel<ExtraData>, rhs: UserModel<ExtraData>) -> Bool {
+extension _ChatUser: Hashable {
+    public static func == (lhs: _ChatUser<ExtraData>, rhs: _ChatUser<ExtraData>) -> Bool {
         lhs.id == rhs.id
     }
     
@@ -80,7 +80,7 @@ extension UserModel: Hashable {
     }
 }
 
-extension UserModel {
+extension _ChatUser {
     public subscript<T>(dynamicMember keyPath: KeyPath<ExtraData, T>) -> T {
         // TODO: Solve double optional
         extraData[keyPath: keyPath]
@@ -99,9 +99,9 @@ public enum UserRole: String, Codable, Hashable {
 }
 
 /// Convenience `UserModel` typealias with `NameAndImageExtraData`.
-public typealias User = UserModel<NameAndImageExtraData>
+public typealias ChatUser = _ChatUser<NameAndImageExtraData>
 
-public extension User {
+public extension ChatUser {
     /// Creates a new `User` object.
     ///
     /// - Parameters:

--- a/Sources_v3/Query/ChannelQuery_Tests.swift
+++ b/Sources_v3/Query/ChannelQuery_Tests.swift
@@ -15,7 +15,7 @@ class ChannelQuery_Tests: XCTestCase {
         let options: QueryOptions = .all
 
         // Create ChannelQuery
-        let query = ChannelQuery<DefaultDataTypes>(
+        let query = ChannelQuery<DefaultExtraData>(
             cid: cid,
             messagesPagination: messagesPagination,
             membersPagination: membersPagination,

--- a/Sources_v3/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware_Tests.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware_Tests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class ChannelMemberTypingStateUpdaterMiddleware_Tests: XCTestCase {
     var database: DatabaseContainerMock!
-    var middleware: ChannelMemberTypingStateUpdaterMiddleware<DefaultDataTypes>!
+    var middleware: ChannelMemberTypingStateUpdaterMiddleware<DefaultExtraData>!
     
     // MARK: - Set up
     

--- a/Sources_v3/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware_Tests.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware_Tests.swift
@@ -74,7 +74,7 @@ final class ChannelMemberTypingStateUpdaterMiddleware_Tests: XCTestCase {
         try database.createMember(userId: memberId, cid: cid)
         
         // Load the channel
-        var channel: Channel {
+        var channel: ChatChannel {
             database.viewContext.channel(cid: cid)!.asModel()
         }
         
@@ -110,7 +110,7 @@ final class ChannelMemberTypingStateUpdaterMiddleware_Tests: XCTestCase {
         }
         
         // Load the channel
-        var channel: Channel {
+        var channel: ChatChannel {
             database.viewContext.channel(cid: cid)!.asModel()
         }
         

--- a/Sources_v3/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
@@ -28,7 +28,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         }
         
         // Load the channel from the db and check the if fields are correct
-        var loadedChannel: ChannelModel<DefaultExtraData>? {
+        var loadedChannel: _ChatChannel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)?.asModel()
         }
         
@@ -74,7 +74,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         }
 
         // Load the channel from the db and check the if fields are correct
-        var loadedChannel: ChannelModel<DefaultExtraData>? {
+        var loadedChannel: _ChatChannel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)?.asModel()
         }
         
@@ -135,7 +135,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         }
         
         // Load the channel from the db and check the if fields are correct
-        var loadedChannel: ChannelModel<DefaultExtraData>? {
+        var loadedChannel: _ChatChannel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)?.asModel()
         }
         

--- a/Sources_v3/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
-    var middleware: ChannelReadUpdaterMiddleware<DefaultDataTypes>!
+    var middleware: ChannelReadUpdaterMiddleware<DefaultExtraData>!
     fileprivate var database: DatabaseContainerMock!
     
     override func setUp() {
@@ -28,7 +28,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         }
         
         // Load the channel from the db and check the if fields are correct
-        var loadedChannel: ChannelModel<DefaultDataTypes>? {
+        var loadedChannel: ChannelModel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)?.asModel()
         }
         
@@ -39,14 +39,14 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         // with a read date later than original read
         let newReadDate = Date(timeIntervalSince1970: 2)
         // Create EventPayload for MessageReadEvent
-        let eventPayload = EventPayload<DefaultDataTypes>(
+        let eventPayload = EventPayload<DefaultExtraData>(
             eventType: .messageRead,
             cid: channelId,
             user: dummyCurrentUser,
             unreadCount: .noUnread,
             createdAt: newReadDate
         )
-        let messageReadEvent = try MessageReadEvent<DefaultDataTypes>(from: eventPayload)
+        let messageReadEvent = try MessageReadEvent<DefaultExtraData>(from: eventPayload)
         
         // Let the middleware handle the event
         // Middleware should mutate the loadedChannel's read
@@ -74,7 +74,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         }
 
         // Load the channel from the db and check the if fields are correct
-        var loadedChannel: ChannelModel<DefaultDataTypes>? {
+        var loadedChannel: ChannelModel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)?.asModel()
         }
         
@@ -85,7 +85,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         // with a read date later than original read
         let newReadDate = Date(timeIntervalSince1970: 2)
         // Unfortunately, ChannelDetailPayload is needed for NotificationMarkReadEvent...
-        let channelDetailPayload = ChannelDetailPayload<DefaultDataTypes>(
+        let channelDetailPayload = ChannelDetailPayload<DefaultExtraData>(
             cid: channelId,
             extraData: lukeExtraData,
             typeRawValue: "",
@@ -101,14 +101,14 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
             members: nil
         )
         // Create EventPayload for NotificationMarkReadEvent
-        let eventPayload = EventPayload<DefaultDataTypes>(
+        let eventPayload = EventPayload<DefaultExtraData>(
             eventType: .notificationMarkRead,
             user: dummyCurrentUser,
             channel: channelDetailPayload,
             unreadCount: .noUnread,
             createdAt: newReadDate
         )
-        let notificationMarkReadEvent = try NotificationMarkReadEvent<DefaultDataTypes>(from: eventPayload)
+        let notificationMarkReadEvent = try NotificationMarkReadEvent<DefaultExtraData>(from: eventPayload)
         
         // Let the middleware handle the event
         let handledEvent = try await { middleware.handle(event: notificationMarkReadEvent, completion: $0) }
@@ -135,7 +135,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         }
         
         // Load the channel from the db and check the if fields are correct
-        var loadedChannel: ChannelModel<DefaultDataTypes>? {
+        var loadedChannel: ChannelModel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)?.asModel()
         }
         
@@ -147,7 +147,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         // with a read date later than original read
         let newReadDate = Date(timeIntervalSince1970: 2)
         // Create EventPayload for NotificationMarkAllReadEvent
-        let eventPayload = EventPayload<DefaultDataTypes>(
+        let eventPayload = EventPayload<DefaultExtraData>(
             eventType: .notificationMarkRead,
             user: dummyCurrentUser,
             createdAt: newReadDate

--- a/Sources_v3/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 class EventDataProcessorMiddleware_Tests: XCTestCase {
-    var middleware: EventDataProcessorMiddleware<DefaultDataTypes>!
+    var middleware: EventDataProcessorMiddleware<DefaultExtraData>!
     fileprivate var database: DatabaseContainerMock!
     
     override func setUp() {
@@ -37,7 +37,7 @@ class EventDataProcessorMiddleware_Tests: XCTestCase {
         let completion = try await { middleware.handle(event: testEvent, completion: $0) }
         
         // Assert the channel data is saved and the event is forwarded
-        var loadedChannel: ChannelModel<DefaultDataTypes>? {
+        var loadedChannel: ChannelModel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)!.asModel()
         }
         XCTAssertEqual(loadedChannel?.cid, channelId)
@@ -51,7 +51,7 @@ class EventDataProcessorMiddleware_Tests: XCTestCase {
         }
         
         // This is not really used, we just need to have something to create the event with
-        let somePayload = EventPayload<DefaultDataTypes>(eventType: .healthCheck)
+        let somePayload = EventPayload<DefaultExtraData>(eventType: .healthCheck)
         
         let testEvent = TestEvent(payload: somePayload)
         

--- a/Sources_v3/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
@@ -37,7 +37,7 @@ class EventDataProcessorMiddleware_Tests: XCTestCase {
         let completion = try await { middleware.handle(event: testEvent, completion: $0) }
         
         // Assert the channel data is saved and the event is forwarded
-        var loadedChannel: ChannelModel<DefaultExtraData>? {
+        var loadedChannel: _ChatChannel<DefaultExtraData>? {
             database.viewContext.channel(cid: channelId)!.asModel()
         }
         XCTAssertEqual(loadedChannel?.cid, channelId)

--- a/Sources_v3/WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware_Tests.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 class TypingStartCleanupMiddleware_Tests: XCTestCase {
-    var middleware: TypingStartCleanupMiddleware<DefaultDataTypes>!
+    var middleware: TypingStartCleanupMiddleware<DefaultExtraData>!
     var currentUser: User!
     
     var time: VirtualTime!

--- a/Sources_v3/WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware_Tests.swift
+++ b/Sources_v3/WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware_Tests.swift
@@ -7,14 +7,14 @@ import XCTest
 
 class TypingStartCleanupMiddleware_Tests: XCTestCase {
     var middleware: TypingStartCleanupMiddleware<DefaultExtraData>!
-    var currentUser: User!
+    var currentUser: ChatUser!
     
     var time: VirtualTime!
     
     override func setUp() {
         super.setUp()
         
-        currentUser = User(id: "Luke")
+        currentUser = ChatUser(id: "Luke")
         middleware = TypingStartCleanupMiddleware(excludedUserIds: { [self.currentUser.id] })
         
         time = VirtualTime()
@@ -38,7 +38,7 @@ class TypingStartCleanupMiddleware_Tests: XCTestCase {
     
     func test_stopTypingEvent_sentAfterTimeout() {
         // Simulate some user started typing
-        let otherUser = User(id: UUID().uuidString)
+        let otherUser = ChatUser(id: UUID().uuidString)
         let cid = ChannelId.unique
         
         var result: [EquatableEvent?] = []

--- a/Sources_v3/WebSocketClient/Events/ChannelEvents_Tests.swift
+++ b/Sources_v3/WebSocketClient/Events/ChannelEvents_Tests.swift
@@ -6,18 +6,18 @@
 import XCTest
 
 class ChannelEvents_Tests: XCTestCase {
-    let eventDecoder = EventDecoder<DefaultDataTypes>()
+    let eventDecoder = EventDecoder<DefaultExtraData>()
     
     func test_updated() throws {
         let json = XCTestCase.mockData(fromFile: "ChannelUpdated")
-        let event = try eventDecoder.decode(from: json) as? ChannelUpdatedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? ChannelUpdatedEvent<DefaultExtraData>
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_7070"))
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
     }
     
     func test_deleted() throws {
         let json = XCTestCase.mockData(fromFile: "ChannelDeleted")
-        let event = try eventDecoder.decode(from: json) as? ChannelDeletedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? ChannelDeletedEvent<DefaultExtraData>
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_6631"))
         XCTAssertEqual(event?.deletedAt.description, "2020-07-17 12:02:39 +0000")
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
@@ -26,7 +26,7 @@ class ChannelEvents_Tests: XCTestCase {
     func test_hidden() throws {
         // Channel was hidden.
         var json = XCTestCase.mockData(fromFile: "ChannelHidden")
-        var event = try eventDecoder.decode(from: json) as? ChannelHiddenEvent<DefaultDataTypes>
+        var event = try eventDecoder.decode(from: json) as? ChannelHiddenEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_7011"))
         XCTAssertEqual(event?.hiddenAt.description, "2020-07-17 12:10:44 +0000")
@@ -34,7 +34,7 @@ class ChannelEvents_Tests: XCTestCase {
         
         // Channel was hidden and the history was cleared.
         json = XCTestCase.mockData(fromFile: "ChannelHiddenCleared")
-        event = try eventDecoder.decode(from: json) as? ChannelHiddenEvent<DefaultDataTypes>
+        event = try eventDecoder.decode(from: json) as? ChannelHiddenEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_1328"))
         XCTAssertEqual(event?.hiddenAt.description, "2020-07-17 12:11:46 +0000")

--- a/Sources_v3/WebSocketClient/Events/ConnectionEvents.swift
+++ b/Sources_v3/WebSocketClient/Events/ConnectionEvents.swift
@@ -23,7 +23,7 @@ public struct HealthCheckEvent: ConnectionEvent, EventWithPayload {
     
     init(connectionId: String) {
         self.connectionId = connectionId
-        payload = EventPayload<DefaultDataTypes>(
+        payload = EventPayload<DefaultExtraData>(
             eventType: .healthCheck,
             connectionId: connectionId,
             cid: nil,

--- a/Sources_v3/WebSocketClient/Events/EventPayload_Tests.swift
+++ b/Sources_v3/WebSocketClient/Events/EventPayload_Tests.swift
@@ -5,11 +5,11 @@
 @testable import StreamChatClient
 import XCTest
 
-typealias DefaultEventPayload = EventPayload<DefaultDataTypes>
+typealias DefaultEventPayload = EventPayload<DefaultExtraData>
 
 class EventPayload_Tests: XCTestCase {
     let eventJSON = XCTestCase.mockData(fromFile: "NotificationAddedToChannel")
-    let eventDecoder = EventDecoder<DefaultDataTypes>()
+    let eventDecoder = EventDecoder<DefaultExtraData>()
     
     func test_eventJSON_isSerialized_withDefaultExtraData() throws {
         let payload = try JSONDecoder.default.decode(DefaultEventPayload.self, from: eventJSON)

--- a/Sources_v3/WebSocketClient/Events/MemberEvents_Tests.swift
+++ b/Sources_v3/WebSocketClient/Events/MemberEvents_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 class MemberEvents_Tests: XCTestCase {
-    let eventDecoder = EventDecoder<DefaultDataTypes>()
+    let eventDecoder = EventDecoder<DefaultExtraData>()
     
     func test_added() throws {
         let json = XCTestCase.mockData(fromFile: "MemberAdded")

--- a/Sources_v3/WebSocketClient/Events/MessageEvents_Tests.swift
+++ b/Sources_v3/WebSocketClient/Events/MessageEvents_Tests.swift
@@ -6,12 +6,12 @@
 import XCTest
 
 class MessageEvents_Tests: XCTestCase {
-    let eventDecoder = EventDecoder<DefaultDataTypes>()
+    let eventDecoder = EventDecoder<DefaultExtraData>()
     let messageId: MessageId = "1ff9f6d0-df70-4703-aef0-379f95ad7366"
     
     func test_new() throws {
         let json = XCTestCase.mockData(fromFile: "MessageNew")
-        let event = try eventDecoder.decode(from: json) as? MessageNewEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? MessageNewEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "general"))
         XCTAssertEqual(event?.messageId, messageId)
@@ -22,7 +22,7 @@ class MessageEvents_Tests: XCTestCase {
     
     func test_new_withMissingFields() throws {
         let json = XCTestCase.mockData(fromFile: "MessageNew+MissingFields")
-        let event = try eventDecoder.decode(from: json) as? MessageNewEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? MessageNewEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "general"))
         XCTAssertEqual(event?.messageId, messageId)
@@ -33,7 +33,7 @@ class MessageEvents_Tests: XCTestCase {
     
     func test_updated() throws {
         let json = XCTestCase.mockData(fromFile: "MessageUpdated")
-        let event = try eventDecoder.decode(from: json) as? MessageUpdatedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? MessageUpdatedEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "general"))
         XCTAssertEqual(event?.messageId, messageId)
@@ -42,7 +42,7 @@ class MessageEvents_Tests: XCTestCase {
     
     func test_deleted() throws {
         let json = XCTestCase.mockData(fromFile: "MessageDeleted")
-        let event = try eventDecoder.decode(from: json) as? MessageDeletedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? MessageDeletedEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "general"))
         XCTAssertEqual(event?.messageId, messageId)
@@ -51,7 +51,7 @@ class MessageEvents_Tests: XCTestCase {
     
     func test_read() throws {
         let json = XCTestCase.mockData(fromFile: "MessageRead")
-        let event = try eventDecoder.decode(from: json) as? MessageReadEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? MessageReadEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, "steep-moon-9")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "general"))
         XCTAssertEqual(event?.readAt.description, "2020-07-17 13:55:56 +0000")

--- a/Sources_v3/WebSocketClient/Events/NotificationEvents_Tests.swift
+++ b/Sources_v3/WebSocketClient/Events/NotificationEvents_Tests.swift
@@ -6,11 +6,11 @@
 import XCTest
 
 class NotificationsEvents_Tests: XCTestCase {
-    let eventDecoder = EventDecoder<DefaultDataTypes>()
+    let eventDecoder = EventDecoder<DefaultExtraData>()
     
     func test_messageNew() throws {
         let json = XCTestCase.mockData(fromFile: "NotificationMessageNew")
-        let event = try eventDecoder.decode(from: json) as? NotificationMessageNewEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? NotificationMessageNewEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, "steep-moon-9")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "general"))
         XCTAssertEqual(event?.messageId, "042772db-4af2-460d-beaa-1e49d1b8e3b9")
@@ -20,13 +20,13 @@ class NotificationsEvents_Tests: XCTestCase {
     
     func test_markAllRead() throws {
         let json = XCTestCase.mockData(fromFile: "NotificationMarkAllRead")
-        let event = try eventDecoder.decode(from: json) as? NotificationMarkAllReadEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? NotificationMarkAllReadEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, "steep-moon-9")
     }
     
     func test_markRead() throws {
         let json = XCTestCase.mockData(fromFile: "NotificationMarkRead")
-        let event = try eventDecoder.decode(from: json) as? NotificationMarkReadEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? NotificationMarkReadEvent<DefaultExtraData>
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "general"))
         XCTAssertEqual(event?.userId, "steep-moon-9")
         XCTAssertEqual(event?.unreadCount, .init(channels: 8, messages: 55))
@@ -34,20 +34,20 @@ class NotificationsEvents_Tests: XCTestCase {
     
     func test_mutesUpdated() throws {
         let json = XCTestCase.mockData(fromFile: "NotificationMutesUpdated")
-        let event = try eventDecoder.decode(from: json) as? NotificationMutesUpdatedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? NotificationMutesUpdatedEvent<DefaultExtraData>
         XCTAssertEqual(event?.currentUserId, "broken-waterfall-5")
     }
     
     func test_addToChannel() throws {
         let json = XCTestCase.mockData(fromFile: "NotificationAddedToChannel")
-        let event = try eventDecoder.decode(from: json) as? NotificationAddedToChannelEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? NotificationAddedToChannelEvent<DefaultExtraData>
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_5905"))
         XCTAssertEqual(event?.unreadCount, .init(channels: 2, messages: 2))
     }
     
     func test_removedFromChannel() throws {
         let json = XCTestCase.mockData(fromFile: "NotificationRemovedFromChannel")
-        let event = try eventDecoder.decode(from: json) as? NotificationRemovedFromChannelEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? NotificationRemovedFromChannelEvent<DefaultExtraData>
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_5905"))
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
         XCTAssertEqual(event?.memberRole, .member)
@@ -55,7 +55,7 @@ class NotificationsEvents_Tests: XCTestCase {
     
     func test_invited() throws {
         let json = XCTestCase.mockData(fromFile: "NotificationInvited")
-        let event = try eventDecoder.decode(from: json) as? NotificationInvitedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? NotificationInvitedEvent<DefaultExtraData>
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_1394"))
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
         XCTAssertEqual(event?.memberRole, .member)
@@ -63,7 +63,7 @@ class NotificationsEvents_Tests: XCTestCase {
     
     func test_inviteAccepted() throws {
         let json = XCTestCase.mockData(fromFile: "NotificationInviteAccepted")
-        let event = try eventDecoder.decode(from: json) as? NotificationInviteAcceptedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? NotificationInviteAcceptedEvent<DefaultExtraData>
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_6293"))
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
         XCTAssertEqual(event?.memberRole, .member)
@@ -72,7 +72,7 @@ class NotificationsEvents_Tests: XCTestCase {
     
     func test_inviteRejected() throws {
         let json = XCTestCase.mockData(fromFile: "NotificationInviteRejected")
-        let event = try eventDecoder.decode(from: json) as? NotificationInviteRejectedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? NotificationInviteRejectedEvent<DefaultExtraData>
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_6293"))
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
         XCTAssertEqual(event?.memberRole, .member)

--- a/Sources_v3/WebSocketClient/Events/ReactionEvents_Tests.swift
+++ b/Sources_v3/WebSocketClient/Events/ReactionEvents_Tests.swift
@@ -6,14 +6,14 @@
 import XCTest
 
 class ReactionEvents_Tests: XCTestCase {
-    let eventDecoder = EventDecoder<DefaultDataTypes>()
+    let eventDecoder = EventDecoder<DefaultExtraData>()
     let userId = "broken-waterfall-5"
     let cid = ChannelId(type: .messaging, id: "general")
     let messageId = "0e042a9c-d648-4a28-8ed6-dbdb2b7b4779"
     
     func test_new() throws {
         let json = XCTestCase.mockData(fromFile: "ReactionNew")
-        let event = try eventDecoder.decode(from: json) as? ReactionNewEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? ReactionNewEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, userId)
         XCTAssertEqual(event?.cid, cid)
         XCTAssertEqual(event?.messageId, messageId)
@@ -24,7 +24,7 @@ class ReactionEvents_Tests: XCTestCase {
     
     func test_updated() throws {
         let json = XCTestCase.mockData(fromFile: "ReactionUpdated")
-        let event = try eventDecoder.decode(from: json) as? ReactionUpdatedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? ReactionUpdatedEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, userId)
         XCTAssertEqual(event?.cid, cid)
         XCTAssertEqual(event?.messageId, messageId)
@@ -35,7 +35,7 @@ class ReactionEvents_Tests: XCTestCase {
     
     func test_deleted() throws {
         let json = XCTestCase.mockData(fromFile: "ReactionDeleted")
-        let event = try eventDecoder.decode(from: json) as? ReactionDeletedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? ReactionDeletedEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, userId)
         XCTAssertEqual(event?.cid, cid)
         XCTAssertEqual(event?.messageId, messageId)

--- a/Sources_v3/WebSocketClient/Events/TypingEvent_Tests.swift
+++ b/Sources_v3/WebSocketClient/Events/TypingEvent_Tests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 class TypingEvent_Tests: XCTestCase {
     func test_Typing() throws {
-        let eventDecoder = EventDecoder<DefaultDataTypes>()
+        let eventDecoder = EventDecoder<DefaultExtraData>()
         let cid = ChannelId(type: .messaging, id: "general")
         
         // User Started Typing Event.

--- a/Sources_v3/WebSocketClient/Events/UserEvents_Tests.swift
+++ b/Sources_v3/WebSocketClient/Events/UserEvents_Tests.swift
@@ -6,25 +6,25 @@
 import XCTest
 
 class UserEvents_Tests: XCTestCase {
-    let eventDecoder = EventDecoder<DefaultDataTypes>()
+    let eventDecoder = EventDecoder<DefaultExtraData>()
     
     func test_userPresenceEvent() throws {
         let json = XCTestCase.mockData(fromFile: "UserPresence")
-        let event = try eventDecoder.decode(from: json) as? UserPresenceChangedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? UserPresenceChangedEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, "steep-moon-9")
         XCTAssertEqual(event?.createdAt?.description, "2020-07-16 15:44:19 +0000")
     }
     
     func test_watchingEvent() throws {
         var json = XCTestCase.mockData(fromFile: "UserStartWatching")
-        var event = try eventDecoder.decode(from: json) as? UserWatchingEvent<DefaultDataTypes>
+        var event = try eventDecoder.decode(from: json) as? UserWatchingEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
         XCTAssertTrue(event?.isStarted ?? false)
         XCTAssertTrue(event?.watcherCount ?? 0 > 0)
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_7070"))
         
         json = XCTestCase.mockData(fromFile: "UserStopWatching")
-        event = try eventDecoder.decode(from: json) as? UserWatchingEvent<DefaultDataTypes>
+        event = try eventDecoder.decode(from: json) as? UserWatchingEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, "steep-moon-9")
         XCTAssertFalse(event?.isStarted ?? false)
         XCTAssertTrue(event?.watcherCount ?? 0 > 0)
@@ -33,7 +33,7 @@ class UserEvents_Tests: XCTestCase {
     
     func test_userBannedEvent() throws {
         let json = XCTestCase.mockData(fromFile: "UserBanned")
-        let event = try eventDecoder.decode(from: json) as? UserBannedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? UserBannedEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
         XCTAssertEqual(event?.ownerId, "steep-moon-9")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_7070"))
@@ -42,7 +42,7 @@ class UserEvents_Tests: XCTestCase {
     
     func test_userUnbannedEvent() throws {
         let json = XCTestCase.mockData(fromFile: "UserUnbanned")
-        let event = try eventDecoder.decode(from: json) as? UserUnbannedEvent<DefaultDataTypes>
+        let event = try eventDecoder.decode(from: json) as? UserUnbannedEvent<DefaultExtraData>
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_7070"))
     }

--- a/Sources_v3/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Sources_v3/WebSocketClient/WebSocketClient_Tests.swift
@@ -21,7 +21,7 @@ class WebSocketClient_Tests: StressTestCase {
     private var reconnectionStrategy: MockReconnectionStrategy!
     var engine: WebSocketEngineMock { webSocketClient.engine as! WebSocketEngineMock }
     var connectionId: String!
-    var user: User!
+    var user: ChatUser!
     var backgroundTaskScheduler: MockBackgroundTaskScheduler!
     var requestEncoder: TestRequestEncoder!
     var pingController: WebSocketPingControllerMock { webSocketClient.pingController as! WebSocketPingControllerMock }
@@ -74,7 +74,7 @@ class WebSocketClient_Tests: StressTestCase {
         )
         
         connectionId = UUID().uuidString
-        user = User(id: "test_user_\(UUID().uuidString)")
+        user = ChatUser(id: "test_user_\(UUID().uuidString)")
     }
     
     override func tearDown() {

--- a/Sources_v3/Workers/Background/ChannelWatchStateUpdater_Tests.swift
+++ b/Sources_v3/Workers/Background/ChannelWatchStateUpdater_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 class ChannelWatchStateUpdater_Tests: StressTestCase {
-    typealias ExtraData = DefaultDataTypes
+    typealias ExtraData = DefaultExtraData
     
     var database: DatabaseContainerMock!
     var webSocketClient: WebSocketClientMock!

--- a/Sources_v3/Workers/Background/MessageEditor_Tests.swift
+++ b/Sources_v3/Workers/Background/MessageEditor_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 final class MessageEditor_Tests: StressTestCase {
-    typealias ExtraData = DefaultDataTypes
+    typealias ExtraData = DefaultExtraData
     
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!

--- a/Sources_v3/Workers/Background/MessageSender_Tests.swift
+++ b/Sources_v3/Workers/Background/MessageSender_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 class MessageSender_Tests: StressTestCase {
-    typealias ExtraData = DefaultDataTypes
+    typealias ExtraData = DefaultExtraData
     
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!

--- a/Sources_v3/Workers/Background/MissingEventsPublisher.swift
+++ b/Sources_v3/Workers/Background/MissingEventsPublisher.swift
@@ -78,7 +78,7 @@ class MissingEventsPublisher<ExtraData: ExtraDataTypes>: Worker {
         }
     }
     
-    private var allChannels: [ChannelModel<ExtraData>] {
+    private var allChannels: [_ChatChannel<ExtraData>] {
         do {
             return try database.backgroundReadOnlyContext.fetch(ChannelDTO.allChannelsFetchRequest).map { $0.asModel() }
         } catch {

--- a/Sources_v3/Workers/Background/MissingEventsPublisher_Tests.swift
+++ b/Sources_v3/Workers/Background/MissingEventsPublisher_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 final class MissingEventsPublisher_Tests: StressTestCase {
-    typealias ExtraData = DefaultDataTypes
+    typealias ExtraData = DefaultExtraData
     
     var database: DatabaseContainerMock!
     var webSocketClient: WebSocketClientMock!

--- a/Sources_v3/Workers/Background/NewChannelQueryUpdater_Tests.swift
+++ b/Sources_v3/Workers/Background/NewChannelQueryUpdater_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 class NewChannelQueryUpdater_Tests: StressTestCase {
-    typealias ExtraData = DefaultDataTypes
+    typealias ExtraData = DefaultExtraData
     
     private var env: TestEnvironment!
     
@@ -112,9 +112,9 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
 }
 
 private class TestEnvironment {
-    var channelQueryUpdater: ChannelListUpdaterMock<DefaultDataTypes>?
+    var channelQueryUpdater: ChannelListUpdaterMock<DefaultExtraData>?
     
-    lazy var environment = NewChannelQueryUpdater<DefaultDataTypes>.Environment(createChannelListUpdater: { [unowned self] in
+    lazy var environment = NewChannelQueryUpdater<DefaultExtraData>.Environment(createChannelListUpdater: { [unowned self] in
         self.channelQueryUpdater = ChannelListUpdaterMock(
             database: $0,
             webSocketClient: $1,

--- a/Sources_v3/Workers/ChannelListUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelListUpdater_Tests.swift
@@ -10,7 +10,7 @@ class ChannelListUpdater_Tests: StressTestCase {
     var apiClient: APIClientMock!
     var database: DatabaseContainer!
     
-    var listUpdater: ChannelListUpdater<DefaultDataTypes>!
+    var listUpdater: ChannelListUpdater<DefaultExtraData>!
     
     override func setUp() {
         super.setUp()
@@ -35,7 +35,7 @@ class ChannelListUpdater_Tests: StressTestCase {
         let query = ChannelListQuery(filter: .in("member", ["Luke"]))
         listUpdater.update(channelListQuery: query)
         
-        let referenceEndpoint: Endpoint<ChannelListPayload<DefaultDataTypes>> = .channels(query: query)
+        let referenceEndpoint: Endpoint<ChannelListPayload<DefaultExtraData>> = .channels(query: query)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
     }
     
@@ -50,7 +50,7 @@ class ChannelListUpdater_Tests: StressTestCase {
         
         // Simualte API response with channel data
         let cid = ChannelId(type: .messaging, id: .unique)
-        let payload = ChannelListPayload<DefaultDataTypes>(channels: [dummyPayload(with: cid)])
+        let payload = ChannelListPayload<DefaultExtraData>(channels: [dummyPayload(with: cid)])
         apiClient.test_simulateResponse(.success(payload))
         
         // Assert the data is stored in the DB
@@ -71,7 +71,7 @@ class ChannelListUpdater_Tests: StressTestCase {
         
         // Simualte API response with failure
         let error = TestError()
-        apiClient.test_simulateResponse(Result<ChannelListPayload<DefaultDataTypes>, Error>.failure(error))
+        apiClient.test_simulateResponse(Result<ChannelListPayload<DefaultExtraData>, Error>.failure(error))
         
         // Assert the completion is called with the error
         AssertAsync.willBeEqual(completionCalledError as? TestError, error)

--- a/Sources_v3/Workers/ChannelListUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelListUpdater_Tests.swift
@@ -54,7 +54,7 @@ class ChannelListUpdater_Tests: StressTestCase {
         apiClient.test_simulateResponse(.success(payload))
         
         // Assert the data is stored in the DB
-        var channel: Channel? {
+        var channel: ChatChannel? {
             database.viewContext.channel(cid: cid)?.asModel()
         }
         AssertAsync {

--- a/Sources_v3/Workers/ChannelUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelUpdater_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 class ChannelUpdater_Tests: StressTestCase {
-    typealias ExtraData = DefaultDataTypes
+    typealias ExtraData = DefaultExtraData
     
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!
@@ -133,7 +133,7 @@ class ChannelUpdater_Tests: StressTestCase {
         let arguments: String = .unique
         let parentMessageId: MessageId = .unique
         let showReplyInChannel = true
-        let extraData: DefaultDataTypes.Message = .defaultValue
+        let extraData: DefaultExtraData.Message = .defaultValue
         
         // Create new message
         let newMesageId: MessageId = try await { completion in
@@ -209,7 +209,7 @@ class ChannelUpdater_Tests: StressTestCase {
     // MARK: - Update channel
 
     func test_updateChannel_makesCorrectAPICall() {
-        let channelPayload: ChannelEditDetailPayload<DefaultDataTypes> = .unique
+        let channelPayload: ChannelEditDetailPayload<DefaultExtraData> = .unique
 
         // Simulate `updateChannel(channelPayload:, completion:)` call
         channelUpdater.updateChannel(channelPayload: channelPayload)

--- a/Sources_v3/Workers/ChannelUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelUpdater_Tests.swift
@@ -56,7 +56,7 @@ class ChannelUpdater_Tests: StressTestCase {
         apiClient.test_simulateResponse(.success(payload))
         
         // Assert the data is stored in the DB
-        var channel: Channel? {
+        var channel: ChatChannel? {
             database.viewContext.channel(cid: cid)?.asModel()
         }
         AssertAsync {
@@ -84,7 +84,7 @@ class ChannelUpdater_Tests: StressTestCase {
         let query = ChannelQuery(channelPayload: .unique)
         var cid: ChannelId = .unique
 
-        var channel: Channel? {
+        var channel: ChatChannel? {
             database.viewContext.channel(cid: cid)?.asModel()
         }
 

--- a/Sources_v3/Workers/ChannelUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelUpdater_Tests.swift
@@ -154,7 +154,7 @@ class ChannelUpdater_Tests: StressTestCase {
             }
         }
         
-        var message: Message? {
+        var message: ChatMessage? {
             database.viewContext.message(id: newMesageId)?.asModel()
         }
         

--- a/Sources_v3/Workers/EventSender_Tests.swift
+++ b/Sources_v3/Workers/EventSender_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 class EventSender_Tests: StressTestCase {
-    typealias ExtraData = DefaultDataTypes
+    typealias ExtraData = DefaultExtraData
     
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!

--- a/Sources_v3/Workers/MessageUpdater_Tests.swift
+++ b/Sources_v3/Workers/MessageUpdater_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 final class MessageUpdater_Tests: StressTestCase {
-    typealias ExtraData = DefaultDataTypes
+    typealias ExtraData = DefaultExtraData
     
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -102,7 +102,7 @@
 		798779FD2498E47700015F8B /* OtherUser.json in Resources */ = {isa = PBXBuildFile; fileRef = 798779F82498E47700015F8B /* OtherUser.json */; };
 		798779FE2498E47700015F8B /* CurrentUser.json in Resources */ = {isa = PBXBuildFile; fileRef = 798779F92498E47700015F8B /* CurrentUser.json */; };
 		798779FF2498E47700015F8B /* ChannelsQuery.json in Resources */ = {isa = PBXBuildFile; fileRef = 798779FA2498E47700015F8B /* ChannelsQuery.json */; };
-		79877A092498E4BC00015F8B /* UserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A012498E4BB00015F8B /* UserModel.swift */; };
+		79877A092498E4BC00015F8B /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A012498E4BB00015F8B /* User.swift */; };
 		79877A0A2498E4BC00015F8B /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A022498E4BB00015F8B /* Device.swift */; };
 		79877A0B2498E4BC00015F8B /* MemberModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A032498E4BB00015F8B /* MemberModel.swift */; };
 		79877A0C2498E4BC00015F8B /* ChannelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A042498E4BB00015F8B /* ChannelType.swift */; };
@@ -476,7 +476,7 @@
 		798779F82498E47700015F8B /* OtherUser.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = OtherUser.json; sourceTree = "<group>"; };
 		798779F92498E47700015F8B /* CurrentUser.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = CurrentUser.json; sourceTree = "<group>"; };
 		798779FA2498E47700015F8B /* ChannelsQuery.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ChannelsQuery.json; sourceTree = "<group>"; };
-		79877A012498E4BB00015F8B /* UserModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserModel.swift; sourceTree = "<group>"; };
+		79877A012498E4BB00015F8B /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		79877A022498E4BB00015F8B /* Device.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		79877A032498E4BB00015F8B /* MemberModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemberModel.swift; sourceTree = "<group>"; };
 		79877A042498E4BB00015F8B /* ChannelType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelType.swift; sourceTree = "<group>"; };
@@ -1131,7 +1131,7 @@
 				79877A052498E4BC00015F8B /* CurrentUser.swift */,
 				79877A022498E4BB00015F8B /* Device.swift */,
 				79877A032498E4BB00015F8B /* MemberModel.swift */,
-				79877A012498E4BB00015F8B /* UserModel.swift */,
+				79877A012498E4BB00015F8B /* User.swift */,
 				799C9431247D2FB9001F1104 /* Message.swift */,
 				794927EC249E0BE2009D7EB7 /* ExtraData.swift */,
 				8AAB1C6524CB39F2009B783F /* UnreadCount.swift */,
@@ -1924,7 +1924,7 @@
 				F65D9091250A5989000B8CEB /* WebSocketConnectEndpoint.swift in Sources */,
 				DAE566EB24FFD26C00E39431 /* CurrentUserController+SwiftUI.swift in Sources */,
 				799C945E247D7283001F1104 /* DatabaseContainer.swift in Sources */,
-				79877A092498E4BC00015F8B /* UserModel.swift in Sources */,
+				79877A092498E4BC00015F8B /* User.swift in Sources */,
 				79B5517324E593C200CE9FEC /* UserPayloads.swift in Sources */,
 				DA99D0D024ED63C600AD5354 /* NewChannelQueryUpdater.swift in Sources */,
 				8A0175F02501174000570345 /* EventSender.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -104,7 +104,7 @@
 		798779FF2498E47700015F8B /* ChannelsQuery.json in Resources */ = {isa = PBXBuildFile; fileRef = 798779FA2498E47700015F8B /* ChannelsQuery.json */; };
 		79877A092498E4BC00015F8B /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A012498E4BB00015F8B /* User.swift */; };
 		79877A0A2498E4BC00015F8B /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A022498E4BB00015F8B /* Device.swift */; };
-		79877A0B2498E4BC00015F8B /* MemberModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A032498E4BB00015F8B /* MemberModel.swift */; };
+		79877A0B2498E4BC00015F8B /* Member.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A032498E4BB00015F8B /* Member.swift */; };
 		79877A0C2498E4BC00015F8B /* ChannelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A042498E4BB00015F8B /* ChannelType.swift */; };
 		79877A0D2498E4BC00015F8B /* CurrentUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A052498E4BC00015F8B /* CurrentUser.swift */; };
 		79877A0E2498E4BC00015F8B /* ChannelModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79877A062498E4BC00015F8B /* ChannelModel.swift */; };
@@ -478,7 +478,7 @@
 		798779FA2498E47700015F8B /* ChannelsQuery.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ChannelsQuery.json; sourceTree = "<group>"; };
 		79877A012498E4BB00015F8B /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		79877A022498E4BB00015F8B /* Device.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
-		79877A032498E4BB00015F8B /* MemberModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemberModel.swift; sourceTree = "<group>"; };
+		79877A032498E4BB00015F8B /* Member.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Member.swift; sourceTree = "<group>"; };
 		79877A042498E4BB00015F8B /* ChannelType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelType.swift; sourceTree = "<group>"; };
 		79877A052498E4BC00015F8B /* CurrentUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrentUser.swift; sourceTree = "<group>"; };
 		79877A062498E4BC00015F8B /* ChannelModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelModel.swift; sourceTree = "<group>"; };
@@ -1130,7 +1130,7 @@
 				79877A042498E4BB00015F8B /* ChannelType.swift */,
 				79877A052498E4BC00015F8B /* CurrentUser.swift */,
 				79877A022498E4BB00015F8B /* Device.swift */,
-				79877A032498E4BB00015F8B /* MemberModel.swift */,
+				79877A032498E4BB00015F8B /* Member.swift */,
 				79877A012498E4BB00015F8B /* User.swift */,
 				799C9431247D2FB9001F1104 /* Message.swift */,
 				794927EC249E0BE2009D7EB7 /* ExtraData.swift */,
@@ -1911,7 +1911,7 @@
 				F6FF1DA624FD17B400151735 /* MessageController.swift in Sources */,
 				797E10A824EAF6DE00353791 /* UniqueId.swift in Sources */,
 				F6ED5F7425023EB4005D7327 /* MissingEventsPublisher.swift in Sources */,
-				79877A0B2498E4BC00015F8B /* MemberModel.swift in Sources */,
+				79877A0B2498E4BC00015F8B /* Member.swift in Sources */,
 				F670B50F24FE6EA900003B1A /* MessageEditor.swift in Sources */,
 				7991D83D24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift in Sources */,
 				8A0D64A724E57A520017A3C0 /* GuestUserTokenRequestPayload.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -120,7 +120,7 @@
 		7988F6B124D010890004219B /* TestRunnerEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7988F6B024D010890004219B /* TestRunnerEnvironment.swift */; };
 		7988F6B724D15F100004219B /* StressTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7988F6B624D15F100004219B /* StressTestCase.swift */; };
 		79896D5C2506593E00BA8F1C /* ChannelReadDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796FD215250654940076C99B /* ChannelReadDTO.swift */; };
-		79896D5E25065ECD00BA8F1C /* ChannelReadModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79896D5D25065E6900BA8F1C /* ChannelReadModel.swift */; };
+		79896D5E25065ECD00BA8F1C /* ChannelRead.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79896D5D25065E6900BA8F1C /* ChannelRead.swift */; };
 		79896D622507B16000BA8F1C /* ChannelListUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79896D602507B0DD00BA8F1C /* ChannelListUpdater_Mock.swift */; };
 		79896D64250A63A200BA8F1C /* ChannelReadUpdaterMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79896D63250A62EE00BA8F1C /* ChannelReadUpdaterMiddleware.swift */; };
 		79896D66250A6D1800BA8F1C /* ChannelReadUpdaterMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79896D65250A6D1500BA8F1C /* ChannelReadUpdaterMiddleware_Tests.swift */; };
@@ -493,7 +493,7 @@
 		79877A222498E50D00015F8B /* UserDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDTO.swift; sourceTree = "<group>"; };
 		7988F6B024D010890004219B /* TestRunnerEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestRunnerEnvironment.swift; sourceTree = "<group>"; };
 		7988F6B624D15F100004219B /* StressTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StressTestCase.swift; sourceTree = "<group>"; };
-		79896D5D25065E6900BA8F1C /* ChannelReadModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelReadModel.swift; sourceTree = "<group>"; };
+		79896D5D25065E6900BA8F1C /* ChannelRead.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelRead.swift; sourceTree = "<group>"; };
 		79896D602507B0DD00BA8F1C /* ChannelListUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListUpdater_Mock.swift; sourceTree = "<group>"; };
 		79896D63250A62EE00BA8F1C /* ChannelReadUpdaterMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelReadUpdaterMiddleware.swift; sourceTree = "<group>"; };
 		79896D65250A6D1500BA8F1C /* ChannelReadUpdaterMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelReadUpdaterMiddleware_Tests.swift; sourceTree = "<group>"; };
@@ -1123,8 +1123,8 @@
 			isa = PBXGroup;
 			children = (
 				79877A072498E4BC00015F8B /* ChannelId.swift */,
-				79896D5D25065E6900BA8F1C /* ChannelReadModel.swift */,
 				8A5D3EF824AF749200E2FE35 /* ChannelId_Tests.swift */,
+				79896D5D25065E6900BA8F1C /* ChannelRead.swift */,
 				79877A062498E4BC00015F8B /* ChannelModel.swift */,
 				8A62706D24BF45360040BFD6 /* BanEnabling.swift */,
 				79877A042498E4BB00015F8B /* ChannelType.swift */,
@@ -1796,7 +1796,7 @@
 			files = (
 				DAE566E724FFD22300E39431 /* ChannelController+SwiftUI.swift in Sources */,
 				792CA62624CEE93700D70A5E /* ChannelListUpdater.swift in Sources */,
-				79896D5E25065ECD00BA8F1C /* ChannelReadModel.swift in Sources */,
+				79896D5E25065ECD00BA8F1C /* ChannelRead.swift in Sources */,
 				79DDF80E249CB920002F4412 /* RequestDecoder.swift in Sources */,
 				DAF1BED1250660F8003CEDC0 /* MessageController+SwiftUI.swift in Sources */,
 				8AC9CBD624C73689006E236C /* NotificationEvents.swift in Sources */,


### PR DESCRIPTION
This PR is mainly about changing names for public-facing types and functions.

The following rules are applied:

- too broad names prefixed with `Chat` i.e.: `ChatUser`, `ChatClient`, etc.
- `_` prefix used for the generic variant of a type i.e. `ChatClient = _ChatClient<DefaultExtraData>`

Documentation comments are not updated yet. It will be done in CIS-358