### PR TITLE
Sample v3: Separate login configurations into a new screen + persistence

### DIFF
--- a/Sample_v3/Base.lproj/Main.storyboard
+++ b/Sample_v3/Base.lproj/Main.storyboard
@@ -8,7 +8,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Login-->
+        <!--Samples-->
         <scene sceneID="rZd-md-sUL">
             <objects>
                 <tableViewController id="dqB-UX-E5D" customClass="LoginViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
@@ -17,158 +17,11 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <sections>
-                            <tableViewSection headerTitle="CREDENTIALS" footerTitle="" id="tzF-qB-HHi">
-                                <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="Dzv-sw-GWr">
-                                        <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Dzv-sw-GWr" id="d7i-Yp-ZNs">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="qk4nn7rpcn75" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1zn-J3-bHH">
-                                                    <rect key="frame" x="118" y="4" width="276" height="34.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <textInputTraits key="textInputTraits"/>
-                                                </textField>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="API Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zex-gH-dgG">
-                                                    <rect key="frame" x="52" y="11" width="58" height="21.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="bottom" secondItem="zex-gH-dgG" secondAttribute="bottom" constant="11.5" id="4o7-Dg-jJ3"/>
-                                                <constraint firstItem="zex-gH-dgG" firstAttribute="top" secondItem="d7i-Yp-ZNs" secondAttribute="top" constant="11" id="7Q5-CP-aiq"/>
-                                                <constraint firstItem="1zn-J3-bHH" firstAttribute="top" secondItem="d7i-Yp-ZNs" secondAttribute="top" constant="4" id="YOL-J5-fLB"/>
-                                                <constraint firstAttribute="bottom" secondItem="1zn-J3-bHH" secondAttribute="bottom" constant="5.5" id="cEf-Qe-fBE"/>
-                                                <constraint firstItem="1zn-J3-bHH" firstAttribute="width" secondItem="d7i-Yp-ZNs" secondAttribute="width" multiplier="2/3" id="qMu-31-2OL"/>
-                                                <constraint firstAttribute="trailing" secondItem="1zn-J3-bHH" secondAttribute="trailing" constant="20" symbolic="YES" id="vpQ-7f-Ead"/>
-                                                <constraint firstItem="1zn-J3-bHH" firstAttribute="leading" secondItem="zex-gH-dgG" secondAttribute="trailing" constant="8" symbolic="YES" id="zjT-dy-9IU"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="Grw-4P-tPF">
-                                        <rect key="frame" x="0.0" y="99" width="414" height="43.5"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Grw-4P-tPF" id="gIw-Xq-S9A">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="broken-waterfall-5" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="OME-Hr-SoK">
-                                                    <rect key="frame" x="118" y="4" width="276" height="34.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <textInputTraits key="textInputTraits"/>
-                                                </textField>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="User Id" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lh3-b2-zLt">
-                                                    <rect key="frame" x="55" y="11" width="55" height="21.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="bottom" secondItem="OME-Hr-SoK" secondAttribute="bottom" constant="5.5" id="CmS-So-bv5"/>
-                                                <constraint firstAttribute="bottom" secondItem="lh3-b2-zLt" secondAttribute="bottom" constant="11.5" id="RAy-pH-TOb"/>
-                                                <constraint firstAttribute="trailing" secondItem="OME-Hr-SoK" secondAttribute="trailing" constant="20" symbolic="YES" id="Zcf-08-JUA"/>
-                                                <constraint firstItem="OME-Hr-SoK" firstAttribute="top" secondItem="gIw-Xq-S9A" secondAttribute="top" constant="4" id="ehw-aK-VWo"/>
-                                                <constraint firstItem="lh3-b2-zLt" firstAttribute="top" secondItem="gIw-Xq-S9A" secondAttribute="top" constant="11" id="iEu-4D-ulY"/>
-                                                <constraint firstItem="OME-Hr-SoK" firstAttribute="width" secondItem="gIw-Xq-S9A" secondAttribute="width" multiplier="2/3" id="lK0-yk-aeI"/>
-                                                <constraint firstItem="OME-Hr-SoK" firstAttribute="leading" secondItem="lh3-b2-zLt" secondAttribute="trailing" constant="8" symbolic="YES" id="sNG-Wr-Su8"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="l8G-z1-86f">
-                                        <rect key="frame" x="0.0" y="142.5" width="414" height="43.5"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="l8G-z1-86f" id="W34-p7-1mf">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Broken Waterfall" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="YFW-le-5LN">
-                                                    <rect key="frame" x="118" y="4" width="276" height="34.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <textInputTraits key="textInputTraits"/>
-                                                </textField>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="User Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QPw-6K-Ffr">
-                                                    <rect key="frame" x="24" y="11" width="86" height="21.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="YFW-le-5LN" firstAttribute="leading" secondItem="QPw-6K-Ffr" secondAttribute="trailing" constant="8" symbolic="YES" id="CsK-qX-loz"/>
-                                                <constraint firstAttribute="trailing" secondItem="YFW-le-5LN" secondAttribute="trailing" constant="20" symbolic="YES" id="KXa-OK-1bh"/>
-                                                <constraint firstItem="YFW-le-5LN" firstAttribute="width" secondItem="W34-p7-1mf" secondAttribute="width" multiplier="2/3" id="LfY-H6-jNf"/>
-                                                <constraint firstAttribute="bottom" secondItem="QPw-6K-Ffr" secondAttribute="bottom" constant="11.5" id="ORX-34-h9c"/>
-                                                <constraint firstItem="YFW-le-5LN" firstAttribute="top" secondItem="W34-p7-1mf" secondAttribute="top" constant="4" id="bVL-XL-iMr"/>
-                                                <constraint firstAttribute="bottom" secondItem="YFW-le-5LN" secondAttribute="bottom" constant="5.5" id="it3-TN-FWd"/>
-                                                <constraint firstItem="QPw-6K-Ffr" firstAttribute="top" secondItem="W34-p7-1mf" secondAttribute="top" constant="11" id="wxs-65-XFt"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="qt3-Vc-sT5">
-                                        <rect key="frame" x="0.0" y="186" width="414" height="43.5"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qt3-Vc-sT5" id="XHM-4Z-Rin">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="OmY-AP-TuN">
-                                                    <rect key="frame" x="54.5" y="6" width="305" height="32.5"/>
-                                                    <segments>
-                                                        <segment title="Token"/>
-                                                        <segment title="Guest"/>
-                                                        <segment title="Development"/>
-                                                    </segments>
-                                                </segmentedControl>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="OmY-AP-TuN" firstAttribute="centerX" secondItem="XHM-4Z-Rin" secondAttribute="centerX" id="Eja-0s-8BP"/>
-                                                <constraint firstAttribute="bottom" secondItem="OmY-AP-TuN" secondAttribute="bottom" constant="6.5" id="Qvi-LI-uZq"/>
-                                                <constraint firstItem="OmY-AP-TuN" firstAttribute="top" secondItem="XHM-4Z-Rin" secondAttribute="top" constant="6" id="jBN-Pg-YES"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="tLc-Jq-1jE">
-                                        <rect key="frame" x="0.0" y="229.5" width="414" height="43.5"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tLc-Jq-1jE" id="Mnr-GI-rML">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.d1xKTlD_D0G-VsBoDBNbaLjO-2XWNA8rlTm4ru4sMHg" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="UwJ-fM-gmv">
-                                                    <rect key="frame" x="118" y="4" width="276" height="34.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <textInputTraits key="textInputTraits"/>
-                                                </textField>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="JWT" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zeo-7e-42P">
-                                                    <rect key="frame" x="74.5" y="11" width="35.5" height="21.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="bottom" secondItem="zeo-7e-42P" secondAttribute="bottom" constant="11.5" id="6cL-zh-fVq"/>
-                                                <constraint firstAttribute="trailing" secondItem="UwJ-fM-gmv" secondAttribute="trailing" constant="20" symbolic="YES" id="7eI-IK-Jyk"/>
-                                                <constraint firstItem="zeo-7e-42P" firstAttribute="top" secondItem="Mnr-GI-rML" secondAttribute="top" constant="11" id="DAH-0u-ppN"/>
-                                                <constraint firstItem="UwJ-fM-gmv" firstAttribute="leading" secondItem="zeo-7e-42P" secondAttribute="trailing" constant="8" symbolic="YES" id="JsB-uj-pvx"/>
-                                                <constraint firstItem="UwJ-fM-gmv" firstAttribute="top" secondItem="Mnr-GI-rML" secondAttribute="top" constant="4" id="KKy-7K-StF"/>
-                                                <constraint firstItem="UwJ-fM-gmv" firstAttribute="width" secondItem="Mnr-GI-rML" secondAttribute="width" multiplier="2/3" id="UxT-1P-OsN"/>
-                                                <constraint firstAttribute="bottom" secondItem="UwJ-fM-gmv" secondAttribute="bottom" constant="5.5" id="fAP-tw-RXC"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
                             <tableViewSection headerTitle="STREAM CHAT SAMPLES" id="uJ9-GW-DgN">
                                 <string key="footerTitle">These samples are built on top of StreamChat. It provides local database logic and API calls, but no UI components. Use StreamChat if you want to build a completely custom UI from scratch.</string>
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Dab-pb-Oad" style="IBUITableViewCellStyleDefault" id="UXl-OF-aT4">
-                                        <rect key="frame" x="0.0" y="340.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UXl-OF-aT4" id="wF5-QV-9Sk">
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
@@ -185,7 +38,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="CU2-fB-61Z" style="IBUITableViewCellStyleDefault" id="ROL-9U-3uT">
-                                        <rect key="frame" x="0.0" y="384" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="99" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ROL-9U-3uT" id="yiW-PX-gME">
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
@@ -202,7 +55,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="3da-4F-gdY" style="IBUITableViewCellStyleDefault" id="qqJ-q2-6Di">
-                                        <rect key="frame" x="0.0" y="427.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="142.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qqJ-q2-6Di" id="x7H-2o-hZ3">
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
@@ -224,7 +77,7 @@
                                 <string key="footerTitle">These samples are built on top of StreamChatUI. It provides UIKit components that run on top of StreamChat. Use StreamChatUI if you want a ready-made UI with some customizability options.</string>
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="vXx-3A-JmD" detailTextLabel="hXI-Sb-R1n" style="IBUITableViewCellStyleValue1" id="VTJ-un-u6c">
-                                        <rect key="frame" x="0.0" y="594.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="309.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="VTJ-un-u6c" id="x0s-2k-XiA">
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
@@ -248,7 +101,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Z05-VX-7G3" detailTextLabel="R4R-yM-JyU" style="IBUITableViewCellStyleValue1" id="o9Q-qi-bx4">
-                                        <rect key="frame" x="0.0" y="638" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="353" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="o9Q-qi-bx4" id="jee-hr-pe6">
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
@@ -272,7 +125,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="klX-fb-HOm" detailTextLabel="8ge-Ge-KvY" style="IBUITableViewCellStyleValue1" id="4AE-di-rGW">
-                                        <rect key="frame" x="0.0" y="681.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="396.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="4AE-di-rGW" id="295-qe-DjT">
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
@@ -297,64 +150,259 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection headerTitle="CONFIGURATION" id="YEq-FG-SEn">
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="dqB-UX-E5D" id="NUo-jP-fcc"/>
+                            <outlet property="delegate" destination="dqB-UX-E5D" id="Lkv-5b-Swj"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Samples" largeTitleDisplayMode="always" id="Ba1-TA-K7f">
+                        <barButtonItem key="rightBarButtonItem" title="Item" image="person" catalog="system" id="Hji-HJ-WFU">
+                            <connections>
+                                <segue destination="bWo-Jb-4W7" kind="presentation" id="mgl-1m-Lyb"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="swiftUICell" destination="qqJ-q2-6Di" id="hDj-Jk-A7I"/>
+                        <outlet property="uiKitAndCombineCell" destination="ROL-9U-3uT" id="udb-Vo-Cfz"/>
+                        <outlet property="uiKitAndDelegatesCell" destination="UXl-OF-aT4" id="59C-FP-kff"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="whq-Im-sGF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1513.0434782608697" y="87.723214285714278"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="qSf-ZL-c74">
+            <objects>
+                <navigationController id="bWo-Jb-4W7" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Cdp-Mn-ZIf">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="cRN-bf-0sE" kind="relationship" relationship="rootViewController" id="ofm-WP-K0y"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="3kK-dT-a7w" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-723" y="88"/>
+        </scene>
+        <!--Configuration-->
+        <scene sceneID="b7p-8L-jsY">
+            <objects>
+                <tableViewController id="cRN-bf-0sE" customClass="ConfigurationViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="KDK-8f-JRs">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <sections>
+                            <tableViewSection headerTitle="CREDENTIALS" footerTitle="" id="D0b-Dx-SOx">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="4w0-u9-Txz" style="IBUITableViewCellStyleDefault" id="O7K-8Y-mj4">
-                                        <rect key="frame" x="0.0" y="841" width="414" height="43.5"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="weR-r5-c7f">
+                                        <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="O7K-8Y-mj4" id="HTd-UD-6wR">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="weR-r5-c7f" id="Apz-zc-B47">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Is Local Storage Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="4w0-u9-Txz">
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="qk4nn7rpcn75" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="QxN-0T-C5N">
+                                                    <rect key="frame" x="118" y="4" width="276" height="34.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="API Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O9V-S5-Tu3">
+                                                    <rect key="frame" x="52" y="11" width="58" height="21.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="O9V-S5-Tu3" secondAttribute="bottom" constant="11.5" id="GiC-hu-jgI"/>
+                                                <constraint firstItem="QxN-0T-C5N" firstAttribute="width" secondItem="Apz-zc-B47" secondAttribute="width" multiplier="2/3" id="IkO-2V-KCJ"/>
+                                                <constraint firstItem="QxN-0T-C5N" firstAttribute="top" secondItem="Apz-zc-B47" secondAttribute="top" constant="4" id="OK6-5w-K2w"/>
+                                                <constraint firstItem="O9V-S5-Tu3" firstAttribute="top" secondItem="Apz-zc-B47" secondAttribute="top" constant="11" id="TVq-Fe-vwB"/>
+                                                <constraint firstItem="QxN-0T-C5N" firstAttribute="leading" secondItem="O9V-S5-Tu3" secondAttribute="trailing" constant="8" symbolic="YES" id="eJI-lD-53Z"/>
+                                                <constraint firstAttribute="trailing" secondItem="QxN-0T-C5N" secondAttribute="trailing" constant="20" symbolic="YES" id="kNs-ge-q4x"/>
+                                                <constraint firstAttribute="bottom" secondItem="QxN-0T-C5N" secondAttribute="bottom" constant="5.5" id="zXc-yn-RIo"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="w6b-WU-bQZ">
+                                        <rect key="frame" x="0.0" y="99" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="w6b-WU-bQZ" id="dsS-Gx-hSz">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="broken-waterfall-5" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="yOy-bA-WeZ">
+                                                    <rect key="frame" x="118" y="4" width="276" height="34.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="User Id" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g4c-z5-52n">
+                                                    <rect key="frame" x="55" y="11" width="55" height="21.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="yOy-bA-WeZ" secondAttribute="trailing" constant="20" symbolic="YES" id="279-li-QHd"/>
+                                                <constraint firstItem="g4c-z5-52n" firstAttribute="top" secondItem="dsS-Gx-hSz" secondAttribute="top" constant="11" id="Ae1-LS-491"/>
+                                                <constraint firstAttribute="bottom" secondItem="yOy-bA-WeZ" secondAttribute="bottom" constant="5.5" id="FEk-HN-Yb7"/>
+                                                <constraint firstItem="yOy-bA-WeZ" firstAttribute="width" secondItem="dsS-Gx-hSz" secondAttribute="width" multiplier="2/3" id="Jcd-R5-8sh"/>
+                                                <constraint firstAttribute="bottom" secondItem="g4c-z5-52n" secondAttribute="bottom" constant="11.5" id="OdK-5C-cxc"/>
+                                                <constraint firstItem="yOy-bA-WeZ" firstAttribute="leading" secondItem="g4c-z5-52n" secondAttribute="trailing" constant="8" symbolic="YES" id="tNF-tK-dTf"/>
+                                                <constraint firstItem="yOy-bA-WeZ" firstAttribute="top" secondItem="dsS-Gx-hSz" secondAttribute="top" constant="4" id="uFN-vM-95M"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="SQ1-dG-CdI">
+                                        <rect key="frame" x="0.0" y="142.5" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="SQ1-dG-CdI" id="liV-Q3-kAK">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Broken Waterfall" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="CKA-A2-xBI">
+                                                    <rect key="frame" x="118" y="4" width="276" height="34.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="User Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MD7-e5-EhG">
+                                                    <rect key="frame" x="24" y="11" width="86" height="21.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="MD7-e5-EhG" secondAttribute="bottom" constant="11.5" id="1Ol-Il-eOu"/>
+                                                <constraint firstItem="CKA-A2-xBI" firstAttribute="width" secondItem="liV-Q3-kAK" secondAttribute="width" multiplier="2/3" id="6u5-Kg-lLF"/>
+                                                <constraint firstAttribute="trailing" secondItem="CKA-A2-xBI" secondAttribute="trailing" constant="20" symbolic="YES" id="KOp-iF-A6g"/>
+                                                <constraint firstItem="CKA-A2-xBI" firstAttribute="top" secondItem="liV-Q3-kAK" secondAttribute="top" constant="4" id="LCj-0z-3Bq"/>
+                                                <constraint firstAttribute="bottom" secondItem="CKA-A2-xBI" secondAttribute="bottom" constant="5.5" id="gzY-eM-7bS"/>
+                                                <constraint firstItem="CKA-A2-xBI" firstAttribute="leading" secondItem="MD7-e5-EhG" secondAttribute="trailing" constant="8" symbolic="YES" id="uEO-uF-SwW"/>
+                                                <constraint firstItem="MD7-e5-EhG" firstAttribute="top" secondItem="liV-Q3-kAK" secondAttribute="top" constant="11" id="xUk-Xo-gas"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="fYE-c4-fd8">
+                                        <rect key="frame" x="0.0" y="186" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fYE-c4-fd8" id="lpc-3H-YSZ">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="dL6-um-wPW">
+                                                    <rect key="frame" x="54.5" y="6" width="305" height="32.5"/>
+                                                    <segments>
+                                                        <segment title="Token"/>
+                                                        <segment title="Guest"/>
+                                                        <segment title="Development"/>
+                                                    </segments>
+                                                </segmentedControl>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="dL6-um-wPW" secondAttribute="bottom" constant="6.5" id="Cgh-b8-3pB"/>
+                                                <constraint firstItem="dL6-um-wPW" firstAttribute="top" secondItem="lpc-3H-YSZ" secondAttribute="top" constant="6" id="MQi-CH-O5h"/>
+                                                <constraint firstItem="dL6-um-wPW" firstAttribute="centerX" secondItem="lpc-3H-YSZ" secondAttribute="centerX" id="iJF-8N-6Kr"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="iu6-eS-uFS">
+                                        <rect key="frame" x="0.0" y="229.5" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iu6-eS-uFS" id="9JF-D9-wDG">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.d1xKTlD_D0G-VsBoDBNbaLjO-2XWNA8rlTm4ru4sMHg" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="st4-0y-dXp">
+                                                    <rect key="frame" x="118" y="4" width="276" height="34.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="JWT" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c6J-OZ-Csy">
+                                                    <rect key="frame" x="74.5" y="11" width="35.5" height="21.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="c6J-OZ-Csy" firstAttribute="top" secondItem="9JF-D9-wDG" secondAttribute="top" constant="11" id="01W-Pw-kYb"/>
+                                                <constraint firstItem="st4-0y-dXp" firstAttribute="top" secondItem="9JF-D9-wDG" secondAttribute="top" constant="4" id="FyE-fj-T1k"/>
+                                                <constraint firstAttribute="bottom" secondItem="st4-0y-dXp" secondAttribute="bottom" constant="5.5" id="apA-Pz-6CN"/>
+                                                <constraint firstItem="st4-0y-dXp" firstAttribute="leading" secondItem="c6J-OZ-Csy" secondAttribute="trailing" constant="8" symbolic="YES" id="ceW-3U-k8H"/>
+                                                <constraint firstAttribute="bottom" secondItem="c6J-OZ-Csy" secondAttribute="bottom" constant="11.5" id="fVW-P2-g2L"/>
+                                                <constraint firstAttribute="trailing" secondItem="st4-0y-dXp" secondAttribute="trailing" constant="20" symbolic="YES" id="k1i-rl-dgt"/>
+                                                <constraint firstItem="st4-0y-dXp" firstAttribute="width" secondItem="9JF-D9-wDG" secondAttribute="width" multiplier="2/3" id="uBZ-uv-Xl5"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="CONFIGURATION" id="lhA-iK-qFK">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="mLR-jy-93e" style="IBUITableViewCellStyleDefault" id="MhY-Dl-4Sv">
+                                        <rect key="frame" x="0.0" y="333" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="MhY-Dl-4Sv" id="kny-nE-9zl">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Is Local Storage Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="mLR-jy-93e">
                                                     <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GrW-Y8-e7w">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IrL-0h-8la">
                                                     <rect key="frame" x="350" y="5.5" width="49" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 </switch>
                                             </subviews>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <outlet property="accessoryView" destination="GrW-Y8-e7w" id="23r-CU-BdF"/>
