### PR TITLE
[CIS-405] User flagging

### DIFF
--- a/Sources_v3/APIClient/Endpoints/ModerationEndpoints.swift
+++ b/Sources_v3/APIClient/Endpoints/ModerationEndpoints.swift
@@ -50,6 +50,20 @@ extension Endpoint {
     }
 }
 
+// MARK: - User flagging
+
+extension Endpoint {
+    static func flagUser<ExtraData: UserExtraData>(_ flag: Bool, with userId: UserId) -> Endpoint<FlagUserPayload<ExtraData>> {
+        .init(
+            path: "moderation/\(flag ? "flag" : "unflag")",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["target_user_id": userId]
+        )
+    }
+}
+
 // MARK: - Private
 
 private extension Endpoint {

--- a/Sources_v3/APIClient/Endpoints/ModerationEndpoints_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/ModerationEndpoints_Tests.swift
@@ -86,4 +86,29 @@ final class ModerationEndpoints_Tests: XCTestCase {
         // Assert endpoint is built correctly.
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
     }
+    
+    func test_flagUser_buildsCorrectly() {
+        let testCases = [
+            (true, "moderation/flag"),
+            (false, "moderation/unflag")
+        ]
+        
+        for (flag, path) in testCases {
+            let userId: UserId = .unique
+            
+            let expectedEndpoint = Endpoint<FlagUserPayload<DefaultExtraData.User>>(
+                path: path,
+                method: .post,
+                queryItems: nil,
+                requiresConnectionId: false,
+                body: ["target_user_id": userId]
+            )
+            
+            // Build endpoint.
+            let endpoint: Endpoint<FlagUserPayload<DefaultExtraData.User>> = .flagUser(flag, with: userId)
+            
+            // Assert endpoint is built correctly.
+            XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        }
+    }
 }

--- a/Sources_v3/APIClient/Endpoints/Payloads/FlagUserPayload.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/FlagUserPayload.swift
@@ -1,0 +1,38 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The type describes the incoming JSON from `moderation/(un)flag` user endpoint.
+struct FlagUserPayload<ExtraData: UserExtraData>: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case flag
+        case currentUser = "user"
+        case flaggedUser = "target_user"
+    }
+    
+    /// The payload of a current user who performed flag/unflag action.
+    let currentUser: CurrentUserPayload<ExtraData>
+    /// The payload of a user who was flagged or unflagged.
+    let flaggedUser: UserPayload<ExtraData>
+    
+    init(from decoder: Decoder) throws {
+        let nestedContainer = try decoder
+            .container(keyedBy: CodingKeys.self)
+            .nestedContainer(keyedBy: CodingKeys.self, forKey: .flag)
+        
+        self.init(
+            currentUser: try nestedContainer.decode(CurrentUserPayload<ExtraData>.self, forKey: .currentUser),
+            flaggedUser: try nestedContainer.decode(UserPayload<ExtraData>.self, forKey: .flaggedUser)
+        )
+    }
+    
+    init(
+        currentUser: CurrentUserPayload<ExtraData>,
+        flaggedUser: UserPayload<ExtraData>
+    ) {
+        self.currentUser = currentUser
+        self.flaggedUser = flaggedUser
+    }
+}

