### PR TITLE
[CIS-386] Member list controller

### DIFF
--- a/Sources_v3/Controllers/EntityDatabaseObserver.swift
+++ b/Sources_v3/Controllers/EntityDatabaseObserver.swift
@@ -33,7 +33,7 @@ extension EntityChange: CustomStringConvertible {
 
 extension EntityChange {
     /// Returns the underlaying item that was changed
-    public var item: Item {
+    var item: Item {
         switch self {
         case let .create(item):
             return item

--- a/Sources_v3/Controllers/ListDatabaseObserver.swift
+++ b/Sources_v3/Controllers/ListDatabaseObserver.swift
@@ -35,6 +35,37 @@ extension ListChange: CustomStringConvertible {
     }
 }
 
+extension ListChange {
+    /// Returns the underlaying item that was changed.
+    var item: Item {
+        switch self {
+        case let .insert(item, _):
+            return item
+        case let .move(item, _, _):
+            return item
+        case let .remove(item, _):
+            return item
+        case let .update(item, _):
+            return item
+        }
+    }
+    
+    /// Returns `ListChange` of the same type but for the specific `Item` field.
+    func fieldChange<Value>(_ path: KeyPath<Item, Value>) -> ListChange<Value> {
+        let field = item[keyPath: path]
+        switch self {
+        case let .insert(_, at):
+            return .insert(field, index: at)
+        case let .move(_, from, to):
+            return .move(field, fromIndex: from, toIndex: to)
+        case let .remove(_, at):
+            return .remove(field, index: at)
+        case let .update(_, at):
+            return .update(field, index: at)
+        }
+    }
+}
+
 extension ListChange: Equatable where Item: Equatable {}
 
 /// Observes changes of the list of items specified using an `NSFetchRequest`in the provided `NSManagedObjectContext`.

--- a/Sources_v3/Controllers/ListDatabaseObserver_Mock.swift
+++ b/Sources_v3/Controllers/ListDatabaseObserver_Mock.swift
@@ -1,0 +1,19 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChatClient
+import XCTest
+
+final class ListDatabaseObserverMock<Item, DTO: NSManagedObject>: ListDatabaseObserver<Item, DTO> {
+    var synchronizeError: Error?
+    
+    override func startObserving() throws {
+        if let error = synchronizeError {
+            throw error
+        } else {
+            try super.startObserving()
+        }
+    }
+}

--- a/Sources_v3/Controllers/ListDatabaseObserver_Tests.swift
+++ b/Sources_v3/Controllers/ListDatabaseObserver_Tests.swift
@@ -32,6 +32,52 @@ final class ListChange_Tests: XCTestCase {
             XCTAssertEqual(change.description, description)
         }
     }
+    
+    func test_item() {
+        let insertedItem: String = .unique
+        let updatedItem: String = .unique
+        let removedItem: String = .unique
+        let movedItem: String = .unique
+
+        XCTAssertEqual(ListChange.insert(insertedItem, index: [0, 0]).item, insertedItem)
+        XCTAssertEqual(ListChange.update(updatedItem, index: [0, 0]).item, updatedItem)
+        XCTAssertEqual(ListChange.remove(removedItem, index: [0, 0]).item, removedItem)
+        XCTAssertEqual(ListChange.move(movedItem, fromIndex: [0, 0], toIndex: [0, 1]).item, movedItem)
+    }
+    
+    func test_fieldChange() {
+        let insertedItem: MemberPayload<DefaultExtraData.User> = .dummy()
+        let insertedAt = IndexPath(row: 1, section: 1)
+
+        let updatedItem: MemberPayload<DefaultExtraData.User> = .dummy()
+        let updatedAt = IndexPath(row: 2, section: 3)
+
+        let removedItem: MemberPayload<DefaultExtraData.User> = .dummy()
+        let removedAt = IndexPath(row: 3, section: 4)
+
+        let movedItem: MemberPayload<DefaultExtraData.User> = .dummy()
+        let movedFrom = IndexPath(row: 5, section: 6)
+        let movedTo = IndexPath(row: 7, section: 8)
+
+        let path = \MemberPayload<DefaultExtraData.User>.user.id
+
+        XCTAssertEqual(
+            ListChange.insert(insertedItem, index: insertedAt).fieldChange(path),
+            .insert(insertedItem.user.id, index: insertedAt)
+        )
+        XCTAssertEqual(
+            ListChange.update(updatedItem, index: updatedAt).fieldChange(path),
+            .update(updatedItem.user.id, index: updatedAt)
+        )
+        XCTAssertEqual(
+            ListChange.remove(removedItem, index: removedAt).fieldChange(path),
+            .remove(removedItem.user.id, index: removedAt)
+        )
+        XCTAssertEqual(
+            ListChange.move(movedItem, fromIndex: movedFrom, toIndex: movedTo).fieldChange(path),
+            .move(movedItem.user.id, fromIndex: movedFrom, toIndex: movedTo)
+        )
+    }
 }
 
 class ListDatabaseObserver_Tests: XCTestCase {

--- a/Sources_v3/Controllers/MemberListController/MemberListController.swift
+++ b/Sources_v3/Controllers/MemberListController/MemberListController.swift
@@ -1,0 +1,305 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+extension _ChatClient {
+    /// Creates a new `_ChatChannelMemberListController` with the provided query.
+    /// - Parameter query: The query specify the filter and sorting options for members the controller should fetch.
+    /// - Returns: A new instance of `_ChatChannelMemberListController`.
+    public func memberListController(query: ChannelMemberListQuery) -> _ChatChannelMemberListController<ExtraData> {
+        .init(query: query, client: self)
+    }
+}
+
+/// `_ChatChannelMemberListController` is a controller class which allows observing a list of
+/// channel members based on the provided query.
+///
+/// Learn more about `_ChatChannelMemberListController` and its usage in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#user-list).
+///
+/// - Note: `ChatChannelMemberListController` is a typealias of `_ChatChannelMemberListController` with default extra data.
+/// If you're using custom extra data, create your own typealias of `_ChatChannelMemberListController`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+public typealias ChatChannelMemberListController = _ChatChannelMemberListController<DefaultExtraData>
+
+/// `_ChatChannelMemberListController` is a controller class which allows observing
+/// a list of chat users based on the provided query.
+///
+/// Learn more about `_ChatChannelMemberListController` and its usage in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#user-list).
+///
+/// - Note: `_ChatChannelMemberListController` type is not meant to be used directly. If you're using default extra data, use
+/// `ChatChannelMemberListController` typealias instead. If you're using custom extra data, create your own typealias
+/// of `_ChatChannelMemberListController`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+public class _ChatChannelMemberListController<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
+    /// The query specifying sorting and filtering for the list of channel members.
+    @Atomic public private(set) var query: ChannelMemberListQuery
+    
+    /// The `ChatClient` instance this controller belongs to.
+    public let client: _ChatClient<ExtraData>
+    
+    /// The channel members matching the query.
+    /// To observe the member list changes, set your class as a delegate of this controller or use the provided
+    /// `Combine` publishers.
+    public var members: [_ChatChannelMember<ExtraData.User>] {
+        startObservingIfNeeded()
+        return memberListObserver.items
+    }
+    
+    /// The worker used to fetch the remote data and communicate with servers.
+    private lazy var memberListUpdater = createMemberListUpdater()
+
+    /// The observer used to observe the changes in the database.
+    private lazy var memberListObserver = createMemberListObserver()
+    
+    /// The type-erased delegate.
+    var multicastDelegate: MulticastDelegate<AnyChatChannelMemberListControllerDelegate<ExtraData>> = .init() {
+        didSet {
+            stateMulticastDelegate.mainDelegate = multicastDelegate.mainDelegate
+            stateMulticastDelegate.additionalDelegates = multicastDelegate.additionalDelegates
+            startObservingIfNeeded()
+        }
+    }
+    
+    private let environment: Environment
+    
+    /// Creates a new `_ChatChannelMemberListController`
+    /// - Parameters:
+    ///   - query: The query used for filtering and sorting the channel members.
+    ///   - client: The `Client` this controller belongs to.
+    ///   - environment: Environment for this controller.
+    init(query: ChannelMemberListQuery, client: _ChatClient<ExtraData>, environment: Environment = .init()) {
+        self.client = client
+        self.query = query
+        self.environment = environment
+    }
+    
+    override public func synchronize(_ completion: ((_ error: Error?) -> Void)? = nil) {
+        startObservingIfNeeded()
+        
+        if case let .localDataFetchFailed(error) = state {
+            callback { completion?(error) }
+            return
+        }
+        
+        memberListUpdater.load(query) { [weak self] error in
+            guard let self = self else { return }
+            self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
+            self.callback { completion?(error) }
+        }
+    }
+    
+    /// Sets the provided object as a delegate of this controller.
+    ///
+    /// - Note: If you don't use custom extra data types, you can set the delegate directly using `controller.delegate = self`.
+    /// Due to the current limits of Swift and the way it handles protocols with associated types, it's required to use this
+    /// method to set the delegate, if you're using custom extra data types.
+    ///
+    /// - Parameter delegate: The object used as a delegate. It's referenced weakly, so you need to keep the object
+    /// alive if you want keep receiving updates.
+    ///
+    public func setDelegate<Delegate: _ChatChannelMemberListControllerDelegate>(_ delegate: Delegate)
+        where Delegate.ExtraData == ExtraData {
+        multicastDelegate.mainDelegate = AnyChatChannelMemberListControllerDelegate(delegate)
+    }
+    
+    private func createMemberListUpdater() -> ChannelMemberListUpdater<ExtraData> {
+        environment.memberListUpdaterBuilder(
+            client.databaseContainer,
+            client.webSocketClient,
+            client.apiClient
+        )
+    }
+    
+    private func createMemberListObserver() -> ListDatabaseObserver<_ChatChannelMember<ExtraData.User>, MemberDTO> {
+        let observer = environment.memberListObserverBuilder(
+            client.databaseContainer.viewContext,
+            MemberDTO.members(matching: query),
+            { $0.asModel() },
+            NSFetchedResultsController<MemberDTO>.self
+        )
+        
+        observer.onChange = { [unowned self] changes in
+            self.delegateCallback {
+                $0.memberListController(self, didChangeMembers: changes)
+            }
+        }
+        
+        return observer
+    }
+    
+    private func startObservingIfNeeded() {
+        guard state == .initialized else { return }
+        
+        do {
+            try memberListObserver.startObserving()
+            state = .localDataFetched
+        } catch {
+            log.error("Observing members matching <\(query)> failed: \(error). Accessing `members` will always return `[]`.")
+            state = .localDataFetchFailed(ClientError(with: error))
+        }
+    }
+}
+
+// MARK: - Actions
+
+public extension _ChatChannelMemberListController {
+    /// Loads next members from backend.
+    /// - Parameters:
+    ///   - limit: The page size.
+    ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    ///                 If request fails, the completion will be called with an error.
+    func loadNextMembers(
+        limit: Int = 25,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        var updatedQuery = query
+        updatedQuery.pagination = [.limit(limit), .offset(members.count)]
+        memberListUpdater.load(updatedQuery) { [weak self] error in
+            self?.query = updatedQuery
+            self?.callback {
+                completion?(error)
+            }
+        }
+    }
+}
+
+extension _ChatChannelMemberListController {
+    struct Environment {
+        var memberListUpdaterBuilder: (
+            _ database: DatabaseContainer,
+            _ webSocketClient: WebSocketClient,
+            _ apiClient: APIClient
+        ) -> ChannelMemberListUpdater<ExtraData> = ChannelMemberListUpdater.init
+
+        var memberListObserverBuilder: (
+            _ context: NSManagedObjectContext,
+            _ fetchRequest: NSFetchRequest<MemberDTO>,
+            _ itemCreator: @escaping (MemberDTO) -> _ChatChannelMember<ExtraData.User>?,
+            _ controllerType: NSFetchedResultsController<MemberDTO>.Type
+        ) -> ListDatabaseObserver<_ChatChannelMember<ExtraData.User>, MemberDTO> = ListDatabaseObserver.init
+    }
+}
+
+extension _ChatChannelMemberListController where ExtraData == DefaultExtraData {
+    /// Set the delegate of `ChatChannelMemberListController` to observe the changes in the system.
+    ///
+    /// - Note: The delegate can be set directly only if you're **not** using custom extra data types. Due to the current
+    /// limits of Swift and the way it handles protocols with associated types, it's required to use `setDelegate` method
+    /// instead to set the delegate, if you're using custom extra data types.
+    public var delegate: ChatChannelMemberListControllerDelegate? {
+        get { multicastDelegate.mainDelegate?.wrappedDelegate as? ChatChannelMemberListControllerDelegate }
+        set { multicastDelegate.mainDelegate = AnyChatChannelMemberListControllerDelegate(newValue) }
+    }
+}
+
+/// `ChatChannelMemberListController` uses this protocol to communicate changes to its delegate.
+///
+/// This protocol can be used only when no custom extra data are specified. If you're using custom extra data types,
+/// please use `_ChatChannelMemberListControllerDelegate` instead.
+public protocol ChatChannelMemberListControllerDelegate: DataControllerStateDelegate {
+    /// Controller observed a change in the channel member list.
+    func memberListController(
+        _ controller: ChatChannelMemberListController,
+        didChangeMembers changes: [ListChange<ChatChannelMember>]
+    )
+}
+
+public extension ChatUserListControllerDelegate {
+    func memberListController(
+        _ controller: ChatChannelMemberListController,
+        didChangeMembers changes: [ListChange<ChatChannelMember>]
+    ) {}
+}
+
+/// `_ChatChannelMemberListController` uses this protocol to communicate changes to its delegate.
+///
+/// If you're **not** using custom extra data types, you can use a convenience version of this protocol
+/// named `ChatChannelMemberListControllerDelegate`, which hides the generic types, and make the usage easier.
+///
+public protocol _ChatChannelMemberListControllerDelegate: DataControllerStateDelegate {
+    associatedtype ExtraData: ExtraDataTypes
+    
+    /// Controller observed a change in the channel member list.
+    func memberListController(
+        _ controller: _ChatChannelMemberListController<ExtraData>,
+        didChangeMembers changes: [ListChange<_ChatChannelMember<ExtraData.User>>]
+    )
+}
+
+public extension _ChatChannelMemberListControllerDelegate {
+    func memberListController(
+        _ controller: _ChatChannelMemberListController<ExtraData>,
+        didChangeMembers changes: [ListChange<_ChatChannelMember<ExtraData.User>>]
+    ) {}
+}
+
+// MARK: - Delegate type eraser
+
+final class AnyChatChannelMemberListControllerDelegate<ExtraData: ExtraDataTypes>: _ChatChannelMemberListControllerDelegate {
+    private let _controllerDidChangeState: (DataController, DataController.State) -> Void
+    
+    private let _controllerDidChangeMembers: (
+        _ChatChannelMemberListController<ExtraData>,
+        [ListChange<_ChatChannelMember<ExtraData.User>>]
+    ) -> Void
+    
+    weak var wrappedDelegate: AnyObject?
+    
+    init(
+        wrappedDelegate: AnyObject?,
+        controllerDidChangeState: @escaping (DataController, DataController.State) -> Void,
+        controllerDidChangeMembers: @escaping (
+            _ChatChannelMemberListController<ExtraData>,
+            [ListChange<_ChatChannelMember<ExtraData.User>>]
+        ) -> Void
+    ) {
+        self.wrappedDelegate = wrappedDelegate
+        _controllerDidChangeState = controllerDidChangeState
+        _controllerDidChangeMembers = controllerDidChangeMembers
+    }
+
+    func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        _controllerDidChangeState(controller, state)
+    }
+
+    func memberListController(
+        _ controller: _ChatChannelMemberListController<ExtraData>,
+        didChangeMembers changes: [ListChange<_ChatChannelMember<ExtraData.User>>]
+    ) {
+        _controllerDidChangeMembers(controller, changes)
+    }
+}
+
+extension AnyChatChannelMemberListControllerDelegate {
+    convenience init<Delegate: _ChatChannelMemberListControllerDelegate>(_ delegate: Delegate)
+        where Delegate.ExtraData == ExtraData {
+        self.init(
+            wrappedDelegate: delegate,
+            controllerDidChangeState: { [weak delegate] in
+                delegate?.controller($0, didChangeState: $1)
+            },
+            controllerDidChangeMembers: { [weak delegate] in
+                delegate?.memberListController($0, didChangeMembers: $1)
+            }
+        )
+    }
+}
+
+extension AnyChatChannelMemberListControllerDelegate where ExtraData == DefaultExtraData {
+    convenience init(_ delegate: ChatChannelMemberListControllerDelegate?) {
+        self.init(
+            wrappedDelegate: delegate,
+            controllerDidChangeState: { [weak delegate] in
+                delegate?.controller($0, didChangeState: $1)
+            },
+            controllerDidChangeMembers: { [weak delegate] in
+                delegate?.memberListController($0, didChangeMembers: $1)
+            }
+        )
+    }
+}

--- a/Sources_v3/Controllers/MemberListController/MemberListController_Tests.swift
+++ b/Sources_v3/Controllers/MemberListController/MemberListController_Tests.swift
@@ -1,0 +1,497 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChatClient
+import XCTest
+
+final class MemberListController_Tests: StressTestCase {
+    private var env: TestEnvironment!
+    
+    var query: ChannelMemberListQuery!
+    var client: ChatClient!
+    var controller: ChatChannelMemberListController!
+    var controllerCallbackQueueID: UUID!
+    var callbackQueueID: UUID { controllerCallbackQueueID }
+    
+    override func setUp() {
+        super.setUp()
+        
+        env = TestEnvironment()
+        client = _ChatClient.mock
+        query = .init(cid: .unique)
+        controller = .init(query: query, client: client, environment: env.environment)
+        controllerCallbackQueueID = UUID()
+        controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)
+    }
+    
+    override func tearDown() {
+        client.mockAPIClient.cleanUp()
+        
+        query = nil
+        controllerCallbackQueueID = nil
+        
+        AssertAsync {
+            Assert.canBeReleased(&controller)
+            Assert.canBeReleased(&client)
+            Assert.canBeReleased(&env)
+        }
+        
+        super.tearDown()
+    }
+    
+    // MARK: - Controller setup
+    
+    func test_client_createsUserControllerCorrectly() throws {
+        let controller = client.memberListController(query: query)
+        
+        // Assert `state` is correct.
+        XCTAssertEqual(controller.state, .initialized)
+        
+        // Assert `client` is assigned correctly.
+        XCTAssertTrue(controller.client === client)
+        
+        // Assert `query` is correct.
+        XCTAssertEqual(controller.query.queryHash, query.queryHash)
+    }
+    
+    func test_initialState() throws {
+        // Assert `state` is correct.
+        XCTAssertEqual(controller.state, .initialized)
+        
+        // Assert `client` is assigned correctly.
+        XCTAssertTrue(controller.client === client)
+        
+        // Assert `query` is correct.
+        XCTAssertEqual(controller.query.queryHash, query.queryHash)
+    }
+    
+    // MARK: - Synchronize tests
+    
+    func test_synchronize_changesState_and_callsCompletionOnCallbackQueue() {
+        // Simulate `synchronize` call.
+        var completionIsCalled = false
+        controller.synchronize { [callbackQueueID] error in
+            // Assert callback queue is correct.
+            AssertTestQueue(withId: callbackQueueID)
+            // Assert there is no error.
+            XCTAssertNil(error)
+            completionIsCalled = true
+        }
+        
+        // Assert controller is in `localDataFetched` state.
+        XCTAssertEqual(controller.state, .localDataFetched)
+        
+        // Simulate successfull network call.
+        env.memberListUpdater!.load_completion!(nil)
+        
+        AssertAsync {
+            // Assert controller is in `remoteDataFetched` state.
+            Assert.willBeEqual(self.controller.state, .remoteDataFetched)
+            // Assert completion is called
+            Assert.willBeTrue(completionIsCalled)
+        }
+    }
+    
+    func test_synchronize_changesState_and_propogatesObserverErrorOnCallbackQueue() {
+        // Update observer to throw the error.
+        let observerError = TestError()
+        env.memberListObserverSynchronizeError = observerError
+        
+        // Simulate `synchronize` call.
+        var synchronizeError: Error?
+        controller.synchronize { [callbackQueueID] error in
+            AssertTestQueue(withId: callbackQueueID)
+            synchronizeError = error
+        }
+        
+        // Assert controller is in `localDataFetchFailed` state.
+        XCTAssertEqual(controller.state, .localDataFetchFailed(ClientError(with: observerError)))
+        
+        // Assert error from observer is forwarded.
+        AssertAsync.willBeEqual(synchronizeError as? ClientError, ClientError(with: observerError))
+    }
+    
+    func test_synchronize_changesState_and_propogatesListUpdaterErrorOnCallbackQueue() {
+        // Simulate `synchronize` call.
+        var synchronizeError: Error?
+        controller.synchronize { [callbackQueueID] error in
+            AssertTestQueue(withId: callbackQueueID)
+            synchronizeError = error
+        }
+        
+        // Simulate failed network call.
+        let updaterError = TestError()
+        env.memberListUpdater!.load_completion?(updaterError)
+        
+        AssertAsync {
+            // Assert controller is in `remoteDataFetchFailed` state.
+            Assert.willBeEqual(self.controller.state, .remoteDataFetchFailed(ClientError(with: updaterError)))
+            // Assert error from updater is forwarded.
+            Assert.willBeEqual(synchronizeError as? TestError, updaterError)
+        }
+    }
+    
+    func test_synchronize_doesNotInvokeUpdater_ifObserverFails() {
+        // Update observer to throw the error.
+        env.memberListObserverSynchronizeError = TestError()
+        
+        // Simulate `synchronize` call.
+        controller.synchronize()
+        
+        // Assert updater in not called.
+        XCTAssertNil(env.memberListUpdater?.load_query)
+    }
+    
+    func test_synchronize_callsUserUpdater_ifObserverSucceeds() {
+        // Simulate `synchronize` call.
+        controller.synchronize()
+        
+        // Assert updater in called.
+        XCTAssertEqual(env.memberListUpdater!.load_query!.queryHash, controller.query.queryHash)
+        XCTAssertNotNil(env.memberListUpdater!.load_completion)
+    }
+    
+    // MARK: - Local data fetching triggers
+    
+    func test_observerIsTriggeredOnlyOnce() {
+        // Check initial state
+        XCTAssertEqual(controller.state, .initialized)
+        
+        // Set the delegate
+        controller.delegate = TestDelegate(expectedQueueId: callbackQueueID)
+        
+        // Assert state changed
+        AssertAsync.willBeEqual(controller.state, .localDataFetched)
+        
+        // Update observer to throw the error
+        env.memberListObserver?.synchronizeError = TestError()
+        
+        // Set `delegate` / call `synchronize` / access `member` again
+        _ = controller.members
+        
+        // Assert controllers stays in `localDataFetched`
+        AssertAsync.staysEqual(controller.state, .localDataFetched)
+    }
+    
+    func test_localDataIsFetched_whenDelegateIsSet() {
+        // Check initial state
+        XCTAssertEqual(controller.state, .initialized)
+        
+        // Set the delegate
+        controller.delegate = TestDelegate(expectedQueueId: callbackQueueID)
+        
+        // Assert state changed
+        AssertAsync.willBeEqual(controller.state, .localDataFetched)
+    }
+    
+    func test_localDataIsFetched_whenUserIsAccessed() {
+        // Check initial state
+        XCTAssertEqual(controller.state, .initialized)
+        
+        // Access the members
+        _ = controller.members
+        
+        // Assert state changed
+        AssertAsync.willBeEqual(controller.state, .localDataFetched)
+    }
+    
+    func test_localDataIsFetched_whenSynchronizedIsCalled() {
+        // Check initial state
+        XCTAssertEqual(controller.state, .initialized)
+        
+        // Set the delegate
+        controller.synchronize()
+        
+        // Assert state changed
+        AssertAsync.willBeEqual(controller.state, .localDataFetched)
+    }
+    
+    // MARK: - Delegate
+    
+    func test_delegate_isAssignedCorrectly() {
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
+        
+        // Set the delegate
+        controller.delegate = delegate
+        
+        // Assert the delegate is assigned correctly
+        XCTAssert(controller.delegate === delegate)
+    }
+    
+    func test_delegate_isNotifiedAboutStateChanges() throws {
+        // Set the delegate
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
+        controller.delegate = delegate
+        
+        // Synchronize
+        controller.synchronize()
+        
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .localDataFetched)
+        
+        // Simulate network call response
+        env.memberListUpdater!.load_completion!(nil)
+        
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)
+    }
+    
+    func test_genericDelegate_isNotifiedAboutStateChanges() throws {
+        // Set the generic delegate
+        let delegate = TestDelegateGeneric(expectedQueueId: callbackQueueID)
+        controller.setDelegate(delegate)
+        
+        // Synchronize
+        controller.synchronize()
+        
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .localDataFetched)
+        
+        // Simulate network call response
+        env.memberListUpdater!.load_completion!(nil)
+        
+        // Assert delegate is notified about state changes
+        AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)
+    }
+    
+    func test_delegate_isNotifiedAboutMembersUpdates() throws {
+        let member1ID: UserId = .unique
+        let member2ID: UserId = .unique
+        
+        // Set the delegate
+        let delegate = TestDelegate(expectedQueueId: callbackQueueID)
+        controller.delegate = delegate
+        
+        // Create channel in the database.
+        try client.databaseContainer.createChannel(cid: query.cid)
+        
+        // Create 2 members, the first updated more recently
+        var member1: MemberPayload = .dummy(
+            userId: member1ID,
+            updatedAt: Date()
+        )
+        var member2: MemberPayload = .dummy(
+            userId: member2ID,
+            updatedAt: Date().addingTimeInterval(-10)
+        )
+        
+        // Save both memebers to the database and link to the query.
+        try client.databaseContainer.writeSynchronously { session in
+            for member in [member1, member2] {
+                try session.saveMember(
+                    payload: member,
+                    channelId: self.query.cid,
+                    query: self.query
+                )
+            }
+        }
+        
+        // Assert `insert` changes are received by the delegate.
+        AssertAsync {
+            Assert.willBeEqual(delegate.didUpdateMembers_changes?.count, 2)
+            Assert
+                .willBeTrue(
+                    (delegate.didUpdateMembers_changes ?? []).map { $0.fieldChange(\.id) }
+                        .contains(.insert(member1ID, index: [0, 0]))
+                )
+            Assert
+                .willBeTrue(
+                    (delegate.didUpdateMembers_changes ?? []).map { $0.fieldChange(\.id) }
+                        .contains(.insert(member2ID, index: [0, 1]))
+                )
+        }
+        
+        // Simulate `synchronize` call to fetch user from remote
+        controller.synchronize()
+
+        // Update 2 members, the first updated more recently
+        member1 = .dummy(
+            userId: member1ID,
+            updatedAt: Date()
+        )
+        member2 = .dummy(
+            userId: member2ID,
+            updatedAt: Date().addingTimeInterval(-10)
+        )
+        
+        // Save both memebers to the database and link to the query.
+        try client.databaseContainer.writeSynchronously { session in
+            for member in [member1, member2] {
+                try session.saveMember(payload: member, channelId: self.query.cid, query: self.query)
+            }
+        }
+        env.memberListUpdater!.load_completion!(nil)
+
+        // Assert `update` changes are received by the delegate.
+        AssertAsync {
+            Assert.willBeEqual(delegate.didUpdateMembers_changes?.count, 2)
+            Assert
+                .willBeTrue(
+                    (delegate.didUpdateMembers_changes ?? []).map { $0.fieldChange(\.id) }
+                        .contains(.update(member1ID, index: [0, 0]))
+                )
+            Assert
+                .willBeTrue(
+                    (delegate.didUpdateMembers_changes ?? []).map { $0.fieldChange(\.id) }
+                        .contains(.update(member2ID, index: [0, 1]))
+                )
+        }
+        
+        // Update second member to be updated earlier than the first one.
+        try client.databaseContainer.writeSynchronously { session in
+            session.member(userId: member2.user.id, cid: self.query.cid)?.memberUpdatedAt = Date()
+        }
+        
+        // Assert `move` change is received for the second member.
+        AssertAsync {
+            Assert.willBeEqual(delegate.didUpdateMembers_changes?.count, 1)
+            Assert
+                .willBeTrue(
+                    (delegate.didUpdateMembers_changes ?? []).map { $0.fieldChange(\.id) }
+                        .contains(.move(member2ID, fromIndex: [0, 1], toIndex: [0, 0]))
+                )
+        }
+        
+        // Simulate database flush
+        try client.databaseContainer.removeAllData()
+
+        // Assert `remove` entity changes are received by the delegate.
+        AssertAsync {
+            Assert.willBeEqual(delegate.didUpdateMembers_changes?.count, 2)
+            Assert
+                .willBeTrue(
+                    (delegate.didUpdateMembers_changes ?? []).map { $0.fieldChange(\.id) }
+                        .contains(.remove(member1ID, index: [0, 1]))
+                )
+            Assert
+                .willBeTrue(
+                    (delegate.didUpdateMembers_changes ?? []).map { $0.fieldChange(\.id) }
+                        .contains(.remove(member2ID, index: [0, 0]))
+                )
+            Assert.willBeEqual(self.controller.members, [])
+        }
+    }
+    
+    // MARK: - Load next members
+    
+    func test_loadNextMembers_propogatesError() {
+        // Simulate `loadNextMembers` call and catch the completion.
+        var completionError: Error?
+        controller.loadNextMembers { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionError = $0
+        }
+        
+        // Simulate network response with the error.
+        let networkError = TestError()
+        env.memberListUpdater!.load_completion!(networkError)
+        
+        // Assert error is propogated.
+        AssertAsync.willBeEqual(completionError as? TestError, networkError)
+    }
+    
+    func test_loadNextMembers_propogatesNilError() {
+        // Simulate `loadNextMembers` call and catch the completion.
+        var completionIsCalled = false
+        controller.loadNextMembers { [callbackQueueID] error in
+            // Assert callback queue is correct.
+            AssertTestQueue(withId: callbackQueueID)
+            // Assert there is no error.
+            XCTAssertNil(error)
+            completionIsCalled = true
+        }
+        
+        // Simulate successful network response.
+        env.memberListUpdater!.load_completion!(nil)
+        
+        // Assert completion is called.
+        AssertAsync.willBeTrue(completionIsCalled)
+    }
+    
+    func test_loadNextMembers_callsUserUpdaterWithCorrectValues_and_updatesTheQuery() {
+        let limit = 10
+        let oldPagination = controller.query.pagination
+        let newPagination: Pagination = [.limit(limit), .offset(controller.members.count)]
+        
+        // Simulate `loadNextMembers` call.
+        controller.loadNextMembers(limit: limit)
+        
+        // Assert update is called with updated pagination.
+        XCTAssertEqual(env.memberListUpdater!.load_query!.pagination, newPagination)
+        // Assert controller still has old pagination.
+        XCTAssertEqual(controller.query.pagination, oldPagination)
+        
+        // Simulate successful network response.
+        env.memberListUpdater!.load_completion!(nil)
+        
+        // Assert controller's query is updated with the new pagination.
+        AssertAsync.willBeEqual(controller.query.pagination, newPagination)
+    }
+}
+
+private class TestEnvironment {
+    @Atomic var memberListUpdater: ChannelMemberListUpdaterMock<DefaultExtraData>?
+    @Atomic var memberListObserver: ListDatabaseObserverMock<ChatChannelMember, MemberDTO>?
+    @Atomic var memberListObserverSynchronizeError: Error?
+    
+    lazy var environment: ChatChannelMemberListController.Environment = .init(
+        memberListUpdaterBuilder: { [unowned self] in
+            self.memberListUpdater = .init(
+                database: $0,
+                webSocketClient: $1,
+                apiClient: $2
+            )
+            return self.memberListUpdater!
+        },
+        memberListObserverBuilder: { [unowned self] in
+            self.memberListObserver = .init(
+                context: $0,
+                fetchRequest: $1,
+                itemCreator: $2,
+                fetchedResultsControllerType: $3
+            )
+            self.memberListObserver?.synchronizeError = self.memberListObserverSynchronizeError
+            return self.memberListObserver!
+        }
+    )
+}
+
+// A concrete `ChatChannelMemberListControllerDelegate` implementation allowing capturing the delegate calls
+private class TestDelegate: QueueAwareDelegate, ChatChannelMemberListControllerDelegate {
+    @Atomic var state: DataController.State?
+    @Atomic var didUpdateMembers_changes: [ListChange<ChatChannelMember>]?
+    
+    func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        validateQueue()
+        self.state = state
+    }
+    
+    func memberListController(
+        _ controller: ChatChannelMemberListController,
+        didChangeMembers changes: [ListChange<ChatChannelMember>]
+    ) {
+        validateQueue()
+        didUpdateMembers_changes = changes
+    }
+}
+
+// A concrete `_ChatChannelMemberListControllerDelegate` implementation allowing capturing the delegate calls.
+private class TestDelegateGeneric: QueueAwareDelegate, _ChatChannelMemberListControllerDelegate {
+    @Atomic var state: DataController.State?
+    @Atomic var didUpdateMembers_changes: [ListChange<ChatChannelMember>]?
+    
+    func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        validateQueue()
+        self.state = state
+    }
+    
+    func memberListController(
+        _ controller: ChatChannelMemberListController,
+        didChangeMembers changes: [ListChange<ChatChannelMember>]
+    ) {
+        validateQueue()
+        didUpdateMembers_changes = changes
+    }
+}

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -146,9 +146,18 @@ extension DatabaseContainer {
         }
     }
     