+                                            <outlet property="accessoryView" destination="IrL-0h-8la" id="gat-Rk-vVr"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="5xN-RP-adz" style="IBUITableViewCellStyleDefault" id="G6M-FD-pfS">
-                                        <rect key="frame" x="0.0" y="884.5" width="414" height="43.5"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="bQ8-mv-tQe" style="IBUITableViewCellStyleDefault" id="ZV4-XE-viS">
+                                        <rect key="frame" x="0.0" y="376.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="G6M-FD-pfS" id="TXU-GT-OsW">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZV4-XE-viS" id="4Zn-u9-OD3">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Flush Local Storage On Start" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="5xN-RP-adz">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Flush Local Storage On Start" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bQ8-mv-tQe">
                                                     <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="xNQ-S2-GHG">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="qlc-Kt-jPI">
                                                     <rect key="frame" x="350" y="6" width="49" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 </switch>
                                             </subviews>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <outlet property="accessoryView" destination="xNQ-S2-GHG" id="hn8-Fu-5XZ"/>
+                                            <outlet property="accessoryView" destination="qlc-Kt-jPI" id="tPi-TM-vZz"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="iNr-EL-HaW">
-                                        <rect key="frame" x="0.0" y="928" width="414" height="43.5"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="JjC-it-bYH">
+                                        <rect key="frame" x="0.0" y="420" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iNr-EL-HaW" id="0yv-6t-xoW">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="JjC-it-bYH" id="bAw-wZ-LOg">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="bxQ-EB-Eqp">
+                                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="1oS-LE-iTH">
                                                     <rect key="frame" x="43.5" y="6" width="327" height="32.5"/>
                                                     <segments>
                                                         <segment title="U.S East"/>
