### PR TITLE
[CIS-242] Implement message replies

### DIFF
--- a/Sources_v3/APIClient/Endpoints/MessageEndpoints.swift
+++ b/Sources_v3/APIClient/Endpoints/MessageEndpoints.swift
@@ -35,10 +35,25 @@ extension Endpoint {
             body: ["message": payload]
         )
     }
+    
+    static func loadReplies<ExtraData: ExtraDataTypes>(messageId: MessageId, pagination: MessagesPagination)
+        -> Endpoint<MessageRepliesPayload<ExtraData>> {
+        .init(
+            path: messageId.repliesPath,
+            method: .get,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: pagination
+        )
+    }
 }
 
 private extension MessageId {
     var path: String {
         "messages/\(self)"
+    }
+    
+    var repliesPath: String {
+        "messages/\(self)/replies"
     }
 }

--- a/Sources_v3/APIClient/Endpoints/MessageEndpoints_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/MessageEndpoints_Tests.swift
@@ -64,4 +64,23 @@ final class MessageEndpoints_Tests: XCTestCase {
         // Assert endpoint is built correctly
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
     }
+    
+    func test_loadReplies_buildsCorrectly() {
+        let messageId: MessageId = .unique
+        let pagination: MessagesPagination = .init(pageSize: 10)
+        
+        let expectedEndpoint = Endpoint<MessageRepliesPayload<DefaultExtraData>>(
+            path: "messages/\(messageId)/replies",
+            method: .get,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: pagination
+        )
+        
+        // Build endpoint
+        let endpoint: Endpoint<MessageRepliesPayload<DefaultExtraData>> = .loadReplies(messageId: messageId, pagination: pagination)
+        
+        // Assert endpoint is built correctly
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
 }

--- a/Sources_v3/APIClient/Endpoints/Payloads/MessagePayloads.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/MessagePayloads.swift
@@ -155,6 +155,11 @@ struct MessageRequestBody<ExtraData: ExtraDataTypes>: Encodable {
     }
 }
 
+/// An object describing the message replies JSON payload.
+struct MessageRepliesPayload<ExtraData: ExtraDataTypes>: Decodable {
+    let messages: [MessagePayload<ExtraData>]
+}
+
 // TODO: Command???
 
 /// A command in a message, e.g. /giphy.

--- a/Sources_v3/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
@@ -83,6 +83,16 @@ class MessageRequestBody_Tests: XCTestCase {
     }
 }
 
