### PR TITLE
[CIS-261] User muting

### DIFF
--- a/Sources_v3/APIClient/Endpoints/ModerationEndpoints.swift
+++ b/Sources_v3/APIClient/Endpoints/ModerationEndpoints.swift
@@ -1,0 +1,31 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - User muting
+
+extension Endpoint {
+    static func muteUser(_ userId: UserId) -> Endpoint<EmptyResponse> {
+        muteUser(true, with: userId)
+    }
+    
+    static func unmuteUser(_ userId: UserId) -> Endpoint<EmptyResponse> {
+        muteUser(false, with: userId)
+    }
+}
+
+// MARK: - Private
+
+private extension Endpoint {
+    static func muteUser(_ mute: Bool, with userId: UserId) -> Endpoint<EmptyResponse> {
+        .init(
+            path: "moderation/\(mute ? "mute" : "unmute")",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["target_id": userId]
+        )
+    }
+}

--- a/Sources_v3/APIClient/Endpoints/ModerationEndpoints_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/ModerationEndpoints_Tests.swift
@@ -1,0 +1,44 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class ModerationEndpoints_Tests: XCTestCase {
+    func test_muteUser_buildsCorrectly() {
+        let userId: UserId = .unique
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: "moderation/mute",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["target_id": userId]
+        )
+        
+        // Build endpoint
+        let endpoint: Endpoint<EmptyResponse> = .muteUser(userId)
+        
+        // Assert endpoint is built correctly
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
+    
+    func test_unmuteUser_buildsCorrectly() {
+        let userId: UserId = .unique
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: "moderation/unmute",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["target_id": userId]
+        )
+        
+        // Build endpoint
+        let endpoint: Endpoint<EmptyResponse> = .unmuteUser(userId)
+        
+        // Assert endpoint is built correctly
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
+}

