### PR TITLE
[CIS-378] Showcase 1-1 channels and UserController in Sample app

### DIFF
--- a/Sample_v3/Extensions/Channel+Extensions.swift
+++ b/Sample_v3/Extensions/Channel+Extensions.swift
@@ -19,3 +19,15 @@ func createTypingMemberString(for channel: ChatChannel?) -> String? {
     let names = members.map { $0.name ?? $0.id }.sorted()
     return names.joined(separator: ", ") + " \(names.count == 1 ? "is" : "are") typing..."
 }
+
+/// Creates title for channel. If it is direct message chat it will return users name.
+///
+/// Example result: `"Joe Biden"`
+func createChannelTitle(for channel: ChatChannel?, _ currentUserId: UserId?) -> String {
+    guard let channel = channel, let currentUserId = currentUserId else { return "Unnamed channel" }
+    if channel.isDirectMessage {
+        return Array(channel.cachedMembers).first(where: { member in member.id != currentUserId })?.name ?? "Unnamed channel"
+    } else {
+        return channel.extraData.name ?? channel.cid.description
+    }
+}

--- a/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChat.storyboard
+++ b/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChat.storyboard
@@ -52,18 +52,18 @@
                                 <rect key="frame" x="0.0" y="28" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="W2n-we-iYD" id="rqX-7l-GNm">
-                                    <rect key="frame" x="0.0" y="0.0" width="383" height="55.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="395" height="55.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="channel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="KC1-Rc-dsO">
-                                            <rect key="frame" x="20" y="10" width="60" height="20.5"/>
+                                            <rect key="frame" x="15" y="10" width="60" height="20.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="last message" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Scs-Wu-zzc">
-                                            <rect key="frame" x="20" y="31.5" width="74.5" height="14.5"/>
+                                            <rect key="frame" x="15" y="31.5" width="74.5" height="14.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -108,7 +108,7 @@
         <!--Cool Channel-->
         <scene sceneID="0dN-EP-EqE">
             <objects>
-                <tableViewController id="47C-ND-0Qu" customClass="CombineSimpleChatViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController storyboardIdentifier="CombineSimpleChatViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="47C-ND-0Qu" customClass="CombineSimpleChatViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="nDU-Ia-SV6">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -122,7 +122,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bBO-9b-79z">
-                                            <rect key="frame" x="15" y="0.0" width="391" height="43.5"/>
+                                            <rect key="frame" x="20" y="0.0" width="386" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -143,7 +143,7 @@
             </objects>
             <point key="canvasLocation" x="1579.7101449275362" y="87.723214285714278"/>
         </scene>
-        <!--Users-->
+        <!--Select user to start chat:-->
         <scene sceneID="dBz-5c-EVa">
             <objects>
                 <tableViewController storyboardIdentifier="CombineSimpleUsersViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="CGP-Mu-ipv" customClass="CombineSimpleUsersViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
@@ -166,29 +166,12 @@
                             <outlet property="delegate" destination="CGP-Mu-ipv" id="O8j-VJ-Ul6"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Users" id="TJN-BR-iJX"/>
+                    <navigationItem key="navigationItem" title="Select user to start chat:" id="TJN-BR-iJX"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="S2K-qs-XPD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1580" y="822"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="Vf2-wk-g1f">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="hxL-EY-U5B" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="JXx-e1-Ta1">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="CGP-Mu-ipv" kind="relationship" relationship="rootViewController" id="95e-Mi-2aK"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="8TT-TA-U5M" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="825" y="822"/>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>

--- a/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChatViewController.swift
+++ b/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChatViewController.swift
@@ -125,7 +125,8 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
         channelController
             .typingMembersPublisher
             .sink { [weak self] _ in
-                self?.title = self?.channelController.channel.flatMap { $0.extraData.name ?? $0.cid.description }
+                self?.title = self?.channelController.channel
+                    .flatMap { createChannelTitle(for: $0, self?.channelController.client.currentUserId) }
                 self?.navigationItem.prompt = self?.channelController.channel.flatMap {
                     createTypingMemberString(for: $0) ?? createMemberInfoString(for: $0)
                 }

--- a/Sample_v3/Samples/SimpleChat/SimpleChannelsViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChannelsViewController.swift
@@ -107,9 +107,9 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
         } else {
             subtitle = "No messages"
         }