--- a/Sources_v3/APIClient/Endpoints/Payloads/FlagUserPayload_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/FlagUserPayload_Tests.swift
@@ -1,0 +1,71 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class FlagUserPayload_Tests: XCTestCase {
+    func test_json_isDeserialized_withDefaultExtraData() throws {
+        let json = XCTestCase.mockData(fromFile: "FlagUserPayload+DefaultExtraData", extension: "json")
+        let payload = try JSONDecoder.default.decode(FlagUserPayload<DefaultExtraData.User>.self, from: json)
+        
+        // Assert current user payload is deserialized correctly.
+        let currentUser = payload.currentUser
+        XCTAssertEqual(currentUser.id, "broken-waterfall-5")
+        XCTAssertEqual(
+            currentUser.extraData,
+            .init(
+                name: "Broken Waterfall",
+                imageURL: URL(string: "https://s3.amazonaws.com/eventmobi-test-assets/eventsbyids/8024/people/100no-pic.png")
+            )
+        )
+        
+        // Assert flagged user payload is deserialized correctly.
+        let flaggedUser = payload.flaggedUser
+        XCTAssertEqual(flaggedUser.id, "steep-moon-9")
+        XCTAssertEqual(
+            flaggedUser.extraData,
+            .init(
+                name: "Steep Moon",
+                imageURL: URL(string: "https://i.imgur.com/EgEPqWZ.jpg")
+            )
+        )
+    }
+    
+    func test_json_isDeserialized_withNoExtraData() throws {
+        let json = XCTestCase.mockData(fromFile: "FlagUserPayload+NoExtraData", extension: "json")
+        let payload = try JSONDecoder.default.decode(FlagUserPayload<NoExtraDataTypes.User>.self, from: json)
+        
+        // Assert current user payload is deserialized correctly.
+        XCTAssertEqual(payload.currentUser.id, "broken-waterfall-5")
+        
+        // Assert flagged user payload is deserialized correctly.
+        XCTAssertEqual(payload.flaggedUser.id, "steep-moon-9")
+    }
+
+    func test_json_isDeserialized_withCustomData() throws {
+        let json = XCTestCase.mockData(fromFile: "FlagUserPayload+CustomExtraData", extension: "json")
+        let payload = try JSONDecoder.default.decode(FlagUserPayload<TestExtraData>.self, from: json)
+            
+        // Assert current user payload is deserialized correctly.
+        let currentUser = payload.currentUser
+        XCTAssertEqual(currentUser.id, "broken-waterfall-5")
+        XCTAssertEqual(currentUser.extraData.secretNote, "broken-waterfall-5 is Vader ;-)")
+        
+        // Assert flagged user payload is deserialized correctly.
+        let flaggedUser = payload.flaggedUser
+        XCTAssertEqual(flaggedUser.id, "steep-moon-9")
+        XCTAssertEqual(flaggedUser.extraData.secretNote, "Anakin is Vader ;-)")
+    }
+}
+
+private struct TestExtraData: UserExtraData {
+    enum CodingKeys: String, CodingKey {
+        case secretNote = "secret_note"
+    }
+    
+    static let defaultValue = TestExtraData(secretNote: "no secrets")
+    
+    let secretNote: String
+}

--- a/Sources_v3/Controllers/UserController/UserController.swift
+++ b/Sources_v3/Controllers/UserController/UserController.swift
@@ -181,6 +181,28 @@ public extension _ChatUserController {
             }
         }
     }
