### PR TITLE
[CIS-406] Message flagging

### DIFF
--- a/Sources_v3/APIClient/Endpoints/ModerationEndpoints.swift
+++ b/Sources_v3/APIClient/Endpoints/ModerationEndpoints.swift
@@ -64,6 +64,23 @@ extension Endpoint {
     }
 }
 
+// MARK: - Message flagging
+
+extension Endpoint {
+    static func flagMessage<ExtraData: UserExtraData>(
+        _ flag: Bool,
+        with messageId: MessageId
+    ) -> Endpoint<FlagMessagePayload<ExtraData>> {
+        .init(
+            path: "moderation/\(flag ? "flag" : "unflag")",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["target_message_id": messageId]
+        )
+    }
+}
+
 // MARK: - Private
 
 private extension Endpoint {

--- a/Sources_v3/APIClient/Endpoints/ModerationEndpoints_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/ModerationEndpoints_Tests.swift
@@ -111,4 +111,29 @@ final class ModerationEndpoints_Tests: XCTestCase {
             XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
         }
     }
+    
+    func test_flagMessage_buildsCorrectly() {
+        let testCases = [
+            (true, "moderation/flag"),
+            (false, "moderation/unflag")
+        ]
+        
+        for (flag, path) in testCases {
+            let messageId: MessageId = .unique
+            
+            let expectedEndpoint = Endpoint<FlagMessagePayload<DefaultExtraData.User>>(
+                path: path,
+                method: .post,
+                queryItems: nil,
+                requiresConnectionId: false,
+                body: ["target_message_id": messageId]
+            )
+            
+            // Build endpoint.
+            let endpoint: Endpoint<FlagMessagePayload<DefaultExtraData.User>> = .flagMessage(flag, with: messageId)
+            
+            // Assert endpoint is built correctly.
+            XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        }
+    }
 }

--- a/Sources_v3/APIClient/Endpoints/Payloads/FlagMessagePayload.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/FlagMessagePayload.swift
@@ -1,0 +1,38 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The type describes the incoming JSON from `moderation/(un)flag` message endpoint.
+struct FlagMessagePayload<ExtraData: UserExtraData>: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case flag
+        case currentUser = "user"
+        case flaggedMessageId = "target_message_id"
+    }
+    
+    /// The payload of the current user who performed flag/unflag action.
+    let currentUser: CurrentUserPayload<ExtraData>
+    /// The `id` of the message which was flagged or unflagged.
+    let flaggedMessageId: MessageId
+    
+    init(from decoder: Decoder) throws {
+        let nestedContainer = try decoder
+            .container(keyedBy: CodingKeys.self)
+            .nestedContainer(keyedBy: CodingKeys.self, forKey: .flag)
+        
+        self.init(
+            currentUser: try nestedContainer.decode(CurrentUserPayload<ExtraData>.self, forKey: .currentUser),
+            flaggedMessageId: try nestedContainer.decode(MessageId.self, forKey: .flaggedMessageId)
+        )
+    }
+    
+    init(
+        currentUser: CurrentUserPayload<ExtraData>,
+        flaggedMessageId: MessageId
+    ) {
+        self.currentUser = currentUser
+        self.flaggedMessageId = flaggedMessageId
+    }
+}