--- a/Sources_v3/APIClient/Endpoints/Payloads/CurrentUserPayloads.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/CurrentUserPayloads.swift
@@ -9,7 +9,7 @@ class CurrentUserPayload<ExtraData: UserExtraData>: UserPayload<ExtraData> {
     /// A list of devices.
     let devices: [Device]
     /// Muted users.
-    let mutedUsers: [MutedUser<ExtraData>]
+    let mutedUsers: [MutedUserPayload<ExtraData>]
     /// Unread channel and message counts
     let unreadCount: UnreadCount?
     
@@ -25,7 +25,7 @@ class CurrentUserPayload<ExtraData: UserExtraData>: UserPayload<ExtraData> {
         teams: [String] = [],
         extraData: ExtraData,
         devices: [Device] = [],
-        mutedUsers: [MutedUser<ExtraData>] = [],
+        mutedUsers: [MutedUserPayload<ExtraData>] = [],
         unreadCount: UnreadCount? = nil
     ) {
         self.devices = devices
@@ -49,7 +49,7 @@ class CurrentUserPayload<ExtraData: UserExtraData>: UserPayload<ExtraData> {
     required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: UserPayloadsCodingKeys.self)
         devices = try container.decodeIfPresent([Device].self, forKey: .devices) ?? []
-        mutedUsers = try container.decodeIfPresent([MutedUser<ExtraData>].self, forKey: .mutedUsers) ?? []
+        mutedUsers = try container.decodeIfPresent([MutedUserPayload<ExtraData>].self, forKey: .mutedUsers) ?? []
         unreadCount = try? UnreadCount(from: decoder)
         
         try super.init(from: decoder)
@@ -61,8 +61,8 @@ class CurrentUserRequestBody<ExtraData: UserExtraData>: Encodable {
     // TODO: Add more fields while working on CIS-235
 }
 
-/// A muted user.
-struct MutedUser<ExtraData: UserExtraData>: Decodable {
+/// An object describing the incoming muted-user JSON payload.
+struct MutedUserPayload<ExtraData: UserExtraData>: Decodable {
     private enum CodingKeys: String, CodingKey {
         case mutedUser = "target"
         case created = "created_at"
@@ -74,8 +74,8 @@ struct MutedUser<ExtraData: UserExtraData>: Decodable {
     let updated: Date
 }
 
-extension MutedUser: Equatable {
-    static func == (lhs: MutedUser<ExtraData>, rhs: MutedUser<ExtraData>) -> Bool {
+extension MutedUserPayload: Equatable {
+    static func == (lhs: MutedUserPayload<ExtraData>, rhs: MutedUserPayload<ExtraData>) -> Bool {
         lhs.mutedUser.id == rhs.mutedUser.id && lhs.created == rhs.created
     }
 }
@@ -88,7 +88,7 @@ struct MutedUsersResponse<ExtraData: UserExtraData>: Decodable {
     }
     
     /// A muted user.
-    public let mutedUser: MutedUser<ExtraData>
+    public let mutedUser: MutedUserPayload<ExtraData>
     /// The current user.
     public let currentUser: CurrentUserPayload<ExtraData>
 }

--- a/Sources_v3/Controllers/UserController/UserController.swift
+++ b/Sources_v3/Controllers/UserController/UserController.swift
@@ -1,0 +1,308 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+public extension _ChatClient {
+    /// Creates a new `_ChatUserController` for the user with the provided `userId`.
+    ///
+    /// - Parameter userId: The user identifier.
+    /// - Returns: A new instance of `_ChatUserController`.
+    func userController(userId: UserId) -> _ChatUserController<ExtraData> {
+        .init(userId: userId, client: self)
+    }
+}
+
+/// `ChatUserController` is a controller class which allows mutating and observing changes of a specific chat user.
+///
+/// `ChatUserController` objects are lightweight, and they can be used for both, continuous data change observations, and for quick user actions (like mute/unmute).
+///
+/// - Note: `ChatUserController` is a typealias of `_ChatUserController` with default extra data. If you're using custom
+/// extra data, create your own typealias of `_ChatUserController`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public typealias ChatUserController = _ChatUserController<DefaultExtraData>
+
+/// `_ChatUserController` is a controller class which allows mutating and observing changes of a specific chat user.
+///
+/// `_ChatUserController` objects are lightweight, and they can be used for both, continuous data change observations, and for quick user actions (like mute/unmute).
+///
+/// - Note: `ChatUserController` is a typealias of `_ChatUserController` with default extra data. If you're using custom
+/// extra data, create your own typealias of `_ChatUserController`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public class _ChatUserController<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
+    /// The identifier of tge user this controller observes.
+    public let userId: UserId
+    
+    /// The `ChatClient` instance this controller belongs to.
+    public let client: _ChatClient<ExtraData>
+    
+    /// The user the controller represents.
+    ///
+    /// To observe changes of the user, set your class as a delegate of this controller or use the provided
+    /// `Combine` publishers.
+    public var user: _ChatUser<ExtraData.User>? {
+        startObservingIfNeeded()
+        return userObserver.item
+    }
+    
+    /// A type-erased delegate.
+    var multicastDelegate: MulticastDelegate<AnyChatUserControllerDelegate<ExtraData>> = .init() {
+        didSet {
+            stateMulticastDelegate.mainDelegate = multicastDelegate.mainDelegate
+            stateMulticastDelegate.additionalDelegates = multicastDelegate.additionalDelegates
+            startObservingIfNeeded()
+        }
+    }
+    
+    /// The worker used to fetch the remote data and communicate with servers.
+    private lazy var userUpdater = createUserUpdater()
+    
+    /// The observer used to track the user changes in the database.
+    private lazy var userObserver = createUserObserver()
+        .onChange { [unowned self] change in
+            self.delegateCallback {
+                $0.userController(self, didUpdateUser: change)
+            }
+        }
+    
+    private let environment: Environment
+
+    /// Creates a new `_ChatUserController`
+    /// - Parameters:
+    ///   - userId: The identifier of the user this controller manages.
+    ///   - client: The `Client` this controller belongs to.
+    ///   - environment: Environment for this controller.
+    init(
+        userId: UserId,
+        client: _ChatClient<ExtraData>,
+        environment: Environment = .init()
+    ) {
+        self.userId = userId
+        self.client = client
+        self.environment = environment
+    }
+    
+    override public func synchronize(_ completion: ((_ error: Error?) -> Void)? = nil) {
+        startObservingIfNeeded()
+        
+        if case let .localDataFetchFailed(error) = state {
+            callback { completion?(error) }
+            return
+        }
+        
+        userUpdater.loadUser(userId) { [weak self] error in
+            guard let self = self else { return }
+            self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
+            self.callback { completion?(error) }
+        }
+    }
+    
+    /// Sets the provided object as a delegate of this controller.
+    ///
+    /// - Note: If you don't use custom extra data types, you can set the delegate directly using `controller.delegate = self`.
+    /// Due to the current limits of Swift and the way it handles protocols with associated types, it's required to use this
+    /// method to set the delegate, if you're using custom extra data types.
+    ///
+    /// - Parameter delegate: The object used as a delegate. It's referenced weakly, so you need to keep the object
+    /// alive if you want keep receiving updates.
+    ///
+    public func setDelegate<Delegate: _ChatUserControllerDelegate>(_ delegate: Delegate)
+        where Delegate.ExtraData == ExtraData {
+        multicastDelegate.mainDelegate = AnyChatUserControllerDelegate(delegate)
+    }
+    
+    // MARK: - Private
+    
+    private func createUserUpdater() -> UserUpdater<ExtraData> {
+        environment.userUpdaterBuilder(
+            client.databaseContainer,
+            client.webSocketClient,
+            client.apiClient
+        )
+    }
+    
+    private func createUserObserver() -> EntityDatabaseObserver<_ChatUser<ExtraData.User>, UserDTO> {
+        environment.userObserverBuilder(
+            client.databaseContainer.viewContext,
+            UserDTO.user(withID: userId),
+            { $0.asModel() },
+            NSFetchedResultsController<UserDTO>.self
+        )
+    }
+    
+    private func startObservingIfNeeded() {
+        guard state == .initialized else { return }
+        
+        do {
+            try userObserver.startObserving()
+            state = .localDataFetched
+        } catch {
+            log.error("Observing user with id <\(userId)> failed: \(error). Accessing `user` will always return `nil`")
+            state = .localDataFetchFailed(ClientError(with: error))
+        }
+    }
+}
+
+// MARK: - User actions
+
+public extension _ChatUserController {
+    /// Mutes the user this controller manages.
+    /// - Parameter completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    ///                         If request fails, the completion will be called with an error.
+    func mute(completion: ((Error?) -> Void)? = nil) {
+        userUpdater.muteUser(userId) { [weak self] error in
+            self?.callback {
+                completion?(error)
+            }
+        }
+    }
+    
+    /// Unmutes the user this controller manages.
+    /// - Parameter completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    ///
+    func unmute(completion: ((Error?) -> Void)? = nil) {
+        userUpdater.unmuteUser(userId) { [weak self] error in
+            self?.callback {
+                completion?(error)
+            }
+        }
+    }
+}
+
+extension _ChatUserController {
+    struct Environment {
+        var userUpdaterBuilder: (
+            _ database: DatabaseContainer,
+            _ webSocketClient: WebSocketClient,
+            _ apiClient: APIClient
+        ) -> UserUpdater<ExtraData> = UserUpdater.init
+        
+        var userObserverBuilder: (
+            _ context: NSManagedObjectContext,
+            _ fetchRequest: NSFetchRequest<UserDTO>,
+            _ itemCreator: @escaping (UserDTO) -> _ChatUser<ExtraData.User>,
+            _ fetchedResultsControllerType: NSFetchedResultsController<UserDTO>.Type
+        ) -> EntityDatabaseObserver<_ChatUser<ExtraData.User>, UserDTO> = EntityDatabaseObserver.init
+    }
+}
+
+public extension _ChatUserController where ExtraData == DefaultExtraData {
+    /// Set the delegate of `ChatUserController` to observe the changes in the system.
+    ///
+    /// - Note: The delegate can be set directly only if you're **not** using custom extra data types. Due to the current
+    /// limits of Swift and the way it handles protocols with associated types, it's required to use `setDelegate` method
+    /// instead to set the delegate, if you're using custom extra data types.
+    var delegate: ChatUserControllerDelegate? {
+        set { multicastDelegate.mainDelegate = AnyChatUserControllerDelegate(newValue) }
+        get { multicastDelegate.mainDelegate?.wrappedDelegate as? ChatUserControllerDelegate }
+    }
+}
+
+// MARK: - Delegates
+
+/// `ChatUserControllerDelegate` uses this protocol to communicate changes to its delegate.
+///
+/// This protocol can be used only when no custom extra data are specified. If you're using custom extra data types,
+/// please use `_ChatUserControllerDelegate` instead.
+///
+public protocol ChatUserControllerDelegate: DataControllerStateDelegate {
+    /// The controller observed a change in the `ChatUser` entity.
+    func userController(
+        _ controller: ChatUserController,
+        didUpdateUser change: EntityChange<ChatUser>
+    )
+}
+
+public extension ChatChannelControllerDelegate {
+    func userController(
+        _ controller: ChatUserController,
+        didUpdateUser change: EntityChange<ChatUser>
+    ) {}
+}
+
+// MARK: Generic Delegates
+
+/// `ChatChannelController` uses this protocol to communicate changes to its delegate.
+///
+/// If you're **not** using custom extra data types, you can use a convenience version of this protocol
+/// named `ChatChannelControllerDelegate`, which hides the generic types, and make the usage easier.
+///
+public protocol _ChatUserControllerDelegate: DataControllerStateDelegate {
+    associatedtype ExtraData: ExtraDataTypes
+    
+    /// The controller observed a change in the `_ChatUser<ExtraData.User>` entity.
+    func userController(
+        _ controller: _ChatUserController<ExtraData>,
+        didUpdateUser change: EntityChange<_ChatUser<ExtraData.User>>
+    )
+}
+
+public extension _ChatChannelControllerDelegate {
+    func userController(
+        _ controller: _ChatUserController<ExtraData>,
+        didUpdateUser change: EntityChange<_ChatUser<ExtraData.User>>
+    ) {}
+}
+
+// MARK: Type erased Delegate
+
+class AnyChatUserControllerDelegate<ExtraData: ExtraDataTypes>: _ChatChannelControllerDelegate {
+    private var _controllerDidChangeState: (DataController, DataController.State) -> Void
+    
+    private var _controllerDidUpdateUser: (
+        _ChatUserController<ExtraData>,
+        EntityChange<_ChatUser<ExtraData.User>>
+    ) -> Void
+    
+    weak var wrappedDelegate: AnyObject?
+    
+    init(
+        wrappedDelegate: AnyObject?,
+        controllerDidChangeState: @escaping (DataController, DataController.State) -> Void,
+        controllerDidUpdateUser: @escaping (
+            _ChatUserController<ExtraData>,
+            EntityChange<_ChatUser<ExtraData.User>>
+        ) -> Void
+    ) {
+        self.wrappedDelegate = wrappedDelegate
+        _controllerDidChangeState = controllerDidChangeState
+        _controllerDidUpdateUser = controllerDidUpdateUser
+    }
+    
+    func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        _controllerDidChangeState(controller, state)
+    }
+    
+    func userController(
+        _ controller: _ChatUserController<ExtraData>,
+        didUpdateUser change: EntityChange<_ChatUser<ExtraData.User>>
+    ) {
+        _controllerDidUpdateUser(controller, change)
+    }
+}
+
+extension AnyChatUserControllerDelegate {
+    convenience init<Delegate: _ChatUserControllerDelegate>(_ delegate: Delegate) where Delegate.ExtraData == ExtraData {
+        self.init(
+            wrappedDelegate: delegate,
+            controllerDidChangeState: { [weak delegate] in delegate?.controller($0, didChangeState: $1) },
+            controllerDidUpdateUser: { [weak delegate] in delegate?.userController($0, didUpdateUser: $1) }
+        )
+    }
+}
+
+extension AnyChatUserControllerDelegate where ExtraData == DefaultExtraData {
+    convenience init(_ delegate: ChatUserControllerDelegate?) {
+        self.init(
+            wrappedDelegate: delegate,
+            controllerDidChangeState: { [weak delegate] in delegate?.controller($0, didChangeState: $1) },
+            controllerDidUpdateUser: { [weak delegate] in delegate?.userController($0, didUpdateUser: $1) }
+        )
+    }
+}

--- a/Sources_v3/Controllers/UserController/UserController_Tests.swift
+++ b/Sources_v3/Controllers/UserController/UserController_Tests.swift
@@ -1,0 +1,452 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChatClient
+import XCTest
+
+final class UserController_Tests: StressTestCase {
+    fileprivate var env: TestEnvironment!
+    
+    var userId: UserId!
+    var client: ChatClient!
+    var controller: ChatUserController!
+    var controllerCallbackQueueID: UUID!
+    /// Workaround for uwrapping **controllerCallbackQueueID!** in each closure that captures it
+    private var callbackQueueID: UUID { controllerCallbackQueueID }
+    
+    override func setUp() {
+        super.setUp()
+        
+        env = TestEnvironment()
+        client = _ChatClient.mock
+        userId = .unique
+        controller = ChatUserController(userId: userId, client: client, environment: env.environment)
+        controllerCallbackQueueID = UUID()
+        controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)
+    }
+    
+    override func tearDown() {
+        userId = nil
+        
+        AssertAsync {
+            Assert.canBeReleased(&controller)
+            Assert.canBeReleased(&client)
+            Assert.canBeReleased(&env)
+        }
+        
+        super.tearDown()
+    }
+    
+    // MARK: - Controller setup
+    
+    func test_client_createsUserControllerCorrectly() throws {
+        let controller = client.userController(userId: userId)
+        
+        // Assert `state` is correct.
+        XCTAssertEqual(controller.state, .initialized)
+        
+        // Assert `client` is assigned correctly.
+        XCTAssertTrue(controller.client === client)
+        
+        // Assert `userId` is correct.
+        XCTAssertEqual(controller.userId, userId)
+    }
+    
+    func test_initialState() throws {
+        // Assert `state` is correct.
+        XCTAssertEqual(controller.state, .initialized)
+        
+        // Assert `client` is assigned correctly.
+        XCTAssertTrue(controller.client === client)
+        
+        // Assert `userId` is correct.
+        XCTAssertEqual(controller.userId, userId)
+    }
+    
+    // MARK: - Synchronize tests
+        
+    func test_synchronize_changesStateand_and_callsCompletionOnCallbackQueue() {
+        // Simulate `synchronize` call.
+        var completionIsCalled = false
+        controller.synchronize { [callbackQueueID] error in
+            // Assert callback queue is correct.
+            AssertTestQueue(withId: callbackQueueID)
+            // Assert there is no error.
+            XCTAssertNil(error)
+            completionIsCalled = true
+        }
+        
+        // Assert controller is in `localDataFetched` state.
+        XCTAssertEqual(controller.state, .localDataFetched)
+        
+        // Simulate successfull network call.
+        env.userUpdater!.loadUser_completion?(nil)
+        
+        AssertAsync {
+            // Assert controller is in `remoteDataFetched` state.
+            Assert.willBeEqual(self.controller.state, .remoteDataFetched)
+            // Assert completion is called
+            Assert.willBeTrue(completionIsCalled)
+        }
+    }
+    
+    func test_synchronize_changesState_and_propogatesObserverErrorOnCallbackQueue() {
+        // Update observer to throw the error.
+        let observerError = TestError()
+        env.userObserverSynchronizeError = observerError
+        
+        // Simulate `synchronize` call.
+        var synchronizeError: Error?
+        controller.synchronize { [callbackQueueID] error in
+            AssertTestQueue(withId: callbackQueueID)
+            synchronizeError = error
+        }
+        
+        // Assert controller is in `localDataFetchFailed` state.
+        XCTAssertEqual(controller.state, .localDataFetchFailed(ClientError(with: observerError)))
+        
+        // Assert error from observer is forwarded.
+        AssertAsync.willBeEqual(synchronizeError as? ClientError, ClientError(with: observerError))
+    }
+    
+    func test_synchronize_changesState_and_propogatesUpdaterErrorOnCallbackQueue() {
+        // Simulate `synchronize` call.
+        var synchronizeError: Error?
+        controller.synchronize { [callbackQueueID] error in
+            AssertTestQueue(withId: callbackQueueID)
+            synchronizeError = error
+        }
+
+        // Simulate failed network call.
+        let updaterError = TestError()
+        env.userUpdater!.loadUser_completion?(updaterError)
+
+        AssertAsync {
+            // Assert controller is in `remoteDataFetchFailed` state.
+            Assert.willBeEqual(self.controller.state, .remoteDataFetchFailed(ClientError(with: updaterError)))
+            // Assert error from updater is forwarded.
+            Assert.willBeEqual(synchronizeError as? TestError, updaterError)
+        }
+    }
+    
+    func test_synchronize_doesNotInvokeUpdater_ifObserverFails() {
+        // Update observer to throw the error.
+        env.userObserverSynchronizeError = TestError()
+        
+        // Simulate `synchronize` call.
+        controller.synchronize()
+        
+        // Assert updater in not called.
+        XCTAssertNil(env.userUpdater?.loadUser_userId)
+    }
+    
+    func test_synchronize_callsUserUpdater_ifObserverSucceeds() {
+        // Simulate `synchronize` call.
+        controller.synchronize()
+        
+        // Assert updater in called
+        XCTAssertEqual(env.userUpdater!.loadUser_userId, controller.userId)
+        XCTAssertNotNil(env.userUpdater!.loadUser_completion)
+    }
+    
+    // MARK: - Mute user
+    
+    func test_muteUser_propogatesError() {
+        // Simulate `mute` call and catch the completion.
+        var completionError: Error?
+        controller.mute { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionError = $0
+        }
+        
+        // Simulate network response with the error.
+        let networkError = TestError()
+        env.userUpdater!.muteUser_completion?(networkError)
+        
+        // Assert error is propogated.
+        AssertAsync.willBeEqual(completionError as? TestError, networkError)
+    }
+    
+    func test_muteUser_propogatesNilError() {
+        // Simulate `mute` call and catch the completion.
+        var completionIsCalled = false
+        controller.mute { [callbackQueueID] error in
+            // Assert callback queue is correct.
+            AssertTestQueue(withId: callbackQueueID)
+            // Assert there is no error.
+            XCTAssertNil(error)
+            completionIsCalled = true
+        }
+        
+        // Simulate successful network response.
+        env.userUpdater!.muteUser_completion!(nil)
+        
+        // Assert completion is called.
+        AssertAsync.willBeTrue(completionIsCalled)
+    }
+    
+    func test_muteUser_callsUserUpdater_withCorrectValues() {
+        // Simulate `mute` call.
+        controller.mute()
+        
+        // Assert updater is called with correct `userId`
+        XCTAssertEqual(env.userUpdater!.muteUser_userId, controller.userId)
+    }
+    
+    // MARK: - Local data fetching triggers
+    
+    func test_observerIsTriggeredOnlyOnce() {
+        // Check initial state
+        XCTAssertEqual(controller.state, .initialized)
+        
+        // Set the delegate
+        controller.delegate = TestDelegate(expectedQueueId: callbackQueueID)
+        
+        // Assert state changed
+        AssertAsync.willBeEqual(controller.state, .localDataFetched)
+        
+        // Update observer to throw the error
+        env.userObserver?.synchronizeError = TestError()
+         
+        // Set `delegate` / call `synchronize` / access `user` again
+        _ = controller.user
+        
+        // Assert controllers stays in `localDataFetched`
+        AssertAsync.staysEqual(controller.state, .localDataFetched)
+    }
+    
+    func test_localDataIsFetched_whenDelegateIsSet() {
+        // Check initial state
+        XCTAssertEqual(controller.state, .initialized)
+        
+        // Set the delegate
+        controller.delegate = TestDelegate(expectedQueueId: callbackQueueID)
+        
+        // Assert state changed
+        AssertAsync.willBeEqual(controller.state, .localDataFetched)
+    }
+    
+    func test_localDataIsFetched_whenUserIsAccessed() {
+        // Check initial state
+        XCTAssertEqual(controller.state, .initialized)
+        
+        // Access the user
+        _ = controller.user
+        
+        // Assert state changed
+        AssertAsync.willBeEqual(controller.state, .localDataFetched)
+    }
+    
+    func test_localDataIsFetched_whenSynchronizedIsCalled() {
+        // Check initial state
+        XCTAssertEqual(controller.state, .initialized)
+        
+        // Set the delegate
+        controller.synchronize()
+        
+        // Assert state changed
+        AssertAsync.willBeEqual(controller.state, .localDataFetched)
+    }
+    
+    // MARK: - Delegate
+
+    func test_delegate_isAssignedCorrectly() {
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
+
+        // Set the delegate
+        controller.delegate = delegate
+
+        // Assert the delegate is assigned correctly
+        XCTAssert(controller.delegate === delegate)
+    }
+
+    func test_delegate_isNotifiedAboutStateChanges() throws {
+        // Set the delegate
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
+        controller.delegate = delegate
+
+        // Synchronize
+        controller.synchronize()
+        
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .localDataFetched)
+            
+        // Simulate network call response
+        env.userUpdater!.loadUser_completion!(nil)
+        
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)
+    }
+
+    func test_genericDelegate_isNotifiedAboutStateChanges() throws {
+        // Set the generic delegate
+        let delegate = TestDelegateGeneric(expectedQueueId: callbackQueueID)
+        controller.setDelegate(delegate)
+
+        // Synchronize
+        controller.synchronize()
+        
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .localDataFetched)
+        
+        // Simulate network call response
+        env.userUpdater!.loadUser_completion!(nil)
+        
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)
+    }
+
+    func test_delegate_isNotifiedAboutCreatedUser() throws {
+        // Set the delegate
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
+        controller.delegate = delegate
+        
+        // Create user in the database.
+        try client.databaseContainer.createUser(id: userId)
+        
+        // Assert `create` entity change is received by the delegate
+        AssertAsync.willBeEqual(delegate.didUpdateUser_change?.fieldChange(\.id), .create(userId))
+    }
+    
+    func test_delegate_isNotifiedAboutUpdatedUser() throws {
+        // Set the delegate
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
+        controller.delegate = delegate
+        
+        // Create user in the database.
+        let initialExtraData: NameAndImageExtraData = .dummy
+        try client.databaseContainer.createUser(id: userId, extraData: initialExtraData)
+        
+        // Assert `create` entity change is received by the delegate
+        AssertAsync {
+            Assert.willBeEqual(delegate.didUpdateUser_change?.fieldChange(\.id), .create(self.userId))
+            Assert.willBeEqual(delegate.didUpdateUser_change?.fieldChange(\.extraData), .create(initialExtraData))
+        }
+        
+        // Simulate `synchronize` call to fetch user from remote
+        controller.synchronize()
+                
+        // Simulate response from a backend with updated user
+        let updatedExtraData: NameAndImageExtraData = .dummy
+        try client.databaseContainer.writeSynchronously { session in
+            let dto = try XCTUnwrap(session.user(id: self.userId))
+            dto.extraData = try JSONEncoder.stream.encode(updatedExtraData)
+        }
+        env.userUpdater!.loadUser_completion!(nil)
+        
+        // Assert `update` entity change is received by the delegate
+        AssertAsync {
+            Assert.willBeEqual(delegate.didUpdateUser_change?.fieldChange(\.id), .update(self.userId))
+            Assert.willBeEqual(delegate.didUpdateUser_change?.fieldChange(\.extraData), .update(updatedExtraData))
+        }
+    }
+    
+    func test_delegate_isNotifiedAboutDeletedUser() throws {
+        XCTAssert(true)
+    }
+    
+    // MARK: - Unmute user
+    
+    func test_unmuteUser_propogatesError() {
+        // Simulate `unmute` call and catch the completion.
+        var completionError: Error?
+        controller.unmute { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionError = $0
+        }
+        
+        // Simulate network response with the error.
+        let networkError = TestError()
+        env.userUpdater!.unmuteUser_completion?(networkError)
+        
+        // Assert error is propogated.
+        AssertAsync.willBeEqual(completionError as? TestError, networkError)
+    }
+    
+    func test_unmuteUser_propogatesNilError() {
+        // Simulate `unmute` call and catch the completion.
+        var completionIsCalled = false
+        controller.unmute { [callbackQueueID] error in
+            // Assert callback queue is correct.
+            AssertTestQueue(withId: callbackQueueID)
+            // Assert there is no error.
+            XCTAssertNil(error)
+            completionIsCalled = true
+        }
+        
+        // Simulate successful network response.
+        env.userUpdater!.unmuteUser_completion!(nil)
+        
+        // Assert completion is called.
+        AssertAsync.willBeTrue(completionIsCalled)
+    }
+    
+    func test_unmuteUser_callsUserUpdater_withCorrectValues() {
+        // Simulate `unmute` call.
+        controller.unmute()
+        
+        // Assert updater is called with correct `userId`
+        XCTAssertEqual(env.userUpdater!.unmuteUser_userId, controller.userId)
+    }
+}
+
+private class TestEnvironment {
+    @Atomic var userUpdater: UserUpdaterMock<DefaultExtraData>?
+    @Atomic var userObserver: EntityDatabaseObserverMock<ChatUser, UserDTO>?
+    @Atomic var userObserverSynchronizeError: Error?
+
+    lazy var environment: ChatUserController.Environment = .init(
+        userUpdaterBuilder: { [unowned self] in
+            self.userUpdater = .init(
+                database: $0,
+                webSocketClient: $1,
+                apiClient: $2
+            )
+            return self.userUpdater!
+        },
+        userObserverBuilder: { [unowned self] in
+            self.userObserver = .init(
+                context: $0,
+                fetchRequest: $1,
+                itemCreator: $2,
+                fetchedResultsControllerType: $3
+            )
+            self.userObserver?.synchronizeError = self.userObserverSynchronizeError
+            return self.userObserver!
+        }
+    )
+}
+
+// A concrete `ChatUserControllerDelegate` implementation allowing capturing the delegate calls
+private class TestDelegate: QueueAwareDelegate, ChatUserControllerDelegate {
+    @Atomic var state: DataController.State?
+    @Atomic var didUpdateUser_change: EntityChange<ChatUser>?
+    
+    func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        validateQueue()
+        self.state = state
+    }
+    
+    func userController(_ controller: ChatUserController, didUpdateUser change: EntityChange<ChatUser>) {
+        validateQueue()
+        didUpdateUser_change = change
+    }
+}
+
+// A concrete `_ChatUserControllerDelegate` implementation allowing capturing the delegate calls.
+private class TestDelegateGeneric: QueueAwareDelegate, _ChatUserControllerDelegate {
+    @Atomic var state: DataController.State?
+    @Atomic var didUpdateUser_change: EntityChange<ChatUser>?
+    
+    func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        self.state = state
+        validateQueue()
+    }
+    
+    func userController(_ controller: ChatUserController, didUpdateUser change: EntityChange<ChatUser>) {
+        validateQueue()
+        didUpdateUser_change = change
+    }
+}