-    func createMember(userId: UserId = .unique, role: MemberRole = .member, cid: ChannelId) throws {
+    func createMember(
+        userId: UserId = .unique,
+        role: MemberRole = .member,
+        cid: ChannelId,
+        query: ChannelMemberListQuery? = nil
+    ) throws {
         try writeSynchronously { session in
-            try session.saveMember(payload: .dummy(userId: userId, role: role), channelId: cid)
+            try session.saveMember(
+                payload: .dummy(userId: userId, role: role),
+                channelId: query?.cid ?? cid,
+                query: query
+            )
         }
     }
 }

--- a/Sources_v3/Query/Sorting.swift
+++ b/Sources_v3/Query/Sorting.swift
@@ -175,3 +175,26 @@ public extension ChannelMemberListSortingKey {
     /// When used this key sorts the member list by member's `updatedAt` field.
     static let updatedAt = Self(rawValue: "updated_at")
 }
+
+extension ChannelMemberListSortingKey {
+    static var defaultSortDescriptor: NSSortDescriptor {
+        .init(keyPath: \MemberDTO.memberUpdatedAt, ascending: false)
+    }
+    
+    func sortDescriptor(isAscending: Bool) -> NSSortDescriptor? {
+        var keyPath: KeyPath<MemberDTO, Date>? {
+            switch self {
+            case .createdAt:
+                return \.memberCreatedAt
+            case .updatedAt:
+                return \.memberUpdatedAt
+            default:
+                return nil
+            }
+        }
+        
+        return keyPath.flatMap {
+            .init(keyPath: $0, ascending: isAscending)
+        }
+    }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -234,6 +234,8 @@
 		88D85D9A252F168B00AE1030 /* MemberController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85D99252F168B00AE1030 /* MemberController+Combine.swift */; };
 		88D85D9D252F16A300AE1030 /* MemberController+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85D9C252F16A300AE1030 /* MemberController+SwiftUI_Tests.swift */; };
 		88D85DA0252F16B400AE1030 /* MemberController+Combine_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85D9F252F16B400AE1030 /* MemberController+Combine_Tests.swift */; };
