### PR TITLE
[CIS-370] Call `setUser` completion with error when WS connection fails

### DIFF
--- a/Sample_v3/Extensions/UIViewController+Alert.swift
+++ b/Sample_v3/Extensions/UIViewController+Alert.swift
@@ -5,9 +5,9 @@
 import UIKit
 
 extension UIViewController {
-    func alert(title: String, message: String) {
+    func alert(title: String, message: String, completion: @escaping () -> Void = {}) {
         let controller = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        controller.addAction(.init(title: "OK", style: .default))
+        controller.addAction(.init(title: "OK", style: .default, handler: { _ in completion() }))
         present(controller, animated: true)
     }
     

--- a/Sample_v3/LoginViewController.swift
+++ b/Sample_v3/LoginViewController.swift
@@ -39,8 +39,10 @@ class LoginViewController: UITableViewController {
             guard let error = error else { return }
             
             DispatchQueue.main.async {
-                self.alert(title: "Error", message: "Error logging in: \(error)")
-                self.navigationController?.popToRootViewController(animated: true)
+                let viewController = UIApplication.shared.keyWindow?.rootViewController
+                viewController?.alert(title: "Error", message: "Error logging in: \(error)") {
+                    viewController?.moveToStoryboard(.main, options: [.transitionFlipFromRight])
+                }
             }
         }
         

--- a/Sources_v3/ChatClient.swift
+++ b/Sources_v3/ChatClient.swift
@@ -333,8 +333,15 @@ extension _ChatClient: ConnectionStateDelegate {
             self.connectionId = connectionId
             connectionIdWaiters.forEach { $0(connectionId) }
             connectionIdWaiters.removeAll()
+            
         } else {
             connectionId = nil
+
+            if case .disconnected = state {
+                // No reconnection attempt schedule, we should fail all existing connecitonId waiters.
+                connectionIdWaiters.forEach { $0(nil) }
+                connectionIdWaiters.removeAll()
+            }
         }
     }
 }

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
@@ -172,11 +172,16 @@ public extension _CurrentChatUserController {
         }
         
         // Set up a waiter for the new connection id to know when the connection process is finished
-        client.provideConnectionId { connectionId in
+        client.provideConnectionId { [weak self] connectionId in
             if connectionId != nil {
                 completion?(nil)
             } else {
-                completion?(ClientError.ConnectionNotSuccessfull())
+                // Try to get a concrete error
+                if case let .disconnected(error) = self?.client.webSocketClient.connectionState {
+                    completion?(ClientError.ConnectionNotSuccessfull(with: error))
+                } else {
+                    completion?(ClientError.ConnectionNotSuccessfull())
+                }
             }
         }
         

--- a/Sources_v3/Errors/ErrorPayload.swift
+++ b/Sources_v3/Errors/ErrorPayload.swift
@@ -19,7 +19,7 @@ struct ErrorPayload: LocalizedError, Codable, CustomDebugStringConvertible, Equa
     public let code: Int
     /// A message.
     public let message: String
-    /// A status code.
+    /// An HTTP status code.
     public let statusCode: Int
     
     public var errorDescription: String? {
@@ -27,6 +27,6 @@ struct ErrorPayload: LocalizedError, Codable, CustomDebugStringConvertible, Equa
     }
     
     public var debugDescription: String {
-        "ClientErrorResponse(code: \(code), message: \"\(message)\", statusCode: \(statusCode)))."
+        "ServerErrorPayload(code: \(code), message: \"\(message)\", statusCode: \(statusCode)))."
     }
 }

--- a/Sources_v3/WebSocketClient/WebSocketReconnectionStrategy.swift
+++ b/Sources_v3/WebSocketClient/WebSocketReconnectionStrategy.swift
@@ -37,11 +37,16 @@ class DefaultReconnectionStrategy: WebSocketClientReconnectionStrategy {
             }
         }
         
-        if
-            let serverInitiatedError = error as? ErrorPayload,
-            ErrorPayload.tokenInvadlidErrorCodes ~= serverInitiatedError.code {
-            // Don't reconnect on invalid token errors
-            return nil
+        if let serverInitiatedError = error as? ErrorPayload {
+            if ErrorPayload.tokenInvadlidErrorCodes ~= serverInitiatedError.code {
+                // Don't reconnect on invalid token errors
+                return nil
+            }
+        
+            if 400...499 ~= serverInitiatedError.statusCode {
+                // Don't reconnect on client side errors
+                return nil
+            }
         }
         
         let maxDelay: TimeInterval = min(0.5 + Double(consecutiveFailures * 2), Self.maximumReconnectionDelay)

--- a/Sources_v3/WebSocketClient/WebSocketReconnectionStrategy_Tests.swift
+++ b/Sources_v3/WebSocketClient/WebSocketReconnectionStrategy_Tests.swift
@@ -78,4 +78,19 @@ class DefaultReconnectionStrategy_Tests: XCTestCase {
         let delay = strategy.reconnectionDelay(forConnectionError: error)
         XCTAssertNil(delay)
     }
+    
+    func test_returnsNil_forClientSideErrorStatusCodes() {
+        let clientSideErrorStatusCodes = 400...499
+        
+        clientSideErrorStatusCodes.forEach { statusCode in
+            let error = ErrorPayload(code: 0, message: "", statusCode: statusCode)
+            let delay = strategy.reconnectionDelay(forConnectionError: error)
+            XCTAssertNil(delay)
+        }
+        
+        // Check server erros return a non-nil delay
+        let error = ErrorPayload(code: 0, message: "", statusCode: 500)
+        let delay = strategy.reconnectionDelay(forConnectionError: error)
+        XCTAssertNotNil(delay)
+    }
 }


### PR DESCRIPTION
The original implementation tried to reconnect the web socket when the connection failed with a 400...499 status code.

The new implementation doesn't try to reconnect in those cases, and the completion of `set(Guest/Anonymous)User` is called with an error instead.

---

@cardoso It seems the sample app doesn't handle this case properly in `setUserCompletion`. Would you mind taking a look and fixing it, please? Feel free to push more commits to this PR directly.