--- a/Sources_v3/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO.swift
@@ -60,8 +60,10 @@ extension CurrentUserDTO {
 extension NSManagedObjectContext: CurrentUserDatabaseSession {
     func saveCurrentUser<ExtraData: UserExtraData>(payload: CurrentUserPayload<ExtraData>) throws -> CurrentUserDTO {
         let dto = CurrentUserDTO.loadOrCreate(context: self)
-        dto.mutedUsers = [] // TODO: mutedUsers
         dto.user = try saveUser(payload: payload)
+
+        let mutedUsers = try payload.mutedUsers.map { try saveUser(payload: $0.mutedUser) }
+        dto.mutedUsers = Set(mutedUsers)
         
         if let unreadCount = payload.unreadCount {
             try saveCurrentUserUnreadCount(count: unreadCount)

--- a/Sources_v3/Database/DTOs/CurrentUserDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO_Tests.swift
@@ -20,8 +20,15 @@ class CurrentUserModelDTO_Tests: XCTestCase {
         let payload: CurrentUserPayload<NameAndImageExtraData> = .dummy(
             userId: userId,
             role: .admin,
-            extraData: extraData
+            extraData: extraData,
+            mutedUsers: [
+                .dummy(userId: .unique),
+                .dummy(userId: .unique),
+                .dummy(userId: .unique)
+            ]
         )
+        
+        let mutedUserIDs = Set(payload.mutedUsers.map(\.mutedUser.id))
         
         // Asynchronously save the payload to the db
         database.write { session in
@@ -46,14 +53,25 @@ class CurrentUserModelDTO_Tests: XCTestCase {
             Assert.willBeEqual(payload.extraData, loadedCurrentUser.map {
                 try? JSONDecoder.default.decode(NameAndImageExtraData.self, from: $0.user.extraData)
             })
-            // TODO: Teams, Mutes, Devices
+            Assert.willBeEqual(mutedUserIDs, Set(loadedCurrentUser?.mutedUsers.map(\.id) ?? []))
+            // TODO: Teams, Devices
         }
     }
     
     func test_currentUserPayload_withNoExtraData_isStoredAndLoadedFromDB() {
         let userId = UUID().uuidString
         
-        let payload: CurrentUserPayload<NoExtraData> = .dummy(userId: userId, role: .user)
+        let payload: CurrentUserPayload<NoExtraData> = .dummy(
+            userId: userId,
+            role: .user,
+            mutedUsers: [
+                .dummy(userId: .unique),
+                .dummy(userId: .unique),
+                .dummy(userId: .unique)
+            ]
+        )
+        
+        let mutedUserIDs = Set(payload.mutedUsers.map(\.mutedUser.id))
         
         // Asynchronously save the payload to the db
         database.write { session in
@@ -78,8 +96,8 @@ class CurrentUserModelDTO_Tests: XCTestCase {
             Assert.willBeEqual(payload.extraData, loadedCurrentUser.map {
                 try? JSONDecoder.default.decode(NoExtraData.self, from: $0.user.extraData)
             })
-            
-            // TODO: Teams, Mutes, Devices
+            Assert.willBeEqual(mutedUserIDs, Set(loadedCurrentUser?.mutedUsers.map(\.id) ?? []))
+            // TODO: Teams, Devices
         }
     }
     

--- a/Sources_v3/Database/DTOs/UserDTO.swift
+++ b/Sources_v3/Database/DTOs/UserDTO.swift
@@ -16,6 +16,14 @@ class UserDTO: NSManagedObject {
     @NSManaged var userCreatedAt: Date
     @NSManaged var userRoleRaw: String
     @NSManaged var userUpdatedAt: Date
+    
+    /// Returns a fetch request for the dto with the provided `userId`.
+    static func user(withID userId: UserId) -> NSFetchRequest<UserDTO> {
+        let request = NSFetchRequest<UserDTO>(entityName: UserDTO.entityName)
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \UserDTO.id, ascending: false)]
+        request.predicate = NSPredicate(format: "id == %@", userId)
+        return request
+    }
 }
 
 extension UserDTO: EphemeralValuesContainer {

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -67,9 +67,9 @@ extension DatabaseContainer {
     }
 
     /// Synchronously creates a new UserDTO in the DB with the given id.
-    func createUser(id: UserId = .unique) throws {
+    func createUser(id: UserId = .unique, extraData: NameAndImageExtraData = .dummy) throws {
         try writeSynchronously { session in
-            try session.saveUser(payload: .dummy(userId: id))
+            try session.saveUser(payload: .dummy(userId: id, extraData: extraData))
         }
     }
 

--- a/Sources_v3/Query/UserListQuery.swift
+++ b/Sources_v3/Query/UserListQuery.swift
@@ -51,3 +51,12 @@ public struct UserListQuery: Encodable {
         try options.encode(to: encoder)
     }
 }
+
+extension UserListQuery {
+    /// Builds `UserListQuery` for a user with the provided `userId`
+    /// - Parameter userId: The user identifier
+    /// - Returns: `UserListQuery` for a specific user
+    static func user(withID userId: UserId) -> Self {
+        .init(filter: .equal("id", to: userId))
+    }
+}

--- a/Sources_v3/Query/UserListQuery_Tests.swift
+++ b/Sources_v3/Query/UserListQuery_Tests.swift
@@ -32,4 +32,17 @@ class UserListQuery_Tests: XCTestCase {
         // Assert UserListQuery encoded correctly
         AssertJSONEqual(expectedJSON, encodedJSON)
     }
+    
+    func test_singleUserQuery_worksCorrectly() throws {
+        let userId: UserId = .unique
+        
+        let actual = UserListQuery.user(withID: userId)
+        let actualJSON = try JSONEncoder.default.encode(actual)
+
+        let expected = UserListQuery(filter: .equal("id", to: userId))
+        let expectedJSON = try JSONEncoder.default.encode(expected)
+    
+        // Assert queries match
+        AssertJSONEqual(actualJSON, expectedJSON)
+    }
 }

--- a/Sources_v3/Workers/UserUpdater.swift
+++ b/Sources_v3/Workers/UserUpdater.swift
@@ -1,0 +1,75 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Makes user-related calls to the backend and updates the local storage with the results.
+class UserUpdater<ExtraData: ExtraDataTypes>: Worker {
+    /// Mutes the user with the provided `userId`.
+    /// - Parameters:
+    ///   - userId: The user identifier.
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
+    ///
+    func muteUser(_ userId: UserId, completion: ((Error?) -> Void)? = nil) {
+        apiClient.request(endpoint: .muteUser(userId)) {
+            completion?($0.error)
+        }
+    }
+    
+    /// Unmutes the user with the provided `userId`.
+    /// - Parameters:
+    ///   - userId: The user identifier.
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
+    ///
+    func unmuteUser(_ userId: UserId, completion: ((Error?) -> Void)? = nil) {
+        apiClient.request(endpoint: .unmuteUser(userId)) {
+            completion?($0.error)
+        }
+    }
+    
+    /// Makes a single user query call to the backend and updates the local storage with the results.
+    ///
+    /// - Parameters:
+    ///   - userId: The user identifier
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
+    ///
+    func loadUser(_ userId: UserId, completion: ((Error?) -> Void)? = nil) {
+        apiClient
+            .request(endpoint: .users(query: .user(withID: userId))) { (result: Result<UserListPayload<ExtraData.User>, Error>) in
+                switch result {
+                case let .success(payload):
+                    guard payload.users.count <= 1 else {
+                        completion?(ClientError.Unexpected(
+                            "UserUpdater.loadUser must fetch exactly 0 or 1 user. Fetched: \(payload.users)"
+                        ))
+                        return
+                    }
+                
+                    guard let user = payload.users.first else {
+                        completion?(ClientError.UserDoesNotExist(userId: userId))
+                        return
+                    }
+                
+                    self.database.write({ session in
+                        try session.saveUser(payload: user)
+                    }, completion: { error in
+                        if let error = error {
+                            log.error("Failed to save user with id: <\(userId)> to the database. Error: \(error)")
+                        }
+                        completion?(error)
+                    })
+                case let .failure(error):
+                    completion?(error)
+                }
+            }
+    }
+}
+
+extension ClientError {
+    class UserDoesNotExist: ClientError {
+        init(userId: UserId) {
+            super.init("There is no user with id: <\(userId)>.")
+        }
+    }
+}

--- a/Sources_v3/Workers/UserUpdater_Mock.swift
+++ b/Sources_v3/Workers/UserUpdater_Mock.swift
@@ -1,0 +1,33 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+/// Mock implementation of `UserUpdater`
+final class UserUpdaterMock<ExtraData: ExtraDataTypes>: UserUpdater<ExtraData> {
+    @Atomic var muteUser_userId: UserId?
+    @Atomic var muteUser_completion: ((Error?) -> Void)?
+
+    @Atomic var unmuteUser_userId: UserId?
+    @Atomic var unmuteUser_completion: ((Error?) -> Void)?
+
+    @Atomic var loadUser_userId: UserId?
+    @Atomic var loadUser_completion: ((Error?) -> Void)?
+
+    override func muteUser(_ userId: UserId, completion: ((Error?) -> Void)? = nil) {
+        muteUser_userId = userId
+        muteUser_completion = completion
+    }
+    
+    override func unmuteUser(_ userId: UserId, completion: ((Error?) -> Void)? = nil) {
+        unmuteUser_userId = userId
+        unmuteUser_completion = completion
+    }
+    
+    override func loadUser(_ userId: UserId, completion: ((Error?) -> Void)? = nil) {
+        loadUser_userId = userId
+        loadUser_completion = completion
+    }
+}

--- a/Sources_v3/Workers/UserUpdater_Tests.swift
+++ b/Sources_v3/Workers/UserUpdater_Tests.swift
@@ -1,0 +1,248 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class UserUpdater_Tests: StressTestCase {
+    typealias ExtraData = DefaultExtraData
+    
+    var webSocketClient: WebSocketClientMock!
+    var apiClient: APIClientMock!
+    var database: DatabaseContainerMock!
+    
+    var userUpdater: UserUpdater<ExtraData>!
+    
+    // MARK: Setup
+    
+    override func setUp() {
+        super.setUp()
+        
+        webSocketClient = WebSocketClientMock()
+        apiClient = APIClientMock()
+        database = DatabaseContainerMock()
+        
+        userUpdater = .init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+    }
+    
+    override func tearDown() {
+        apiClient.cleanUp()
+        
+        AssertAsync {
+            Assert.canBeReleased(&userUpdater)
+            Assert.canBeReleased(&webSocketClient)
+            Assert.canBeReleased(&apiClient)
+            Assert.canBeReleased(&database)
+        }
+        
+        super.tearDown()
+    }
+        
+    // MARK: - Mute user
+
+    func test_muteUser_makesCorrectAPICall() {
+        let userId: UserId = .unique
+
+        // Simulate `muteUser` call
+        userUpdater.muteUser(userId)
+
+        // Assert correct endpoint is called
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(.muteUser(userId)))
+    }
+
+    func test_muteUser_propagatesSuccessfulResponse() {
+        // Simulate `muteUser` call
+        var completionCalled = false
+        userUpdater.muteUser(.unique) { error in
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+
+        // Assert completion is not called yet
+        XCTAssertFalse(completionCalled)
+
+        // Simulate API response with success
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.success(.init()))
+
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+    }
+
+    func test_muteUser_propagatesError() {
+        // Simulate `muteUser` call
+        var completionCalledError: Error?
+        userUpdater.muteUser(.unique) {
+            completionCalledError = $0
+        }
+
+        // Simulate API response with failure
+        let error = TestError()
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(error))
+
+        // Assert the completion is called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, error)
+    }
+    
+    // MARK: - Unmute user
+
+    func test_unmuteUser_makesCorrectAPICall() {
+        let userId: UserId = .unique
+
+        // Simulate `unmuteUser` call
+        userUpdater.unmuteUser(userId)
+
+        // Assert correct endpoint is called
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(.unmuteUser(userId)))
+    }
+
+    func test_unmuteUser_propagatesSuccessfulResponse() {
+        // Simulate `muteUser` call
+        var completionCalled = false
+        userUpdater.unmuteUser(.unique) { error in
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+
+        // Assert completion is not called yet
+        XCTAssertFalse(completionCalled)
+
+        // Simulate API response with success
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.success(.init()))
+
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+    }
+
+    func test_unmuteUser_propagatesError() {
+        // Simulate `muteUser` call
+        var completionCalledError: Error?
+        userUpdater.unmuteUser(.unique) {
+            completionCalledError = $0
+        }
+
+        // Simulate API response with failure
+        let error = TestError()
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(error))
+
+        // Assert the completion is called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, error)
+    }
+    
+    // TODO: - Load user
+    
+    func test_loadUser_sendCorrectAPICall() {
+        let userId: UserId = .unique
+        
+        // Simulate `loadUser(_ userId:)` call.
+        userUpdater.loadUser(userId)
+
+        // Assert correct endpoint is called.
+        let expectedEndpoint: Endpoint<UserListPayload<ExtraData.User>> = .users(query: .user(withID: userId))
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
+    }
+    
+    func test_loadUser_propogatesNetworkError() {
+        // Simulate `loadUser(_ userId:)` call.
+        var completionError: Error?
+        userUpdater.loadUser(.unique) {
+            completionError = $0
+        }
+        
+        // Simulate API response with failure
+        let error = TestError()
+        apiClient.test_simulateResponse(Result<UserListPayload<ExtraData.User>, Error>.failure(error))
+        
+        // Assert the completion is called with the error
+        AssertAsync.willBeEqual(completionError as? TestError, error)
+    }
+    
+    func test_loadUser_propogatesUserDoesNotExistError() {
+        // Simulate `loadUser(_ userId:)` call.
+        var completionError: Error?
+        userUpdater.loadUser(.unique) {
+            completionError = $0
+        }
+        
+        // Simulate API response with empty users list
+        let response = Result<UserListPayload<ExtraData.User>, Error>.success(.init(users: []))
+        apiClient.test_simulateResponse(response)
+        
+        // Assert the `UserDoesNotExist` is received
+        AssertAsync.willBeTrue(completionError is ClientError.UserDoesNotExist)
+    }
+    
+    func test_loadUser_propogatesUnexpectedError_ifMultipleUsersCome() {
+        let userId: UserId = .unique
+        
+        // Simulate `loadUser(_ userId:)` call.
+        var completionError: Error?
+        userUpdater.loadUser(userId) {
+            completionError = $0
+        }
+        
+        // Simulate API response with multiple users
+        let response = Result<UserListPayload<ExtraData.User>, Error>.success(.init(users: [
+            .dummy(userId: userId),
+            .dummy(userId: userId),
+            .dummy(userId: userId)
+        ]))
+        apiClient.test_simulateResponse(response)
+        
+        // Load the user
+        var loadedUser: UserDTO? {
+            database.viewContext.user(id: userId)
+        }
+        
+        AssertAsync {
+            // Assert `Unexpected` error is received
+            Assert.willBeTrue(completionError is ClientError.Unexpected)
+            // Assert non of the received users is saved to the database
+            Assert.staysTrue(loadedUser == nil)
+        }
+    }
+    
+    func test_loadUser_propogatesDatabaseError() {
+        let databaseError = TestError()
+        database.write_errorResponse = databaseError
+        
+        // Simulate `loadUser(_ userId:)` call.
+        var completionError: Error?
+        userUpdater.loadUser(.unique) {
+            completionError = $0
+        }
+        
+        // Simulate API response with one user
+        let userPayload = UserPayload.dummy(userId: .unique)
+        let response = Result<UserListPayload<ExtraData.User>, Error>.success(.init(users: [userPayload]))
+        apiClient.test_simulateResponse(response)
+        
+        // Assert the database error is propogated
+        AssertAsync.willBeEqual(completionError as? TestError, databaseError)
+    }
+    
+    func test_loadUser_savesReceivedUserToDatabase() {
+        // Simulate `loadUser(_ userId:)` call.
+        var completionIsCalled = false
+        userUpdater.loadUser(.unique) { _ in
+            completionIsCalled = true
+        }
+        
+        // Simulate API response with empty users list
+        let userPayload = UserPayload.dummy(userId: .unique)
+        let response = Result<UserListPayload<ExtraData.User>, Error>.success(.init(users: [userPayload]))
+        apiClient.test_simulateResponse(response)
+        
+        // Load the user
+        var user: UserDTO? {
+            database.viewContext.user(id: userPayload.id)
+        }
+        
+        AssertAsync {
+            // Assert the completion is called
+            Assert.willBeTrue(completionIsCalled)
+            // Assert the user is saved to the database
+            Assert.willBeEqual(user?.id, userPayload.id)
+        }
+    }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -200,7 +200,10 @@
 		805A11492506FBBD0089DFC4 /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805A11472506FBB30089DFC4 /* UIViewController+Alert.swift */; };
 		80C6026F2514281000A6B714 /* UITableViewController+Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */; };
 		80C6027B25157E4D00A6B714 /* View+AlertTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */; };