@@ -365,9 +413,9 @@
                                                 </segmentedControl>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="bxQ-EB-Eqp" firstAttribute="top" secondItem="0yv-6t-xoW" secondAttribute="top" constant="6" id="Qlg-4G-zod"/>
-                                                <constraint firstAttribute="bottom" secondItem="bxQ-EB-Eqp" secondAttribute="bottom" constant="6.5" id="Xaj-WO-NLP"/>
-                                                <constraint firstItem="bxQ-EB-Eqp" firstAttribute="centerX" secondItem="0yv-6t-xoW" secondAttribute="centerX" id="qxO-4V-Ufp"/>
+                                                <constraint firstItem="1oS-LE-iTH" firstAttribute="centerX" secondItem="bAw-wZ-LOg" secondAttribute="centerX" id="4F7-Za-Aap"/>
+                                                <constraint firstAttribute="bottom" secondItem="1oS-LE-iTH" secondAttribute="bottom" constant="6.5" id="MaE-wu-Dc8"/>
+                                                <constraint firstItem="1oS-LE-iTH" firstAttribute="top" secondItem="bAw-wZ-LOg" secondAttribute="top" constant="6" id="aBX-um-ojc"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -375,35 +423,39 @@
                             </tableViewSection>
                         </sections>
                         <connections>