+class MessageRepliesPayload_Tests: XCTestCase {
+    func test_isSerialized() throws {
+        let mockJSON = XCTestCase.mockData(fromFile: "Messages")
+        let payload = try JSONDecoder.default.decode(MessageRepliesPayload<CustomData>.self, from: mockJSON)
+        
+        // Assert 2 messages successfully decoded.
+        XCTAssertTrue(payload.messages.count == 2)
+    }
+}
+
 private struct TestExtraMessageData: MessageExtraData {
     static var defaultValue: Self = .init(secretNote: "no secrets")
     

--- a/Sources_v3/Controllers/ChannelController/ChannelController.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController.swift
@@ -644,9 +644,6 @@ public extension _ChatChannelController {
     ///
     /// - Parameters:
     ///   - text: Text of the message.
-    ///   - parentMessageId: If the message is a reply, the `MessageId` of the message this message replies to.
-    ///   - showReplyInChannel: Set this flag to `true` if you want the message to be also visible in the channel, not only
-    ///   in the response thread.
     ///   - extraData: Additional extra data of the message object.
     ///   - completion: Called when saving the message to the local DB finishes.
     ///
@@ -654,8 +651,6 @@ public extension _ChatChannelController {
         text: String,
 //        command: String? = nil,
 //        arguments: String? = nil,
-        parentMessageId: MessageId? = nil,
-        showReplyInChannel: Bool = false,
         extraData: ExtraData.Message = .defaultValue,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -667,7 +662,7 @@ public extension _ChatChannelController {
             return
         }
         
-        // Send stop typing event.
+        /// Send stop typing event.
         eventSender.stopTyping(in: cid)
         
         updater.createNewMessage(
@@ -675,8 +670,6 @@ public extension _ChatChannelController {
             text: text,
             command: nil,
             arguments: nil,
-            parentMessageId: parentMessageId,
-            showReplyInChannel: showReplyInChannel,
             extraData: extraData
         ) { [weak self] result in
             self?.callback {

--- a/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController_Tests.swift
@@ -1186,8 +1186,6 @@ class ChannelController_Tests: StressTestCase {
         let text: String = .unique
 //        let command: String = .unique
 //        let arguments: String = .unique
-        let parentMessageId: MessageId = .unique
-        let showReplyInChannel = true
         let extraData: DefaultExtraData.Message = .defaultValue
         
         // Simulate `createNewMessage` calls and catch the completion
@@ -1196,8 +1194,6 @@ class ChannelController_Tests: StressTestCase {
             text: text,
 //            command: command,
 //            arguments: arguments,
-            parentMessageId: parentMessageId,
-            showReplyInChannel: showReplyInChannel,
             extraData: extraData
         ) { [callbackQueueID] result in
             AssertTestQueue(withId: callbackQueueID)
@@ -1218,8 +1214,6 @@ class ChannelController_Tests: StressTestCase {
         XCTAssertEqual(env.channelUpdater?.createNewMessage_text, text)
 //        XCTAssertEqual(env.channelUpdater?.createNewMessage_command, command)
 //        XCTAssertEqual(env.channelUpdater?.createNewMessage_arguments, arguments)
-        XCTAssertEqual(env.channelUpdater?.createNewMessage_parentMessageId, parentMessageId)
-        XCTAssertEqual(env.channelUpdater?.createNewMessage_showReplyInChannel, showReplyInChannel)
         XCTAssertEqual(env.channelUpdater?.createNewMessage_extraData, extraData)
     }
     
@@ -1234,8 +1228,6 @@ class ChannelController_Tests: StressTestCase {
                 text: .unique,
 //                command: .unique,
 //                arguments: .unique,
-                parentMessageId: .unique,
-                showReplyInChannel: true,
                 extraData: .defaultValue
             ) { result in
                 AssertTestQueue(withId: callbackQueueID)

--- a/Sources_v3/Controllers/MessageController/MessageController.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController.swift
@@ -147,6 +147,38 @@ public extension _ChatMessageController {
             }
         }
     }
+    
+    /// Creates a new reply message locally and schedules it for send.
+    ///
+    /// - Parameters:
+    ///   - text: Text of the message.
+    ///   - showReplyInChannel: Set this flag to `true` if you want the message to be also visible in the channel, not only
+    ///   in the response thread.
+    ///   - extraData: Additional extra data of the message object.
+    ///   - completion: Called when saving the message to the local DB finishes.
+    ///
+    func createNewReply(
+        text: String,
+//        command: String? = nil,
+//        arguments: String? = nil,
+        showReplyInChannel: Bool = false,
+        extraData: ExtraData.Message = .defaultValue,
+        completion: ((Result<MessageId, Error>) -> Void)? = nil
+    ) {
+        messageUpdater.createNewReply(
+            in: cid,
+            text: text,
+            command: nil,
+            arguments: nil,
+            parentMessageId: messageId,
+            showReplyInChannel: showReplyInChannel,
+            extraData: extraData
+        ) { result in
+            self.callback {
+                completion?(result)
+            }
+        }
+    }
 }
 
 // MARK: - Environment

--- a/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -136,6 +136,7 @@
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="messages" inverseEntity="ChannelDTO"/>
         <relationship name="mentionedUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="mentionedMessages" inverseEntity="UserDTO"/>
+        <relationship name="replies" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="messages" inverseEntity="UserDTO"/>
         <fetchIndex name="id">
             <fetchIndexElement property="id" type="Binary" order="ascending"/>
@@ -209,7 +210,7 @@
         <element name="CurrentUserDTO" positionX="0" positionY="0" width="128" height="148"/>
         <element name="DeviceDTO" positionX="9" positionY="153" width="128" height="88"/>
         <element name="MemberDTO" positionX="0" positionY="0" width="128" height="193"/>
-        <element name="MessageDTO" positionX="0" positionY="0" width="128" height="343"/>
+        <element name="MessageDTO" positionX="0" positionY="0" width="128" height="358"/>
         <element name="TeamDTO" positionX="0" positionY="0" width="128" height="88"/>
         <element name="UserDTO" positionX="0" positionY="0" width="128" height="313"/>
         <element name="UserListQueryDTO" positionX="9" positionY="153" width="128" height="88"/>

--- a/Sources_v3/Query/Pagination.swift
+++ b/Sources_v3/Query/Pagination.swift
@@ -53,6 +53,12 @@ public struct MessagesPagination: Encodable, Equatable {
         self.parameter = parameter
     }
     
+    /// Initializer with required page size.
+    init(pageSize: Int, parameter: PaginationParameter? = nil) {
+        self.pageSize = pageSize
+        self.parameter = parameter
+    }
+    
     private enum CodingKeys: String, CodingKey {
         case pageSize = "limit"
     }

--- a/Sources_v3/Workers/ChannelUpdater.swift
+++ b/Sources_v3/Workers/ChannelUpdater.swift
@@ -92,13 +92,14 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
     /// - Parameters:
     ///   - cid: The cid of the channel the message is create in.
     ///   - text: Text of the message.
+    ///   - extraData: Additional extra data of the message object.
+    ///   - completion: Called when saving the message to the local DB finishes.
+    ///
     func createNewMessage(
         in cid: ChannelId,
         text: String,
         command: String?,
         arguments: String?,
-        parentMessageId: MessageId?,
-        showReplyInChannel: Bool,
         extraData: ExtraData.Message,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -109,8 +110,8 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
                 text: text,
                 command: command,
                 arguments: arguments,
-                parentMessageId: parentMessageId,
-                showReplyInChannel: showReplyInChannel,
+                parentMessageId: nil,
+                showReplyInChannel: false,
                 extraData: extraData
             )
             

--- a/Sources_v3/Workers/ChannelUpdater_Mock.swift
+++ b/Sources_v3/Workers/ChannelUpdater_Mock.swift
@@ -42,8 +42,6 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
     @Atomic var createNewMessage_text: String?
     @Atomic var createNewMessage_command: String?
     @Atomic var createNewMessage_arguments: String?
-    @Atomic var createNewMessage_parentMessageId: MessageId?
-    @Atomic var createNewMessage_showReplyInChannel: Bool?
     @Atomic var createNewMessage_extraData: ExtraData.Message?
     @Atomic var createNewMessage_completion: ((Result<MessageId, Error>) -> Void)?
     
@@ -94,8 +92,6 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         text: String,
         command: String?,
         arguments: String?,
-        parentMessageId: MessageId?,
-        showReplyInChannel: Bool,
         extraData: ExtraData.Message,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -103,8 +99,6 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         createNewMessage_text = text
         createNewMessage_command = command
         createNewMessage_arguments = arguments
-        createNewMessage_parentMessageId = parentMessageId
-        createNewMessage_showReplyInChannel = showReplyInChannel
         createNewMessage_extraData = extraData
         createNewMessage_completion = completion
     }

--- a/Sources_v3/Workers/ChannelUpdater_Tests.swift
+++ b/Sources_v3/Workers/ChannelUpdater_Tests.swift
@@ -131,19 +131,15 @@ class ChannelUpdater_Tests: StressTestCase {
         let text: String = .unique
         let command: String = .unique
         let arguments: String = .unique
-        let parentMessageId: MessageId = .unique
-        let showReplyInChannel = true
         let extraData: DefaultExtraData.Message = .defaultValue
         
         // Create new message
-        let newMesageId: MessageId = try await { completion in
+        let newMessageId: MessageId = try await { completion in
             channelUpdater.createNewMessage(
                 in: cid,
                 text: text,
                 command: command,
                 arguments: arguments,
-                parentMessageId: parentMessageId,
-                showReplyInChannel: showReplyInChannel,
                 extraData: extraData
             ) { result in
                 if let newMessageId = try? result.get() {
@@ -155,15 +151,13 @@ class ChannelUpdater_Tests: StressTestCase {
         }
         
         var message: ChatMessage? {
-            database.viewContext.message(id: newMesageId)?.asModel()
+            database.viewContext.message(id: newMessageId)?.asModel()
         }
         
         AssertAsync {
             Assert.willBeEqual(message?.text, text)
             Assert.willBeEqual(message?.command, command)
             Assert.willBeEqual(message?.arguments, arguments)
-            Assert.willBeEqual(message?.parentMessageId, parentMessageId)
-            Assert.willBeEqual(message?.showReplyInChannel, showReplyInChannel)
             Assert.willBeEqual(message?.extraData, extraData)
             Assert.willBeEqual(message?.localState, .pendingSend)
         }
@@ -197,8 +191,6 @@ class ChannelUpdater_Tests: StressTestCase {
                 text: .unique,
                 command: .unique,
                 arguments: .unique,
-                parentMessageId: .unique,
-                showReplyInChannel: true,
                 extraData: .defaultValue
             ) { completion($0) }
         }

--- a/Sources_v3/Workers/MessageUpdater_Mock.swift
+++ b/Sources_v3/Workers/MessageUpdater_Mock.swift
@@ -27,6 +27,29 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
     @Atomic var createNewReply_extraData: ExtraData.Message?
     @Atomic var createNewReply_completion: ((Result<MessageId, Error>) -> Void)?
     
+    // Cleans up all recorded values
+    func cleanUp() {
+        getMessage_cid = nil
+        getMessage_messageId = nil
+        getMessage_completion = nil
+
+        deleteMessage_messageId = nil
+        deleteMessage_completion = nil
+
+        editMessage_messageId = nil
+        editMessage_text = nil
+        editMessage_completion = nil
+        
+        createNewReply_cid = nil
+        createNewReply_text = nil
+        createNewReply_command = nil
+        createNewReply_arguments = nil
+        createNewReply_parentMessageId = nil
+        createNewReply_showReplyInChannel = nil
+        createNewReply_extraData = nil
+        createNewReply_completion = nil
+    }
+    
     override func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Error?) -> Void)? = nil) {
         getMessage_cid = cid
         getMessage_messageId = messageId

--- a/Sources_v3/Workers/MessageUpdater_Mock.swift
+++ b/Sources_v3/Workers/MessageUpdater_Mock.swift
@@ -27,6 +27,11 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
     @Atomic var createNewReply_extraData: ExtraData.Message?
     @Atomic var createNewReply_completion: ((Result<MessageId, Error>) -> Void)?
     
+    @Atomic var loadReplies_cid: ChannelId?
+    @Atomic var loadReplies_messageId: MessageId?
+    @Atomic var loadReplies_pagination: MessagesPagination?
+    @Atomic var loadReplies_completion: ((Error?) -> Void)?
+    
     // Cleans up all recorded values
     func cleanUp() {
         getMessage_cid = nil
@@ -48,6 +53,11 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         createNewReply_showReplyInChannel = nil
         createNewReply_extraData = nil
         createNewReply_completion = nil
+        
+        loadReplies_cid = nil
+        loadReplies_messageId = nil
+        loadReplies_pagination = nil
+        loadReplies_completion = nil
     }
     
     override func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Error?) -> Void)? = nil) {
@@ -85,5 +95,17 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         createNewReply_showReplyInChannel = showReplyInChannel
         createNewReply_extraData = extraData
         createNewReply_completion = completion
+    }
+    
+    override func loadReplies(
+        cid: ChannelId,
+        messageId: MessageId,
+        pagination: MessagesPagination,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        loadReplies_cid = cid
+        loadReplies_messageId = messageId
+        loadReplies_pagination = pagination
+        loadReplies_completion = completion
     }
 }

--- a/Sources_v3/Workers/MessageUpdater_Mock.swift
+++ b/Sources_v3/Workers/MessageUpdater_Mock.swift
@@ -18,6 +18,15 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
     @Atomic var editMessage_text: String?
     @Atomic var editMessage_completion: ((Error?) -> Void)?
     
+    @Atomic var createNewReply_cid: ChannelId?
+    @Atomic var createNewReply_text: String?
+    @Atomic var createNewReply_command: String?
+    @Atomic var createNewReply_arguments: String?
+    @Atomic var createNewReply_parentMessageId: MessageId?
+    @Atomic var createNewReply_showReplyInChannel: Bool?
+    @Atomic var createNewReply_extraData: ExtraData.Message?
+    @Atomic var createNewReply_completion: ((Result<MessageId, Error>) -> Void)?
+    
     override func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Error?) -> Void)? = nil) {
         getMessage_cid = cid
         getMessage_messageId = messageId
@@ -33,5 +42,25 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         editMessage_messageId = messageId
         editMessage_text = text
         editMessage_completion = completion
+    }
+    
+    override func createNewReply(
+        in cid: ChannelId,
+        text: String,
+        command: String?,
+        arguments: String?,
+        parentMessageId: MessageId?,
+        showReplyInChannel: Bool,
+        extraData: ExtraData.Message,
+        completion: ((Result<MessageId, Error>) -> Void)? = nil
+    ) {
+        createNewReply_cid = cid
+        createNewReply_text = text
+        createNewReply_command = command
+        createNewReply_arguments = arguments
+        createNewReply_parentMessageId = parentMessageId
+        createNewReply_showReplyInChannel = showReplyInChannel
+        createNewReply_extraData = extraData
+        createNewReply_completion = completion
     }
 }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -353,6 +353,7 @@
 		DA640FBB2535CF8500D32944 /* ChannelListSortingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA640FBA2535CF8500D32944 /* ChannelListSortingKey.swift */; };
 		DA640FBE2535CF9200D32944 /* UserListSortingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA640FBD2535CF9200D32944 /* UserListSortingKey.swift */; };
 		DA640FC12535CFA100D32944 /* ChannelMemberListSortingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA640FC02535CFA100D32944 /* ChannelMemberListSortingKey.swift */; };
