### PR TITLE
[CIS-380] Implement member controller

### DIFF
--- a/Sources_v3/APIClient/Endpoints/MemberEndpoints.swift
+++ b/Sources_v3/APIClient/Endpoints/MemberEndpoints.swift
@@ -1,0 +1,19 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension Endpoint {
+    static func channelMembers<ExtraData: UserExtraData>(
+        query: ChannelMemberListQuery
+    ) -> Endpoint<ChannelMemberListPayload<ExtraData>> {
+        .init(
+            path: "members",
+            method: .get,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["payload": query]
+        )
+    }
+}

--- a/Sources_v3/APIClient/Endpoints/MemberEndpoints_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/MemberEndpoints_Tests.swift
@@ -1,0 +1,31 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class MemberEndpoints_Tests: XCTestCase {
+    func test_channelMembers_buildsCorrectly() {
+        let query = ChannelMemberListQuery(
+            cid: .unique,
+            filter: .contains("name", "a"),
+            sort: [.init(key: .updatedAt)],
+            pagination: [.offset(3)]
+        )
+        
+        let expectedEndpoint = Endpoint<ChannelMemberListPayload<DefaultExtraData.User>>(
+            path: "members",
+            method: .get,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["payload": query]
+        )
+        
+        // Build endpoint.
+        let endpoint: Endpoint<ChannelMemberListPayload<DefaultExtraData.User>> = .channelMembers(query: query)
+        
+        // Assert endpoint is built correctly.
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
+}

--- a/Sources_v3/APIClient/Endpoints/ModerationEndpoints.swift
+++ b/Sources_v3/APIClient/Endpoints/ModerationEndpoints.swift
@@ -16,6 +16,40 @@ extension Endpoint {
     }
 }
 
+// MARK: - User banning
+
+extension Endpoint {
+    static func banMember(
+        _ userId: UserId,
+        cid: ChannelId,
+        timeoutInMinutes: Int? = nil,
+        reason: String? = nil
+    ) -> Endpoint<EmptyResponse> {
+        .init(
+            path: "moderation/ban",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ChannelMemberBanRequestPayload(
+                userId: userId,
+                cid: cid,
+                timeoutInMinutes: timeoutInMinutes,
+                reason: reason
+            )
+        )
+    }
+    
+    static func unbanMember(_ userId: UserId, cid: ChannelId) -> Endpoint<EmptyResponse> {
+        .init(
+            path: "moderation/ban",
+            method: .delete,
+            queryItems: ChannelMemberBanRequestPayload(userId: userId, cid: cid),
+            requiresConnectionId: false,
+            body: nil
+        )
+    }
+}
+
 // MARK: - Private
 
 private extension Endpoint {

--- a/Sources_v3/APIClient/Endpoints/ModerationEndpoints_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/ModerationEndpoints_Tests.swift
@@ -41,4 +41,49 @@ final class ModerationEndpoints_Tests: XCTestCase {
         // Assert endpoint is built correctly
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
     }
+    
+    func test_banMember_buildsCorrectly() {
+        let userId: UserId = .unique
+        let cid: ChannelId = .unique
+        let timeoutInMinutes = 15
+        let reason: String = .unique
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: "moderation/ban",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ChannelMemberBanRequestPayload(
+                userId: userId,
+                cid: cid,
+                timeoutInMinutes: timeoutInMinutes,
+                reason: reason
+            )
+        )
+        
+        // Build endpoint.
+        let endpoint: Endpoint<EmptyResponse> = .banMember(userId, cid: cid, timeoutInMinutes: timeoutInMinutes, reason: reason)
+        
+        // Assert endpoint is built correctly.
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
+    
+    func test_unbanMember_buildsCorrectly() {
+        let userId: UserId = .unique
+        let cid: ChannelId = .unique
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: "moderation/ban",
+            method: .delete,
+            queryItems: ChannelMemberBanRequestPayload(userId: userId, cid: cid),
+            requiresConnectionId: false,
+            body: nil
+        )
+        
+        // Build endpoint.
+        let endpoint: Endpoint<EmptyResponse> = .unbanMember(userId, cid: cid)
+        
+        // Assert endpoint is built correctly.
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
 }

--- a/Sources_v3/APIClient/Endpoints/Payloads/ChannelMemberListPayload.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/ChannelMemberListPayload.swift
@@ -1,0 +1,11 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The type describes the incoming JSON from `/members` endpoint.
+struct ChannelMemberListPayload<ExtraData: UserExtraData>: Decodable {
+    /// A list of channel members for the specific `ChannelMemberListQuery`.
+    let members: [MemberPayload<ExtraData>]
+}

--- a/Sources_v3/APIClient/Endpoints/Payloads/ChannelMemberListPayload_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/ChannelMemberListPayload_Tests.swift
@@ -1,0 +1,14 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class ChannelMemberListPayload_Tests: XCTestCase {
+    func test_queryJSON_isDeserialized_withDefaultExtraData() throws {
+        let json = XCTestCase.mockData(fromFile: "ChannelMembersQuery", extension: "json")
+        let payload = try JSONDecoder.default.decode(ChannelMemberListPayload<DefaultExtraData.User>.self, from: json)
+        XCTAssertEqual(payload.members.count, 1)
+    }
+}

--- a/Sources_v3/APIClient/Endpoints/Requests/ChannelMemberBanRequestPayload.swift
+++ b/Sources_v3/APIClient/Endpoints/Requests/ChannelMemberBanRequestPayload.swift
@@ -1,0 +1,35 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The type describes the outgoing JSON to `moderation/ban` endpoint
+struct ChannelMemberBanRequestPayload: Encodable {
+    private enum CodingKeys: String, CodingKey {
+        case userId = "target_user_id"
+        case channelType = "type"
+        case channelId = "id"
+        case timeoutInMinutes = "timeout"
+        case reason
+    }
+    
+    let userId: String
+    let channelType: ChannelType
+    let channelId: String
+    let timeoutInMinutes: Int?
+    let reason: String?
+    
+    init(
+        userId: UserId,
+        cid: ChannelId,
+        timeoutInMinutes: Int? = nil,
+        reason: String? = nil
+    ) {
+        self.userId = userId
+        channelType = cid.type
+        channelId = cid.id
+        self.timeoutInMinutes = timeoutInMinutes
+        self.reason = reason
+    }
+}

--- a/Sources_v3/APIClient/Endpoints/Requests/ChannelMemberBanRequestPayload_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/Requests/ChannelMemberBanRequestPayload_Tests.swift
@@ -1,0 +1,35 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class ChannelMemberBanRequestPayload_Tests: XCTestCase {
+    func test_payload_isBuiltAndEncodedCorrectly() throws {
+        let userId: UserId = .unique
+        let cid: ChannelId = .unique
+        let timeoutInMinutes = 15
+        let reason: String = .unique
+        
+        // Build the payload.
+        let payload = ChannelMemberBanRequestPayload(
+            userId: userId,
+            cid: cid,
+            timeoutInMinutes: timeoutInMinutes,
+            reason: reason
+        )
+        
+        // Encode the payload.
+        let json = try JSONEncoder.default.encode(payload)
+        
+        // Assert encoding is correct.
+        AssertJSONEqual(json, [
+            "target_user_id": userId,
+            "type": cid.type.rawValue,
+            "id": cid.id,
+            "timeout": timeoutInMinutes,
+            "reason": reason
+        ])
+    }
+}

--- a/Sources_v3/Controllers/MemberController/MemberController.swift
+++ b/Sources_v3/Controllers/MemberController/MemberController.swift
@@ -1,0 +1,341 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+public extension _ChatClient {
+    /// Creates a new `_ChatChannelMemberController` for the user with the provided `userId` and `cid`.
+    /// - Parameters:
+    ///   - userId: The user identifier.
+    ///   - cid: The channel identifier.
+    /// - Returns: A new instance of `_ChatChannelMemberController`.
+    func memberController(userId: UserId, in cid: ChannelId) -> _ChatChannelMemberController<ExtraData> {
+        .init(userId: userId, cid: cid, client: self)
+    }
+}
+
+/// `ChatChannelMemberController` is a controller class which allows mutating and observing changes of a specific chat member.
+///
+/// `ChatChannelMemberController` objects are lightweight, and they can be used for both, continuous data change observations,
+/// and for quick user actions (like ban/unban).
+///
+/// - Note: `ChatChannelMemberController` is a typealias of `_ChatChannelMemberController` with default extra data.
+/// If you're using custom extra data, create your own typealias of `_ChatChannelMemberController`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public typealias ChatChannelMemberController = _ChatChannelMemberController<DefaultExtraData>
+
+/// `_ChatChannelMemberController` is a controller class which allows mutating and observing changes of a specific chat member.
+///
+/// `_ChatChannelMemberController` objects are lightweight, and they can be used for both, continuous data change observations,
+/// and for quick user actions (like mute/unmute).
+///
+/// - Note: `ChatChannelMemberController` is a typealias of `_ChatChannelMemberController` with default extra data.
+/// If you're using custom extra data, create your own typealias of `_ChatChannelMemberController`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public class _ChatChannelMemberController<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
+    /// The identifier of the user this controller observes.
+    public let userId: UserId
+    
+    /// The identifier of the channel the user is member of.
+    public let cid: ChannelId
+    
+    /// The `ChatClient` instance this controller belongs to.
+    public let client: _ChatClient<ExtraData>
+    
+    /// The user the controller represents.
+    ///
+    /// To observe changes of the chat member, set your class as a delegate of this controller or use the provided
+    /// `Combine` publishers.
+    public var member: _ChatChannelMember<ExtraData.User>? {
+        startObservingIfNeeded()
+        return memberObserver.item
+    }
+    
+    /// A type-erased delegate.
+    var multicastDelegate: MulticastDelegate<AnyChatMemberControllerDelegate<ExtraData>> = .init() {
+        didSet {
+            stateMulticastDelegate.mainDelegate = multicastDelegate.mainDelegate
+            stateMulticastDelegate.additionalDelegates = multicastDelegate.additionalDelegates
+            startObservingIfNeeded()
+        }
+    }
+    
+    /// The worker used to update channel members.
+    private lazy var memberUpdater = createMemberUpdater()
+    
+    /// The worker used to fetch channel members.
+    private lazy var memberListUpdater = createMemberListUpdater()
+    
+    /// The observer used to track the user changes in the database.
+    private lazy var memberObserver = createMemberObserver()
+        .onChange { [unowned self] change in
+            self.delegateCallback {
+                $0.memberController(self, didUpdateMember: change)
+            }
+        }
+    
+    private let environment: Environment
+
+    /// Creates a new `_ChatChannelMemberController`
+    /// - Parameters:
+    ///   - userId: The user identifier.
+    ///   - cid: The channel identifier the user is member of.
+    ///   - client: The `Client` this controller belongs to.
+    ///   - environment: Environment for this controller.
+    init(
+        userId: UserId,
+        cid: ChannelId,
+        client: _ChatClient<ExtraData>,
+        environment: Environment = .init()
+    ) {
+        self.userId = userId
+        self.cid = cid
+        self.client = client
+        self.environment = environment
+    }
+    
+    override public func synchronize(_ completion: ((_ error: Error?) -> Void)? = nil) {
+        startObservingIfNeeded()
+        
+        if case let .localDataFetchFailed(error) = state {
+            callback { completion?(error) }
+            return
+        }
+        
+        memberListUpdater.load(.channelMember(userId: userId, cid: cid)) { [weak self] error in
+            guard let self = self else { return }
+            self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
+            self.callback { completion?(error) }
+        }
+    }
+    
+    /// Sets the provided object as a delegate of this controller.
+    ///
+    /// - Note: If you don't use custom extra data types, you can set the delegate directly using `controller.delegate = self`.
+    /// Due to the current limits of Swift and the way it handles protocols with associated types, it's required to use this
+    /// method to set the delegate, if you're using custom extra data types.
+    ///
+    /// - Parameter delegate: The object used as a delegate. It's referenced weakly, so you need to keep the object
+    /// alive if you want keep receiving updates.
+    ///
+    public func setDelegate<Delegate: _ChatMemberControllerDelegate>(_ delegate: Delegate)
+        where Delegate.ExtraData == ExtraData {
+        multicastDelegate.mainDelegate = AnyChatMemberControllerDelegate(delegate)
+    }
+    
+    // MARK: - Private
+    
+    private func createMemberUpdater() -> ChannelMemberUpdater {
+        environment.memberUpdaterBuilder(
+            client.databaseContainer,
+            client.webSocketClient,
+            client.apiClient
+        )
+    }
+    
+    private func createMemberListUpdater() -> ChannelMemberListUpdater<ExtraData> {
+        environment.memberListUpdaterBuilder(
+            client.databaseContainer,
+            client.webSocketClient,
+            client.apiClient
+        )
+    }
+    
+    private func createMemberObserver() -> EntityDatabaseObserver<_ChatChannelMember<ExtraData.User>, MemberDTO> {
+        environment.memberObserverBuilder(
+            client.databaseContainer.viewContext,
+            MemberDTO.member(userId, in: cid),
+            { $0.asModel() },
+            NSFetchedResultsController<MemberDTO>.self
+        )
+    }
+    
+    private func startObservingIfNeeded() {
+        guard state == .initialized else { return }
+        
+        do {
+            try memberObserver.startObserving()
+            state = .localDataFetched
+        } catch {
+            log.error("Observing member with id <\(userId)> failed: \(error). Accessing `member` will always return `nil`")
+            state = .localDataFetchFailed(ClientError(with: error))
+        }
+    }
+}
+
+// MARK: - Actions
+
+public extension _ChatChannelMemberController {
+    /// Bans the channel member for a specific # of minutes.
+    /// - Parameters:
+    ///   - timeoutInMinutes: The # of minutes the user should be banned for.
+    ///   - reason: The ban reason.
+    ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    ///                 If request fails, the completion will be called with an error.
+    func ban(
+        for timeoutInMinutes: Int? = nil,
+        reason: String? = nil,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        memberUpdater.banMember(userId, in: cid, for: timeoutInMinutes, reason: reason) { [weak self] error in
+            self?.callback {
+                completion?(error)
+            }
+        }
+    }
+    
+    /// Unbans the channel member.
+    /// - Parameter completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    ///                         If request fails, the completion will be called with an error.
+    func unban(completion: ((Error?) -> Void)? = nil) {
+        memberUpdater.unbanMember(userId, in: cid) { [weak self] error in
+            self?.callback {
+                completion?(error)
+            }
+        }
+    }
+}
+
+extension _ChatChannelMemberController {
+    struct Environment {
+        var memberUpdaterBuilder: (
+            _ database: DatabaseContainer,
+            _ webSocketClient: WebSocketClient,
+            _ apiClient: APIClient
+        ) -> ChannelMemberUpdater = ChannelMemberUpdater.init
+        
+        var memberListUpdaterBuilder: (
+            _ database: DatabaseContainer,
+            _ webSocketClient: WebSocketClient,
+            _ apiClient: APIClient
+        ) -> ChannelMemberListUpdater<ExtraData> = ChannelMemberListUpdater.init
+        
+        var memberObserverBuilder: (
+            _ context: NSManagedObjectContext,
+            _ fetchRequest: NSFetchRequest<MemberDTO>,
+            _ itemCreator: @escaping (MemberDTO) -> _ChatChannelMember<ExtraData.User>,
+            _ fetchedResultsControllerType: NSFetchedResultsController<MemberDTO>.Type
+        ) -> EntityDatabaseObserver<_ChatChannelMember<ExtraData.User>, MemberDTO> = EntityDatabaseObserver.init
+    }
+}
+
+public extension _ChatChannelMemberController where ExtraData == DefaultExtraData {
+    /// Set the delegate of `ChatMemberController` to observe the changes in the system.
+    ///
+    /// - Note: The delegate can be set directly only if you're **not** using custom extra data types. Due to the current
+    /// limits of Swift and the way it handles protocols with associated types, it's required to use `setDelegate` method
+    /// instead to set the delegate, if you're using custom extra data types.
+    var delegate: ChatMemberControllerDelegate? {
+        get { multicastDelegate.mainDelegate?.wrappedDelegate as? ChatMemberControllerDelegate }
+        set { multicastDelegate.mainDelegate = AnyChatMemberControllerDelegate(newValue) }
+    }
+}
+
+// MARK: - Delegates
+
+/// `ChatMemberControllerDelegate` uses this protocol to communicate changes to its delegate.
+///
+/// This protocol can be used only when no custom extra data are specified. If you're using custom extra data types,
+/// please use `_ChatMemberControllerDelegate` instead.
+///
+public protocol ChatMemberControllerDelegate: DataControllerStateDelegate {
+    /// The controller observed a change in the `ChatChannelMember` entity.
+    func memberController(
+        _ controller: ChatChannelMemberController,
+        didUpdateMember change: EntityChange<ChatChannelMember>
+    )
+}
+
+public extension ChatMemberControllerDelegate {
+    func memberController(
+        _ controller: ChatChannelMemberController,
+        didUpdateMember change: EntityChange<ChatChannelMember>
+    ) {}
+}
+
+// MARK: Generic Delegates
+
+/// `_ChatChannelMemberController` uses this protocol to communicate changes to its delegate.
+///
+/// If you're **not** using custom extra data types, you can use a convenience version of this protocol
+/// named `ChatMemberControllerDelegate`, which hides the generic types, and make the usage easier.
+///
+public protocol _ChatMemberControllerDelegate: DataControllerStateDelegate {
+    associatedtype ExtraData: ExtraDataTypes
+    
+    /// The controller observed a change in the `_ChatChannelMember<ExtraData.User>` entity.
+    func memberController(
+        _ controller: _ChatChannelMemberController<ExtraData>,
+        didUpdateMember change: EntityChange<_ChatChannelMember<ExtraData.User>>
+    )
+}
+
+public extension _ChatMemberControllerDelegate {
+    func memberController(
+        _ controller: _ChatChannelMemberController<ExtraData>,
+        didUpdateMember change: EntityChange<_ChatChannelMember<ExtraData.User>>
+    ) {}
+}
+
+// MARK: Type erased Delegate
+
+class AnyChatMemberControllerDelegate<ExtraData: ExtraDataTypes>: _ChatMemberControllerDelegate {
+    private var _controllerDidChangeState: (DataController, DataController.State) -> Void
+    
+    private var _controllerDidUpdateMember: (
+        _ChatChannelMemberController<ExtraData>,
+        EntityChange<_ChatChannelMember<ExtraData.User>>
+    ) -> Void
+    
+    weak var wrappedDelegate: AnyObject?
+    
+    init(
+        wrappedDelegate: AnyObject?,
+        controllerDidChangeState: @escaping (DataController, DataController.State) -> Void,
+        controllerDidUpdateMember: @escaping (
+            _ChatChannelMemberController<ExtraData>,
+            EntityChange<_ChatChannelMember<ExtraData.User>>
+        ) -> Void
+    ) {
+        self.wrappedDelegate = wrappedDelegate
+        _controllerDidChangeState = controllerDidChangeState
+        _controllerDidUpdateMember = controllerDidUpdateMember
+    }
+    
+    func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        _controllerDidChangeState(controller, state)
+    }
+    
+    func memberController(
+        _ controller: _ChatChannelMemberController<ExtraData>,
+        didUpdateMember change: EntityChange<_ChatChannelMember<ExtraData.User>>
+    ) {
+        _controllerDidUpdateMember(controller, change)
+    }
+}
+
+extension AnyChatMemberControllerDelegate {
+    convenience init<Delegate: _ChatMemberControllerDelegate>(_ delegate: Delegate) where Delegate.ExtraData == ExtraData {
+        self.init(
+            wrappedDelegate: delegate,
+            controllerDidChangeState: { [weak delegate] in delegate?.controller($0, didChangeState: $1) },
+            controllerDidUpdateMember: { [weak delegate] in delegate?.memberController($0, didUpdateMember: $1) }
+        )
+    }
+}
+
+extension AnyChatMemberControllerDelegate where ExtraData == DefaultExtraData {
+    convenience init(_ delegate: ChatMemberControllerDelegate?) {
+        self.init(
+            wrappedDelegate: delegate,
+            controllerDidChangeState: { [weak delegate] in delegate?.controller($0, didChangeState: $1) },
+            controllerDidUpdateMember: { [weak delegate] in delegate?.memberController($0, didUpdateMember: $1) }
+        )
+    }
+}