-                            <outlet property="dataSource" destination="dqB-UX-E5D" id="NUo-jP-fcc"/>
-                            <outlet property="delegate" destination="dqB-UX-E5D" id="Lkv-5b-Swj"/>
+                            <outlet property="dataSource" destination="cRN-bf-0sE" id="eat-Od-KGh"/>
+                            <outlet property="delegate" destination="cRN-bf-0sE" id="kvo-Mp-Upo"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Login" largeTitleDisplayMode="always" id="Ba1-TA-K7f">
-                        <barButtonItem key="rightBarButtonItem" systemItem="refresh" id="7V9-hH-avZ">
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" title="Configuration" id="ZUk-cy-K4T">
+                        <barButtonItem key="leftBarButtonItem" style="done" systemItem="done" id="FpN-wz-Xvg">
                             <connections>
-                                <action selector="randomUserPressed:" destination="dqB-UX-E5D" id="DsR-Ga-XVo"/>
+                                <action selector="donePressed:" destination="cRN-bf-0sE" id="5Pp-ET-371"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" systemItem="refresh" id="Xds-YX-lR2">
+                            <connections>
+                                <action selector="randomUserPressed:" destination="cRN-bf-0sE" id="YoX-Li-29b"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="apiKeyTextField" destination="1zn-J3-bHH" id="8CD-yJ-FV0"/>
-                        <outlet property="flushLocalStorageSwitch" destination="xNQ-S2-GHG" id="Wub-FF-nVv"/>
-                        <outlet property="jwtCell" destination="tLc-Jq-1jE" id="SUa-Og-FT3"/>
-                        <outlet property="jwtTextField" destination="UwJ-fM-gmv" id="CSh-S4-QOK"/>
-                        <outlet property="localStorageEnabledSwitch" destination="GrW-Y8-e7w" id="bfb-gU-uz4"/>
-                        <outlet property="regionSegmentedControl" destination="bxQ-EB-Eqp" id="RW4-eQ-Tua"/>
-                        <outlet property="swiftUICell" destination="qqJ-q2-6Di" id="hDj-Jk-A7I"/>
-                        <outlet property="tokenTypeSegmentedControl" destination="OmY-AP-TuN" id="fPj-Q3-NVV"/>
-                        <outlet property="uiKitAndCombineCell" destination="ROL-9U-3uT" id="udb-Vo-Cfz"/>
-                        <outlet property="uiKitAndDelegatesCell" destination="UXl-OF-aT4" id="59C-FP-kff"/>
-                        <outlet property="userIdTextField" destination="OME-Hr-SoK" id="9nN-hT-VVp"/>
-                        <outlet property="userNameTextField" destination="YFW-le-5LN" id="FFr-qg-rEv"/>
+                        <outlet property="apiKeyTextField" destination="QxN-0T-C5N" id="x6X-UY-XKi"/>
+                        <outlet property="flushLocalStorageSwitch" destination="qlc-Kt-jPI" id="sKb-6x-iz5"/>
+                        <outlet property="jwtCell" destination="iu6-eS-uFS" id="3UT-Pi-gvo"/>
+                        <outlet property="jwtTextField" destination="st4-0y-dXp" id="Css-rk-Myt"/>
+                        <outlet property="localStorageEnabledSwitch" destination="IrL-0h-8la" id="oSz-z1-6AR"/>
+                        <outlet property="regionSegmentedControl" destination="1oS-LE-iTH" id="f6d-Ri-9AA"/>
+                        <outlet property="tokenTypeSegmentedControl" destination="dL6-um-wPW" id="62v-dI-cPA"/>
+                        <outlet property="userIdTextField" destination="yOy-bA-WeZ" id="yyj-yr-flu"/>
+                        <outlet property="userNameTextField" destination="CKA-A2-xBI" id="p2y-5t-u2h"/>
                     </connections>
                 </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="whq-Im-sGF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="qpo-B4-Scu" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-1513.0434782608697" y="87.723214285714278"/>
