### PR TITLE
[CIS-300] Change `removeAllData` implementation to emit callback

### DIFF
--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController.swift
@@ -145,12 +145,17 @@ public class _CurrentChatUserController<ExtraData: ExtraDataTypes>: Controller, 
             // Re-create backgroundWorker's so their ongoing requests won't affect database state
             client.createBackgroundWorkers()
 
-            // Reset all existing local data
-            client.databaseContainer.removeAllData(force: true) { completion($0) }
-        } else {
-            // Otherwise we're done
-            completion(nil)
+            do {
+                // Reset all existing local data
+                try client.databaseContainer.removeAllData(force: true)
+
+            } catch {
+                completion(error)
+            }
         }
+
+        // Otherwise we're done
+        completion(nil)
     }
 }
 

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -243,7 +243,7 @@ final class CurrentUserController_Tests: StressTestCase {
     func test_setAnonymousUser_forwardsDatabaseError() throws {
         // Set the error to be thrown on database write
         let databaseError = TestError()
-        client.mockDatabaseContainer.write_errorResponse = databaseError
+        client.mockDatabaseContainer.recreatePersistentStore_errorResponse = databaseError
         
         // Set up a new anonymous user and wait for the completion
         let completionError = try await(controller.setAnonymousUser)
@@ -292,7 +292,7 @@ final class CurrentUserController_Tests: StressTestCase {
     func test_setUser_forwardsDatabaseError() throws {
         // Set the error to be thrown on database write
         let databaseError = TestError()
-        client.mockDatabaseContainer.write_errorResponse = databaseError
+        client.mockDatabaseContainer.recreatePersistentStore_errorResponse = databaseError
         
         // Set up a new anonymous user and wait for the completion
         let completionError = try await {
@@ -409,7 +409,7 @@ final class CurrentUserController_Tests: StressTestCase {
     func test_setGuestUser_forwardsDatabaseError() throws {
         // Set the error to be thrown on database write
         let databaseError = TestError()
-        client.mockDatabaseContainer.write_errorResponse = databaseError
+        client.mockDatabaseContainer.recreatePersistentStore_errorResponse = databaseError
         
         // Set up a new guest user and wait for the completion
         let completionError = try await {

--- a/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources_v3/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -221,17 +221,7 @@ final class CurrentUserController_Tests: StressTestCase {
         // Assert delegate received correct unread count
         AssertAsync.willBeEqual(delegate.didChangeCurrentUserUnreadCount_count, unreadCount)
     }
-    
-    func test_delegate_isNotifiedAboutDeletedUser() {
-        // TODO: Write the test once the db flushing is fixed
-        XCTAssertTrue(true)
-    }
-    
-    func test_delegate_isNotifiedAboutNoUnreadCount_whenUserIsDeleted() {
-        // TODO: Write the test once the db flushing is fixed
-        XCTAssertTrue(true)
-    }
-    
+
     // MARK: - Setting new user
     
     func test_setUser_updatesClientToken() {

--- a/Sources_v3/Controllers/EntityDatabaseObserver.swift
+++ b/Sources_v3/Controllers/EntityDatabaseObserver.swift
@@ -111,6 +111,9 @@ class EntityDatabaseObserver<Item, DTO: NSManagedObject> {
     let request: NSFetchRequest<DTO>
     let context: NSManagedObjectContext
     
+    /// When called, release the nofication observers
+    var releaseNotificationObservers: (() -> Void)?
+    
     /// Creates a new `ListObserver`.
     ///
     /// Please note that no updates are reported until you call `startUpdating`.
@@ -144,6 +147,12 @@ class EntityDatabaseObserver<Item, DTO: NSManagedObject> {
             
             return fetchedObjects.first.flatMap(itemCreator)
         }
+        
+        listenForRemoveAllDataNotifications()
+    }
+    
+    deinit {
+        releaseNotificationObservers?()
     }
     
     /// Starts observing the changes in the database. The current items in the list are synchronously available in the
@@ -156,6 +165,55 @@ class EntityDatabaseObserver<Item, DTO: NSManagedObject> {
         _item.reset()
         
         frc.delegate = changeAggregator
+    }
+    
+    /// Listens for `Will/DidRemoveAllData` notifications from the context and simulates the callback when the notifications
+    /// are received.
+    private func listenForRemoveAllDataNotifications() {
+        let notificationCenter = NotificationCenter.default
+        
+        // When `WillRemoveAllDataNotification` is received, we need to simulate the callback from change observer, like all
+        // existing entities are being removed. At this point, these entities still existing in the context, and it's safe to
+        // access and serialize them.
+        let willRemoveAllDataNotificationObserver = notificationCenter.addObserver(
+            forName: DatabaseContainer.WillRemoveAllDataNotification,
+            object: context,
+            queue: .main
+        ) { [unowned self] _ in
+            // Simulate ChangeObserver callbacks like all data are being removed
+            self.changeAggregator.controllerWillChangeContent(self.frc as! NSFetchedResultsController<NSFetchRequestResult>)
+            
+            self.frc.fetchedObjects?.enumerated().forEach { index, item in
+                self.changeAggregator.controller(
+                    self.frc as! NSFetchedResultsController<NSFetchRequestResult>,
+                    didChange: item,
+                    at: IndexPath(item: index, section: 0),
+                    for: .delete,
+                    newIndexPath: nil
+                )
+            }
+        }
+        
+        // When `DidRemoveAllDataNotification` is received, we need to reset the FRC. At this point, the entities are removed but
+        // the FRC doesn't know about it yet. Resetting the FRC removes the content of `FRC.fetchedObjects`. We also need to
+        // call `controllerDidChangeContent` on the change agregator to finish reporting about the removed object which started
+        // in the `WillRemoveAllDataNotification` handler above.
+        let didRemoveAllDataNotificationObserver = notificationCenter.addObserver(
+            forName: DatabaseContainer.DidRemoveAllDataNotification,
+            object: context,
+            queue: .main
+        ) { [unowned self] _ in
+            // Reset FRC which causes the current `frc.fetchedObjects` to be reloaded
+            try! self.startObserving()
+            
+            // Publish the changes started in `WillRemoveAllDataNotification`
+            self.changeAggregator.controllerDidChangeContent(self.frc as! NSFetchedResultsController<NSFetchRequestResult>)
+        }
+        
+        releaseNotificationObservers = { [weak notificationCenter] in
+            notificationCenter?.removeObserver(willRemoveAllDataNotificationObserver)
+            notificationCenter?.removeObserver(didRemoveAllDataNotificationObserver)
+        }
     }
 }
 

--- a/Sources_v3/Database/DatabaseContainer.swift
+++ b/Sources_v3/Database/DatabaseContainer.swift
@@ -104,7 +104,7 @@ class DatabaseContainer: NSPersistentContainer {
         
         persistentStoreDescriptions = [description]
                 
-        if shouldFlushOnStart, kind != .inMemory {
+        if shouldFlushOnStart {
             try recreatePersistentStore()
         } else {
             try setupPersistentStore()

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -28,9 +28,9 @@ class DatabaseContainerMock: DatabaseContainer {
         try super.init(kind: kind, shouldFlushOnStart: shouldFlushOnStart, modelName: modelName, bundle: bundle)
     }
     
-    override func removeAllData(force: Bool, completion: ((Error?) -> Void)? = nil) {
+    override func removeAllData(force: Bool = true) throws {
         flush_called = true
-        super.removeAllData(force: force, completion: completion)
+        try super.removeAllData(force: force)
     }
     
     override func recreatePersistentStore() throws {

--- a/Sources_v3/Database/DatabaseContainer_Tests.swift
+++ b/Sources_v3/Database/DatabaseContainer_Tests.swift
@@ -128,7 +128,7 @@ class DatabaseContainer_Tests: StressTestCase {
         AssertAsync.canBeReleased(&newDatabase)
     }
     
-    func test_databaseContainer_flushes_on_start() throws {
+    func test_databaseContainer_removesAllData_whenShouldFlushOnStartIsTrue() throws {
         // Create a new on-disc database with the test data model
         let dbURL = URL.newTemporaryFileURL()
         var database: DatabaseContainerMock? = try DatabaseContainerMock(
@@ -158,17 +158,16 @@ class DatabaseContainer_Tests: StressTestCase {
         XCTAssertNil(testObject)
     }
     
-    func test_databaseContainer_skipping_flush_for_inMemory_type() throws {
-        // Create a new in-memory database that should flush on start.
-        let database: DatabaseContainerMock? = try DatabaseContainerMock(
-            kind: .inMemory,
-            shouldFlushOnStart: true,
-            modelName: "TestDataModel",
-            bundle: Bundle(for: DatabaseContainer_Tests.self)
+    func test_databaseContainer_hasDefinedBehaviorForInMemoryStore_whenShouldFlushOnStartIsTrue() throws {
+        // Create a new in-memory database that should flush on start and assert no error is thrown
+        XCTAssertNoThrow(
+            try DatabaseContainerMock(
+                kind: .inMemory,
+                shouldFlushOnStart: true,
+                modelName: "TestDataModel",
+                bundle: Bundle(for: DatabaseContainer_Tests.self)
+            )
         )
-        
-        // Assert recreatePersistentStore is not called for in-memory DB.
-        XCTAssertFalse(database!.recreatePersistentStore_called)
     }
 }
 

--- a/Sources_v3/Models/CurrentUser.swift
+++ b/Sources_v3/Models/CurrentUser.swift
@@ -6,11 +6,11 @@ import Foundation
 
 extension UserId {
     /// The prefix used for anonymous user ids
-    private static let anonymousIdPrefix = "## ANONYMOUS ##"
+    private static let anonymousIdPrefix = "__anonymous__"
     
     /// Creates a new anonymous User id.
     static var anonymous: UserId {
-        anonymousIdPrefix + " " + UUID().uuidString
+        anonymousIdPrefix + UUID().uuidString
     }
     
     var isAnonymousUser: Bool {

--- a/Sources_v3/Utils/MainQueue+Synchronous.swift
+++ b/Sources_v3/Utils/MainQueue+Synchronous.swift
@@ -1,0 +1,22 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension DispatchQueue {
+    /// Synchronously performs the provided action on the main thread.
+    ///
+    /// Performing this action is safe because the function checks the current thread, and if it's currently in the main
+    /// one, it performs the action safely without dead-locking the thread.
+    ///
+    static func performSynchronouslyOnMainQueue(_ action: () throws -> Void) rethrows {
+        if Thread.current.isMainThread {
+            try action()
+        } else {
+            try DispatchQueue.main.sync {
+                try action()
+            }
+        }
+    }
+}

--- a/Sources_v3/Workers/MessageUpdater_Tests.swift
+++ b/Sources_v3/Workers/MessageUpdater_Tests.swift
@@ -94,7 +94,7 @@ final class MessageUpdater_Tests: StressTestCase {
             let updatedText: String = .unique
             
             // Flush the database
-            try database.flush()
+            try database.removeAllData()
             
             // Create current user is the database
             try database.createCurrentUser(id: currentUserId)
@@ -136,7 +136,7 @@ final class MessageUpdater_Tests: StressTestCase {
             let updatedText: String = .unique
             
             // Flush the database
-            try database.flush()
+            try database.removeAllData()
             
             // Create current user is the database
             try database.createCurrentUser(id: currentUserId)
@@ -277,7 +277,7 @@ final class MessageUpdater_Tests: StressTestCase {
             let messageId: MessageId = .unique
 
             // Flush the database
-            try database.flush()
+            try database.removeAllData()
             
             // Create current user in the database
             try database.createCurrentUser(id: currentUserId)
@@ -318,7 +318,7 @@ final class MessageUpdater_Tests: StressTestCase {
             let messageId: MessageId = .unique
             
             // Flush the database
-            try database.flush()
+            try database.removeAllData()
             
             // Create current user in the database
             try database.createCurrentUser(id: currentUserId)

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		797EEA4624FFAF4F00C81203 /* DataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797EEA4524FFAF4F00C81203 /* DataStore.swift */; };
 		797EEA4824FFB4C200C81203 /* DataStore_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797EEA4724FFB4C200C81203 /* DataStore_Tests.swift */; };
 		797EEA4A24FFC37600C81203 /* ConnectionStatus_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797EEA4924FFC37600C81203 /* ConnectionStatus_Tests.swift */; };
+		7985BDAA252B1E53002B8C30 /* MainQueue+Synchronous.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7985BDA9252B1E53002B8C30 /* MainQueue+Synchronous.swift */; };
 		798779FB2498E47700015F8B /* Member.json in Resources */ = {isa = PBXBuildFile; fileRef = 798779F62498E47700015F8B /* Member.json */; };
 		798779FC2498E47700015F8B /* Channel.json in Resources */ = {isa = PBXBuildFile; fileRef = 798779F72498E47700015F8B /* Channel.json */; };
 		798779FD2498E47700015F8B /* OtherUser.json in Resources */ = {isa = PBXBuildFile; fileRef = 798779F82498E47700015F8B /* OtherUser.json */; };
@@ -500,6 +501,7 @@
 		797EEA4524FFAF4F00C81203 /* DataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStore.swift; sourceTree = "<group>"; };
 		797EEA4724FFB4C200C81203 /* DataStore_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStore_Tests.swift; sourceTree = "<group>"; };
 		797EEA4924FFC37600C81203 /* ConnectionStatus_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatus_Tests.swift; sourceTree = "<group>"; };
+		7985BDA9252B1E53002B8C30 /* MainQueue+Synchronous.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainQueue+Synchronous.swift"; sourceTree = "<group>"; };
 		798779F62498E47700015F8B /* Member.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Member.json; sourceTree = "<group>"; };
 		798779F72498E47700015F8B /* Channel.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Channel.json; sourceTree = "<group>"; };
 		798779F82498E47700015F8B /* OtherUser.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = OtherUser.json; sourceTree = "<group>"; };
@@ -972,6 +974,7 @@
 				797E10A724EAF6DE00353791 /* UniqueId.swift */,
 				79CD959124F9380B00E87377 /* MulticastDelegate.swift */,
 				79CD959324F9381700E87377 /* MulticastDelegate_Tests.swift */,
+				7985BDA9252B1E53002B8C30 /* MainQueue+Synchronous.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1908,6 +1911,7 @@
 				F6FF1DA824FD232C00151735 /* MessageUpdater.swift in Sources */,
 				7931818C24FD2660002F8C84 /* ChannelListController+Combine.swift in Sources */,
 				8A62706E24BF45360040BFD6 /* BanEnabling.swift in Sources */,
+				7985BDAA252B1E53002B8C30 /* MainQueue+Synchronous.swift in Sources */,
 				79877A0A2498E4BC00015F8B /* Device.swift in Sources */,
 				DA8407062524F84F005A0F62 /* UserListQuery.swift in Sources */,
 				79280F4F2485308100CDEB89 /* DataController.swift in Sources */,


### PR DESCRIPTION
This PR fixed the problem specified in CIS-300.

**Solution:**
- `DatabaseContainer.removeAllData` is changed such that it sends `WillRemoveAllData` and `DidRemoveAllData` notifications for every context is owns. It also uses a different (and simplified) way of deleting all data by destroying the underlying persistent store.
- Because we never use `NSFetchedResults` controller directly (this turned out to be a very wise decision) we can tweak the `ListDatabaseObserver` and `EntityDatabaseObsever` implementation. The observers now listen for the notifications above posted by the context they observe. If the notification is received, the observers simulate a callback from the underlying FRC like when the data were deleted. The observers also call `performFetch()` on their FRC which forces them to reload the data, and get the data from the persistent store, which is empty -> no data loaded.

---

This PR is based on the approach suggested in #497, thanks @evsaev!