+		88D85DA7252F3C1D00AE1030 /* MemberListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85DA6252F3C1D00AE1030 /* MemberListController.swift */; };
+		88D85DAB252F3C2A00AE1030 /* MemberListController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85DAA252F3C2A00AE1030 /* MemberListController_Tests.swift */; };
 		88D85DAE252F468B00AE1030 /* ListDatabaseObserver_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85DAD252F468B00AE1030 /* ListDatabaseObserver_Mock.swift */; };
 		88F6DF91252C8845009A8AF0 /* ChannelMemberUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */; };
 		88F6DF94252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */; };
@@ -669,6 +671,8 @@
 		88D85D99252F168B00AE1030 /* MemberController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberController+Combine.swift"; sourceTree = "<group>"; };
 		88D85D9C252F16A300AE1030 /* MemberController+SwiftUI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberController+SwiftUI_Tests.swift"; sourceTree = "<group>"; };
 		88D85D9F252F16B400AE1030 /* MemberController+Combine_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberController+Combine_Tests.swift"; sourceTree = "<group>"; };
+		88D85DA6252F3C1D00AE1030 /* MemberListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberListController.swift; sourceTree = "<group>"; };
+		88D85DAA252F3C2A00AE1030 /* MemberListController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberListController_Tests.swift; sourceTree = "<group>"; };
 		88D85DAD252F468B00AE1030 /* ListDatabaseObserver_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListDatabaseObserver_Mock.swift; sourceTree = "<group>"; };
 		88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater.swift; sourceTree = "<group>"; };
 		88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater_Tests.swift; sourceTree = "<group>"; };
@@ -1319,6 +1323,7 @@
 				8A0D64AD24E5853F0017A3C0 /* DataController_Tests.swift */,
 				8819DFD32525F48800FD1A50 /* UserController */,
 				888E8C53252B522F00195E03 /* MemberController */,
