### PR TITLE
[CIS-209] Bump `Startscream` dependency

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "daltoniam/Starscream" ~> 3.1
+github "daltoniam/Starscream" ~> 4.0
 
 github "ReactiveX/RxSwift" ~> 5.1
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "ReactiveX/RxSwift" "5.1.1"
 github "RxSwiftCommunity/RxGesture" "3.0.3"
 github "SnapKit/SnapKit" "5.0.1"
-github "daltoniam/Starscream" "3.1.1"
+github "daltoniam/Starscream" "4.0.4"
 github "kean/Nuke" "8.4.1"
 github "kirualex/SwiftyGif" "5.2.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,17 +42,8 @@
         "repositoryURL": "https://github.com/daltoniam/Starscream.git",
         "state": {
           "branch": null,
-          "revision": "e6b65c6d9077ea48b4a7bdda8994a1d3c6969c8d",
-          "version": "3.1.1"
-        }
-      },
-      {
-        "package": "swift-nio-zlib-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
-        "state": {
-          "branch": null,
-          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
-          "version": "1.0.0"
+          "revision": "df8d82047f6654d8e4b655d1b1525c64e1059d21",
+          "version": "4.0.4"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         // Core
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.1.0"),
         // Client
-        .package(url: "https://github.com/daltoniam/Starscream.git", from: "3.1.0"),
+        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.0"),
     ],
     targets: [
         .target(

--- a/Sources/Client/WebSocket/Provider/StarscreamWebSocketProvider.swift
+++ b/Sources/Client/WebSocket/Provider/StarscreamWebSocketProvider.swift
@@ -20,7 +20,7 @@ final class StarscreamWebSocketProvider: WebSocketProvider {
         }
     }
     
-    var isConnected: Bool { webSocket.isConnected }
+    private(set) var isConnected = false
     var callbackQueue: DispatchQueue { webSocket.callbackQueue }
     weak var delegate: WebSocketProviderDelegate?
     
@@ -35,7 +35,7 @@ final class StarscreamWebSocketProvider: WebSocketProvider {
     }
     
     func disconnect() {
-        webSocket.disconnect(forceTimeout: 0)
+        webSocket.disconnect()
     }
     
     func sendPing() {
@@ -45,26 +45,42 @@ final class StarscreamWebSocketProvider: WebSocketProvider {
 
 extension StarscreamWebSocketProvider: Starscream.WebSocketDelegate {
     
-    func websocketDidConnect(socket: Starscream.WebSocketClient) {
+    func didReceive(event: Starscream.WebSocketEvent, client: Starscream.WebSocket) {
+        switch event {
+        case .connected:
+            didConnect()
+        case let .text(text):
+            delegate?.websocketDidReceiveMessage(text)
+        case let .error(error):
+            didDisconnect(error: error.flatMap {
+                .init(reason: $0.localizedDescription,
+                      code: Int(($0 as? WSError)?.code ?? 0),
+                      providerType: StarscreamWebSocketProvider.self,
+                      providerError: $0)
+            })
+        case let .disconnected(reason, code):
+            didDisconnect(error: .init(reason: reason,
+                                       code: Int(code),
+                                       providerType: StarscreamWebSocketProvider.self,
+                                       providerError: nil))
+        case .cancelled:
+            didDisconnect(error: .init(reason: "Cancelled",
+                                       code: -1,
+                                       providerType: StarscreamWebSocketProvider.self,
+                                       providerError: nil))
+        default:
+            break
+        }
+    }
+    
+    private func didConnect() {
+        isConnected = true
         delegate?.websocketDidConnect()
     }
     
-    func websocketDidDisconnect(socket: Starscream.WebSocketClient, error: Error?) {
-        var webSocketProviderError: WebSocketProviderError?
-        
-        if let error = error {
-            webSocketProviderError = .init(reason: error.localizedDescription,
-                                           code: (error as? WSError)?.code ?? 0,
-                                           providerType: StarscreamWebSocketProvider.self,
-                                           providerError: error)
-        }
-        
-        delegate?.websocketDidDisconnect(error: webSocketProviderError)
+    private func didDisconnect(error: WebSocketProviderError?) {
+        isConnected = false
+        delegate?.websocketDidDisconnect(error: error)
     }
     
-    func websocketDidReceiveMessage(socket: Starscream.WebSocketClient, text: String) {
-        delegate?.websocketDidReceiveMessage(text)
-    }
-    
-    func websocketDidReceiveData(socket: Starscream.WebSocketClient, data: Data) {}
 }

--- a/StreamChatClient.podspec
+++ b/StreamChatClient.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |spec|
 
   spec.framework = "Foundation", "UIKit"
 
-  spec.dependency "Starscream", "~> 3.1"
+  spec.dependency "Starscream", "~> 4.0"
 end


### PR DESCRIPTION
**This PR:** 

- bumps `Startscream` dependency from `~> 3.1` to `~> 4.0` for both **v2** and **v3** SDK versions for all dependency managers (Carthage/CocoaPods/SPM)
- updates **v2** and **v3** SDK versions to meet the new API