+            <point key="canvasLocation" x="52" y="88"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="qGL-We-3WZ">
@@ -425,6 +477,7 @@
         </scene>
     </scenes>
     <resources>
+        <image name="person" catalog="system" width="128" height="117"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Sample_v3/Configuration.swift
+++ b/Sample_v3/Configuration.swift
@@ -6,51 +6,74 @@ import Foundation
 import StreamChatClient
 
 struct Configuration {
+    struct PersistenceKeys {
+        static let apiKey = "apiKey"
+        static let userId = "userId"
+        static let userName = "userName"
+        static let baseURL = "baseURL"
+        static let token = "token"
+        static let isLocalStorageEnabled = "isLocalStorageEnabled"
+        static let shouldFlushLocalStorageOnStart = "shouldFlushLocalStorageOnStart"
+    }
+    
+    struct DefaultValues {
+        static let apiKey = "qk4nn7rpcn75"
+        static let userId = "broken-waterfall-5"
+        static let userName = "Broken Waterfall"
+        static let baseURL = BaseURL.usEast
+        static let token =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.d1xKTlD_D0G-VsBoDBNbaLjO-2XWNA8rlTm4ru4sMHg"
+        static let isLocalStorageEnabled = true
+        static let shouldFlushLocalStorageOnStart = false
+    }
+    
     static var apiKey: String {
-        get { UserDefaults.standard.string(forKey: "apiKey") ?? "qk4nn7rpcn75" }
-        set { UserDefaults.standard.setValue(newValue, forKey: "apiKey") }
+        get { UserDefaults.standard.string(forKey: PersistenceKeys.apiKey) ?? DefaultValues.apiKey }
+        set { UserDefaults.standard.setValue(newValue, forKey: PersistenceKeys.apiKey) }
     }
     
     static var userId: String {
-        get { UserDefaults.standard.string(forKey: "userId") ?? "broken-waterfall-5" }
-        set { UserDefaults.standard.setValue(newValue, forKey: "userId") }
+        get { UserDefaults.standard.string(forKey: PersistenceKeys.userId) ?? DefaultValues.userId }
+        set { UserDefaults.standard.setValue(newValue, forKey: PersistenceKeys.userId) }
     }
     
     static var userName: String {
-        get { UserDefaults.standard.string(forKey: "userName") ?? "Broken Waterfall" }
-        set { UserDefaults.standard.setValue(newValue, forKey: "userName") }
+        get { UserDefaults.standard.string(forKey: PersistenceKeys.userName) ?? DefaultValues.userName }
+        set { UserDefaults.standard.setValue(newValue, forKey: PersistenceKeys.userName) }
     }
     
     static var baseURL: BaseURL {
         get {
             guard
-                let string = UserDefaults.standard.string(forKey: "baseURL"),
+                let string = UserDefaults.standard.string(forKey: PersistenceKeys.baseURL),
                 let url = URL(string: string)
             else {
-                return .usEast
+                return DefaultValues.baseURL
             }
             
             return BaseURL(url: url)
         }
-        set { UserDefaults.standard.setValue(newValue.description, forKey: "baseURL") }
+        set { UserDefaults.standard.setValue(newValue.description, forKey: PersistenceKeys.baseURL) }
     }
 
     static var token: Token? {
-        get {
-            UserDefaults.standard
-                .string(forKey: "token") ??
-                "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.d1xKTlD_D0G-VsBoDBNbaLjO-2XWNA8rlTm4ru4sMHg"
-        }
-        set { UserDefaults.standard.setValue(newValue, forKey: "token") }
+        get { UserDefaults.standard.string(forKey: "token") ?? DefaultValues.token }
+        set { UserDefaults.standard.setValue(newValue, forKey: PersistenceKeys.token) }
     }
     
     static var isLocalStorageEnabled: Bool {
-        get { UserDefaults.standard.value(forKey: "isLocalStorageEnabled") as? Bool ?? true }
-        set { UserDefaults.standard.setValue(newValue, forKey: "isLocalStorageEnabled") }
+        get {
+            UserDefaults.standard.value(forKey: PersistenceKeys.isLocalStorageEnabled) as? Bool ?? DefaultValues
+                .isLocalStorageEnabled
+        }
+        set { UserDefaults.standard.setValue(newValue, forKey: PersistenceKeys.isLocalStorageEnabled) }
     }
     
     static var shouldFlushLocalStorageOnStart: Bool {
-        get { UserDefaults.standard.value(forKey: "shouldFlushLocalStorageOnStart") as? Bool ?? false }
-        set { UserDefaults.standard.setValue(newValue, forKey: "shouldFlushLocalStorageOnStart") }
+        get {
+            UserDefaults.standard.value(forKey: PersistenceKeys.shouldFlushLocalStorageOnStart) as? Bool ?? DefaultValues
+                .shouldFlushLocalStorageOnStart
+        }
+        set { UserDefaults.standard.setValue(newValue, forKey: PersistenceKeys.shouldFlushLocalStorageOnStart) }
     }
 }

