### PR TITLE
For #550: Fix replies request pagination not encoded correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐞 Fixed
 - `ComposerView` disables send button but retains the message after user taps send. Now, composerView resets its state after user taps send, so user can send multiple messages [#555](https://github.com/GetStream/stream-chat-swift/issues/555)
+- Fix pagination for message replies not encoded correctly [#550](https://github.com/GetStream/stream-chat-swift/issues/550)
 
 # [2.4.0](https://github.com/GetStream/stream-chat-swift/releases/tag/2.4.0)
 _October 01, 2020_

--- a/Sources/Client/Client/Endpoint.swift
+++ b/Sources/Client/Client/Endpoint.swift
@@ -235,7 +235,13 @@ extension Endpoint {
         case .removeDevice(deviceId: let deviceId, let user):
             return ["id": deviceId, "user_id": user.id]
         case .replies(_, let pagination):
-            return pagination
+            let paginationOptions: [(String, Encodable)] = pagination
+                .flatMap({ $0.parameters })
+                .compactMap({
+                    guard let value = $1 as? Encodable else { return nil }
+                    return ($0, value)
+                })
+            return Dictionary(paginationOptions.map({ ($0, AnyEncodable($1)) }), uniquingKeysWith: { $1 })
         case .deleteImage(let url, _), .deleteFile(let url, _):
             return ["url": url]
         case .unban(let userBan):

--- a/Sources/Client/Model/Pagination.swift
+++ b/Sources/Client/Model/Pagination.swift
@@ -32,17 +32,6 @@ public extension KeyedEncodingContainer {
 }
 
 /// Pagination options.
-///
-/// For example:
-/// ```
-/// // Limit by 20.
-/// var pagination = Pagination.limit(20)
-/// // add the offset to the limit:
-/// pagination += .offset(40)
-///
-/// // Another pagination:
-/// let pagination = Pagination.limit(50) + .lessThan("some_id")
-/// ```
 public enum PaginationOption: Encodable, Hashable {
     /// Default queryUsers page size
     public static let usersPageSize: Self = .limit(25)


### PR DESCRIPTION
Since we've changed the type of Pagination, replies endpoint did not encode pagination correctly. This was caused from Pagination being an array, and we don't support encoding arrays as query items.

Fixes #550
