### PR TITLE
[CIS-356] Fix bugs in alpha version

### DIFF
--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
@@ -216,7 +216,7 @@ public extension _CurrentChatUserController {
     ///   - extraData: The extra data of the new guest-user.
     ///   - completion: The completion. Will be called when the new guest user is set.
     ///                 If setting up the new user fails the completion will be called with an error.
-    func setGuestUser(userId: UserId, extraData: ExtraData.User, completion: ((Error?) -> Void)? = nil) {
+    func setGuestUser(userId: UserId, extraData: ExtraData.User = .defaultValue, completion: ((Error?) -> Void)? = nil) {
         disconnect()
         prepareEnvironmentForNewUser(userId: userId, role: .guest, extraData: extraData) { error in
             guard error == nil else {

--- a/Sources_v3/Controllers/EntityDatabaseObserver.swift
+++ b/Sources_v3/Controllers/EntityDatabaseObserver.swift
@@ -17,6 +17,20 @@ public enum EntityChange<Item> {
     case remove(_ item: Item)
 }
 
+extension EntityChange: CustomStringConvertible {
+    /// Returns pretty `EntityChange` description
+    public var description: String {
+        switch self {
+        case let .create(item):
+            return "Create: \(item)"
+        case let .update(item):
+            return "Update: \(item)"
+        case let .remove(item):
+            return "Remove: \(item)"
+        }
+    }
+}
+
 extension EntityChange {
     /// Returns the underlaying item that was changed
     public var item: Item {

--- a/Sources_v3/Controllers/EntityDatabaseObserver_Tests.swift
+++ b/Sources_v3/Controllers/EntityDatabaseObserver_Tests.swift
@@ -28,6 +28,22 @@ class EntityChange_Tests: XCTestCase {
         XCTAssertEqual(EntityChange.update(updatedItem).fieldChange(path), .update(updatedItem.value))
         XCTAssertEqual(EntityChange.remove(removedItem).fieldChange(path), .remove(removedItem.value))
     }
+    
+    func test_description() {
+        let createdItem: String = .unique
+        let updatedItem: String = .unique
+        let removedItem: String = .unique
+        
+        let pairs: [(EntityChange<String>, String)] = [
+            (.create(createdItem), "Create: \(createdItem)"),
+            (.update(updatedItem), "Update: \(updatedItem)"),
+            (.remove(removedItem), "Remove: \(removedItem)")
+        ]
+        
+        for (change, description) in pairs {
+            XCTAssertEqual(change.description, description)
+        }
+    }
 }
 
 class EntityDatabaseObserver_Tests: XCTestCase {

--- a/Sources_v3/Controllers/ListDatabaseObserver.swift
+++ b/Sources_v3/Controllers/ListDatabaseObserver.swift
@@ -19,6 +19,22 @@ public enum ListChange<Item> {
     case remove(_ item: Item, index: IndexPath)
 }
 
+extension ListChange: CustomStringConvertible {
+    /// Returns pretty `ListChange` description
+    public var description: String {
+        switch self {
+        case let .insert(item, indexPath):
+            return "Insert at \(indexPath): \(item)"
+        case let .move(item, from, to):
+            return "Move from \(from) to \(to): \(item)"
+        case let .update(item, indexPath):
+            return "Update at \(indexPath): \(item)"
+        case let .remove(item, indexPath):
+            return "Remove at \(indexPath): \(item)"
+        }
+    }
+}
+
 extension ListChange: Equatable where Item: Equatable {}
 
 /// Observes changes of the list of items specified using an `NSFetchRequest`in the provided `NSManagedObjectContext`.

--- a/Sources_v3/Controllers/ListDatabaseObserver_Tests.swift
+++ b/Sources_v3/Controllers/ListDatabaseObserver_Tests.swift
@@ -6,6 +6,34 @@ import CoreData
 @testable import StreamChatClient
 import XCTest
 
+final class ListChange_Tests: XCTestCase {
+    func test_description() {
+        let createdItem: String = .unique
+        let createdAt: IndexPath = [1, 0]
+        
+        let movedItem: String = .unique
+        let movedFrom: IndexPath = [1, 0]
+        let movedTo: IndexPath = [0, 1]
+        
+        let updatedItem: String = .unique
+        let updatedAt: IndexPath = [0, 1]
+        
+        let removedItem: String = .unique
+        let removedAt: IndexPath = [0, 1]
+        
+        let pairs: [(ListChange<String>, String)] = [
+            (.insert(createdItem, index: createdAt), "Insert at \(createdAt): \(createdItem)"),
+            (.move(movedItem, fromIndex: movedFrom, toIndex: movedTo), "Move from \(movedFrom) to \(movedTo): \(movedItem)"),
+            (.update(updatedItem, index: updatedAt), "Update at \(updatedAt): \(updatedItem)"),
+            (.remove(removedItem, index: removedAt), "Remove at \(removedAt): \(removedItem)")
+        ]
+        
+        for (change, description) in pairs {
+            XCTAssertEqual(change.description, description)
+        }
+    }
+}
+
 class ListDatabaseObserver_Tests: XCTestCase {
     var observer: ListDatabaseObserver<String, TestManagedObject>!
     var fetchRequest: NSFetchRequest<TestManagedObject>!

--- a/Sources_v3/Database/DTOs/ChannelReadDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelReadDTO.swift
@@ -8,7 +8,7 @@ import Foundation
 @objc(ChannelReadDTO)
 class ChannelReadDTO: NSManagedObject {
     @NSManaged var lastReadAt: Date
-    @NSManaged var unreadMessageCount: Int
+    @NSManaged var unreadMessageCount: Int32
     
     // MARK: - Relationships
     
@@ -64,7 +64,7 @@ extension NSManagedObjectContext {
         dto.user = try saveUser(payload: payload.user)
         
         dto.lastReadAt = payload.lastReadAt
-        dto.unreadMessageCount = payload.unreadMessagesCount
+        dto.unreadMessageCount = Int32(payload.unreadMessagesCount)
         
         return dto
     }
@@ -80,6 +80,6 @@ extension NSManagedObjectContext {
 
 extension _ChatChannelRead {
     fileprivate static func create(fromDTO dto: ChannelReadDTO) -> _ChatChannelRead {
-        .init(lastReadAt: dto.lastReadAt, unreadMessagesCount: dto.unreadMessageCount, user: dto.user.asModel())
+        .init(lastReadAt: dto.lastReadAt, unreadMessagesCount: Int(dto.unreadMessageCount), user: dto.user.asModel())
     }
 }

--- a/Sources_v3/Workers/Background/MissingEventsPublisher.swift
+++ b/Sources_v3/Workers/Background/MissingEventsPublisher.swift
@@ -62,6 +62,11 @@ class MissingEventsPublisher<ExtraData: ExtraDataTypes>: Worker {
             
             let watchedChannelIDs = allChannels.filter { $0.isWatched }.map(\.cid)
             
+            guard !watchedChannelIDs.isEmpty else {
+                log.info("Skipping `/sync` endpoint call as there are no channels to watch.")
+                return
+            }
+            
             let endpoint: Endpoint<MissingEventsPayload<ExtraData>> = .missingEvents(
                 since: lastSyncedAt,
                 cids: watchedChannelIDs

--- a/Sources_v3/Workers/Background/MissingEventsPublisher_Tests.swift
+++ b/Sources_v3/Workers/Background/MissingEventsPublisher_Tests.swift
@@ -55,6 +55,26 @@ final class MissingEventsPublisher_Tests: StressTestCase {
         AssertAsync.staysTrue(apiClient.request_endpoint == nil)
     }
     
+    func test_endpointIsNotCalled_ifThereAreNoWatchedChannels() throws {
+        // Create current user in the database
+        try database.createCurrentUser()
+        
+        // Set `lastReceivedEventDate` field
+        try database.writeSynchronously {
+            let dto = try XCTUnwrap($0.currentUser())
+            dto.lastReceivedEventDate = Date()
+        }
+        
+        // Simulate `.connecting` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connecting)
+        
+        // Simulate `.connected` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        
+        // Assert endpoint is not called as there are no watched channels
+        AssertAsync.staysTrue(apiClient.request_endpoint == nil)
+    }
+    
     func test_endpointIsCalled_whenStatusBecomesConnected() throws {
         let cid: ChannelId = .unique
         let lastReceivedEventDate: Date = .unique


### PR DESCRIPTION
**This PR**:
- fixes `setGuestUser` to have **extraData = .defaultValue**;
- fixes `MissingEventsPublisher` not to call `/sync` if there are no channels;
- fixes `unreadMessageCount` in `ChannelReadDTO` to match database model;
- provides `description` for `EntityChange` and `ListChange` types.