+				88D85DA5252F3C0900AE1030 /* MemberListController */,
 				DAE566F22500F97E00E39431 /* ChannelController */,
 				DAE566F32500F98D00E39431 /* ChannelListController */,
 				DAE566F42500F99900E39431 /* CurrentUserController */,
@@ -1483,6 +1488,15 @@
 				88D85D9F252F16B400AE1030 /* MemberController+Combine_Tests.swift */,
 			);
 			path = MemberController;
+			sourceTree = "<group>";
+		};
+		88D85DA5252F3C0900AE1030 /* MemberListController */ = {
+			isa = PBXGroup;
+			children = (
+				88D85DA6252F3C1D00AE1030 /* MemberListController.swift */,
+				88D85DAA252F3C2A00AE1030 /* MemberListController_Tests.swift */,
+			);
+			path = MemberListController;
 			sourceTree = "<group>";
 		};
 		8A0C3BC124C0AD6E00CAFD19 /* User */ = {
@@ -2107,6 +2121,7 @@
 				F63CC37324E592D30052844D /* MemberEventObserver.swift in Sources */,
 				8AE335A824FCF999002B6677 /* Reachability_Vendor.swift in Sources */,
 				79877A0C2498E4BC00015F8B /* ChannelType.swift in Sources */,
+				88D85DA7252F3C1D00AE1030 /* MemberListController.swift in Sources */,
 				79280F4B248523C000CDEB89 /* ConnectionEvents.swift in Sources */,
 				882C574A252C767E00E60C44 /* ChannelMemberListPayload.swift in Sources */,
 				DAFAD6A324DD8E1A0043ED06 /* ChannelEditDetailPayload.swift in Sources */,
@@ -2274,6 +2289,7 @@
 				7931818E24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift in Sources */,
 				F62BE7922506692700D13B86 /* MissingEventsPublisher_Tests.swift in Sources */,
 				79200D42250118A1002F4EB1 /* iOS13TestCase.swift in Sources */,
+				88D85DAE252F468B00AE1030 /* ListDatabaseObserver_Mock.swift in Sources */,
 				79877A292498E51500015F8B /* ChannelDTO_Tests.swift in Sources */,
 				DAEAF4B824DC026C0015FB28 /* ChannelEndpoints_Tests.swift in Sources */,
 				792FCB4D24A3D56D000290C7 /* DatabaseSession_Tests.swift in Sources */,
@@ -2322,6 +2338,7 @@
 				8A0C3BE224C1F74200CAFD19 /* MessageEvents_Tests.swift in Sources */,
 				791C0B6524EFBD260013CA2F /* UnwrapAsync.swift in Sources */,
 				7990503224CEEAA600689CDC /* MessageDTO_Tests.swift in Sources */,
+				88D85DAB252F3C2A00AE1030 /* MemberListController_Tests.swift in Sources */,
 				8819DFDE252622D900FD1A50 /* ModerationEndpoints_Tests.swift in Sources */,
 				F65D9093250A5CD4000B8CEB /* WebSocketConnectEndpoint_Tests.swift in Sources */,
 			);

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		88D85D9A252F168B00AE1030 /* MemberController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85D99252F168B00AE1030 /* MemberController+Combine.swift */; };
 		88D85D9D252F16A300AE1030 /* MemberController+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85D9C252F16A300AE1030 /* MemberController+SwiftUI_Tests.swift */; };
 		88D85DA0252F16B400AE1030 /* MemberController+Combine_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85D9F252F16B400AE1030 /* MemberController+Combine_Tests.swift */; };