--- a/Sources_v3/APIClient/Endpoints/Payloads/FlagMessagePayload_Tests.swift
+++ b/Sources_v3/APIClient/Endpoints/Payloads/FlagMessagePayload_Tests.swift
@@ -1,0 +1,61 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class FlagMessagePayload_Tests: XCTestCase {
+    func test_json_isDeserialized_withDefaultExtraData() throws {
+        let json = XCTestCase.mockData(fromFile: "FlagMessagePayload+DefaultExtraData", extension: "json")
+        let payload = try JSONDecoder.default.decode(FlagMessagePayload<DefaultExtraData.User>.self, from: json)
+        
+        // Assert current user payload is deserialized correctly.
+        let currentUser = payload.currentUser
+        XCTAssertEqual(currentUser.id, "broken-waterfall-5")
+        XCTAssertEqual(
+            currentUser.extraData,
+            .init(
+                name: "Broken Waterfall",
+                imageURL: URL(string: "https://s3.amazonaws.com/eventmobi-test-assets/eventsbyids/8024/people/100no-pic.png")
+            )
+        )
+        
+        // Assert flagged message data is deserialized correctly.
+        XCTAssertEqual(payload.flaggedMessageId, "5961F803-1613-4891-B14C-7511BC719D35")
+    }
+    
+    func test_json_isDeserialized_withNoExtraData() throws {
+        let json = XCTestCase.mockData(fromFile: "FlagMessagePayload+NoExtraData", extension: "json")
+        let payload = try JSONDecoder.default.decode(FlagMessagePayload<NoExtraDataTypes.User>.self, from: json)
+        
+        // Assert current user payload is deserialized correctly.
+        XCTAssertEqual(payload.currentUser.id, "broken-waterfall-5")
+        
+        // Assert flagged message data is deserialized correctly.
+        XCTAssertEqual(payload.flaggedMessageId, "5961F803-1613-4891-B14C-7511BC719D35")
+    }
+
+    func test_json_isDeserialized_withCustomData() throws {
+        let json = XCTestCase.mockData(fromFile: "FlagMessagePayload+CustomExtraData", extension: "json")
+        let payload = try JSONDecoder.default.decode(FlagMessagePayload<TestExtraData>.self, from: json)
+            
+        // Assert current user payload is deserialized correctly.
+        let currentUser = payload.currentUser
+        XCTAssertEqual(currentUser.id, "broken-waterfall-5")
+        XCTAssertEqual(currentUser.extraData.secretNote, "broken-waterfall-5 is Vader ;-)")
+        
+        // Assert flagged message data is deserialized correctly.
+        XCTAssertEqual(payload.flaggedMessageId, "5961F803-1613-4891-B14C-7511BC719D35")
+    }
+}
+
+private struct TestExtraData: UserExtraData {
+    enum CodingKeys: String, CodingKey {
+        case secretNote = "secret_note"
+    }
+    
+    static let defaultValue = TestExtraData(secretNote: "no secrets")
+    
+    let secretNote: String
+}

--- a/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources_v3/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -155,7 +155,8 @@ extension _ChatMessage {
             author: .init(id: .unique),
             mentionedUsers: [],
             latestReplies: [],
-            localState: nil
+            localState: nil,
+            isFlaggedByCurrentUser: false
         )
     }
 }

--- a/Sources_v3/Controllers/MessageController/MessageController.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController.swift
@@ -275,6 +275,30 @@ public extension _ChatMessageController {
             self?.callback { completion?(error) }
         }
     }
+    
+    /// Flags the message this controller manages.
+    ///
+    /// - Parameter completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    ///
+    func flag(completion: ((Error?) -> Void)? = nil) {
+        messageUpdater.flagMessage(true, with: messageId, in: cid) { error in
+            self.callback {
+                completion?(error)
+            }
+        }
+    }
+    
+    /// Unflags the message this controller manages.
+    ///
+    /// - Parameter completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    ///
+    func unflag(completion: ((Error?) -> Void)? = nil) {
+        messageUpdater.flagMessage(false, with: messageId, in: cid) { error in
+            self.callback {
+                completion?(error)
+            }
+        }
+    }
 }
 
 // MARK: - Environment

--- a/Sources_v3/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources_v3/Controllers/MessageController/MessageController_Tests.swift
@@ -449,6 +449,126 @@ final class MessageController_Tests: StressTestCase {
         XCTAssertEqual(env.messageUpdater.editMessage_text, updatedText)
     }
     