--- a/Sources_v3/Controllers/MemberController/MemberController_Tests.swift
+++ b/Sources_v3/Controllers/MemberController/MemberController_Tests.swift
@@ -1,0 +1,471 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+ import CoreData
+ @testable import StreamChatClient
+ import XCTest
+
+ final class MemberController_Tests: StressTestCase {
+    fileprivate var env: TestEnvironment!
+
+    var userId: UserId!
+    var cid: ChannelId!
+    var client: ChatClient!
+    var controller: ChatChannelMemberController!
+    var controllerCallbackQueueID: UUID!
+    /// Workaround for uwrapping **controllerCallbackQueueID!** in each closure that captures it
+    private var callbackQueueID: UUID { controllerCallbackQueueID }
+
+    override func setUp() {
+        super.setUp()
+
+        env = TestEnvironment()
+        client = _ChatClient.mock
+        userId = .unique
+        cid = .unique
+        controller = ChatChannelMemberController(userId: userId, cid: cid, client: client, environment: env.environment)
+        controllerCallbackQueueID = UUID()
+        controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)
+    }
+
+    override func tearDown() {
+        userId = nil
+        cid = nil
+
+        AssertAsync {
+            Assert.canBeReleased(&controller)
+            Assert.canBeReleased(&client)
+            Assert.canBeReleased(&env)
+        }
+
+        super.tearDown()
+    }
+
+    // MARK: - Controller setup
+
+    func test_client_createsUserControllerCorrectly() throws {
+        let controller = client.memberController(userId: userId, in: cid)
+
+        // Assert `state` is correct.
+        XCTAssertEqual(controller.state, .initialized)
+
+        // Assert `client` is assigned correctly.
+        XCTAssertTrue(controller.client === client)
+
+        // Assert `userId` is correct.
+        XCTAssertEqual(controller.userId, userId)
+
+        // Assert `cid` is correct.
+        XCTAssertEqual(controller.cid, cid)
+    }
+
+    func test_initialState() throws {
+        // Assert `state` is correct.
+        XCTAssertEqual(controller.state, .initialized)
+
+        // Assert `client` is assigned correctly.
+        XCTAssertTrue(controller.client === client)
+
+        // Assert `userId` is correct.
+        XCTAssertEqual(controller.userId, userId)
+
+        // Assert `cid` is correct.
+        XCTAssertEqual(controller.cid, cid)
+    }
+
+    // MARK: - Synchronize tests
+
+    func test_synchronize_changesState_and_callsCompletionOnCallbackQueue() {
+        // Simulate `synchronize` call.
+        var completionIsCalled = false
+        controller.synchronize { [callbackQueueID] error in
+            // Assert callback queue is correct.
+            AssertTestQueue(withId: callbackQueueID)
+            // Assert there is no error.
+            XCTAssertNil(error)
+            completionIsCalled = true
+        }
+
+        // Assert controller is in `localDataFetched` state.
+        XCTAssertEqual(controller.state, .localDataFetched)
+
+        // Simulate successfull network call.
+        env.memberListUpdater!.load_completion!(nil)
+
+        AssertAsync {
+            // Assert controller is in `remoteDataFetched` state.
+            Assert.willBeEqual(self.controller.state, .remoteDataFetched)
+            // Assert completion is called
+            Assert.willBeTrue(completionIsCalled)
+        }
+    }
+
+    func test_synchronize_changesState_and_propogatesObserverErrorOnCallbackQueue() {
+        // Update observer to throw the error.
+        let observerError = TestError()
+        env.memberObserverSynchronizeError = observerError
+
+        // Simulate `synchronize` call.
+        var synchronizeError: Error?
+        controller.synchronize { [callbackQueueID] error in
+            AssertTestQueue(withId: callbackQueueID)
+            synchronizeError = error
+        }
+
+        // Assert controller is in `localDataFetchFailed` state.
+        XCTAssertEqual(controller.state, .localDataFetchFailed(ClientError(with: observerError)))
+
+        // Assert error from observer is forwarded.
+        AssertAsync.willBeEqual(synchronizeError as? ClientError, ClientError(with: observerError))
+    }
+
+    func test_synchronize_changesState_and_propogatesListUpdaterErrorOnCallbackQueue() {
+        // Simulate `synchronize` call.
+        var synchronizeError: Error?
+        controller.synchronize { [callbackQueueID] error in
+            AssertTestQueue(withId: callbackQueueID)
+            synchronizeError = error
+        }
+
+        // Simulate failed network call.
+        let updaterError = TestError()
+        env.memberListUpdater!.load_completion?(updaterError)
+
+        AssertAsync {
+            // Assert controller is in `remoteDataFetchFailed` state.
+            Assert.willBeEqual(self.controller.state, .remoteDataFetchFailed(ClientError(with: updaterError)))
+            // Assert error from updater is forwarded.
+            Assert.willBeEqual(synchronizeError as? TestError, updaterError)
+        }
+    }
+
+    func test_synchronize_doesNotInvokeUpdater_ifObserverFails() {
+        // Update observer to throw the error.
+        env.memberObserverSynchronizeError = TestError()
+
+        // Simulate `synchronize` call.
+        controller.synchronize()
+
+        // Assert updater in not called.
+        XCTAssertNil(env.memberListUpdater?.load_query)
+    }
+
+    func test_synchronize_callsUserUpdater_ifObserverSucceeds() {
+        // Simulate `synchronize` call.
+        controller.synchronize()
+
+        // Assert updater in called
+        XCTAssertEqual(env.memberListUpdater!.load_query!.cid, controller.cid)
+        XCTAssertNotNil(env.memberListUpdater!.load_completion)
+    }
+
+    // MARK: - Local data fetching triggers
+
+    func test_observerIsTriggeredOnlyOnce() {
+        // Check initial state
+        XCTAssertEqual(controller.state, .initialized)
+
+        // Set the delegate
+        controller.delegate = TestDelegate(expectedQueueId: callbackQueueID)
+
+        // Assert state changed
+        AssertAsync.willBeEqual(controller.state, .localDataFetched)
+
+        // Update observer to throw the error
+        env.memberObserver?.synchronizeError = TestError()
+
+        // Set `delegate` / call `synchronize` / access `member` again
+        _ = controller.member
+
+        // Assert controllers stays in `localDataFetched`
+        AssertAsync.staysEqual(controller.state, .localDataFetched)
+    }
+
+    func test_localDataIsFetched_whenDelegateIsSet() {
+        // Check initial state
+        XCTAssertEqual(controller.state, .initialized)
+
+        // Set the delegate
+        controller.delegate = TestDelegate(expectedQueueId: callbackQueueID)
+
+        // Assert state changed
+        AssertAsync.willBeEqual(controller.state, .localDataFetched)
+    }
+
+    func test_localDataIsFetched_whenUserIsAccessed() {
+        // Check initial state
+        XCTAssertEqual(controller.state, .initialized)
+
+        // Access the member
+        _ = controller.member
+
+        // Assert state changed
+        AssertAsync.willBeEqual(controller.state, .localDataFetched)
+    }
+
+    func test_localDataIsFetched_whenSynchronizedIsCalled() {
+        // Check initial state
+        XCTAssertEqual(controller.state, .initialized)
+
+        // Set the delegate
+        controller.synchronize()
+
+        // Assert state changed
+        AssertAsync.willBeEqual(controller.state, .localDataFetched)
+    }
+
+    // MARK: - Delegate
+
+    func test_delegate_isAssignedCorrectly() {
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
+
+        // Set the delegate
+        controller.delegate = delegate
+
+        // Assert the delegate is assigned correctly
+        XCTAssert(controller.delegate === delegate)
+    }
+
+    func test_delegate_isNotifiedAboutStateChanges() throws {
+        // Set the delegate
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
+        controller.delegate = delegate
+
+        // Synchronize
+        controller.synchronize()
+
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .localDataFetched)
+
+        // Simulate network call response
+        env.memberListUpdater!.load_completion!(nil)
+
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)
+    }
+
+    func test_genericDelegate_isNotifiedAboutStateChanges() throws {
+        // Set the generic delegate
+        let delegate = TestDelegateGeneric(expectedQueueId: callbackQueueID)
+        controller.setDelegate(delegate)
+
+        // Synchronize
+        controller.synchronize()
+
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .localDataFetched)
+
+        // Simulate network call response
+        env.memberListUpdater!.load_completion!(nil)
+
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)
+    }
+    
+    func test_delegate_isNotifiedAboutMemberUpdates() throws {
+        // Set the delegate
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
+        controller.delegate = delegate
+
+        // Create member in the database.
+        let initialRole: MemberRole = .member
+        try client.databaseContainer.createMember(userId: userId, role: initialRole, cid: cid)
+
+        // Assert `create` entity change is received by the delegate
+        AssertAsync {
+            Assert.willBeEqual(delegate.didUpdateMember_change?.fieldChange(\.id), .create(self.userId))
+            Assert.willBeEqual(delegate.didUpdateMember_change?.fieldChange(\.memberRole), .create(initialRole))
+        }
+
+        // Simulate `synchronize` call to fetch user from remote
+        controller.synchronize()
+
+        // Simulate response from a backend with updated member
+        let updatedRole: MemberRole = .admin
+        try client.databaseContainer.writeSynchronously { session in
+            let dto = try XCTUnwrap(session.member(userId: self.userId, cid: self.cid))
+            dto.channelRoleRaw = updatedRole.rawValue
+        }
+        env.memberListUpdater!.load_completion!(nil)
+
+        // Assert `update` entity change is received by the delegate
+        AssertAsync {
+            Assert.willBeEqual(delegate.didUpdateMember_change?.fieldChange(\.id), .update(self.userId))
+            Assert.willBeEqual(delegate.didUpdateMember_change?.fieldChange(\.memberRole), .update(updatedRole))
+        }
+        
+        // Simulate database flush
+        try client.databaseContainer.removeAllData()
+        
+        // Assert `remove` entity change is received by the delegate
+        AssertAsync {
+            Assert.willBeEqual(delegate.didUpdateMember_change?.fieldChange(\.id), .remove(self.userId))
+            Assert.willBeEqual(delegate.didUpdateMember_change?.fieldChange(\.memberRole), .remove(updatedRole))
+            Assert.willBeNil(self.controller.member)
+        }
+    }
+
+    // MARK: - Ban user
+
+    func test_ban_propogatesError() {
+        // Simulate `ban` call and catch the completion.
+        var completionError: Error?
+        controller.ban { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionError = $0
+        }
+
+        // Simulate network response with the error.
+        let networkError = TestError()
+        env.memberUpdater!.banMember_completion!(networkError)
+
+        // Assert error is propogated.
+        AssertAsync.willBeEqual(completionError as? TestError, networkError)
+    }
+
+    func test_ban_propogatesNilError() {
+        // Simulate `ban` call and catch the completion.
+        var completionIsCalled = false
+        controller.ban { [callbackQueueID] error in
+            // Assert callback queue is correct.
+            AssertTestQueue(withId: callbackQueueID)
+            // Assert there is no error.
+            XCTAssertNil(error)
+            completionIsCalled = true
+        }
+
+        // Simulate successful network response.
+        env.memberUpdater!.banMember_completion!(nil)
+
+        // Assert completion is called.
+        AssertAsync.willBeTrue(completionIsCalled)
+    }
+
+    func test_ban_callsMemberUpdater_withCorrectValues() {
+        let timeout = 10
+        let reason: String = .unique
+        
+        // Simulate `ban` call.
+        controller.ban(for: timeout, reason: reason)
+
+        // Assert updater is called with correct values
+        XCTAssertEqual(env.memberUpdater!.banMember_userId, controller.userId)
+        XCTAssertEqual(env.memberUpdater!.banMember_cid, controller.cid)
+        XCTAssertEqual(env.memberUpdater!.banMember_timeoutInMinutes, timeout)
+        XCTAssertEqual(env.memberUpdater!.banMember_reason, reason)
+    }
+
+    // MARK: - Unban user
+
+    func test_unban_propogatesError() {
+        // Simulate `unban` call and catch the completion.
+        var completionError: Error?
+        controller.unban { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionError = $0
+        }
+
+        // Simulate network response with the error.
+        let networkError = TestError()
+        env.memberUpdater!.unbanMember_completion!(networkError)
+
+        // Assert error is propogated.
+        AssertAsync.willBeEqual(completionError as? TestError, networkError)
+    }
+
+    func test_unban_propogatesNilError() {
+        // Simulate `unban` call and catch the completion.
+        var completionIsCalled = false
+        controller.unban { [callbackQueueID] error in
+            // Assert callback queue is correct.
+            AssertTestQueue(withId: callbackQueueID)
+            // Assert there is no error.
+            XCTAssertNil(error)
+            completionIsCalled = true
+        }
+
+        // Simulate successful network response.
+        env.memberUpdater!.unbanMember_completion!(nil)
+
+        // Assert completion is called.
+        AssertAsync.willBeTrue(completionIsCalled)
+    }
+
+    func test_unban_callsUserUpdater_withCorrectValues() {
+        // Simulate `unban` call.
+        controller.unban()
+
+        // Assert updater is called with correct values
+        XCTAssertEqual(env.memberUpdater!.unbanMember_userId, controller.userId)
+        XCTAssertEqual(env.memberUpdater!.unbanMember_cid, controller.cid)
+    }
+ }
+
+ private class TestEnvironment {
+    @Atomic var memberUpdater: ChannelMemberUpdaterMock?
+    @Atomic var memberListUpdater: ChannelMemberListUpdaterMock<DefaultExtraData>?
+    @Atomic var memberObserver: EntityDatabaseObserverMock<ChatChannelMember, MemberDTO>?
+    @Atomic var memberObserverSynchronizeError: Error?
+
+    lazy var environment: ChatChannelMemberController.Environment = .init(
+        memberUpdaterBuilder: { [unowned self] in
+            self.memberUpdater = .init(
+                database: $0,
+                webSocketClient: $1,
+                apiClient: $2
+            )
+            return self.memberUpdater!
+        },
+        memberListUpdaterBuilder: { [unowned self] in
+            self.memberListUpdater = .init(
+                database: $0,
+                webSocketClient: $1,
+                apiClient: $2
+            )
+            return self.memberListUpdater!
+        },
+        memberObserverBuilder: { [unowned self] in
+            self.memberObserver = .init(
+                context: $0,
+                fetchRequest: $1,
+                itemCreator: $2,
+                fetchedResultsControllerType: $3
+            )
+            self.memberObserver?.synchronizeError = self.memberObserverSynchronizeError
+            return self.memberObserver!
+        }
+    )
+ }
+
+// A concrete `ChatMemberControllerDelegate` implementation allowing capturing the delegate calls
+ private class TestDelegate: QueueAwareDelegate, ChatMemberControllerDelegate {
+    @Atomic var state: DataController.State?
+    @Atomic var didUpdateMember_change: EntityChange<ChatChannelMember>?
+
+    func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        validateQueue()
+        self.state = state
+    }
+
+    func memberController(_ controller: ChatChannelMemberController, didUpdateMember change: EntityChange<ChatChannelMember>) {
+        validateQueue()
+        didUpdateMember_change = change
+    }
+ }
+
+// A concrete `_ChatMemberControllerDelegate` implementation allowing capturing the delegate calls.
+ private class TestDelegateGeneric: QueueAwareDelegate, _ChatMemberControllerDelegate {
+    @Atomic var state: DataController.State?
+    @Atomic var didUpdateMember_change: EntityChange<ChatChannelMember>?
+
+    func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        self.state = state
+        validateQueue()
+    }
+
+    func memberController(_ controller: ChatChannelMemberController, didUpdateMember change: EntityChange<ChatChannelMember>) {
+        validateQueue()
+        didUpdateMember_change = change
+    }
+ }