-        
+    
         return channelCellWithName(
-            channel.extraData.name ?? channel.cid.description,
+            createChannelTitle(for: channel, chatClient.currentUserId),
             subtitle: subtitle,
             unreadCount: channel.unreadCount.messages
         )
@@ -205,8 +205,33 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
         else { return }
         
         usersViewController.userListController = chatClient
-            .userListController(query: .init())
-        navigationController?.pushViewController(usersViewController, animated: true)
+            .userListController(query: .init(sort: [.init(key: .createdAt)]))
+        
+        /// Push direct message chat screen with selected user.
+        /// If there were no chat with this user previously it will be created.
+        func pushDirectMessageChat(for userIds: UserId) {
+            if let chatVC = UIStoryboard.simpleChat
+                .instantiateViewController(withIdentifier: "SimpleChatViewController") as? SimpleChatViewController {
+                let newChatMemebers = [userIds, chatClient.currentUserId]
+                let controller = try! chatClient.channelController(
+                    createDirectMessageChannelWith: Set(newChatMemebers),
+                    extraData: .init()
+                )
+                chatVC.channelController = controller
+                self.navigationController?.pushViewController(chatVC, animated: true)
+            }
+        }
+        
+        /// `openDirectMessagesChat` closure that is passed to `SimpleUsersViewController`.
+        /// After user selection it will dismiss user list screen and show direct message chat with the selected user.
+        let openDirectMessagesChat: ((UserId) -> Void)? = { [weak self] userId in
+            guard let self = self else { return }
+            self.dismiss(animated: true, completion: { pushDirectMessageChat(for: userId) })
+        }
+        
+        usersViewController.openDirectMessagesChat = openDirectMessagesChat
+        let navigationController = UINavigationController(rootViewController: usersViewController)
+        present(navigationController, animated: true, completion: nil)
     }
     
     ///
@@ -329,5 +354,3 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
         true
     }
 }
-
-// MARK: - Private

--- a/Sample_v3/Samples/SimpleChat/SimpleChat.storyboard
+++ b/Sample_v3/Samples/SimpleChat/SimpleChat.storyboard
@@ -52,18 +52,18 @@
                                 <rect key="frame" x="0.0" y="28" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="W2n-we-iYD" id="rqX-7l-GNm">
-                                    <rect key="frame" x="0.0" y="0.0" width="383" height="55.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="395" height="55.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="channel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="KC1-Rc-dsO">
-                                            <rect key="frame" x="20" y="10" width="60" height="20.5"/>
+                                            <rect key="frame" x="15" y="10" width="60" height="20.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="last message" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Scs-Wu-zzc">
-                                            <rect key="frame" x="20" y="31.5" width="74.5" height="14.5"/>
+                                            <rect key="frame" x="15" y="31.5" width="74.5" height="14.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -108,7 +108,7 @@
         <!--Cool Channel-->
         <scene sceneID="0dN-EP-EqE">
             <objects>
-                <tableViewController id="47C-ND-0Qu" customClass="SimpleChatViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController storyboardIdentifier="SimpleChatViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="47C-ND-0Qu" customClass="SimpleChatViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="nDU-Ia-SV6">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -143,7 +143,7 @@
             </objects>
             <point key="canvasLocation" x="1579.7101449275362" y="87.723214285714278"/>
         </scene>
-        <!--Users-->
+        <!--Select user to start chat:-->
         <scene sceneID="0Vo-0L-bKj">
             <objects>
                 <tableViewController storyboardIdentifier="SimpleUsersViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="VDe-2P-uXR" customClass="SimpleUsersViewController" customModule="Sample" customModuleProvider="target" sceneMemberID="viewController">
@@ -166,29 +166,12 @@
                             <outlet property="delegate" destination="VDe-2P-uXR" id="zRO-BL-lKu"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Users" id="FMm-ef-Va0"/>
+                    <navigationItem key="navigationItem" title="Select user to start chat:" id="FMm-ef-Va0"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="csm-As-H7n" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1580" y="822"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="pAn-JW-0bD">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Lyc-fZ-rE2" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="9zu-oR-gow">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="VDe-2P-uXR" kind="relationship" relationship="rootViewController" id="oiS-qz-SQN"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Y42-g3-UGH" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="825" y="822"/>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>