+    // MARK: - Flag message
+    
+    func test_flag_propogatesError() {
+        // Simulate `flag` call and catch the completion.
+        var completionError: Error?
+        controller.flag { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionError = $0
+        }
+        
+        // Simulate network response with the error.
+        let networkError = TestError()
+        env.messageUpdater!.flagMessage_completion!(networkError)
+        
+        // Assert error is propogated.
+        AssertAsync.willBeEqual(completionError as? TestError, networkError)
+    }
+    
+    func test_flag_propogatesNilError() {
+        // Simulate `flag` call and catch the completion.
+        var completionIsCalled = false
+        controller.flag { [callbackQueueID] error in
+            // Assert callback queue is correct.
+            AssertTestQueue(withId: callbackQueueID)
+            // Assert there is no error.
+            XCTAssertNil(error)
+            completionIsCalled = true
+        }
+        
+        // Simulate successful network response.
+        env.messageUpdater!.flagMessage_completion!(nil)
+        
+        // Assert completion is called.
+        AssertAsync.willBeTrue(completionIsCalled)
+    }
+    
+    func test_flag_callsUpdater_withCorrectValues() {
+        // Simulate `flag` call.
+        controller.flag()
+        
+        // Assert updater is called with correct `flag`.
+        XCTAssertEqual(env.messageUpdater!.flagMessage_flag, true)
+        // Assert updater is called with correct `messageId`.
+        XCTAssertEqual(env.messageUpdater!.flagMessage_messageId, controller.messageId)
+        // Assert updater is called with correct `cid`.
+        XCTAssertEqual(env.messageUpdater!.flagMessage_cid, controller.cid)
+    }
+    
+    func test_flag_keepsControllerAlive() {
+        // Simulate `flag` call.
+        controller.flag()
+        
+        // Create a weak ref and release a controller.
+        weak var weakController = controller
+        controller = nil
+        
+        // Assert controller is kept alive.
+        AssertAsync.staysTrue(weakController != nil)
+    }
+    
+    // MARK: - Unflag message
+    
+    func test_unflag_propogatesError() {
+        // Simulate `unflag` call and catch the completion.
+        var completionError: Error?
+        controller.unflag { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionError = $0
+        }
+        
+        // Simulate network response with the error.
+        let networkError = TestError()
+        env.messageUpdater!.flagMessage_completion!(networkError)
+        
+        // Assert error is propogated.
+        AssertAsync.willBeEqual(completionError as? TestError, networkError)
+    }
+    
+    func test_unflag_propogatesNilError() {
+        // Simulate `unflag` call and catch the completion.
+        var completionIsCalled = false
+        controller.unflag { [callbackQueueID] error in
+            // Assert callback queue is correct.
+            AssertTestQueue(withId: callbackQueueID)
+            // Assert there is no error.
+            XCTAssertNil(error)
+            completionIsCalled = true
+        }
+        
+        // Simulate successful network response.
+        env.messageUpdater!.flagMessage_completion!(nil)
+        
+        // Assert completion is called.
+        AssertAsync.willBeTrue(completionIsCalled)
+    }
+    
+    func test_unflag_callsUpdater_withCorrectValues() {
+        // Simulate `unflag` call.
+        controller.unflag()
+        
+        // Assert updater is called with correct `flag`.
+        XCTAssertEqual(env.messageUpdater!.flagMessage_flag, false)
+        // Assert updater is called with correct `messageId`.
+        XCTAssertEqual(env.messageUpdater!.flagMessage_messageId, controller.messageId)
+        // Assert updater is called with correct `cid`.
+        XCTAssertEqual(env.messageUpdater!.flagMessage_cid, controller.cid)
+    }
+    
+    func test_unflag_keepsControllerAlive() {
+        // Simulate `unflag` call.
+        controller.unflag()
+        
+        // Create a weak ref and release a controller.
+        weak var weakController = controller
+        controller = nil
+        
+        // Assert controller is kept alive.
+        AssertAsync.staysTrue(weakController != nil)
+    }
+    
     // MARK: - Create new reply
     
     func test_createNewReply_callsChannelUpdater() {

--- a/Sources_v3/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO.swift
@@ -16,6 +16,7 @@ class CurrentUserDTO: NSManagedObject {
     @NSManaged var lastReceivedEventDate: Date?
 
     @NSManaged var flaggedUsers: Set<UserDTO>
+    @NSManaged var flaggedMessages: Set<MessageDTO>
     @NSManaged var mutedUsers: Set<UserDTO>
     @NSManaged var user: UserDTO
     @NSManaged var devices: Set<DeviceDTO>

--- a/Sources_v3/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources_v3/Database/DTOs/CurrentUserDTO.swift
@@ -140,7 +140,8 @@ extension _CurrentChatUser {
         
         let mutedUsers: [_ChatUser<ExtraData>] = dto.mutedUsers.map { $0.asModel() }
         let flaggedUsers: [_ChatUser<ExtraData>] = dto.flaggedUsers.map { $0.asModel() }
-        
+        let flaggedMessagesIDs: [MessageId] = dto.flaggedMessages.map(\.id)
+
         return _CurrentChatUser(
             id: user.id,
             isOnline: user.isOnline,
@@ -154,6 +155,7 @@ extension _CurrentChatUser {
             currentDevice: nil,
             mutedUsers: Set(mutedUsers),
             flaggedUsers: Set(flaggedUsers),
+            flaggedMessageIDs: Set(flaggedMessagesIDs),
             unreadCount: UnreadCount(
                 channels: Int(dto.unreadChannelsCount),
                 messages: Int(dto.unreadMessagesCount)

--- a/Sources_v3/Database/DTOs/MessageDTO.swift
+++ b/Sources_v3/Database/DTOs/MessageDTO.swift
@@ -28,6 +28,7 @@ class MessageDTO: NSManagedObject {
     @NSManaged var mentionedUsers: Set<UserDTO>
     @NSManaged var channel: ChannelDTO
     @NSManaged var replies: Set<MessageDTO>
+    @NSManaged var flaggedBy: CurrentUserDTO?
     
     // The timestamp the message was created locally. Applies only for the messages of the current user.
     @NSManaged var locallyCreatedAt: Date?

--- a/Sources_v3/Database/DTOs/MessageDTO.swift
+++ b/Sources_v3/Database/DTOs/MessageDTO.swift
@@ -300,6 +300,8 @@ extension _ChatMessage {
             .map(_ChatMessage.init)
         
         localState = dto.localMessageState
+        
+        isFlaggedByCurrentUser = dto.flaggedBy != nil
     }
 }
 

--- a/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources_v3/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -76,6 +76,7 @@
         <attribute name="unreadChannelsCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="unreadMessagesCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="devices" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DeviceDTO" inverseName="user" inverseEntity="DeviceDTO"/>
+        <relationship name="flaggedMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="flaggedBy" inverseEntity="MessageDTO"/>
         <relationship name="flaggedUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="flaggedBy" inverseEntity="UserDTO"/>
         <relationship name="mutedUsers" toMany="YES" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="mutedBy" inverseEntity="UserDTO"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="currentUser" inverseEntity="UserDTO"/>
@@ -135,6 +136,7 @@
         <attribute name="type" attributeType="String"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="messages" inverseEntity="ChannelDTO"/>
+        <relationship name="flaggedBy" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CurrentUserDTO" inverseName="flaggedMessages" inverseEntity="CurrentUserDTO"/>
         <relationship name="mentionedUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="mentionedMessages" inverseEntity="UserDTO"/>
         <relationship name="parentMessage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="replies" inverseEntity="MessageDTO"/>
         <relationship name="replies" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="parentMessage" inverseEntity="MessageDTO"/>

--- a/Sources_v3/Models/CurrentUser.swift
+++ b/Sources_v3/Models/CurrentUser.swift
@@ -47,7 +47,16 @@ public class _CurrentChatUser<ExtraData: UserExtraData>: _ChatUser<ExtraData> {
     public let mutedUsers: Set<_ChatUser<ExtraData>>
     
     /// A set of users flagged by the user.
+    ///
+    /// - Note: Please be aware that the value of this field is not persisted on the server,
+    /// and is valid only locally for the current session.
     public let flaggedUsers: Set<_ChatUser<ExtraData>>
+    
+    /// A set of message ids flagged by the user.
+    ///
+    /// - Note: Please be aware that the value of this field is not persisted on the server,
+    /// and is valid only locally for the current session.
+    public let flaggedMessageIDs: Set<MessageId>
     
     /// The unread counts for the current user.
     public let unreadCount: UnreadCount
@@ -65,12 +74,14 @@ public class _CurrentChatUser<ExtraData: UserExtraData>: _ChatUser<ExtraData> {
         currentDevice: Device? = nil,
         mutedUsers: Set<_ChatUser<ExtraData>> = [],
         flaggedUsers: Set<_ChatUser<ExtraData>> = [],
+        flaggedMessageIDs: Set<MessageId> = [],
         unreadCount: UnreadCount = .noUnread
     ) {
         self.devices = devices
         self.currentDevice = currentDevice
         self.mutedUsers = mutedUsers
         self.flaggedUsers = flaggedUsers
+        self.flaggedMessageIDs = flaggedMessageIDs
         self.unreadCount = unreadCount
         
         super.init(

--- a/Sources_v3/Models/Message.swift
+++ b/Sources_v3/Models/Message.swift
@@ -92,6 +92,12 @@ public struct _ChatMessage<ExtraData: ExtraDataTypes> {
     /// use of this value is to check if a message is pending send/delete, and update the UI accordingly.
     ///
     public let localState: LocalMessageState?
+    
+    /// An indicator whether the message is flagged by the current user.
+    ///
+    /// - Note: Please be aware that the value of this field is not persisted on the server,
+    /// and is valid only locally for the current session.
+    public let isFlaggedByCurrentUser: Bool
 }
 
 extension _ChatMessage: Hashable {

--- a/Sources_v3/Workers/MessageUpdater_Mock.swift
+++ b/Sources_v3/Workers/MessageUpdater_Mock.swift
@@ -32,6 +32,11 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
     @Atomic var loadReplies_pagination: MessagesPagination?
     @Atomic var loadReplies_completion: ((Error?) -> Void)?
     
+    @Atomic var flagMessage_flag: Bool?
+    @Atomic var flagMessage_messageId: MessageId?
+    @Atomic var flagMessage_cid: ChannelId?
+    @Atomic var flagMessage_completion: ((Error?) -> Void)?
+    
     // Cleans up all recorded values
     func cleanUp() {
         getMessage_cid = nil
@@ -58,6 +63,11 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         loadReplies_messageId = nil
         loadReplies_pagination = nil
         loadReplies_completion = nil
+        
+        flagMessage_flag = nil
+        flagMessage_messageId = nil
+        flagMessage_cid = nil
+        flagMessage_completion = nil
     }
     
     override func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Error?) -> Void)? = nil) {
@@ -107,5 +117,12 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         loadReplies_messageId = messageId
         loadReplies_pagination = pagination
         loadReplies_completion = completion
+    }
+    
+    override func flagMessage(_ flag: Bool, with messageId: MessageId, in cid: ChannelId, completion: ((Error?) -> Void)? = nil) {
+        flagMessage_flag = flag
+        flagMessage_messageId = messageId
+        flagMessage_cid = cid
+        flagMessage_completion = completion
     }
 }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -268,6 +268,11 @@
 		88F6DF91252C8845009A8AF0 /* ChannelMemberUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */; };
 		88F6DF94252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */; };
 		88F6DF97252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF96252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift */; };
+		88F896EE2541AB1000DE517D /* FlagMessagePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F896ED2541AB1000DE517D /* FlagMessagePayload.swift */; };
+		88F896F22541AB2100DE517D /* FlagMessagePayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F896F12541AB2100DE517D /* FlagMessagePayload_Tests.swift */; };
+		88F896F92541AC0900DE517D /* FlagMessagePayload+NoExtraData.json in Resources */ = {isa = PBXBuildFile; fileRef = 88F896F62541AC0900DE517D /* FlagMessagePayload+NoExtraData.json */; };
+		88F896FA2541AC0900DE517D /* FlagMessagePayload+DefaultExtraData.json in Resources */ = {isa = PBXBuildFile; fileRef = 88F896F72541AC0900DE517D /* FlagMessagePayload+DefaultExtraData.json */; };
+		88F896FB2541AC0900DE517D /* FlagMessagePayload+CustomExtraData.json in Resources */ = {isa = PBXBuildFile; fileRef = 88F896F82541AC0900DE517D /* FlagMessagePayload+CustomExtraData.json */; };
 		8A0175F02501174000570345 /* EventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175EF2501174000570345 /* EventSender.swift */; };
 		8A0175F425013B6400570345 /* EventSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0175F325013B6400570345 /* EventSender_Tests.swift */; };
 		8A08C6A624D437DF00DEF995 /* WebSocketPingController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */; };