--- a/Sources_v3/Database/DTOs/ChannelMemberListQueryDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelMemberListQueryDTO.swift
@@ -1,0 +1,36 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+
+@objc(ChannelMemberListQueryDTO)
+final class ChannelMemberListQueryDTO: NSManagedObject {
+    /// Unique identifier of the query.
+    @NSManaged var queryHash: String
+    
+    /// Serialized `Filter` JSON which can be used in cases the query needs to be repeated.
+    @NSManaged var filterJSONData: Data
+    
+    /// The channel the query works with.
+    @NSManaged var channel: ChannelDTO
+        
+    /// Set of members matching the query.
+    @NSManaged var members: Set<MemberDTO>
+        
+    static func load(queryHash: String, context: NSManagedObjectContext) -> ChannelMemberListQueryDTO? {
+        let request = NSFetchRequest<ChannelMemberListQueryDTO>(entityName: ChannelMemberListQueryDTO.entityName)
+        request.predicate = NSPredicate(format: "queryHash == %@", queryHash)
+        return try? context.fetch(request).first
+    }
+    
+    static func loadOrCreate(queryHash: String, context: NSManagedObjectContext) -> ChannelMemberListQueryDTO {
+        if let existing = Self.load(queryHash: queryHash, context: context) {
+            return existing
+        }
+        
+        let new = ChannelMemberListQueryDTO(context: context)
+        new.queryHash = queryHash
+        return new
+    }
+}

--- a/Sources_v3/Database/DTOs/ChannelMemberListQueryDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelMemberListQueryDTO.swift
@@ -45,7 +45,7 @@ extension NSManagedObjectContext: MemberListQueryDatabaseSession {
             throw ClientError.ChannelDoesNotExist(cid: query.cid)
         }
         
-        let dto = ChannelMemberListQueryDTO.loadOrCreate(queryHash: query.hash, context: self)
+        let dto = ChannelMemberListQueryDTO.loadOrCreate(queryHash: query.queryHash, context: self)
         dto.channel = channelDTO
 
         let jsonData: Data

--- a/Sources_v3/Database/DTOs/ChannelMemberListQueryDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/ChannelMemberListQueryDTO_Tests.swift
@@ -31,11 +31,11 @@ final class ChannelMemberListQueryDTO_Tests: XCTestCase {
         try database.writeSynchronously {
             let dto = ChannelMemberListQueryDTO(context: $0 as! NSManagedObjectContext)
             dto.filterJSONData = try JSONEncoder.default.encode(query.filter)
-            dto.queryHash = query.hash
+            dto.queryHash = query.queryHash
         }
         
         // Load dto and assert it is correct.
-        let queryDTO = try XCTUnwrap(database.viewContext.channelMemberListQuery(queryHash: query.hash))
+        let queryDTO = try XCTUnwrap(database.viewContext.channelMemberListQuery(queryHash: query.queryHash))
         assert(queryDTO, match: query)
     }
     
@@ -50,7 +50,7 @@ final class ChannelMemberListQueryDTO_Tests: XCTestCase {
         try database.createMemberListQuery(query: query)
         
         // Load dto and assert it is correct.
-        let queryDTO = try XCTUnwrap(database.viewContext.channelMemberListQuery(queryHash: query.hash))
+        let queryDTO = try XCTUnwrap(database.viewContext.channelMemberListQuery(queryHash: query.queryHash))
         assert(queryDTO, match: query)
     }
     
@@ -69,7 +69,7 @@ final class ChannelMemberListQueryDTO_Tests: XCTestCase {
 
     private func assert(_ dto: ChannelMemberListQueryDTO, match query: ChannelMemberListQuery) {
         let filter = try? JSONDecoder.default.decode(Filter.self, from: dto.filterJSONData)
-        XCTAssertEqual(dto.queryHash, query.hash)
+        XCTAssertEqual(dto.queryHash, query.queryHash)
         XCTAssertEqual(filter?.filterHash, query.filter.filterHash)
     }
 }