+		8819DFCF2525F3C600FD1A50 /* UserUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFCE2525F3C600FD1A50 /* UserUpdater.swift */; };
 		8819DFDE252622D900FD1A50 /* ModerationEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFDD252622D900FD1A50 /* ModerationEndpoints_Tests.swift */; };
+		8819DFE2252628CA00FD1A50 /* UserUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE1252628CA00FD1A50 /* UserUpdater_Tests.swift */; };
+		8819DFE925262EBA00FD1A50 /* UserUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */; };
 		8836133825274F5F003CB958 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133725274F5F003CB958 /* ExtraData.swift */; };
 		8836133C25275170003CB958 /* MutedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133B25275170003CB958 /* MutedUser.swift */; };
 		88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */; };
@@ -592,7 +595,10 @@
 		805A11472506FBB30089DFC4 /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewController+Cells.swift"; sourceTree = "<group>"; };
 		80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AlertTextField.swift"; sourceTree = "<group>"; };
+		8819DFCE2525F3C600FD1A50 /* UserUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater.swift; sourceTree = "<group>"; };
 		8819DFDD252622D900FD1A50 /* ModerationEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints_Tests.swift; sourceTree = "<group>"; };
+		8819DFE1252628CA00FD1A50 /* UserUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater_Tests.swift; sourceTree = "<group>"; };
+		8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater_Mock.swift; sourceTree = "<group>"; };
 		8836133725274F5F003CB958 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
 		8836133B25275170003CB958 /* MutedUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUser.swift; sourceTree = "<group>"; };
 		88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints.swift; sourceTree = "<group>"; };
@@ -1147,6 +1153,9 @@
 				DA8407022524F7E6005A0F62 /* UserListUpdater.swift */,
 				DA84072F2526002D005A0F62 /* UserListUpdater_Mock.swift */,
 				DA8407322526003D005A0F62 /* UserListUpdater_Tests.swift */,