--- a/Sample_v3/Configuration.swift
+++ b/Sample_v3/Configuration.swift
@@ -1,0 +1,56 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamChatClient
+
+struct Configuration {
+    static var apiKey: String {
+        get { UserDefaults.standard.string(forKey: "apiKey") ?? "qk4nn7rpcn75" }
+        set { UserDefaults.standard.setValue(newValue, forKey: "apiKey") }
+    }
+    
+    static var userId: String {
+        get { UserDefaults.standard.string(forKey: "userId") ?? "broken-waterfall-5" }
+        set { UserDefaults.standard.setValue(newValue, forKey: "userId") }
+    }
+    
+    static var userName: String {
+        get { UserDefaults.standard.string(forKey: "userName") ?? "Broken Waterfall" }
+        set { UserDefaults.standard.setValue(newValue, forKey: "userName") }
+    }
+    
+    static var baseURL: BaseURL {
+        get {
+            guard
+                let string = UserDefaults.standard.string(forKey: "baseURL"),
+                let url = URL(string: string)
+            else {
+                return .usEast
+            }
+            
+            return BaseURL(url: url)
+        }
+        set { UserDefaults.standard.setValue(newValue.description, forKey: "baseURL") }
+    }
+
+    static var token: Token? {
+        get {
+            UserDefaults.standard
+                .string(forKey: "token") ??
+                "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.d1xKTlD_D0G-VsBoDBNbaLjO-2XWNA8rlTm4ru4sMHg"
+        }
+        set { UserDefaults.standard.setValue(newValue, forKey: "token") }
+    }
+    
+    static var isLocalStorageEnabled: Bool {
+        get { UserDefaults.standard.value(forKey: "isLocalStorageEnabled") as? Bool ?? true }
+        set { UserDefaults.standard.setValue(newValue, forKey: "isLocalStorageEnabled") }
+    }
+    
+    static var shouldFlushLocalStorageOnStart: Bool {
+        get { UserDefaults.standard.value(forKey: "shouldFlushLocalStorageOnStart") as? Bool ?? false }
+        set { UserDefaults.standard.setValue(newValue, forKey: "shouldFlushLocalStorageOnStart") }
+    }
+}

--- a/Sample_v3/ConfigurationViewController.swift
+++ b/Sample_v3/ConfigurationViewController.swift
@@ -1,0 +1,194 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import StreamChatClient
+import UIKit
+
+class ConfigurationViewController: UITableViewController {
+    @IBOutlet var jwtCell: UITableViewCell!
+    
+    @IBOutlet var apiKeyTextField: UITextField!
+    @IBOutlet var userIdTextField: UITextField!
+    @IBOutlet var userNameTextField: UITextField!
+    @IBOutlet var jwtTextField: UITextField!
+    
+    @IBOutlet var tokenTypeSegmentedControl: UISegmentedControl!
+    @IBOutlet var regionSegmentedControl: UISegmentedControl!
+
+    @IBOutlet var localStorageEnabledSwitch: UISwitch!
+    @IBOutlet var flushLocalStorageSwitch: UISwitch!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tokenTypeSegmentedControl.addTarget(self, action: #selector(tokenTypeSegmentedControlDidChangeValue), for: .valueChanged)
+    }
+    
+    @objc func tokenTypeSegmentedControlDidChangeValue() {
+        tableView.beginUpdates()
+        tableView.endUpdates()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        apiKey = Configuration.apiKey
+        userId = Configuration.userId
+        userName = Configuration.userName
+        baseURL = Configuration.baseURL
+        token = Configuration.token
+        isLocalStorageEnabled = Configuration.isLocalStorageEnabled
+        shouldFlushLocalStorageOnStart = Configuration.shouldFlushLocalStorageOnStart
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        Configuration.apiKey = apiKey
+        Configuration.userId = userId
+        Configuration.userName = userName
+        Configuration.baseURL = baseURL
+        Configuration.token = token
+        Configuration.isLocalStorageEnabled = isLocalStorageEnabled
+        Configuration.shouldFlushLocalStorageOnStart = shouldFlushLocalStorageOnStart
+    }
+    
+    @IBAction func randomUserPressed(_ sender: Any) {
+        let users = [
+            (
+                name: "Broken Waterfall",
+                id: "broken-waterfall-5",
+                jwt: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.d1xKTlD_D0G-VsBoDBNbaLjO-2XWNA8rlTm4ru4sMHg"
+            ),
+            (
+                name: "Suspicious Coyote",
+                id: "suspicious-coyote-3",
+                jwt: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoic3VzcGljaW91cy1jb3lvdGUtMyJ9.xVaBHFTexlYPEymPmlgIYCM5M_iQVHrygaGS1QhkaEE"
+            ),
+            (
+                name: "Steep Moon",
+                id: "steep-moon-9",
+                jwt: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoic3RlZXAtbW9vbi05In0.xwGjOwnTy3r4o2owevNTyzZLWMsMh_bK7e5s1OQ2zXU"
+            )
+        ]
+        
+        if let user = users.randomElement() {
+            userId = user.id
+            userName = user.name
+            token = user.jwt
+        }
+    }
+    
+    @IBAction func donePressed(_ sender: Any) {
+        dismiss(animated: true)
+    }
+}
+
+// MARK: - UITableView
+
+extension ConfigurationViewController {
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        switch tableView.cellForRow(at: indexPath) {
+        case jwtCell:
+            return heightForJwtCell()
+        default:
+            return super.tableView(tableView, heightForRowAt: indexPath)
+        }
+    }
+    
+    func heightForJwtCell() -> CGFloat {
+        if tokenTypeSegmentedControl.selectedSegmentIndex != 0 {
+            return 0
+        } else {
+            return jwtCell.intrinsicContentSize.height
+        }
+    }
+}
+
+// MARK: - Inputs
+
+extension ConfigurationViewController {
+    var apiKey: String {
+        get { apiKeyTextField.text ?? "" }
+        set { apiKeyTextField.text = newValue }
+    }
+    
+    var userId: String {
+        get { userIdTextField.text ?? "" }
+        set { userIdTextField.text = newValue }
+    }
+    
+    var userName: String {
+        get { userNameTextField.text ?? "" }
+        set { userNameTextField.text = newValue }
+    }
+    
+    var baseURL: BaseURL {
+        get {
+            switch regionSegmentedControl.selectedSegmentIndex {
+            case 0:
+                return .usEast
+            case 1:
+                return .dublin
+            case 2:
+                return .singapore
+            case 3:
+                return .sydney
+            default:
+                fatalError("Segmented Control out of bounds")
+            }
+        }
+        
+        set {
+            switch newValue.description {
+            case BaseURL.usEast.description:
+                regionSegmentedControl.selectedSegmentIndex = 0
+            case BaseURL.dublin.description:
+                regionSegmentedControl.selectedSegmentIndex = 1
+            case BaseURL.singapore.description:
+                regionSegmentedControl.selectedSegmentIndex = 2
+            case BaseURL.sydney.description:
+                regionSegmentedControl.selectedSegmentIndex = 3
+            default:
+                fatalError("Unknown BaseURL")
+            }
+        }
+    }
+
+    var token: Token? {
+        get {
+            switch tokenTypeSegmentedControl.selectedSegmentIndex {
+            case 0:
+                return jwtTextField.text ?? ""
+            case 1:
+                return nil
+            case 2:
+                return .development
+            default:
+                fatalError("Segmented Control out of bounds")
+            }
+        }
+        
+        set {
+            switch newValue {
+            case nil:
+                tokenTypeSegmentedControl.selectedSegmentIndex = 1
+            case Token.development:
+                tokenTypeSegmentedControl.selectedSegmentIndex = 2
+            default:
+                tokenTypeSegmentedControl.selectedSegmentIndex = 0
+            }
+            
+            tableView.beginUpdates()
+            tableView.endUpdates()
+        }
+    }
+    
+    var isLocalStorageEnabled: Bool {
+        get { localStorageEnabledSwitch.isOn }
+        set { localStorageEnabledSwitch.setOn(newValue, animated: false) }
+    }
+    
+    var shouldFlushLocalStorageOnStart: Bool {
+        get { flushLocalStorageSwitch.isOn }
+        set { flushLocalStorageSwitch.setOn(newValue, animated: false) }
+    }
+}

