### PR TITLE
[CIS-375] NewUserQueryUpdater

### DIFF
--- a/Sources_v3/ChatClient.swift
+++ b/Sources_v3/ChatClient.swift
@@ -211,6 +211,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         let workerBuilders: [WorkerBuilder] = [
             MessageSender<ExtraData>.init,
             NewChannelQueryUpdater<ExtraData>.init,
+            NewUserQueryUpdater<ExtraData.User>.init,
             ChannelWatchStateUpdater<ExtraData>.init,
             MessageEditor<ExtraData>.init,
             MissingEventsPublisher<ExtraData>.init

--- a/Sources_v3/ChatClient_Tests.swift
+++ b/Sources_v3/ChatClient_Tests.swift
@@ -33,6 +33,7 @@ class ChatClient_Tests: StressTestCase {
     var workerBuilders: [WorkerBuilder] = [
         MessageSender<DefaultExtraData>.init,
         NewChannelQueryUpdater<DefaultExtraData>.init,
+        NewUserQueryUpdater<DefaultExtraData.User>.init,
         ChannelWatchStateUpdater<DefaultExtraData>.init
     ]
     
@@ -317,6 +318,7 @@ class ChatClient_Tests: StressTestCase {
         // Check all the mandatory background workers are initialized
         XCTAssert(client.backgroundWorkers.contains { $0 is MessageSender<DefaultExtraData> })
         XCTAssert(client.backgroundWorkers.contains { $0 is NewChannelQueryUpdater<DefaultExtraData> })
+        XCTAssert(client.backgroundWorkers.contains { $0 is NewUserQueryUpdater<DefaultExtraData.User> })
         XCTAssert(client.backgroundWorkers.contains { $0 is ChannelWatchStateUpdater<DefaultExtraData> })
         XCTAssert(client.backgroundWorkers.contains { $0 is MessageEditor<DefaultExtraData> })
         XCTAssert(client.backgroundWorkers.contains { $0 is MissingEventsPublisher<DefaultExtraData> })

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -132,7 +132,7 @@ class ChannelListController_Tests: StressTestCase {
         }
         
         // Assert the updater is called with the query
-        XCTAssertEqual(env.channelListUpdater!.update_query?.filter.filterHash, query.filter.filterHash)
+        XCTAssertEqual(env.channelListUpdater!.update_queries.first?.filter.filterHash, query.filter.filterHash)
         // Completion shouldn't be called yet
         XCTAssertFalse(completionCalled)
         
@@ -287,7 +287,10 @@ class ChannelListController_Tests: StressTestCase {
         AssertAsync.willBeTrue(completionCalled)
         
         // Assert correct `Pagination` is created
-        XCTAssertEqual(env!.channelListUpdater?.update_query?.pagination, [.limit(limit), .offset(controller.channels.count)])
+        XCTAssertEqual(
+            env!.channelListUpdater?.update_queries.first?.pagination,
+            [.limit(limit), .offset(controller.channels.count)]
+        )
     }
     
     func test_loadNextChannels_callsChannelUpdaterWithError() {

--- a/Sources_v3/Controllers/UserListController/UserListController+Tests.swift
+++ b/Sources_v3/Controllers/UserListController/UserListController+Tests.swift
@@ -127,7 +127,7 @@ class UserListController_Tests: StressTestCase {
         }
         
         // Assert the updater is called with the query
-        XCTAssertEqual(env.userListUpdater!.update_query?.filter.filterHash, query.filter.filterHash)
+        XCTAssertEqual(env.userListUpdater!.update_queries.first?.filter.filterHash, query.filter.filterHash)
         // Completion shouldn't be called yet
         XCTAssertFalse(completionCalled)
         
@@ -281,7 +281,7 @@ class UserListController_Tests: StressTestCase {
         AssertAsync.willBeTrue(completionCalled)
         
         // Assert correct `Pagination` is created
-        XCTAssertEqual(env!.userListUpdater?.update_query?.pagination, [.limit(limit), .offset(controller.users.count)])
+        XCTAssertEqual(env!.userListUpdater?.update_queries.first?.pagination, [.limit(limit), .offset(controller.users.count)])
     }
     
     func test_loadNextUsers_callsUserUpdaterWithError() {

--- a/Sources_v3/Database/DTOs/UserDTO.swift
+++ b/Sources_v3/Database/DTOs/UserDTO.swift
@@ -122,7 +122,7 @@ extension UserDTO {
         let sortDescriptors = query.sort.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
         request.sortDescriptors = sortDescriptors.isEmpty ? [UserListSortingKey.defaultSortDescriptor] : sortDescriptors
                 
-        request.predicate = NSPredicate(format: "queries.filterHash == %@", query.filter.filterHash)
+        request.predicate = NSPredicate(format: "ANY queries.filterHash == %@", query.filter.filterHash)
         return request
     }
 

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -109,6 +109,18 @@ extension DatabaseContainer {
         }
     }
     
+    func createUserListQuery(filter: Filter = .contains(.unique, String.unique)) throws {
+        try writeSynchronously { session in
+            let dto = NSEntityDescription
+                .insertNewObject(
+                    forEntityName: UserListQueryDTO.entityName,
+                    into: session as! NSManagedObjectContext
+                ) as! UserListQueryDTO
+            dto.filterHash = filter.filterHash
+            dto.filterJSONData = try JSONEncoder.default.encode(filter)
+        }
+    }
+    
     /// Synchronously creates a new MessageDTO in the DB with the given id.
     func createMessage(
         id: MessageId = .unique,

--- a/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -150,7 +150,7 @@
         <relationship name="mentionedMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="mentionedUsers" inverseEntity="MessageDTO"/>
         <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="user" inverseEntity="MessageDTO"/>
         <relationship name="mutedBy" toMany="YES" deletionRule="Nullify" destinationEntity="CurrentUserDTO" inverseName="mutedUsers" inverseEntity="CurrentUserDTO"/>
-        <relationship name="queries" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserListQueryDTO" inverseName="users" inverseEntity="UserListQueryDTO"/>
+        <relationship name="queries" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserListQueryDTO" inverseName="users" inverseEntity="UserListQueryDTO"/>
         <relationship name="teams" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TeamDTO" inverseName="users" inverseEntity="TeamDTO"/>
         <relationship name="watchedChannels" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="watchers" inverseEntity="ChannelDTO"/>
         <fetchIndex name="id">

--- a/Sources_v3/Workers/Background/NewUserQueryUpdater.swift
+++ b/Sources_v3/Workers/Background/NewUserQueryUpdater.swift
@@ -1,0 +1,128 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+
+/// After creating new user it's not observed cause it's not linked to any UserListQuery.
+/// The only job of `NewUserQueryUpdater` is to find whether new user belongs to any of the exsisting queries
+/// and link it to the user if so.
+///     1. This worker observers DB for the insertations of the new `UserDTO`s without any linked queries.
+///     2. When new user is found, all exsisting queries are fetched from DB and we modify exsiting queries filters so
+///     in response for `update(userListQuery` request new user will be returned if it is part of the original query filter.
+///     3. After sending `update(userListQuery` for all queries `UserListUpdater` does the job of linking
+///     corresponding queries to the user.
+final class NewUserQueryUpdater<ExtraData: UserExtraData>: Worker {
+    private let environment: Environment
+        
+    private lazy var userListUpdater: UserListUpdater<ExtraData> = self.environment
+        .createUserListUpdater(
+            database,
+            webSocketClient,
+            apiClient
+        )
+    
+    private lazy var usersObserver: ListDatabaseObserver = .init(
+        context: self.database.backgroundReadOnlyContext,
+        fetchRequest: UserDTO.userWithoutQueryFetchRequest
+    )
+    
+    private var queries: [UserListQueryDTO] {
+        do {
+            let queries = try database.backgroundReadOnlyContext
+                .fetch(NSFetchRequest<UserListQueryDTO>(entityName: UserListQueryDTO.entityName))
+            return queries
+        } catch {
+            log.error("Internal error: Failed to fetch [UserListQueryDTO]: \(error)")
+        }
+        return []
+    }
+    
+    init(database: DatabaseContainer, webSocketClient: WebSocketClient, apiClient: APIClient, env: Environment) {
+        environment = env
+        super.init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        
+        startObserving()
+    }
+    
+    override convenience init(database: DatabaseContainer, webSocketClient: WebSocketClient, apiClient: APIClient) {
+        self.init(database: database, webSocketClient: webSocketClient, apiClient: apiClient, env: .init())
+    }
+    
+    private func startObserving() {
+        // We have to initialize the lazy variables synchronously
+        _ = userListUpdater
+        _ = usersObserver
+        
+        // But the observing can be started on a background queue
+        DispatchQueue.global().async { [weak self] in
+            do {
+                self?.usersObserver.onChange = { changes in
+                    self?.handle(changes: changes)
+                }
+                try self?.usersObserver.startObserving()
+                self?.usersObserver.items.forEach { self?.updateUserListQuery(for: $0) }
+            } catch {
+                log.error("Error starting NewUserQueryUpdater observer: \(error)")
+            }
+        }
+    }
+    
+    private func handle(changes: [ListChange<UserDTO>]) {
+        // Observe `UserDTO` insertations
+        changes.forEach { change in
+            switch change {
+            case let .insert(userDTO, _):
+                updateUserListQuery(for: userDTO)
+            default: return
+            }
+        }
+    }
+    
+    private func updateUserListQuery(for userDTO: UserDTO) {
+        database.backgroundReadOnlyContext.perform { [weak self] in
+            guard let queries = self?.queries else { return }
+            var updatedQueries: [UserListQuery] = []
+            
+            do {
+                updatedQueries = try queries.map {
+                    // Modify original query filter
+                    try $0.asUserListQueryWithUpdatedFilter(filterToAdd: .equal("id", to: userDTO.id))
+                }
+                
+            } catch {
+                log.error("Internal error. Failed to update UserListQueries for the new user: \(error)")
+            }
+            
+            // Send `update(userListQuery:` requests so corresponding queries will be linked to the user
+            updatedQueries.forEach {
+                self?.userListUpdater.update(userListQuery: $0) { error in
+                    if let error = error {
+                        log
+                            .error("Internal error. Failed to update UserListQueries for the new user: \(error)")
+                    }
+                }
+            }
+        }
+    }
+}
+
+extension NewUserQueryUpdater {
+    struct Environment {
+        var createUserListUpdater: (
+            _ database: DatabaseContainer,
+            _ webSocketClient: WebSocketClient,
+            _ apiClient: APIClient
+        ) -> UserListUpdater<ExtraData> = UserListUpdater.init
+    }
+}
+
+private extension UserListQueryDTO {
+    func asUserListQueryWithUpdatedFilter(filterToAdd filter: Filter) throws -> UserListQuery {
+        let encodedFilter = try JSONDecoder().decode(Filter.self, from: filterJSONData)
+        // We need to pass original `filterHash` so user will be linked to original query, not the modified one
+        let updatedFilter: Filter = .explicitFilterHash(.and([encodedFilter, filter]), filterHash)
+        
+        return UserListQuery(filter: updatedFilter)
+    }
+}

--- a/Sources_v3/Workers/Background/NewUserQueryUpdater_Tests.swift
+++ b/Sources_v3/Workers/Background/NewUserQueryUpdater_Tests.swift
@@ -1,0 +1,125 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+class NewUserQueryUpdater_Tests: StressTestCase {
+    typealias ExtraData = DefaultExtraData.User
+    
+    private var env: TestEnvironment!
+    
+    var database: DatabaseContainerMock!
+    var webSocketClient: WebSocketClientMock!
+    var apiClient: APIClientMock!
+    
+    var newUserQueryUpdater: NewUserQueryUpdater<ExtraData>?
+    
+    override func setUp() {
+        super.setUp()
+        env = TestEnvironment()
+        
+        database = try! DatabaseContainerMock(kind: .inMemory)
+        webSocketClient = WebSocketClientMock()
+        apiClient = APIClientMock()
+        
+        newUserQueryUpdater = NewUserQueryUpdater(
+            database: database,
+            webSocketClient: webSocketClient,
+            apiClient: apiClient,
+            env: env.environment
+        )
+    }
+    
+    override func tearDown() {
+        apiClient.cleanUp()
+        
+        AssertAsync {
+            Assert.canBeReleased(&newUserQueryUpdater)
+            Assert.canBeReleased(&database)
+            Assert.canBeReleased(&webSocketClient)
+            Assert.canBeReleased(&apiClient)
+            Assert.canBeReleased(&env)
+        }
+        
+        super.tearDown()
+    }
+    
+    func test_update_called_for_each_query() throws {
+        let filter1: Filter = .contains(.unique, String.unique)
+        let filter2: Filter = .notEqual(.unique, to: 1)
+        
+        try database.createUserListQuery(filter: filter1)
+        try database.createUserListQuery(filter: filter2)
+                
+        try database.createUser()
+        
+        // Assert `update(userListQuery` called for each query in DB
+        AssertAsync.willBeEqual(env!.userQueryUpdater?.update_calls_counter, 2)
+    }
+    
+    func test_update_called_for_existingUser() throws {
+        // Deinitialize newUserQueryUpdater
+        newUserQueryUpdater = nil
+        
+        let filter: Filter = .notEqual(.unique, to: 1)
+        try database.createUserListQuery(filter: filter)
+        try database.createUser(id: .unique)
+        
+        // Assert `update(userListQuery` is not called
+        AssertAsync.willBeNil(env!.userQueryUpdater?.update_query)
+        
+        // Create `newUserQueryUpdater`
+        newUserQueryUpdater = NewUserQueryUpdater(
+            database: database,
+            webSocketClient: webSocketClient,
+            apiClient: apiClient,
+            env: env.environment
+        )
+        
+        // Assert `update(userListQuery` called for user that was in DB before observing started
+        AssertAsync.willBeEqual(env!.userQueryUpdater?.update_query?.filter.filterHash, filter.filterHash)
+    }
+    
+    func test_filter_is_Modified() throws {
+        let id: UserId = .unique
+        let filter: Filter = .notEqual(.unique, to: 1)
+        
+        try database.createUserListQuery(filter: filter)
+        try database.createUser(id: id)
+        
+        let expectedFilter: Filter = .and([filter, .equal("id", to: id)])
+        
+        // Assert `update(userListQuery` called with modified query
+        AssertAsync {
+            Assert.willBeEqual(self.env!.userQueryUpdater?.update_query?.filter.filterHash, filter.filterHash)
+            Assert.willBeEqual(self.env!.userQueryUpdater?.update_query?.filter.description, expectedFilter.description)
+        }
+    }
+    
+    func test_newUserQueryUpdater_doesNotRetainItself() throws {
+        let filter: Filter = .contains(.unique, String.unique)
+        try database.createUserListQuery(filter: filter)
+        try database.createUser()
+        
+        // Assert `update(userListQuery` is called
+        AssertAsync.willBeEqual(env!.userQueryUpdater?.update_calls_counter, 1)
+        
+        // Assert `newUserQueryUpdater` can be released even though network response hasn't come yet
+        AssertAsync.canBeReleased(&newUserQueryUpdater)
+    }
+}
+
+private class TestEnvironment {
+    var userQueryUpdater: UserListUpdaterMock<DefaultExtraData.User>?
+    
+    lazy var environment = NewUserQueryUpdater<DefaultExtraData.User>.Environment(createUserListUpdater: { [unowned self] in
+        self.userQueryUpdater = UserListUpdaterMock(
+            database: $0,
+            webSocketClient: $1,
+            apiClient: $2
+        )
+        return self.userQueryUpdater!
+    })
+}

--- a/Sources_v3/Workers/ChannelListUpdater_Mock.swift
+++ b/Sources_v3/Workers/ChannelListUpdater_Mock.swift
@@ -7,16 +7,14 @@ import XCTest
 
 /// Mock implementation of ChannelListUpdater
 class ChannelListUpdaterMock<ExtraData: ExtraDataTypes>: ChannelListUpdater<ExtraData> {
-    @Atomic var update_query: ChannelListQuery?
-    @Atomic var update_calls_counter = 0
+    @Atomic var update_queries: [ChannelListQuery] = []
     @Atomic var update_completion: ((Error?) -> Void)?
     
     @Atomic var markAllRead_completion: ((Error?) -> Void)?
     
     override func update(channelListQuery: ChannelListQuery, completion: ((Error?) -> Void)? = nil) {
-        update_query = channelListQuery
+        _update_queries.mutate { $0.append(channelListQuery) }
         update_completion = completion
-        _update_calls_counter.mutate { $0 += 1 }
     }
     
     override func markAllRead(completion: ((Error?) -> Void)? = nil) {

--- a/Sources_v3/Workers/UserListUpdater_Mock.swift
+++ b/Sources_v3/Workers/UserListUpdater_Mock.swift
@@ -7,13 +7,11 @@ import XCTest
 
 /// Mock implementation of UserListUpdater
 class UserListUpdaterMock<ExtraData: UserExtraData>: UserListUpdater<ExtraData> {
-    @Atomic var update_query: UserListQuery?
-    @Atomic var update_calls_counter = 0
+    @Atomic var update_queries: [UserListQuery] = []
     @Atomic var update_completion: ((Error?) -> Void)?
         
     override func update(userListQuery: UserListQuery, completion: ((Error?) -> Void)? = nil) {
-        update_query = userListQuery
+        _update_queries.mutate { $0.append(userListQuery) }
         update_completion = completion
-        _update_calls_counter.mutate { $0 += 1 }
     }
 }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -287,6 +287,8 @@
 		DA4AA3B22502718600FAAF6E /* ChannelController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4AA3B12502718600FAAF6E /* ChannelController+Combine.swift */; };
 		DA4AA3B8250271BD00FAAF6E /* CurrentUserController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4AA3B7250271BD00FAAF6E /* CurrentUserController+Combine.swift */; };
 		DA4AA3BA2502731900FAAF6E /* Publisher+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4AA3B92502731900FAAF6E /* Publisher+Extensions.swift */; };
+		DA4EE59E252B43B700CB26D4 /* NewUserQueryUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4EE59D252B43B700CB26D4 /* NewUserQueryUpdater.swift */; };
+		DA4EE5A1252B443400CB26D4 /* NewUserQueryUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4EE5A0252B443400CB26D4 /* NewUserQueryUpdater_Tests.swift */; };
 		DA7229E424E140600074503A /* ChannelEditDetailPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7229E224E140260074503A /* ChannelEditDetailPayload_Tests.swift */; };
 		DA8407002524F778005A0F62 /* UserListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8406FF2524F778005A0F62 /* UserListController.swift */; };
 		DA8407032524F7E6005A0F62 /* UserListUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8407022524F7E6005A0F62 /* UserListUpdater.swift */; };