@@ -729,6 +734,11 @@
 		88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater.swift; sourceTree = "<group>"; };
 		88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater_Tests.swift; sourceTree = "<group>"; };
 		88F6DF96252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater_Mock.swift; sourceTree = "<group>"; };
+		88F896ED2541AB1000DE517D /* FlagMessagePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagMessagePayload.swift; sourceTree = "<group>"; };
+		88F896F12541AB2100DE517D /* FlagMessagePayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagMessagePayload_Tests.swift; sourceTree = "<group>"; };
+		88F896F62541AC0900DE517D /* FlagMessagePayload+NoExtraData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "FlagMessagePayload+NoExtraData.json"; sourceTree = "<group>"; };
+		88F896F72541AC0900DE517D /* FlagMessagePayload+DefaultExtraData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "FlagMessagePayload+DefaultExtraData.json"; sourceTree = "<group>"; };
+		88F896F82541AC0900DE517D /* FlagMessagePayload+CustomExtraData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "FlagMessagePayload+CustomExtraData.json"; sourceTree = "<group>"; };
 		8A0175EF2501174000570345 /* EventSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender.swift; sourceTree = "<group>"; };
 		8A0175F325013B6400570345 /* EventSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender_Tests.swift; sourceTree = "<group>"; };
 		8A08C6A524D437DF00DEF995 /* WebSocketPingController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketPingController_Tests.swift; sourceTree = "<group>"; };
@@ -1204,6 +1214,8 @@
 				790A4C4D252E0901001F4A23 /* DevicePayloads_Tests.swift */,
 				8836FFBA2540741D009FDF73 /* FlagUserPayload.swift */,
 				8836FFC225408210009FDF73 /* FlagUserPayload_Tests.swift */,
