### PR TITLE
[CIS-395] Improve DSL for filters

### DIFF
--- a/Sample_v3/LoginViewController.swift
+++ b/Sample_v3/LoginViewController.swift
@@ -63,7 +63,7 @@ extension LoginViewController {
         
         let channelListController = chatClient.channelListController(
             query: ChannelListQuery(
-                filter: .in("members", [chatClient.currentUserId]),
+                filter: .containMembers(userIds: [chatClient.currentUserId]),
                 pagination: [.limit(25)],
                 options: [.watch]
             )

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
@@ -95,7 +95,7 @@ struct ChannelListView: View {
         }
     }
     
-    /// Channel cell containter view.
+    /// Channel cell container view.
     private func channelView(for index: Int) -> some View {
         HStack {
             VStack(alignment: .leading) {
@@ -130,8 +130,7 @@ struct ChannelListView: View {
     
     /// `UserLisView` for users matching the query.
     var userListView: some View {
-        let query: UserListQuery = .init()
-        let controller = channelList.controller.client.userListController(query: query)
+        let controller = channelList.controller.client.userListController()
         return UserListView(userList: controller.observableObject)
     }
     

--- a/Sources_v3/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources_v3/APIClient/Endpoints/ChannelEndpoints.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 extension Endpoint {
-    static func channels<ExtraData: ExtraDataTypes>(query: ChannelListQuery)
+    static func channels<ExtraData: ExtraDataTypes>(query: ChannelListQuery<ExtraData.Channel>)
         -> Endpoint<ChannelListPayload<ExtraData>> {
         .init(
             path: "channels",

--- a/Sources_v3/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -7,9 +7,9 @@ import XCTest
 
 final class ChannelEndpoints_Tests: XCTestCase {
     func test_channels_buildsCorrectly() {
-        let filter = Filter.in("member", ["Luke"])
+        let filter: Filter<ChannelListFilterScope<NameAndImageExtraData>> = .containMembers(userIds: [.unique])
         
-        let testCases: [(ChannelListQuery, Bool)] = [
+        let testCases: [(ChannelListQuery<NameAndImageExtraData>, Bool)] = [
             (.init(filter: filter, options: .state), true),
             (.init(filter: filter, options: .presence), true),
             (.init(filter: filter, options: .watch), true),

--- a/Sources_v3/APIClient/Endpoints/MemberEndpoints.swift
+++ b/Sources_v3/APIClient/Endpoints/MemberEndpoints.swift
@@ -6,7 +6,7 @@ import Foundation
 
 extension Endpoint {
     static func channelMembers<ExtraData: UserExtraData>(
-        query: ChannelMemberListQuery
+        query: ChannelMemberListQuery<ExtraData>
     ) -> Endpoint<ChannelMemberListPayload<ExtraData>> {
         .init(
             path: "members",

--- a/Sources_v3/APIClient/Endpoints/MemberEndpoints_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/MemberEndpoints_Tests.swift
@@ -7,9 +7,9 @@ import XCTest
 
 final class MemberEndpoints_Tests: XCTestCase {
     func test_channelMembers_buildsCorrectly() {
-        let query = ChannelMemberListQuery(
+        let query = ChannelMemberListQuery<NameAndImageExtraData>(
             cid: .unique,
-            filter: .contains("name", "a"),
+            filter: .equal(.id, to: "Luke"),
             sort: [.init(key: .createdAt)],
             pagination: [.offset(3)]
         )

--- a/Sources_v3/APIClient/Endpoints/UserEndpoints.swift
+++ b/Sources_v3/APIClient/Endpoints/UserEndpoints.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 extension Endpoint {
-    static func users<ExtraData: UserExtraData>(query: UserListQuery)
+    static func users<ExtraData: UserExtraData>(query: UserListQuery<ExtraData>)
         -> Endpoint<UserListPayload<ExtraData>> {
         .init(
             path: "users",

--- a/Sources_v3/APIClient/Endpoints/UserEndpoints_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/UserEndpoints_Tests.swift
@@ -7,8 +7,8 @@ import XCTest
 
 final class UserEndpoints_Tests: XCTestCase {
     func test_users_buildsCorrectly() {
-        let query: UserListQuery = .init(
-            filter: .contains("name", "a"),
+        let query: UserListQuery<DefaultExtraData.User> = .init(
+            filter: .equal(.id, to: .unique),
             sort: [.init(key: .lastActivityAt)],
             pagination: [.offset(3)]
         )

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController.swift
@@ -12,7 +12,7 @@ extension _ChatClient {
     ///
     /// - Returns: A new instance of `ChannelController`.
     ///
-    public func channelListController(query: ChannelListQuery) -> _ChatChannelListController<ExtraData> {
+    public func channelListController(query: ChannelListQuery<ExtraData.Channel>) -> _ChatChannelListController<ExtraData> {
         .init(query: query, client: self)
     }
 }
@@ -40,7 +40,7 @@ public typealias ChatChannelListController = _ChatChannelListController<DefaultE
 ///
 public class _ChatChannelListController<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
     /// The query specifying and filtering the list of channels.
-    public let query: ChannelListQuery
+    public let query: ChannelListQuery<ExtraData.Channel>
     
     /// The `ChatClient` instance this controller belongs to.
     public let client: _ChatClient<ExtraData>
@@ -111,7 +111,7 @@ public class _ChatChannelListController<ExtraData: ExtraDataTypes>: DataControll
     /// - Parameters:
     ///   - query: The query used for filtering the channels.
     ///   - client: The `Client` instance this controller belongs to.
-    init(query: ChannelListQuery, client: _ChatClient<ExtraData>, environment: Environment = .init()) {
+    init(query: ChannelListQuery<ExtraData.Channel>, client: _ChatClient<ExtraData>, environment: Environment = .init()) {
         self.client = client
         self.query = query
         self.environment = environment

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -15,7 +15,7 @@ class ChannelListController_Tests: StressTestCase {
     
     var controller: ChatChannelListController!
     var controllerCallbackQueueID: UUID!
-    /// Workaround for uwrapping **controllerCallbackQueueID!** in each closure that captures it
+    /// Workaround for unwrapping **controllerCallbackQueueID!** in each closure that captures it
     private var callbackQueueID: UUID { controllerCallbackQueueID }
     
     override func setUp() {
@@ -57,7 +57,7 @@ class ChannelListController_Tests: StressTestCase {
         // Simulate `synchronize` call
         controller.synchronize()
         
-        // Simulate successfull network call.
+        // Simulate successful network call.
         env.channelListUpdater?.update_completion?(nil)
         
         // Check if state changed after successful network call.

--- a/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -11,7 +11,7 @@ class ChannelListController_Tests: StressTestCase {
     
     var client: ChatClient!
     
-    var query: ChannelListQuery!
+    var query: ChannelListQuery<NameAndImageExtraData>!
     
     var controller: ChatChannelListController!
     var controllerCallbackQueueID: UUID!
@@ -23,7 +23,7 @@ class ChannelListController_Tests: StressTestCase {
         
         env = TestEnvironment()
         client = _ChatClient.mock
-        query = .init(filter: .in("members", ["Luke"]))
+        query = .init(filter: .in(.members, values: [.unique]))
         controller = ChatChannelListController(query: query, client: client, environment: env.environment)
         controllerCallbackQueueID = UUID()
         controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)

--- a/Sources_v3/Controllers/MemberController/MemberController+SwiftUI.swift
+++ b/Sources_v3/Controllers/MemberController/MemberController+SwiftUI.swift
@@ -10,7 +10,8 @@ extension _ChatChannelMemberController {
     /// A wrapper object that exposes the controller variables in the form of `ObservableObject` to be used in SwiftUI.
     public var observableObject: ObservableObject { .init(controller: self) }
     
-    /// A wrapper object for `_ChatChannelMemberController` type which makes it possible to use the controller comfortably in SwiftUI.
+    /// A wrapper object for `_ChatChannelMemberController` type which makes it possible to use the controller
+    /// comfortably in SwiftUI.
     public class ObservableObject: SwiftUI.ObservableObject {
         /// The underlying controller. You can still access it and call methods on it.
         public let controller: _ChatChannelMemberController

--- a/Sources_v3/Controllers/MemberListController/MemberListController.swift
+++ b/Sources_v3/Controllers/MemberListController/MemberListController.swift
@@ -9,7 +9,9 @@ extension _ChatClient {
     /// Creates a new `_ChatChannelMemberListController` with the provided query.
     /// - Parameter query: The query specify the filter and sorting options for members the controller should fetch.
     /// - Returns: A new instance of `_ChatChannelMemberListController`.
-    public func memberListController(query: ChannelMemberListQuery) -> _ChatChannelMemberListController<ExtraData> {
+    public func memberListController(
+        query: ChannelMemberListQuery<ExtraData.User>
+    ) -> _ChatChannelMemberListController<ExtraData> {
         .init(query: query, client: self)
     }
 }
@@ -37,7 +39,7 @@ public typealias ChatChannelMemberListController = _ChatChannelMemberListControl
 /// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
 public class _ChatChannelMemberListController<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
     /// The query specifying sorting and filtering for the list of channel members.
-    @Atomic public private(set) var query: ChannelMemberListQuery
+    @Atomic public private(set) var query: ChannelMemberListQuery<ExtraData.User>
     
     /// The `ChatClient` instance this controller belongs to.
     public let client: _ChatClient<ExtraData>
@@ -72,7 +74,7 @@ public class _ChatChannelMemberListController<ExtraData: ExtraDataTypes>: DataCo
     ///   - query: The query used for filtering and sorting the channel members.
     ///   - client: The `Client` this controller belongs to.
     ///   - environment: Environment for this controller.
-    init(query: ChannelMemberListQuery, client: _ChatClient<ExtraData>, environment: Environment = .init()) {
+    init(query: ChannelMemberListQuery<ExtraData.User>, client: _ChatClient<ExtraData>, environment: Environment = .init()) {
         self.client = client
         self.query = query
         self.environment = environment

--- a/Sources_v3/Controllers/MemberListController/MemberListController_Tests.swift
+++ b/Sources_v3/Controllers/MemberListController/MemberListController_Tests.swift
@@ -9,7 +9,7 @@ import XCTest
 final class MemberListController_Tests: StressTestCase {
     private var env: TestEnvironment!
     
-    var query: ChannelMemberListQuery!
+    var query: ChannelMemberListQuery<NameAndImageExtraData>!
     var client: ChatClient!
     var controller: ChatChannelMemberListController!
     var controllerCallbackQueueID: UUID!

--- a/Sources_v3/Controllers/UserListController/UserListController.swift
+++ b/Sources_v3/Controllers/UserListController/UserListController.swift
@@ -12,7 +12,7 @@ extension _ChatClient {
     ///
     /// - Returns: A new instance of `_ChatUserListController`.
     ///
-    public func userListController(query: UserListQuery) -> _ChatUserListController<ExtraData> {
+    public func userListController(query: UserListQuery<ExtraData.User>) -> _ChatUserListController<ExtraData> {
         .init(query: query, client: self)
     }
 }
@@ -40,7 +40,7 @@ public typealias ChatUserListController = _ChatUserListController<DefaultExtraDa
 ///
 public class _ChatUserListController<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
     /// The query specifying and filtering the list of users.
-    public let query: UserListQuery
+    public let query: UserListQuery<ExtraData.User>
     
     /// The `ChatClient` instance this controller belongs to.
     public let client: _ChatClient<ExtraData>
@@ -111,7 +111,7 @@ public class _ChatUserListController<ExtraData: ExtraDataTypes>: DataController,
     /// - Parameters:
     ///   - query: The query used for filtering the users.
     ///   - client: The `Client` instance this controller belongs to.
-    init(query: UserListQuery, client: _ChatClient<ExtraData>, environment: Environment = .init()) {
+    init(query: UserListQuery<ExtraData.User>, client: _ChatClient<ExtraData>, environment: Environment = .init()) {
         self.client = client
         self.query = query
         self.environment = environment

--- a/Sources_v3/Controllers/UserListController/UserListController.swift
+++ b/Sources_v3/Controllers/UserListController/UserListController.swift
@@ -12,7 +12,7 @@ extension _ChatClient {
     ///
     /// - Returns: A new instance of `_ChatUserListController`.
     ///
-    public func userListController(query: UserListQuery<ExtraData.User>) -> _ChatUserListController<ExtraData> {
+    public func userListController(query: UserListQuery<ExtraData.User> = .init()) -> _ChatUserListController<ExtraData> {
         .init(query: query, client: self)
     }
 }

--- a/Sources_v3/Controllers/UserListController/UserListController_Tests.swift
+++ b/Sources_v3/Controllers/UserListController/UserListController_Tests.swift
@@ -11,7 +11,7 @@ class UserListController_Tests: StressTestCase {
     
     var client: ChatClient!
     
-    var query: UserListQuery!
+    var query: UserListQuery<NameAndImageExtraData>!
     
     var controller: ChatUserListController!
     var controllerCallbackQueueID: UUID!
@@ -23,7 +23,7 @@ class UserListController_Tests: StressTestCase {
         
         env = TestEnvironment()
         client = _ChatClient.mock
-        query = .init(filter: .contains("name", "a"))
+        query = .init(filter: .query(.id, text: .unique))
         controller = ChatUserListController(query: query, client: client, environment: env.environment)
         controllerCallbackQueueID = UUID()
         controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)

--- a/Sources_v3/Database/DTOs/ChannelDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO.swift
@@ -75,7 +75,7 @@ extension ChannelDTO: EphemeralValuesContainer {
 extension NSManagedObjectContext {
     func saveChannel<ExtraData: ExtraDataTypes>(
         payload: ChannelDetailPayload<ExtraData>,
-        query: ChannelListQuery?
+        query: ChannelListQuery<ExtraData.Channel>?
     ) throws -> ChannelDTO {
         let dto = ChannelDTO.loadOrCreate(cid: payload.cid, context: self)
         dto.extraData = try JSONEncoder.default.encode(payload.extraData)
@@ -112,7 +112,7 @@ extension NSManagedObjectContext {
     
     func saveChannel<ExtraData: ExtraDataTypes>(
         payload: ChannelPayload<ExtraData>,
-        query: ChannelListQuery?
+        query: ChannelListQuery<ExtraData.Channel>?
     ) throws -> ChannelDTO {
         let dto = try saveChannel(payload: payload.channel, query: query)
         
@@ -139,7 +139,9 @@ extension NSManagedObjectContext {
 // To get the data from the DB
 
 extension ChannelDTO {
-    static func channelListFetchRequest(query: ChannelListQuery) -> NSFetchRequest<ChannelDTO> {
+    static func channelListFetchRequest<ExtraData: ChannelExtraData>(
+        query: ChannelListQuery<ExtraData>
+    ) -> NSFetchRequest<ChannelDTO> {
         let request = NSFetchRequest<ChannelDTO>(entityName: ChannelDTO.entityName)
         
         // Fetch results controller requires at least one sorting descriptor.

--- a/Sources_v3/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/ChannelDTO_Tests.swift
@@ -246,7 +246,9 @@ class ChannelDTO_Tests: XCTestCase {
     }
     
     func test_channelWithChannelListQuery_isSavedAndLoaded() {
-        let query = ChannelListQuery(filter: .equal("name", to: "Luke Skywalker") & .less("age", than: 50))
+        let query = ChannelListQuery<NameAndImageExtraData>(
+            filter: .and([.less(.createdAt, than: .unique), .exists(.deletedAt, exists: false)])
+        )
         
         // Create two channels
         let channel1Id: ChannelId = .unique
@@ -272,7 +274,7 @@ class ChannelDTO_Tests: XCTestCase {
     
     func test_channelListQuery_withSorting() {
         // Create two channels queries with different sortings.
-        let filter = Filter.equal("some", to: String.unique)
+        let filter: Filter<ChannelListFilterScope<NameAndImageExtraData>> = .in(.members, values: [.unique])
         let queryWithDefaultSorting = ChannelListQuery(filter: filter)
         let queryWithUpdatedAtSorting = ChannelListQuery(filter: filter, sort: [.init(key: .updatedAt, isAscending: false)])
 

--- a/Sources_v3/Database/DTOs/ChannelListQueryDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelListQueryDTO.swift
@@ -28,7 +28,7 @@ extension NSManagedObjectContext {
         ChannelListQueryDTO.load(filterHash: filterHash, context: self)
     }
     
-    func saveQuery(query: ChannelListQuery) -> ChannelListQueryDTO {
+    func saveQuery<ExtraData: ChannelExtraData>(query: ChannelListQuery<ExtraData>) -> ChannelListQueryDTO {
         if let existingDTO = ChannelListQueryDTO.load(filterHash: query.filter.filterHash, context: self) {
             return existingDTO
         }

--- a/Sources_v3/Database/DTOs/ChannelMemberListQueryDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelMemberListQueryDTO.swift
@@ -15,7 +15,7 @@ final class ChannelMemberListQueryDTO: NSManagedObject {
     /// The channel the query works with.
     @NSManaged var channel: ChannelDTO
         
-    /// Set of members matching the query.
+    /// A set of members matching the query.
     @NSManaged var members: Set<MemberDTO>
         
     static func load(queryHash: String, context: NSManagedObjectContext) -> ChannelMemberListQueryDTO? {

--- a/Sources_v3/Database/DTOs/ChannelMemberListQueryDTO.swift
+++ b/Sources_v3/Database/DTOs/ChannelMemberListQueryDTO.swift
@@ -40,7 +40,7 @@ extension NSManagedObjectContext: MemberListQueryDatabaseSession {
         ChannelMemberListQueryDTO.load(queryHash: queryHash, context: self)
     }
     
-    func saveQuery(_ query: ChannelMemberListQuery) throws -> ChannelMemberListQueryDTO {
+    func saveQuery<ExtraData: UserExtraData>(_ query: ChannelMemberListQuery<ExtraData>) throws -> ChannelMemberListQueryDTO {
         guard let channelDTO = channel(cid: query.cid) else {
             throw ClientError.ChannelDoesNotExist(cid: query.cid)
         }

--- a/Sources_v3/Database/DTOs/ChannelMemberListQueryDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/ChannelMemberListQueryDTO_Tests.swift
@@ -25,7 +25,7 @@ final class ChannelMemberListQueryDTO_Tests: XCTestCase {
     
     func test_channelMemberListQuery_loadsCorrectQuery() throws {
         // Create the query.
-        let query = ChannelMemberListQuery(cid: .unique, filter: .contains("name", String.unique))
+        let query = ChannelMemberListQuery<NameAndImageExtraData>(cid: .unique, filter: .query(.id, text: .unique))
         
         // Save the query to the database.
         try database.writeSynchronously {
@@ -41,7 +41,7 @@ final class ChannelMemberListQueryDTO_Tests: XCTestCase {
     
     func test_saveQuery_savesQueryCorrectly_ifChannelExists() throws {
         // Create the query.
-        let query = ChannelMemberListQuery(cid: .unique, filter: .contains("name", String.unique))
+        let query = ChannelMemberListQuery<NameAndImageExtraData>(cid: .unique, filter: .query(.id, text: .unique))
         
         // Save channel to the database.
         try database.createChannel(cid: query.cid)
@@ -56,7 +56,7 @@ final class ChannelMemberListQueryDTO_Tests: XCTestCase {
     
     func test_saveQuery_throwsError_ifChannelDoesNotExist() throws {
         // Create the query.
-        let query = ChannelMemberListQuery(cid: .unique, filter: .contains("name", String.unique))
+        let query = ChannelMemberListQuery<NameAndImageExtraData>(cid: .unique, filter: .query(.id, text: .unique))
         
         // Try to save query to the database.
         XCTAssertThrowsError(try database.createMemberListQuery(query: query)) { error in
@@ -67,11 +67,14 @@ final class ChannelMemberListQueryDTO_Tests: XCTestCase {
     
     // MARK: - Tests
 
-    private func assert(_ dto: ChannelMemberListQueryDTO, match query: ChannelMemberListQuery) {
+    private func assert(_ dto: ChannelMemberListQueryDTO, match query: ChannelMemberListQuery<NameAndImageExtraData>) {
         XCTAssertEqual(dto.queryHash, query.queryHash)
         
         if let filterJSONData = dto.filterJSONData {
-            let filter = try? JSONDecoder.default.decode(Filter.self, from: filterJSONData)
+            let filter = try? JSONDecoder.default.decode(
+                Filter<MemberListFilterScope<NameAndImageExtraData>>.self,
+                from: filterJSONData
+            )
             XCTAssertEqual(filter?.filterHash, query.filter?.filterHash)
         }
     }

--- a/Sources_v3/Database/DTOs/MemberModelDTO.swift
+++ b/Sources_v3/Database/DTOs/MemberModelDTO.swift
@@ -40,7 +40,7 @@ extension MemberDTO {
     }
     
     /// Returns a fetch request for the DTOs matching the provided `query`.
-    static func members(matching query: ChannelMemberListQuery) -> NSFetchRequest<MemberDTO> {
+    static func members<ExtraData: UserExtraData>(matching query: ChannelMemberListQuery<ExtraData>) -> NSFetchRequest<MemberDTO> {
         let request = NSFetchRequest<MemberDTO>(entityName: MemberDTO.entityName)
         request.predicate = NSPredicate(format: "ANY queries.queryHash == %@", query.queryHash)
         request.sortDescriptors = query.sortDescriptors
@@ -78,7 +78,7 @@ extension NSManagedObjectContext {
     func saveMember<ExtraData: UserExtraData>(
         payload: MemberPayload<ExtraData>,
         channelId: ChannelId,
-        query: ChannelMemberListQuery?
+        query: ChannelMemberListQuery<ExtraData>?
     ) throws -> MemberDTO {
         let dto = MemberDTO.loadOrCreate(id: payload.user.id, channelId: channelId, context: self)
         

--- a/Sources_v3/Database/DTOs/MemberModelDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/MemberModelDTO_Tests.swift
@@ -154,7 +154,7 @@ class MemberModelDTO_Tests: XCTestCase {
 
         // Create member and query.
         let member: MemberPayload<DefaultExtraData.User> = .dummy(userId: userId)
-        let query = ChannelMemberListQuery(cid: cid, filter: .equal("id", to: userId))
+        let query = ChannelMemberListQuery<NameAndImageExtraData>(cid: cid, filter: .equal("id", to: userId))
 
         // Save channel, then member, and pass the query in.
         try database.writeSynchronously { session in

--- a/Sources_v3/Database/DTOs/UserDTO.swift
+++ b/Sources_v3/Database/DTOs/UserDTO.swift
@@ -68,9 +68,9 @@ extension NSManagedObjectContext: UserDatabaseSession {
         UserDTO.load(id: id, context: self)
     }
     
-    func saveUser<ExtraUserData: Codable & Hashable>(
-        payload: UserPayload<ExtraUserData>,
-        query: UserListQuery?
+    func saveUser<ExtraData: UserExtraData>(
+        payload: UserPayload<ExtraData>,
+        query: UserListQuery<ExtraData>?
     ) throws -> UserDTO {
         let dto = UserDTO.loadOrCreate(id: payload.id, context: self)
         

--- a/Sources_v3/Database/DTOs/UserDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/UserDTO_Tests.swift
@@ -176,7 +176,7 @@ class UserDTO_Tests: XCTestCase {
     }
     
     func test_userWithUserListQuery_isSavedAndLoaded() {
-        let query = UserListQuery(filter: .contains("name", "a"))
+        let query = UserListQuery(filter: .query(.name, text: "a"))
         
         // Create user
         let payload1 = dummyUser
@@ -201,7 +201,7 @@ class UserDTO_Tests: XCTestCase {
     
     func test_userListQuery_withSorting() {
         // Create two user queries with different sortings.
-        let filter = Filter.equal("some", to: String.unique)
+        let filter = Filter<UserListFilterScope<NameAndImageExtraData>>.query(.name, text: "a")
         let queryWithLastActiveAtSorting = UserListQuery(filter: filter, sort: [.init(key: .lastActivityAt, isAscending: false)])
         let queryWithIdSorting = UserListQuery(filter: filter, sort: [.init(key: .id, isAscending: false)])
 

--- a/Sources_v3/Database/DTOs/UserDTO_Tests.swift
+++ b/Sources_v3/Database/DTOs/UserDTO_Tests.swift
@@ -198,7 +198,26 @@ class UserDTO_Tests: XCTestCase {
         XCTAssertEqual(loadedUsers.count, 1)
         XCTAssertEqual(loadedUsers.first?.id, id1)
     }
-    
+
+    func test_userListQueryWithoutFilter_matchesAllUsers() throws {
+        let query = UserListQuery<DefaultExtraData.User>()
+        
+        // Save 4 users to the DB
+        try database.writeSynchronously { session in
+            try session.saveUser(payload: self.dummyUser(id: .unique))
+            try session.saveUser(payload: self.dummyUser(id: .unique))
+            try session.saveUser(payload: self.dummyUser(id: .unique))
+            try session.saveUser(payload: self.dummyUser(id: .unique))
+        }
+        
+        let fetchRequest = UserDTO.userListFetchRequest(query: query)
+        var loadedUsers: [UserDTO] {
+            try! database.viewContext.fetch(fetchRequest)
+        }
+        
+        XCTAssertEqual(loadedUsers.count, 4)
+    }
+
     func test_userListQuery_withSorting() {
         // Create two user queries with different sortings.
         let filter = Filter<UserListFilterScope<NameAndImageExtraData>>.query(.name, text: "a")

--- a/Sources_v3/Database/DTOs/UserListQueryDTO.swift
+++ b/Sources_v3/Database/DTOs/UserListQueryDTO.swift
@@ -10,7 +10,7 @@ class UserListQueryDTO: NSManagedObject {
     @NSManaged var filterHash: String
     
     /// Serialized `Filter` JSON which can be used in cases the query needs to be repeated.
-    @NSManaged var filterJSONData: Data?
+    @NSManaged var filterJSONData: Data
     
     // MARK: - Relationships
     
@@ -28,25 +28,25 @@ extension NSManagedObjectContext {
         UserListQueryDTO.load(filterHash: filterHash, context: self)
     }
     
-    func saveQuery(query: UserListQuery) -> UserListQueryDTO {
-        if let existingDTO = UserListQueryDTO.load(filterHash: query.filter?.filterHash ?? Filter.nilFilterHash, context: self) {
+    func saveQuery<ExtraData: UserExtraData>(query: UserListQuery<ExtraData>) throws -> UserListQueryDTO? {
+        guard let filterHash = query.filter?.filterHash else {
+            // A query without a filter doesn't have to be saved to the DB because it matches all users by default.
+            return nil
+        }
+        
+        if let existingDTO = UserListQueryDTO.load(filterHash: filterHash, context: self) {
             return existingDTO
         }
         
         let newDTO = NSEntityDescription
             .insertNewObject(forEntityName: UserListQueryDTO.entityName, into: self) as! UserListQueryDTO
-        newDTO.filterHash = query.filter?.filterHash ?? Filter.nilFilterHash
+        newDTO.filterHash = filterHash
         
-        var jsonData: Data?
         do {
-            // On iOS 12 attempt of encoding nil value will produce an error.
-            // We can remove this nil check after dropping iOS 12 support.
-            jsonData = (query.filter == nil) ? nil : try JSONEncoder.default.encode(query.filter)
+            newDTO.filterJSONData = try JSONEncoder.default.encode(query.filter)
         } catch {
             log.error("Failed encoding query Filter data with error: \(error).")
         }
-        
-        newDTO.filterJSONData = jsonData
         
         return newDTO
     }

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -110,17 +110,15 @@ extension DatabaseContainer {
         }
     }
     
-    func createUserListQuery(filter: Filter<UserListFilterScope<NameAndImageExtraData>>? = .query(.id, text: .unique)) throws {
+    func createUserListQuery(filter: Filter<UserListFilterScope<NameAndImageExtraData>> = .query(.id, text: .unique)) throws {
         try writeSynchronously { session in
             let dto = NSEntityDescription
                 .insertNewObject(
                     forEntityName: UserListQueryDTO.entityName,
                     into: session as! NSManagedObjectContext
                 ) as! UserListQueryDTO
-            dto.filterHash = filter?.filterHash ?? Filter.nilFilterHash
-            // On iOS 12 attempt of encoding nil value will produce an error.
-            // We can remove this nil check after dropping iOS 12 support.
-            dto.filterJSONData = (filter == nil) ? nil : try JSONEncoder.default.encode(filter)
+            dto.filterHash = filter.filterHash
+            dto.filterJSONData = try JSONEncoder.default.encode(filter)
         }
     }
     

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -96,7 +96,9 @@ extension DatabaseContainer {
         }
     }
     
-    func createChannelListQuery(filter: Filter = .contains(.unique, String.unique)) throws {
+    func createChannelListQuery(
+        filter: Filter<ChannelListFilterScope<NameAndImageExtraData>> = .query(.cid, text: .unique)
+    ) throws {
         try writeSynchronously { session in
             let dto = NSEntityDescription
                 .insertNewObject(

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -110,7 +110,7 @@ extension DatabaseContainer {
         }
     }
     
-    func createUserListQuery(filter: Filter? = .contains(.unique, String.unique)) throws {
+    func createUserListQuery(filter: Filter<UserListFilterScope<NameAndImageExtraData>>? = .query(.id, text: .unique)) throws {
         try writeSynchronously { session in
             let dto = NSEntityDescription
                 .insertNewObject(

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -122,7 +122,7 @@ extension DatabaseContainer {
         }
     }
     
-    func createMemberListQuery(query: ChannelMemberListQuery) throws {
+    func createMemberListQuery<ExtraData: UserExtraData>(query: ChannelMemberListQuery<ExtraData>) throws {
         try writeSynchronously { session in
             try session.saveQuery(query)
         }
@@ -150,7 +150,7 @@ extension DatabaseContainer {
         userId: UserId = .unique,
         role: MemberRole = .member,
         cid: ChannelId,
-        query: ChannelMemberListQuery? = nil
+        query: ChannelMemberListQuery<NameAndImageExtraData>? = nil
     ) throws {
         try writeSynchronously { session in
             try session.saveMember(

--- a/Sources_v3/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/Database/DatabaseContainer_Mock.swift
@@ -83,7 +83,7 @@ extension DatabaseContainer {
         }
     }
     
-    /// Synchrnously creates a new ChannelDTO in the DB with the given cid.
+    /// Synchronously creates a new ChannelDTO in the DB with the given cid.
     func createChannel(cid: ChannelId = .unique, withMessages: Bool = true) throws {
         try writeSynchronously { session in
             let dto = try session.saveChannel(payload: XCTestCase().dummyPayload(with: cid))

--- a/Sources_v3/Database/DatabaseSession.swift
+++ b/Sources_v3/Database/DatabaseSession.swift
@@ -146,7 +146,7 @@ protocol MemberListQueryDatabaseSession {
     
     /// Creates a new `MemberListQueryDatabaseSession` object in the database based in the given `ChannelMemberListQuery`.
     @discardableResult
-    func saveQuery(_ query: ChannelMemberListQuery) throws -> ChannelMemberListQueryDTO
+    func saveQuery<ExtraData: UserExtraData>(_ query: ChannelMemberListQuery<ExtraData>) throws -> ChannelMemberListQueryDTO
 }
 
 protocol DatabaseSession: UserDatabaseSession,

--- a/Sources_v3/Database/DatabaseSession.swift
+++ b/Sources_v3/Database/DatabaseSession.swift
@@ -10,7 +10,7 @@ protocol UserDatabaseSession {
     /// Saves the provided payload to the DB. Return's the matching `UserDTO` if the save was successfull. Throws an error
     /// if the save fails.
     @discardableResult
-    func saveUser<ExtraData: UserExtraData>(payload: UserPayload<ExtraData>, query: UserListQuery?) throws -> UserDTO
+    func saveUser<ExtraData: UserExtraData>(payload: UserPayload<ExtraData>, query: UserListQuery<ExtraData>?) throws -> UserDTO
     
     /// Fetchtes `UserDTO` with the given `id` from the DB. Returns `nil` if no `UserDTO` matching the `id` exists.
     func user(id: UserId) -> UserDTO?

--- a/Sources_v3/Database/DatabaseSession.swift
+++ b/Sources_v3/Database/DatabaseSession.swift
@@ -7,23 +7,23 @@ import CoreData
 extension NSManagedObjectContext: DatabaseSession {}
 
 protocol UserDatabaseSession {
-    /// Saves the provided payload to the DB. Return's the matching `UserDTO` if the save was successfull. Throws an error
+    /// Saves the provided payload to the DB. Return's the matching `UserDTO` if the save was successful. Throws an error
     /// if the save fails.
     @discardableResult
     func saveUser<ExtraData: UserExtraData>(payload: UserPayload<ExtraData>, query: UserListQuery<ExtraData>?) throws -> UserDTO
     
-    /// Fetchtes `UserDTO` with the given `id` from the DB. Returns `nil` if no `UserDTO` matching the `id` exists.
+    /// Fetches `UserDTO` with the given `id` from the DB. Returns `nil` if no `UserDTO` matching the `id` exists.
     func user(id: UserId) -> UserDTO?
 }
 
 protocol CurrentUserDatabaseSession {
-    /// Saves the provided payload to the DB. Return's a `CurrentUserDTO` if the save was successfull. Throws an error
+    /// Saves the provided payload to the DB. Return's a `CurrentUserDTO` if the save was successful. Throws an error
     /// if the save fails.
     @discardableResult
     func saveCurrentUser<ExtraData: UserExtraData>(payload: CurrentUserPayload<ExtraData>) throws -> CurrentUserDTO
 
     /// Updates the `CurrentUserDTO` with the provided unread.
-    /// If there is no current user, the error will be thown
+    /// If there is no current user, the error will be thrown.
     func saveCurrentUserUnreadCount(count: UnreadCount) throws
     
     /// Updates the `CurrentUserDTO.devices` with the provided `DevicesPayload`
@@ -64,7 +64,7 @@ protocol MessageDatabaseSession {
         for cid: ChannelId
     ) throws -> MessageDTO
     
-    /// Fetchtes `MessageDTO` with the given `id` from the DB. Returns `nil` if no `MessageDTO` matching the `id` exists.
+    /// Fetches `MessageDTO` with the given `id` from the DB. Returns `nil` if no `MessageDTO` matching the `id` exists.
     func message(id: MessageId) -> MessageDTO?
     
     /// Deletes the provided dto from a database
@@ -119,11 +119,11 @@ protocol ChannelReadDatabaseSession {
         for cid: ChannelId
     ) throws -> ChannelReadDTO
     
-    /// Fetchtes `ChannelReadDTO` with the given `cid` and `userId` from the DB.
+    /// Fetches `ChannelReadDTO` with the given `cid` and `userId` from the DB.
     /// Returns `nil` if no `ChannelReadDTO` matching the `cid` and `userId`  exists.
     func loadChannelRead(cid: ChannelId, userId: String) -> ChannelReadDTO?
     
-    /// Fetchtes `ChannelReadDTO`entities for the given `userId` from the DB.
+    /// Fetches `ChannelReadDTO`entities for the given `userId` from the DB.
     func loadChannelReads(for userId: UserId) -> [ChannelReadDTO]
 }
 
@@ -133,15 +133,15 @@ protocol MemberDatabaseSession {
     func saveMember<ExtraData: UserExtraData>(
         payload: MemberPayload<ExtraData>,
         channelId: ChannelId,
-        query: ChannelMemberListQuery?
+        query: ChannelMemberListQuery<ExtraData>?
     ) throws -> MemberDTO
     
-    /// Fetchtes `MemberDTO`entity for the given `userId` and `cid`.
+    /// Fetches `MemberDTO`entity for the given `userId` and `cid`.
     func member(userId: UserId, cid: ChannelId) -> MemberDTO?
 }
 
 protocol MemberListQueryDatabaseSession {
-    /// Fetchtes `MemberListQueryDatabaseSession` entity for the given `filterHash`.
+    /// Fetches `MemberListQueryDatabaseSession` entity for the given `filterHash`.
     func channelMemberListQuery(queryHash: String) -> ChannelMemberListQueryDTO?
     
     /// Creates a new `MemberListQueryDatabaseSession` object in the database based in the given `ChannelMemberListQuery`.

--- a/Sources_v3/Database/DatabaseSession.swift
+++ b/Sources_v3/Database/DatabaseSession.swift
@@ -98,13 +98,16 @@ extension MessageDatabaseSession {
 protocol ChannelDatabaseSession {
     /// Creates a new `ChannelDTO` object in the database with the given `payload` and `query`.
     @discardableResult
-    func saveChannel<ExtraData: ExtraDataTypes>(payload: ChannelPayload<ExtraData>, query: ChannelListQuery?) throws -> ChannelDTO
+    func saveChannel<ExtraData: ExtraDataTypes>(
+        payload: ChannelPayload<ExtraData>,
+        query: ChannelListQuery<ExtraData.Channel>?
+    ) throws -> ChannelDTO
     
     /// Creates a new `ChannelDTO` object in the database with the given `payload` and `query`.
     @discardableResult
     func saveChannel<ExtraData: ExtraDataTypes>(
         payload: ChannelDetailPayload<ExtraData>,
-        query: ChannelListQuery?
+        query: ChannelListQuery<ExtraData.Channel>?
     ) throws -> ChannelDTO
     
     /// Fetches `ChannelDTO` with the given `cid` from the database.

--- a/Sources_v3/Database/DatabaseSession.swift
+++ b/Sources_v3/Database/DatabaseSession.swift
@@ -14,9 +14,6 @@ protocol UserDatabaseSession {
     
     /// Fetchtes `UserDTO` with the given `id` from the DB. Returns `nil` if no `UserDTO` matching the `id` exists.
     func user(id: UserId) -> UserDTO?
-    
-    /// Updates user with the query if both user and query exist.
-    func updateQuery(for userId: UserId, queryFilterHash: String) throws
 }
 
 protocol CurrentUserDatabaseSession {

--- a/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17192" systemVersion="19G2021" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17192" systemVersion="19E266" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ChannelDTO" representedClassName="ChannelDTO" syncable="YES">
         <attribute name="cid" attributeType="String"/>
         <attribute name="config" attributeType="Binary"/>
@@ -188,7 +188,7 @@
     </entity>
     <entity name="UserListQueryDTO" representedClassName="UserListQueryDTO" syncable="YES">
         <attribute name="filterHash" attributeType="String"/>
-        <attribute name="filterJSONData" optional="YES" attributeType="Binary"/>
+        <attribute name="filterJSONData" attributeType="Binary"/>
         <relationship name="users" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="queries" inverseEntity="UserDTO"/>
         <fetchIndex name="filterHash">
             <fetchIndexElement property="filterHash" type="Binary" order="ascending"/>

--- a/Sources_v3/Models/ExtraData.swift
+++ b/Sources_v3/Models/ExtraData.swift
@@ -18,7 +18,7 @@ public struct NoExtraData: Codable, Hashable, UserExtraData, ChannelExtraData, M
 
 /// The extra data type with `name` and `imageURL` properties.
 public struct NameAndImageExtraData: ChannelExtraData, UserExtraData {
-    private enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case name
         case imageURL = "image"
     }

--- a/Sources_v3/Models/User.swift
+++ b/Sources_v3/Models/User.swift
@@ -107,7 +107,7 @@ public enum UserRole: String, Codable, Hashable {
     /// A user that connected using guest user authentication.
     case guest
     
-    /// A user that connected using anynonymous authentication.
+    /// A user that connected using anonymous authentication.
     case anonymous
 }
 

--- a/Sources_v3/Query/ChannelListQuery.swift
+++ b/Sources_v3/Query/ChannelListQuery.swift
@@ -4,9 +4,69 @@
 
 import Foundation
 
+/// A namespace for the `FilterKey`s suitable to be used for `ChannelListQuery`. This scope is not aware of any extra data types.
+public protocol AnyChannelListFilterScope {}
+
+/// An extra-data-specific namespace for the `FilterKey`s suitable to be used for `ChannelListQuery`.
+public struct ChannelListFilterScope<ExtraData: ChannelExtraData>: FilterScope, AnyChannelListFilterScope {}
+
+public extension Filter where Scope: AnyChannelListFilterScope {
+    /// Filter to match channels containing members with specified user ids.
+    static func containMembers(userIds: [UserId]) -> Filter<Scope> {
+        .in(.members, values: userIds)
+    }
+}
+
+// We don't want to expose `members` publicly because it can't be used with any other operator
+// then `$in`. We expose it publicly via the `containMembers` filter helper.
+extension FilterKey where Scope: AnyChannelListFilterScope {
+    static var members: FilterKey<Scope, UserId> { "members" }
+}
+
+/// Non extra-data-specific filer keys for channel list.
+public extension FilterKey where Scope: AnyChannelListFilterScope {
+    /// A filter key for matching the `cid` value.
+    static var cid: FilterKey<Scope, ChannelId> { "cid" }
+    
+    /// A filter key for matching the `type` value.
+    static var type: FilterKey<Scope, ChannelType> { "type" }
+    
+    /// A filter key for matching the `lastMessageAt` value.
+    static var lastMessageAt: FilterKey<Scope, Date> { "last_message_at" }
+    
+    /// A filter key for matching the `createdBy` value.
+    static var createdBy: FilterKey<Scope, UserId> { "created_by" }
+    
+    /// A filter key for matching the `createdAt` value.
+    static var createdAt: FilterKey<Scope, Date> { "created_at" }
+    
+    /// A filter key for matching the `updatedAt` value.
+    static var updatedAt: FilterKey<Scope, Date> { "updated_at" }
+    
+    /// A filter key for matching the `deletedAt` value.
+    static var deletedAt: FilterKey<Scope, Date> { "deleted_at" }
+    
+    /// A filter key for matching the `frozen` value.
+    static var frozen: FilterKey<Scope, Bool> { "frozen" }
+
+    /// A filter key for matching the `memberCount` value.
+    static var memberCount: FilterKey<Scope, Int> { "member_count" }
+    
+    //    static var team: FilterKey<Scope, > { "team" }
+}
+
+/// Channel list filter keys for `NameAndImageExtraData`.
+public extension FilterKey where Scope == ChannelListFilterScope<NameAndImageExtraData> {
+    /// A filter key for matching the `name` value.
+    static var name: FilterKey<Scope, String> { "name" }
+
+    /// A filter key for matching the `image` value.
+    static var imageURL: FilterKey<Scope, URL> { "image" }
+}
+
 /// A query is used for querying specific channels from backend.
 /// You can specify filter, sorting, pagination, limit for fetched messages in channel and other options.
-public struct ChannelListQuery: Encodable {
+public struct ChannelListQuery<ExtraData: ChannelExtraData>: Encodable {
     private enum CodingKeys: String, CodingKey {
         case filter = "filter_conditions"
         case sort
@@ -19,7 +79,7 @@ public struct ChannelListQuery: Encodable {
     }
     
     /// A filter for the query (see `Filter`).
-    public let filter: Filter
+    public let filter: Filter<ChannelListFilterScope<ExtraData>>
     /// A sorting for the query (see `Sorting`).
     public let sort: [Sorting<ChannelListSortingKey>]
     /// A pagination.
@@ -37,7 +97,7 @@ public struct ChannelListQuery: Encodable {
     ///   - messagesLimit: a messages pagination for the each channel.
     ///   - options: a query options (see `QueryOptions`).
     public init(
-        filter: Filter,
+        filter: Filter<ChannelListFilterScope<ExtraData>>,
         sort: [Sorting<ChannelListSortingKey>] = [],
         pagination: Pagination = [.channelsPageSize],
         messagesLimit: Pagination = [.messagesPageSize],
@@ -63,11 +123,3 @@ public struct ChannelListQuery: Encodable {
         try pagination.encode(to: encoder)
     }
 }
-
-// MARK: - Channels Response
-
-/// A channels query response.
-// public struct ChannelsResponse: Decodable {
-//    /// A list of channels response (see `ChannelQuery`).
-//    public let channels: [ChannelResponse]
-// }

--- a/Sources_v3/Query/ChannelListQuery_Tests.swift
+++ b/Sources_v3/Query/ChannelListQuery_Tests.swift
@@ -1,0 +1,42 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatClient
+import XCTest
+
+final class ChannelListFilterScope_Tests: XCTestCase {
+    typealias Key<T: FilterValue> = FilterKey<ChannelListFilterScope<NoExtraData>, T>
+    
+    func test_filterKeys_matchChannelCodingKeys() {
+        XCTAssertEqual(Key<ChannelId>.cid.rawValue, ChannelCodingKeys.cid.rawValue)
+        XCTAssertEqual(Key<ChannelType>.type.rawValue, ChannelCodingKeys.typeRawValue.rawValue)
+        XCTAssertEqual(Key<Date>.lastMessageAt.rawValue, ChannelCodingKeys.lastMessageAt.rawValue)
+        XCTAssertEqual(Key<UserId>.createdBy.rawValue, ChannelCodingKeys.createdBy.rawValue)
+        XCTAssertEqual(Key<Date>.createdAt.rawValue, ChannelCodingKeys.createdAt.rawValue)
+        XCTAssertEqual(Key<Date>.updatedAt.rawValue, ChannelCodingKeys.updatedAt.rawValue)
+        XCTAssertEqual(Key<Date>.deletedAt.rawValue, ChannelCodingKeys.deletedAt.rawValue)
+        XCTAssertEqual(Key<Bool>.frozen.rawValue, ChannelCodingKeys.frozen.rawValue)
+        XCTAssertEqual(Key<Int>.memberCount.rawValue, ChannelCodingKeys.memberCount.rawValue)
+    }
+
+    func test_filterKeys_matchNameAndImageExtraDataCodingKeys() {
+        XCTAssertEqual(
+            FilterKey<ChannelListFilterScope<NameAndImageExtraData>, String>.name.rawValue,
+            NameAndImageExtraData.CodingKeys.name.rawValue
+        )
+        XCTAssertEqual(
+            FilterKey<ChannelListFilterScope<NameAndImageExtraData>, URL>.imageURL.rawValue,
+            NameAndImageExtraData.CodingKeys.imageURL.rawValue
+        )
+    }
+
+    func test_containMembersHelper() {
+        // Check the `containMembers` helper translates to `members $in [ids]`
+        let ids: [UserId] = [.unique, .unique]
+        XCTAssertEqual(
+            Filter<ChannelListFilterScope<NoExtraData>>.containMembers(userIds: ids),
+            Filter<ChannelListFilterScope<NoExtraData>>.in(.members, values: ids)
+        )
+    }
+}

--- a/Sources_v3/Query/ChannelMemberListQuery.swift
+++ b/Sources_v3/Query/ChannelMemberListQuery.swift
@@ -6,10 +6,16 @@ import Foundation
 
 /// A namespace for the `FilterKey`s suitable to be used for `ChannelMemberListQuery`. This scope is not aware of any
 /// extra data types.
-public typealias AnyMemberListFilterScope = AnyUserListFilterScope
+public protocol AnyMemberListFilterScope: AnyUserListFilterScope {}
 
 /// An extra-data-specific namespace for the `FilterKey`s suitable to be used for `ChannelMemberListQuery`.
-public typealias MemberListFilterScope<ExtraData: UserExtraData> = UserListFilterScope<ExtraData>
+public class MemberListFilterScope<ExtraData: UserExtraData>: UserListFilterScope<ExtraData>, AnyMemberListFilterScope {}
+
+/// Non extra-data-specific filer keys for member list.
+public extension FilterKey where Scope: AnyMemberListFilterScope {
+    /// A filter key for matching moderators of a channel.
+    static var isModerator: FilterKey<Scope, Bool> { "is_moderator" }
+}
 
 /// A query type used for fetching channel members from the backend.
 public struct ChannelMemberListQuery<ExtraData: UserExtraData>: Encodable {

--- a/Sources_v3/Query/ChannelMemberListQuery_Tests.swift
+++ b/Sources_v3/Query/ChannelMemberListQuery_Tests.swift
@@ -5,6 +5,39 @@
 @testable import StreamChatClient
 import XCTest
 
+final class MemberListFilterScope_Tests: XCTestCase {
+    typealias Key<T: FilterValue> = FilterKey<MemberListFilterScope<NoExtraData>, T>
+    
+    func test_filterKeys_matchChannelCodingKeys() {
+        // Member specific coding keys
+        XCTAssertEqual(Key<Bool>.isModerator.rawValue, "is_moderator")
+        
+        // User-related coding keys
+        XCTAssertEqual(Key<UserId>.id.rawValue, UserPayloadsCodingKeys.id.rawValue)
+        XCTAssertEqual(Key<UserRole>.role.rawValue, UserPayloadsCodingKeys.role.rawValue)
+        XCTAssertEqual(Key<Bool>.isOnline.rawValue, UserPayloadsCodingKeys.isOnline.rawValue)
+        XCTAssertEqual(Key<Bool>.isBanned.rawValue, UserPayloadsCodingKeys.isBanned.rawValue)
+        XCTAssertEqual(Key<Date>.createdAt.rawValue, UserPayloadsCodingKeys.createdAt.rawValue)
+        XCTAssertEqual(Key<Date>.updatedAt.rawValue, UserPayloadsCodingKeys.updatedAt.rawValue)
+        XCTAssertEqual(Key<Date>.lastActiveAt.rawValue, UserPayloadsCodingKeys.lastActiveAt.rawValue)
+        XCTAssertEqual(Key<Bool>.isInvisible.rawValue, UserPayloadsCodingKeys.isInvisible.rawValue)
+        XCTAssertEqual(Key<Int>.unreadChannelsCount.rawValue, UserPayloadsCodingKeys.unreadChannelsCount.rawValue)
+        XCTAssertEqual(Key<Int>.unreadMessagesCount.rawValue, UserPayloadsCodingKeys.unreadMessagesCount.rawValue)
+        XCTAssertEqual(Key<Bool>.isAnonymous.rawValue, UserPayloadsCodingKeys.isAnonymous.rawValue)
+    }
+    
+    func test_filterKeys_matchNameAndImageExtraDataCodingKeys() {
+        XCTAssertEqual(
+            FilterKey<MemberListFilterScope<NameAndImageExtraData>, String>.name.rawValue,
+            NameAndImageExtraData.CodingKeys.name.rawValue
+        )
+        XCTAssertEqual(
+            FilterKey<MemberListFilterScope<NameAndImageExtraData>, URL>.imageURL.rawValue,
+            NameAndImageExtraData.CodingKeys.imageURL.rawValue
+        )
+    }
+}
+
 final class ChannelMemberListQuery_Tests: XCTestCase {
     func test_query_isEncodedCorrectly() throws {
         // Create the query.

--- a/Sources_v3/Query/Filter.swift
+++ b/Sources_v3/Query/Filter.swift
@@ -77,6 +77,7 @@ extension Filter: FilterValue {}
 
 extension ChannelId: FilterValue {}
 extension ChannelType: FilterValue {}
+extension UserRole: FilterValue {}
 
 /// Filter is used to specify the details about which elements should be returned from a specific query.
 ///

--- a/Sources_v3/Query/Filter_Tests.swift
+++ b/Sources_v3/Query/Filter_Tests.swift
@@ -6,100 +6,123 @@
 import XCTest
 
 class Filter_Tests: XCTestCase {
-    func testOperators() {
-        var filter = Filter.equal("a", to: "b")
-        XCTAssertEqual(filter.json, "{\"a\":\"b\"}")
+    func test_helperOperators() {
+        var filter: Filter<TestScope> = .equal(.testKey, to: "equal value")
+        XCTAssertEqual(filter.key, FilterKey<TestScope, String>.testKey.rawValue)
+        XCTAssertEqual(filter.value as? String, "equal value")
+        XCTAssertEqual(filter.operator, FilterOperator.equal.rawValue)
         
-        filter = .notEqual("a", to: "b")
-        XCTAssertEqual(filter.json, "{\"a\":{\"$ne\":\"b\"}}")
+        filter = .notEqual(.testKey, to: "not equal value")
+        XCTAssertEqual(filter.key, FilterKey<TestScope, String>.testKey.rawValue)
+        XCTAssertEqual(filter.value as? String, "not equal value")
+        XCTAssertEqual(filter.operator, FilterOperator.notEqual.rawValue)
         
-        filter = .greater("a", than: "b")
-        XCTAssertEqual(filter.json, "{\"a\":{\"$gt\":\"b\"}}")
+        filter = .greater(.testKey, than: "greater value")
+        XCTAssertEqual(filter.key, FilterKey<TestScope, String>.testKey.rawValue)
+        XCTAssertEqual(filter.value as? String, "greater value")
+        XCTAssertEqual(filter.operator, FilterOperator.greater.rawValue)
         
-        filter = .greaterOrEqual("a", than: "b")
-        XCTAssertEqual(filter.json, "{\"a\":{\"$gte\":\"b\"}}")
+        filter = .greaterOrEqual(.testKey, than: "greater or equal value")
+        XCTAssertEqual(filter.key, FilterKey<TestScope, String>.testKey.rawValue)
+        XCTAssertEqual(filter.value as? String, "greater or equal value")
+        XCTAssertEqual(filter.operator, FilterOperator.greaterOrEqual.rawValue)
         
-        filter = .less("a", than: "b")
-        XCTAssertEqual(filter.json, "{\"a\":{\"$lt\":\"b\"}}")
+        filter = .less(.testKey, than: "less value")
+        XCTAssertEqual(filter.key, FilterKey<TestScope, String>.testKey.rawValue)
+        XCTAssertEqual(filter.value as? String, "less value")
+        XCTAssertEqual(filter.operator, FilterOperator.less.rawValue)
         
-        filter = .lessOrEqual("a", than: "b")
-        XCTAssertEqual(filter.json, "{\"a\":{\"$lte\":\"b\"}}")
+        filter = .lessOrEqual(.testKey, than: "less or equal value")
+        XCTAssertEqual(filter.key, FilterKey<TestScope, String>.testKey.rawValue)
+        XCTAssertEqual(filter.value as? String, "less or equal value")
+        XCTAssertEqual(filter.operator, FilterOperator.lessOrEqual.rawValue)
         
-        filter = .in("a", ["b"])
-        XCTAssertEqual(filter.json, "{\"a\":{\"$in\":[\"b\"]}}")
+        filter = .in(.testKey, values: ["in value 1", "in value 2"])
+        XCTAssertEqual(filter.key, FilterKey<TestScope, String>.testKey.rawValue)
+        XCTAssertEqual(filter.value as? [String], ["in value 1", "in value 2"])
+        XCTAssertEqual(filter.operator, FilterOperator.in.rawValue)
         
-        filter = .notIn("a", ["b"])
-        XCTAssertEqual(filter.json, "{\"a\":{\"$nin\":[\"b\"]}}")
+        filter = .notIn(.testKey, values: ["nin value 1", "nin value 2"])
+        XCTAssertEqual(filter.key, FilterKey<TestScope, String>.testKey.rawValue)
+        XCTAssertEqual(filter.value as? [String], ["nin value 1", "nin value 2"])
+        XCTAssertEqual(filter.operator, FilterOperator.notIn.rawValue)
         
-        filter = .query("a", with: "b")
-        XCTAssertEqual(filter.json, "{\"a\":{\"$q\":\"b\"}}")
+        filter = .query(.testKey, text: "searched text")
+        XCTAssertEqual(filter.key, FilterKey<TestScope, String>.testKey.rawValue)
+        XCTAssertEqual(filter.value as? String, "searched text")
+        XCTAssertEqual(filter.operator, FilterOperator.query.rawValue)
         
-        filter = .autocomplete("a", with: "b")
-        XCTAssertEqual(filter.json, "{\"a\":{\"$autocomplete\":\"b\"}}")
+        filter = .autocomplete(.testKey, text: "atocomplete text")
+        XCTAssertEqual(filter.key, FilterKey<TestScope, String>.testKey.rawValue)
+        XCTAssertEqual(filter.value as? String, "atocomplete text")
+        XCTAssertEqual(filter.operator, FilterOperator.autocomplete.rawValue)
         
-        filter = .contains("a", "b")
-        XCTAssertEqual(filter.json, "{\"a\":{\"$contains\":\"b\"}}")
+        filter = .exists(.testKey, exists: false)
+        XCTAssertEqual(filter.key, FilterKey<TestScope, String>.testKey.rawValue)
+        XCTAssertEqual(filter.value as? Bool, false)
+        XCTAssertEqual(filter.operator, FilterOperator.exists.rawValue)
         
-        filter = .custom("myOperator", key: "a", value: "b")
-        XCTAssertEqual(filter.json, "{\"a\":{\"$myOperator\":\"b\"}}")
+        let filter1: Filter<TestScope> = .init(operator: "$" + .unique, key: .unique, value: String.unique)
+        let filter2: Filter<TestScope> = .init(operator: "$" + .unique, key: .unique, value: String.unique)
+        
+        filter = .and([filter1, filter2])
+        XCTAssertEqual(filter.key, nil)
+        XCTAssertEqual(filter.value as? [Filter<TestScope>], [filter1, filter2])
+        XCTAssertEqual(filter.operator, FilterOperator.and.rawValue)
+        
+        filter = .or([filter1, filter2])
+        XCTAssertEqual(filter.key, nil)
+        XCTAssertEqual(filter.value as? [Filter<TestScope>], [filter1, filter2])
+        XCTAssertEqual(filter.operator, FilterOperator.or.rawValue)
+        
+        filter = .nor([filter1, filter2])
+        XCTAssertEqual(filter.key, nil)
+        XCTAssertEqual(filter.value as? [Filter<TestScope>], [filter1, filter2])
+        XCTAssertEqual(filter.operator, FilterOperator.nor.rawValue)
     }
     
-    func testFilterEncoding() {
-        let filter1 = Filter.equal("a", to: "b")
-        let filter2 = Filter.equal("c", to: "d")
-        let filter3 = Filter.equal("e", to: "f")
+    func test_operatorEncodingAndDecoding() {
+        // Test non-group filter
+        var filter: Filter<TestScope> = .init(operator: FilterOperator.equal.rawValue, key: "test_key", value: "test_value")
+        var jsonString: String { filter.serialized }
+        XCTAssertEqual(jsonString, #"{"test_key":{"$eq":"test_value"}}"#)
+        XCTAssertEqual(jsonString.deserialize(), filter)
         
-        // And
-        var filter = filter1
-        filter &= filter2
-        XCTAssertEqual((filter1 & filter2).json, "{\"$and\":[{\"a\":\"b\"},{\"c\":\"d\"}]}")
-        XCTAssertEqual(filter.json, "{\"$and\":[{\"a\":\"b\"},{\"c\":\"d\"}]}")
+        // Test in filter
+        filter = .init(operator: FilterOperator.in.rawValue, key: "test_key", value: [1, 2, 3])
+        XCTAssertEqual(filter.serialized, #"{"test_key":{"$in":[1,2,3]}}"#)
+        XCTAssertEqual(jsonString.deserialize(), filter)
         
-        // Or
-        filter = filter1
-        filter |= filter2
-        XCTAssertEqual((filter1 | filter2).json, "{\"$or\":[{\"a\":\"b\"},{\"c\":\"d\"}]}")
-        XCTAssertEqual(filter.json, "{\"$or\":[{\"a\":\"b\"},{\"c\":\"d\"}]}")
-        
-        // Combination of Or + And
-        XCTAssertEqual(
-            ((filter1 | filter2) & filter3).json,
-            "{\"$and\":[{\"$or\":[{\"a\":\"b\"},{\"c\":\"d\"}]},{\"e\":\"f\"}]}"
-        )
-        XCTAssertEqual(
-            (filter1 | (filter2 & filter3)).json,
-            "{\"$or\":[{\"a\":\"b\"},{\"$and\":[{\"c\":\"d\"},{\"e\":\"f\"}]}]}"
-        )
-        
-        // Nor
-        XCTAssertEqual(Filter.nor([filter1, filter2]).json, "{\"$nor\":[{\"a\":\"b\"},{\"c\":\"d\"}]}")
-    }
-    
-    func testFilterDecoding() throws {
-        let filter1: Filter = .and([.and([.or([.equal(.unique, to: String.unique)])])])
-        let filter2: Filter = .custom(String.unique, key: .unique, value: 1)
-        let filter3: Filter = .nor([.notIn(.unique, [1, 2, 3, 4, 5]), .in(.unique, [1.1, 2.2, 3.3])])
-        
-        // Encode filters
-        let encoded1 = try JSONEncoder.default.encode(filter1)
-        let encoded2 = try JSONEncoder.default.encode(filter2)
-        let encoded3 = try JSONEncoder.default.encode(filter3)
-        
-        // Decode filters
-        let decoded1 = try JSONDecoder.default.decode(Filter.self, from: encoded1)
-        let decoded2 = try JSONDecoder.default.decode(Filter.self, from: encoded2)
-        let decoded3 = try JSONDecoder.default.decode(Filter.self, from: encoded3)
-        
-        // Assert filters decoded correctly
-        XCTAssertEqual(filter1.filterHash, decoded1.filterHash)
-        XCTAssertEqual(filter2.filterHash, decoded2.filterHash)
-        XCTAssertEqual(filter3.filterHash, decoded3.filterHash)
+        // Test group filter
+        let filter1: Filter<TestScope> = .equal(.testKey, to: "test_value_1")
+        let filter2: Filter<TestScope> = .notEqual(.testKey, to: "test_value_2")
+        filter = .or([filter1, filter2])
+        XCTAssertEqual(filter.serialized, #"{"$or":[{"test_key":{"$eq":"test_value_1"}},{"test_key":{"$ne":"test_value_2"}}]}"#)
+        XCTAssertEqual(jsonString.deserialize(), filter)
     }
 }
 
-extension Filter {
-    var json: String {
+private struct TestScope: FilterScope {}
+
+private extension FilterKey where Scope == TestScope {
+    static var testKey: FilterKey<Scope, String> { "test_key" }
+}
+
+extension Filter: Equatable {
+    public static func == (lhs: Filter<Scope>, rhs: Filter<Scope>) -> Bool {
+        String(describing: lhs) == String(describing: rhs)
+    }
+}
+
+private extension Filter {
+    var serialized: String {
         let data = try! JSONEncoder.default.encode(self)
         return String(data: data, encoding: .utf8)!
+    }
+}
+
+private extension String {
+    func deserialize<Scope: FilterScope>() -> Filter<Scope>? {
+        try? JSONDecoder.default.decode(Filter<Scope>.self, from: data(using: .utf8)!)
     }
 }

--- a/Sources_v3/Query/QueryOptions.swift
+++ b/Sources_v3/Query/QueryOptions.swift
@@ -16,10 +16,13 @@ public struct QueryOptions: OptionSet, Encodable {
     
     /// A query will return a channel state, e.g. messages.
     public static let state = QueryOptions(rawValue: 1 << 0)
-    /// Listen for a channel changes in real time, e.g. a new message evevnt.
+    
+    /// Listen for a channel changes in real time, e.g. a new message event.
     public static let watch = QueryOptions(rawValue: 1 << 1)
+    
     /// Get updates when the user goes offline/online.
     public static let presence = QueryOptions(rawValue: 1 << 2)
+    
     /// Includes all query options: state, watch and presence.
     public static let all: QueryOptions = [.state, .watch, .presence]
     

--- a/Sources_v3/Query/UserListQuery.swift
+++ b/Sources_v3/Query/UserListQuery.swift
@@ -68,7 +68,8 @@ public struct UserListQuery<ExtraData: UserExtraData>: Encodable {
     }
     
     /// A filter for the query (see `Filter`).
-    public let filter: Filter?
+    public let filter: Filter<UserListFilterScope<ExtraData>>?
+    
     /// A sorting for the query (see `Sorting`).
     public let sort: [Sorting<UserListSortingKey>]
     /// A pagination.

--- a/Sources_v3/Query/UserListQuery.swift
+++ b/Sources_v3/Query/UserListQuery.swift
@@ -8,7 +8,7 @@ import Foundation
 public protocol AnyUserListFilterScope {}
 
 /// An extra-data-specific namespace for the `FilterKey`s suitable to be used for `UserListQuery`.
-public struct UserListFilterScope<ExtraData: UserExtraData>: FilterScope, AnyUserListFilterScope {}
+public class UserListFilterScope<ExtraData: UserExtraData>: FilterScope, AnyUserListFilterScope {}
 
 /// Non extra-data-specific filer keys for channel list.
 public extension FilterKey where Scope: AnyUserListFilterScope {
@@ -49,7 +49,7 @@ public extension FilterKey where Scope: AnyUserListFilterScope {
 }
 
 /// Channel list filter keys for `NameAndImageExtraData`.
-public extension FilterKey where Scope == UserListFilterScope<NameAndImageExtraData> {
+public extension FilterKey where Scope: UserListFilterScope<NameAndImageExtraData> {
     /// A filter key for matching the `name` value.
     static var name: FilterKey<Scope, String> { "name" }
     

--- a/Sources_v3/Query/UserListQuery.swift
+++ b/Sources_v3/Query/UserListQuery.swift
@@ -63,7 +63,6 @@ public struct UserListQuery<ExtraData: UserExtraData>: Encodable {
     private enum CodingKeys: String, CodingKey {
         case filter = "filter_conditions"
         case sort
-        case presence
         case pagination
     }
     
@@ -72,10 +71,12 @@ public struct UserListQuery<ExtraData: UserExtraData>: Encodable {
     
     /// A sorting for the query (see `Sorting`).
     public let sort: [Sorting<UserListSortingKey>]
+    
     /// A pagination.
     public var pagination: Pagination
-    /// Query options.
-    let options: QueryOptions = [.presence]
+    
+    /// Query options. By default the query options contain `presence`.
+    var options: QueryOptions = [.presence]
     
     /// Init a users query.
     /// - Parameters:

--- a/Sources_v3/Query/UserListQuery.swift
+++ b/Sources_v3/Query/UserListQuery.swift
@@ -4,9 +4,62 @@
 
 import Foundation
 
+/// A namespace for the `FilterKey`s suitable to be used for `UserListQuery`. This scope is not aware of any extra data types.
+public protocol AnyUserListFilterScope {}
+
+/// An extra-data-specific namespace for the `FilterKey`s suitable to be used for `UserListQuery`.
+public struct UserListFilterScope<ExtraData: UserExtraData>: FilterScope, AnyUserListFilterScope {}
+
+/// Non extra-data-specific filer keys for channel list.
+public extension FilterKey where Scope: AnyUserListFilterScope {
+    /// A filter key for matching the `id` value.
+    static var id: FilterKey<Scope, UserId> { "id" }
+    
+    /// A filter key for matching the `role` value.
+    static var role: FilterKey<Scope, UserRole> { "role" }
+    
+    /// A filter key for matching the `isOnline` value.
+    static var isOnline: FilterKey<Scope, Bool> { "online" }
+    
+    /// A filter key for matching the `isBanned` value.
+    static var isBanned: FilterKey<Scope, Bool> { "banned" }
+    
+    /// A filter key for matching the `createdAt` value.
+    static var createdAt: FilterKey<Scope, Date> { "created_at" }
+    
+    /// A filter key for matching the `updatedAt` value.
+    static var updatedAt: FilterKey<Scope, Date> { "updated_at" }
+    
+    /// A filter key for matching the `lastActiveAt` value.
+    static var lastActiveAt: FilterKey<Scope, Date> { "last_active" }
+    
+    /// A filter key for matching the `isInvisible` value.
+    static var isInvisible: FilterKey<Scope, Bool> { "invisible" }
+    
+    /// A filter key for matching the `unreadChannelsCount` value.
+    static var unreadChannelsCount: FilterKey<Scope, Int> { "unread_channels" }
+    
+    /// A filter key for matching the `unreadMessagesCount` value.
+    static var unreadMessagesCount: FilterKey<Scope, Int> { "total_unread_count" }
+    
+    /// A filter key for matching the `isAnonymous` value.
+    static var isAnonymous: FilterKey<Scope, Bool> { "anon" }
+    
+    //    static var team: FilterKey<Scope, > { "team" }
+}
+
+/// Channel list filter keys for `NameAndImageExtraData`.
+public extension FilterKey where Scope == UserListFilterScope<NameAndImageExtraData> {
+    /// A filter key for matching the `name` value.
+    static var name: FilterKey<Scope, String> { "name" }
+    
+    /// A filter key for matching the `image` value.
+    static var imageURL: FilterKey<Scope, URL> { "image" }
+}
+
 /// A query is used for querying specific users from backend.
 /// You can specify filter, sorting and pagination.
-public struct UserListQuery: Encodable {
+public struct UserListQuery<ExtraData: UserExtraData>: Encodable {
     private enum CodingKeys: String, CodingKey {
         case filter = "filter_conditions"
         case sort
@@ -29,7 +82,7 @@ public struct UserListQuery: Encodable {
     ///   - sort: a sorting list for users.
     ///   - pagination: a users pagination.
     public init(
-        filter: Filter? = nil,
+        filter: Filter<UserListFilterScope<ExtraData>>? = nil,
         sort: [Sorting<UserListSortingKey>] = [],
         pagination: Pagination = [.usersPageSize]
     ) {
@@ -44,8 +97,6 @@ public struct UserListQuery: Encodable {
         if let filter = filter {
             try container.encode(filter, forKey: .filter)
         } else {
-            // Backend expects empty object for "filter_conditions" in case no filter specified.
-            struct EmptyObject: Encodable {}
             try container.encode(EmptyObject(), forKey: .filter)
         }
 
@@ -63,6 +114,9 @@ extension UserListQuery {
     /// - Parameter userId: The user identifier
     /// - Returns: `UserListQuery` for a specific user
     static func user(withID userId: UserId) -> Self {
-        .init(filter: .equal("id", to: userId))
+        .init(filter: .equal(.id, to: userId))
     }
 }
+
+// Backend expects empty object for "filter_conditions" in case no filter specified.
+private struct EmptyObject: Encodable {}

--- a/Sources_v3/Query/UserListQuery_Tests.swift
+++ b/Sources_v3/Query/UserListQuery_Tests.swift
@@ -5,10 +5,39 @@
 @testable import StreamChatClient
 import XCTest
 
+final class UserListFilterScope_Tests: XCTestCase {
+    typealias Key<T: FilterValue> = FilterKey<UserListFilterScope<NoExtraData>, T>
+    
+    func test_filterKeys_matchChannelCodingKeys() {
+        XCTAssertEqual(Key<UserId>.id.rawValue, UserPayloadsCodingKeys.id.rawValue)
+        XCTAssertEqual(Key<UserRole>.role.rawValue, UserPayloadsCodingKeys.role.rawValue)
+        XCTAssertEqual(Key<Bool>.isOnline.rawValue, UserPayloadsCodingKeys.isOnline.rawValue)
+        XCTAssertEqual(Key<Bool>.isBanned.rawValue, UserPayloadsCodingKeys.isBanned.rawValue)
+        XCTAssertEqual(Key<Date>.createdAt.rawValue, UserPayloadsCodingKeys.createdAt.rawValue)
+        XCTAssertEqual(Key<Date>.updatedAt.rawValue, UserPayloadsCodingKeys.updatedAt.rawValue)
+        XCTAssertEqual(Key<Date>.lastActiveAt.rawValue, UserPayloadsCodingKeys.lastActiveAt.rawValue)
+        XCTAssertEqual(Key<Bool>.isInvisible.rawValue, UserPayloadsCodingKeys.isInvisible.rawValue)
+        XCTAssertEqual(Key<Int>.unreadChannelsCount.rawValue, UserPayloadsCodingKeys.unreadChannelsCount.rawValue)
+        XCTAssertEqual(Key<Int>.unreadMessagesCount.rawValue, UserPayloadsCodingKeys.unreadMessagesCount.rawValue)
+        XCTAssertEqual(Key<Bool>.isAnonymous.rawValue, UserPayloadsCodingKeys.isAnonymous.rawValue)
+    }
+    
+    func test_filterKeys_matchNameAndImageExtraDataCodingKeys() {
+        XCTAssertEqual(
+            FilterKey<UserListFilterScope<NameAndImageExtraData>, String>.name.rawValue,
+            NameAndImageExtraData.CodingKeys.name.rawValue
+        )
+        XCTAssertEqual(
+            FilterKey<UserListFilterScope<NameAndImageExtraData>, URL>.imageURL.rawValue,
+            NameAndImageExtraData.CodingKeys.imageURL.rawValue
+        )
+    }
+}
+
 class UserListQuery_Tests: XCTestCase {
     // Test UserListQuery encoded correctly
     func test_UserListQuery_encodedCorrectly() throws {
-        let filter: Filter = .contains("name", "a")
+        let filter: Filter<UserListFilterScope<NameAndImageExtraData>> = .equal(.id, to: "luke")
         let sort: [Sorting<UserListSortingKey>] = [.init(key: .lastActivityAt)]
         let pagination: Pagination = .init(arrayLiteral: .offset(3))
 
@@ -22,7 +51,7 @@ class UserListQuery_Tests: XCTestCase {
         let expectedData: [String: Any] = [
             "presence": true,
             "offset": 3,
-            "filter_conditions": ["name": ["$contains": "a"]],
+            "filter_conditions": ["id": ["$eq": "luke"]],
             "sort": [["field": "last_active", "direction": -1]]
         ]
 
@@ -36,10 +65,10 @@ class UserListQuery_Tests: XCTestCase {
     func test_singleUserQuery_worksCorrectly() throws {
         let userId: UserId = .unique
         
-        let actual = UserListQuery.user(withID: userId)
+        let actual = UserListQuery<NoExtraData>.user(withID: userId)
         let actualJSON = try JSONEncoder.default.encode(actual)
 
-        let expected = UserListQuery(filter: .equal("id", to: userId))
+        let expected = UserListQuery<NoExtraData>(filter: .equal("id", to: userId))
         let expectedJSON = try JSONEncoder.default.encode(expected)
     
         // Assert queries match

--- a/Sources_v3/Workers/Background/ChannelWatchStateUpdater_Tests.swift
+++ b/Sources_v3/Workers/Background/ChannelWatchStateUpdater_Tests.swift
@@ -74,8 +74,8 @@ class ChannelWatchStateUpdater_Tests: StressTestCase {
         // Simulate WebSocket successfully connected
         webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
         
-        let query: ChannelListQuery = .init(
-            filter: .in("cid", [cid].map(\.rawValue)),
+        let query: ChannelListQuery<NameAndImageExtraData> = .init(
+            filter: .in(.cid, values: [cid]),
             pagination: [.limit(1)],
             options: [.watch]
         )

--- a/Sources_v3/Workers/Background/ChannelWatchStateUpdater_Tests.swift
+++ b/Sources_v3/Workers/Background/ChannelWatchStateUpdater_Tests.swift
@@ -64,7 +64,7 @@ class ChannelWatchStateUpdater_Tests: StressTestCase {
         AssertAsync.staysTrue(apiClient.request_endpoint == nil)
     }
     
-    func test_apiClient_called_on_websocket_connected() throws {
+    func test_apiClient_called_on_webSocket_connected() throws {
         let cid: ChannelId = .unique
         
         try database.createChannel(cid: cid, withMessages: false)

--- a/Sources_v3/Workers/Background/NewChannelQueryUpdater.swift
+++ b/Sources_v3/Workers/Background/NewChannelQueryUpdater.swift
@@ -5,10 +5,10 @@
 import CoreData
 
 /// After creating new channel it's not observed cause it's not linked to any ChannelListQuery.
-/// The only job of `NewChannelQueryUpdater` is to find whether new channel belongs to any of the exsisting queries
+/// The only job of `NewChannelQueryUpdater` is to find whether new channel belongs to any of the existing queries
 /// and link it to the channel if so.
-///     1. This worker observers DB for the insertations of the new `ChannelDTO`s without any linked queries.
-///     2. When new channel is found, all exsisting queries are fetched from DB and we modify exsiting queries filters so
+///     1. This worker observers DB for the insertions of the new `ChannelDTO`s without any linked queries.
+///     2. When new channel is found, all existing queries are fetched from DB and we modify existing queries filters so
 ///     in response for `update(channelListQuery` request new channel will be returned if it is part of the original query filter.
 ///     3. After sending `update(channelListQuery` for all queries `ChannelListUpdater` does the job of linking
 ///     corresponding queries to the channel.
@@ -69,7 +69,7 @@ final class NewChannelQueryUpdater<ExtraData: ExtraDataTypes>: Worker {
     }
     
     private func handle(changes: [ListChange<ChannelDTO>]) {
-        // Observe `ChannelDTO` insertations
+        // Observe `ChannelDTO` insertions
         changes.forEach { change in
             switch change {
             case let .insert(channelDTO, _):

--- a/Sources_v3/Workers/Background/NewChannelQueryUpdater_Tests.swift
+++ b/Sources_v3/Workers/Background/NewChannelQueryUpdater_Tests.swift
@@ -47,8 +47,8 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
     }
     
     func test_update_called_forEachQuery() throws {
-        let filter1: Filter = .contains(.unique, String.unique)
-        let filter2: Filter = .notEqual(.unique, to: 1)
+        let filter1: Filter<ChannelListFilterScope<NameAndImageExtraData>> = .equal(.frozen, to: true)
+        let filter2: Filter<ChannelListFilterScope<NameAndImageExtraData>> = .equal(.cid, to: .unique)
         
         try database.createChannelListQuery(filter: filter1)
         try database.createChannelListQuery(filter: filter2)
@@ -66,7 +66,7 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
         // Deinitialize newChannelQueryUpdater
         newChannelQueryUpdater = nil
         
-        let filter: Filter = .notEqual(.unique, to: 1)
+        let filter: Filter<ChannelListFilterScope<NameAndImageExtraData>> = .equal(.cid, to: .unique)
         try database.createChannelListQuery(filter: filter)
         try database.createChannel(cid: .unique)
         
@@ -87,7 +87,7 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
     
     func test_filter_isModified() throws {
         let cid: ChannelId = .unique
-        let filter: Filter = .notEqual(.unique, to: 1)
+        let filter: Filter<ChannelListFilterScope<NameAndImageExtraData>> = .equal(.cid, to: .unique)
         
         try database.createChannelListQuery(filter: filter)
         try database.createChannel(cid: cid)
@@ -102,7 +102,7 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
     }
     
     func test_newChannelQueryUpdater_doesNotRetainItself() throws {
-        let filter: Filter = .contains(.unique, String.unique)
+        let filter: Filter<ChannelListFilterScope<NameAndImageExtraData>> = .equal(.cid, to: .unique)
         try database.createChannelListQuery(filter: filter)
         try database.createChannel()
         

--- a/Sources_v3/Workers/Background/NewUserQueryUpdater.swift
+++ b/Sources_v3/Workers/Background/NewUserQueryUpdater.swift
@@ -81,18 +81,10 @@ final class NewUserQueryUpdater<ExtraData: UserExtraData>: Worker {
     
     private func updateUserListQuery(for userDTO: UserDTO) {
         database.backgroundReadOnlyContext.perform { [weak self] in
-            guard var queries = self?.queries else { return }
+            guard let queries = self?.queries else { return }
+
+            // Existing queries with modified filter parameter
             var updatedQueries: [UserListQuery<ExtraData>] = []
-            
-            // For query with `nil` Filter we don't need to make any requests cause all users are part of this query
-            // and we can just link it.
-            let nilFilterCondition: ((UserListQueryDTO) -> Bool) = { $0.filterHash == Filter.nilFilterHash }
-            if let nilFilterQuery = queries.first(where: nilFilterCondition) {
-                self?.database.write { session in
-                    try session.updateQuery(for: userDTO.id, queryFilterHash: nilFilterQuery.filterHash)
-                }
-                queries.removeAll(where: nilFilterCondition)
-            }
             
             do {
                 updatedQueries = try queries.map {
@@ -131,7 +123,6 @@ private extension UserListQueryDTO {
     func asUserListQueryWithUpdatedFilter<ExtraData: UserExtraData>(
         filterToAdd filter: Filter<UserListFilterScope<ExtraData>>
     ) throws -> UserListQuery<ExtraData> {
-        guard let filterJSONData = filterJSONData else { throw ClientError() }
         let encodedFilter = try JSONDecoder.default.decode(Filter<UserListFilterScope<ExtraData>>.self, from: filterJSONData)
         
         // We need to pass original `filterHash` so user will be linked to original query, not the modified one

--- a/Sources_v3/Workers/Background/NewUserQueryUpdater_Tests.swift
+++ b/Sources_v3/Workers/Background/NewUserQueryUpdater_Tests.swift
@@ -47,8 +47,8 @@ class NewUserQueryUpdater_Tests: StressTestCase {
     }
     
     func test_update_called_forEachQuery() throws {
-        let filter1: Filter = .contains(.unique, String.unique)
-        let filter2: Filter = .notEqual(.unique, to: 1)
+        let filter1: Filter<UserListFilterScope<NameAndImageExtraData>> = .equal(.id, to: .unique)
+        let filter2: Filter<UserListFilterScope<NameAndImageExtraData>> = .notEqual(.id, to: .unique)
         
         try database.createUserListQuery(filter: filter1)
         try database.createUserListQuery(filter: filter2)
@@ -84,7 +84,7 @@ class NewUserQueryUpdater_Tests: StressTestCase {
         // Deinitialize newUserQueryUpdater
         newUserQueryUpdater = nil
         
-        let filter: Filter = .notEqual(.unique, to: 1)
+        let filter: Filter<UserListFilterScope<NameAndImageExtraData>> = .notEqual(.id, to: .unique)
         try database.createUserListQuery(filter: filter)
         try database.createUser(id: .unique)
         
@@ -105,12 +105,12 @@ class NewUserQueryUpdater_Tests: StressTestCase {
     
     func test_filter_isModified() throws {
         let id: UserId = .unique
-        let filter: Filter = .notEqual(.unique, to: 1)
+        let filter: Filter<UserListFilterScope<NameAndImageExtraData>> = .notEqual(.id, to: .unique)
         
         try database.createUserListQuery(filter: filter)
         try database.createUser(id: id)
         
-        let expectedFilter: Filter = .and([filter, .equal("id", to: id)])
+        let expectedFilter: Filter = .and([filter, .equal(.id, to: id)])
         
         // Assert `update(userListQuery` called with modified query
         AssertAsync {
@@ -120,7 +120,7 @@ class NewUserQueryUpdater_Tests: StressTestCase {
     }
     
     func test_newUserQueryUpdater_doesNotRetainItself() throws {
-        let filter: Filter = .contains(.unique, String.unique)
+        let filter: Filter<UserListFilterScope<NameAndImageExtraData>> = .notEqual(.id, to: .unique)
         try database.createUserListQuery(filter: filter)
         try database.createUser()
         

--- a/Sources_v3/Workers/Background/NewUserQueryUpdater_Tests.swift
+++ b/Sources_v3/Workers/Background/NewUserQueryUpdater_Tests.swift
@@ -62,24 +62,6 @@ class NewUserQueryUpdater_Tests: StressTestCase {
         )
     }
     
-    func test_update_isNotCalled_forNilFilterQuery() throws {
-        try database.createUserListQuery(filter: nil)
-        try database.createUser()
-        
-        // Assert `update(userListQuery` is not called for .none filter query
-        AssertAsync.willBeTrue(env!.userQueryUpdater?.update_queries.isEmpty)
-    }
-    
-    func test_newUser_updated_withNilFilterQuery() throws {
-        let id: UserId = .unique
-        
-        try database.createUserListQuery(filter: nil)
-        try database.createUser(id: id, extraData: .defaultValue)
-        
-        // Assert .none filter query linked to new user
-        AssertAsync.willBeTrue(database.viewContext.userListQuery(filterHash: Filter.nilFilterHash)?.users.map(\.id).contains(id))
-    }
-    
     func test_update_called_forExistingUser() throws {
         // Deinitialize newUserQueryUpdater
         newUserQueryUpdater = nil

--- a/Sources_v3/Workers/ChannelListUpdater.swift
+++ b/Sources_v3/Workers/ChannelListUpdater.swift
@@ -12,7 +12,7 @@ class ChannelListUpdater<ExtraData: ExtraDataTypes>: Worker {
     ///   - channelListQuery: The channels query used in the request
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     ///
-    func update(channelListQuery: ChannelListQuery, completion: ((Error?) -> Void)? = nil) {
+    func update(channelListQuery: ChannelListQuery<ExtraData.Channel>, completion: ((Error?) -> Void)? = nil) {
         apiClient
             .request(endpoint: .channels(query: channelListQuery)) { (result: Result<ChannelListPayload<ExtraData>, Error>) in
                 switch result {

--- a/Sources_v3/Workers/ChannelListUpdater_Mock.swift
+++ b/Sources_v3/Workers/ChannelListUpdater_Mock.swift
@@ -7,12 +7,12 @@ import XCTest
 
 /// Mock implementation of ChannelListUpdater
 class ChannelListUpdaterMock<ExtraData: ExtraDataTypes>: ChannelListUpdater<ExtraData> {
-    @Atomic var update_queries: [ChannelListQuery] = []
+    @Atomic var update_queries: [ChannelListQuery<ExtraData.Channel>] = []
     @Atomic var update_completion: ((Error?) -> Void)?
     
     @Atomic var markAllRead_completion: ((Error?) -> Void)?
     
-    override func update(channelListQuery: ChannelListQuery, completion: ((Error?) -> Void)? = nil) {
+    override func update(channelListQuery: ChannelListQuery<ExtraData.Channel>, completion: ((Error?) -> Void)? = nil) {
         _update_queries.mutate { $0.append(channelListQuery) }
         update_completion = completion
     }

--- a/Sources_v3/Workers/ChannelListUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelListUpdater_Tests.swift
@@ -41,7 +41,7 @@ class ChannelListUpdater_Tests: StressTestCase {
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
     }
     
-    func test_update_successfullReponseData_areSavedToDB() {
+    func test_update_successfulResponseData_areSavedToDB() {
         // Simulate `update` call
         let query = ChannelListQuery<NameAndImageExtraData>(filter: .in(.members, values: [.unique]))
         var completionCalled = false
@@ -50,7 +50,7 @@ class ChannelListUpdater_Tests: StressTestCase {
             completionCalled = true
         })
         
-        // Simualte API response with channel data
+        // Simulate API response with channel data
         let cid = ChannelId(type: .messaging, id: .unique)
         let payload = ChannelListPayload<DefaultExtraData>(channels: [dummyPayload(with: cid)])
         apiClient.test_simulateResponse(.success(payload))
@@ -71,7 +71,7 @@ class ChannelListUpdater_Tests: StressTestCase {
         var completionCalledError: Error?
         listUpdater.update(channelListQuery: query, completion: { completionCalledError = $0 })
         
-        // Simualte API response with failure
+        // Simulate API response with failure
         let error = TestError()
         apiClient.test_simulateResponse(Result<ChannelListPayload<DefaultExtraData>, Error>.failure(error))
         

--- a/Sources_v3/Workers/ChannelListUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelListUpdater_Tests.swift
@@ -34,7 +34,7 @@ class ChannelListUpdater_Tests: StressTestCase {
     
     func test_update_makesCorrectAPICall() {
         // Simulate `update` call
-        let query = ChannelListQuery(filter: .in("member", ["Luke"]))
+        let query = ChannelListQuery<NameAndImageExtraData>(filter: .in(.members, values: [.unique]))
         listUpdater.update(channelListQuery: query)
         
         let referenceEndpoint: Endpoint<ChannelListPayload<DefaultExtraData>> = .channels(query: query)
@@ -43,7 +43,7 @@ class ChannelListUpdater_Tests: StressTestCase {
     
     func test_update_successfullReponseData_areSavedToDB() {
         // Simulate `update` call
-        let query = ChannelListQuery(filter: .in("member", ["Luke"]))
+        let query = ChannelListQuery<NameAndImageExtraData>(filter: .in(.members, values: [.unique]))
         var completionCalled = false
         listUpdater.update(channelListQuery: query, completion: { error in
             XCTAssertNil(error)
@@ -67,7 +67,7 @@ class ChannelListUpdater_Tests: StressTestCase {
     
     func test_update_errorResponse_isPropagatedToCompletion() {
         // Simulate `update` call
-        let query = ChannelListQuery(filter: .in("member", ["Luke"]))
+        let query = ChannelListQuery<NameAndImageExtraData>(filter: .in(.members, values: [.unique]))
         var completionCalledError: Error?
         listUpdater.update(channelListQuery: query, completion: { completionCalledError = $0 })
         

--- a/Sources_v3/Workers/ChannelMemberListUpdater_Mock.swift
+++ b/Sources_v3/Workers/ChannelMemberListUpdater_Mock.swift
@@ -7,10 +7,10 @@ import XCTest
 
 /// Mock implementation of `ChannelMemberListUpdater`
 final class ChannelMemberListUpdaterMock<ExtraData: ExtraDataTypes>: ChannelMemberListUpdater<ExtraData> {
-    @Atomic var load_query: ChannelMemberListQuery?
+    @Atomic var load_query: ChannelMemberListQuery<ExtraData.User>?
     @Atomic var load_completion: ((Error?) -> Void)?
 
-    override func load(_ query: ChannelMemberListQuery, completion: ((Error?) -> Void)? = nil) {
+    override func load(_ query: ChannelMemberListQuery<ExtraData.User>, completion: ((Error?) -> Void)? = nil) {
         load_query = query
         load_completion = completion
     }

--- a/Sources_v3/Workers/ChannelMemberListUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelMemberListUpdater_Tests.swift
@@ -9,7 +9,7 @@ final class ChannelMemberListUpdater_Tests: StressTestCase {
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!
     var database: DatabaseContainerMock!
-    var query: ChannelMemberListQuery!
+    var query: ChannelMemberListQuery<NameAndImageExtraData>!
 
     var listUpdater: ChannelMemberListUpdater<DefaultExtraData>!
     
@@ -19,7 +19,7 @@ final class ChannelMemberListUpdater_Tests: StressTestCase {
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
         database = DatabaseContainerMock()
-        query = ChannelMemberListQuery(cid: .unique, filter: .contains("name", "a"))
+        query = ChannelMemberListQuery(cid: .unique, filter: .query(.id, text: "Luke"))
 
         listUpdater = .init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
     }

--- a/Sources_v3/Workers/UserListUpdater.swift
+++ b/Sources_v3/Workers/UserListUpdater.swift
@@ -12,7 +12,7 @@ class UserListUpdater<ExtraData: UserExtraData>: Worker {
     ///   - userListQuery: The users query used in the request
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     ///
-    func update(userListQuery: UserListQuery, completion: ((Error?) -> Void)? = nil) {
+    func update(userListQuery: UserListQuery<ExtraData>, completion: ((Error?) -> Void)? = nil) {
         apiClient
             .request(endpoint: .users(query: userListQuery)) { (result: Result<UserListPayload<ExtraData>, Error>) in
                 switch result {

--- a/Sources_v3/Workers/UserListUpdater_Mock.swift
+++ b/Sources_v3/Workers/UserListUpdater_Mock.swift
@@ -7,10 +7,10 @@ import XCTest
 
 /// Mock implementation of UserListUpdater
 class UserListUpdaterMock<ExtraData: UserExtraData>: UserListUpdater<ExtraData> {
-    @Atomic var update_queries: [UserListQuery] = []
+    @Atomic var update_queries: [UserListQuery<ExtraData>] = []
     @Atomic var update_completion: ((Error?) -> Void)?
         
-    override func update(userListQuery: UserListQuery, completion: ((Error?) -> Void)? = nil) {
+    override func update(userListQuery: UserListQuery<ExtraData>, completion: ((Error?) -> Void)? = nil) {
         _update_queries.mutate { $0.append(userListQuery) }
         update_completion = completion
     }

--- a/Sources_v3/Workers/UserListUpdater_Tests.swift
+++ b/Sources_v3/Workers/UserListUpdater_Tests.swift
@@ -34,7 +34,7 @@ class UserListUpdater_Tests: StressTestCase {
     
     func test_update_makesCorrectAPICall() {
         // Simulate `update` call
-        let query = UserListQuery(filter: .contains("name", "a"))
+        let query = UserListQuery<DefaultExtraData.User>(filter: .equal(.id, to: "Luke"))
         listUpdater.update(userListQuery: query)
         
         let referenceEndpoint: Endpoint<UserListPayload<DefaultExtraData.User>> = .users(query: query)
@@ -43,7 +43,7 @@ class UserListUpdater_Tests: StressTestCase {
     
     func test_update_successfullReponseData_areSavedToDB() {
         // Simulate `update` call
-        let query = UserListQuery(filter: .contains("name", "a"))
+        let query = UserListQuery<DefaultExtraData.User>(filter: .equal(.id, to: "Luke"))
         var completionCalled = false
         listUpdater.update(userListQuery: query, completion: { error in
             XCTAssertNil(error)
@@ -69,7 +69,7 @@ class UserListUpdater_Tests: StressTestCase {
     
     func test_update_errorResponse_isPropagatedToCompletion() {
         // Simulate `update` call
-        let query = UserListQuery(filter: .contains("name", "a"))
+        let query = UserListQuery<DefaultExtraData.User>(filter: .equal(.id, to: "Luke"))
         var completionCalledError: Error?
         listUpdater.update(userListQuery: query, completion: { completionCalledError = $0 })
         

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		799C9476247D7E94001F1104 /* TemporaryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C9474247D7D41001F1104 /* TemporaryData.swift */; };
 		799C9479247E3DEA001F1104 /* StreamChatModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 799C9477247E3DEA001F1104 /* StreamChatModel.xcdatamodeld */; };
 		799C947D247E6114001F1104 /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C947B247E6051001F1104 /* TestError.swift */; };
+		799F611B2530B62C007F218C /* ChannelListQuery_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799F611A2530B62C007F218C /* ChannelListQuery_Tests.swift */; };
 		79A0E9AD2498BD0C00E9BD50 /* ChatClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9AC2498BD0C00E9BD50 /* ChatClient.swift */; };
 		79A0E9AF2498BFD800E9BD50 /* WebSocketClient_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9AE2498BFD800E9BD50 /* WebSocketClient_Tests.swift */; };
 		79A0E9B02498C09900E9BD50 /* ConnectionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C750BD2490D0130023F0B7 /* ConnectionStatus.swift */; };
@@ -613,6 +614,7 @@
 		799C9474247D7D41001F1104 /* TemporaryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporaryData.swift; sourceTree = "<group>"; };
 		799C9478247E3DEA001F1104 /* StreamChatModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = StreamChatModel.xcdatamodel; sourceTree = "<group>"; };
 		799C947B247E6051001F1104 /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
+		799F611A2530B62C007F218C /* ChannelListQuery_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListQuery_Tests.swift; sourceTree = "<group>"; };
 		79A0E9AC2498BD0C00E9BD50 /* ChatClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatClient.swift; sourceTree = "<group>"; };
 		79A0E9AE2498BFD800E9BD50 /* WebSocketClient_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSocketClient_Tests.swift; sourceTree = "<group>"; };
 		79A0E9B82498C31300E9BD50 /* TypingStartCleanupMiddleware_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypingStartCleanupMiddleware_Tests.swift; sourceTree = "<group>"; };
@@ -1086,6 +1088,7 @@
 				882C5745252C6FDF00E60C44 /* ChannelMemberListQuery.swift */,
 				889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */,
 				792A4F4C248011E500EAF71D /* ChannelListQuery.swift */,
+				799F611A2530B62C007F218C /* ChannelListQuery_Tests.swift */,
 				DA8407052524F84F005A0F62 /* UserListQuery.swift */,
 				DA8407292525EB2F005A0F62 /* UserListQuery_Tests.swift */,
 				792A4F4A248010A600EAF71D /* QueryOptions.swift */,
@@ -2313,6 +2316,7 @@
 				792FCB4724A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift in Sources */,
 				797EEA4A24FFC37600C81203 /* ConnectionStatus_Tests.swift in Sources */,
 				79877A2B2498E51500015F8B /* UserDTO_Tests.swift in Sources */,
+				799F611B2530B62C007F218C /* ChannelListQuery_Tests.swift in Sources */,
 				792921C524C0479700116BBB /* ChannelListUpdater_Tests.swift in Sources */,
 				79177A2D248A6A2600F053A2 /* AssertAsync+Events.swift in Sources */,
 				F6C56D1424F7B89D0012BB1F /* EventMiddleware_Mock.swift in Sources */,


### PR DESCRIPTION
### This PR changes the way we deal with filters

**Main changes**
- The filters now offer autocompletion for operators and available keys:
![filter_autocompletion](https://user-images.githubusercontent.com/6388510/95729166-c6758280-0c7c-11eb-86d8-4ca6ab24262f.gif)
- Operators make it easy to use the correct format for the value. 
Examples:
  - the `query` operator always require a text value:
<img width="393" alt="Screen Shot 2020-10-12 at 16 48 37" src="https://user-images.githubusercontent.com/6388510/95759997-c8563a80-0caa-11eb-9be2-ead1ce1e584b.png">

  - the `in` operator always requires an array:
<img width="457" alt="Screen Shot 2020-10-12 at 16 49 30" src="https://user-images.githubusercontent.com/6388510/95760120-e754cc80-0caa-11eb-8bcf-4a3e42cfae1f.png">

- Customers can easily add their own filter keys:
```swift
extension FilterKey where Scope == ChannelListFilterScope<CustomExtraData> {
    static var customValue: FilterKey<Scope, String> { "custom coding key" }
}
```
- Query structs are now generic over extra data to be able to offer autocompletion for extra data.

- **I also changed the way we handle `nil` filter in `UserListQuery`.** The original implementation stored an extra `UserListQueryDTO` entity in the DB fro the situation when the filter value was `nil`. The new implementation completely ignores this possibility and simply modifies the `userListFetchRequest(query:)` helper to return all users when the filter is `nil`. We will probably migrate to the model `ChannelMemberQuery` uses where it creates the hash from the whole query, not just the filter, but this is a nice semi-step.