@@ -708,6 +710,8 @@
 		DA4AA3B5250271B100FAAF6E /* CurrentUserController+Combine_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CurrentUserController+Combine_Tests.swift"; sourceTree = "<group>"; };
 		DA4AA3B7250271BD00FAAF6E /* CurrentUserController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CurrentUserController+Combine.swift"; sourceTree = "<group>"; };
 		DA4AA3B92502731900FAAF6E /* Publisher+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Extensions.swift"; sourceTree = "<group>"; };
+		DA4EE59D252B43B700CB26D4 /* NewUserQueryUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewUserQueryUpdater.swift; sourceTree = "<group>"; };
+		DA4EE5A0252B443400CB26D4 /* NewUserQueryUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewUserQueryUpdater_Tests.swift; sourceTree = "<group>"; };
 		DA7229E224E140260074503A /* ChannelEditDetailPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelEditDetailPayload_Tests.swift; sourceTree = "<group>"; };
 		DA8406FF2524F778005A0F62 /* UserListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListController.swift; sourceTree = "<group>"; };
 		DA8407022524F7E6005A0F62 /* UserListUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListUpdater.swift; sourceTree = "<group>"; };
@@ -873,6 +877,8 @@
 			children = (
 				799C9448247D5211001F1104 /* MessageSender.swift */,
 				791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */,