+				88F896ED2541AB1000DE517D /* FlagMessagePayload.swift */,
+				88F896F12541AB2100DE517D /* FlagMessagePayload_Tests.swift */,
 			);
 			path = Payloads;
 			sourceTree = "<group>";
@@ -1221,6 +1233,7 @@
 				798779F92498E47700015F8B /* CurrentUser.json */,
 				798779FA2498E47700015F8B /* ChannelsQuery.json */,
 				DA8407252525E90D005A0F62 /* UsersQuery.json */,
+				88F896F52541AC0900DE517D /* FlagMessage */,
 				8836FFCF254082FF009FDF73 /* FlagUser */,
 				F62BE7882506616900D13B86 /* Sync */,
 				8A0D649E24E57A260017A3C0 /* GuestUser */,
@@ -1591,6 +1604,16 @@
 				88BEBCD82536FDDB00D9E8B7 /* MemberListController+Combine_Tests.swift */,
 			);
 			path = MemberListController;
+			sourceTree = "<group>";
+		};
+		88F896F52541AC0900DE517D /* FlagMessage */ = {
+			isa = PBXGroup;
+			children = (
+				88F896F62541AC0900DE517D /* FlagMessagePayload+NoExtraData.json */,
+				88F896F72541AC0900DE517D /* FlagMessagePayload+DefaultExtraData.json */,
+				88F896F82541AC0900DE517D /* FlagMessagePayload+CustomExtraData.json */,
+			);
+			path = FlagMessage;
 			sourceTree = "<group>";
 		};
 		8A0C3BC124C0AD6E00CAFD19 /* User */ = {
@@ -2030,6 +2053,7 @@
 				8AC9CBDF24C74DD0006E236C /* NotificationRemovedFromChannel.json in Resources */,
 				8A0C3BDF24C1F18700CAFD19 /* MessageRead.json in Resources */,
 				8A0C3BBF24C0ACAB00CAFD19 /* UserPresence.json in Resources */,
+				88F896FA2541AC0900DE517D /* FlagMessagePayload+DefaultExtraData.json in Resources */,
 				8A0C3BDD24C1F18700CAFD19 /* MessageUpdated.json in Resources */,
 				8A0C3BC624C0AEDB00CAFD19 /* UserStopWatching.json in Resources */,
 				8836FFD3254082FF009FDF73 /* FlagUserPayload+CustomExtraData.json in Resources */,
@@ -2041,11 +2065,13 @@
 				798779FD2498E47700015F8B /* OtherUser.json in Resources */,
 				F64F9B6225077CF600834F55 /* MessageNew+MissingFields.json in Resources */,
 				8836FFD4254082FF009FDF73 /* FlagUserPayload+DefaultExtraData.json in Resources */,
+				88F896FB2541AC0900DE517D /* FlagMessagePayload+CustomExtraData.json in Resources */,
 				8A0C3BE024C1F18700CAFD19 /* NotificationMarkRead.json in Resources */,
 				8A0CC9EF24C604E000705CF9 /* MemberUpdated.json in Resources */,
 				8A0C3BCE24C1CB0500CAFD19 /* ChannelDeleted.json in Resources */,
 				798779FE2498E47700015F8B /* CurrentUser.json in Resources */,
 				8AC9CBE624C7500E006E236C /* NotificationMarkAllRead.json in Resources */,
+				88F896F92541AC0900DE517D /* FlagMessagePayload+NoExtraData.json in Resources */,
 				8A0CC9ED24C602B600705CF9 /* MemberRemoved.json in Resources */,
 				8A0C3BC724C0AEDB00CAFD19 /* UserBanned.json in Resources */,
 				8A0D64A424E57A260017A3C0 /* GuestUser+CustomExtraData.json in Resources */,
@@ -2225,6 +2251,7 @@
 				F6ED5F76250278D7005D7327 /* SyncEndpoint.swift in Sources */,
 				797A756824814F0D003CF16D /* BundleExtensions.swift in Sources */,
 				792B805024D95B5D00C2963E /* Cached.swift in Sources */,
+				88F896EE2541AB1000DE517D /* FlagMessagePayload.swift in Sources */,
 				DA0BB1612513B5F200CAEFBD /* StringInterpolation+Extenstions.swift in Sources */,
 				799C9479247E3DEA001F1104 /* StreamChatModel.xcdatamodeld in Sources */,
 				888E8C55252B525300195E03 /* MemberController.swift in Sources */,
@@ -2451,6 +2478,7 @@
 				8A08C6A624D437DF00DEF995 /* WebSocketPingController_Tests.swift in Sources */,
 				8A62706C24BF3DBC0040BFD6 /* ChannelEvents_Tests.swift in Sources */,
 				79280F8424891C6A00CDEB89 /* VirtualTime.swift in Sources */,
+				88F896F22541AB2100DE517D /* FlagMessagePayload_Tests.swift in Sources */,
 				799C9476247D7E94001F1104 /* TemporaryData.swift in Sources */,
 				F649B2392500FD56008F98C8 /* EntityDatabaseObserver_Mock.swift in Sources */,
 				79CD959424F9381700E87377 /* MulticastDelegate_Tests.swift in Sources */,

--- a/Tests_v3/MockEnpointResponses/FlagMessage/FlagMessagePayload+CustomExtraData.json
+++ b/Tests_v3/MockEnpointResponses/FlagMessage/FlagMessagePayload+CustomExtraData.json
@@ -1,0 +1,27 @@
+{
+    "flag" : {
+        "reviewed_by" : "",
+        "rejected_at" : "0001-01-01T00:00:00Z",
+        "created_by_automod" : false,
+        "created_at" : "2020-10-22T12:01:30.157753Z",
+        "approved_at" : "0001-01-01T00:00:00Z",
+        "target_message_id" : "5961F803-1613-4891-B14C-7511BC719D35",
+        "updated_at" : "2020-10-22T12:01:30.157753Z",
+        "reviewed_at" : "0001-01-01T00:00:00Z",
+        "user" : {
+            "id" : "broken-waterfall-5",
+            "banned" : false,
+            "last_active" : "2020-10-21T14:31:31.692634Z",
+            "created_at" : "2019-12-12T15:33:46.488935Z",
+            "devices" : null,
+            "invisible" : false,
+            "team" : 1,
+            "channel_mutes" : null,
+            "secret_note" : "broken-waterfall-5 is Vader ;-)",
+            "updated_at" : "2020-10-21T14:43:22.80866Z",
+            "role" : "user",
+            "online" : true
+        }
+    },
+    "duration" : "9.32ms"
+}

--- a/Tests_v3/MockEnpointResponses/FlagMessage/FlagMessagePayload+DefaultExtraData.json
+++ b/Tests_v3/MockEnpointResponses/FlagMessage/FlagMessagePayload+DefaultExtraData.json
@@ -1,0 +1,28 @@
+{
+    "flag" : {
+        "reviewed_by" : "",
+        "rejected_at" : "0001-01-01T00:00:00Z",
+        "created_by_automod" : false,
+        "created_at" : "2020-10-22T12:01:30.157753Z",
+        "approved_at" : "0001-01-01T00:00:00Z",
+        "target_message_id" : "5961F803-1613-4891-B14C-7511BC719D35",
+        "updated_at" : "2020-10-22T12:01:30.157753Z",
+        "reviewed_at" : "0001-01-01T00:00:00Z",
+        "user" : {
+            "id" : "broken-waterfall-5",
+            "banned" : false,
+            "last_active" : "2020-10-21T14:31:31.692634Z",
+            "created_at" : "2019-12-12T15:33:46.488935Z",
+            "devices" : null,
+            "invisible" : false,
+            "team" : 1,
+            "channel_mutes" : null,
+            "image" : "https:\/\/s3.amazonaws.com\/eventmobi-test-assets\/eventsbyids\/8024\/people\/100no-pic.png",
+            "updated_at" : "2020-10-21T14:43:22.80866Z",
+            "role" : "user",
+            "online" : true,
+            "name" : "Broken Waterfall"
+        }
+    },
+    "duration" : "9.32ms"
+}

--- a/Tests_v3/MockEnpointResponses/FlagMessage/FlagMessagePayload+NoExtraData.json
+++ b/Tests_v3/MockEnpointResponses/FlagMessage/FlagMessagePayload+NoExtraData.json
@@ -1,0 +1,26 @@
+{
+    "flag" : {
+        "reviewed_by" : "",
+        "rejected_at" : "0001-01-01T00:00:00Z",
+        "created_by_automod" : false,
+        "created_at" : "2020-10-22T12:01:30.157753Z",
+        "approved_at" : "0001-01-01T00:00:00Z",
+        "target_message_id" : "5961F803-1613-4891-B14C-7511BC719D35",
+        "updated_at" : "2020-10-22T12:01:30.157753Z",
+        "reviewed_at" : "0001-01-01T00:00:00Z",
+        "user" : {
+            "id" : "broken-waterfall-5",
+            "banned" : false,
+            "last_active" : "2020-10-21T14:31:31.692634Z",
+            "created_at" : "2019-12-12T15:33:46.488935Z",
+            "devices" : null,
+            "invisible" : false,
+            "team" : 1,
+            "channel_mutes" : null,
+            "updated_at" : "2020-10-21T14:43:22.80866Z",
+            "role" : "user",
+            "online" : true
+        }
+    },
+    "duration" : "9.32ms"
+}


### PR DESCRIPTION
**This PR:**
- exposes `flagMessage/unflagMessage` by `MessageController`
- expose `flagMessage/unflagMessage` by `MessageUpdater`
- adds `CurrentUserDTO <->> MessageDTO` relation for flagged messages and updates the models
- introduces `FlagMessagePayload` and `flagMessage/unflagMessage` endpoints