--- a/Sources_v3/Database/DTOs/ChannelMemberListQueryDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/ChannelMemberListQueryDTO_Tests.swift
@@ -1,0 +1,75 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+import CoreData
+
+final class ChannelMemberListQueryDTO_Tests: XCTestCase {
+    var database: DatabaseContainer!
+    
+    // MARK: - Setup
+    
+    override func setUp() {
+        super.setUp()
+        database = try! DatabaseContainer(kind: .inMemory)
+    }
+    
+    override func tearDown() {
+        database = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Tests
+    
+    func test_channelMemberListQuery_loadsCorrectQuery() throws {
+        // Create the query.
+        let query = ChannelMemberListQuery(cid: .unique, filter: .contains("name", String.unique))
+        
+        // Save the query to the database.
+        try database.writeSynchronously {
+            let dto = ChannelMemberListQueryDTO(context: $0 as! NSManagedObjectContext)
+            dto.filterJSONData = try JSONEncoder.default.encode(query.filter)
+            dto.queryHash = query.hash
+        }
+        
+        // Load dto and assert it is correct.
+        let queryDTO = try XCTUnwrap(database.viewContext.channelMemberListQuery(queryHash: query.hash))
+        assert(queryDTO, match: query)
+    }
+    
+    func test_saveQuery_savesQueryCorrectly_ifChannelExists() throws {
+        // Create the query.
+        let query = ChannelMemberListQuery(cid: .unique, filter: .contains("name", String.unique))
+        
+        // Save channel to the database.
+        try database.createChannel(cid: query.cid)
+        
+        // Save query to the database.
+        try database.createMemberListQuery(query: query)
+        
+        // Load dto and assert it is correct.
+        let queryDTO = try XCTUnwrap(database.viewContext.channelMemberListQuery(queryHash: query.hash))
+        assert(queryDTO, match: query)
+    }
+    
+    func test_saveQuery_throwsError_ifChannelDoesNotExist() throws {
+        // Create the query.
+        let query = ChannelMemberListQuery(cid: .unique, filter: .contains("name", String.unique))
+        
+        // Try to save query to the database.
+        XCTAssertThrowsError(try database.createMemberListQuery(query: query)) { error in
+            // Assert `ClientError.ChannelDoesNotExist` is thrown
+            XCTAssertTrue(error is ClientError.ChannelDoesNotExist)
+        }
+    }
+    
+    // MARK: - Tests
+
+    private func assert(_ dto: ChannelMemberListQueryDTO, match query: ChannelMemberListQuery) {
+        let filter = try? JSONDecoder.default.decode(Filter.self, from: dto.filterJSONData)
+        XCTAssertEqual(dto.queryHash, query.hash)
+        XCTAssertEqual(filter?.filterHash, query.filter.filterHash)
+    }
+}

--- a/Sources_v3/Database/DTOs/MemberModelDTO.swift
+++ b/Sources_v3/Database/DTOs/MemberModelDTO.swift
@@ -26,6 +26,14 @@ class MemberDTO: NSManagedObject {
     private static func createId(userId: String, channeldId: ChannelId) -> String {
         channeldId.rawValue + userId
     }
+    
+    /// Returns a fetch request for the dto with the provided `userId`.
+    static func member(_ userId: UserId, in cid: ChannelId) -> NSFetchRequest<MemberDTO> {
+        let request = NSFetchRequest<MemberDTO>(entityName: MemberDTO.entityName)
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \MemberDTO.memberCreatedAt, ascending: false)]
+        request.predicate = NSPredicate(format: "id == %@", Self.createId(userId: userId, channeldId: cid))
+        return request
+    }
 }
 
 extension MemberDTO {

--- a/Sources_v3/Database/DTOs/MemberModelDTO.swift
+++ b/Sources_v3/Database/DTOs/MemberModelDTO.swift
@@ -55,7 +55,11 @@ extension MemberDTO {
 }
 
 extension NSManagedObjectContext {
-    func saveMember<ExtraData: UserExtraData>(payload: MemberPayload<ExtraData>, channelId: ChannelId) throws -> MemberDTO {
+    func saveMember<ExtraData: UserExtraData>(
+        payload: MemberPayload<ExtraData>,
+        channelId: ChannelId,
+        query: ChannelMemberListQuery?
+    ) throws -> MemberDTO {
         let dto = MemberDTO.loadOrCreate(id: payload.user.id, channelId: channelId, context: self)
         
         // Save user-part of member first
@@ -68,6 +72,11 @@ extension NSManagedObjectContext {
         
         dto.memberCreatedAt = payload.createdAt
         dto.memberUpdatedAt = payload.updatedAt
+        
+        if let query = query {
+            let queryDTO = try saveQuery(query)
+            queryDTO.members.insert(dto)
+        }
         
         return dto
     }

--- a/Sources_v3/Database/DTOs/MemberModelDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/MemberModelDTO_Tests.swift
@@ -163,7 +163,7 @@ class MemberModelDTO_Tests: XCTestCase {
         }
         
         // Assert query and member exists in the database and linked.
-        let loadedQuery = try XCTUnwrap(database.viewContext.channelMemberListQuery(queryHash: query.hash))
+        let loadedQuery = try XCTUnwrap(database.viewContext.channelMemberListQuery(queryHash: query.queryHash))
         let loadedMember = try XCTUnwrap(database.viewContext.member(userId: userId, cid: cid))
         XCTAssertTrue(loadedQuery.members.contains(loadedMember))
     }

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -120,6 +120,12 @@ extension DatabaseContainer {
         }
     }
     
+    func createMemberListQuery(query: ChannelMemberListQuery) throws {
+        try writeSynchronously { session in
+            try session.saveQuery(query)
+        }
+    }
+    
     /// Synchronously creates a new MessageDTO in the DB with the given id.
     func createMessage(
         id: MessageId = .unique,

--- a/Sources_v3/Database/DatabaseSession.swift
+++ b/Sources_v3/Database/DatabaseSession.swift
@@ -120,12 +120,22 @@ protocol MemberDatabaseSession {
     func member(userId: UserId, cid: ChannelId) -> MemberDTO?
 }
 
+protocol MemberListQueryDatabaseSession {
+    /// Fetchtes `MemberListQueryDatabaseSession` entity for the given `filterHash`.
+    func channelMemberListQuery(queryHash: String) -> ChannelMemberListQueryDTO?
+    
+    /// Creates a new `MemberListQueryDatabaseSession` object in the database based in the given `ChannelMemberListQuery`.
+    @discardableResult
+    func saveQuery(_ query: ChannelMemberListQuery) throws -> ChannelMemberListQueryDTO
+}
+
 protocol DatabaseSession: UserDatabaseSession,
     CurrentUserDatabaseSession,
     MessageDatabaseSession,
     ChannelReadDatabaseSession,
     ChannelDatabaseSession,
-    MemberDatabaseSession {}
+    MemberDatabaseSession,
+    MemberListQueryDatabaseSession {}
 
 extension DatabaseSession {
     @discardableResult

--- a/Sources_v3/Database/DatabaseSession.swift
+++ b/Sources_v3/Database/DatabaseSession.swift
@@ -114,7 +114,11 @@ protocol ChannelReadDatabaseSession {
 protocol MemberDatabaseSession {
     /// Creates a new `MemberDTO` object in the database with the given `payload` in the channel with `channelId`.
     @discardableResult
-    func saveMember<ExtraData: UserExtraData>(payload: MemberPayload<ExtraData>, channelId: ChannelId) throws -> MemberDTO
+    func saveMember<ExtraData: UserExtraData>(
+        payload: MemberPayload<ExtraData>,
+        channelId: ChannelId,
+        query: ChannelMemberListQuery?
+    ) throws -> MemberDTO
     
     /// Fetchtes `MemberDTO`entity for the given `userId` and `cid`.
     func member(userId: UserId, cid: ChannelId) -> MemberDTO?
@@ -146,6 +150,14 @@ extension DatabaseSession {
     @discardableResult
     func saveUser<ExtraData: UserExtraData>(payload: UserPayload<ExtraData>) throws -> UserDTO {
         try saveUser(payload: payload, query: nil)
+    }
+    
+    @discardableResult
+    func saveMember<ExtraData: UserExtraData>(
+        payload: MemberPayload<ExtraData>,
+        channelId: ChannelId
+    ) throws -> MemberDTO {
+        try saveMember(payload: payload, channelId: channelId, query: nil)
     }
     
     // MARK: - Event

--- a/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -15,6 +15,7 @@
         <attribute name="watcherCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="createdBy" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="createdChannels" inverseEntity="UserDTO"/>
         <relationship name="currentlyTypingMembers" toMany="YES" deletionRule="Nullify" destinationEntity="MemberDTO" inverseName="typingIn" inverseEntity="MemberDTO"/>
+        <relationship name="memberListQueries" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelMemberListQueryDTO" inverseName="channel" inverseEntity="ChannelMemberListQueryDTO"/>
         <relationship name="members" toMany="YES" deletionRule="Nullify" destinationEntity="MemberDTO" inverseName="channel" inverseEntity="MemberDTO"/>
         <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="channel" inverseEntity="MessageDTO"/>
         <relationship name="queries" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelListQueryDTO" inverseName="channels" inverseEntity="ChannelListQueryDTO"/>
@@ -52,6 +53,17 @@
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>
+    <entity name="ChannelMemberListQueryDTO" representedClassName="ChannelMemberListQueryDTO" syncable="YES">
+        <attribute name="filterJSONData" optional="YES" attributeType="Binary"/>
+        <attribute name="queryHash" attributeType="String"/>
+        <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="memberListQueries" inverseEntity="ChannelDTO"/>
+        <relationship name="members" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MemberDTO" inverseName="queries" inverseEntity="MemberDTO"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="queryHash"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
     <entity name="ChannelReadDTO" representedClassName="ChannelReadDTO" syncable="YES">
         <attribute name="lastReadAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="unreadMessageCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
@@ -80,6 +92,7 @@
         <attribute name="memberCreatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="memberUpdatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="members" inverseEntity="ChannelDTO"/>
+        <relationship name="queries" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelMemberListQueryDTO" inverseName="members" inverseEntity="ChannelMemberListQueryDTO"/>
         <relationship name="typingIn" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="currentlyTypingMembers" inverseEntity="ChannelDTO"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="members" inverseEntity="UserDTO"/>
         <fetchIndex name="id">
@@ -178,6 +191,7 @@
     <elements>
         <element name="ChannelDTO" positionX="0" positionY="0" width="128" height="343"/>
         <element name="ChannelListQueryDTO" positionX="0" positionY="0" width="128" height="88"/>
+        <element name="ChannelMemberListQueryDTO" positionX="9" positionY="153" width="128" height="88"/>
         <element name="ChannelReadDTO" positionX="9" positionY="153" width="128" height="103"/>
         <element name="CurrentUserDTO" positionX="0" positionY="0" width="128" height="118"/>
         <element name="MemberDTO" positionX="0" positionY="0" width="128" height="193"/>

--- a/Sources_v3/Query/ChannelMemberListQuery.swift
+++ b/Sources_v3/Query/ChannelMemberListQuery.swift
@@ -52,7 +52,7 @@ public struct ChannelMemberListQuery: Encodable {
 }
 
 extension ChannelMemberListQuery {
-    var hash: String {
+    var queryHash: String {
         [
             cid.rawValue,
             filter.filterHash,

--- a/Sources_v3/Query/ChannelMemberListQuery.swift
+++ b/Sources_v3/Query/ChannelMemberListQuery.swift
@@ -1,0 +1,73 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A query type used for fetching channel members from the backend.
+public struct ChannelMemberListQuery: Encodable {
+    private enum CodingKeys: String, CodingKey {
+        case filter = "filter_conditions"
+        case sort
+        case channelId = "id"
+        case channelType = "type"
+    }
+    
+    /// A channel identifier the members should be fetched for.
+    public let cid: ChannelId
+    /// A filter for the query (see `Filter`).
+    public let filter: Filter
+    /// A sorting for the query (see `Sorting`).
+    public let sort: [Sorting<ChannelMemberListSortingKey>]
+    /// A pagination.
+    public var pagination: Pagination
+    
+    /// Creates new `ChannelMemberListQuery` instance.
+    /// - Parameters:
+    ///   - cid: The channel identifier.
+    ///   - filter: The members filter.
+    ///   - sort: The sorting for members list.
+    ///   - pagination: The pagination.
+    public init(
+        cid: ChannelId,
+        filter: Filter,
+        sort: [Sorting<ChannelMemberListSortingKey>] = [],
+        pagination: Pagination = [.channelMembersPageSize]
+    ) {
+        self.cid = cid
+        self.filter = filter
+        self.sort = sort
+        self.pagination = pagination
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        try container.encode(cid.id, forKey: .channelId)
+        try container.encode(cid.type, forKey: .channelType)
+        try container.encode(filter, forKey: .filter)
+        try pagination.encode(to: encoder)
+        if !sort.isEmpty { try container.encode(sort, forKey: .sort) }
+    }
+}
+
+extension ChannelMemberListQuery {
+    var hash: String {
+        [
+            cid.rawValue,
+            filter.filterHash,
+            sort.map(\.description).joined()
+        ].joined(separator: "-")
+    }
+}
+
+extension ChannelMemberListQuery {
+    /// Builds `ChannelMemberListQuery` for a single member in a specific channel
+    /// - Parameters:
+    ///   - userId: The user identifier.
+    ///   - cid: The channel identifier.
+    /// - Returns: `ChannelMemberListQuery` for a specific user in a specific channel
+    static func channelMember(userId: UserId, cid: ChannelId) -> Self {
+        .init(cid: cid, filter: .equal("id", to: userId))
+    }
+}

--- a/Sources_v3/Query/ChannelMemberListQuery_Tests.swift
+++ b/Sources_v3/Query/ChannelMemberListQuery_Tests.swift
@@ -1,0 +1,101 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class ChannelMemberListQuery_Tests: XCTestCase {
+    func test_query_isEncodedCorrectly() throws {
+        // Create the query.
+        let query = ChannelMemberListQuery(
+            cid: .unique,
+            filter: .contains("name", "a"),
+            sort: [.init(key: .createdAt, isAscending: true)],
+            pagination: [.offset(3)]
+        )
+
+        // Encode the query.
+        let json = try JSONEncoder.default.encode(query)
+
+        // Assert query is encoded correctly.
+        AssertJSONEqual(json, [
+            "id": query.cid.id,
+            "type": query.cid.type.rawValue,
+            "filter_conditions": ["name": ["$contains": "a"]],
+            "sort": [["key": "created_at", "direction": 1]] as NSArray,
+            "offset": 3
+        ])
+    }
+    
+    func test_hash_isCalculatedCorrectly() {
+        // Create the query.
+        let query = ChannelMemberListQuery(
+            cid: .unique,
+            filter: .contains("name", "a"),
+            sort: [.init(key: .createdAt, isAscending: true)]
+        )
+        
+        let expectedHash = [
+            query.cid.rawValue,
+            query.filter.filterHash,
+            query.sort.map(\.description).joined()
+        ].joined(separator: "-")
+        
+        // Assert hash is calculated correctly.
+        XCTAssertEqual(query.hash, expectedHash)
+    }
+    
+    func test_emptySorting_isNotEncoded() throws {
+        // Create the query without any sort options.
+        let query = ChannelMemberListQuery(
+            cid: .unique,
+            filter: .contains("name", "a"),
+            pagination: [.offset(3)]
+        )
+
+        // Encode the query.
+        let json = try JSONEncoder.default.encode(query)
+
+        // Assert encoding does not contain `sort` key.
+        AssertJSONEqual(json, [
+            "id": query.cid.id,
+            "type": query.cid.type.rawValue,
+            "filter_conditions": ["name": ["$contains": "a"]],
+            "offset": 3
+        ])
+    }
+    
+    func test_defaultPageSizeIsUsed_ifNotSpecified() throws {
+        // Create the query with default params.
+        let query = ChannelMemberListQuery(
+            cid: .unique,
+            filter: .contains("name", "a")
+        )
+
+        // Encode the query.
+        let json = try JSONEncoder.default.encode(query)
+
+        // Assert encoding does not contain `sort` key AND has default page size.
+        AssertJSONEqual(json, [
+            "id": query.cid.id,
+            "type": query.cid.type.rawValue,
+            "filter_conditions": ["name": ["$contains": "a"]],
+            "limit": PaginationOption.channelMembersPageSize.limit!
+        ])
+    }
+    
+    func test_singleMemberQuery_worksCorrectly() throws {
+        let userId: UserId = .unique
+        let cid: ChannelId = .unique
+
+        let actual = ChannelMemberListQuery.channelMember(userId: userId, cid: cid)
+        let actualJSON = try JSONEncoder.default.encode(actual)
+
+        let expected = ChannelMemberListQuery(cid: cid, filter: .equal("id", to: userId))
+        let expectedJSON = try JSONEncoder.default.encode(expected)
+    
+        // Assert queries match
+        AssertJSONEqual(actualJSON, expectedJSON)
+    }
+}

--- a/Sources_v3/Query/ChannelMemberListQuery_Tests.swift
+++ b/Sources_v3/Query/ChannelMemberListQuery_Tests.swift
@@ -42,8 +42,8 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
             query.sort.map(\.description).joined()
         ].joined(separator: "-")
         
-        // Assert hash is calculated correctly.
-        XCTAssertEqual(query.hash, expectedHash)
+        // Assert queryHash is calculated correctly.
+        XCTAssertEqual(query.queryHash, expectedHash)
     }
     
     func test_emptySorting_isNotEncoded() throws {

--- a/Sources_v3/Query/Pagination.swift
+++ b/Sources_v3/Query/Pagination.swift
@@ -50,6 +50,8 @@ public enum PaginationOption: Encodable, Hashable {
     public static let messagesNextPageSize: Self = .limit(50)
     /// A default users page size.
     public static let usersPageSize: Self = .limit(30)
+    /// A default channel members page size.
+    public static let channelMembersPageSize: Self = .limit(30)
     
     private enum CodingKeys: String, CodingKey {
         case limit

--- a/Sources_v3/Query/Sorting.swift
+++ b/Sources_v3/Query/Sorting.swift
@@ -156,3 +156,22 @@ extension UserListSortingKey {
         return nil
     }
 }
+
+// MARK: - Members Sorting
+
+/// `ChannelMemberListSortingKey` describes the keys by which you can get sorted channel members after query.
+public struct ChannelMemberListSortingKey: RawRepresentable, Equatable, SortingKey {
+    public let rawValue: String
+    
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+public extension ChannelMemberListSortingKey {
+    /// When used this key sorts the member list by member's `createdAt` field.
+    static let createdAt = Self(rawValue: "created_at")
+    
+    /// When used this key sorts the member list by member's `updatedAt` field.
+    static let updatedAt = Self(rawValue: "updated_at")
+}

--- a/Sources_v3/Workers/ChannelMemberListUpdater.swift
+++ b/Sources_v3/Workers/ChannelMemberListUpdater.swift
@@ -1,0 +1,81 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+
+/// Makes a channel members query call to the backend and updates the local storage with the results.
+class ChannelMemberListUpdater<ExtraData: ExtraDataTypes>: Worker {
+    /// Makes a channel members query call to the backend and updates the local storage with the results.
+    /// - Parameters:
+    ///   - query: The query used in the request.
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
+    func load(_ query: ChannelMemberListQuery, completion: ((Error?) -> Void)? = nil) {
+        fetchAndSaveChannelIfNeeded(query.cid) { error in
+            guard error == nil else {
+                completion?(error)
+                return
+            }
+            
+            let membersEndpoint: Endpoint<ChannelMemberListPayload<ExtraData.User>> = .channelMembers(query: query)
+            self.apiClient.request(endpoint: membersEndpoint) { membersResult in
+                switch membersResult {
+                case .success(let memberListPayload):
+                    self.database.write({ session in
+                        try memberListPayload.members.forEach {
+                            try session.saveMember(
+                                payload: $0,
+                                channelId: query.cid,
+                                query: query
+                            )
+                        }
+                    }, completion: { error in
+                        if let error = error {
+                            log.error("Failed to save `ChannelMemberListQuery` related data to the database. Error: \(error)")
+                        }
+                        completion?(error)
+                    })
+                case .failure(let error):
+                    completion?(error)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Private
+
+private extension ChannelMemberListUpdater {
+    func fetchAndSaveChannelIfNeeded(_ cid: ChannelId, completion: @escaping (Error?) -> Void) {
+        checkChannelExistsLocally(with: cid) { exists in
+            exists ? completion(nil) : self.fetchAndSaveChannel(with: cid, completion: completion)
+        }
+    }
+    
+    func fetchAndSaveChannel(with cid: ChannelId, completion: @escaping (Error?) -> Void) {
+        let query = ChannelQuery<ExtraData>(cid: cid)
+        apiClient.request(endpoint: .channel(query: query)) {
+            switch $0 {
+            case .success(let payload):
+                self.database.write({ session in
+                    try session.saveChannel(payload: payload)
+                }, completion: { error in
+                    if let error = error {
+                        log.error("Failed to save channel to the database. Error: \(error)")
+                    }
+                    completion(error)
+                })
+            case .failure(let error):
+                completion(error)
+            }
+        }
+    }
+    
+    func checkChannelExistsLocally(with cid: ChannelId, completion: @escaping (Bool) -> Void) {
+        let context = database.backgroundReadOnlyContext
+        context.perform {
+            let exists = context.channel(cid: cid) != nil
+            completion(exists)
+        }
+    }
+}

--- a/Sources_v3/Workers/ChannelMemberListUpdater_Mock.swift
+++ b/Sources_v3/Workers/ChannelMemberListUpdater_Mock.swift
@@ -1,0 +1,17 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+/// Mock implementation of `ChannelMemberListUpdater`
+final class ChannelMemberListUpdaterMock<ExtraData: ExtraDataTypes>: ChannelMemberListUpdater<ExtraData> {
+    @Atomic var load_query: ChannelMemberListQuery?
+    @Atomic var load_completion: ((Error?) -> Void)?
+
+    override func load(_ query: ChannelMemberListQuery, completion: ((Error?) -> Void)? = nil) {
+        load_query = query
+        load_completion = completion
+    }
+}

--- a/Sources_v3/Workers/ChannelMemberListUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelMemberListUpdater_Tests.swift
@@ -65,7 +65,7 @@ final class ChannelMemberListUpdater_Tests: StressTestCase {
         
         // Load query.
         var queryDTO: ChannelMemberListQueryDTO? {
-            database.viewContext.channelMemberListQuery(queryHash: query.hash)
+            database.viewContext.channelMemberListQuery(queryHash: query.queryHash)
         }
         
         AssertAsync {
@@ -117,7 +117,7 @@ final class ChannelMemberListUpdater_Tests: StressTestCase {
         
         // Load query.
         var queryDTO: ChannelMemberListQueryDTO? {
-            database.viewContext.channelMemberListQuery(queryHash: query.hash)
+            database.viewContext.channelMemberListQuery(queryHash: query.queryHash)
         }
         
         AssertAsync {

--- a/Sources_v3/Workers/ChannelMemberListUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelMemberListUpdater_Tests.swift
@@ -1,0 +1,225 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class ChannelMemberListUpdater_Tests: StressTestCase {
+    var webSocketClient: WebSocketClientMock!
+    var apiClient: APIClientMock!
+    var database: DatabaseContainerMock!
+    var query: ChannelMemberListQuery!
+
+    var listUpdater: ChannelMemberListUpdater<DefaultExtraData>!
+    
+    override func setUp() {
+        super.setUp()
+        
+        webSocketClient = WebSocketClientMock()
+        apiClient = APIClientMock()
+        database = DatabaseContainerMock()
+        query = ChannelMemberListQuery(cid: .unique, filter: .contains("name", "a"))
+
+        listUpdater = .init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+    }
+    
+    override func tearDown() {
+        query = nil
+        apiClient.cleanUp()
+        
+        AssertAsync {
+            Assert.canBeReleased(&listUpdater)
+            Assert.canBeReleased(&webSocketClient)
+            Assert.canBeReleased(&apiClient)
+            Assert.canBeReleased(&database)
+        }
+        
+        super.tearDown()
+    }
+    
+    // MARK: - Load
+    
+    func test_load_happyPath_whenChannelExistsLocally() throws {
+        // Save channel to the database.
+        try database.createChannel(cid: query.cid)
+        
+        // Simulate `load` call.
+        var completionCalled = false
+        listUpdater.load(query) { error in
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+        
+        // Assert members endpoint is called.
+        let membersEndpoint: Endpoint<ChannelMemberListPayload<DefaultExtraData.User>> = .channelMembers(query: query)
+        AssertAsync.willBeEqual(apiClient.request_endpoint, AnyEndpoint(membersEndpoint))
+        
+        // Simulate members response.
+        let payload = ChannelMemberListPayload<DefaultExtraData.User>(members: [
+            .dummy(userId: .unique),
+            .dummy(userId: .unique),
+            .dummy(userId: .unique)
+        ])
+        apiClient.test_simulateResponse(.success(payload))
+        
+        // Load query.
+        var queryDTO: ChannelMemberListQueryDTO? {
+            database.viewContext.channelMemberListQuery(queryHash: query.hash)
+        }
+        
+        AssertAsync {
+            // Assert completion is called.
+            Assert.willBeTrue(completionCalled)
+            // Assert query is saved to the database.
+            Assert.willBeTrue(queryDTO != nil)
+            // Assert query members are saved to the database.
+            Assert.willBeEqual(Set(queryDTO?.members.map(\.user.id) ?? []), Set(payload.members.map(\.user.id)))
+        }
+    }
+    
+    func test_load_happyPath_whenChannelDoesNotExistsLocally() {
+        // Simulate `load` call.
+        var completionCalled = false
+        listUpdater.load(query) { error in
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+        
+        // Assert channel endpoint is called.
+        let channelEndpoint: Endpoint<ChannelPayload<DefaultExtraData>> = .channel(query: .init(cid: query.cid))
+        AssertAsync.willBeEqual(apiClient.request_endpoint, AnyEndpoint(channelEndpoint))
+        
+        // Simulate successful channel response.
+        let dymmyChannelPayload = dummyPayload(with: query.cid)
+        apiClient.test_simulateResponse(.success(dymmyChannelPayload))
+        
+        // Load channel.
+        var channelDTO: ChannelDTO? {
+            database.viewContext.channel(cid: query.cid)
+        }
+        
+        let membersEndpoint: Endpoint<ChannelMemberListPayload<DefaultExtraData.User>> = .channelMembers(query: query)
+        AssertAsync {
+            // Assert channel is saved to the database.
+            Assert.willBeTrue(channelDTO != nil)
+            // Assert members endpoint is called.
+            Assert.willBeEqual(self.apiClient.request_endpoint, AnyEndpoint(membersEndpoint))
+        }
+        
+        // Simulate members response.
+        let payload = ChannelMemberListPayload<DefaultExtraData.User>(members: [
+            .dummy(userId: .unique),
+            .dummy(userId: .unique),
+            .dummy(userId: .unique)
+        ])
+        apiClient.test_simulateResponse(.success(payload))
+        
+        // Load query.
+        var queryDTO: ChannelMemberListQueryDTO? {
+            database.viewContext.channelMemberListQuery(queryHash: query.hash)
+        }
+        
+        AssertAsync {
+            // Assert completion is called.
+            Assert.willBeTrue(completionCalled)
+            // Assert query is saved to the database.
+            Assert.willBeTrue(queryDTO != nil)
+            // Assert query members are saved to the database.
+            Assert.willBeEqual(Set(queryDTO?.members.map(\.user.id) ?? []), Set(payload.members.map(\.user.id)))
+        }
+    }
+    
+    func test_load_propagatesChannelNetworkError() {
+        // Simulate `load` call and catch the error.
+        var completionCalledError: Error?
+        listUpdater.load(query) {
+            completionCalledError = $0
+        }
+        
+        // Assert channel endpoint is called.
+        let channelEndpoint: Endpoint<ChannelPayload<DefaultExtraData>> = .channel(query: .init(cid: query.cid))
+        AssertAsync.willBeEqual(apiClient.request_endpoint, AnyEndpoint(channelEndpoint))
+        
+        // Simulate channel response with failure.
+        let networkError = TestError()
+        apiClient.test_simulateResponse(Result<ChannelPayload<DefaultExtraData>, Error>.failure(networkError))
+        
+        // Assert the channel network error is propogated.
+        AssertAsync.willBeEqual(completionCalledError as? TestError, networkError)
+    }
+    
+    func test_load_propagatesChannelDatabaseError() {
+        // Update database to throw the error.
+        let databaseError = TestError()
+        database.write_errorResponse = databaseError
+        
+        // Simulate `load` call and catch the error.
+        var completionCalledError: Error?
+        listUpdater.load(query) {
+            completionCalledError = $0
+        }
+        
+        // Assert channel endpoint is called.
+        let channelEndpoint: Endpoint<ChannelPayload<DefaultExtraData>> = .channel(query: .init(cid: query.cid))
+        AssertAsync.willBeEqual(apiClient.request_endpoint, AnyEndpoint(channelEndpoint))
+        
+        // Simulate channel response with  success.
+        apiClient.test_simulateResponse(.success(dummyPayload(with: query.cid)))
+        
+        // Assert the channel database error is propogated.
+        AssertAsync.willBeEqual(completionCalledError as? TestError, databaseError)
+    }
+    
+    func test_load_propagatesMembersNetworkError() throws {
+        // Save channel to the database.
+        try database.createChannel(cid: query.cid)
+        
+        // Simulate `load` call and catch the error.
+        var completionCalledError: Error?
+        listUpdater.load(query) {
+            completionCalledError = $0
+        }
+        
+        // Assert members endpoint is called.
+        let membersEndpoint: Endpoint<ChannelMemberListPayload<DefaultExtraData.User>> = .channelMembers(query: query)
+        AssertAsync.willBeEqual(apiClient.request_endpoint, AnyEndpoint(membersEndpoint))
+
+        // Simulate members response with failure.
+        let networkError = TestError()
+        apiClient.test_simulateResponse(Result<ChannelMemberListPayload<DefaultExtraData.User>, Error>.failure(networkError))
+        
+        // Assert the members network call error is propogated.
+        AssertAsync.willBeEqual(completionCalledError as? TestError, networkError)
+    }
+    
+    func test_load_propagatesMembersDatabaseError() throws {
+        // Save channel to the database.
+        try database.createChannel(cid: query.cid)
+        
+        // Simulate `load` call and catch the error.
+        var completionCalledError: Error?
+        listUpdater.load(query) {
+            completionCalledError = $0
+        }
+        
+        // Assert members endpoint is called.
+        let membersEndpoint: Endpoint<ChannelMemberListPayload<DefaultExtraData.User>> = .channelMembers(query: query)
+        AssertAsync.willBeEqual(apiClient.request_endpoint, AnyEndpoint(membersEndpoint))
+        
+        // Update database to throw the error.
+        let databaseError = TestError()
+        database.write_errorResponse = databaseError
+        
+        // Simulate members response with success.
+        let payload = ChannelMemberListPayload<DefaultExtraData.User>(members: [
+            .dummy(userId: .unique),
+            .dummy(userId: .unique),
+            .dummy(userId: .unique)
+        ])
+        apiClient.test_simulateResponse(.success(payload))
+        
+        // Assert the database error is propogated.
+        AssertAsync.willBeEqual(completionCalledError as? TestError, databaseError)
+    }
+}

--- a/Sources_v3/Workers/ChannelMemberUpdater.swift
+++ b/Sources_v3/Workers/ChannelMemberUpdater.swift
@@ -1,0 +1,41 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Makes channel member related calls to the backend.
+class ChannelMemberUpdater: Worker {
+    /// Bans the user in the channel for a specific # of minutes.
+    /// - Parameters:
+    ///   - userId: The user identifier to ban.
+    ///   - cid: The channel identifier to ban in.
+    ///   - timeoutInMinutes: The # of minutes the user should be banned for.
+    ///   - reason: The ban reason.
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
+    func banMember(
+        _ userId: UserId,
+        in cid: ChannelId,
+        for timeoutInMinutes: Int? = nil,
+        reason: String? = nil,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        apiClient.request(endpoint: .banMember(userId, cid: cid, timeoutInMinutes: timeoutInMinutes, reason: reason)) {
+            completion?($0.error)
+        }
+    }
+    
+    /// Unbans the user in the channel.
+    /// - Parameters:
+    ///   - userId: The user identifier to unban.
+    ///   - cid: The channel identifier to unban in.
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
+    func unbanMember(
+        _ userId: UserId,
+        in cid: ChannelId, completion: ((Error?) -> Void)? = nil
+    ) {
+        apiClient.request(endpoint: .unbanMember(userId, cid: cid)) {
+            completion?($0.error)
+        }
+    }
+}

--- a/Sources_v3/Workers/ChannelMemberUpdater_Mock.swift
+++ b/Sources_v3/Workers/ChannelMemberUpdater_Mock.swift
@@ -1,0 +1,42 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+/// Mock implementation of `ChannelMemberUpdater`
+final class ChannelMemberUpdaterMock: ChannelMemberUpdater {
+    @Atomic var banMember_userId: UserId?
+    @Atomic var banMember_cid: ChannelId?
+    @Atomic var banMember_timeoutInMinutes: Int??
+    @Atomic var banMember_reason: String??
+    @Atomic var banMember_completion: ((Error?) -> Void)?
+    
+    @Atomic var unbanMember_userId: UserId?
+    @Atomic var unbanMember_cid: ChannelId?
+    @Atomic var unbanMember_completion: ((Error?) -> Void)?
+
+    override func banMember(
+        _ userId: UserId,
+        in cid: ChannelId,
+        for timeoutInMinutes: Int? = nil,
+        reason: String? = nil,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        banMember_userId = userId
+        banMember_cid = cid
+        banMember_timeoutInMinutes = timeoutInMinutes
+        banMember_reason = reason
+        banMember_completion = completion
+    }
+    
+    override func unbanMember(
+        _ userId: UserId,
+        in cid: ChannelId, completion: ((Error?) -> Void)? = nil
+    ) {
+        unbanMember_userId = userId
+        unbanMember_cid = cid
+        unbanMember_completion = completion
+    }
+}

--- a/Sources_v3/Workers/ChannelMemberUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelMemberUpdater_Tests.swift
@@ -1,0 +1,136 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class ChannelMemberUpdater_Tests: StressTestCase {
+    var webSocketClient: WebSocketClientMock!
+    var apiClient: APIClientMock!
+    var database: DatabaseContainerMock!
+    
+    var updater: ChannelMemberUpdater!
+    
+    // MARK: Setup
+    
+    override func setUp() {
+        super.setUp()
+        
+        webSocketClient = WebSocketClientMock()
+        apiClient = APIClientMock()
+        database = DatabaseContainerMock()
+        
+        updater = .init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+    }
+    
+    override func tearDown() {
+        apiClient.cleanUp()
+        
+        AssertAsync {
+            Assert.canBeReleased(&updater)
+            Assert.canBeReleased(&webSocketClient)
+            Assert.canBeReleased(&apiClient)
+            Assert.canBeReleased(&database)
+        }
+        
+        super.tearDown()
+    }
+    
+    // MARK: - Ban user
+
+    func test_banMember_makesCorrectAPICall() {
+        let userId: UserId = .unique
+        let cid: ChannelId = .unique
+        let timeoutInMinutes = 15
+        let reason: String = .unique
+
+        // Simulate `banMember` call
+        updater.banMember(userId, in: cid, for: timeoutInMinutes, reason: reason)
+
+        // Assert correct endpoint is called
+        XCTAssertEqual(
+            apiClient.request_endpoint,
+            AnyEndpoint(.banMember(userId, cid: cid, timeoutInMinutes: timeoutInMinutes, reason: reason))
+        )
+    }
+
+    func test_banMember_propagatesSuccessfulResponse() {
+        // Simulate `banMember` call
+        var completionCalled = false
+        updater.banMember(.unique, in: .unique) { error in
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+
+        // Assert completion is not called yet
+        XCTAssertFalse(completionCalled)
+
+        // Simulate API response with success
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.success(.init()))
+
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+    }
+
+    func test_banMember_propagatesError() {
+        // Simulate `banMember` call
+        var completionCalledError: Error?
+        updater.banMember(.unique, in: .unique) { error in
+            completionCalledError = error
+        }
+
+        // Simulate API response with failure
+        let error = TestError()
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(error))
+
+        // Assert the completion is called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, error)
+    }
+    
+    // MARK: - Unban user
+
+    func test_unbanMember_makesCorrectAPICall() {
+        let userId: UserId = .unique
+        let cid: ChannelId = .unique
+        
+        // Simulate `unbanMember` call
+        updater.unbanMember(userId, in: cid)
+
+        // Assert correct endpoint is called
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(.unbanMember(userId, cid: cid)))
+    }
+
+    func test_unbanMember_propagatesSuccessfulResponse() {
+        // Simulate `unbanMember` call
+        var completionCalled = false
+        updater.unbanMember(.unique, in: .unique) { error in
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+
+        // Assert completion is not called yet
+        XCTAssertFalse(completionCalled)
+
+        // Simulate API response with success
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.success(.init()))
+
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+    }
+
+    func test_unbanMember_propagatesError() {
+        // Simulate `unbanMember` call
+        var completionCalledError: Error?
+        updater.unbanMember(.unique, in: .unique) { error in
+            completionCalledError = error
+        }
+
+        // Simulate API response with failure
+        let error = TestError()
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(error))
+
+        // Assert the completion is called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, error)
+    }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -656,6 +656,9 @@
 		889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQuery_Tests.swift; sourceTree = "<group>"; };
 		889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQueryDTO_Tests.swift; sourceTree = "<group>"; };
 		88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints.swift; sourceTree = "<group>"; };
+		88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater.swift; sourceTree = "<group>"; };
+		88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater_Tests.swift; sourceTree = "<group>"; };
+		88F6DF96252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater_Mock.swift; sourceTree = "<group>"; };
 		8A0175EF2501174000570345 /* EventSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender.swift; sourceTree = "<group>"; };
 		8A0175F325013B6400570345 /* EventSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender_Tests.swift; sourceTree = "<group>"; };
 		8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketPingController_Tests.swift; sourceTree = "<group>"; };
@@ -1234,6 +1237,9 @@
 				882C5755252C791400E60C44 /* ChannelMemberListUpdater.swift */,
 				882C5762252C7F6500E60C44 /* ChannelMemberListUpdater_Mock.swift */,
 				882C5765252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift */,
+				88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */,
+				88F6DF96252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift */,
+				88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */,
 				F63CC36D24E591690052844D /* EventObservers */,
 				79280F4524850ECC00CDEB89 /* Background */,
 			);
@@ -2074,6 +2080,7 @@
 				79280F4B248523C000CDEB89 /* ConnectionEvents.swift in Sources */,
 				882C574A252C767E00E60C44 /* ChannelMemberListPayload.swift in Sources */,
 				DAFAD6A324DD8E1A0043ED06 /* ChannelEditDetailPayload.swift in Sources */,
+				88F6DF91252C8845009A8AF0 /* ChannelMemberUpdater.swift in Sources */,
 				79BF83F2248F8F60007611A1 /* Logger.swift in Sources */,
 				799C943B247D2FB9001F1104 /* MessageDTO.swift in Sources */,
 				79877A0D2498E4BC00015F8B /* CurrentUser.swift in Sources */,
@@ -2135,6 +2142,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				88F6DF94252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift in Sources */,
 				793C14DC24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift in Sources */,
 				79A0E9AF2498BFD800E9BD50 /* WebSocketClient_Tests.swift in Sources */,
 				DA8407232525E871005A0F62 /* UserListPayload_Tests.swift in Sources */,
@@ -2178,6 +2186,7 @@
 				882C5766252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift in Sources */,
 				8836133C25275170003CB958 /* MutedUserPayload.swift in Sources */,
 				DA4EE5A1252B443400CB26D4 /* NewUserQueryUpdater_Tests.swift in Sources */,
+				88F6DF97252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift in Sources */,
 				7991D83F24F8F1BF00D21BA3 /* ChatClient_Mock.swift in Sources */,
 				DA4EE5BB252B69FD00CB26D4 /* UserListController+Combine_Tests.swift in Sources */,
 				792921CB24C077B400116BBB /* TestDispatchQueue.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -211,6 +211,8 @@
 		882C574A252C767E00E60C44 /* ChannelMemberListPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C5749252C767E00E60C44 /* ChannelMemberListPayload.swift */; };
 		882C574E252C76A400E60C44 /* ChannelMemberListPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C574D252C76A300E60C44 /* ChannelMemberListPayload_Tests.swift */; };
 		882C5752252C770900E60C44 /* ChannelMembersQuery.json in Resources */ = {isa = PBXBuildFile; fileRef = 882C5751252C770900E60C44 /* ChannelMembersQuery.json */; };
+		882C5759252C794900E60C44 /* MemberEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C5758252C794900E60C44 /* MemberEndpoints.swift */; };
+		882C575C252C79E900E60C44 /* MemberEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C575B252C79E900E60C44 /* MemberEndpoints_Tests.swift */; };
 		8836133825274F5F003CB958 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133725274F5F003CB958 /* ExtraData.swift */; };
 		8836133C25275170003CB958 /* MutedUserPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133B25275170003CB958 /* MutedUserPayload.swift */; };
 		888E8C36252B2AAF00195E03 /* UserController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C35252B2AAF00195E03 /* UserController+SwiftUI.swift */; };
@@ -627,6 +629,8 @@
 		882C5749252C767E00E60C44 /* ChannelMemberListPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListPayload.swift; sourceTree = "<group>"; };
 		882C574D252C76A300E60C44 /* ChannelMemberListPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListPayload_Tests.swift; sourceTree = "<group>"; };
 		882C5751252C770900E60C44 /* ChannelMembersQuery.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ChannelMembersQuery.json; sourceTree = "<group>"; };
+		882C5758252C794900E60C44 /* MemberEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEndpoints.swift; sourceTree = "<group>"; };
+		882C575B252C79E900E60C44 /* MemberEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEndpoints_Tests.swift; sourceTree = "<group>"; };
 		8836133725274F5F003CB958 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
 		8836133B25275170003CB958 /* MutedUserPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUserPayload.swift; sourceTree = "<group>"; };
 		888E8C35252B2AAF00195E03 /* UserController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+SwiftUI.swift"; sourceTree = "<group>"; };
@@ -1135,6 +1139,8 @@
 				8819DFDD252622D900FD1A50 /* ModerationEndpoints_Tests.swift */,
 				F65D9090250A5989000B8CEB /* WebSocketConnectEndpoint.swift */,
 				F65D9092250A5CD4000B8CEB /* WebSocketConnectEndpoint_Tests.swift */,
+				882C5758252C794900E60C44 /* MemberEndpoints.swift */,
+				882C575B252C79E900E60C44 /* MemberEndpoints_Tests.swift */,
 			);
 			path = Endpoints;
 			sourceTree = "<group>";
@@ -2023,6 +2029,7 @@
 				79877A1C2498E4EE00015F8B /* Endpoint.swift in Sources */,
 				DAEAF4B324DAD99E0015FB28 /* HideChannelRequest.swift in Sources */,
 				DA4EE59E252B43B700CB26D4 /* NewUserQueryUpdater.swift in Sources */,
+				882C5759252C794900E60C44 /* MemberEndpoints.swift in Sources */,
 				792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */,
 				79A0E9AD2498BD0C00E9BD50 /* ChatClient.swift in Sources */,
 				F688643624E6DA8700A71361 /* CurrentUserController.swift in Sources */,
@@ -2123,6 +2130,7 @@
 				F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */,
 				F62BE7872506525700D13B86 /* MissingEventsRequestBody_Tests.swift in Sources */,
 				79DDF81B249CE38B002F4412 /* AssertNetworkRequest.swift in Sources */,
+				882C575C252C79E900E60C44 /* MemberEndpoints_Tests.swift in Sources */,
 				791C0B6324EEBDF40013CA2F /* MessageSender_Tests.swift in Sources */,
 				797EEA4824FFB4C200C81203 /* DataStore_Tests.swift in Sources */,
 				882C574E252C76A400E60C44 /* ChannelMemberListPayload_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		888E8C3F252B2AD600195E03 /* UserController+Combine_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C3E252B2AD600195E03 /* UserController+Combine_Tests.swift */; };
 		888E8C41252B2ADC00195E03 /* UserController+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C3B252B2AC900195E03 /* UserController+SwiftUI_Tests.swift */; };
 		889B00E5252C972C007709A8 /* ChannelMemberListQuery_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */; };
+		889B00E9252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */; };
 		88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */; };
 		8A0175F02501174000570345 /* EventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175EF2501174000570345 /* EventSender.swift */; };
 		8A0175F425013B6400570345 /* EventSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175F325013B6400570345 /* EventSender_Tests.swift */; };