+				DA4EE59D252B43B700CB26D4 /* NewUserQueryUpdater.swift */,
+				DA4EE5A0252B443400CB26D4 /* NewUserQueryUpdater_Tests.swift */,
 				DA99D0CF24ED63C600AD5354 /* NewChannelQueryUpdater.swift */,
 				DAFC1D4524F50C2C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift */,
 				F670B50E24FE6EA900003B1A /* MessageEditor.swift */,
@@ -1971,6 +1977,7 @@
 				799C9479247E3DEA001F1104 /* StreamChatModel.xcdatamodeld in Sources */,
 				79877A1C2498E4EE00015F8B /* Endpoint.swift in Sources */,
 				DAEAF4B324DAD99E0015FB28 /* HideChannelRequest.swift in Sources */,
+				DA4EE59E252B43B700CB26D4 /* NewUserQueryUpdater.swift in Sources */,
 				792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */,
 				79A0E9AD2498BD0C00E9BD50 /* ChatClient.swift in Sources */,
 				F688643624E6DA8700A71361 /* CurrentUserController.swift in Sources */,
@@ -2082,6 +2089,7 @@
 				F6CCA25125124BA9004C1859 /* MemberPayload.swift in Sources */,
 				F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */,
 				8836133C25275170003CB958 /* MutedUserPayload.swift in Sources */,
+				DA4EE5A1252B443400CB26D4 /* NewUserQueryUpdater_Tests.swift in Sources */,
 				7991D83F24F8F1BF00D21BA3 /* ChatClient_Mock.swift in Sources */,
 				792921CB24C077B400116BBB /* TestDispatchQueue.swift in Sources */,
 				79B5517724E595DA00CE9FEC /* CurrentUserPayloads_Tests.swift in Sources */,


### PR DESCRIPTION
**In this PR:** 

- Introduce `NewUserQueryUpdater`

_I’ve tried unifying it by creating generic NewDTOQueryUpdater, but it will lead to creating a lot of protocols, and methods of modifying filters will still be different so I decided we don’t need it at this point._