### PR TITLE
[CIS-359] Ensure delegates always have expected-queue-id set in tests

### DIFF
--- a/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
@@ -269,8 +269,7 @@ class ChannelController_Tests: StressTestCase {
     // MARK: - Delegate tests
     
     func test_settingDelegate_leads_to_FetchingLocalData() {
-        let delegate = TestDelegate()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegate(expectedQueueId: controllerCallbackQueueID)
            
         // Check initial state
         XCTAssertEqual(controller.state, .initialized)
@@ -283,8 +282,7 @@ class ChannelController_Tests: StressTestCase {
     
     func test_delegate_isNotifiedAboutStateChanges() throws {
         // Set the delegate
-        let delegate = TestDelegate()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegate(expectedQueueId: controllerCallbackQueueID)
         controller.delegate = delegate
         
         // Assert delegate is notified about state changes
@@ -302,8 +300,7 @@ class ChannelController_Tests: StressTestCase {
 
     func test_genericDelegate_isNotifiedAboutStateChanges() throws {
         // Set the generic delegate
-        let delegate = TestDelegateGeneric()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegateGeneric(expectedQueueId: controllerCallbackQueueID)
         controller.setDelegate(delegate)
         
         // Assert delegate is notified about state changes
@@ -331,8 +328,7 @@ class ChannelController_Tests: StressTestCase {
         controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)
 
         // Setup delegate
-        let delegate = TestDelegate()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegate(expectedQueueId: controllerCallbackQueueID)
         controller.delegate = delegate
 
         // Simulate `synchronize` call
@@ -382,11 +378,8 @@ class ChannelController_Tests: StressTestCase {
     }
     
     func test_channelMemberEvents_areForwaredToDelegate() throws {
-        let delegate = TestDelegate()
+        let delegate = TestDelegate(expectedQueueId: controllerCallbackQueueID)
         controller.delegate = delegate
-        
-        // Set the queue for delegate calls
-        delegate.expectedQueueId = controllerCallbackQueueID
         
         // Simulate `synchronize()` call
         controller.synchronize()
@@ -401,11 +394,8 @@ class ChannelController_Tests: StressTestCase {
     }
     
     func test_channelMemberEvents_areForwaredToGenericDelegate() throws {
-        let delegate = TestDelegateGeneric()
+        let delegate = TestDelegateGeneric(expectedQueueId: controllerCallbackQueueID)
         controller.setDelegate(delegate)
-        
-        // Set the queue for delegate calls
-        delegate.expectedQueueId = controllerCallbackQueueID
         
         // Simulate `synchronize()` call
         controller.synchronize()
@@ -427,9 +417,8 @@ class ChannelController_Tests: StressTestCase {
         try client.databaseContainer.createMember(userId: memberId, cid: channelId)
         
         // Set the queue for delegate calls
-        let delegate = TestDelegate()
+        let delegate = TestDelegate(expectedQueueId: controllerCallbackQueueID)
         controller.delegate = delegate
-        delegate.expectedQueueId = controllerCallbackQueueID
         
         // Simulate `synchronize()` call
         controller.synchronize()
@@ -458,9 +447,8 @@ class ChannelController_Tests: StressTestCase {
         try client.databaseContainer.createMember(userId: memberId, cid: channelId)
         
         // Set the queue for delegate calls
-        let delegate = TestDelegateGeneric()
+        let delegate = TestDelegateGeneric(expectedQueueId: controllerCallbackQueueID)
         controller.setDelegate(delegate)
-        delegate.expectedQueueId = controllerCallbackQueueID
         
         // Simulate `synchronize()` call
         controller.synchronize()
@@ -482,15 +470,12 @@ class ChannelController_Tests: StressTestCase {
     }
     
     func test_delegateMethodsAreCalled() throws {
-        let delegate = TestDelegate()
+        let delegate = TestDelegate(expectedQueueId: controllerCallbackQueueID)
         controller.delegate = delegate
         
         // Assert the delegate is assigned correctly. We should test this because of the type-erasing we
         // do in the controller.
         XCTAssert(controller.delegate === delegate)
-        
-        // Set the queue for delegate calls
-        delegate.expectedQueueId = controllerCallbackQueueID
         
         // Simulate `synchronize()` call
         controller.synchronize()
@@ -513,11 +498,8 @@ class ChannelController_Tests: StressTestCase {
     }
     
     func test_genericDelegate() throws {
-        let delegate = TestDelegateGeneric()
+        let delegate = TestDelegateGeneric(expectedQueueId: controllerCallbackQueueID)
         controller.setDelegate(delegate)
-        
-        // Set the queue for delegate calls
-        delegate.expectedQueueId = controllerCallbackQueueID
         
         // Simulate `synchronize()` call
         controller.synchronize()

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -183,8 +183,7 @@ class ChannelListController_Tests: StressTestCase {
     // MARK: - Delegate tests
     
     func test_settingDelegate_leads_to_FetchingLocalData() {
-        let delegate = TestDelegate()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegate(expectedQueueId: controllerCallbackQueueID)
            
         // Check initial state
         XCTAssertEqual(controller.state, .initialized)
@@ -197,8 +196,7 @@ class ChannelListController_Tests: StressTestCase {
     
     func test_delegate_isNotifiedAboutStateChanges() throws {
         // Set the delegate
-        let delegate = TestDelegate()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegate(expectedQueueId: controllerCallbackQueueID)
         controller.delegate = delegate
         
         // Assert delegate is notified about state changes
@@ -216,8 +214,7 @@ class ChannelListController_Tests: StressTestCase {
 
     func test_genericDelegate_isNotifiedAboutStateChanges() throws {
         // Set the generic delegate
-        let delegate = TestDelegateGeneric()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegateGeneric(expectedQueueId: controllerCallbackQueueID)
         controller.setDelegate(delegate)
         
         // Assert delegate is notified about state changes
@@ -234,12 +231,8 @@ class ChannelListController_Tests: StressTestCase {
     }
     
     func test_delegateMethodsAreCalled() throws {
-        let delegate = TestDelegate()
-        
-        // Set the queue for delegate calls
-        let delegateQueueId = UUID()
-        delegate.expectedQueueId = delegateQueueId
-        controller.callbackQueue = DispatchQueue.testQueue(withId: delegateQueueId)
+        // Set the delegate
+        let delegate = TestDelegate(expectedQueueId: controllerCallbackQueueID)
         controller.delegate = delegate
         
         // Assert the delegate is assigned correctly. We should test this because of the type-erasing we
@@ -260,14 +253,8 @@ class ChannelListController_Tests: StressTestCase {
     }
     
     func test_genericDelegate() throws {
-        let delegate = TestDelegateGeneric()
-        
-        // Set the queue for delegate calls
-        let delegateQueueId = UUID()
-        delegate.expectedQueueId = delegateQueueId
-        controller.callbackQueue = .testQueue(withId: delegateQueueId)
-        
         // Set delegate
+        let delegate = TestDelegateGeneric(expectedQueueId: controllerCallbackQueueID)
         controller.setDelegate(delegate)
         
         // Simulate DB update

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -88,9 +88,8 @@ final class CurrentUserController_Tests: StressTestCase {
     // MARK: - Delegate
     
     func test_delegate_isAssignedCorrectly() {
-        let delegate = TestDelegate()
-        
         // Set the delegate
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
         controller.delegate = delegate
         
         // Assert the delegate is assigned correctly
@@ -99,7 +98,7 @@ final class CurrentUserController_Tests: StressTestCase {
     
     func test_delegate_isReferencedWeakly() {
         // Create the delegate
-        var delegate: TestDelegate? = TestDelegate()
+        var delegate: TestDelegate? = .init(expectedQueueId: callbackQueueID)
         
         // Set the delegate
         controller.delegate = delegate
@@ -113,7 +112,7 @@ final class CurrentUserController_Tests: StressTestCase {
     
     func test_genericDelegate_isReferencedWeakly() {
         // Create the delegate
-        var delegate: TestDelegateGeneric? = TestDelegateGeneric()
+        var delegate: TestDelegateGeneric? = .init(expectedQueueId: callbackQueueID)
         
         // Set the delegate
         controller.setDelegate(delegate)
@@ -127,8 +126,7 @@ final class CurrentUserController_Tests: StressTestCase {
     
     func test_delegate_isNotifiedAboutConnectionStatusChanges() {
         // Set the delegate
-        let delegate = TestDelegate()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
         controller.delegate = delegate
         
         // Assert no connection status changes received so far
@@ -151,8 +149,7 @@ final class CurrentUserController_Tests: StressTestCase {
         )
         
         // Set the delegate
-        let delegate = TestDelegate()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
         controller.delegate = delegate
 
         // Simulate saving current user to a database
@@ -176,8 +173,7 @@ final class CurrentUserController_Tests: StressTestCase {
         )
         
         // Set the delegate
-        let delegate = TestDelegate()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
         controller.delegate = delegate
 
         // Simulate saving current user to a database
@@ -209,8 +205,7 @@ final class CurrentUserController_Tests: StressTestCase {
         let unreadCount = UnreadCount(channels: 10, messages: 15)
         
         // Set the delegate
-        let delegate = TestDelegate()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
         controller.delegate = delegate
 
         // Simulate saving current user to a database

--- a/Sources_v3/Controllers/DataController_Tests.swift
+++ b/Sources_v3/Controllers/DataController_Tests.swift
@@ -9,9 +9,8 @@ class DataController_Tests: XCTestCase {
     func test_delegateMethodIsCalled() {
         let controller = DataController()
         let delegateQueueId = UUID()
-        let delegate = TestDelegate()
+        let delegate = TestDelegate(expectedQueueId: delegateQueueId)
         
-        delegate.expectedQueueId = delegateQueueId
         controller.stateMulticastDelegate.mainDelegate = delegate
         controller.callbackQueue = DispatchQueue.testQueue(withId: delegateQueueId)
         

--- a/Sources_v3/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController_Tests.swift
@@ -157,7 +157,7 @@ final class MessageController_Tests: StressTestCase {
     // MARK: - Delegate
 
     func test_delegate_isAssignedCorrectly() {
-        let delegate = TestDelegate()
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
 
         // Set the delegate
         controller.delegate = delegate
@@ -167,12 +167,11 @@ final class MessageController_Tests: StressTestCase {
     }
     
     func test_settingDelegate_leads_to_FetchingLocalData() {
-        let delegate = TestDelegate()
-        delegate.expectedQueueId = controllerCallbackQueueID
-        
         // Check initial state
         XCTAssertEqual(controller.state, .initialized)
         
+        // Set the delegate
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
         controller.delegate = delegate
         
         // Assert state changed
@@ -181,8 +180,7 @@ final class MessageController_Tests: StressTestCase {
 
     func test_delegate_isNotifiedAboutStateChanges() throws {
         // Set the delegate
-        let delegate = TestDelegate()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
         controller.delegate = delegate
         
         // Assert delegate is notified about state changes
@@ -200,8 +198,7 @@ final class MessageController_Tests: StressTestCase {
 
     func test_genericDelegate_isNotifiedAboutStateChanges() throws {
         // Set the generic delegate
-        let delegate = TestDelegateGeneric()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegateGeneric(expectedQueueId: callbackQueueID)
         controller.setDelegate(delegate)
         
         // Assert delegate is notified about state changes
@@ -225,8 +222,7 @@ final class MessageController_Tests: StressTestCase {
         try client.databaseContainer.createChannel(cid: cid)
         
         // Set the delegate
-        let delegate = TestDelegate()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
         controller.delegate = delegate
         
         // Simulate `synchronize` call
@@ -262,8 +258,7 @@ final class MessageController_Tests: StressTestCase {
         try client.databaseContainer.createMessage(id: messageId, authorId: currentUserId, cid: cid, text: initialMessageText)
         
         // Set the delegate
-        let delegate = TestDelegate()
-        delegate.expectedQueueId = controllerCallbackQueueID
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
         controller.delegate = delegate
         
         // Simulate `synchronize` call

--- a/Tests_v3/QueueAwareDelegate.swift
+++ b/Tests_v3/QueueAwareDelegate.swift
@@ -15,25 +15,23 @@ import XCTest
 /// }
 /// ```
 class QueueAwareDelegate {
-    // If set, checks the delegate was called on the correct queue
-    var expectedQueueId: UUID?
-    
+    // Checks the delegate was called on the correct queue
+    let expectedQueueId: UUID
     let file: StaticString
     let line: UInt
     
-    init(file: StaticString = #file, line: UInt = #line) {
+    init(expectedQueueId: UUID, file: StaticString = #file, line: UInt = #line) {
+        self.expectedQueueId = expectedQueueId
         self.file = file
         self.line = line
     }
     
     func validateQueue(function: StaticString = #function) {
-        if let queueId = expectedQueueId {
-            XCTAssertTrue(
-                DispatchQueue.isTestQueue(withId: queueId),
-                "Delegate method \(function) called on an incorrect queue",
-                file: file,
-                line: line
-            )
-        }
+        XCTAssertTrue(
+            DispatchQueue.isTestQueue(withId: expectedQueueId),
+            "Delegate method \(function) called on an incorrect queue",
+            file: file,
+            line: line
+        )
     }
 }


### PR DESCRIPTION
This PR is another iteration of eliminating the failing stress tests issue. It updates `QueueAwareDelegate` to receive `expectedQueueId` via init other than having it as a mutable optional property. This ensures the `expectedQueueId` to always exist when any of the delegate method is called.