+				8819DFCE2525F3C600FD1A50 /* UserUpdater.swift */,
+				8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */,
+				8819DFE1252628CA00FD1A50 /* UserUpdater_Tests.swift */,
 				F63CC36D24E591690052844D /* EventObservers */,
 				79280F4524850ECC00CDEB89 /* Background */,
 			);
@@ -1913,6 +1922,7 @@
 				7937282A2498FFD300E13FE5 /* MemberPayload.swift in Sources */,
 				799C944C247D5766001F1104 /* ChannelController.swift in Sources */,
 				792A4F3F247FFDE700EAF71D /* Codable+Extensions.swift in Sources */,
+				8819DFCF2525F3C600FD1A50 /* UserUpdater.swift in Sources */,
 				79C750BB248FC4100023F0B7 /* ErrorPayload.swift in Sources */,
 				799BE2EA248A8C9D00DAC8A0 /* WebSocketReconnectionStrategy.swift in Sources */,
 				DA84070C25250581005A0F62 /* UserListPayload.swift in Sources */,
@@ -2035,6 +2045,7 @@
 				79896D622507B16000BA8F1C /* ChannelListUpdater_Mock.swift in Sources */,
 				79877A2A2498E51500015F8B /* MemberModelDTO_Tests.swift in Sources */,
 				F649B2372500F785008F98C8 /* MessageController_Tests.swift in Sources */,