@@ -640,6 +641,7 @@
 		888E8C3B252B2AC900195E03 /* UserController+SwiftUI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+SwiftUI_Tests.swift"; sourceTree = "<group>"; };
 		888E8C3E252B2AD600195E03 /* UserController+Combine_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+Combine_Tests.swift"; sourceTree = "<group>"; };
 		889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQuery_Tests.swift; sourceTree = "<group>"; };
+		889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQueryDTO_Tests.swift; sourceTree = "<group>"; };
 		88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints.swift; sourceTree = "<group>"; };
 		8A0175EF2501174000570345 /* EventSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender.swift; sourceTree = "<group>"; };
 		8A0175F325013B6400570345 /* EventSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender_Tests.swift; sourceTree = "<group>"; };
@@ -962,6 +964,8 @@
 				796FD215250654940076C99B /* ChannelReadDTO.swift */,
 				7964F3A3249A0ACF002A09EC /* ChannelListQueryDTO.swift */,
 				7991D83A24F5427E00D21BA3 /* EphemeralValuesContainer.swift */,
+				882C575F252C7CC400E60C44 /* ChannelMemberListQueryDTO.swift */,
+				889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */,
 			);
 			path = DTOs;
 			sourceTree = "<group>";
@@ -2118,6 +2122,7 @@
 				DAFC1D4724F50C5C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift in Sources */,
 				7964F3AA249A19EA002A09EC /* Filter_Tests.swift in Sources */,
 				DA84072D2525EF8D005A0F62 /* UserEndpoints_Tests.swift in Sources */,