+		DA653BBA253F47EB00B448A0 /* Messages.json in Resources */ = {isa = PBXBuildFile; fileRef = DA653BB9253F47EB00B448A0 /* Messages.json */; };
 		DA6AC7F62538725B009C1B39 /* Pagination_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6AC7F22538724F009C1B39 /* Pagination_Tests.swift */; };
 		DA7229E424E140600074503A /* ChannelEditDetailPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7229E224E140260074503A /* ChannelEditDetailPayload_Tests.swift */; };
 		DA8407002524F778005A0F62 /* UserListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8406FF2524F778005A0F62 /* UserListController.swift */; };
@@ -831,6 +832,7 @@
 		DA640FBA2535CF8500D32944 /* ChannelListSortingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListSortingKey.swift; sourceTree = "<group>"; };
 		DA640FBD2535CF9200D32944 /* UserListSortingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListSortingKey.swift; sourceTree = "<group>"; };
 		DA640FC02535CFA100D32944 /* ChannelMemberListSortingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListSortingKey.swift; sourceTree = "<group>"; };
+		DA653BB9253F47EB00B448A0 /* Messages.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Messages.json; sourceTree = "<group>"; };
 		DA6AC7F22538724F009C1B39 /* Pagination_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pagination_Tests.swift; sourceTree = "<group>"; };
 		DA7229E224E140260074503A /* ChannelEditDetailPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelEditDetailPayload_Tests.swift; sourceTree = "<group>"; };
 		DA8406FF2524F778005A0F62 /* UserListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListController.swift; sourceTree = "<group>"; };
@@ -1214,6 +1216,7 @@
 				790A4C50252E0957001F4A23 /* Devices.json */,
 				798779F72498E47700015F8B /* Channel.json */,
 				79F3ABE924EAB9CD00AB9505 /* Message.json */,