--- a/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
@@ -341,7 +341,7 @@ final class SimpleChatViewController: UITableViewController, ChatChannelControll
 
 extension SimpleChatViewController {
     func updateNavigationTitleAndPrompt() {
-        title = channelController.channel.flatMap { $0.extraData.name ?? $0.cid.description }
+        title = channelController.channel.flatMap { createChannelTitle(for: $0, channelController.client.currentUserId) }
         navigationItem.prompt = channelController.channel.flatMap {
             createTypingMemberString(for: $0) ?? createMemberInfoString(for: $0)
         }

--- a/Sample_v3/Samples/SimpleChat/SimpleUsersViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleUsersViewController.swift
@@ -29,6 +29,46 @@ class SimpleUsersViewController: UITableViewController, ChatUserListControllerDe
         }
     }
     
+    // MARK: - Actions
+    
+    ///
+    /// # openDirectMessagesChat
+    ///
+    /// Closure that will be triggered on `didSelectRowAt`.
+    /// After user selection it will dismiss current controller and show direct message chat with the selected user.
+    ///
+    var openDirectMessagesChat: ((UserId) -> Void)?
+    
+    ///
+    /// # handleLongPress
+    ///
+    /// The method below handles long press on user cells by displaying a `UIAlertController` with actions that can be taken on the `userController`. (`mute` and `unmute`)
+    @objc func handleLongPress(_ gestureRecognizer: UILongPressGestureRecognizer) {
+        guard
+            let indexPath = tableView.indexPathForRow(at: gestureRecognizer.location(in: tableView)),
+            gestureRecognizer.state == .began
+        else {
+            return
+        }
+
+        let userId = userListController.users[indexPath.row].id
+        let userController = userListController.client.userController(userId: userId)
+
+        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        let actions = [
+            UIAlertAction(title: "Mute", style: .default) { _ in
+                userController.mute()
+            },
+            UIAlertAction(title: "Unmute", style: .default) { _ in
+                userController.unmute()
+            },
+            UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+        ]
+        actions.forEach(actionSheet.addAction)
+
+        present(actionSheet, animated: true)
+    }
+    
     // MARK: - ChatUserControllerDelegate
 
     ///
@@ -95,6 +135,19 @@ class SimpleUsersViewController: UITableViewController, ChatUserListControllerDe
         }
         
         cell!.textLabel?.text = user.name
+        
+        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
+        /// Check if user is muted.
+        let isUserMuted = (
+            userListController.client.currentUserController().currentUser?.mutedUsers
+                .contains(where: { $0.id == user.id })
+        )!
+        /// Show muted icon for users that were muted by current user.
+        if #available(iOS 13.0, *), isUserMuted {
+            imageView.image = UIImage(systemName: "speaker.slash.fill")
+        }
+        cell!.accessoryView = imageView
+        
         return cell!
     }
     
@@ -111,5 +164,34 @@ class SimpleUsersViewController: UITableViewController, ChatUserListControllerDe
             indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1 {
             userListController.loadNextUsers()
         }
+    }
+    
+    ///
+    /// # didSelectRowAt
+    ///
+    /// The method below handles the user selection.
+    ///
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        openDirectMessagesChat?(userListController.users[indexPath.row].id)
+    }
+    
+    // MARK: - UI Code
+    
+    private lazy var longPressRecognizer = UILongPressGestureRecognizer(
+        target: self,
+        action: #selector(handleLongPress)
+    )
+    
+    override func viewDidLoad() {
+        tableView.addGestureRecognizer(longPressRecognizer)
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: self,
+            action: #selector(dismissHandler)
+        )
+    }
+    
+    @objc func dismissHandler() {
+        dismiss(animated: true, completion: nil)
     }
 }

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
@@ -35,7 +35,10 @@ struct ChatView: View {
         }))
         /// Set title to channel's name.
         .navigationBarTitle(
-            Text(createTypingMemberString(for: channel.channel) ?? channel.channel?.extraData.name ?? "Unnamed Channel"),
+            Text(
+                createTypingMemberString(for: channel.channel) ??
+                    createChannelTitle(for: channel.channel, channel.controller.client.currentUserId)
+            ),
             displayMode: .inline
         )
         /// Channel actions button.