+				889B00E9252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift in Sources */,
 				F67415C024F0129800C3222F /* UnreadCount.swift in Sources */,
 				8A0175F425013B6400570345 /* EventSender_Tests.swift in Sources */,
 				79DDF819249CE38B002F4412 /* MockNetworkURLProtocol.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -207,12 +207,14 @@
 		8819DFE2252628CA00FD1A50 /* UserUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE1252628CA00FD1A50 /* UserUpdater_Tests.swift */; };
 		8819DFE625262B1500FD1A50 /* UserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE525262B1500FD1A50 /* UserController_Tests.swift */; };
 		8819DFE925262EBA00FD1A50 /* UserUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */; };
+		882C5746252C6FDF00E60C44 /* ChannelMemberListQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C5745252C6FDF00E60C44 /* ChannelMemberListQuery.swift */; };
 		8836133825274F5F003CB958 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133725274F5F003CB958 /* ExtraData.swift */; };
 		8836133C25275170003CB958 /* MutedUserPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133B25275170003CB958 /* MutedUserPayload.swift */; };
 		888E8C36252B2AAF00195E03 /* UserController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C35252B2AAF00195E03 /* UserController+SwiftUI.swift */; };
 		888E8C39252B2ABB00195E03 /* UserController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C38252B2ABB00195E03 /* UserController+Combine.swift */; };
 		888E8C3F252B2AD600195E03 /* UserController+Combine_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C3E252B2AD600195E03 /* UserController+Combine_Tests.swift */; };
 		888E8C41252B2ADC00195E03 /* UserController+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C3B252B2AC900195E03 /* UserController+SwiftUI_Tests.swift */; };