+				DA653BB9253F47EB00B448A0 /* Messages.json */,
 				798779F82498E47700015F8B /* OtherUser.json */,
 				798779F92498E47700015F8B /* CurrentUser.json */,
 				798779FA2498E47700015F8B /* ChannelsQuery.json */,
@@ -2066,6 +2069,7 @@
 				8AC9CBE224C74DD0006E236C /* NotificationInviteRejected.json in Resources */,
 				8A0CC9EC24C602B600705CF9 /* MemberAdded.json in Resources */,
 				DA8407262525E90D005A0F62 /* UsersQuery.json in Resources */,
+				DA653BBA253F47EB00B448A0 /* Messages.json in Resources */,
 				F62BE7902506620000D13B86 /* MissingEventsPayload.json in Resources */,
 				8A0CC9F624C608C500705CF9 /* ReactionNew.json in Resources */,
 			);

--- a/Tests_v3/Dummy data/MessagePayload.swift
+++ b/Tests_v3/Dummy data/MessagePayload.swift
@@ -9,13 +9,15 @@ extension MessagePayload {
     /// Creates a dummy `MessagePayload` with the given `messageId` and `userId` of the author.
     static func dummy<T: ExtraDataTypes>(
         messageId: MessageId,
+        parentId: MessageId? = nil,
+        showReplyInChannel: Bool = false,
         authorUserId: UserId,
         text: String = .unique,
         extraData: T.Message = .defaultValue
     ) -> MessagePayload<T> where T.User == NameAndImageExtraData {
         .init(
             id: messageId,
-            type: .regular,
+            type: parentId == nil ? .regular : .reply,
             user: UserPayload.dummy(userId: authorUserId) as UserPayload<T.User>,
             createdAt: .unique,
             updatedAt: .unique,
@@ -23,8 +25,8 @@ extension MessagePayload {
             text: text,
             command: .unique,
             args: .unique,
-            parentId: .unique,
-            showReplyInChannel: true,
+            parentId: parentId,
+            showReplyInChannel: showReplyInChannel,
             mentionedUsers: [UserPayload.dummy(userId: .unique)],
             replyCount: .random(in: 0...1000),
             extraData: extraData,

--- a/Tests_v3/MockEnpointResponses/Messages.json
+++ b/Tests_v3/MockEnpointResponses/Messages.json
@@ -1,0 +1,225 @@
+{
+    "messages" : [
+    {
+    "id" : "7baa1533-3294-4c0c-9a62-c9d0928bf733",
+    "reaction_counts" : {
+        "love" : 1
+    },
+    "silent" : true,
+    "created_at" : "2020-07-16T15:39:03.010717Z",
+    "deleted_at" : "2020-07-16T15:55:03.010717Z",
+    "reaction_scores" : {
+        "love" : 1
+    },
+    "type" : "regular",
+    "latest_reactions" : [
+        {
+            "score" : 1,
+            "message_id" : "7baa1533-3294-4c0c-9a62-c9d0928bf733",
+            "created_at" : "2020-08-17T13:15:39.892884Z",
+            "user_id" : "broken-waterfall-5",
+            "type" : "love",
+            "updated_at" : "2020-08-17T13:15:39.892884Z",
+            "user" : {
+                "id" : "broken-waterfall-5",
+                "banned" : false,
+                "unread_channels" : 0,
+                "totalUnreadCount" : 0,
+                "extraData" : {
+                    "name" : "Tester"
+                },
+                "last_active" : "2020-08-17T13:00:51.509134Z",
+                "created_at" : "2019-12-12T15:33:46.488935Z",
+                "invisible" : false,
+                "unreadChannels" : 0,
+                "unread_count" : 0,
+                "image" : "https:\/\/s3.amazonaws.com\/eventmobi-test-assets\/eventsbyids\/8024\/people\/100no-pic.png",
+                "updated_at" : "2020-08-17T13:15:27.5564Z",
+                "role" : "user",
+                "total_unread_count" : 0,
+                "online" : true,
+                "name" : "John Doe"
+            }
+        }
+    ],
+    "text" : "No, I am your father!",
+    "show_in_channel": true,
+    "parent_id": "3294-4c0c-9a62-c9d0928bf733",
+    "secret_note": "Anakin is Vader!",
+    "attachments" : [
+        {
+            "type" : "image",
+            "fallback" : "IMG_0007.JPG",
+            "image_url" : "https:\/\/stream-cloud-uploads-dev.imgix.net\/images\/47574\/8493ab56-a02e-49fb-becf-1a6bbed2ac62.IMG_0007.JPG?ro=0&s=09ace099e749ea6f8902aa4b9a6957eb"
+        }
+    ],
+    "own_reactions" : [
+        {
+            "score" : 1,
+            "message_id" : "7baa1533-3294-4c0c-9a62-c9d0928bf733",
+            "created_at" : "2020-08-17T13:15:39.892884Z",
+            "user_id" : "broken-waterfall-5",
+            "type" : "love",
+            "updated_at" : "2020-08-17T13:15:39.892884Z",
+            "user" : {
+                "id" : "broken-waterfall-5",
+                "banned" : false,
+                "unread_channels" : 0,
+                "totalUnreadCount" : 0,
+                "extraData" : {
+                    "name" : "Tester"
+                },
+                "last_active" : "2020-08-17T13:00:51.509134Z",
+                "created_at" : "2019-12-12T15:33:46.488935Z",
+                "invisible" : false,
+                "unreadChannels" : 0,
+                "unread_count" : 0,
+                "image" : "https:\/\/s3.amazonaws.com\/eventmobi-test-assets\/eventsbyids\/8024\/people\/100no-pic.png",
+                "updated_at" : "2020-08-17T13:15:27.5564Z",
+                "role" : "user",
+                "total_unread_count" : 0,
+                "online" : true,
+                "name" : "John Doe"
+            }
+        }
+    ],
+    "updated_at" : "2020-08-17T13:15:39.895109Z",
+    "reply_count" : 0,
+    "user" : {
+        "id" : "broken-waterfall-5",
+        "banned" : false,
+        "extraData" : {
+            "name" : "Tester"
+        },
+        "totalUnreadCount" : 0,
+        "unread_channels" : 0,
+        "last_active" : "2020-08-17T13:00:51.509134Z",
+        "created_at" : "2019-12-12T15:33:46.488935Z",
+        "invisible" : false,
+        "unreadChannels" : 0,
+        "unread_count" : 0,
+        "image" : "https:\/\/s3.amazonaws.com\/eventmobi-test-assets\/eventsbyids\/8024\/people\/100no-pic.png",
+        "updated_at" : "2020-08-17T13:15:27.5564Z",
+        "role" : "user",
+        "total_unread_count" : 0,
+        "online" : true,
+        "name" : "John Doe"
+    },
+    "mentioned_users" : [
+        
+    ],
+    "html" : "<p>Hi<\/p>\n"
+    },
+    {
+    "id" : "7baa1533-3294-4c0c-9a32-c9d0928bf733",
+    "reaction_counts" : {
+        "love" : 1
+    },
+    "silent" : true,
+    "created_at" : "2020-07-16T15:39:03.010717Z",
+    "deleted_at" : "2020-07-16T15:55:03.010717Z",
+    "reaction_scores" : {
+        "love" : 1
+    },
+    "type" : "regular",
+    "latest_reactions" : [
+        {
+            "score" : 1,
+            "message_id" : "7baa1533-3294-4c0c-9a62-c9d0928bf733",
+            "created_at" : "2020-08-17T13:15:39.892884Z",
+            "user_id" : "broken-waterfall-5",
+            "type" : "love",
+            "updated_at" : "2020-08-17T13:15:39.892884Z",
+            "user" : {
+                "id" : "broken-waterfall-5",
+                "banned" : false,
+                "unread_channels" : 0,
+                "totalUnreadCount" : 0,
+                "extraData" : {
+                    "name" : "Tester"
+                },
+                "last_active" : "2020-08-17T13:00:51.509134Z",
+                "created_at" : "2019-12-12T15:33:46.488935Z",
+                "invisible" : false,
+                "unreadChannels" : 0,
+                "unread_count" : 0,
+                "image" : "https:\/\/s3.amazonaws.com\/eventmobi-test-assets\/eventsbyids\/8024\/people\/100no-pic.png",
+                "updated_at" : "2020-08-17T13:15:27.5564Z",
+                "role" : "user",
+                "total_unread_count" : 0,
+                "online" : true,
+                "name" : "John Doe"
+            }
+        }
+    ],
+    "text" : "No, I am your father!",
+    "show_in_channel": true,
+    "parent_id": "3294-4c0c-9a62-c9d0928bf733",
+    "secret_note": "Anakin is Vader!",
+    "attachments" : [
+        {
+            "type" : "image",
+            "fallback" : "IMG_0007.JPG",
+            "image_url" : "https:\/\/stream-cloud-uploads-dev.imgix.net\/images\/47574\/8493ab56-a02e-49fb-becf-1a6bbed2ac62.IMG_0007.JPG?ro=0&s=09ace099e749ea6f8902aa4b9a6957eb"
+        }
+    ],
+    "own_reactions" : [
+        {
+            "score" : 1,
+            "message_id" : "7baa1533-3294-4c0c-9a62-c9d0928bf733",
+            "created_at" : "2020-08-17T13:15:39.892884Z",
+            "user_id" : "broken-waterfall-5",
+            "type" : "love",
+            "updated_at" : "2020-08-17T13:15:39.892884Z",
+            "user" : {
+                "id" : "broken-waterfall-5",
+                "banned" : false,
+                "unread_channels" : 0,
+                "totalUnreadCount" : 0,
+                "extraData" : {
+                    "name" : "Tester"
+                },
+                "last_active" : "2020-08-17T13:00:51.509134Z",
+                "created_at" : "2019-12-12T15:33:46.488935Z",
+                "invisible" : false,
+                "unreadChannels" : 0,
+                "unread_count" : 0,
+                "image" : "https:\/\/s3.amazonaws.com\/eventmobi-test-assets\/eventsbyids\/8024\/people\/100no-pic.png",
+                "updated_at" : "2020-08-17T13:15:27.5564Z",
+                "role" : "user",
+                "total_unread_count" : 0,
+                "online" : true,
+                "name" : "John Doe"
+            }
+        }
+    ],
+    "updated_at" : "2020-08-17T13:15:39.895109Z",
+    "reply_count" : 0,
+    "user" : {
+        "id" : "broken-waterfall-5",
+        "banned" : false,
+        "extraData" : {
+            "name" : "Tester"
+        },
+        "totalUnreadCount" : 0,
+        "unread_channels" : 0,
+        "last_active" : "2020-08-17T13:00:51.509134Z",
+        "created_at" : "2019-12-12T15:33:46.488935Z",
+        "invisible" : false,
+        "unreadChannels" : 0,
+        "unread_count" : 0,
+        "image" : "https:\/\/s3.amazonaws.com\/eventmobi-test-assets\/eventsbyids\/8024\/people\/100no-pic.png",
+        "updated_at" : "2020-08-17T13:15:27.5564Z",
+        "role" : "user",
+        "total_unread_count" : 0,
+        "online" : true,
+        "name" : "John Doe"
+    },
+    "mentioned_users" : [
+        
+    ],
+    "html" : "<p>Hi<\/p>\n"
+    }
+],
+    "duration" : 2.3
+}


### PR DESCRIPTION
**In this PR:** 

- Link replies to `MessageDTO`
- Separate `createNewMessage` and `createNewReply` APIs
- Remove replies from channel message list
- Introduce `MessageRepliesPayload`
- Introduce `loadReplies` endpoint
- Add `loadReplies` method to `MessageUpdater`
- Add `loadReplies` method to `MessageController`