### PR TITLE
[CIS-359] Nullify callback-queue-id for controllers in tests

### DIFF
--- a/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
@@ -30,6 +30,7 @@ class ChannelController_Tests: StressTestCase {
     }
     
     override func tearDown() {
+        channelId = nil
         controllerCallbackQueueID = nil
         
         AssertAsync {

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -30,6 +30,9 @@ class ChannelListController_Tests: StressTestCase {
     }
     
     override func tearDown() {
+        query = nil
+        controllerCallbackQueueID = nil
+        
         AssertAsync {
             Assert.canBeReleased(&controller)
             Assert.canBeReleased(&client)

--- a/Sources_v3/Controllers/MemberController/MemberController_Tests.swift
+++ b/Sources_v3/Controllers/MemberController/MemberController_Tests.swift
@@ -32,6 +32,7 @@
     override func tearDown() {
         userId = nil
         cid = nil
+        controllerCallbackQueueID = nil
 
         AssertAsync {
             Assert.canBeReleased(&controller)

--- a/Sources_v3/Controllers/UserController/UserController_Tests.swift
+++ b/Sources_v3/Controllers/UserController/UserController_Tests.swift
@@ -29,6 +29,7 @@ final class UserController_Tests: StressTestCase {
     
     override func tearDown() {
         userId = nil
+        controllerCallbackQueueID = nil
         
         AssertAsync {
             Assert.canBeReleased(&controller)

--- a/Sources_v3/Controllers/UserListController/UserListController_Tests.swift
+++ b/Sources_v3/Controllers/UserListController/UserListController_Tests.swift
@@ -30,6 +30,9 @@ class UserListController_Tests: StressTestCase {
     }
     
     override func tearDown() {
+        query = nil
+        controllerCallbackQueueID = nil
+        
         AssertAsync {
             Assert.canBeReleased(&controller)
             Assert.canBeReleased(&client)


### PR DESCRIPTION
This PR nullifies the callback-queue-id in `tearDown` for all the controllers.
This PR is one of the many containing possible fixes for failing stress tests.