--- a/Sources_v3/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources_v3/APIClient/Endpoints/ChannelEndpoints.swift
@@ -18,7 +18,7 @@ extension Endpoint {
     
     static func channel<ExtraData: ExtraDataTypes>(query: ChannelQuery<ExtraData>) -> Endpoint<ChannelPayload<ExtraData>> {
         .init(
-            path: "channels/\(query.cid.type.rawValue)/\(query.cid.id)/query",
+            path: "channels/\(query.cid.type.rawValue)\(query.cid.id == "*" ? "" : "/\(query.cid.id)")/query",
             method: .post,
             queryItems: nil,
             requiresConnectionId: query.options.contains(oneOf: [.presence, .state, .watch]),

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -388,7 +388,7 @@
 		F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69C4BC524F66CC200A3D740 /* EventLogger.swift */; };
 		F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */; };
 		F6C56D1424F7B89D0012BB1F /* EventMiddleware_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */; };
-		F6CA70932513A1450024ED5D /* Channel+MembersInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CA70912513A1400024ED5D /* Channel+MembersInfo.swift */; };
+		F6CA70932513A1450024ED5D /* Channel+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CA70912513A1400024ED5D /* Channel+Extensions.swift */; };
 		F6CCA24D251235F7004C1859 /* ChannelMemberTypingStateUpdaterMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CCA24C251235F7004C1859 /* ChannelMemberTypingStateUpdaterMiddleware.swift */; };
 		F6CCA24F2512491B004C1859 /* ChannelMemberTypingStateUpdaterMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CCA24E2512491B004C1859 /* ChannelMemberTypingStateUpdaterMiddleware_Tests.swift */; };
 		F6CCA25125124BA9004C1859 /* MemberPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CCA25025124BA9004C1859 /* MemberPayload.swift */; };
@@ -840,7 +840,7 @@
 		F69C4BC524F66CC200A3D740 /* EventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogger.swift; sourceTree = "<group>"; };
 		F69E7F7C24ED7562000F5252 /* CurrentUserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserController_Tests.swift; sourceTree = "<group>"; };
 		F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMiddleware_Mock.swift; sourceTree = "<group>"; };
-		F6CA70912513A1400024ED5D /* Channel+MembersInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Channel+MembersInfo.swift"; sourceTree = "<group>"; };
+		F6CA70912513A1400024ED5D /* Channel+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Channel+Extensions.swift"; sourceTree = "<group>"; };
 		F6CCA24C251235F7004C1859 /* ChannelMemberTypingStateUpdaterMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberTypingStateUpdaterMiddleware.swift; sourceTree = "<group>"; };
 		F6CCA24E2512491B004C1859 /* ChannelMemberTypingStateUpdaterMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberTypingStateUpdaterMiddleware_Tests.swift; sourceTree = "<group>"; };
 		F6CCA25025124BA9004C1859 /* MemberPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberPayload.swift; sourceTree = "<group>"; };
@@ -1406,7 +1406,7 @@
 				8008C19E24F84DB600F5BCCE /* UITableViewController+KeyboardAvoidance.swift */,
 				8040BC5C24FDA9B200DE369F /* UIColor+ForUsername.swift */,
 				80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */,
-				F6CA70912513A1400024ED5D /* Channel+MembersInfo.swift */,
+				F6CA70912513A1400024ED5D /* Channel+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1991,7 +1991,7 @@
 				DA4EE5D3252CB64900CB26D4 /* UserListView.swift in Sources */,
 				80C6027B25157E4D00A6B714 /* View+AlertTextField.swift in Sources */,
 				8040BC5E24FDAB1E00DE369F /* UIColor+ForUsername.swift in Sources */,
-				F6CA70932513A1450024ED5D /* Channel+MembersInfo.swift in Sources */,
+				F6CA70932513A1450024ED5D /* Channel+Extensions.swift in Sources */,
 				8008C18124ED64D300F5BCCE /* UIViewController+MoveToStoryboard.swift in Sources */,
 				805A11492506FBBD0089DFC4 /* UIViewController+Alert.swift in Sources */,
 				792A4F27247FF01800EAF71D /* SceneDelegate.swift in Sources */,


### PR DESCRIPTION
**In this PR:** 

- Showcase `1-1 channels` and `UserController` in Sample app

**Notes:** 
- Kept both `Users` and `add channel` buttons for now cause probably what we need is `TabBar`.
- In `SwiftUI` sample after tapping the user direct chat will be created but not opened. (navigation limitation, decided not to dive into it at this point)
- We don't have `mutedUsers` available initially on `currentUser`. They will appear only after muting someone and receiving corresponding event. Are we aware of this?