+		88D85DAE252F468B00AE1030 /* ListDatabaseObserver_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85DAD252F468B00AE1030 /* ListDatabaseObserver_Mock.swift */; };
 		88F6DF91252C8845009A8AF0 /* ChannelMemberUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */; };
 		88F6DF94252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */; };
 		88F6DF97252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF96252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift */; };
@@ -668,6 +669,7 @@
 		88D85D99252F168B00AE1030 /* MemberController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberController+Combine.swift"; sourceTree = "<group>"; };
 		88D85D9C252F16A300AE1030 /* MemberController+SwiftUI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberController+SwiftUI_Tests.swift"; sourceTree = "<group>"; };
 		88D85D9F252F16B400AE1030 /* MemberController+Combine_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberController+Combine_Tests.swift"; sourceTree = "<group>"; };
+		88D85DAD252F468B00AE1030 /* ListDatabaseObserver_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListDatabaseObserver_Mock.swift; sourceTree = "<group>"; };
 		88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater.swift; sourceTree = "<group>"; };
 		88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater_Tests.swift; sourceTree = "<group>"; };
 		88F6DF96252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater_Mock.swift; sourceTree = "<group>"; };
@@ -1323,6 +1325,7 @@
 				F649B23F250125C9008F98C8 /* MessageController */,
 				DA8406FE2524F761005A0F62 /* UserListController */,
 				79E2B83F24CAC8D60024752F /* ListDatabaseObserver.swift */,