+				8819DFE925262EBA00FD1A50 /* UserUpdater_Mock.swift in Sources */,
 				799C947D247E6114001F1104 /* TestError.swift in Sources */,
 				799C946A247D791A001F1104 /* AssertAsync.swift in Sources */,
 				DA8407302526002D005A0F62 /* UserListUpdater_Mock.swift in Sources */,
@@ -2072,6 +2083,7 @@
 				79BA19F324B3386B00E11FC2 /* CurrentUserDTO_Tests.swift in Sources */,
 				F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */,
 				79280F7D24891B1300CDEB89 /* WebSocketEngine_Mock.swift in Sources */,
+				8819DFE2252628CA00FD1A50 /* UserUpdater_Tests.swift in Sources */,
 				79B5517C24E6A1CA00CE9FEC /* MessagePayloads_Tests.swift in Sources */,
 				F6D61D9D2510B57F00EB0624 /* NSManagedObject_Tests.swift in Sources */,
 				79896D66250A6D1800BA8F1C /* ChannelReadUpdaterMiddleware_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		80C6026F2514281000A6B714 /* UITableViewController+Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */; };
 		80C6027B25157E4D00A6B714 /* View+AlertTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */; };
 		8836133825274F5F003CB958 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133725274F5F003CB958 /* ExtraData.swift */; };
+		8836133C25275170003CB958 /* MutedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133B25275170003CB958 /* MutedUser.swift */; };
 		8A0175F02501174000570345 /* EventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175EF2501174000570345 /* EventSender.swift */; };
 		8A0175F425013B6400570345 /* EventSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175F325013B6400570345 /* EventSender_Tests.swift */; };
 		8A08C6A624D437DF00DEF995 /* WebSocketPingController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */; };
@@ -590,6 +591,7 @@
 		80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewController+Cells.swift"; sourceTree = "<group>"; };
 		80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AlertTextField.swift"; sourceTree = "<group>"; };
 		8836133725274F5F003CB958 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
+		8836133B25275170003CB958 /* MutedUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUser.swift; sourceTree = "<group>"; };
 		8A0175EF2501174000570345 /* EventSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender.swift; sourceTree = "<group>"; };
 		8A0175F325013B6400570345 /* EventSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender_Tests.swift; sourceTree = "<group>"; };
 		8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketPingController_Tests.swift; sourceTree = "<group>"; };
@@ -803,6 +805,7 @@
 				F67415BF24F0129800C3222F /* UnreadCount.swift */,
 				F6CCA25025124BA9004C1859 /* MemberPayload.swift */,
 				8836133725274F5F003CB958 /* ExtraData.swift */,
+				8836133B25275170003CB958 /* MutedUser.swift */,
 			);
 			path = "Dummy data";
 			sourceTree = "<group>";
