### PR TITLE
[CIS-357] Update current-user controller

### DIFF
--- a/Sample_v3/Samples/SettingsViewController.swift
+++ b/Sample_v3/Samples/SettingsViewController.swift
@@ -24,10 +24,7 @@ class SettingsViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        currentUserController.startUpdating { [weak self] _ in
-            guard let self = self else { return }
-            self.updateUserCell(with: self.currentUserController.currentUser)
-        }
+        updateUserCell(with: currentUserController.currentUser)
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+Combine.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+Combine.swift
@@ -44,11 +44,6 @@ extension _CurrentChatUserController {
             connectionStatus = .init(controller.connectionStatus)
             
             controller.multicastDelegate.additionalDelegates.append(AnyCurrentUserControllerDelegate(self))
-            
-            if controller.state == .initialized {
-                // Start updating and load the current data
-                controller.startUpdating()
-            }
         }
     }
 }

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+Combine.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+Combine.swift
@@ -7,11 +7,6 @@ import UIKit
 
 @available(iOS 13, *)
 extension _CurrentChatUserController {
-    /// A publisher emitting a new value every time the state of the controller changes.
-    public var statePublisher: AnyPublisher<DataController.State, Never> {
-        basePublishers.state.keepAlive(self)
-    }
-    
     /// A publisher emitting a new value every time the current user changes.
     public var currentUserChangePublisher: AnyPublisher<EntityChange<_CurrentChatUser<ExtraData.User>>, Never> {
         basePublishers.currentUserChange.keepAlive(self)
@@ -34,9 +29,6 @@ extension _CurrentChatUserController {
         /// The wrapper controller
         unowned let controller: _CurrentChatUserController
         
-        /// A backing subject for `statePublisher`.
-        let state: CurrentValueSubject<DataController.State, Never>
-        
         /// A backing subject for `currentUserChangePublisher`.
         let currentUserChange: PassthroughSubject<EntityChange<_CurrentChatUser<ExtraData.User>>, Never> = .init()
         
@@ -48,7 +40,6 @@ extension _CurrentChatUserController {
                 
         init(controller: _CurrentChatUserController<ExtraData>) {
             self.controller = controller
-            state = .init(controller.state)
             unreadCount = .init(.noUnread)
             connectionStatus = .init(controller.connectionStatus)
             
@@ -64,10 +55,6 @@ extension _CurrentChatUserController {
 
 @available(iOS 13, *)
 extension _CurrentChatUserController.BasePublishers: _CurrentChatUserControllerDelegate {
-    func controller(_ controller: DataController, didChangeState state: DataController.State) {
-        self.state.send(state)
-    }
-    
     func currentUserController(
         _ controller: _CurrentChatUserController<ExtraData>,
         didChangeCurrentUserUnreadCount unreadCount: UnreadCount

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+Combine_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+Combine_Tests.swift
@@ -27,30 +27,10 @@ class CurrentUserController_Combine_Tests: iOS13TestCase {
     
     func test_startUpdatingIsCalled_whenPublisherIsAccessed() {
         assert(currentUserController.startUpdating_called == false)
-        _ = currentUserController.statePublisher
+        _ = currentUserController.currentUserChangePublisher
         XCTAssertTrue(currentUserController.startUpdating_called)
     }
     
-    func test_statePublisher() {
-        // Setup Recording publishers
-        var recording = Record<DataController.State, Never>.Recording()
-        
-        // Setup the chain
-        currentUserController
-            .statePublisher
-            .sink(receiveValue: { recording.receive($0) })
-            .store(in: &cancellables)
-        
-        // Keep only the weak reference to the controller. The existing publisher should keep it alive.
-        weak var controller: CurrentUserControllerMock? = currentUserController
-        currentUserController = nil
-        
-        controller?.delegateCallback { $0.controller(controller!, didChangeState: .localDataFetched) }
-        controller?.delegateCallback { $0.controller(controller!, didChangeState: .remoteDataFetched) }
-        
-        XCTAssertEqual(recording.output, [.initialized, .localDataFetched, .remoteDataFetched])
-    }
-
     func test_currentUserChangePublisher() {
         // Setup Recording publishers
         var recording = Record<EntityChange<CurrentChatUser>, Never>.Recording()

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+Combine_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+Combine_Tests.swift
@@ -25,12 +25,6 @@ class CurrentUserController_Combine_Tests: iOS13TestCase {
         super.tearDown()
     }
     
-    func test_startUpdatingIsCalled_whenPublisherIsAccessed() {
-        assert(currentUserController.startUpdating_called == false)
-        _ = currentUserController.currentUserChangePublisher
-        XCTAssertTrue(currentUserController.startUpdating_called)
-    }
-    
     func test_currentUserChangePublisher() {
         // Setup Recording publishers
         var recording = Record<EntityChange<CurrentChatUser>, Never>.Recording()

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI.swift
@@ -31,11 +31,6 @@ extension _CurrentChatUserController {
             
             controller.multicastDelegate.additionalDelegates.append(AnyCurrentUserControllerDelegate(self))
             
-            if controller.state == .initialized {
-                // Start updating and load the current data
-                controller.startUpdating()
-            }
-            
             currentUser = controller.currentUser
             unreadCount = controller.unreadCount
         }

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI.swift
@@ -21,16 +21,12 @@ extension _CurrentChatUserController {
         /// The unread messages and channels count for the current user.
         @Published public private(set) var unreadCount: UnreadCount = .noUnread
         
-        /// The current state of the Controller.
-        @Published public private(set) var state: DataController.State
-        
         /// The connection status.
         @Published public private(set) var connectionStatus: ConnectionStatus
         
         /// Creates a new `ObservableObject` wrapper with the provided controller instance.
         init(controller: _CurrentChatUserController<ExtraData>) {
             self.controller = controller
-            state = controller.state
             connectionStatus = controller.connectionStatus
             
             controller.multicastDelegate.additionalDelegates.append(AnyCurrentUserControllerDelegate(self))
@@ -60,10 +56,6 @@ extension _CurrentChatUserController.ObservableObject: _CurrentChatUserControlle
         didChangeCurrentUser currentUser: EntityChange<_CurrentChatUser<ExtraData.User>>
     ) {
         self.currentUser = controller.currentUser
-    }
-    
-    public func controller(_ controller: DataController, didChangeState state: DataController.State) {
-        self.state = state
     }
     
     public func currentUserController(

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI_Tests.swift
@@ -21,12 +21,10 @@ class CurrentUserController_SwiftUI_Tests: iOS13TestCase {
     }
     
     func test_controllerInitialValuesAreLoaded() {
-        currentUserController.state_simulated = .localDataFetched
         currentUserController.currentUser_simulated = .init(id: .unique)
         
         let observableObject = currentUserController.observableObject
         
-        XCTAssertEqual(observableObject.state, currentUserController.state)
         XCTAssertEqual(observableObject.currentUser, currentUserController.currentUser)
     }
     
@@ -62,22 +60,6 @@ class CurrentUserController_SwiftUI_Tests: iOS13TestCase {
         AssertAsync.willBeEqual(observableObject.unreadCount, newUnreadCount)
     }
     
-    func test_observableObject_reactsToDelegateStateChangesCallback() {
-        let observableObject = currentUserController.observableObject
-        
-        // Simulate state change
-        let newState: DataController.State = .remoteDataFetchFailed(ClientError(with: TestError()))
-        currentUserController.state_simulated = newState
-        currentUserController.delegateCallback {
-            $0.controller(
-                self.currentUserController,
-                didChangeState: newState
-            )
-        }
-        
-        AssertAsync.willBeEqual(observableObject.state, newState)
-    }
-    
     func test_observableObject_reactsToDelegateConnectionStatusChangesCallback() {
         let observableObject = currentUserController.observableObject
         
@@ -105,12 +87,6 @@ class CurrentUserControllerMock: CurrentChatUserController {
     var unreadCount_simulated: UnreadCount?
     override var unreadCount: UnreadCount {
         unreadCount_simulated ?? super.unreadCount
-    }
-
-    var state_simulated: DataController.State?
-    override var state: DataController.State {
-        get { state_simulated ?? super.state }
-        set { super.state = newValue }
     }
     
     init() {

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController+SwiftUI_Tests.swift
@@ -14,12 +14,6 @@ class CurrentUserController_SwiftUI_Tests: iOS13TestCase {
         currentUserController = CurrentUserControllerMock()
     }
     
-    func test_startUpdatingIsCalled_whenObservableObjectCreated() {
-        assert(currentUserController.startUpdating_called == false)
-        _ = currentUserController.observableObject
-        XCTAssertTrue(currentUserController.startUpdating_called)
-    }
-    
     func test_controllerInitialValuesAreLoaded() {
         currentUserController.currentUser_simulated = .init(id: .unique)
         
@@ -77,8 +71,6 @@ class CurrentUserController_SwiftUI_Tests: iOS13TestCase {
 }
 
 class CurrentUserControllerMock: CurrentChatUserController {
-    @Atomic var startUpdating_called = false
-    
     var currentUser_simulated: _CurrentChatUser<DefaultExtraData.User>?
     override var currentUser: _CurrentChatUser<DefaultExtraData.User>? {
         currentUser_simulated ?? super.currentUser
@@ -91,9 +83,5 @@ class CurrentUserControllerMock: CurrentChatUserController {
     
     init() {
         super.init(client: .mock)
-    }
-
-    override func startUpdating(_ completion: ((Error?) -> Void)? = nil) {
-        startUpdating_called = true
     }
 }

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
@@ -9,7 +9,7 @@ public extension _ChatClient {
     /// Creates a new `CurrentUserControllerGeneric`
     /// - Returns: A new instance of `ChannelController`.
     func currentUserController() -> _CurrentChatUserController<ExtraData> {
-        .init(client: self, environment: .init())
+        .init(client: self)
     }
 }
 

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -161,44 +161,6 @@ final class CurrentUserController_Tests: StressTestCase {
         AssertAsync.willBeEqual(delegate.didUpdateConnectionStatus_statuses, [.connecting, .connected])
     }
     
-    func test_delegate_isNotifiedAboutStateChanges() throws {
-        // Set the delegate
-        let delegate = TestDelegate()
-        delegate.expectedQueueId = controllerCallbackQueueID
-        controller.delegate = delegate
-        
-        // Assert no state changes received so far
-        XCTAssertNil(delegate.state)
-        
-        // Start updating
-        let startUpdatingError = try await(controller.startUpdating)
-        
-        // Assert `startUpdating` finished without any error
-        XCTAssertNil(startUpdatingError)
-        
-        // Assert delegate is notified about state changes
-        AssertAsync.willBeEqual(delegate.state, .localDataFetched)
-    }
-    
-    func test_genericDelegate_isNotifiedAboutStateChanges() throws {
-        // Set the delegate
-        let delegate = TestDelegateGeneric()
-        delegate.expectedQueueId = controllerCallbackQueueID
-        controller.setDelegate(delegate)
-        
-        // Assert no state changes received so far
-        XCTAssertNil(delegate.state)
-        
-        // Start updating
-        let startUpdatingError = try await(controller.startUpdating)
-        
-        // Assert `startUpdating` finished without any error
-        XCTAssertNil(startUpdatingError)
-        
-        // Assert delegate is notified about state changes
-        AssertAsync.willBeEqual(delegate.state, .localDataFetched)
-    }
-    
     func test_delegate_isNotifiedAboutCreatedUser() throws {
         let extraData = NameAndImageExtraData(name: .unique, imageURL: .unique())
         let currentUserPayload: CurrentUserPayload<DefaultExtraData.User> = .dummy(

--- a/Tests_v3/Await.swift
+++ b/Tests_v3/Await.swift
@@ -37,9 +37,11 @@ func await<T>(
 ) throws -> T {
     let expecation = XCTestExpectation(description: "Action completed")
     var result: T?
-    action {
-        result = $0
-        expecation.fulfill()
+    action { resultValue in
+        DispatchQueue.main.async {
+            result = resultValue
+            expecation.fulfill()
+        }
     }
     
     let waiterResult = XCTWaiter.wait(for: [expecation], timeout: timeout)


### PR DESCRIPTION
**This PR**:

- removes `startUpdating` from `CurrentChatUserController`
- updates `CurrentChatUserController` not to be `DataController`
- updates swift-ui & combine wrappers