--- a/Sample_v3/ConfigurationViewController.swift
+++ b/Sample_v3/ConfigurationViewController.swift
@@ -175,6 +175,7 @@ extension ConfigurationViewController {
                 tokenTypeSegmentedControl.selectedSegmentIndex = 2
             default:
                 tokenTypeSegmentedControl.selectedSegmentIndex = 0
+                jwtTextField.text = newValue
             }
             
             tableView.beginUpdates()

--- a/Sample_v3/LoginViewController.swift
+++ b/Sample_v3/LoginViewController.swift
@@ -8,32 +8,20 @@ import UIKit
 import StreamChatClient
 
 class LoginViewController: UITableViewController {
-    @IBOutlet var tokenTypeSegmentedControl: UISegmentedControl!
-    @IBOutlet var jwtCell: UITableViewCell!
-    @IBOutlet var apiKeyTextField: UITextField!
-    @IBOutlet var userIdTextField: UITextField!
-    @IBOutlet var userNameTextField: UITextField!
-    @IBOutlet var jwtTextField: UITextField!
-    
-    @IBOutlet var regionSegmentedControl: UISegmentedControl!
-    @IBOutlet var localStorageEnabledSwitch: UISwitch!
-    @IBOutlet var flushLocalStorageSwitch: UISwitch!
-    
     @IBOutlet var uiKitAndDelegatesCell: UITableViewCell!
     @IBOutlet var uiKitAndCombineCell: UITableViewCell!
     @IBOutlet var swiftUICell: UITableViewCell!
     
     func logIn() -> ChatClient {
-        var config = ChatClientConfig(apiKey: APIKey(apiKey))
-        
-        config.isLocalStorageEnabled = localStorageEnabledSwitch.isOn
-        config.shouldFlushLocalStorageOnStart = flushLocalStorageSwitch.isOn
-        config.baseURL = baseURL
+        var config = ChatClientConfig(apiKey: APIKey(Configuration.apiKey))
+        config.isLocalStorageEnabled = Configuration.isLocalStorageEnabled
+        config.shouldFlushLocalStorageOnStart = Configuration.shouldFlushLocalStorageOnStart
+        config.baseURL = Configuration.baseURL
         
         let chatClient = ChatClient(config: config)
         
         let currentUserController = chatClient.currentUserController()
-        let extraData = NameAndImageExtraData(name: userName, imageURL: nil)
+        let extraData = NameAndImageExtraData(name: Configuration.userName, imageURL: nil)
         
         func setUserCompletion(_ error: Error?) {
             guard let error = error else { return }
@@ -46,81 +34,22 @@ class LoginViewController: UITableViewController {
             }
         }
         
-        if let token = token {
+        if let token = Configuration.token {
             currentUserController.setUser(
-                userId: userId,
+                userId: Configuration.userId,
                 userExtraData: extraData,
                 token: token,
                 completion: setUserCompletion
             )
         } else {
             currentUserController.setGuestUser(
-                userId: userId,
+                userId: Configuration.userId,
                 extraData: extraData,
                 completion: setUserCompletion
             )
         }
         
         return chatClient
-    }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        tokenTypeSegmentedControl.addTarget(self, action: #selector(tokenTypeSegmentedControlDidChangeValue), for: .valueChanged)
-    }
-    
-    @objc
-    func tokenTypeSegmentedControlDidChangeValue() {
-        tableView.beginUpdates()
-        tableView.endUpdates()
-    }
-
-    @IBAction func randomUserPressed(_ sender: Any) {
-        let users = [
-            (
-                name: "Broken Waterfall",
-                id: "broken-waterfall-5",
-                jwt: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.d1xKTlD_D0G-VsBoDBNbaLjO-2XWNA8rlTm4ru4sMHg"
-            ),
-            (
-                name: "Suspicious Coyote",
-                id: "suspicious-coyote-3",
-                jwt: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoic3VzcGljaW91cy1jb3lvdGUtMyJ9.xVaBHFTexlYPEymPmlgIYCM5M_iQVHrygaGS1QhkaEE"
-            ),
-            (
-                name: "Steep Moon",
-                id: "steep-moon-9",
-                jwt: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoic3RlZXAtbW9vbi05In0.xwGjOwnTy3r4o2owevNTyzZLWMsMh_bK7e5s1OQ2zXU"
-            )
-        ]
-        
-        if let user = users.randomElement() {
-            userIdTextField.text = user.id
-            userNameTextField.text = user.name
-            jwtTextField.text = user.jwt
-        }
-    }
-}
-
-// MARK: - UITableView
-
-extension LoginViewController {
-    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        switch tableView.cellForRow(at: indexPath) {
-        case jwtCell:
-            return heightForJwtCell()
-        default:
-            return super.tableView(tableView, heightForRowAt: indexPath)
-        }
-    }
-    
-    func heightForJwtCell() -> CGFloat {
-        if tokenTypeSegmentedControl.selectedSegmentIndex != 0 {
-            return 0
-        } else {
-            return jwtCell.intrinsicContentSize.height
-        }
     }
 }
 