+		889B00E5252C972C007709A8 /* ChannelMemberListQuery_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */; };
 		88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */; };
 		8A0175F02501174000570345 /* EventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175EF2501174000570345 /* EventSender.swift */; };
 		8A0175F425013B6400570345 /* EventSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175F325013B6400570345 /* EventSender_Tests.swift */; };
@@ -618,12 +620,14 @@
 		8819DFE1252628CA00FD1A50 /* UserUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater_Tests.swift; sourceTree = "<group>"; };
 		8819DFE525262B1500FD1A50 /* UserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserController_Tests.swift; sourceTree = "<group>"; };
 		8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater_Mock.swift; sourceTree = "<group>"; };
+		882C5745252C6FDF00E60C44 /* ChannelMemberListQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQuery.swift; sourceTree = "<group>"; };
 		8836133725274F5F003CB958 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
 		8836133B25275170003CB958 /* MutedUserPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUserPayload.swift; sourceTree = "<group>"; };
 		888E8C35252B2AAF00195E03 /* UserController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+SwiftUI.swift"; sourceTree = "<group>"; };
 		888E8C38252B2ABB00195E03 /* UserController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+Combine.swift"; sourceTree = "<group>"; };
 		888E8C3B252B2AC900195E03 /* UserController+SwiftUI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+SwiftUI_Tests.swift"; sourceTree = "<group>"; };
 		888E8C3E252B2AD600195E03 /* UserController+Combine_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+Combine_Tests.swift"; sourceTree = "<group>"; };
+		889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQuery_Tests.swift; sourceTree = "<group>"; };
 		88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints.swift; sourceTree = "<group>"; };
 		8A0175EF2501174000570345 /* EventSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender.swift; sourceTree = "<group>"; };
 		8A0175F325013B6400570345 /* EventSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender_Tests.swift; sourceTree = "<group>"; };
@@ -996,6 +1000,8 @@
 		792A4F412480103A00EAF71D /* Query */ = {
 			isa = PBXGroup;
 			children = (
+				882C5745252C6FDF00E60C44 /* ChannelMemberListQuery.swift */,
+				889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */,
 				792A4F4C248011E500EAF71D /* ChannelListQuery.swift */,
 				DA8407052524F84F005A0F62 /* UserListQuery.swift */,
 				DA8407292525EB2F005A0F62 /* UserListQuery_Tests.swift */,
@@ -1966,6 +1972,7 @@
 				DA84071025250720005A0F62 /* UserListQueryDTO.swift in Sources */,
 				799C9449247D5211001F1104 /* MessageSender.swift in Sources */,
 				792A4F4D248011E500EAF71D /* ChannelListQuery.swift in Sources */,
+				882C5746252C6FDF00E60C44 /* ChannelMemberListQuery.swift in Sources */,
 				7964F3B8249A314D002A09EC /* ConsoleLogDestination.swift in Sources */,
 				799C9445247D3DD2001F1104 /* WebSocketClient.swift in Sources */,
 				797A756624814EF8003CF16D /* SystemEnvironment.swift in Sources */,
@@ -2168,6 +2175,7 @@
 				79DDF810249CB92E002F4412 /* RequestDecoder_Tests.swift in Sources */,
 				DAE566FA25011A4E00E39431 /* ChannelWatchStateUpdater_Tests.swift in Sources */,
 				8A62706A24BF02D80040BFD6 /* XCTAssertEqual+Difference.swift in Sources */,
+				889B00E5252C972C007709A8 /* ChannelMemberListQuery_Tests.swift in Sources */,
 				7931818E24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift in Sources */,
 				F62BE7922506692700D13B86 /* MissingEventsPublisher_Tests.swift in Sources */,
 				79200D42250118A1002F4EB1 /* iOS13TestCase.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -225,6 +225,8 @@
 		888E8C41252B2ADC00195E03 /* UserController+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C3B252B2AC900195E03 /* UserController+SwiftUI_Tests.swift */; };
 		888E8C4E252B4B1C00195E03 /* ChannelMemberBanRequestPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C4D252B4B1C00195E03 /* ChannelMemberBanRequestPayload.swift */; };
 		888E8C51252B4BAB00195E03 /* ChannelMemberBanRequestPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C50252B4BAB00195E03 /* ChannelMemberBanRequestPayload_Tests.swift */; };
+		888E8C55252B525300195E03 /* MemberController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C54252B525300195E03 /* MemberController.swift */; };
+		888E8C59252B56A100195E03 /* MemberController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C58252B56A100195E03 /* MemberController_Tests.swift */; };
 		889B00E5252C972C007709A8 /* ChannelMemberListQuery_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */; };
 		889B00E9252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */; };
 		88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */; };
@@ -653,6 +655,8 @@
 		888E8C3E252B2AD600195E03 /* UserController+Combine_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+Combine_Tests.swift"; sourceTree = "<group>"; };
 		888E8C4D252B4B1C00195E03 /* ChannelMemberBanRequestPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberBanRequestPayload.swift; sourceTree = "<group>"; };
 		888E8C50252B4BAB00195E03 /* ChannelMemberBanRequestPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberBanRequestPayload_Tests.swift; sourceTree = "<group>"; };
+		888E8C54252B525300195E03 /* MemberController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberController.swift; sourceTree = "<group>"; };
+		888E8C58252B56A100195E03 /* MemberController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberController_Tests.swift; sourceTree = "<group>"; };
 		889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQuery_Tests.swift; sourceTree = "<group>"; };
 		889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQueryDTO_Tests.swift; sourceTree = "<group>"; };
 		88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints.swift; sourceTree = "<group>"; };
@@ -1304,6 +1308,7 @@
 				79280F4E2485308100CDEB89 /* DataController.swift */,
 				8A0D64AD24E5853F0017A3C0 /* DataController_Tests.swift */,
 				8819DFD32525F48800FD1A50 /* UserController */,
+				888E8C53252B522F00195E03 /* MemberController */,
 				DAE566F22500F97E00E39431 /* ChannelController */,
 				DAE566F32500F98D00E39431 /* ChannelListController */,
 				DAE566F42500F99900E39431 /* CurrentUserController */,
@@ -1454,6 +1459,15 @@
 				888E8C3B252B2AC900195E03 /* UserController+SwiftUI_Tests.swift */,
 			);
 			path = UserController;
+			sourceTree = "<group>";
+		};
+		888E8C53252B522F00195E03 /* MemberController */ = {
+			isa = PBXGroup;
+			children = (
+				888E8C54252B525300195E03 /* MemberController.swift */,
+				888E8C58252B56A100195E03 /* MemberController_Tests.swift */,
+			);
+			path = MemberController;
 			sourceTree = "<group>";
 		};
 		8A0C3BC124C0AD6E00CAFD19 /* User */ = {
@@ -2058,6 +2072,7 @@
 				792B805024D95B5D00C2963E /* Cached.swift in Sources */,
 				DA0BB1612513B5F200CAEFBD /* StringInterpolation+Extenstions.swift in Sources */,
 				799C9479247E3DEA001F1104 /* StreamChatModel.xcdatamodeld in Sources */,
+				888E8C55252B525300195E03 /* MemberController.swift in Sources */,
 				79877A1C2498E4EE00015F8B /* Endpoint.swift in Sources */,
 				DAEAF4B324DAD99E0015FB28 /* HideChannelRequest.swift in Sources */,
 				DA4EE59E252B43B700CB26D4 /* NewUserQueryUpdater.swift in Sources */,
@@ -2217,6 +2232,7 @@
 				8A5D3EF924AF749200E2FE35 /* ChannelId_Tests.swift in Sources */,
 				799C945C247D59D8001F1104 /* ChatClient_Tests.swift in Sources */,
 				79BA19F324B3386B00E11FC2 /* CurrentUserDTO_Tests.swift in Sources */,
+				888E8C59252B56A100195E03 /* MemberController_Tests.swift in Sources */,
 				8819DFE625262B1500FD1A50 /* UserController_Tests.swift in Sources */,
 				F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */,
 				79280F7D24891B1300CDEB89 /* WebSocketEngine_Mock.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		882C5752252C770900E60C44 /* ChannelMembersQuery.json in Resources */ = {isa = PBXBuildFile; fileRef = 882C5751252C770900E60C44 /* ChannelMembersQuery.json */; };
 		882C5759252C794900E60C44 /* MemberEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C5758252C794900E60C44 /* MemberEndpoints.swift */; };
 		882C575C252C79E900E60C44 /* MemberEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C575B252C79E900E60C44 /* MemberEndpoints_Tests.swift */; };
+		882C5760252C7CC400E60C44 /* ChannelMemberListQueryDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C575F252C7CC400E60C44 /* ChannelMemberListQueryDTO.swift */; };
 		8836133825274F5F003CB958 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133725274F5F003CB958 /* ExtraData.swift */; };
 		8836133C25275170003CB958 /* MutedUserPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133B25275170003CB958 /* MutedUserPayload.swift */; };
 		888E8C36252B2AAF00195E03 /* UserController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C35252B2AAF00195E03 /* UserController+SwiftUI.swift */; };
@@ -631,6 +632,7 @@
 		882C5751252C770900E60C44 /* ChannelMembersQuery.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ChannelMembersQuery.json; sourceTree = "<group>"; };
 		882C5758252C794900E60C44 /* MemberEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEndpoints.swift; sourceTree = "<group>"; };
 		882C575B252C79E900E60C44 /* MemberEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEndpoints_Tests.swift; sourceTree = "<group>"; };
+		882C575F252C7CC400E60C44 /* ChannelMemberListQueryDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQueryDTO.swift; sourceTree = "<group>"; };
 		8836133725274F5F003CB958 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
 		8836133B25275170003CB958 /* MutedUserPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUserPayload.swift; sourceTree = "<group>"; };
 		888E8C35252B2AAF00195E03 /* UserController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+SwiftUI.swift"; sourceTree = "<group>"; };
@@ -2001,6 +2003,7 @@
 				79200D4C25025B81002F4EB1 /* Error+InternetNotAvailable.swift in Sources */,
 				8A0CC9F124C606EF00705CF9 /* ReactionEvents.swift in Sources */,
 				79877A0F2498E4BC00015F8B /* ChannelId.swift in Sources */,
+				882C5760252C7CC400E60C44 /* ChannelMemberListQueryDTO.swift in Sources */,
 				792A4F492480107A00EAF71D /* Sorting.swift in Sources */,
 				7937282A2498FFD300E13FE5 /* MemberPayload.swift in Sources */,
 				799C944C247D5766001F1104 /* ChannelController.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -223,6 +223,8 @@
 		888E8C39252B2ABB00195E03 /* UserController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C38252B2ABB00195E03 /* UserController+Combine.swift */; };
 		888E8C3F252B2AD600195E03 /* UserController+Combine_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C3E252B2AD600195E03 /* UserController+Combine_Tests.swift */; };
 		888E8C41252B2ADC00195E03 /* UserController+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C3B252B2AC900195E03 /* UserController+SwiftUI_Tests.swift */; };
+		888E8C4E252B4B1C00195E03 /* ChannelMemberBanRequestPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C4D252B4B1C00195E03 /* ChannelMemberBanRequestPayload.swift */; };
+		888E8C51252B4BAB00195E03 /* ChannelMemberBanRequestPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C50252B4BAB00195E03 /* ChannelMemberBanRequestPayload_Tests.swift */; };
 		889B00E5252C972C007709A8 /* ChannelMemberListQuery_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */; };
 		889B00E9252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */; };
 		88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */; };
@@ -649,6 +651,8 @@
 		888E8C38252B2ABB00195E03 /* UserController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+Combine.swift"; sourceTree = "<group>"; };
 		888E8C3B252B2AC900195E03 /* UserController+SwiftUI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+SwiftUI_Tests.swift"; sourceTree = "<group>"; };
 		888E8C3E252B2AD600195E03 /* UserController+Combine_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+Combine_Tests.swift"; sourceTree = "<group>"; };
+		888E8C4D252B4B1C00195E03 /* ChannelMemberBanRequestPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberBanRequestPayload.swift; sourceTree = "<group>"; };
+		888E8C50252B4BAB00195E03 /* ChannelMemberBanRequestPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberBanRequestPayload_Tests.swift; sourceTree = "<group>"; };
 		889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQuery_Tests.swift; sourceTree = "<group>"; };
 		889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQueryDTO_Tests.swift; sourceTree = "<group>"; };
 		88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints.swift; sourceTree = "<group>"; };
@@ -1672,6 +1676,8 @@
 				DAEAF4B224DAD99E0015FB28 /* HideChannelRequest.swift */,
 				F6ED5F7725027907005D7327 /* MissingEventsRequestBody.swift */,
 				F62BE7862506525700D13B86 /* MissingEventsRequestBody_Tests.swift */,