+    
+    /// Flags the user this controller manages.
+    /// - Parameter completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    ///                         If request fails, the completion will be called with an error.
+    func flag(completion: ((Error?) -> Void)? = nil) {
+        userUpdater.flagUser(true, with: userId) { error in
+            self.callback {
+                completion?(error)
+            }
+        }
+    }
+    
+    /// Unflags the user this controller manages.
+    /// - Parameter completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    ///
+    func unflag(completion: ((Error?) -> Void)? = nil) {
+        userUpdater.flagUser(false, with: userId) { error in
+            self.callback {
+                completion?(error)
+            }
+        }
+    }
 }
 
 extension _ChatUserController {

--- a/Sources_v3/Controllers/UserController/UserController_Tests.swift
+++ b/Sources_v3/Controllers/UserController/UserController_Tests.swift
@@ -28,6 +28,8 @@ final class UserController_Tests: StressTestCase {
     }
     
     override func tearDown() {
+        env.userUpdater?.cleanUp()
+        
         userId = nil
         controllerCallbackQueueID = nil
         

--- a/Sources_v3/Controllers/UserController/UserController_Tests.swift
+++ b/Sources_v3/Controllers/UserController/UserController_Tests.swift
@@ -393,6 +393,122 @@ final class UserController_Tests: StressTestCase {
         // Assert updater is called with correct `userId`
         XCTAssertEqual(env.userUpdater!.unmuteUser_userId, controller.userId)
     }
+    
+    // MARK: - Flag user
+    
+    func test_flagUser_propogatesError() {
+        // Simulate `flag` call and catch the completion.
+        var completionError: Error?
+        controller.flag { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionError = $0
+        }
+        
+        // Simulate network response with the error.
+        let networkError = TestError()
+        env.userUpdater!.flagUser_completion!(networkError)
+        
+        // Assert error is propogated.
+        AssertAsync.willBeEqual(completionError as? TestError, networkError)
+    }
+    
+    func test_flagUser_propogatesNilError() {
+        // Simulate `flag` call and catch the completion.
+        var completionIsCalled = false
+        controller.flag { [callbackQueueID] error in
+            // Assert callback queue is correct.
+            AssertTestQueue(withId: callbackQueueID)
+            // Assert there is no error.
+            XCTAssertNil(error)
+            completionIsCalled = true
+        }
+        
+        // Simulate successful network response.
+        env.userUpdater!.flagUser_completion!(nil)
+        
+        // Assert completion is called.
+        AssertAsync.willBeTrue(completionIsCalled)
+    }
+    
+    func test_flagUser_callsUserUpdater_withCorrectValues() {
+        // Simulate `flag` call.
+        controller.flag()
+        
+        // Assert updater is called with correct `flag`
+        XCTAssertEqual(env.userUpdater!.flagUser_flag, true)
+        // Assert updater is called with correct `userId`
+        XCTAssertEqual(env.userUpdater!.flagUser_userId, controller.userId)
+    }
+    
+    func test_flagUser_keepsControllerAlive() {
+        // Simulate `flag` call.
+        controller.flag()
+        
+        // Create a weak ref and release a controller.
+        weak var weakController = controller
+        controller = nil
+        
+        // Assert controller is kept alive
+        AssertAsync.staysTrue(weakController != nil)
+    }
+    
+    // MARK: - Unlag user
+    
+    func test_unflagUser_propogatesError() {
+        // Simulate `unflag` call and catch the completion.
+        var completionError: Error?
+        controller.unflag { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionError = $0
+        }
+        
+        // Simulate network response with the error.
+        let networkError = TestError()
+        env.userUpdater!.flagUser_completion!(networkError)
+        
+        // Assert error is propogated.
+        AssertAsync.willBeEqual(completionError as? TestError, networkError)
+    }
+    
+    func test_unflagUser_propogatesNilError() {
+        // Simulate `unflag` call and catch the completion.
+        var completionIsCalled = false
+        controller.unflag { [callbackQueueID] error in
+            // Assert callback queue is correct.
+            AssertTestQueue(withId: callbackQueueID)
+            // Assert there is no error.
+            XCTAssertNil(error)
+            completionIsCalled = true
+        }
+        
+        // Simulate successful network response.
+        env.userUpdater!.flagUser_completion!(nil)
+        
+        // Assert completion is called.
+        AssertAsync.willBeTrue(completionIsCalled)
+    }
+    
+    func test_unflagUser_callsUserUpdater_withCorrectValues() {
+        // Simulate `unflag` call.
+        controller.unflag()
+        
+        // Assert updater is called with correct `flag`
+        XCTAssertEqual(env.userUpdater!.flagUser_flag, false)
+        // Assert updater is called with correct `userId`
+        XCTAssertEqual(env.userUpdater!.flagUser_userId, controller.userId)
+    }
+    
+    func test_unflagUser_keepsControllerAlive() {
+        // Simulate `unflag` call.
+        controller.unflag()
+        
+        // Create a weak ref and release a controller.
+        weak var weakController = controller
+        controller = nil
+        
+        // Assert controller is kept alive
+        AssertAsync.staysTrue(weakController != nil)
+    }
 }
 
 private class TestEnvironment {

--- a/Sources_v3/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO.swift
@@ -15,6 +15,7 @@ class CurrentUserDTO: NSManagedObject {
     /// that returns all events that happen after the given date
     @NSManaged var lastReceivedEventDate: Date?
 
+    @NSManaged var flaggedUsers: Set<UserDTO>
     @NSManaged var mutedUsers: Set<UserDTO>
     @NSManaged var user: UserDTO
     @NSManaged var devices: Set<DeviceDTO>

--- a/Sources_v3/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO.swift
@@ -138,6 +138,7 @@ extension _CurrentChatUser {
         }
         
         let mutedUsers: [_ChatUser<ExtraData>] = dto.mutedUsers.map { $0.asModel() }
+        let flaggedUsers: [_ChatUser<ExtraData>] = dto.flaggedUsers.map { $0.asModel() }
         
         return _CurrentChatUser(
             id: user.id,
@@ -151,6 +152,7 @@ extension _CurrentChatUser {
             devices: dto.devices.map { $0.asModel() },
             currentDevice: nil,
             mutedUsers: Set(mutedUsers),
+            flaggedUsers: Set(flaggedUsers),
             unreadCount: UnreadCount(
                 channels: Int(dto.unreadChannelsCount),
                 messages: Int(dto.unreadMessagesCount)

--- a/Sources_v3/Database/DTOs/UserDTO.swift
+++ b/Sources_v3/Database/DTOs/UserDTO.swift
@@ -153,6 +153,7 @@ extension _ChatUser {
             id: dto.id,
             isOnline: dto.isOnline,
             isBanned: dto.isBanned,
+            isFlaggedByCurrentUser: dto.flaggedBy != nil,
             userRole: UserRole(rawValue: dto.userRoleRaw)!,
             createdAt: dto.userCreatedAt,
             updatedAt: dto.userUpdatedAt,

--- a/Sources_v3/Database/DTOs/UserDTO.swift
+++ b/Sources_v3/Database/DTOs/UserDTO.swift
@@ -17,6 +17,8 @@ class UserDTO: NSManagedObject {
     @NSManaged var userRoleRaw: String
     @NSManaged var userUpdatedAt: Date
     
+    @NSManaged var flaggedBy: CurrentUserDTO?
+    
     /// Returns a fetch request for the dto with the provided `userId`.
     static func user(withID userId: UserId) -> NSFetchRequest<UserDTO> {
         let request = NSFetchRequest<UserDTO>(entityName: UserDTO.entityName)

--- a/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17192" systemVersion="19E266" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17192" systemVersion="19G2021" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ChannelDTO" representedClassName="ChannelDTO" syncable="YES">
         <attribute name="cid" attributeType="String"/>
         <attribute name="config" attributeType="Binary"/>
@@ -76,6 +76,7 @@
         <attribute name="unreadChannelsCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="unreadMessagesCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="devices" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DeviceDTO" inverseName="user" inverseEntity="DeviceDTO"/>
+        <relationship name="flaggedUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="flaggedBy" inverseEntity="UserDTO"/>
         <relationship name="mutedUsers" toMany="YES" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="mutedBy" inverseEntity="UserDTO"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="currentUser" inverseEntity="UserDTO"/>
         <uniquenessConstraints>
@@ -170,6 +171,7 @@
         <relationship name="channelReads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelReadDTO" inverseName="user" inverseEntity="ChannelReadDTO"/>
         <relationship name="createdChannels" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="createdBy" inverseEntity="ChannelDTO"/>
         <relationship name="currentUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CurrentUserDTO" inverseName="user" inverseEntity="CurrentUserDTO"/>
+        <relationship name="flaggedBy" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CurrentUserDTO" inverseName="flaggedUsers" inverseEntity="CurrentUserDTO"/>
         <relationship name="members" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MemberDTO" inverseName="user" inverseEntity="MemberDTO"/>
         <relationship name="mentionedMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="mentionedUsers" inverseEntity="MessageDTO"/>
         <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="user" inverseEntity="MessageDTO"/>

--- a/Sources_v3/Models/CurrentUser.swift
+++ b/Sources_v3/Models/CurrentUser.swift
@@ -46,6 +46,9 @@ public class _CurrentChatUser<ExtraData: UserExtraData>: _ChatUser<ExtraData> {
     /// A set of users muted by the user.
     public let mutedUsers: Set<_ChatUser<ExtraData>>
     
+    /// A set of users flagged by the user.
+    public let flaggedUsers: Set<_ChatUser<ExtraData>>
+    
     /// The unread counts for the current user.
     public let unreadCount: UnreadCount
     
@@ -61,11 +64,13 @@ public class _CurrentChatUser<ExtraData: UserExtraData>: _ChatUser<ExtraData> {
         devices: [Device] = [],
         currentDevice: Device? = nil,
         mutedUsers: Set<_ChatUser<ExtraData>> = [],
+        flaggedUsers: Set<_ChatUser<ExtraData>> = [],
         unreadCount: UnreadCount = .noUnread
     ) {
         self.devices = devices
         self.currentDevice = currentDevice
         self.mutedUsers = mutedUsers
+        self.flaggedUsers = flaggedUsers
         self.unreadCount = unreadCount
         
         super.init(

--- a/Sources_v3/Models/User.swift
+++ b/Sources_v3/Models/User.swift
@@ -34,6 +34,12 @@ public class _ChatUser<ExtraData: UserExtraData> {
     /// An indicator whether the user is banned.
     public let isBanned: Bool
     
+    /// An indicator whether the user is flagged by the current user.
+    ///
+    /// - Note: Please be aware that the value of this field is not persisted on the server,
+    /// and is valid only locally for the current session.
+    public let isFlaggedByCurrentUser: Bool
+    
     /// The role of the user.
     public let userRole: UserRole
     
@@ -62,6 +68,7 @@ public class _ChatUser<ExtraData: UserExtraData> {
         id: UserId,
         isOnline: Bool = false,
         isBanned: Bool = false,
+        isFlaggedByCurrentUser: Bool = false,
         userRole: UserRole = .user,
         createdAt: Date = .init(),
         updatedAt: Date = .init(),
@@ -72,6 +79,7 @@ public class _ChatUser<ExtraData: UserExtraData> {
         self.id = id
         self.isOnline = isOnline
         self.isBanned = isBanned
+        self.isFlaggedByCurrentUser = isFlaggedByCurrentUser
         self.userRole = userRole
         userCreatedAt = createdAt
         userUpdatedAt = updatedAt

--- a/Sources_v3/Workers/UserUpdater_Mock.swift
+++ b/Sources_v3/Workers/UserUpdater_Mock.swift
@@ -40,4 +40,20 @@ final class UserUpdaterMock<ExtraData: ExtraDataTypes>: UserUpdater<ExtraData> {
         flagUser_userId = userId
         flagUser_completion = completion
     }
+    
+    // Cleans up all recorded values
+    func cleanUp() {
+        muteUser_userId = nil
+        muteUser_completion = nil
+        
+        unmuteUser_userId = nil
+        unmuteUser_completion = nil
+        
+        loadUser_userId = nil
+        loadUser_completion = nil
+        
+        flagUser_flag = nil
+        flagUser_userId = nil
+        flagUser_completion = nil
+    }
 }

--- a/Sources_v3/Workers/UserUpdater_Mock.swift
+++ b/Sources_v3/Workers/UserUpdater_Mock.swift
@@ -15,6 +15,10 @@ final class UserUpdaterMock<ExtraData: ExtraDataTypes>: UserUpdater<ExtraData> {
 
     @Atomic var loadUser_userId: UserId?
     @Atomic var loadUser_completion: ((Error?) -> Void)?
+    
+    @Atomic var flagUser_flag: Bool?
+    @Atomic var flagUser_userId: UserId?
+    @Atomic var flagUser_completion: ((Error?) -> Void)?
 
     override func muteUser(_ userId: UserId, completion: ((Error?) -> Void)? = nil) {
         muteUser_userId = userId
@@ -29,5 +33,11 @@ final class UserUpdaterMock<ExtraData: ExtraDataTypes>: UserUpdater<ExtraData> {
     override func loadUser(_ userId: UserId, completion: ((Error?) -> Void)? = nil) {
         loadUser_userId = userId
         loadUser_completion = completion
+    }
+    
+    override func flagUser(_ flag: Bool, with userId: UserId, completion: ((Error?) -> Void)? = nil) {
+        flagUser_flag = flag
+        flagUser_userId = userId
+        flagUser_completion = completion
     }
 }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -232,6 +232,11 @@
 		882C5766252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882C5765252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift */; };
 		8836133825274F5F003CB958 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133725274F5F003CB958 /* ExtraData.swift */; };
 		8836133C25275170003CB958 /* MutedUserPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836133B25275170003CB958 /* MutedUserPayload.swift */; };
+		8836FFBB2540741D009FDF73 /* FlagUserPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836FFBA2540741D009FDF73 /* FlagUserPayload.swift */; };
+		8836FFC325408210009FDF73 /* FlagUserPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8836FFC225408210009FDF73 /* FlagUserPayload_Tests.swift */; };
+		8836FFD3254082FF009FDF73 /* FlagUserPayload+CustomExtraData.json in Resources */ = {isa = PBXBuildFile; fileRef = 8836FFD0254082FF009FDF73 /* FlagUserPayload+CustomExtraData.json */; };
+		8836FFD4254082FF009FDF73 /* FlagUserPayload+DefaultExtraData.json in Resources */ = {isa = PBXBuildFile; fileRef = 8836FFD1254082FF009FDF73 /* FlagUserPayload+DefaultExtraData.json */; };
+		8836FFD5254082FF009FDF73 /* FlagUserPayload+NoExtraData.json in Resources */ = {isa = PBXBuildFile; fileRef = 8836FFD2254082FF009FDF73 /* FlagUserPayload+NoExtraData.json */; };
 		8837C6342539B39700D8FE86 /* CombineSimpleChannelMembersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8837C6332539B39700D8FE86 /* CombineSimpleChannelMembersViewController.swift */; };
 		8837C63A2539B4A600D8FE86 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8837C6392539B4A600D8FE86 /* Date+Extensions.swift */; };
 		8837C6442539C17A00D8FE86 /* ChannelMember+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8837C6432539C17A00D8FE86 /* ChannelMember+Extensions.swift */; };
@@ -687,6 +692,11 @@
 		882C5765252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListUpdater_Tests.swift; sourceTree = "<group>"; };
 		8836133725274F5F003CB958 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
 		8836133B25275170003CB958 /* MutedUserPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutedUserPayload.swift; sourceTree = "<group>"; };
+		8836FFBA2540741D009FDF73 /* FlagUserPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagUserPayload.swift; sourceTree = "<group>"; };
+		8836FFC225408210009FDF73 /* FlagUserPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagUserPayload_Tests.swift; sourceTree = "<group>"; };
+		8836FFD0254082FF009FDF73 /* FlagUserPayload+CustomExtraData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "FlagUserPayload+CustomExtraData.json"; sourceTree = "<group>"; };
+		8836FFD1254082FF009FDF73 /* FlagUserPayload+DefaultExtraData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "FlagUserPayload+DefaultExtraData.json"; sourceTree = "<group>"; };
+		8836FFD2254082FF009FDF73 /* FlagUserPayload+NoExtraData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "FlagUserPayload+NoExtraData.json"; sourceTree = "<group>"; };
 		8837C6332539B39700D8FE86 /* CombineSimpleChannelMembersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineSimpleChannelMembersViewController.swift; sourceTree = "<group>"; };
 		8837C6392539B4A600D8FE86 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
 		8837C6432539C17A00D8FE86 /* ChannelMember+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelMember+Extensions.swift"; sourceTree = "<group>"; };
@@ -1190,6 +1200,8 @@
 				F62BE7842506309B00D13B86 /* MissingEventsPayload_Tests.swift */,
 				790A4C44252DD4F1001F4A23 /* DevicePayloads.swift */,
 				790A4C4D252E0901001F4A23 /* DevicePayloads_Tests.swift */,
+				8836FFBA2540741D009FDF73 /* FlagUserPayload.swift */,
+				8836FFC225408210009FDF73 /* FlagUserPayload_Tests.swift */,
 			);
 			path = Payloads;
 			sourceTree = "<group>";
@@ -1206,6 +1218,7 @@
 				798779F92498E47700015F8B /* CurrentUser.json */,
 				798779FA2498E47700015F8B /* ChannelsQuery.json */,
 				DA8407252525E90D005A0F62 /* UsersQuery.json */,
+				8836FFCF254082FF009FDF73 /* FlagUser */,
 				F62BE7882506616900D13B86 /* Sync */,
 				8A0D649E24E57A260017A3C0 /* GuestUser */,
 				8A62705F24BE31B20040BFD6 /* Events */,
@@ -1538,6 +1551,16 @@
 				888E8C3B252B2AC900195E03 /* UserController+SwiftUI_Tests.swift */,
 			);
 			path = UserController;
+			sourceTree = "<group>";
+		};
+		8836FFCF254082FF009FDF73 /* FlagUser */ = {
+			isa = PBXGroup;
+			children = (
+				8836FFD1254082FF009FDF73 /* FlagUserPayload+DefaultExtraData.json */,
+				8836FFD0254082FF009FDF73 /* FlagUserPayload+CustomExtraData.json */,
+				8836FFD2254082FF009FDF73 /* FlagUserPayload+NoExtraData.json */,
+			);
+			path = FlagUser;
 			sourceTree = "<group>";
 		};
 		888E8C53252B522F00195E03 /* MemberController */ = {
@@ -1999,12 +2022,14 @@
 				8A0CC9F724C608C500705CF9 /* ReactionUpdated.json in Resources */,
 				8A62706524BE403C0040BFD6 /* UserStopTyping.json in Resources */,
 				794927F3249E3F77009D7EB7 /* NotificationAddedToChannel.json in Resources */,
+				8836FFD5254082FF009FDF73 /* FlagUserPayload+NoExtraData.json in Resources */,
 				790A4C51252E0966001F4A23 /* Devices.json in Resources */,
 				8AC9CBDF24C74DD0006E236C /* NotificationRemovedFromChannel.json in Resources */,
 				8A0C3BDF24C1F18700CAFD19 /* MessageRead.json in Resources */,
 				8A0C3BBF24C0ACAB00CAFD19 /* UserPresence.json in Resources */,
 				8A0C3BDD24C1F18700CAFD19 /* MessageUpdated.json in Resources */,
 				8A0C3BC624C0AEDB00CAFD19 /* UserStopWatching.json in Resources */,
+				8836FFD3254082FF009FDF73 /* FlagUserPayload+CustomExtraData.json in Resources */,
 				8A0D64A224E57A260017A3C0 /* GuestUser+DefaultExtraData.json in Resources */,
 				798779FB2498E47700015F8B /* Member.json in Resources */,
 				8A0CC9F824C608C500705CF9 /* ReactionDeleted.json in Resources */,
@@ -2012,6 +2037,7 @@
 				8A0C3BCC24C1CA9900CAFD19 /* ChannelUpdated.json in Resources */,
 				798779FD2498E47700015F8B /* OtherUser.json in Resources */,
 				F64F9B6225077CF600834F55 /* MessageNew+MissingFields.json in Resources */,
+				8836FFD4254082FF009FDF73 /* FlagUserPayload+DefaultExtraData.json in Resources */,
 				8A0C3BE024C1F18700CAFD19 /* NotificationMarkRead.json in Resources */,
 				8A0CC9EF24C604E000705CF9 /* MemberUpdated.json in Resources */,
 				8A0C3BCE24C1CB0500CAFD19 /* ChannelDeleted.json in Resources */,
@@ -2277,6 +2303,7 @@
 				8A62704E24B8660A0040BFD6 /* EventType.swift in Sources */,
 				F65D9091250A5989000B8CEB /* WebSocketConnectEndpoint.swift in Sources */,
 				DAE566EB24FFD26C00E39431 /* CurrentUserController+SwiftUI.swift in Sources */,
+				8836FFBB2540741D009FDF73 /* FlagUserPayload.swift in Sources */,
 				799C945E247D7283001F1104 /* DatabaseContainer.swift in Sources */,
 				79877A092498E4BC00015F8B /* User.swift in Sources */,
 				79B5517324E593C200CE9FEC /* UserPayloads.swift in Sources */,
@@ -2298,6 +2325,7 @@
 				DA8407232525E871005A0F62 /* UserListPayload_Tests.swift in Sources */,
 				799B5DC5253081C900C108FB /* DevicePayloads.swift in Sources */,
 				F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */,
+				8836FFC325408210009FDF73 /* FlagUserPayload_Tests.swift in Sources */,
 				DAFC1D4724F50C5C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift in Sources */,
 				7964F3AA249A19EA002A09EC /* Filter_Tests.swift in Sources */,
 				DA84072D2525EF8D005A0F62 /* UserEndpoints_Tests.swift in Sources */,

--- a/Tests_v3/MockEnpointResponses/FlagUser/FlagUserPayload+CustomExtraData.json
+++ b/Tests_v3/MockEnpointResponses/FlagUser/FlagUserPayload+CustomExtraData.json
@@ -1,0 +1,44 @@
+{
+    "flag" : {
+        "reviewed_by" : "",
+        "rejected_at" : "0001-01-01T00:00:00Z",
+        "created_by_automod" : false,
+        "created_at" : "2020-10-21T14:45:03.115787Z",
+        "approved_at" : "0001-01-01T00:00:00Z",
+        "updated_at" : "2020-10-21T14:45:03.115787Z",
+        "target_user" : {
+            "id" : "steep-moon-9",
+            "banned" : false,
+            "unread_channels" : 3,
+            "totalUnreadCount" : 0,
+            "last_active" : "2020-10-21T09:39:14.027121Z",
+            "created_at" : "2019-12-12T15:34:00.762372Z",
+            "devices" : null,
+            "invisible" : false,
+            "unreadChannels" : 0,
+            "unread_count" : 21,
+            "channel_mutes" : null,
+            "secret_note" : "Anakin is Vader ;-)",
+            "updated_at" : "2020-10-21T09:39:14.027121Z",
+            "role" : "user",
+            "total_unread_count" : 21,
+            "online" : false
+        },
+        "reviewed_at" : "0001-01-01T00:00:00Z",
+        "user" : {
+            "id" : "broken-waterfall-5",
+            "banned" : false,
+            "last_active" : "2020-10-21T14:31:31.692634Z",
+            "created_at" : "2019-12-12T15:33:46.488935Z",
+            "devices" : null,
+            "invisible" : false,
+            "team" : 1,
+            "channel_mutes" : null,
+            "secret_note" : "broken-waterfall-5 is Vader ;-)",
+            "updated_at" : "2020-10-21T14:43:22.80866Z",
+            "role" : "user",
+            "online" : true
+        }
+    },
+    "duration" : "9.32ms"
+}

--- a/Tests_v3/MockEnpointResponses/FlagUser/FlagUserPayload+DefaultExtraData.json
+++ b/Tests_v3/MockEnpointResponses/FlagUser/FlagUserPayload+DefaultExtraData.json
@@ -1,0 +1,46 @@
+{
+    "flag" : {
+        "reviewed_by" : "",
+        "rejected_at" : "0001-01-01T00:00:00Z",
+        "created_by_automod" : false,
+        "created_at" : "2020-10-21T14:45:03.115787Z",
+        "approved_at" : "0001-01-01T00:00:00Z",
+        "updated_at" : "2020-10-21T14:45:03.115787Z",
+        "target_user" : {
+            "id" : "steep-moon-9",
+            "banned" : false,
+            "unread_channels" : 3,
+            "totalUnreadCount" : 0,
+            "last_active" : "2020-10-21T09:39:14.027121Z",
+            "created_at" : "2019-12-12T15:34:00.762372Z",
+            "devices" : null,
+            "invisible" : false,
+            "unreadChannels" : 0,
+            "unread_count" : 21,
+            "channel_mutes" : null,
+            "image" : "https:\/\/i.imgur.com\/EgEPqWZ.jpg",
+            "updated_at" : "2020-10-21T09:39:14.027121Z",
+            "role" : "user",
+            "total_unread_count" : 21,
+            "online" : false,
+            "name" : "Steep Moon"
+        },
+        "reviewed_at" : "0001-01-01T00:00:00Z",
+        "user" : {
+            "id" : "broken-waterfall-5",
+            "banned" : false,
+            "last_active" : "2020-10-21T14:31:31.692634Z",
+            "created_at" : "2019-12-12T15:33:46.488935Z",
+            "devices" : null,
+            "invisible" : false,
+            "team" : 1,
+            "channel_mutes" : null,
+            "image" : "https:\/\/s3.amazonaws.com\/eventmobi-test-assets\/eventsbyids\/8024\/people\/100no-pic.png",
+            "updated_at" : "2020-10-21T14:43:22.80866Z",
+            "role" : "user",
+            "online" : true,
+            "name" : "Broken Waterfall"
+        }
+    },
+    "duration" : "9.32ms"
+}

--- a/Tests_v3/MockEnpointResponses/FlagUser/FlagUserPayload+NoExtraData.json
+++ b/Tests_v3/MockEnpointResponses/FlagUser/FlagUserPayload+NoExtraData.json
@@ -1,0 +1,42 @@
+{
+    "flag" : {
+        "reviewed_by" : "",
+        "rejected_at" : "0001-01-01T00:00:00Z",
+        "created_by_automod" : false,
+        "created_at" : "2020-10-21T14:45:03.115787Z",
+        "approved_at" : "0001-01-01T00:00:00Z",
+        "updated_at" : "2020-10-21T14:45:03.115787Z",
+        "target_user" : {
+            "id" : "steep-moon-9",
+            "banned" : false,
+            "unread_channels" : 3,
+            "totalUnreadCount" : 0,
+            "last_active" : "2020-10-21T09:39:14.027121Z",
+            "created_at" : "2019-12-12T15:34:00.762372Z",
+            "devices" : null,
+            "invisible" : false,
+            "unreadChannels" : 0,
+            "unread_count" : 21,
+            "channel_mutes" : null,
+            "updated_at" : "2020-10-21T09:39:14.027121Z",
+            "role" : "user",
+            "total_unread_count" : 21,
+            "online" : false
+        },
+        "reviewed_at" : "0001-01-01T00:00:00Z",
+        "user" : {
+            "id" : "broken-waterfall-5",
+            "banned" : false,
+            "last_active" : "2020-10-21T14:31:31.692634Z",
+            "created_at" : "2019-12-12T15:33:46.488935Z",
+            "devices" : null,
+            "invisible" : false,
+            "team" : 1,
+            "channel_mutes" : null,
+            "updated_at" : "2020-10-21T14:43:22.80866Z",
+            "role" : "user",
+            "online" : true
+        }
+    },
+    "duration" : "9.32ms"
+}


### PR DESCRIPTION
**This PR**:
- exposes `flag/unflag` API by `UserController`
- adds `CurrentUserDTO <->> UserDTO` relation for flagged users and updates the models
- adds `flagUser` to `UserUpdater`
- introduces `FlagUserPayload`
- updates mock `UserUpdater` to have a `cleanUp` function