@@ -2030,6 +2033,7 @@
 				DA8407302526002D005A0F62 /* UserListUpdater_Mock.swift in Sources */,
 				F6CCA25125124BA9004C1859 /* MemberPayload.swift in Sources */,
 				F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */,
+				8836133C25275170003CB958 /* MutedUser.swift in Sources */,
 				7991D83F24F8F1BF00D21BA3 /* ChatClient_Mock.swift in Sources */,
 				792921CB24C077B400116BBB /* TestDispatchQueue.swift in Sources */,
 				79B5517724E595DA00CE9FEC /* CurrentUserPayloads_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -201,8 +201,10 @@
 		80C6026F2514281000A6B714 /* UITableViewController+Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */; };
 		80C6027B25157E4D00A6B714 /* View+AlertTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */; };
 		8819DFCF2525F3C600FD1A50 /* UserUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFCE2525F3C600FD1A50 /* UserUpdater.swift */; };
+		8819DFD52525F49D00FD1A50 /* UserController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFD42525F49D00FD1A50 /* UserController.swift */; };
 		8819DFDE252622D900FD1A50 /* ModerationEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFDD252622D900FD1A50 /* ModerationEndpoints_Tests.swift */; };
 		8819DFE2252628CA00FD1A50 /* UserUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE1252628CA00FD1A50 /* UserUpdater_Tests.swift */; };
+		8819DFE625262B1500FD1A50 /* UserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE525262B1500FD1A50 /* UserController_Tests.swift */; };
 		8819DFE925262EBA00FD1A50 /* UserUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */; };
 		8836133825274F5F003CB958 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133725274F5F003CB958 /* ExtraData.swift */; };
 		8836133C25275170003CB958 /* MutedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133B25275170003CB958 /* MutedUser.swift */; };
@@ -596,8 +598,10 @@
 		80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewController+Cells.swift"; sourceTree = "<group>"; };
 		80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AlertTextField.swift"; sourceTree = "<group>"; };
 		8819DFCE2525F3C600FD1A50 /* UserUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater.swift; sourceTree = "<group>"; };
+		8819DFD42525F49D00FD1A50 /* UserController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserController.swift; sourceTree = "<group>"; };
 		8819DFDD252622D900FD1A50 /* ModerationEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints_Tests.swift; sourceTree = "<group>"; };
 		8819DFE1252628CA00FD1A50 /* UserUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater_Tests.swift; sourceTree = "<group>"; };
+		8819DFE525262B1500FD1A50 /* UserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserController_Tests.swift; sourceTree = "<group>"; };
 		8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater_Mock.swift; sourceTree = "<group>"; };
 		8836133725274F5F003CB958 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
 		8836133B25275170003CB958 /* MutedUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUser.swift; sourceTree = "<group>"; };
@@ -1219,6 +1223,7 @@
 				DAD539DA250B8A9C00CFC649 /* Controller.swift */,
 				79280F4E2485308100CDEB89 /* DataController.swift */,
 				8A0D64AD24E5853F0017A3C0 /* DataController_Tests.swift */,
+				8819DFD32525F48800FD1A50 /* UserController */,
 				DAE566F22500F97E00E39431 /* ChannelController */,
 				DAE566F32500F98D00E39431 /* ChannelListController */,
 				DAE566F42500F99900E39431 /* CurrentUserController */,
@@ -1354,6 +1359,15 @@
 				804B126B24E712C2002B00EA /* SimpleChat.storyboard */,
 			);
 			path = SimpleChat;
+			sourceTree = "<group>";
+		};
+		8819DFD32525F48800FD1A50 /* UserController */ = {
+			isa = PBXGroup;
+			children = (
+				8819DFD42525F49D00FD1A50 /* UserController.swift */,
+				8819DFE525262B1500FD1A50 /* UserController_Tests.swift */,
+			);
+			path = UserController;
 			sourceTree = "<group>";
 		};
 		8A0C3BC124C0AD6E00CAFD19 /* User */ = {
@@ -1997,6 +2011,7 @@
 				792FCB4524A33B5B000290C7 /* EventDataProcessorMiddleware.swift in Sources */,
 				79A0E9BE2498C33100E9BD50 /* TypingEvent.swift in Sources */,
 				79896D5C2506593E00BA8F1C /* ChannelReadDTO.swift in Sources */,
+				8819DFD52525F49D00FD1A50 /* UserController.swift in Sources */,
 				F6CCA24D251235F7004C1859 /* ChannelMemberTypingStateUpdaterMiddleware.swift in Sources */,
 				8A618E4524D19D510003D83C /* WebSocketPingController.swift in Sources */,
 				8A62704E24B8660A0040BFD6 /* EventType.swift in Sources */,
@@ -2081,6 +2096,7 @@
 				8A5D3EF924AF749200E2FE35 /* ChannelId_Tests.swift in Sources */,
 				799C945C247D59D8001F1104 /* ChatClient_Tests.swift in Sources */,
 				79BA19F324B3386B00E11FC2 /* CurrentUserDTO_Tests.swift in Sources */,
+				8819DFE625262B1500FD1A50 /* UserController_Tests.swift in Sources */,
 				F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */,
 				79280F7D24891B1300CDEB89 /* WebSocketEngine_Mock.swift in Sources */,
 				8819DFE2252628CA00FD1A50 /* UserUpdater_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -207,7 +207,7 @@
 		8819DFE625262B1500FD1A50 /* UserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE525262B1500FD1A50 /* UserController_Tests.swift */; };
 		8819DFE925262EBA00FD1A50 /* UserUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */; };
 		8836133825274F5F003CB958 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133725274F5F003CB958 /* ExtraData.swift */; };
-		8836133C25275170003CB958 /* MutedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133B25275170003CB958 /* MutedUser.swift */; };
+		8836133C25275170003CB958 /* MutedUserPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133B25275170003CB958 /* MutedUserPayload.swift */; };
 		88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */; };
 		8A0175F02501174000570345 /* EventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175EF2501174000570345 /* EventSender.swift */; };
 		8A0175F425013B6400570345 /* EventSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175F325013B6400570345 /* EventSender_Tests.swift */; };
@@ -604,7 +604,7 @@
 		8819DFE525262B1500FD1A50 /* UserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserController_Tests.swift; sourceTree = "<group>"; };
 		8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater_Mock.swift; sourceTree = "<group>"; };
 		8836133725274F5F003CB958 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
-		8836133B25275170003CB958 /* MutedUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUser.swift; sourceTree = "<group>"; };
+		8836133B25275170003CB958 /* MutedUserPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUserPayload.swift; sourceTree = "<group>"; };
 		88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints.swift; sourceTree = "<group>"; };
 		8A0175EF2501174000570345 /* EventSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender.swift; sourceTree = "<group>"; };
 		8A0175F325013B6400570345 /* EventSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender_Tests.swift; sourceTree = "<group>"; };
@@ -819,7 +819,7 @@
 				F67415BF24F0129800C3222F /* UnreadCount.swift */,
 				F6CCA25025124BA9004C1859 /* MemberPayload.swift */,
 				8836133725274F5F003CB958 /* ExtraData.swift */,
-				8836133B25275170003CB958 /* MutedUser.swift */,
+				8836133B25275170003CB958 /* MutedUserPayload.swift */,
 			);
 			path = "Dummy data";
 			sourceTree = "<group>";
@@ -2066,7 +2066,7 @@
 				DA8407302526002D005A0F62 /* UserListUpdater_Mock.swift in Sources */,
 				F6CCA25125124BA9004C1859 /* MemberPayload.swift in Sources */,
 				F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */,
-				8836133C25275170003CB958 /* MutedUser.swift in Sources */,
+				8836133C25275170003CB958 /* MutedUserPayload.swift in Sources */,
 				7991D83F24F8F1BF00D21BA3 /* ChatClient_Mock.swift in Sources */,
 				792921CB24C077B400116BBB /* TestDispatchQueue.swift in Sources */,
 				79B5517724E595DA00CE9FEC /* CurrentUserPayloads_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -200,8 +200,10 @@
 		805A11492506FBBD0089DFC4 /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805A11472506FBB30089DFC4 /* UIViewController+Alert.swift */; };
 		80C6026F2514281000A6B714 /* UITableViewController+Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */; };
 		80C6027B25157E4D00A6B714 /* View+AlertTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */; };
+		8819DFDE252622D900FD1A50 /* ModerationEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFDD252622D900FD1A50 /* ModerationEndpoints_Tests.swift */; };
 		8836133825274F5F003CB958 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133725274F5F003CB958 /* ExtraData.swift */; };
 		8836133C25275170003CB958 /* MutedUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133B25275170003CB958 /* MutedUser.swift */; };
+		88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */; };
 		8A0175F02501174000570345 /* EventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175EF2501174000570345 /* EventSender.swift */; };
 		8A0175F425013B6400570345 /* EventSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175F325013B6400570345 /* EventSender_Tests.swift */; };
 		8A08C6A624D437DF00DEF995 /* WebSocketPingController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */; };
