### PR TITLE
Add custom environment variable usage in SwiftUI sample

### DIFF
--- a/Sample_v3/LoginViewController.swift
+++ b/Sample_v3/LoginViewController.swift
@@ -184,7 +184,8 @@ extension LoginViewController {
                     self.view.window?.rootViewController = UIHostingController(
                         rootView:
                         NavigationView {
-                            ChannelListView(channelList: channelListController.observableObject)
+                            ChannelListView()
+                                .chatClient(chatClient)
                         }
                     )
                 })
@@ -238,5 +239,20 @@ extension LoginViewController {
         default:
             fatalError("Segmented Control out of bounds")
         }
+    }
+}
+
+@available(iOS 13.0, *)
+extension View {
+    func chatClient(_ chatClient: ChatClient) -> some View {
+        environment(\.chatClient, chatClient)
+    }
+}
+
+@available(iOS 13.0, *)
+extension EnvironmentValues {
+    var chatClient: ChatClient {
+        get { self[ChatClientKey.self] }
+        set { self[ChatClientKey.self] = newValue }
     }
 }

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
@@ -8,6 +8,24 @@ import SwiftUI
 
 @available(iOS 14, *)
 struct ChannelListView: View {
+    @Environment(\.chatClient) private var chatClient
+    
+    var body: some View {
+        ChannelList(
+            channelList: chatClient.channelListController(
+                query: ChannelListQuery(
+                    filter: .in("members", [chatClient.currentUserId]),
+                    pagination: [.limit(25)],
+                    options: [.watch]
+                )
+            ).observableObject
+        ).chatClient(chatClient)
+    }
+}
+
+@available(iOS 14, *)
+struct ChannelList: View {
+    @Environment(\.chatClient) private var chatClient
     /// The `ChatChannelListController` used to interact with this channel. Will be synchronized in `onAppear`.
     @StateObject var channelList: ChatChannelListController.ObservableObject
     /// Binding for channel actions ActionSheet.
@@ -172,12 +190,9 @@ struct ChannelListView: View {
         channelList.channels[index]
     }
     
-    private func chatView(for index: Int) -> ChatView {
-        ChatView(
-            channel: channelList.controller.client.channelController(
-                for: channelList.channels[index].cid
-            ).observableObject
-        )
+    private func chatView(for index: Int) -> some View {
+        ChatView(cid: channel(index).cid)
+            .chatClient(chatClient)
     }
 }
 

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
@@ -8,6 +8,20 @@ import SwiftUI
 
 @available(iOS 14, *)
 struct ChatView: View {
+    @Environment(\.chatClient) private var chatClient
+    var cid: ChannelId
+    
+    init(cid: ChannelId) {
+        self.cid = cid
+    }
+
+    var body: some View {
+        Chat(channel: chatClient.channelController(for: cid).observableObject)
+    }
+}
+
+@available(iOS 14, *)
+struct Chat: View {
     /// The `ChannelController` used to interact with this channel. Will be synchronized in `onAppear`.
     @StateObject var channel: ChatChannelController.ObservableObject
     /// The `text` written in the message composer.

--- a/Sources_v3/ChatClient+SwiftUI.swift
+++ b/Sources_v3/ChatClient+SwiftUI.swift
@@ -1,0 +1,10 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import SwiftUI
+
+public struct ChatClientKey<ExtraData: ExtraDataTypes>: EnvironmentKey {
+    public typealias Value = _ChatClient<ExtraData>
+    public static var defaultValue: Value { Value(config: .init(apiKeyString: "Set chatClient value!")) }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -275,6 +275,7 @@
 		DA4AA3B8250271BD00FAAF6E /* CurrentUserController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4AA3B7250271BD00FAAF6E /* CurrentUserController+Combine.swift */; };
 		DA4AA3BA2502731900FAAF6E /* Publisher+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4AA3B92502731900FAAF6E /* Publisher+Extensions.swift */; };
 		DA7229E424E140600074503A /* ChannelEditDetailPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7229E224E140260074503A /* ChannelEditDetailPayload_Tests.swift */; };
+		DA8406F725221646005A0F62 /* ChatClient+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8406F5252215E2005A0F62 /* ChatClient+SwiftUI.swift */; };
 		DA9985EE24E175AA000E9885 /* ChannelCodingKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9985ED24E175AA000E9885 /* ChannelCodingKeys.swift */; };
 		DA99D0D024ED63C600AD5354 /* NewChannelQueryUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA99D0CF24ED63C600AD5354 /* NewChannelQueryUpdater.swift */; };
 		DAD539DB250B8A9C00CFC649 /* Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD539DA250B8A9C00CFC649 /* Controller.swift */; };
@@ -669,6 +670,7 @@
 		DA4AA3B7250271BD00FAAF6E /* CurrentUserController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CurrentUserController+Combine.swift"; sourceTree = "<group>"; };
 		DA4AA3B92502731900FAAF6E /* Publisher+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Extensions.swift"; sourceTree = "<group>"; };
 		DA7229E224E140260074503A /* ChannelEditDetailPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelEditDetailPayload_Tests.swift; sourceTree = "<group>"; };
+		DA8406F5252215E2005A0F62 /* ChatClient+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatClient+SwiftUI.swift"; sourceTree = "<group>"; };
 		DA9985ED24E175AA000E9885 /* ChannelCodingKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelCodingKeys.swift; sourceTree = "<group>"; };
 		DA99D0CF24ED63C600AD5354 /* NewChannelQueryUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewChannelQueryUpdater.swift; sourceTree = "<group>"; };
 		DAD539DA250B8A9C00CFC649 /* Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controller.swift; sourceTree = "<group>"; };
@@ -1039,6 +1041,7 @@
 			isa = PBXGroup;
 			children = (
 				79A0E9AC2498BD0C00E9BD50 /* ChatClient.swift */,
+				DA8406F5252215E2005A0F62 /* ChatClient+SwiftUI.swift */,
 				799C942F247D2FB9001F1104 /* ChatClient_Tests.swift */,
 				7991D83E24F8F1BF00D21BA3 /* ChatClient_Mock.swift */,
 				7962958A2481473A0078EB53 /* Config */,
@@ -1911,6 +1914,7 @@
 				F6FF1DA624FD17B400151735 /* MessageController.swift in Sources */,
 				797E10A824EAF6DE00353791 /* UniqueId.swift in Sources */,
 				F6ED5F7425023EB4005D7327 /* MissingEventsPublisher.swift in Sources */,
+				DA8406F725221646005A0F62 /* ChatClient+SwiftUI.swift in Sources */,
 				79877A0B2498E4BC00015F8B /* Member.swift in Sources */,
 				F670B50F24FE6EA900003B1A /* MessageEditor.swift in Sources */,
 				7991D83D24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift in Sources */,


### PR DESCRIPTION
The goal was to use `@Environment` in our sample app to make it more `SwiftUI`-ish.

The problem there is that we need to initialize our `.ObservableObject` using `chatClient`.
It seems like right now the only way to achieve that is to introduce another level of `View` abstraction. (nil, lazy etc. didn't work)
As soon as it is Sample app I'm not sure we should do that.

Another issue is that we can't introduce some valid `defaultValue`. 
Possible solution was to throw `fatalError()` on attempt of accessing `defaultValue` but that is also not possible cause `defaultValue` is accessed each time we initialize some view even if we provide this value with `.environment` `ViewModifier`.