@@ -129,8 +58,6 @@ extension LoginViewController {
 extension LoginViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        
-        guard indexPath.section == 1 else { return }
 
         let chatClient = logIn()
         
@@ -195,50 +122,6 @@ extension LoginViewController {
             }
         default:
             return
-        }
-    }
-}
-
-// MARK: - Inputs
-
-extension LoginViewController {
-    var apiKey: String {
-        apiKeyTextField.text ?? ""
-    }
-    
-    var userId: String {
-        userIdTextField.text ?? ""
-    }
-    
-    var userName: String {
-        userNameTextField.text ?? ""
-    }
-    
-    var baseURL: BaseURL {
-        switch regionSegmentedControl.selectedSegmentIndex {
-        case 0:
-            return .usEast
-        case 1:
-            return .dublin
-        case 2:
-            return .singapore
-        case 3:
-            return .sydney
-        default:
-            fatalError("Segmented Control out of bounds")
-        }
-    }
-
-    var token: Token? {
-        switch tokenTypeSegmentedControl.selectedSegmentIndex {
-        case 0:
-            return jwtTextField.text ?? ""
-        case 1:
-            return nil
-        case 2:
-            return .development
-        default:
-            fatalError("Segmented Control out of bounds")
         }
     }
 }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -192,6 +192,8 @@
 		8008C1A024F8517000F5BCCE /* UITableViewController+KeyboardAvoidance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8008C19E24F84DB600F5BCCE /* UITableViewController+KeyboardAvoidance.swift */; };
 		8040BC5E24FDAB1E00DE369F /* UIColor+ForUsername.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8040BC5C24FDA9B200DE369F /* UIColor+ForUsername.swift */; };
 		8040BC6124FDD5EA00DE369F /* SplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8040BC5F24FDD58700DE369F /* SplitViewController.swift */; };
+		80437AA3252E519E000920A3 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80437A9F252E4E87000920A3 /* Configuration.swift */; };
+		80437AA7252E51E8000920A3 /* ConfigurationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80437A9C252E0792000920A3 /* ConfigurationViewController.swift */; };
 		804B126924E6C820002B00EA /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804B126724E6C80B002B00EA /* LoginViewController.swift */; };
 		804B127124E712F1002B00EA /* SimpleChannelsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F28247FF01800EAF71D /* SimpleChannelsViewController.swift */; };
 		804B127224E712F5002B00EA /* SimpleChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F2A247FF01800EAF71D /* SimpleChatViewController.swift */; };
@@ -624,6 +626,8 @@
 		8008C19E24F84DB600F5BCCE /* UITableViewController+KeyboardAvoidance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewController+KeyboardAvoidance.swift"; sourceTree = "<group>"; };
 		8040BC5C24FDA9B200DE369F /* UIColor+ForUsername.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+ForUsername.swift"; sourceTree = "<group>"; };
 		8040BC5F24FDD58700DE369F /* SplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewController.swift; sourceTree = "<group>"; };
+		80437A9C252E0792000920A3 /* ConfigurationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationViewController.swift; sourceTree = "<group>"; };
+		80437A9F252E4E87000920A3 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		804B126724E6C80B002B00EA /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		804B126B24E712C2002B00EA /* SimpleChat.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SimpleChat.storyboard; sourceTree = "<group>"; };
 		804B127424ED596C002B00EA /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
@@ -995,9 +999,11 @@
 			children = (
 				792A4F24247FF01800EAF71D /* AppDelegate.swift */,
 				8008C18824EEB8BD00F5BCCE /* LogStore.swift */,
+				80437A9F252E4E87000920A3 /* Configuration.swift */,
 				792A4F26247FF01800EAF71D /* SceneDelegate.swift */,
 				792A4F2C247FF01800EAF71D /* Main.storyboard */,
 				804B126724E6C80B002B00EA /* LoginViewController.swift */,
+				80437A9C252E0792000920A3 /* ConfigurationViewController.swift */,
 				8008C17E24ED647900F5BCCE /* Extensions */,
 				804B126D24E712CC002B00EA /* Samples */,
 				792A4F2F247FF01900EAF71D /* Assets.xcassets */,
@@ -1959,12 +1965,14 @@
 			files = (
 				804B127124E712F1002B00EA /* SimpleChannelsViewController.swift in Sources */,
 				DAD8A8A42507E1C400D05282 /* CombineSimpleChannelsViewController.swift in Sources */,
+				80437AA3252E519E000920A3 /* Configuration.swift in Sources */,
 				804B126924E6C820002B00EA /* LoginViewController.swift in Sources */,
 				8008C19D24F7EF2400F5BCCE /* ChannelListView.swift in Sources */,
 				8008C1A024F8517000F5BCCE /* UITableViewController+KeyboardAvoidance.swift in Sources */,
 				8008C18A24EEB8CA00F5BCCE /* LogStore.swift in Sources */,
 				8040BC6124FDD5EA00DE369F /* SplitViewController.swift in Sources */,
 				8008C18424ED65AB00F5BCCE /* UIStoryboard+Definitions.swift in Sources */,
+				80437AA7252E51E8000920A3 /* ConfigurationViewController.swift in Sources */,
 				8008C19C24F7EF1F00F5BCCE /* ChatView.swift in Sources */,
 				804B127524ED596C002B00EA /* SettingsViewController.swift in Sources */,
 				792A4F25247FF01800EAF71D /* AppDelegate.swift in Sources */,


### PR DESCRIPTION
This PR separates the credentials and other configuration from the first screen into a new modal screen. It also persists these parameters in UserDefaults.

<img width="1072" alt="Screen Shot 2020-10-07 at 21 03 27" src="https://user-images.githubusercontent.com/5606812/95400838-0daced80-08e2-11eb-8938-2c0ac413282d.png">

#no_changelog