+				888E8C4D252B4B1C00195E03 /* ChannelMemberBanRequestPayload.swift */,
+				888E8C50252B4BAB00195E03 /* ChannelMemberBanRequestPayload_Tests.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -2090,6 +2096,7 @@
 				7991D83B24F5427E00D21BA3 /* EphemeralValuesContainer.swift in Sources */,
 				79682C4B24BF37CB0071578E /* ChannelListPayload.swift in Sources */,
 				DA9985EE24E175AA000E9885 /* ChannelCodingKeys.swift in Sources */,
+				888E8C4E252B4B1C00195E03 /* ChannelMemberBanRequestPayload.swift in Sources */,
 				79FC85E724ACCBC500A665ED /* Token.swift in Sources */,
 				79877A0E2498E4BC00015F8B /* Channel.swift in Sources */,
 				DA4AA3B22502718600FAAF6E /* ChannelController+Combine.swift in Sources */,
@@ -2167,6 +2174,7 @@
 				DA8407302526002D005A0F62 /* UserListUpdater_Mock.swift in Sources */,
 				F6CCA25125124BA9004C1859 /* MemberPayload.swift in Sources */,
 				F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */,
+				888E8C51252B4BAB00195E03 /* ChannelMemberBanRequestPayload_Tests.swift in Sources */,
 				882C5766252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift in Sources */,
 				8836133C25275170003CB958 /* MutedUserPayload.swift in Sources */,
 				DA4EE5A1252B443400CB26D4 /* NewUserQueryUpdater_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -211,9 +211,12 @@
 		882C574A252C767E00E60C44 /* ChannelMemberListPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C5749252C767E00E60C44 /* ChannelMemberListPayload.swift */; };
 		882C574E252C76A400E60C44 /* ChannelMemberListPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C574D252C76A300E60C44 /* ChannelMemberListPayload_Tests.swift */; };
 		882C5752252C770900E60C44 /* ChannelMembersQuery.json in Resources */ = {isa = PBXBuildFile; fileRef = 882C5751252C770900E60C44 /* ChannelMembersQuery.json */; };
+		882C5756252C791400E60C44 /* ChannelMemberListUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C5755252C791400E60C44 /* ChannelMemberListUpdater.swift */; };
 		882C5759252C794900E60C44 /* MemberEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C5758252C794900E60C44 /* MemberEndpoints.swift */; };
 		882C575C252C79E900E60C44 /* MemberEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C575B252C79E900E60C44 /* MemberEndpoints_Tests.swift */; };
 		882C5760252C7CC400E60C44 /* ChannelMemberListQueryDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C575F252C7CC400E60C44 /* ChannelMemberListQueryDTO.swift */; };
+		882C5763252C7F6500E60C44 /* ChannelMemberListUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C5762252C7F6500E60C44 /* ChannelMemberListUpdater_Mock.swift */; };
+		882C5766252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C5765252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift */; };
 		8836133825274F5F003CB958 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133725274F5F003CB958 /* ExtraData.swift */; };
 		8836133C25275170003CB958 /* MutedUserPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133B25275170003CB958 /* MutedUserPayload.swift */; };
 		888E8C36252B2AAF00195E03 /* UserController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C35252B2AAF00195E03 /* UserController+SwiftUI.swift */; };
@@ -223,6 +226,9 @@
 		889B00E5252C972C007709A8 /* ChannelMemberListQuery_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */; };
 		889B00E9252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */; };
 		88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */; };
+		88F6DF91252C8845009A8AF0 /* ChannelMemberUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */; };
+		88F6DF94252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */; };
+		88F6DF97252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF96252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift */; };
 		8A0175F02501174000570345 /* EventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175EF2501174000570345 /* EventSender.swift */; };
 		8A0175F425013B6400570345 /* EventSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175F325013B6400570345 /* EventSender_Tests.swift */; };
 		8A08C6A624D437DF00DEF995 /* WebSocketPingController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */; };
@@ -631,9 +637,12 @@
 		882C5749252C767E00E60C44 /* ChannelMemberListPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListPayload.swift; sourceTree = "<group>"; };
 		882C574D252C76A300E60C44 /* ChannelMemberListPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListPayload_Tests.swift; sourceTree = "<group>"; };
 		882C5751252C770900E60C44 /* ChannelMembersQuery.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ChannelMembersQuery.json; sourceTree = "<group>"; };
+		882C5755252C791400E60C44 /* ChannelMemberListUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListUpdater.swift; sourceTree = "<group>"; };
 		882C5758252C794900E60C44 /* MemberEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEndpoints.swift; sourceTree = "<group>"; };
 		882C575B252C79E900E60C44 /* MemberEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEndpoints_Tests.swift; sourceTree = "<group>"; };
 		882C575F252C7CC400E60C44 /* ChannelMemberListQueryDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQueryDTO.swift; sourceTree = "<group>"; };
+		882C5762252C7F6500E60C44 /* ChannelMemberListUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListUpdater_Mock.swift; sourceTree = "<group>"; };
+		882C5765252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListUpdater_Tests.swift; sourceTree = "<group>"; };
 		8836133725274F5F003CB958 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
 		8836133B25275170003CB958 /* MutedUserPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUserPayload.swift; sourceTree = "<group>"; };
 		888E8C35252B2AAF00195E03 /* UserController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+SwiftUI.swift"; sourceTree = "<group>"; };
@@ -1218,6 +1227,9 @@
 				8819DFCE2525F3C600FD1A50 /* UserUpdater.swift */,
 				8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */,
 				8819DFE1252628CA00FD1A50 /* UserUpdater_Tests.swift */,
+				882C5755252C791400E60C44 /* ChannelMemberListUpdater.swift */,
+				882C5762252C7F6500E60C44 /* ChannelMemberListUpdater_Mock.swift */,
+				882C5765252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift */,
 				F63CC36D24E591690052844D /* EventObservers */,
 				79280F4524850ECC00CDEB89 /* Background */,
 			);
@@ -1956,6 +1968,7 @@
 				DA8407032524F7E6005A0F62 /* UserListUpdater.swift in Sources */,
 				DAE566E724FFD22300E39431 /* ChannelController+SwiftUI.swift in Sources */,
 				792CA62624CEE93700D70A5E /* ChannelListUpdater.swift in Sources */,
+				882C5756252C791400E60C44 /* ChannelMemberListUpdater.swift in Sources */,
 				79896D5E25065ECD00BA8F1C /* ChannelRead.swift in Sources */,
 				79DDF80E249CB920002F4412 /* RequestDecoder.swift in Sources */,
 				DAF1BED1250660F8003CEDC0 /* MessageController+SwiftUI.swift in Sources */,
@@ -2133,6 +2146,7 @@
 				F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */,
 				7922F30A24DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift in Sources */,
 				DA84074025260CA3005A0F62 /* UserListController_Tests.swift in Sources */,
+				882C5763252C7F6500E60C44 /* ChannelMemberListUpdater_Mock.swift in Sources */,
 				8A62705E24BE2CD70040BFD6 /* XCTestCase+MockJSON.swift in Sources */,
 				DA84074B2526417B005A0F62 /* JSONEncoder+Extensions.swift in Sources */,
 				F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */,
@@ -2153,6 +2167,7 @@
 				DA8407302526002D005A0F62 /* UserListUpdater_Mock.swift in Sources */,
 				F6CCA25125124BA9004C1859 /* MemberPayload.swift in Sources */,
 				F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */,
+				882C5766252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift in Sources */,
 				8836133C25275170003CB958 /* MutedUserPayload.swift in Sources */,
 				DA4EE5A1252B443400CB26D4 /* NewUserQueryUpdater_Tests.swift in Sources */,
 				7991D83F24F8F1BF00D21BA3 /* ChatClient_Mock.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -208,6 +208,9 @@
 		8819DFE625262B1500FD1A50 /* UserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE525262B1500FD1A50 /* UserController_Tests.swift */; };
 		8819DFE925262EBA00FD1A50 /* UserUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */; };
 		882C5746252C6FDF00E60C44 /* ChannelMemberListQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C5745252C6FDF00E60C44 /* ChannelMemberListQuery.swift */; };
+		882C574A252C767E00E60C44 /* ChannelMemberListPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C5749252C767E00E60C44 /* ChannelMemberListPayload.swift */; };
+		882C574E252C76A400E60C44 /* ChannelMemberListPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C574D252C76A300E60C44 /* ChannelMemberListPayload_Tests.swift */; };
+		882C5752252C770900E60C44 /* ChannelMembersQuery.json in Resources */ = {isa = PBXBuildFile; fileRef = 882C5751252C770900E60C44 /* ChannelMembersQuery.json */; };
 		8836133825274F5F003CB958 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133725274F5F003CB958 /* ExtraData.swift */; };
 		8836133C25275170003CB958 /* MutedUserPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133B25275170003CB958 /* MutedUserPayload.swift */; };
 		888E8C36252B2AAF00195E03 /* UserController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C35252B2AAF00195E03 /* UserController+SwiftUI.swift */; };
@@ -621,6 +624,9 @@
 		8819DFE525262B1500FD1A50 /* UserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserController_Tests.swift; sourceTree = "<group>"; };
 		8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater_Mock.swift; sourceTree = "<group>"; };
 		882C5745252C6FDF00E60C44 /* ChannelMemberListQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQuery.swift; sourceTree = "<group>"; };
+		882C5749252C767E00E60C44 /* ChannelMemberListPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListPayload.swift; sourceTree = "<group>"; };
+		882C574D252C76A300E60C44 /* ChannelMemberListPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListPayload_Tests.swift; sourceTree = "<group>"; };
+		882C5751252C770900E60C44 /* ChannelMembersQuery.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ChannelMembersQuery.json; sourceTree = "<group>"; };
 		8836133725274F5F003CB958 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
 		8836133B25275170003CB958 /* MutedUserPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUserPayload.swift; sourceTree = "<group>"; };
 		888E8C35252B2AAF00195E03 /* UserController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+SwiftUI.swift"; sourceTree = "<group>"; };
@@ -1066,6 +1072,8 @@
 		79682C4724BF37550071578E /* Payloads */ = {
 			isa = PBXGroup;
 			children = (
+				882C5749252C767E00E60C44 /* ChannelMemberListPayload.swift */,
+				882C574D252C76A300E60C44 /* ChannelMemberListPayload_Tests.swift */,
 				DA84070B25250581005A0F62 /* UserListPayload.swift */,
 				DA8407222525E871005A0F62 /* UserListPayload_Tests.swift */,
 				79B5517124E593C200CE9FEC /* UserPayloads.swift */,
@@ -1092,6 +1100,7 @@
 		798779F52498E47700015F8B /* MockEnpointResponses */ = {
 			isa = PBXGroup;
 			children = (
+				882C5751252C770900E60C44 /* ChannelMembersQuery.json */,
 				798779F62498E47700015F8B /* Member.json */,
 				798779F72498E47700015F8B /* Channel.json */,
 				79F3ABE924EAB9CD00AB9505 /* Message.json */,
@@ -1854,6 +1863,7 @@
 				8A0C3BDC24C1F18700CAFD19 /* MessageNew.json in Resources */,
 				8A62706224BE35E40040BFD6 /* UserStartTyping.json in Resources */,
 				8A0C3BDE24C1F18700CAFD19 /* MessageDeleted.json in Resources */,
+				882C5752252C770900E60C44 /* ChannelMembersQuery.json in Resources */,
 				8A0C3BC524C0AEDB00CAFD19 /* UserStartWatching.json in Resources */,
 				8A0D64A324E57A260017A3C0 /* GuestUser+NoExtraData.json in Resources */,
 				798779FC2498E47700015F8B /* Channel.json in Resources */,
@@ -2029,6 +2039,7 @@
 				8AE335A824FCF999002B6677 /* Reachability_Vendor.swift in Sources */,
 				79877A0C2498E4BC00015F8B /* ChannelType.swift in Sources */,
 				79280F4B248523C000CDEB89 /* ConnectionEvents.swift in Sources */,
+				882C574A252C767E00E60C44 /* ChannelMemberListPayload.swift in Sources */,
 				DAFAD6A324DD8E1A0043ED06 /* ChannelEditDetailPayload.swift in Sources */,
 				79BF83F2248F8F60007611A1 /* Logger.swift in Sources */,
 				799C943B247D2FB9001F1104 /* MessageDTO.swift in Sources */,
@@ -2114,6 +2125,7 @@
 				79DDF81B249CE38B002F4412 /* AssertNetworkRequest.swift in Sources */,
 				791C0B6324EEBDF40013CA2F /* MessageSender_Tests.swift in Sources */,
 				797EEA4824FFB4C200C81203 /* DataStore_Tests.swift in Sources */,
+				882C574E252C76A400E60C44 /* ChannelMemberListPayload_Tests.swift in Sources */,
 				8836133825274F5F003CB958 /* ExtraData.swift in Sources */,
 				79896D622507B16000BA8F1C /* ChannelListUpdater_Mock.swift in Sources */,
 				79877A2A2498E51500015F8B /* MemberModelDTO_Tests.swift in Sources */,

--- a/Tests_v3/MockEnpointResponses/ChannelMembersQuery.json
+++ b/Tests_v3/MockEnpointResponses/ChannelMembersQuery.json
@@ -1,0 +1,26 @@
+{
+  "members": [
+      {
+        "created_at" : "2020-06-05T12:53:09.862721Z",
+        "updated_at" : "2020-06-05T12:53:09.862721Z",
+        "role" : "owner",
+        "user" : {
+          "id" : "broken-waterfall-5",
+          "banned" : false,
+          "unread_channels" : 1,
+          "extraData" : {
+            "name" : "Tester"
+          },
+          "last_active" : "2020-06-10T13:24:00.501797Z",
+          "created_at" : "2019-12-12T15:33:46.488935Z",
+          "unread_count" : 2,
+          "image" : "https:\/\/getstream.io\/random_svg\/?id=broken-waterfall-5&amp;name=Broken+waterfall",
+          "updated_at" : "2020-06-10T14:11:29.946106Z",
+          "role" : "user",
+          "total_unread_count" : 2,
+          "online" : true,
+          "name" : "Broken Waterfall"
+        }
+      }
+  ]
+}


### PR DESCRIPTION
**This PR**: 
- introduces `ChatMemberController` for actions on a channel member (currently, only **ban/unban** actions are in)
- introduces `ChannelMemberListUpdater ` and stuff for querying the channel members
- introduces `ChannelMemberUpdater`  and stuff for channel member related API calls
- introduces `ChannelMemberListQueryDTO` and database session for local representation of member queries


