### PR TITLE
Fix composerView retaining messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- `ComposerView` disables send button but retains the message after user taps send. Now, composerView resets its state after user taps send, so user can send multiple messages [#555](https://github.com/GetStream/stream-chat-swift/issues/555)
 
 # [2.4.0](https://github.com/GetStream/stream-chat-swift/releases/tag/2.4.0)
 _October 01, 2020_

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
@@ -191,7 +191,7 @@ extension ChatViewController {
         
         // We don't want users to send the same message multiple times
         // in case their internet is slow and message isn't sent immediately
-        composerView.sendButton.isEnabled = false
+        composerView.reset()
         
         presenter?.rx.send(text: text,
                            showReplyInChannel: composerView.alsoSendToChannelButton.isSelected,
@@ -203,10 +203,8 @@ extension ChatViewController {
                     }
                 },
                 onError: { [weak self] in
-                    self?.composerView.reset()
                     self?.show(error: $0)
-                },
-                onCompleted: { [weak self] in self?.composerView.reset() })
+                })
             .disposed(by: disposeBag)
     }
     


### PR DESCRIPTION
Steps to reproduce:
1. Enable Network Link Conditioner to 3G speed
2. To any channel, write a message
3. Tap send
4. Immediately after 3, write something else

Expected:
- New text will be input on a empty field

Actual:
- New text is input after the last message (until message is actually sent)

Example:
1. Write "Hello"
2. Tap send
3. Write "Again"

Expected to see only "Again", but seeing "HelloAgain" in the text field

Unfortunately, we can't support optimistic updates for now, so messages appearing in the channel immediately after tapping send is not possible.