@@ -590,8 +592,10 @@
 		805A11472506FBB30089DFC4 /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewController+Cells.swift"; sourceTree = "<group>"; };
 		80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AlertTextField.swift"; sourceTree = "<group>"; };
+		8819DFDD252622D900FD1A50 /* ModerationEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints_Tests.swift; sourceTree = "<group>"; };
 		8836133725274F5F003CB958 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
 		8836133B25275170003CB958 /* MutedUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUser.swift; sourceTree = "<group>"; };
+		88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints.swift; sourceTree = "<group>"; };
 		8A0175EF2501174000570345 /* EventSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender.swift; sourceTree = "<group>"; };
 		8A0175F325013B6400570345 /* EventSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender_Tests.swift; sourceTree = "<group>"; };
 		8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketPingController_Tests.swift; sourceTree = "<group>"; };
@@ -1071,6 +1075,8 @@
 				F62BE78225062FC400D13B86 /* SyncEndpoint_Tests.swift */,
 				F6FF1DA924FD23D300151735 /* MessageEndpoints.swift */,
 				F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */,
+				88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */,
+				8819DFDD252622D900FD1A50 /* ModerationEndpoints_Tests.swift */,
 				F65D9090250A5989000B8CEB /* WebSocketConnectEndpoint.swift */,
 				F65D9092250A5CD4000B8CEB /* WebSocketConnectEndpoint_Tests.swift */,
 			);
@@ -1896,6 +1902,7 @@
 				797A756624814EF8003CF16D /* SystemEnvironment.swift in Sources */,
 				799C9438247D2FB9001F1104 /* ChatClientConfig.swift in Sources */,
 				7964F3B6249A314D002A09EC /* PrefixLogFormatter.swift in Sources */,
+				88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */,
 				79A0E9B02498C09900E9BD50 /* ConnectionStatus.swift in Sources */,
 				799C9439247D2FB9001F1104 /* ChannelDTO.swift in Sources */,
 				799C9443247D3DA7001F1104 /* APIClient.swift in Sources */,
@@ -2128,6 +2135,7 @@
 				8A0C3BE224C1F74200CAFD19 /* MessageEvents_Tests.swift in Sources */,
 				791C0B6524EFBD260013CA2F /* UnwrapAsync.swift in Sources */,
 				7990503224CEEAA600689CDC /* MessageDTO_Tests.swift in Sources */,
+				8819DFDE252622D900FD1A50 /* ModerationEndpoints_Tests.swift in Sources */,
 				F65D9093250A5CD4000B8CEB /* WebSocketConnectEndpoint_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 		805A11492506FBBD0089DFC4 /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805A11472506FBB30089DFC4 /* UIViewController+Alert.swift */; };
 		80C6026F2514281000A6B714 /* UITableViewController+Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */; };
 		80C6027B25157E4D00A6B714 /* View+AlertTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */; };
+		8836133825274F5F003CB958 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133725274F5F003CB958 /* ExtraData.swift */; };
 		8A0175F02501174000570345 /* EventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175EF2501174000570345 /* EventSender.swift */; };
 		8A0175F425013B6400570345 /* EventSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175F325013B6400570345 /* EventSender_Tests.swift */; };
 		8A08C6A624D437DF00DEF995 /* WebSocketPingController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */; };
@@ -588,6 +589,7 @@
 		805A11472506FBB30089DFC4 /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewController+Cells.swift"; sourceTree = "<group>"; };
 		80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AlertTextField.swift"; sourceTree = "<group>"; };
+		8836133725274F5F003CB958 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
 		8A0175EF2501174000570345 /* EventSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender.swift; sourceTree = "<group>"; };
 		8A0175F325013B6400570345 /* EventSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender_Tests.swift; sourceTree = "<group>"; };
 		8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketPingController_Tests.swift; sourceTree = "<group>"; };
@@ -800,6 +802,7 @@
 				8A0D649224E5794C0017A3C0 /* CurrentUserPayload.swift */,
 				F67415BF24F0129800C3222F /* UnreadCount.swift */,
 				F6CCA25025124BA9004C1859 /* MemberPayload.swift */,
+				8836133725274F5F003CB958 /* ExtraData.swift */,
 			);
 			path = "Dummy data";
 			sourceTree = "<group>";
@@ -2018,6 +2021,7 @@
 				79DDF81B249CE38B002F4412 /* AssertNetworkRequest.swift in Sources */,
 				791C0B6324EEBDF40013CA2F /* MessageSender_Tests.swift in Sources */,
 				797EEA4824FFB4C200C81203 /* DataStore_Tests.swift in Sources */,
+				8836133825274F5F003CB958 /* ExtraData.swift in Sources */,
 				79896D622507B16000BA8F1C /* ChannelListUpdater_Mock.swift in Sources */,
 				79877A2A2498E51500015F8B /* MemberModelDTO_Tests.swift in Sources */,
 				F649B2372500F785008F98C8 /* MessageController_Tests.swift in Sources */,

--- a/Tests_v3/Dummy data/CurrentUserPayload.swift
+++ b/Tests_v3/Dummy data/CurrentUserPayload.swift
@@ -11,7 +11,8 @@ extension CurrentUserPayload {
         userId: UserId,
         role: UserRole,
         unreadCount: UnreadCount? = .dummy,
-        extraData: T = .defaultValue
+        extraData: T = .defaultValue,
+        mutedUsers: [MutedUser<T>] = []
     ) -> CurrentUserPayload<T> {
         .init(
             id: userId,
@@ -25,7 +26,7 @@ extension CurrentUserPayload {
             teams: [],
             extraData: extraData,
             devices: [.init(.unique)],
-            mutedUsers: [],
+            mutedUsers: mutedUsers,
             unreadCount: unreadCount
         )
     }

--- a/Tests_v3/Dummy data/CurrentUserPayload.swift
+++ b/Tests_v3/Dummy data/CurrentUserPayload.swift
@@ -12,7 +12,7 @@ extension CurrentUserPayload {
         role: UserRole,
         unreadCount: UnreadCount? = .dummy,
         extraData: T = .defaultValue,
-        mutedUsers: [MutedUser<T>] = []
+        mutedUsers: [MutedUserPayload<T>] = []
     ) -> CurrentUserPayload<T> {
         .init(
             id: userId,

--- a/Tests_v3/Dummy data/ExtraData.swift
+++ b/Tests_v3/Dummy data/ExtraData.swift
@@ -1,0 +1,13 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChatClient
+
+extension NameAndImageExtraData {
+    /// Returns a dummy data with unique `name` and `imageURL`
+    static var dummy: Self {
+        .init(name: .unique, imageURL: .unique())
+    }
+}

--- a/Tests_v3/Dummy data/MutedUser.swift
+++ b/Tests_v3/Dummy data/MutedUser.swift
@@ -1,0 +1,31 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChatClient
+
+extension MutedUser {
+    /// Returns a muted user with the given `userId` and `extraData`
+    static func dummy(
+        userId: UserId,
+        extraData: ExtraData = .defaultValue
+    ) -> Self {
+        .init(
+            mutedUser: .init(
+                id: userId,
+                role: .user,
+                createdAt: .unique,
+                updatedAt: .unique,
+                lastActiveAt: .unique,
+                isOnline: true,
+                isInvisible: true,
+                isBanned: true,
+                teams: [],
+                extraData: extraData
+            ),
+            created: .unique,
+            updated: .unique
+        )
+    }
+}

--- a/Tests_v3/Dummy data/MutedUserPayload.swift
+++ b/Tests_v3/Dummy data/MutedUserPayload.swift
@@ -5,7 +5,7 @@
 import Foundation
 @testable import StreamChatClient
 
-extension MutedUser {
+extension MutedUserPayload {
     /// Returns a muted user with the given `userId` and `extraData`
     static func dummy(
         userId: UserId,

--- a/Tests_v3/Dummy data/UserPayload.swift
+++ b/Tests_v3/Dummy data/UserPayload.swift
@@ -6,11 +6,12 @@ import Foundation
 @testable import StreamChatClient
 
 extension UserPayload where ExtraData == NameAndImageExtraData {
-    /// Returns a dummy user payload with the given UserId
-    static func dummy(userId: UserId) -> UserPayload {
-        let lukeExtraData = NameAndImageExtraData(name: "Luke", imageURL: URL(string: UUID().uuidString))
-        
-        return .init(
+    /// Returns a dummy user payload with the given `id` and `extraData`
+    static func dummy(
+        userId: UserId,
+        extraData: NameAndImageExtraData = .dummy
+    ) -> UserPayload {
+        .init(
             id: userId,
             role: .admin,
             createdAt: .unique,
@@ -20,7 +21,7 @@ extension UserPayload where ExtraData == NameAndImageExtraData {
             isInvisible: true,
             isBanned: true,
             teams: [],
-            extraData: lukeExtraData
+            extraData: extraData
         )
     }
 }


### PR DESCRIPTION
**This PR:**
- introduces `ChatUserController` that provided the API for performing user-related actions;
- updates `CurrentUserDatabaseSession` to take `mutedUsers` into account;
- introduces `UserUpdater` that sends API requests representing user-related actions;
