### PR TITLE
[CIS-364] Use `defaultValue` when extra decoding fails

### DIFF
--- a/Sources_v3/Database/DTOs/ChannelDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO.swift
@@ -172,9 +172,17 @@ extension _ChatChannel {
         let members: [_ChatChannelMember<ExtraData.User>] = dto.members.map { $0.asModel() }
         let typingMembers: [_ChatChannelMember<ExtraData.User>] = dto.currentlyTypingMembers.map { $0.asModel() }
 
-        // It's safe to use `try!` here, because the extra data payload comes from the DB, so we know it must
-        // be a valid JSON payload, otherwise it wouldn't be possible to save it there.
-        let extraData = try! JSONDecoder.default.decode(ExtraData.Channel.self, from: dto.extraData)
+        let extraData: ExtraData.Channel
+        do {
+            extraData = try JSONDecoder.default.decode(ExtraData.Channel.self, from: dto.extraData)
+        } catch {
+            log.error(
+                "Failed to decode extra data for Channel with cid: <\(dto.cid)>, using default value instead. "
+                    + "Error: \(error)"
+            )
+            extraData = .defaultValue
+        }
+        
         let cid = try! ChannelId(cid: dto.cid)
         
         let context = dto.managedObjectContext!

--- a/Sources_v3/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO.swift
@@ -104,10 +104,11 @@ extension _CurrentChatUser {
         do {
             extraData = try JSONDecoder.default.decode(ExtraData.self, from: user.extraData)
         } catch {
-            fatalError(
-                "Failed decoding saved extra data with error: \(error). This should never happen because"
-                    + "the extra data must be a valid JSON to be saved."
+            log.error(
+                "Failed to decode extra data for CurrentUser with id: <\(dto.user.id)>, using default value instead. "
+                    + " Error: \(error)"
             )
+            extraData = .defaultValue
         }
         
         let mutedUsers: [_ChatUser<ExtraData>] = dto.mutedUsers.map { $0.asModel() }

--- a/Sources_v3/Database/DTOs/CurrentUserDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO_Tests.swift
@@ -82,4 +82,20 @@ class CurrentUserModelDTO_Tests: XCTestCase {
             // TODO: Teams, Mutes, Devices
         }
     }
+    
+    func test_defaultExtraDataIsUsed_whenExtraDataDecodingFails() throws {
+        let userId: UserId = .unique
+        
+        let payload: CurrentUserPayload<DefaultExtraData.User> = .dummy(userId: userId, role: .user)
+        
+        try database.writeSynchronously { session in
+            // Save the user
+            let userDTO = try! session.saveCurrentUser(payload: payload)
+            // Make the extra data JSON invalid
+            userDTO.user.extraData = #"{"invalid": json}"# .data(using: .utf8)!
+        }
+        
+        let loadedUser: CurrentChatUser? = database.viewContext.currentUser()?.asModel()
+        XCTAssertEqual(loadedUser?.extraData, .defaultValue)
+    }
 }

--- a/Sources_v3/Database/DTOs/MemberModelDTO.swift
+++ b/Sources_v3/Database/DTOs/MemberModelDTO.swift
@@ -87,10 +87,11 @@ extension _ChatChannelMember {
         do {
             extraData = try JSONDecoder.default.decode(ExtraData.self, from: dto.user.extraData)
         } catch {
-            fatalError(
-                "Failed decoding saved extra data with error: \(error). This should never happen because"
-                    + "the extra data must be a valid JSON to be saved."
+            log.error(
+                "Failed to decode extra data for Member with id: <\(dto.user.id)>, using default value instead. "
+                    + "Error: \(error)"
             )
+            extraData = .defaultValue
         }
         
         let role = dto.channelRoleRaw.flatMap { MemberRole(rawValue: $0) } ?? .member

--- a/Sources_v3/Database/DTOs/MessageDTO.swift
+++ b/Sources_v3/Database/DTOs/MessageDTO.swift
@@ -236,9 +236,17 @@ extension _ChatMessage {
         parentMessageId = dto.parentMessageId
         showReplyInChannel = dto.showReplyInChannel
         replyCount = Int(dto.replyCount)
-        extraData = try! JSONDecoder.default.decode(ExtraData.Message.self, from: dto.extraData)
         isSilent = dto.isSilent
         reactionScores = dto.reactionScores
+        
+        let extraData: ExtraData.Message
+        do {
+            extraData = try JSONDecoder.default.decode(ExtraData.Message.self, from: dto.extraData)
+        } catch {
+            log.error("Failed to decode extra data for Message with id: <\(dto.id)>, using default value instead. Error: \(error)")
+            extraData = .defaultValue
+        }
+        self.extraData = extraData
         
         author = dto.user.asModel()
         mentionedUsers = Set(dto.mentionedUsers.map { $0.asModel() })

--- a/Sources_v3/Database/DTOs/UserDTO.swift
+++ b/Sources_v3/Database/DTOs/UserDTO.swift
@@ -104,10 +104,8 @@ extension _ChatUser {
         do {
             extraData = try JSONDecoder.default.decode(ExtraData.self, from: dto.extraData)
         } catch {
-            fatalError(
-                "Failed decoding saved extra data with error: \(error). This should never happen because"
-                    + "the extra data must be a valid JSON to be saved."
-            )
+            log.error("Failed to decode extra data for User with id: <\(dto.id)>, using default value instead. Error: \(error)")
+            extraData = .defaultValue
         }
         
         return _ChatUser(

--- a/Sources_v3/Database/DTOs/UserDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/UserDTO_Tests.swift
@@ -82,6 +82,33 @@ class UserDTO_Tests: XCTestCase {
         }
     }
     
+    func test_defaultExtraDataIsUsed_whenExtraDataDecodingFails() throws {
+        let userId: UserId = .unique
+        
+        let payload: UserPayload<DefaultExtraData.User> = .init(
+            id: userId,
+            role: .admin,
+            createdAt: .unique,
+            updatedAt: .unique,
+            lastActiveAt: .unique,
+            isOnline: true,
+            isInvisible: true,
+            isBanned: true,
+            teams: [],
+            extraData: .defaultValue
+        )
+        
+        try database.writeSynchronously { session in
+            // Save the user
+            let userDTO = try! session.saveUser(payload: payload)
+            // Make the extra data JSON invalid
+            userDTO.extraData = #"{"invalid": json}"# .data(using: .utf8)!
+        }
+        
+        let loadedUser: ChatUser? = database.viewContext.user(id: userId)?.asModel()
+        XCTAssertEqual(loadedUser?.extraData, .defaultValue)
+    }
+    
     func test_DTO_asModel() {
         let userId = UUID().uuidString
         

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -863,8 +863,8 @@
 				79877A212498E50D00015F8B /* MemberModelDTO.swift */,
 				79877A1D2498E50D00015F8B /* MemberModelDTO_Tests.swift */,
 				799C942A247D2FB9001F1104 /* ChannelDTO.swift */,
-				796FD215250654940076C99B /* ChannelReadDTO.swift */,
 				79877A1E2498E50D00015F8B /* ChannelDTO_Tests.swift */,
+				796FD215250654940076C99B /* ChannelReadDTO.swift */,
 				7964F3A3249A0ACF002A09EC /* ChannelListQueryDTO.swift */,
 				7991D83A24F5427E00D21BA3 /* EphemeralValuesContainer.swift */,
 			);


### PR DESCRIPTION
This PR changes the extra decoding logic to be more robust and nicely recover by using `defaultValue` if extra data decoding fails.