+				88D85DAD252F468B00AE1030 /* ListDatabaseObserver_Mock.swift */,
 				793C14DB24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift */,
 				792AF91524D812440010097B /* EntityDatabaseObserver.swift */,
 				7922F30924DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift */,

--- a/Tests_v3/Dummy data/MemberPayload.swift
+++ b/Tests_v3/Dummy data/MemberPayload.swift
@@ -7,12 +7,17 @@ import Foundation
 
 extension MemberPayload where ExtraData == NameAndImageExtraData {
     /// Returns a dummy member payload with the given `userId` and `role`
-    static func dummy(userId: UserId = .unique, role: MemberRole = .member) -> MemberPayload {
+    static func dummy(
+        userId: UserId = .unique,
+        createdAt: Date = .unique,
+        updatedAt: Date = .unique,
+        role: MemberRole = .member
+    ) -> MemberPayload {
         .init(
             user: .dummy(userId: userId),
             role: role,
-            createdAt: .unique,
-            updatedAt: .unique
+            createdAt: createdAt,
+            updatedAt: updatedAt
         )
     }
 }


### PR DESCRIPTION
**This PR**:
- introduces `ChatChannelMemberListController` that manages channel member query
- introduces mock `ListDatabaseObserver`
- adds sort descriptors to `ChannelMemberListSortingKey` 