### PR TITLE
[CIS-359] Fix stress tests

### DIFF
--- a/Tests_v3/StreamChatClientStressTestPlan.xctestplan
+++ b/Tests_v3/StreamChatClientStressTestPlan.xctestplan
@@ -15,8 +15,7 @@
         "key" : "STRESS_TESTS",
         "value" : "TRUE"
       }
-    ],
-    "testExecutionOrdering" : "random"
+    ]
   },
   "testTargets" : [
     {


### PR DESCRIPTION
This PR changes tests execution order `Random` -> `Alphabetical` for stress plan. The goal is to apply this change and see if it helps because debugging stress tests locally takes much time.