### PR TITLE
[CIS-240] Message reactions

### DIFF
--- a/Sources_v3/StreamChat/APIClient/Endpoints/MessageEndpoints.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/MessageEndpoints.swift
@@ -46,6 +46,37 @@ extension Endpoint {
             body: pagination
         )
     }
+    
+    static func addReaction<ExtraData: MessageReactionExtraData>(
+        _ type: MessageReactionType,
+        score: Int,
+        extraData: ExtraData,
+        messageId: MessageId
+    ) -> Endpoint<EmptyResponse> {
+        .init(
+            path: messageId.reactionsPath,
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: [
+                "reaction": MessageReactionRequestPayload(
+                    type: type,
+                    score: score,
+                    extraData: extraData
+                )
+            ]
+        )
+    }
+    
+    static func deleteReaction(_ type: MessageReactionType, messageId: MessageId) -> Endpoint<EmptyResponse> {
+        .init(
+            path: messageId.reactionsPath.appending("/\(type.rawValue)"),
+            method: .delete,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: nil
+        )
+    }
 }
 
 private extension MessageId {
@@ -55,5 +86,9 @@ private extension MessageId {
     
     var repliesPath: String {
         "messages/\(self)/replies"
+    }
+    
+    var reactionsPath: String {
+        path.appending("/reaction")
     }
 }

--- a/Sources_v3/StreamChat/APIClient/Endpoints/MessageEndpoints_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/MessageEndpoints_Tests.swift
@@ -83,4 +83,55 @@ final class MessageEndpoints_Tests: XCTestCase {
         // Assert endpoint is built correctly
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
     }
+    
+    func test_addReaction_buildsCorrectly() {
+        let messageId: MessageId = .unique
+        let reaction: MessageReactionType = .init(rawValue: "like")
+        let score = 5
+        let extraData: NoExtraData = .defaultValue
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: "messages/\(messageId)/reaction",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: [
+                "reaction": MessageReactionRequestPayload(
+                    type: reaction,
+                    score: score,
+                    extraData: extraData
+                )
+            ]
+        )
+        
+        // Build endpoint.
+        let endpoint: Endpoint<EmptyResponse> = .addReaction(
+            reaction,
+            score: score,
+            extraData: extraData,
+            messageId: messageId
+        )
+        
+        // Assert endpoint is built correctly.
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
+    
+    func test_deleteReaction_buildsCorrectly() {
+        let messageId: MessageId = .unique
+        let reaction: MessageReactionType = .init(rawValue: "like")
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: "messages/\(messageId)/reaction/\(reaction.rawValue)",
+            method: .delete,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: nil
+        )
+        
+        // Build endpoint.
+        let endpoint: Endpoint<EmptyResponse> = .deleteReaction(reaction, messageId: messageId)
+        
+        // Assert endpoint is built correctly
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
 }

--- a/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
@@ -50,7 +50,7 @@ struct MessagePayload<ExtraData: ExtraDataTypes>: Decodable {
     
     let latestReactions: [ReactionPayload] = []
     let ownReactions: [ReactionPayload] = []
-    let reactionScores: [String: Int]
+    let reactionScores: [MessageReactionType: Int]
     let isSilent: Bool
     
     init(from decoder: Decoder) throws {
@@ -70,7 +70,9 @@ struct MessagePayload<ExtraData: ExtraDataTypes>: Decodable {
         mentionedUsers = try container.decode([UserPayload<ExtraData.User>].self, forKey: .mentionedUsers)
         replyCount = try container.decode(Int.self, forKey: .replyCount)
         
-        reactionScores = try container.decodeIfPresent([String: Int].self, forKey: .reactionScores) ?? [:]
+        reactionScores = try container
+            .decodeIfPresent([String: Int].self, forKey: .reactionScores)?
+            .mapKeys { MessageReactionType(rawValue: $0) } ?? [:]
         extraData = try ExtraData.Message(from: decoder)
     }
     
@@ -89,7 +91,7 @@ struct MessagePayload<ExtraData: ExtraDataTypes>: Decodable {
         mentionedUsers: [UserPayload<ExtraData.User>],
         replyCount: Int,
         extraData: ExtraData.Message,
-        reactionScores: [String: Int],
+        reactionScores: [MessageReactionType: Int],
         isSilent: Bool
     ) {
         self.id = id

--- a/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
@@ -20,8 +20,8 @@ enum MessagePayloadsCodingKeys: String, CodingKey {
     case showReplyInChannel = "show_in_channel"
     case mentionedUsers = "mentioned_users"
     case replyCount = "reply_count"
-    //        case latestReactions = "latest_reactions"
-    //        case ownReactions = "own_reactions"
+    case latestReactions = "latest_reactions"
+    case ownReactions = "own_reactions"
     case reactionScores = "reaction_scores"
     case isSilent = "silent"
     //        case i18n
@@ -48,8 +48,8 @@ struct MessagePayload<ExtraData: ExtraDataTypes>: Decodable {
     // TODO: Attachments
     // TODO: Translations
     
-    let latestReactions: [ReactionPayload] = []
-    let ownReactions: [ReactionPayload] = []
+    let latestReactions: [MessageReactionPayload<ExtraData>]
+    let ownReactions: [MessageReactionPayload<ExtraData>]
     let reactionScores: [MessageReactionType: Int]
     let isSilent: Bool
     
@@ -70,6 +70,8 @@ struct MessagePayload<ExtraData: ExtraDataTypes>: Decodable {
         mentionedUsers = try container.decode([UserPayload<ExtraData.User>].self, forKey: .mentionedUsers)
         replyCount = try container.decode(Int.self, forKey: .replyCount)
         
+        latestReactions = try container.decode([MessageReactionPayload<ExtraData>].self, forKey: .latestReactions)
+        ownReactions = try container.decode([MessageReactionPayload<ExtraData>].self, forKey: .ownReactions)
         reactionScores = try container
             .decodeIfPresent([String: Int].self, forKey: .reactionScores)?
             .mapKeys { MessageReactionType(rawValue: $0) } ?? [:]
@@ -91,6 +93,8 @@ struct MessagePayload<ExtraData: ExtraDataTypes>: Decodable {
         mentionedUsers: [UserPayload<ExtraData.User>],
         replyCount: Int,
         extraData: ExtraData.Message,
+        latestReactions: [MessageReactionPayload<ExtraData>] = [],
+        ownReactions: [MessageReactionPayload<ExtraData>] = [],
         reactionScores: [MessageReactionType: Int],
         isSilent: Bool
     ) {
@@ -108,6 +112,8 @@ struct MessagePayload<ExtraData: ExtraDataTypes>: Decodable {
         self.mentionedUsers = mentionedUsers
         self.replyCount = replyCount
         self.extraData = extraData
+        self.latestReactions = latestReactions
+        self.ownReactions = ownReactions
         self.reactionScores = reactionScores
         self.isSilent = isSilent
     }

--- a/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/MessageReactionPayload.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/MessageReactionPayload.swift
@@ -1,0 +1,56 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The type describes the incoming message-reaction JSON.
+struct MessageReactionPayload<ExtraData: ExtraDataTypes>: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case score
+        case messageId = "message_id"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case user
+    }
+    
+    let type: MessageReactionType
+    let score: Int
+    let messageId: String
+    let createdAt: Date
+    let updatedAt: Date
+    let user: UserPayload<ExtraData.User>
+    let extraData: ExtraData.MessageReaction
+    
+    init(
+        type: MessageReactionType,
+        score: Int,
+        messageId: String,
+        createdAt: Date,
+        updatedAt: Date,
+        user: UserPayload<ExtraData.User>,
+        extraData: ExtraData.MessageReaction
+    ) {
+        self.type = type
+        self.score = score
+        self.messageId = messageId
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.user = user
+        self.extraData = extraData
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            type: try container.decode(MessageReactionType.self, forKey: .type),
+            score: try container.decode(Int.self, forKey: .score),
+            messageId: try container.decode(MessageId.self, forKey: .messageId),
+            createdAt: try container.decode(Date.self, forKey: .createdAt),
+            updatedAt: try container.decode(Date.self, forKey: .updatedAt),
+            user: try container.decode(UserPayload<ExtraData.User>.self, forKey: .user),
+            extraData: try .init(from: decoder)
+        )
+    }
+}

--- a/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/MessageReactionPayload_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/MessageReactionPayload_Tests.swift
@@ -1,0 +1,71 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class MessageReactionPayload_Tests: XCTestCase {
+    func test_json_isDeserialized_withNoExtraData() throws {
+        let json = XCTestCase.mockData(fromFile: "MessageReactionPayload+NoExtraData", extension: "json")
+        let payload = try JSONDecoder.default.decode(MessageReactionPayload<NoExtraDataTypes>.self, from: json)
+        
+        // Assert payload is deserialized correctly.
+        XCTAssertEqual(payload.type, "love")
+        XCTAssertEqual(payload.score, 1)
+        XCTAssertEqual(payload.messageId, "7baa1533-3294-4c0c-9a62-c9d0928bf733")
+        XCTAssertEqual(payload.createdAt, "2020-08-17T13:15:39.892884Z".toDate())
+        XCTAssertEqual(payload.updatedAt, "2020-08-17T13:15:39.892884Z".toDate())
+        XCTAssertEqual(payload.user.id, "broken-waterfall-5")
+    }
+    
+    func test_json_isDeserialized_withDefaultExtraData() throws {
+        let json = XCTestCase.mockData(fromFile: "MessageReactionPayload+DefaultExtraData", extension: "json")
+        let payload = try JSONDecoder.default.decode(MessageReactionPayload<DefaultExtraData>.self, from: json)
+        
+        // Assert payload is deserialized correctly.
+        XCTAssertEqual(payload.type, "love")
+        XCTAssertEqual(payload.score, 1)
+        XCTAssertEqual(payload.messageId, "7baa1533-3294-4c0c-9a62-c9d0928bf733")
+        XCTAssertEqual(payload.createdAt, "2020-08-17T13:15:39.892884Z".toDate())
+        XCTAssertEqual(payload.updatedAt, "2020-08-17T13:15:39.892884Z".toDate())
+        XCTAssertEqual(payload.user.id, "broken-waterfall-5")
+        XCTAssertEqual(
+            payload.user.extraData,
+            .init(
+                name: "John Doe",
+                imageURL: URL(string: "https://s3.amazonaws.com/100no-pic.png")
+            )
+        )
+    }
+    
+    func test_json_isDeserialized_withCustomExtraData() throws {
+        let json = XCTestCase.mockData(fromFile: "MessageReactionPayload+CustomExtraData", extension: "json")
+        let payload = try JSONDecoder.default.decode(MessageReactionPayload<CustomExtraData>.self, from: json)
+        
+        // Assert payload is deserialized correctly.
+        XCTAssertEqual(payload.type, "love")
+        XCTAssertEqual(payload.score, 1)
+        XCTAssertEqual(payload.messageId, "7baa1533-3294-4c0c-9a62-c9d0928bf733")
+        XCTAssertEqual(payload.createdAt, "2020-08-17T13:15:39.892884Z".toDate())
+        XCTAssertEqual(payload.updatedAt, "2020-08-17T13:15:39.892884Z".toDate())
+        XCTAssertEqual(payload.extraData, .init(mood: "good one"))
+        XCTAssertEqual(payload.user.id, "broken-waterfall-5")
+        XCTAssertEqual(
+            payload.user.extraData,
+            .init(
+                name: "John Doe",
+                imageURL: URL(string: "https://s3.amazonaws.com/100no-pic.png")
+            )
+        )
+    }
+}
+
+private enum CustomExtraData: ExtraDataTypes {
+    typealias MessageReaction = Mood
+}
+
+private struct Mood: MessageReactionExtraData {
+    static var defaultValue: Self { .init(mood: "") }
+    let mood: String
+}

--- a/Sources_v3/StreamChat/APIClient/Endpoints/Requests/MessageReactionRequestPayload.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/Requests/MessageReactionRequestPayload.swift
@@ -1,0 +1,24 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The type describes the outgoing JSON to `message/[message_id]/reaction` endpoint
+struct MessageReactionRequestPayload<ExtraData: MessageReactionExtraData>: Encodable {
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case score
+    }
+    
+    let type: MessageReactionType
+    let score: Int
+    let extraData: ExtraData
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(score, forKey: .score)
+        try extraData.encode(to: encoder)
+    }
+}

--- a/Sources_v3/StreamChat/APIClient/Endpoints/Requests/MessageReactionRequestPayload_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/Requests/MessageReactionRequestPayload_Tests.swift
@@ -1,0 +1,32 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class MessageReactionRequestPayload_Tests: XCTestCase {
+    func test_payload_isBuiltAndEncodedCorrectly() throws {
+        // Build the payload.
+        let payload = MessageReactionRequestPayload(
+            type: "like",
+            score: 10,
+            extraData: Mood(mood: "good one")
+        )
+        
+        // Encode the payload.
+        let json = try JSONEncoder.default.encode(payload)
+        
+        // Assert encoding is correct.
+        AssertJSONEqual(json, [
+            "type": payload.type.rawValue,
+            "score": payload.score,
+            "mood": payload.extraData.mood
+        ])
+    }
+}
+
+private struct Mood: MessageReactionExtraData {
+    static var defaultValue: Self { .init(mood: "") }
+    let mood: String
+}

--- a/Sources_v3/StreamChat/ChatClient.swift
+++ b/Sources_v3/StreamChat/ChatClient.swift
@@ -99,7 +99,8 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
             excludedUserIds: { [weak self] in Set([self?.currentUserId].compactMap { $0 }) }
         ),
         ChannelReadUpdaterMiddleware<ExtraData>(database: databaseContainer),
-        ChannelMemberTypingStateUpdaterMiddleware<ExtraData>(database: databaseContainer)
+        ChannelMemberTypingStateUpdaterMiddleware<ExtraData>(database: databaseContainer),
+        MessageReactionsMiddleware<ExtraData>(database: databaseContainer)
     ])
     
     /// The `APIClient` instance `Client` uses to communicate with Stream REST API.

--- a/Sources_v3/StreamChat/ChatClient.swift
+++ b/Sources_v3/StreamChat/ChatClient.swift
@@ -29,6 +29,9 @@ public protocol ExtraDataTypes {
     
     /// An extra data type for `ChatChannel`.
     associatedtype Channel: ChannelExtraData = NameAndImageExtraData
+    
+    /// An extra data type for `ChatMessageReaction`.
+    associatedtype MessageReaction: MessageReactionExtraData = NoExtraData
 }
 
 /// A concrete implementation of `ExtraDataTypes` with the default extra data type values.

--- a/Sources_v3/StreamChat/ChatClient_Tests.swift
+++ b/Sources_v3/StreamChat/ChatClient_Tests.swift
@@ -174,6 +174,8 @@ class ChatClient_Tests: StressTestCase {
         XCTAssertNotNil(typingStateUpdaterMiddlewareIndex)
         // Assert `ChannelMemberTypingStateUpdaterMiddleware` goes after `TypingStartCleanupMiddleware`
         XCTAssertTrue(typingStateUpdaterMiddlewareIndex! > typingStartCleanupMiddlewareIndex!)
+        // Assert `MessageReactionsMiddleware` exists
+        XCTAssert(middlewares.contains(where: { $0 is MessageReactionsMiddleware<DefaultExtraData> }))
     }
     
     func test_connectionStatus_isExposed() {

--- a/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -156,7 +156,9 @@ extension _ChatMessage {
             mentionedUsers: [],
             latestReplies: [],
             localState: nil,
-            isFlaggedByCurrentUser: false
+            isFlaggedByCurrentUser: false,
+            latestReactions: [],
+            currentUserReactions: []
         )
     }
 }

--- a/Sources_v3/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources_v3/StreamChat/Controllers/MessageController/MessageController.swift
@@ -299,6 +299,40 @@ public extension _ChatMessageController {
             }
         }
     }
+    
+    /// Adds new reaction to the message this controller manages.
+    /// - Parameters:
+    ///   - type: The reaction type.
+    ///   - score: The reaction score.
+    ///   - extraData: The reaction extra data.
+    ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    func addReaction(
+        _ type: MessageReactionType,
+        score: Int = 1,
+        extraData: ExtraData.MessageReaction = .defaultValue,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        messageUpdater.addReaction(type, score: score, extraData: extraData, messageId: messageId) { error in
+            self.callback {
+                completion?(error)
+            }
+        }
+    }
+    
+    /// Deletes the reaction from the message this controller manages.
+    /// - Parameters:
+    ///   - type: The reaction type.
+    ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    func deleteReaction(
+        _ type: MessageReactionType,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        messageUpdater.deleteReaction(type, messageId: messageId) { error in
+            self.callback {
+                completion?(error)
+            }
+        }
+    }
 }
 
 // MARK: - Environment

--- a/Sources_v3/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/MessageDTO.swift
@@ -211,7 +211,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         dto.replyCount = Int32(payload.replyCount)
         dto.extraData = try JSONEncoder.default.encode(payload.extraData)
         dto.isSilent = payload.isSilent
-        dto.reactionScores = payload.reactionScores
+        dto.reactionScores = payload.reactionScores.mapKeys { $0.rawValue }
         dto.channel = ChannelDTO.loadOrCreate(cid: cid, context: self)
         
         let user = try saveUser(payload: payload.user)
@@ -281,7 +281,7 @@ extension _ChatMessage {
         showReplyInChannel = dto.showReplyInChannel
         replyCount = Int(dto.replyCount)
         isSilent = dto.isSilent
-        reactionScores = dto.reactionScores
+        reactionScores = dto.reactionScores.mapKeys { MessageReactionType(rawValue: $0) }
         
         let extraData: ExtraData.Message
         do {

--- a/Sources_v3/StreamChat/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/MessageDTO_Tests.swift
@@ -56,7 +56,7 @@ class MessageDTO_Tests: XCTestCase {
             Assert.willBeEqual(messagePayload.extraData, loadedMessage.map {
                 try? JSONDecoder.default.decode(NoExtraData.self, from: $0.extraData)
             })
-            Assert.willBeEqual(messagePayload.reactionScores, loadedMessage?.reactionScores)
+            Assert.willBeEqual(messagePayload.reactionScores, loadedMessage?.reactionScores.mapKeys(MessageReactionType.init))
             Assert.willBeEqual(messagePayload.isSilent, loadedMessage?.isSilent)
         }
     }
@@ -118,7 +118,7 @@ class MessageDTO_Tests: XCTestCase {
             Assert.willBeEqual(messagePayload.extraData, loadedMessage.map {
                 try? JSONDecoder.default.decode(DeathStarMetadata.self, from: $0.extraData)
             })
-            Assert.willBeEqual(messagePayload.reactionScores, loadedMessage?.reactionScores)
+            Assert.willBeEqual(messagePayload.reactionScores, loadedMessage?.reactionScores.mapKeys(MessageReactionType.init))
             Assert.willBeEqual(messagePayload.isSilent, loadedMessage?.isSilent)
         }
     }

--- a/Sources_v3/StreamChat/Database/DTOs/MessageReactionDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/MessageReactionDTO.swift
@@ -40,6 +40,33 @@ extension MessageReactionDTO {
         return try? context.fetch(request).first
     }
     
+    static func loadReactions(
+        for messageId: MessageId,
+        authoredBy userId: UserId,
+        context: NSManagedObjectContext
+    ) -> [MessageReactionDTO] {
+        let request = NSFetchRequest<MessageReactionDTO>(entityName: MessageReactionDTO.entityName)
+        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            NSPredicate(format: "message.id == %@", messageId),
+            NSPredicate(format: "user.id == %@", userId)
+        ])
+        
+        return (try? context.fetch(request)) ?? []
+    }
+    
+    static func loadLatestReactions(
+        for messageId: MessageId,
+        limit: Int,
+        context: NSManagedObjectContext
+    ) -> [MessageReactionDTO] {
+        let request = NSFetchRequest<MessageReactionDTO>(entityName: MessageReactionDTO.entityName)
+        request.predicate = NSPredicate(format: "message.id == %@", messageId)
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \MessageReactionDTO.updatedAt, ascending: false)]
+        request.fetchLimit = limit
+        
+        return (try? context.fetch(request)) ?? []
+    }
+    
     static func loadOrCreate(
         userId: String,
         messageId: MessageId,

--- a/Sources_v3/StreamChat/Database/DTOs/MessageReactionDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/MessageReactionDTO.swift
@@ -28,6 +28,71 @@ final class MessageReactionDTO: NSManagedObject {
 }
 
 extension MessageReactionDTO {
+    static func load(
+        userId: String,
+        messageId: MessageId,
+        type: MessageReactionType,
+        context: NSManagedObjectContext
+    ) -> MessageReactionDTO? {
+        let id = createId(userId: userId, messageId: messageId, type: type)
+        let request = NSFetchRequest<MessageReactionDTO>(entityName: MessageReactionDTO.entityName)
+        request.predicate = NSPredicate(format: "id == %@", id)
+        return try? context.fetch(request).first
+    }
+    
+    static func loadOrCreate(
+        userId: String,
+        messageId: MessageId,
+        type: MessageReactionType,
+        context: NSManagedObjectContext
+    ) -> MessageReactionDTO {
+        if let existing = Self.load(userId: userId, messageId: messageId, type: type, context: context) {
+            return existing
+        }
+        
+        let new = MessageReactionDTO(context: context)
+        new.id = createId(userId: userId, messageId: messageId, type: type)
+        return new
+    }
+}
+
+extension NSManagedObjectContext {
+    func reaction(messageId: MessageId, userId: UserId, type: MessageReactionType) -> MessageReactionDTO? {
+        MessageReactionDTO.load(userId: userId, messageId: messageId, type: type, context: self)
+    }
+    
+    @discardableResult
+    func saveReaction<ExtraData: ExtraDataTypes>(
+        payload: MessageReactionPayload<ExtraData>
+    ) throws -> MessageReactionDTO {
+        guard let messageDTO = MessageDTO.load(id: payload.messageId, context: self) else {
+            throw ClientError.MessageDoesNotExist(messageId: payload.messageId)
+        }
+        
+        let dto = MessageReactionDTO.loadOrCreate(
+            userId: payload.user.id,
+            messageId: payload.messageId,
+            type: payload.type,
+            context: self
+        )
+        
+        dto.type = payload.type.rawValue
+        dto.score = Int64(payload.score)
+        dto.createdAt = payload.createdAt
+        dto.updatedAt = payload.updatedAt
+        dto.extraData = try JSONEncoder.default.encode(payload.extraData)
+        dto.user = try saveUser(payload: payload.user)
+        dto.message = messageDTO
+        
+        return dto
+    }
+    
+    func delete(reaction: MessageReactionDTO) {
+        delete(reaction)
+    }
+}
+
+extension MessageReactionDTO {
     /// Snapshots the current state of `MessageReactionDTO` and returns an immutable model object from it.
     func asModel<ExtraData: ExtraDataTypes>() -> _ChatMessageReaction<ExtraData> {
         let extraData: ExtraData.MessageReaction

--- a/Sources_v3/StreamChat/Database/DTOs/MessageReactionDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/MessageReactionDTO.swift
@@ -1,0 +1,50 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+@objc(MessageReactionDTO)
+final class MessageReactionDTO: NSManagedObject {
+    @NSManaged fileprivate var id: String
+    
+    @NSManaged var type: String
+    @NSManaged var score: Int64
+    @NSManaged var createdAt: Date
+    @NSManaged var updatedAt: Date
+    @NSManaged var extraData: Data
+    
+    @NSManaged var message: MessageDTO
+    @NSManaged var user: UserDTO
+    
+    private static func createId(
+        userId: String,
+        messageId: MessageId,
+        type: MessageReactionType
+    ) -> String {
+        [userId, messageId, type.rawValue].joined(separator: "/")
+    }
+}
+
+extension MessageReactionDTO {
+    /// Snapshots the current state of `MessageReactionDTO` and returns an immutable model object from it.
+    func asModel<ExtraData: ExtraDataTypes>() -> _ChatMessageReaction<ExtraData> {
+        let extraData: ExtraData.MessageReaction
+        do {
+            extraData = try JSONDecoder.default.decode(ExtraData.MessageReaction.self, from: self.extraData)
+        } catch {
+            log.error("Failed decoding saved extra data with error: \(error)")
+            extraData = .defaultValue
+        }
+        
+        return .init(
+            type: .init(rawValue: type),
+            score: Int(score),
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            extraData: extraData,
+            author: user.asModel()
+        )
+    }
+}

--- a/Sources_v3/StreamChat/Database/DTOs/MessageReactionDTO_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/MessageReactionDTO_Tests.swift
@@ -1,0 +1,254 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChat
+import XCTest
+
+final class MessageReactionDTO_Tests: XCTestCase {
+    var database: DatabaseContainer!
+    
+    // MARK: - Setup
+    
+    override func setUp() {
+        super.setUp()
+        database = try! DatabaseContainer(kind: .inMemory)
+    }
+    
+    override func tearDown() {
+        database = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Save
+    
+    func test_messageReactionPayload_withNoExtraData_isStoredAndLoadedFromDB() throws {
+        // Create message reaction payload with `NoExtraDataTypes`.
+        let payload: MessageReactionPayload<NoExtraDataTypes> = .dummy(
+            messageId: .unique,
+            user: .init(
+                id: .unique,
+                role: .user,
+                createdAt: .unique,
+                updatedAt: .unique,
+                lastActiveAt: .unique,
+                isOnline: true,
+                isInvisible: true,
+                isBanned: true,
+                extraData: .defaultValue
+            )
+        )
+        
+        // Assert message reaction is saved and loaded correctly.
+        try assert_messageReaction_isStoredAndLoadedFromDB(payload)
+    }
+    
+    func test_messageReactionPayload_withDefaultExtraData_isStoredAndLoadedFromDB() throws {
+        // Create message reaction payload with `DefaultExtraData`.
+        let payload: MessageReactionPayload<DefaultExtraData> = .dummy(
+            messageId: .unique,
+            user: dummyUser
+        )
+        
+        // Assert message reaction is saved and loaded correctly.
+        try assert_messageReaction_isStoredAndLoadedFromDB(payload)
+    }
+    
+    func test_messageReactionPayload_withCustomExtraData_isStoredAndLoadedFromDB() throws {
+        // Create message reaction payload with `CustomExtraData`.
+        let payload: MessageReactionPayload<CustomExtraData> = .dummy(
+            messageId: .unique,
+            user: dummyUser,
+            extraData: Mood(mood: .unique)
+        )
+        
+        // Assert message reaction is saved and loaded correctly.
+        try assert_messageReaction_isStoredAndLoadedFromDB(payload)
+    }
+    
+    func test_saveReaction_throwsMessageDoesNotExist_ifThereIsNoMessage() {
+        // Create message reaction payload with `DefaultExtraData`.
+        let payload: MessageReactionPayload<DefaultExtraData> = .dummy(
+            messageId: .unique,
+            user: dummyUser
+        )
+        
+        // Assert saving message reaction with the message throws `MessageDoesNotExist` error.
+        XCTAssertThrowsError(
+            try database.writeSynchronously { session in
+                try session.saveReaction(payload: payload)
+            }
+        ) { error in
+            XCTAssertTrue(error is ClientError.MessageDoesNotExist)
+        }
+    }
+    
+    // MARK: - Convert
+    
+    func test_asModel_buildsCorrectModel() throws {
+        // Create message reaction payload with `DefaultExtraData`.
+        let payload: MessageReactionPayload<DefaultExtraData> = .dummy(
+            messageId: .unique,
+            user: dummyUser
+        )
+        
+        // Save message to the database.
+        try database.createMessage(id: payload.messageId)
+        
+        // Save message reaction to the database and corrupt extra data.
+        try database.writeSynchronously { session in
+            try session.saveReaction(payload: payload)
+        }
+        
+        // Load saved message reaction and build the model.
+        let model: ChatMessageReaction = try XCTUnwrap(
+            database.viewContext.reaction(
+                messageId: payload.messageId,
+                userId: payload.user.id,
+                type: payload.type
+            )
+        ).asModel()
+
+        // Assert model is built up correctly.
+        XCTAssertEqual(model.createdAt, payload.createdAt)
+        XCTAssertEqual(model.updatedAt, payload.updatedAt)
+        XCTAssertEqual(model.type, payload.type)
+        XCTAssertEqual(model.score, payload.score)
+        XCTAssertEqual(model.extraData, payload.extraData)
+        XCTAssertEqual(model.author.id, payload.user.id)
+    }
+    
+    func test_asModel_defaultExtraDataIsUsed_whenExtraDataDecodingFails() throws {
+        // Create message reaction payload with `DefaultExtraData`.
+        let payload: MessageReactionPayload<DefaultExtraData> = .dummy(
+            messageId: .unique,
+            user: dummyUser
+        )
+        
+        // Save message to the database.
+        try database.createMessage(id: payload.messageId)
+        
+        try database.writeSynchronously { session in
+            // Save message reaction to the database.
+            let dto = try session.saveReaction(payload: payload)
+            // Corrupt extra data.
+            dto.extraData = #"{"invalid": json}"# .data(using: .utf8)!
+        }
+        
+        // Load saved message reaction.
+        let model: ChatMessageReaction = try XCTUnwrap(
+            database.viewContext.reaction(
+                messageId: payload.messageId,
+                userId: payload.user.id,
+                type: payload.type
+            )
+        ).asModel()
+        
+        // Assert model is built up with default extra data.
+        XCTAssertEqual(model.extraData, .defaultValue)
+        // Assert other fields have correct values.
+        XCTAssertEqual(model.createdAt, payload.createdAt)
+        XCTAssertEqual(model.updatedAt, payload.updatedAt)
+        XCTAssertEqual(model.type, payload.type)
+        XCTAssertEqual(model.score, payload.score)
+        XCTAssertEqual(model.author.id, payload.user.id)
+    }
+    
+    // MARK: - Delete
+    
+    func test_deleteReaction_worksCorrectly() throws {
+        // Create message reaction payload with `DefaultExtraData`.
+        let payload: MessageReactionPayload<DefaultExtraData> = .dummy(
+            messageId: .unique,
+            user: dummyUser
+        )
+        
+        // Save message to the database.
+        try database.createMessage(id: payload.messageId)
+        
+        // Save message reaction to the database.
+        try database.writeSynchronously { session in
+            try session.saveReaction(payload: payload)
+        }
+        
+        // Delete message reaction from the database.
+        try database.writeSynchronously { session in
+            // Load message reaction.
+            let dto = try XCTUnwrap(
+                session.reaction(
+                    messageId: payload.messageId,
+                    userId: payload.user.id,
+                    type: payload.type
+                )
+            )
+            
+            // Delete message reaction.
+            session.delete(reaction: dto)
+        }
+        
+        // Load reaction.
+        let dto = database.viewContext.reaction(
+            messageId: payload.messageId,
+            userId: payload.user.id,
+            type: payload.type
+        )
+        
+        // Assert dto is `nil`.
+        XCTAssertNil(dto)
+    }
+    
+    // MARK: - Private
+    
+    private func assert_messageReaction_isStoredAndLoadedFromDB<T: ExtraDataTypes>(
+        _ payload: MessageReactionPayload<T>,
+        createMessageInTheDatabase: Bool = true
+    ) throws {
+        // Save message to the database.
+        if createMessageInTheDatabase {
+            try database.createMessage(id: payload.messageId)
+        }
+        
+        // Save message reaction to the database.
+        try database.writeSynchronously { session in
+            try session.saveReaction(payload: payload)
+        }
+        
+        // Load saved message reaction.
+        let dto = try XCTUnwrap(
+            database.viewContext.reaction(
+                messageId: payload.messageId,
+                userId: payload.user.id,
+                type: payload.type
+            )
+        )
+        
+        // Encode extra data.
+        let encoder = JSONEncoder.default
+        let reactionExtraData = try encoder.encode(payload.extraData)
+        let userExtraData = try encoder.encode(payload.user.extraData)
+
+        // Assert loaded message reaction has valid fields.
+        XCTAssertEqual(dto.createdAt, payload.createdAt)
+        XCTAssertEqual(dto.updatedAt, payload.updatedAt)
+        XCTAssertEqual(dto.type, payload.type.rawValue)
+        XCTAssertEqual(dto.score, Int64(payload.score))
+        XCTAssertEqual(dto.extraData, reactionExtraData)
+        XCTAssertEqual(dto.message.id, payload.messageId)
+        
+        // Assert reaction author has valid fields.
+        XCTAssertEqual(dto.user.id, payload.user.id)
+        XCTAssertEqual(dto.user.extraData, userExtraData)
+    }
+}
+
+// MARK: - CustomExtraData
+
+private enum CustomExtraData: ExtraDataTypes {
+    typealias MessageReaction = Mood
+}
+
+private struct Mood: MessageReactionExtraData {
+    static var defaultValue: Self { .init(mood: "") }
+    let mood: String
+}

--- a/Sources_v3/StreamChat/Database/DatabaseSession.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseSession.swift
@@ -70,6 +70,19 @@ protocol MessageDatabaseSession {
     /// Deletes the provided dto from a database
     /// - Parameter message: The DTO to be deleted
     func delete(message: MessageDTO)
+    
+    /// Fetches `MessageReactionDTO` for the given `messageId`, `userId`, and `type` from the DB.
+    /// Returns `nil` if there is no matching `MessageReactionDTO`.
+    func reaction(messageId: MessageId, userId: UserId, type: MessageReactionType) -> MessageReactionDTO?
+    
+    /// Saves the provided reaction payload to the DB. Throws an error if the save fails
+    /// else returns saved `MessageReactionDTO` entity.
+    @discardableResult
+    func saveReaction<ExtraData: ExtraDataTypes>(payload: MessageReactionPayload<ExtraData>) throws -> MessageReactionDTO
+    
+    /// Deletes the provided dto from a database
+    /// - Parameter reaction: The DTO to be deleted
+    func delete(reaction: MessageReactionDTO)
 }
 
 extension MessageDatabaseSession {

--- a/Sources_v3/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources_v3/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -139,11 +139,27 @@
         <relationship name="flaggedBy" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CurrentUserDTO" inverseName="flaggedMessages" inverseEntity="CurrentUserDTO"/>
         <relationship name="mentionedUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="mentionedMessages" inverseEntity="UserDTO"/>
         <relationship name="parentMessage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="replies" inverseEntity="MessageDTO"/>
+        <relationship name="reactions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageReactionDTO" inverseName="message" inverseEntity="MessageReactionDTO"/>
         <relationship name="replies" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="parentMessage" inverseEntity="MessageDTO"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="messages" inverseEntity="UserDTO"/>
         <fetchIndex name="id">
             <fetchIndexElement property="id" type="Binary" order="ascending"/>
         </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="MessageReactionDTO" representedClassName="MessageReactionDTO" syncable="YES">
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="extraData" optional="YES" attributeType="Binary"/>
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="score" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="message" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="reactions" inverseEntity="MessageDTO"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="reactions" inverseEntity="UserDTO"/>
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="id"/>
@@ -181,6 +197,7 @@
         <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="user" inverseEntity="MessageDTO"/>
         <relationship name="mutedBy" toMany="YES" deletionRule="Nullify" destinationEntity="CurrentUserDTO" inverseName="mutedUsers" inverseEntity="CurrentUserDTO"/>
         <relationship name="queries" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserListQueryDTO" inverseName="users" inverseEntity="UserListQueryDTO"/>
+        <relationship name="reactions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageReactionDTO" inverseName="user" inverseEntity="MessageReactionDTO"/>
         <relationship name="teams" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TeamDTO" inverseName="users" inverseEntity="TeamDTO"/>
         <relationship name="watchedChannels" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="watchers" inverseEntity="ChannelDTO"/>
         <fetchIndex name="id">
@@ -214,6 +231,7 @@
         <element name="DeviceDTO" positionX="9" positionY="153" width="128" height="88"/>
         <element name="MemberDTO" positionX="0" positionY="0" width="128" height="193"/>
         <element name="MessageDTO" positionX="0" positionY="0" width="128" height="373"/>
+        <element name="MessageReactionDTO" positionX="9" positionY="153" width="128" height="163"/>
         <element name="TeamDTO" positionX="0" positionY="0" width="128" height="88"/>
         <element name="UserDTO" positionX="0" positionY="0" width="128" height="313"/>
         <element name="UserListQueryDTO" positionX="9" positionY="153" width="128" height="88"/>

--- a/Sources_v3/StreamChat/Models/ExtraData.swift
+++ b/Sources_v3/StreamChat/Models/ExtraData.swift
@@ -11,7 +11,7 @@ public protocol ExtraData: Codable & Hashable {
 }
 
 /// A type representing no extra data for the given model object.
-public struct NoExtraData: Codable, Hashable, UserExtraData, ChannelExtraData, MessageExtraData {
+public struct NoExtraData: Codable, Hashable, UserExtraData, ChannelExtraData, MessageExtraData, MessageReactionExtraData {
     /// Returns a concrete `NoExtraData` instance.
     public static var defaultValue: Self { .init() }
 }

--- a/Sources_v3/StreamChat/Models/Message.swift
+++ b/Sources_v3/StreamChat/Models/Message.swift
@@ -98,6 +98,14 @@ public struct _ChatMessage<ExtraData: ExtraDataTypes> {
     /// - Note: Please be aware that the value of this field is not persisted on the server,
     /// and is valid only locally for the current session.
     public let isFlaggedByCurrentUser: Bool
+
+    /// The latest reactions to the message created by any user.
+    ///
+    /// - Note: There can be `10` reactions at max.
+    public let latestReactions: Set<_ChatMessageReaction<ExtraData>>
+    
+    /// The entire list of reactions to the message left by the current user.
+    public let currentUserReactions: Set<_ChatMessageReaction<ExtraData>>
 }
 
 extension _ChatMessage: Hashable {

--- a/Sources_v3/StreamChat/Models/Message.swift
+++ b/Sources_v3/StreamChat/Models/Message.swift
@@ -75,7 +75,7 @@ public struct _ChatMessage<ExtraData: ExtraDataTypes> {
     public let isSilent: Bool
     
     /// The reactions to the message created by any user.
-    public let reactionScores: [String: Int]
+    public let reactionScores: [MessageReactionType: Int]
     
     /// The user which is the author of the message.
     public let author: _ChatUser<ExtraData.User>

--- a/Sources_v3/StreamChat/Models/MessageReaction.swift
+++ b/Sources_v3/StreamChat/Models/MessageReaction.swift
@@ -1,0 +1,58 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A type representing a message reaction. `ChatMessageReaction` is an immutable snapshot of a message
+/// reaction entity at the given time.
+///
+/// - Note: `ChatMessageReaction` is a typealias of `_ChatMessageReaction` with default extra data.
+/// If you're using custom extra data, create your own typealias of `_ChatMessageReaction`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public typealias ChatMessageReaction = _ChatMessageReaction<DefaultExtraData>
+
+/// A type representing a message reaction. `_ChatMessageReaction` is an immutable snapshot
+/// of a message reaction entity at the given time.
+///
+/// - Note: `_ChatMessageReaction` type is not meant to be used directly. If you're using default extra data,
+/// use `ChatMessageReaction` typealias instead. If you're using custom extra data,
+/// create your own typealias of `_ChatMessageReaction`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+@dynamicMemberLookup
+public struct _ChatMessageReaction<ExtraData: ExtraDataTypes>: Hashable {
+    /// The reaction type.
+    public let type: MessageReactionType
+    
+    /// The reaction score.
+    public let score: Int
+    
+    /// The date the reaction was created.
+    public let createdAt: Date
+    
+    /// The date the reaction was last updated.
+    public let updatedAt: Date
+    
+    /// The reaction's extra data.
+    public let extraData: ExtraData.MessageReaction
+    
+    /// The author.
+    public let author: _ChatUser<ExtraData.User>
+}
+
+extension _ChatMessageReaction {
+    public subscript<T>(dynamicMember keyPath: KeyPath<ExtraData.MessageReaction, T>) -> T {
+        extraData[keyPath: keyPath]
+    }
+}
+
+/// You need to make your custom type conforming to this protocol if you want to use it for extending `ChatMessageReaction` entity
+/// with your custom additional data.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public protocol MessageReactionExtraData: ExtraData {}

--- a/Sources_v3/StreamChat/Models/MessageReactionType.swift
+++ b/Sources_v3/StreamChat/Models/MessageReactionType.swift
@@ -1,0 +1,42 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The type that describes a message reaction type.
+///
+/// The reaction has underlaying type `String` what gives the flexibility to choose the way how the reaction
+/// will be displayed in the application.
+///
+/// Common examples are: "like", "love", "smile", etc.
+public struct MessageReactionType: RawRepresentable, Codable, Hashable, ExpressibleByStringLiteral {
+    
+    // MARK: - RawRepresentable
+    
+    public let rawValue: String
+    
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+    
+    // MARK: - ExpressibleByStringLiteral
+    
+    public init(stringLiteral: String) {
+        self.init(rawValue: stringLiteral)
+    }
+    
+    // MARK: - Codable
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(
+            rawValue: try container.decode(String.self)
+        )
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}

--- a/Sources_v3/StreamChat/Models/MessageReactionType_Tests.swift
+++ b/Sources_v3/StreamChat/Models/MessageReactionType_Tests.swift
@@ -1,0 +1,47 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class MessageReactionType_Tests: XCTestCase {
+    func test_init_rawValue() {
+        let value: String = .unique
+        let reaction = MessageReactionType(rawValue: value)
+        XCTAssertEqual(reaction.rawValue, value)
+    }
+    
+    func test_init_stringLiteral() {
+        let reaction: MessageReactionType = "like"
+        XCTAssertEqual(reaction.rawValue, "like")
+    }
+    
+    func test_reaction_isEncodedCorrectly() throws {
+        let encoder = JSONEncoder.default
+
+        // Create the reaction.
+        let reaction = MessageReactionType(rawValue: .unique)
+        
+        // Assert reaction is encoded as a string
+        XCTAssertEqual(encoder.encodedString(reaction), reaction.rawValue)
+    }
+    
+    func test_reaction_isDecodedCorrectly() throws {
+        // Create the reaction.
+        let reaction = MessageReactionType(rawValue: .unique)
+        
+        // Assert reaction is decoded correctly.
+        XCTAssertEqual(decode(value: reaction.rawValue), reaction)
+    }
+    
+    @available(iOS, deprecated: 12.0, message: "Remove this workaround when dropping iOS 12 support.")
+    private func decode(value: String) -> MessageReactionType? {
+        // We must decode it as a part of JSON because older iOS version don't support JSON fragments
+        let key = String.unique
+        let jsonString = #"{ "\#(key)" : "\#(value)"}"#
+        let data = jsonString.data(using: .utf8)!
+        let serializedJSON = try? JSONDecoder.stream.decode([String: MessageReactionType].self, from: data)
+        return serializedJSON?[key]
+    }
+}

--- a/Sources_v3/StreamChat/Utils/Dictionary+Extensions.swift
+++ b/Sources_v3/StreamChat/Utils/Dictionary+Extensions.swift
@@ -1,0 +1,11 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension Dictionary {
+    func mapKeys<TransformedKey: Hashable>(_ transform: (Key) -> TransformedKey) -> [TransformedKey: Value] {
+        .init(uniqueKeysWithValues: map { (transform($0.key), $0.value) })
+    }
+}

--- a/Sources_v3/StreamChat/Utils/Dictionary_Tests.swift
+++ b/Sources_v3/StreamChat/Utils/Dictionary_Tests.swift
@@ -1,0 +1,36 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class Dictionary_Tests: StressTestCase {
+    func test_mapKeys() {
+        // Declare key transformation closure.
+        let keyTransform: (String) -> String = {
+            return [$0, $0].joined(separator: " ")
+        }
+        
+        // Create array of keys with values.
+        let keysAndValues = [
+            ("like", 4),
+            ("love", 3),
+            ("cat", 1)
+        ]
+        
+        // Create array of mapped keys with values.
+        let mappedKeysAndValues = keysAndValues.map {
+            (keyTransform($0), $1)
+        }
+        
+        // Create dict with initial keys and values.
+        let initial = Dictionary(uniqueKeysWithValues: keysAndValues)
+        
+        // Create dict with mapped keys and values.
+        let expected = Dictionary(uniqueKeysWithValues: mappedKeysAndValues)
+        
+        // Assert `mapKeys` work correctly.
+        XCTAssertEqual(initial.mapKeys(keyTransform), expected)
+    }
+}

--- a/Sources_v3/StreamChat/WebSocketClient/EventMiddlewares/MessageReactionsMiddleware.swift
+++ b/Sources_v3/StreamChat/WebSocketClient/EventMiddlewares/MessageReactionsMiddleware.swift
@@ -1,0 +1,46 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The middleware listens for `EventWithReactionPayload` events and updates `MessageReactionDTO` accordingly.
+struct MessageReactionsMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
+    let database: DatabaseContainer
+    
+    func handle(event: Event, completion: @escaping (Event?) -> Void) {
+        guard
+            let reactionEvent = event as? EventWithReactionPayload,
+            let payload = reactionEvent.payload as? EventPayload<ExtraData>,
+            let reaction = payload.reaction
+        else {
+            completion(event)
+            return
+        }
+        
+        database.write({ session in
+            if reactionEvent is ReactionNewEvent {
+                try session.saveReaction(payload: reaction)
+            } else if reactionEvent is ReactionUpdatedEvent {
+                try session.saveReaction(payload: reaction)
+            } else if reactionEvent is ReactionDeletedEvent {
+                guard
+                    let dto = session.reaction(
+                        messageId: reaction.messageId,
+                        userId: reaction.user.id,
+                        type: reaction.type
+                    )
+                else { return }
+                
+                session.delete(reaction: dto)
+            } else {
+                throw ClientError.Unexpected("Middleware has tried to handle unsupported event type.")
+            }
+        }, completion: { error in
+            if let error = error {
+                log.error("Failed to update message reaction in the database, error: \(error)")
+            }
+            completion(event)
+        })
+    }
+}

--- a/Sources_v3/StreamChat/WebSocketClient/EventMiddlewares/MessageReactionsMiddleware_Tests.swift
+++ b/Sources_v3/StreamChat/WebSocketClient/EventMiddlewares/MessageReactionsMiddleware_Tests.swift
@@ -1,0 +1,209 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class MessageReactionsMiddleware_Tests: XCTestCase {
+    var database: DatabaseContainerMock!
+    var middleware: MessageReactionsMiddleware<DefaultExtraData>!
+    
+    // MARK: - Set up
+    
+    override func setUp() {
+        super.setUp()
+        
+        database = DatabaseContainerMock()
+        middleware = .init(database: database)
+    }
+    
+    override func tearDown() {
+        middleware = nil
+        AssertAsync.canBeReleased(&database)
+
+        super.tearDown()
+    }
+    
+    // MARK: - Tests
+    
+    func tests_middleware_forwardsNonReactionEvents() throws {
+        let event = TestEvent()
+        
+        // Handle non-reaction event
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Assert event is forwarded as it is
+        XCTAssertEqual(forwardedEvent as! TestEvent, event)
+    }
+    
+    func tests_middleware_forwardsReactionEvent_ifDatabaseWriteGeneratesError() throws {
+        let eventPayload: EventPayload<DefaultExtraData> = .init(
+            eventType: .reactionNew,
+            cid: .unique,
+            reaction: .dummy(
+                messageId: .unique,
+                user: UserPayload.dummy(userId: .unique)
+            )
+        )
+        
+        // Set error to be thrown on write.
+        let error = TestError()
+        database.write_errorResponse = error
+        
+        // Simulate and handle reaction event.
+        let event = try ReactionNewEvent(from: eventPayload)
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Assert `ReactionNewEvent` is forwarded even though database error happened.
+        XCTAssertTrue(forwardedEvent is ReactionNewEvent)
+    }
+    
+    func tests_middleware_handlesReactionNewEventCorrectly() throws {
+        // Create reaction payload.
+        let reactionPayload: MessageReactionPayload<DefaultExtraData> = .dummy(
+            messageId: .unique,
+            user: UserPayload.dummy(userId: .unique)
+        )
+        
+        // Create event payload.
+        let eventPayload: EventPayload<DefaultExtraData> = .init(
+            eventType: .reactionNew,
+            cid: .unique,
+            reaction: reactionPayload
+        )
+        
+        // Create event with payload.
+        let event = try ReactionNewEvent(from: eventPayload)
+        
+        // Create message in the database.
+        try database.createMessage(id: reactionPayload.messageId)
+
+        // Simulate `ReactionNewEvent` event.
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Load the message.
+        let message = try XCTUnwrap(
+            database.viewContext.message(id: reactionPayload.messageId)
+        )
+        
+        // Load the reaction.
+        let reaction = try XCTUnwrap(
+            database.viewContext.reaction(
+                messageId: reactionPayload.messageId,
+                userId: reactionPayload.user.id,
+                type: reactionPayload.type
+            )
+        )
+        
+        // Assert event is forwarded.
+        XCTAssertTrue(forwardedEvent is ReactionNewEvent)
+        // Assert reaction is linked to the message.
+        XCTAssertEqual(message.reactions, [reaction])
+    }
+    
+    func tests_middleware_handlesReactionUpdatedEventCorrectly() throws {
+        // Create reaction payload.
+        let reactionPayload: MessageReactionPayload<DefaultExtraData> = .dummy(
+            messageId: .unique,
+            user: UserPayload.dummy(userId: .unique)
+        )
+        
+        // Create event payload.
+        let eventPayload: EventPayload<DefaultExtraData> = .init(
+            eventType: .reactionNew,
+            cid: .unique,
+            reaction: reactionPayload
+        )
+        
+        // Create event with payload.
+        let event = try ReactionUpdatedEvent(from: eventPayload)
+        
+        // Create message in the database.
+        try database.createMessage(id: reactionPayload.messageId)
+
+        // Simulate `ReactionNewEvent` event.
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Load the message.
+        let message = try XCTUnwrap(
+            database.viewContext.message(id: reactionPayload.messageId)
+        )
+        
+        // Load the reaction.
+        let reaction = try XCTUnwrap(
+            database.viewContext.reaction(
+                messageId: reactionPayload.messageId,
+                userId: reactionPayload.user.id,
+                type: reactionPayload.type
+            )
+        )
+        
+        // Assert event is forwarded.
+        XCTAssertTrue(forwardedEvent is ReactionUpdatedEvent)
+        // Assert reaction is linked to the message.
+        XCTAssertEqual(message.reactions, [reaction])
+    }
+    
+    func tests_middleware_handlesReactionDeletedEventCorrectly() throws {
+        // Create reaction payload.
+        let reactionPayload: MessageReactionPayload<DefaultExtraData> = .dummy(
+            messageId: .unique,
+            user: UserPayload.dummy(userId: .unique)
+        )
+        
+        // Create event payload.
+        let eventPayload: EventPayload<DefaultExtraData> = .init(
+            eventType: .reactionNew,
+            cid: .unique,
+            reaction: reactionPayload
+        )
+        
+        // Save message to the database.
+        try database.createMessage(id: reactionPayload.messageId)
+        
+        // Save reaction to the database.
+        try database.writeSynchronously { session in
+            try session.saveReaction(payload: reactionPayload)
+        }
+
+        // Simulate `ReactionDeletedEvent` event.
+        let event = try ReactionDeletedEvent(from: eventPayload)
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Load the message.
+        let message = try XCTUnwrap(
+            database.viewContext.message(id: reactionPayload.messageId)
+        )
+        
+        // Load the reaction.
+        var reaction: MessageReactionDTO? {
+            database.viewContext.reaction(
+                messageId: reactionPayload.messageId,
+                userId: reactionPayload.user.id,
+                type: reactionPayload.type
+            )
+        }
+        
+        // Assert event is forwarded.
+        XCTAssertTrue(forwardedEvent is ReactionDeletedEvent)
+        // Assert message reaction is deleted.
+        XCTAssertNil(reaction)
+        // Assert message reactions are empty.
+        XCTAssertTrue(message.reactions.isEmpty)
+    }
+}
+
+private struct TestEvent: Event, Equatable {
+    let id = UUID()
+}

--- a/Sources_v3/StreamChat/WebSocketClient/Events/Event.swift
+++ b/Sources_v3/StreamChat/WebSocketClient/Events/Event.swift
@@ -47,6 +47,6 @@ protocol EventWithMemberPayload: EventWithPayload {
 
 /// A protocol for reaction `Event` where it has reacction with message payload.
 protocol EventWithReactionPayload: EventWithMessagePayload {
-    var reactionType: ReactionType { get }
+    var reactionType: MessageReactionType { get }
     var reactionScore: Int { get }
 }

--- a/Sources_v3/StreamChat/WebSocketClient/Events/EventPayload.swift
+++ b/Sources_v3/StreamChat/WebSocketClient/Events/EventPayload.swift
@@ -6,8 +6,6 @@ import Foundation
 
 // MARK: - Temporary
 
-public typealias ReactionType = String
-
 struct ReactionPayload: Decodable {
     private enum CodingKeys: String, CodingKey {
         case type

--- a/Sources_v3/StreamChat/WebSocketClient/Events/EventPayload.swift
+++ b/Sources_v3/StreamChat/WebSocketClient/Events/EventPayload.swift
@@ -6,22 +6,6 @@ import Foundation
 
 // MARK: - Temporary
 
-struct ReactionPayload: Decodable {
-    private enum CodingKeys: String, CodingKey {
-        case type
-        case score
-        case createdAt = "created_at"
-        case updatedAt = "updated_at"
-    }
-    
-    let type: ReactionType
-    let score: Int
-    let createdAt: Date
-    let updatedAt: Date
-}
-
-// MARK: Temporary -
-
 /// The DTO object mirroring the JSON representation of an event.
 struct EventPayload<ExtraData: ExtraDataTypes>: Decodable {
     private enum CodingKeys: String, CodingKey {
@@ -51,7 +35,7 @@ struct EventPayload<ExtraData: ExtraDataTypes>: Decodable {
     let memberContainer: MemberContainerPayload<ExtraData.User>?
     let channel: ChannelDetailPayload<ExtraData>?
     let message: MessagePayload<ExtraData>?
-    let reaction: ReactionPayload?
+    let reaction: MessageReactionPayload<ExtraData>?
     let watcherCount: Int?
     let unreadCount: UnreadCount?
     let createdAt: Date?
@@ -69,7 +53,7 @@ struct EventPayload<ExtraData: ExtraDataTypes>: Decodable {
         memberContainer: MemberContainerPayload<ExtraData.User>? = nil,
         channel: ChannelDetailPayload<ExtraData>? = nil,
         message: MessagePayload<ExtraData>? = nil,
-        reaction: ReactionPayload? = nil,
+        reaction: MessageReactionPayload<ExtraData>? = nil,
         watcherCount: Int? = nil,
         unreadCount: UnreadCount? = nil,
         createdAt: Date? = nil,
@@ -108,7 +92,7 @@ struct EventPayload<ExtraData: ExtraDataTypes>: Decodable {
         memberContainer = try container.decodeIfPresent(MemberContainerPayload<ExtraData.User>.self, forKey: .memberContainer)
         channel = try container.decodeIfPresent(ChannelDetailPayload<ExtraData>.self, forKey: .channel)
         message = try container.decodeIfPresent(MessagePayload<ExtraData>.self, forKey: .message)
-        reaction = try container.decodeIfPresent(ReactionPayload.self, forKey: .reaction)
+        reaction = try container.decodeIfPresent(MessageReactionPayload<ExtraData>.self, forKey: .reaction)
         watcherCount = try container.decodeIfPresent(Int.self, forKey: .watcherCount)
         unreadCount = try? UnreadCount(from: decoder)
         createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)

--- a/Sources_v3/StreamChat/WebSocketClient/Events/ReactionEvents.swift
+++ b/Sources_v3/StreamChat/WebSocketClient/Events/ReactionEvents.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct ReactionNewEvent<ExtraData: ExtraDataTypes>: EventWithReactionPayload {
+public struct ReactionNewEvent: EventWithReactionPayload {
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
@@ -14,10 +14,10 @@ public struct ReactionNewEvent<ExtraData: ExtraDataTypes>: EventWithReactionPayl
     
     let payload: Any
     
-    init(from response: EventPayload<ExtraData>) throws {
-        userId = try response.value(at: \.user?.id)
+    init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
+        userId = try response.value(at: \.reaction?.user.id)
         cid = try response.value(at: \.cid)
-        messageId = try response.value(at: \.message?.id)
+        messageId = try response.value(at: \.reaction?.messageId)
         reactionType = try response.value(at: \.reaction?.type)
         reactionScore = try response.value(at: \.reaction?.score)
         createdAt = try response.value(at: \.reaction?.createdAt)
@@ -25,7 +25,7 @@ public struct ReactionNewEvent<ExtraData: ExtraDataTypes>: EventWithReactionPayl
     }
 }
 
-public struct ReactionUpdatedEvent<ExtraData: ExtraDataTypes>: EventWithReactionPayload {
+public struct ReactionUpdatedEvent: EventWithReactionPayload {
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
@@ -35,10 +35,10 @@ public struct ReactionUpdatedEvent<ExtraData: ExtraDataTypes>: EventWithReaction
     
     let payload: Any
     
-    init(from response: EventPayload<ExtraData>) throws {
-        userId = try response.value(at: \.user?.id)
+    init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
+        userId = try response.value(at: \.reaction?.user.id)
         cid = try response.value(at: \.cid)
-        messageId = try response.value(at: \.message?.id)
+        messageId = try response.value(at: \.reaction?.messageId)
         reactionType = try response.value(at: \.reaction?.type)
         reactionScore = try response.value(at: \.reaction?.score)
         updatedAt = try response.value(at: \.reaction?.updatedAt)
@@ -46,7 +46,7 @@ public struct ReactionUpdatedEvent<ExtraData: ExtraDataTypes>: EventWithReaction
     }
 }
 
-public struct ReactionDeletedEvent<ExtraData: ExtraDataTypes>: EventWithReactionPayload {
+public struct ReactionDeletedEvent: EventWithReactionPayload {
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
@@ -55,10 +55,10 @@ public struct ReactionDeletedEvent<ExtraData: ExtraDataTypes>: EventWithReaction
     
     let payload: Any
     
-    init(from response: EventPayload<ExtraData>) throws {
-        userId = try response.value(at: \.user?.id)
+    init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
+        userId = try response.value(at: \.reaction?.user.id)
         cid = try response.value(at: \.cid)
-        messageId = try response.value(at: \.message?.id)
+        messageId = try response.value(at: \.reaction?.messageId)
         reactionType = try response.value(at: \.reaction?.type)
         reactionScore = try response.value(at: \.reaction?.score)
         payload = response

--- a/Sources_v3/StreamChat/WebSocketClient/Events/ReactionEvents.swift
+++ b/Sources_v3/StreamChat/WebSocketClient/Events/ReactionEvents.swift
@@ -8,7 +8,7 @@ public struct ReactionNewEvent<ExtraData: ExtraDataTypes>: EventWithReactionPayl
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
-    public let reactionType: ReactionType
+    public let reactionType: MessageReactionType
     public let reactionScore: Int
     public let createdAt: Date
     
@@ -29,7 +29,7 @@ public struct ReactionUpdatedEvent<ExtraData: ExtraDataTypes>: EventWithReaction
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
-    public let reactionType: ReactionType
+    public let reactionType: MessageReactionType
     public let reactionScore: Int
     public let updatedAt: Date
     
@@ -50,7 +50,7 @@ public struct ReactionDeletedEvent<ExtraData: ExtraDataTypes>: EventWithReaction
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
-    public let reactionType: ReactionType
+    public let reactionType: MessageReactionType
     public let reactionScore: Int
     
     let payload: Any

--- a/Sources_v3/StreamChat/WebSocketClient/Events/ReactionEvents_Tests.swift
+++ b/Sources_v3/StreamChat/WebSocketClient/Events/ReactionEvents_Tests.swift
@@ -13,33 +13,42 @@ class ReactionEvents_Tests: XCTestCase {
     
     func test_new() throws {
         let json = XCTestCase.mockData(fromFile: "ReactionNew")
-        let event = try eventDecoder.decode(from: json) as? ReactionNewEvent<DefaultExtraData>
+        let event = try eventDecoder.decode(from: json) as? ReactionNewEvent
+        let reactionPayload = (event?.payload as? EventPayload<DefaultExtraData>)?[keyPath: \.reaction]
         XCTAssertEqual(event?.userId, userId)
         XCTAssertEqual(event?.cid, cid)
         XCTAssertEqual(event?.messageId, messageId)
         XCTAssertEqual(event?.reactionType, "like")
         XCTAssertEqual(event?.reactionScore, 1)
         XCTAssertEqual(event?.createdAt.description, "2020-07-20 17:09:56 +0000")
+        XCTAssertEqual(reactionPayload?.messageId, messageId)
+        XCTAssertEqual(reactionPayload?.user.id, userId)
     }
     
     func test_updated() throws {
         let json = XCTestCase.mockData(fromFile: "ReactionUpdated")
-        let event = try eventDecoder.decode(from: json) as? ReactionUpdatedEvent<DefaultExtraData>
+        let event = try eventDecoder.decode(from: json) as? ReactionUpdatedEvent
+        let reactionPayload = (event?.payload as? EventPayload<DefaultExtraData>)?[keyPath: \.reaction]
         XCTAssertEqual(event?.userId, userId)
         XCTAssertEqual(event?.cid, cid)
         XCTAssertEqual(event?.messageId, messageId)
         XCTAssertEqual(event?.reactionType, "like")
         XCTAssertEqual(event?.reactionScore, 2)
         XCTAssertEqual(event?.updatedAt.description, "2020-07-20 17:09:56 +0000")
+        XCTAssertEqual(reactionPayload?.messageId, messageId)
+        XCTAssertEqual(reactionPayload?.user.id, userId)
     }
     
     func test_deleted() throws {
         let json = XCTestCase.mockData(fromFile: "ReactionDeleted")
-        let event = try eventDecoder.decode(from: json) as? ReactionDeletedEvent<DefaultExtraData>
+        let event = try eventDecoder.decode(from: json) as? ReactionDeletedEvent
+        let reactionPayload = (event?.payload as? EventPayload<DefaultExtraData>)?[keyPath: \.reaction]
         XCTAssertEqual(event?.userId, userId)
         XCTAssertEqual(event?.cid, cid)
         XCTAssertEqual(event?.messageId, messageId)
         XCTAssertEqual(event?.reactionType, "like")
         XCTAssertEqual(event?.reactionScore, 1)
+        XCTAssertEqual(reactionPayload?.messageId, messageId)
+        XCTAssertEqual(reactionPayload?.user.id, userId)
     }
 }

--- a/Sources_v3/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/MessageUpdater.swift
@@ -237,6 +237,46 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
             }
         }
     }
+    
+    /// Adds a new reaction to the message.
+    /// - Parameters:
+    ///   - type: The reaction type.
+    ///   - score: The reaction score.
+    ///   - extraData: The extra data attached to the reaction.
+    ///   - messageId: The message identifier the reaction will be added to.
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
+    func addReaction(
+        _ type: MessageReactionType,
+        score: Int,
+        extraData: ExtraData.MessageReaction,
+        messageId: MessageId,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        let endpoint: Endpoint<EmptyResponse> = .addReaction(
+            type,
+            score: score,
+            extraData: extraData,
+            messageId: messageId
+        )
+        apiClient.request(endpoint: endpoint) {
+            completion?($0.error)
+        }
+    }
+    
+    /// Deletes the message reaction left by the current user.
+    /// - Parameters:
+    ///   - type: The reaction type.
+    ///   - messageId: The message identifier the reaction will be deleted from.
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
+    func deleteReaction(
+        _ type: MessageReactionType,
+        messageId: MessageId,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        apiClient.request(endpoint: .deleteReaction(type, messageId: messageId)) {
+            completion?($0.error)
+        }
+    }
 }
 
 // MARK: - Private

--- a/Sources_v3/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/Sources_v3/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -37,6 +37,16 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
     @Atomic var flagMessage_cid: ChannelId?
     @Atomic var flagMessage_completion: ((Error?) -> Void)?
     
+    @Atomic var addReaction_type: MessageReactionType?
+    @Atomic var addReaction_score: Int?
+    @Atomic var addReaction_extraData: ExtraData.MessageReaction?
+    @Atomic var addReaction_messageId: MessageId?
+    @Atomic var addReaction_completion: ((Error?) -> Void)?
+    
+    @Atomic var deleteReaction_type: MessageReactionType?
+    @Atomic var deleteReaction_messageId: MessageId?
+    @Atomic var deleteReaction_completion: ((Error?) -> Void)?
+    
     // Cleans up all recorded values
     func cleanUp() {
         getMessage_cid = nil
@@ -68,6 +78,16 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         flagMessage_messageId = nil
         flagMessage_cid = nil
         flagMessage_completion = nil
+        
+        addReaction_type = nil
+        addReaction_score = nil
+        addReaction_extraData = nil
+        addReaction_messageId = nil
+        addReaction_completion = nil
+        
+        deleteReaction_type = nil
+        deleteReaction_messageId = nil
+        deleteReaction_completion = nil
     }
     
     override func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Error?) -> Void)? = nil) {
@@ -124,5 +144,29 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         flagMessage_messageId = messageId
         flagMessage_cid = cid
         flagMessage_completion = completion
+    }
+    
+    override func addReaction(
+        _ type: MessageReactionType,
+        score: Int,
+        extraData: ExtraData.MessageReaction,
+        messageId: MessageId,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        addReaction_type = type
+        addReaction_score = score
+        addReaction_extraData = extraData
+        addReaction_messageId = messageId
+        addReaction_completion = completion
+    }
+    
+    override func deleteReaction(
+        _ type: MessageReactionType,
+        messageId: MessageId,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        deleteReaction_type = type
+        deleteReaction_messageId = messageId
+        deleteReaction_completion = completion
     }
 }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 		8899BC53254318CC003CB98B /* MessageReaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC52254318CC003CB98B /* MessageReaction.swift */; };
 		8899BC3F2542FFA1003CB98B /* MessageReactionPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC3E2542FFA1003CB98B /* MessageReactionPayload.swift */; };
 		8899BC47254305F8003CB98B /* MessageReactionRequestPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC46254305F8003CB98B /* MessageReactionRequestPayload.swift */; };
+		8899BC4D25430E40003CB98B /* MessageReactionDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC4C25430E40003CB98B /* MessageReactionDTO.swift */; };
 		889B00E5252C972C007709A8 /* ChannelMemberListQuery_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */; };
 		889B00E9252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */; };
 		88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */; };
@@ -803,6 +804,7 @@
 		8899BC52254318CC003CB98B /* MessageReaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReaction.swift; sourceTree = "<group>"; };
 		8899BC3E2542FFA1003CB98B /* MessageReactionPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionPayload.swift; sourceTree = "<group>"; };
 		8899BC46254305F8003CB98B /* MessageReactionRequestPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionRequestPayload.swift; sourceTree = "<group>"; };
+		8899BC4C25430E40003CB98B /* MessageReactionDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionDTO.swift; sourceTree = "<group>"; };
 		889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQuery_Tests.swift; sourceTree = "<group>"; };
 		889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQueryDTO_Tests.swift; sourceTree = "<group>"; };
 		88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints.swift; sourceTree = "<group>"; };
@@ -1243,6 +1245,7 @@
 		792A4F18247EA97000EAF71D /* DTOs */ = {
 			isa = PBXGroup;
 			children = (
+				8899BC4C25430E40003CB98B /* MessageReactionDTO.swift */,
 				799C942D247D2FB9001F1104 /* MessageDTO.swift */,
 				7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */,
 				79877A1F2498E50D00015F8B /* TeamDTO.swift */,
@@ -2515,6 +2518,7 @@
 				792A4F4B248010A600EAF71D /* QueryOptions.swift in Sources */,
 				792FCB4B24A3D52A000290C7 /* DatabaseSession.swift in Sources */,
 				792A4F1D247FEA2200EAF71D /* ChannelListController.swift in Sources */,
+				8899BC4D25430E40003CB98B /* MessageReactionDTO.swift in Sources */,
 				79280F49248520B300CDEB89 /* EventDecoder.swift in Sources */,
 				8A0D649B24E579E90017A3C0 /* GuestUserTokenPayload.swift in Sources */,
 				DA84071025250720005A0F62 /* UserListQueryDTO.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -272,9 +272,11 @@
 		888E8C55252B525300195E03 /* MemberController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C54252B525300195E03 /* MemberController.swift */; };
 		888E8C59252B56A100195E03 /* MemberController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C58252B56A100195E03 /* MemberController_Tests.swift */; };
 		8899BC53254318CC003CB98B /* MessageReaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC52254318CC003CB98B /* MessageReaction.swift */; };
+		889062432548387D00E1898E /* MessageReactionsMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889062422548387D00E1898E /* MessageReactionsMiddleware_Tests.swift */; };
 		8899BC3F2542FFA1003CB98B /* MessageReactionPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC3E2542FFA1003CB98B /* MessageReactionPayload.swift */; };
 		8899BC47254305F8003CB98B /* MessageReactionRequestPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC46254305F8003CB98B /* MessageReactionRequestPayload.swift */; };
 		8899BC4D25430E40003CB98B /* MessageReactionDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC4C25430E40003CB98B /* MessageReactionDTO.swift */; };
+		8899BC57254337C7003CB98B /* MessageReactionsMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC56254337C7003CB98B /* MessageReactionsMiddleware.swift */; };
 		889B00E5252C972C007709A8 /* ChannelMemberListQuery_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */; };
 		889B00E9252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */; };
 		88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */; };
@@ -803,9 +805,11 @@
 		888E8C54252B525300195E03 /* MemberController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberController.swift; sourceTree = "<group>"; };
 		888E8C58252B56A100195E03 /* MemberController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberController_Tests.swift; sourceTree = "<group>"; };
 		8899BC52254318CC003CB98B /* MessageReaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReaction.swift; sourceTree = "<group>"; };
+		889062422548387D00E1898E /* MessageReactionsMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionsMiddleware_Tests.swift; sourceTree = "<group>"; };
 		8899BC3E2542FFA1003CB98B /* MessageReactionPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionPayload.swift; sourceTree = "<group>"; };
 		8899BC46254305F8003CB98B /* MessageReactionRequestPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionRequestPayload.swift; sourceTree = "<group>"; };
 		8899BC4C25430E40003CB98B /* MessageReactionDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionDTO.swift; sourceTree = "<group>"; };
+		8899BC56254337C7003CB98B /* MessageReactionsMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionsMiddleware.swift; sourceTree = "<group>"; };
 		889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQuery_Tests.swift; sourceTree = "<group>"; };
 		889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQueryDTO_Tests.swift; sourceTree = "<group>"; };
 		88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints.swift; sourceTree = "<group>"; };
@@ -1383,6 +1387,8 @@
 				79896D65250A6D1500BA8F1C /* ChannelReadUpdaterMiddleware_Tests.swift */,
 				F6CCA24C251235F7004C1859 /* ChannelMemberTypingStateUpdaterMiddleware.swift */,
 				F6CCA24E2512491B004C1859 /* ChannelMemberTypingStateUpdaterMiddleware_Tests.swift */,
+				8899BC56254337C7003CB98B /* MessageReactionsMiddleware.swift */,
+				889062422548387D00E1898E /* MessageReactionsMiddleware_Tests.swift */,
 			);
 			path = EventMiddlewares;
 			sourceTree = "<group>";
@@ -2608,6 +2614,7 @@
 				DAE566F725010CA100E39431 /* ChannelWatchStateUpdater.swift in Sources */,
 				88D85D9A252F168B00AE1030 /* MemberController+Combine.swift in Sources */,
 				792A4F462480107A00EAF71D /* ChannelQuery.swift in Sources */,
+				8899BC57254337C7003CB98B /* MessageReactionsMiddleware.swift in Sources */,
 				799C9447247D50F3001F1104 /* Worker.swift in Sources */,
 				79280F782489181200CDEB89 /* URLSessionWebSocketEngine.swift in Sources */,
 				792A4F3C247FFBB400EAF71D /* Timers.swift in Sources */,
@@ -2823,6 +2830,7 @@
 				79DDF81A249CE38B002F4412 /* RequestRecorderURLProtocol.swift in Sources */,
 				8AC9CBE424C74ECB006E236C /* NotificationEvents_Tests.swift in Sources */,
 				79280F8224891C6A00CDEB89 /* VirtualTimer.swift in Sources */,
+				889062432548387D00E1898E /* MessageReactionsMiddleware_Tests.swift in Sources */,
 				DA4EE5B5252B680700CB26D4 /* UserListController+SwiftUI_Tests.swift in Sources */,
 				F61ED5A124F3F58400874777 /* DatabaseContainer_Mock.swift in Sources */,
 				8A0D649824E579AB0017A3C0 /* GuestEndpoints_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -279,6 +279,7 @@
 		889B00E9252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */; };
 		88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */; };
 		88AA92882547332000BFA0C3 /* MessageReactionPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88AA92872547332000BFA0C3 /* MessageReactionPayload.swift */; };
+		88AA928E254735CF00BFA0C3 /* MessageReactionDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88AA928D254735CF00BFA0C3 /* MessageReactionDTO_Tests.swift */; };
 		88BEBCD32536FD7600D9E8B7 /* MemberListController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BEBCD22536FD7600D9E8B7 /* MemberListController+Combine.swift */; };
 		88BEBCD62536FDBF00D9E8B7 /* MemberListController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BEBCD52536FDBF00D9E8B7 /* MemberListController+SwiftUI.swift */; };
 		88BEBCD92536FDDB00D9E8B7 /* MemberListController+Combine_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BEBCD82536FDDB00D9E8B7 /* MemberListController+Combine_Tests.swift */; };
@@ -809,6 +810,7 @@
 		889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQueryDTO_Tests.swift; sourceTree = "<group>"; };
 		88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints.swift; sourceTree = "<group>"; };
 		88AA92872547332000BFA0C3 /* MessageReactionPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionPayload.swift; sourceTree = "<group>"; };
+		88AA928D254735CF00BFA0C3 /* MessageReactionDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionDTO_Tests.swift; sourceTree = "<group>"; };
 		88BEBCD22536FD7600D9E8B7 /* MemberListController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberListController+Combine.swift"; sourceTree = "<group>"; };
 		88BEBCD52536FDBF00D9E8B7 /* MemberListController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberListController+SwiftUI.swift"; sourceTree = "<group>"; };
 		88BEBCD82536FDDB00D9E8B7 /* MemberListController+Combine_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberListController+Combine_Tests.swift"; sourceTree = "<group>"; };
@@ -1246,6 +1248,7 @@
 			isa = PBXGroup;
 			children = (
 				8899BC4C25430E40003CB98B /* MessageReactionDTO.swift */,
+				88AA928D254735CF00BFA0C3 /* MessageReactionDTO_Tests.swift */,
 				799C942D247D2FB9001F1104 /* MessageDTO.swift */,
 				7990503124CEEAA600689CDC /* MessageDTO_Tests.swift */,
 				79877A1F2498E50D00015F8B /* TeamDTO.swift */,
@@ -2772,6 +2775,7 @@
 				79DDF810249CB92E002F4412 /* RequestDecoder_Tests.swift in Sources */,
 				DAE566FA25011A4E00E39431 /* ChannelWatchStateUpdater_Tests.swift in Sources */,
 				8A62706A24BF02D80040BFD6 /* XCTAssertEqual+Difference.swift in Sources */,
+				88AA928E254735CF00BFA0C3 /* MessageReactionDTO_Tests.swift in Sources */,
 				889B00E5252C972C007709A8 /* ChannelMemberListQuery_Tests.swift in Sources */,
 				7931818E24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift in Sources */,
 				F62BE7922506692700D13B86 /* MissingEventsPublisher_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -272,6 +272,7 @@
 		888E8C55252B525300195E03 /* MemberController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C54252B525300195E03 /* MemberController.swift */; };
 		888E8C59252B56A100195E03 /* MemberController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C58252B56A100195E03 /* MemberController_Tests.swift */; };
 		8899BC53254318CC003CB98B /* MessageReaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC52254318CC003CB98B /* MessageReaction.swift */; };
+		8899BC47254305F8003CB98B /* MessageReactionRequestPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC46254305F8003CB98B /* MessageReactionRequestPayload.swift */; };
 		889B00E5252C972C007709A8 /* ChannelMemberListQuery_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */; };
 		889B00E9252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */; };
 		88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */; };
@@ -290,6 +291,7 @@
 		88D85DAE252F468B00AE1030 /* ListDatabaseObserver_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85DAD252F468B00AE1030 /* ListDatabaseObserver_Mock.swift */; };
 		88EA9AD825470F6A007EE76B /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9AD725470F6A007EE76B /* Dictionary+Extensions.swift */; };
 		88EA9AE225471999007EE76B /* Dictionary_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9AE125471999007EE76B /* Dictionary_Tests.swift */; };
+		88EA9AE825471EF4007EE76B /* MessageReactionRequestPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9AE725471EF4007EE76B /* MessageReactionRequestPayload_Tests.swift */; };
 		88EA9AEE254721C0007EE76B /* MessageReactionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9AED254721C0007EE76B /* MessageReactionType.swift */; };
 		88EA9AFC25472269007EE76B /* MessageReactionType_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9AFB25472269007EE76B /* MessageReactionType_Tests.swift */; };
 		88F6DF91252C8845009A8AF0 /* ChannelMemberUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */; };
@@ -793,6 +795,7 @@
 		888E8C54252B525300195E03 /* MemberController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberController.swift; sourceTree = "<group>"; };
 		888E8C58252B56A100195E03 /* MemberController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberController_Tests.swift; sourceTree = "<group>"; };
 		8899BC52254318CC003CB98B /* MessageReaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReaction.swift; sourceTree = "<group>"; };
+		8899BC46254305F8003CB98B /* MessageReactionRequestPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionRequestPayload.swift; sourceTree = "<group>"; };
 		889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQuery_Tests.swift; sourceTree = "<group>"; };
 		889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQueryDTO_Tests.swift; sourceTree = "<group>"; };
 		88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints.swift; sourceTree = "<group>"; };
@@ -811,6 +814,7 @@
 		88D85DAD252F468B00AE1030 /* ListDatabaseObserver_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListDatabaseObserver_Mock.swift; sourceTree = "<group>"; };
 		88EA9AD725470F6A007EE76B /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extensions.swift"; sourceTree = "<group>"; };
 		88EA9AE125471999007EE76B /* Dictionary_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dictionary_Tests.swift; sourceTree = "<group>"; };
+		88EA9AE725471EF4007EE76B /* MessageReactionRequestPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionRequestPayload_Tests.swift; sourceTree = "<group>"; };
 		88EA9AED254721C0007EE76B /* MessageReactionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionType.swift; sourceTree = "<group>"; };
 		88EA9AFB25472269007EE76B /* MessageReactionType_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionType_Tests.swift; sourceTree = "<group>"; };
 		88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater.swift; sourceTree = "<group>"; };
@@ -2025,6 +2029,8 @@
 				F62BE7862506525700D13B86 /* MissingEventsRequestBody_Tests.swift */,
 				888E8C4D252B4B1C00195E03 /* ChannelMemberBanRequestPayload.swift */,
 				888E8C50252B4BAB00195E03 /* ChannelMemberBanRequestPayload_Tests.swift */,
+				8899BC46254305F8003CB98B /* MessageReactionRequestPayload.swift */,
+				88EA9AE725471EF4007EE76B /* MessageReactionRequestPayload_Tests.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -2462,6 +2468,7 @@
 				F63CC36F24E591840052844D /* EventObserver.swift in Sources */,
 				DA84070925250528005A0F62 /* UserEndpoints.swift in Sources */,
 				8A0D649724E579A50017A3C0 /* GuestEndpoints.swift in Sources */,
+				8899BC47254305F8003CB98B /* MessageReactionRequestPayload.swift in Sources */,
 				8A62705024B867190040BFD6 /* EventPayload.swift in Sources */,
 				F6778F9A24F5144F005E7D22 /* EventNotificationCenter.swift in Sources */,
 				8AE335A924FCF999002B6677 /* InternetConnection.swift in Sources */,
@@ -2688,6 +2695,7 @@
 				8A0D64AE24E5853F0017A3C0 /* DataController_Tests.swift in Sources */,
 				8A0C3BC924C0BBAB00CAFD19 /* UserEvents_Tests.swift in Sources */,
 				F62BE78325062FC400D13B86 /* SyncEndpoint_Tests.swift in Sources */,
+				88EA9AE825471EF4007EE76B /* MessageReactionRequestPayload_Tests.swift in Sources */,
 				F63CC37524E592DD0052844D /* MemberEventObserver_Tests.swift in Sources */,
 				792FCB4724A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift in Sources */,
 				797EEA4A24FFC37600C81203 /* ConnectionStatus_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -289,6 +289,8 @@
 		88D85DAE252F468B00AE1030 /* ListDatabaseObserver_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85DAD252F468B00AE1030 /* ListDatabaseObserver_Mock.swift */; };
 		88EA9AD825470F6A007EE76B /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9AD725470F6A007EE76B /* Dictionary+Extensions.swift */; };
 		88EA9AE225471999007EE76B /* Dictionary_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9AE125471999007EE76B /* Dictionary_Tests.swift */; };
+		88EA9AEE254721C0007EE76B /* MessageReactionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9AED254721C0007EE76B /* MessageReactionType.swift */; };
+		88EA9AFC25472269007EE76B /* MessageReactionType_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9AFB25472269007EE76B /* MessageReactionType_Tests.swift */; };
 		88F6DF91252C8845009A8AF0 /* ChannelMemberUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */; };
 		88F6DF94252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */; };
 		88F6DF97252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF96252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift */; };
@@ -807,6 +809,8 @@
 		88D85DAD252F468B00AE1030 /* ListDatabaseObserver_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListDatabaseObserver_Mock.swift; sourceTree = "<group>"; };
 		88EA9AD725470F6A007EE76B /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extensions.swift"; sourceTree = "<group>"; };
 		88EA9AE125471999007EE76B /* Dictionary_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dictionary_Tests.swift; sourceTree = "<group>"; };
+		88EA9AED254721C0007EE76B /* MessageReactionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionType.swift; sourceTree = "<group>"; };
+		88EA9AFB25472269007EE76B /* MessageReactionType_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionType_Tests.swift; sourceTree = "<group>"; };
 		88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater.swift; sourceTree = "<group>"; };
 		88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater_Tests.swift; sourceTree = "<group>"; };
 		88F6DF96252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater_Mock.swift; sourceTree = "<group>"; };
@@ -1541,6 +1545,8 @@
 				794927EC249E0BE2009D7EB7 /* ExtraData.swift */,
 				8AAB1C6524CB39F2009B783F /* UnreadCount.swift */,
 				7900452525374CA20096ECA1 /* User+SwiftUI.swift */,
+				88EA9AED254721C0007EE76B /* MessageReactionType.swift */,
+				88EA9AFB25472269007EE76B /* MessageReactionType_Tests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2458,6 +2464,7 @@
 				8AE335A924FCF999002B6677 /* InternetConnection.swift in Sources */,
 				F6ED5F7A2502791F005D7327 /* MissingEventsPayload.swift in Sources */,
 				792A4F40247FFDE700EAF71D /* Data+Gzip.swift in Sources */,
+				88EA9AEE254721C0007EE76B /* MessageReactionType.swift in Sources */,
 				79E2B84024CAC8D60024752F /* ListDatabaseObserver.swift in Sources */,
 				796610B9248E651800761629 /* EventMiddleware.swift in Sources */,
 				7964F3B9249A314D002A09EC /* BaseLogDestination.swift in Sources */,
@@ -2747,6 +2754,7 @@
 				79CD959424F9381700E87377 /* MulticastDelegate_Tests.swift in Sources */,
 				792921C724C047DD00116BBB /* APIClient_Mock.swift in Sources */,
 				DAD5C836250278AD0045117A /* ChannelController+Combine_Tests.swift in Sources */,
+				88EA9AFC25472269007EE76B /* MessageReactionType_Tests.swift in Sources */,
 				79A0E9BC2498C31A00E9BD50 /* TypingStartCleanupMiddleware_Tests.swift in Sources */,
 				796610BB248E687000761629 /* EventMiddleware_Tests.swift in Sources */,
 				DA15A20424DF257500BE2423 /* ChannelQuery_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -287,6 +287,8 @@
 		88D85DA7252F3C1D00AE1030 /* MemberListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85DA6252F3C1D00AE1030 /* MemberListController.swift */; };
 		88D85DAB252F3C2A00AE1030 /* MemberListController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85DAA252F3C2A00AE1030 /* MemberListController_Tests.swift */; };
 		88D85DAE252F468B00AE1030 /* ListDatabaseObserver_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85DAD252F468B00AE1030 /* ListDatabaseObserver_Mock.swift */; };
+		88EA9AD825470F6A007EE76B /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9AD725470F6A007EE76B /* Dictionary+Extensions.swift */; };
+		88EA9AE225471999007EE76B /* Dictionary_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9AE125471999007EE76B /* Dictionary_Tests.swift */; };
 		88F6DF91252C8845009A8AF0 /* ChannelMemberUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */; };
 		88F6DF94252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */; };
 		88F6DF97252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF96252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift */; };
@@ -803,6 +805,8 @@
 		88D85DA6252F3C1D00AE1030 /* MemberListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberListController.swift; sourceTree = "<group>"; };
 		88D85DAA252F3C2A00AE1030 /* MemberListController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberListController_Tests.swift; sourceTree = "<group>"; };
 		88D85DAD252F468B00AE1030 /* ListDatabaseObserver_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListDatabaseObserver_Mock.swift; sourceTree = "<group>"; };
+		88EA9AD725470F6A007EE76B /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extensions.swift"; sourceTree = "<group>"; };
+		88EA9AE125471999007EE76B /* Dictionary_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dictionary_Tests.swift; sourceTree = "<group>"; };
 		88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater.swift; sourceTree = "<group>"; };
 		88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater_Tests.swift; sourceTree = "<group>"; };
 		88F6DF96252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater_Mock.swift; sourceTree = "<group>"; };
@@ -1280,6 +1284,8 @@
 				79CD959124F9380B00E87377 /* MulticastDelegate.swift */,
 				79CD959324F9381700E87377 /* MulticastDelegate_Tests.swift */,
 				7985BDA9252B1E53002B8C30 /* MainQueue+Synchronous.swift */,
+				88EA9AD725470F6A007EE76B /* Dictionary+Extensions.swift */,
+				88EA9AE125471999007EE76B /* Dictionary_Tests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2532,6 +2538,7 @@
 				79877A182498E4EE00015F8B /* ChannelEndpoints.swift in Sources */,
 				7964F3BA249A314D002A09EC /* LogDestination.swift in Sources */,
 				F63CC37324E592D30052844D /* MemberEventObserver.swift in Sources */,
+				88EA9AD825470F6A007EE76B /* Dictionary+Extensions.swift in Sources */,
 				8AE335A824FCF999002B6677 /* Reachability_Vendor.swift in Sources */,
 				79877A0C2498E4BC00015F8B /* ChannelType.swift in Sources */,
 				88D85DA7252F3C1D00AE1030 /* MemberListController.swift in Sources */,
@@ -2691,6 +2698,7 @@
 				799C945C247D59D8001F1104 /* ChatClient_Tests.swift in Sources */,
 				79BA19F324B3386B00E11FC2 /* CurrentUserDTO_Tests.swift in Sources */,
 				888E8C59252B56A100195E03 /* MemberController_Tests.swift in Sources */,
+				88EA9AE225471999007EE76B /* Dictionary_Tests.swift in Sources */,
 				8819DFE625262B1500FD1A50 /* UserController_Tests.swift in Sources */,
 				F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */,
 				79280F7D24891B1300CDEB89 /* WebSocketEngine_Mock.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		888E8C51252B4BAB00195E03 /* ChannelMemberBanRequestPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C50252B4BAB00195E03 /* ChannelMemberBanRequestPayload_Tests.swift */; };
 		888E8C55252B525300195E03 /* MemberController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C54252B525300195E03 /* MemberController.swift */; };
 		888E8C59252B56A100195E03 /* MemberController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C58252B56A100195E03 /* MemberController_Tests.swift */; };
+		8899BC53254318CC003CB98B /* MessageReaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC52254318CC003CB98B /* MessageReaction.swift */; };
 		889B00E5252C972C007709A8 /* ChannelMemberListQuery_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */; };
 		889B00E9252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */; };
 		88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */; };
@@ -791,6 +792,7 @@
 		888E8C50252B4BAB00195E03 /* ChannelMemberBanRequestPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberBanRequestPayload_Tests.swift; sourceTree = "<group>"; };
 		888E8C54252B525300195E03 /* MemberController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberController.swift; sourceTree = "<group>"; };
 		888E8C58252B56A100195E03 /* MemberController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberController_Tests.swift; sourceTree = "<group>"; };
+		8899BC52254318CC003CB98B /* MessageReaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReaction.swift; sourceTree = "<group>"; };
 		889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQuery_Tests.swift; sourceTree = "<group>"; };
 		889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQueryDTO_Tests.swift; sourceTree = "<group>"; };
 		88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints.swift; sourceTree = "<group>"; };
@@ -1545,6 +1547,7 @@
 				794927EC249E0BE2009D7EB7 /* ExtraData.swift */,
 				8AAB1C6524CB39F2009B783F /* UnreadCount.swift */,
 				7900452525374CA20096ECA1 /* User+SwiftUI.swift */,
+				8899BC52254318CC003CB98B /* MessageReaction.swift */,
 				88EA9AED254721C0007EE76B /* MessageReactionType.swift */,
 				88EA9AFB25472269007EE76B /* MessageReactionType_Tests.swift */,
 			);
@@ -2607,6 +2610,7 @@
 				799C945E247D7283001F1104 /* DatabaseContainer.swift in Sources */,
 				79877A092498E4BC00015F8B /* User.swift in Sources */,
 				79B5517324E593C200CE9FEC /* UserPayloads.swift in Sources */,
+				8899BC53254318CC003CB98B /* MessageReaction.swift in Sources */,
 				DA99D0D024ED63C600AD5354 /* NewChannelQueryUpdater.swift in Sources */,
 				8A0175F02501174000570345 /* EventSender.swift in Sources */,
 				F6FF1DAA24FD23D300151735 /* MessageEndpoints.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		889B00E5252C972C007709A8 /* ChannelMemberListQuery_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */; };
 		889B00E9252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */; };
 		88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */; };
+		88AA92882547332000BFA0C3 /* MessageReactionPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88AA92872547332000BFA0C3 /* MessageReactionPayload.swift */; };
 		88BEBCD32536FD7600D9E8B7 /* MemberListController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BEBCD22536FD7600D9E8B7 /* MemberListController+Combine.swift */; };
 		88BEBCD62536FDBF00D9E8B7 /* MemberListController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BEBCD52536FDBF00D9E8B7 /* MemberListController+SwiftUI.swift */; };
 		88BEBCD92536FDDB00D9E8B7 /* MemberListController+Combine_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BEBCD82536FDDB00D9E8B7 /* MemberListController+Combine_Tests.swift */; };
@@ -805,6 +806,7 @@
 		889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQuery_Tests.swift; sourceTree = "<group>"; };
 		889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQueryDTO_Tests.swift; sourceTree = "<group>"; };
 		88A00DCF2525F08000259AB4 /* ModerationEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints.swift; sourceTree = "<group>"; };
+		88AA92872547332000BFA0C3 /* MessageReactionPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionPayload.swift; sourceTree = "<group>"; };
 		88BEBCD22536FD7600D9E8B7 /* MemberListController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberListController+Combine.swift"; sourceTree = "<group>"; };
 		88BEBCD52536FDBF00D9E8B7 /* MemberListController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberListController+SwiftUI.swift"; sourceTree = "<group>"; };
 		88BEBCD82536FDDB00D9E8B7 /* MemberListController+Combine_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberListController+Combine_Tests.swift"; sourceTree = "<group>"; };
@@ -1157,6 +1159,7 @@
 				8836133725274F5F003CB958 /* ExtraData.swift */,
 				8836133B25275170003CB958 /* MutedUserPayload.swift */,
 				799B5DC4253081C900C108FB /* DevicePayloads.swift */,
+				88AA92872547332000BFA0C3 /* MessageReactionPayload.swift */,
 			);
 			path = "Dummy data";
 			sourceTree = "<group>";
@@ -2758,6 +2761,7 @@
 				79DDF812249CD5AC002F4412 /* APIClient_Tests.swift in Sources */,
 				DA7229E424E140600074503A /* ChannelEditDetailPayload_Tests.swift in Sources */,
 				799C9462247D78E2001F1104 /* Await.swift in Sources */,
+				88AA92882547332000BFA0C3 /* MessageReactionPayload.swift in Sources */,
 				8A0D64A924E57A560017A3C0 /* GuestUserTokenRequestPayload_Tests.swift in Sources */,
 				79280F732487CD3100CDEB89 /* Atomic_Tests.swift in Sources */,
 				7964F3BE249A5E6E002A09EC /* RequestEncoder_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -272,6 +272,7 @@
 		888E8C55252B525300195E03 /* MemberController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C54252B525300195E03 /* MemberController.swift */; };
 		888E8C59252B56A100195E03 /* MemberController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C58252B56A100195E03 /* MemberController_Tests.swift */; };
 		8899BC53254318CC003CB98B /* MessageReaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC52254318CC003CB98B /* MessageReaction.swift */; };
+		8899BC3F2542FFA1003CB98B /* MessageReactionPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC3E2542FFA1003CB98B /* MessageReactionPayload.swift */; };
 		8899BC47254305F8003CB98B /* MessageReactionRequestPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8899BC46254305F8003CB98B /* MessageReactionRequestPayload.swift */; };
 		889B00E5252C972C007709A8 /* ChannelMemberListQuery_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */; };
 		889B00E9252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */; };
@@ -294,6 +295,10 @@
 		88EA9AE825471EF4007EE76B /* MessageReactionRequestPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9AE725471EF4007EE76B /* MessageReactionRequestPayload_Tests.swift */; };
 		88EA9AEE254721C0007EE76B /* MessageReactionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9AED254721C0007EE76B /* MessageReactionType.swift */; };
 		88EA9AFC25472269007EE76B /* MessageReactionType_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9AFB25472269007EE76B /* MessageReactionType_Tests.swift */; };
+		88EA9B0625472430007EE76B /* MessageReactionPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EA9B0525472430007EE76B /* MessageReactionPayload_Tests.swift */; };
+		88EA9B0F2547271B007EE76B /* MessageReactionPayload+NoExtraData.json in Resources */ = {isa = PBXBuildFile; fileRef = 88EA9B0C2547271B007EE76B /* MessageReactionPayload+NoExtraData.json */; };
+		88EA9B102547271B007EE76B /* MessageReactionPayload+CustomExtraData.json in Resources */ = {isa = PBXBuildFile; fileRef = 88EA9B0D2547271B007EE76B /* MessageReactionPayload+CustomExtraData.json */; };
+		88EA9B112547271B007EE76B /* MessageReactionPayload+DefaultExtraData.json in Resources */ = {isa = PBXBuildFile; fileRef = 88EA9B0E2547271B007EE76B /* MessageReactionPayload+DefaultExtraData.json */; };
 		88F6DF91252C8845009A8AF0 /* ChannelMemberUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */; };
 		88F6DF94252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */; };
 		88F6DF97252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6DF96252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift */; };
@@ -795,6 +800,7 @@
 		888E8C54252B525300195E03 /* MemberController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberController.swift; sourceTree = "<group>"; };
 		888E8C58252B56A100195E03 /* MemberController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberController_Tests.swift; sourceTree = "<group>"; };
 		8899BC52254318CC003CB98B /* MessageReaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReaction.swift; sourceTree = "<group>"; };
+		8899BC3E2542FFA1003CB98B /* MessageReactionPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionPayload.swift; sourceTree = "<group>"; };
 		8899BC46254305F8003CB98B /* MessageReactionRequestPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionRequestPayload.swift; sourceTree = "<group>"; };
 		889B00E4252C972C007709A8 /* ChannelMemberListQuery_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQuery_Tests.swift; sourceTree = "<group>"; };
 		889B00E8252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListQueryDTO_Tests.swift; sourceTree = "<group>"; };
@@ -817,6 +823,10 @@
 		88EA9AE725471EF4007EE76B /* MessageReactionRequestPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionRequestPayload_Tests.swift; sourceTree = "<group>"; };
 		88EA9AED254721C0007EE76B /* MessageReactionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionType.swift; sourceTree = "<group>"; };
 		88EA9AFB25472269007EE76B /* MessageReactionType_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionType_Tests.swift; sourceTree = "<group>"; };
+		88EA9B0525472430007EE76B /* MessageReactionPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageReactionPayload_Tests.swift; sourceTree = "<group>"; };
+		88EA9B0C2547271B007EE76B /* MessageReactionPayload+NoExtraData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "MessageReactionPayload+NoExtraData.json"; sourceTree = "<group>"; };
+		88EA9B0D2547271B007EE76B /* MessageReactionPayload+CustomExtraData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "MessageReactionPayload+CustomExtraData.json"; sourceTree = "<group>"; };
+		88EA9B0E2547271B007EE76B /* MessageReactionPayload+DefaultExtraData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "MessageReactionPayload+DefaultExtraData.json"; sourceTree = "<group>"; };
 		88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater.swift; sourceTree = "<group>"; };
 		88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater_Tests.swift; sourceTree = "<group>"; };
 		88F6DF96252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUpdater_Mock.swift; sourceTree = "<group>"; };
@@ -1398,6 +1408,8 @@
 				790A4C4D252E0901001F4A23 /* DevicePayloads_Tests.swift */,
 				8836FFBA2540741D009FDF73 /* FlagUserPayload.swift */,
 				8836FFC225408210009FDF73 /* FlagUserPayload_Tests.swift */,
+				8899BC3E2542FFA1003CB98B /* MessageReactionPayload.swift */,
+				88EA9B0525472430007EE76B /* MessageReactionPayload_Tests.swift */,
 			);
 			path = Payloads;
 			sourceTree = "<group>";
@@ -1415,6 +1427,7 @@
 				798779F92498E47700015F8B /* CurrentUser.json */,
 				798779FA2498E47700015F8B /* ChannelsQuery.json */,
 				DA8407252525E90D005A0F62 /* UsersQuery.json */,
+				88EA9B0B254726F6007EE76B /* MessageReaction */,
 				88F896F52541AC0900DE517D /* FlagMessage */,
 				8836FFCF254082FF009FDF73 /* FlagUser */,
 				F62BE7882506616900D13B86 /* Sync */,
@@ -1776,6 +1789,16 @@
 				88BEBCD82536FDDB00D9E8B7 /* MemberListController+Combine_Tests.swift */,
 			);
 			path = MemberListController;
+			sourceTree = "<group>";
+		};
+		88EA9B0B254726F6007EE76B /* MessageReaction */ = {
+			isa = PBXGroup;
+			children = (
+				88EA9B0D2547271B007EE76B /* MessageReactionPayload+CustomExtraData.json */,
+				88EA9B0E2547271B007EE76B /* MessageReactionPayload+DefaultExtraData.json */,
+				88EA9B0C2547271B007EE76B /* MessageReactionPayload+NoExtraData.json */,
+			);
+			path = MessageReaction;
 			sourceTree = "<group>";
 		};
 		88F896F52541AC0900DE517D /* FlagMessage */ = {
@@ -2321,6 +2344,7 @@
 				88F896F92541AC0900DE517D /* FlagMessagePayload+NoExtraData.json in Resources */,
 				8A0CC9ED24C602B600705CF9 /* MemberRemoved.json in Resources */,
 				8A0C3BC724C0AEDB00CAFD19 /* UserBanned.json in Resources */,
+				88EA9B112547271B007EE76B /* MessageReactionPayload+DefaultExtraData.json in Resources */,
 				8A0D64A424E57A260017A3C0 /* GuestUser+CustomExtraData.json in Resources */,
 				8AC9CBDE24C74DD0006E236C /* NotificationMutesUpdated.json in Resources */,
 				798779FF2498E47700015F8B /* ChannelsQuery.json in Resources */,
@@ -2328,8 +2352,10 @@
 				79F3ABEA24EAB9CD00AB9505 /* Message.json in Resources */,
 				8A0C3BDC24C1F18700CAFD19 /* MessageNew.json in Resources */,
 				8A62706224BE35E40040BFD6 /* UserStartTyping.json in Resources */,
+				88EA9B102547271B007EE76B /* MessageReactionPayload+CustomExtraData.json in Resources */,
 				7908824B25432CC600896F03 /* StreamChatTestPlan.xctestplan in Resources */,
 				8A0C3BDE24C1F18700CAFD19 /* MessageDeleted.json in Resources */,
+				88EA9B0F2547271B007EE76B /* MessageReactionPayload+NoExtraData.json in Resources */,
 				882C5752252C770900E60C44 /* ChannelMembersQuery.json in Resources */,
 				8A0C3BC524C0AEDB00CAFD19 /* UserStartWatching.json in Resources */,
 				8A0D64A324E57A260017A3C0 /* GuestUser+NoExtraData.json in Resources */,
@@ -2495,6 +2521,7 @@
 				7964F3B8249A314D002A09EC /* ConsoleLogDestination.swift in Sources */,
 				799C9445247D3DD2001F1104 /* WebSocketClient.swift in Sources */,
 				DA640FBB2535CF8500D32944 /* ChannelListSortingKey.swift in Sources */,
+				8899BC3F2542FFA1003CB98B /* MessageReactionPayload.swift in Sources */,
 				797A756624814EF8003CF16D /* SystemEnvironment.swift in Sources */,
 				799C9438247D2FB9001F1104 /* ChatClientConfig.swift in Sources */,
 				7964F3B6249A314D002A09EC /* PrefixLogFormatter.swift in Sources */,
@@ -2741,6 +2768,7 @@
 				7931818E24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift in Sources */,
 				F62BE7922506692700D13B86 /* MissingEventsPublisher_Tests.swift in Sources */,
 				79200D42250118A1002F4EB1 /* iOS13TestCase.swift in Sources */,
+				88EA9B0625472430007EE76B /* MessageReactionPayload_Tests.swift in Sources */,
 				88D85DAE252F468B00AE1030 /* ListDatabaseObserver_Mock.swift in Sources */,
 				79877A292498E51500015F8B /* ChannelDTO_Tests.swift in Sources */,
 				DAEAF4B824DC026C0015FB28 /* ChannelEndpoints_Tests.swift in Sources */,

--- a/Tests_v3/Dummy data/MessagePayload.swift
+++ b/Tests_v3/Dummy data/MessagePayload.swift
@@ -13,7 +13,9 @@ extension MessagePayload {
         showReplyInChannel: Bool = false,
         authorUserId: UserId,
         text: String = .unique,
-        extraData: T.Message = .defaultValue
+        extraData: T.Message = .defaultValue,
+        latestReactions: [MessageReactionPayload<T>] = [],
+        ownReactions: [MessageReactionPayload<T>] = []
     ) -> MessagePayload<T> where T.User == NameAndImageExtraData {
         .init(
             id: messageId,
@@ -30,6 +32,8 @@ extension MessagePayload {
             mentionedUsers: [UserPayload.dummy(userId: .unique)],
             replyCount: .random(in: 0...1000),
             extraData: extraData,
+            latestReactions: latestReactions,
+            ownReactions: ownReactions,
             reactionScores: ["like": 1],
             isSilent: true
         )

--- a/Tests_v3/Dummy data/MessageReactionPayload.swift
+++ b/Tests_v3/Dummy data/MessageReactionPayload.swift
@@ -1,0 +1,25 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import Foundation
+
+extension MessageReactionPayload {
+    static func dummy<T: ExtraDataTypes>(
+        type: MessageReactionType = .init(rawValue: .unique),
+        messageId: String,
+        user: UserPayload<T.User>,
+        extraData: T.MessageReaction = .defaultValue
+    ) -> MessageReactionPayload<T> {
+        .init(
+            type: type,
+            score: .random(in: 0...10),
+            messageId: messageId,
+            createdAt: .unique,
+            updatedAt: .unique,
+            user: user,
+            extraData: extraData
+        )
+    }
+}

--- a/Tests_v3/MockEnpointResponses/MessageReaction/MessageReactionPayload+CustomExtraData.json
+++ b/Tests_v3/MockEnpointResponses/MessageReaction/MessageReactionPayload+CustomExtraData.json
@@ -1,0 +1,26 @@
+{
+    "score" : 1,
+    "message_id" : "7baa1533-3294-4c0c-9a62-c9d0928bf733",
+    "created_at" : "2020-08-17T13:15:39.892884Z",
+    "user_id" : "broken-waterfall-5",
+    "type" : "love",
+    "updated_at" : "2020-08-17T13:15:39.892884Z",
+    "mood" : "good one",
+    "user" : {
+        "id" : "broken-waterfall-5",
+        "banned" : false,
+        "unread_channels" : 0,
+        "totalUnreadCount" : 0,
+        "last_active" : "2020-08-17T13:00:51.509134Z",
+        "created_at" : "2019-12-12T15:33:46.488935Z",
+        "invisible" : false,
+        "unreadChannels" : 0,
+        "unread_count" : 0,
+        "image" : "https:\/\/s3.amazonaws.com\/100no-pic.png",
+        "updated_at" : "2020-08-17T13:15:27.5564Z",
+        "role" : "user",
+        "total_unread_count" : 0,
+        "online" : true,
+        "name" : "John Doe"
+    }
+}

--- a/Tests_v3/MockEnpointResponses/MessageReaction/MessageReactionPayload+DefaultExtraData.json
+++ b/Tests_v3/MockEnpointResponses/MessageReaction/MessageReactionPayload+DefaultExtraData.json
@@ -1,0 +1,25 @@
+{
+    "score" : 1,
+    "message_id" : "7baa1533-3294-4c0c-9a62-c9d0928bf733",
+    "created_at" : "2020-08-17T13:15:39.892884Z",
+    "user_id" : "broken-waterfall-5",
+    "type" : "love",
+    "updated_at" : "2020-08-17T13:15:39.892884Z",
+    "user" : {
+        "id" : "broken-waterfall-5",
+        "banned" : false,
+        "unread_channels" : 0,
+        "totalUnreadCount" : 0,
+        "last_active" : "2020-08-17T13:00:51.509134Z",
+        "created_at" : "2019-12-12T15:33:46.488935Z",
+        "invisible" : false,
+        "unreadChannels" : 0,
+        "unread_count" : 0,
+        "image" : "https:\/\/s3.amazonaws.com\/100no-pic.png",
+        "updated_at" : "2020-08-17T13:15:27.5564Z",
+        "role" : "user",
+        "total_unread_count" : 0,
+        "online" : true,
+        "name" : "John Doe"
+    }
+}

--- a/Tests_v3/MockEnpointResponses/MessageReaction/MessageReactionPayload+NoExtraData.json
+++ b/Tests_v3/MockEnpointResponses/MessageReaction/MessageReactionPayload+NoExtraData.json
@@ -1,0 +1,23 @@
+{
+    "score" : 1,
+    "message_id" : "7baa1533-3294-4c0c-9a62-c9d0928bf733",
+    "created_at" : "2020-08-17T13:15:39.892884Z",
+    "user_id" : "broken-waterfall-5",
+    "type" : "love",
+    "updated_at" : "2020-08-17T13:15:39.892884Z",
+    "user" : {
+        "id" : "broken-waterfall-5",
+        "banned" : false,
+        "unread_channels" : 0,
+        "totalUnreadCount" : 0,
+        "last_active" : "2020-08-17T13:00:51.509134Z",
+        "created_at" : "2019-12-12T15:33:46.488935Z",
+        "invisible" : false,
+        "unreadChannels" : 0,
+        "unread_count" : 0,
+        "updated_at" : "2020-08-17T13:15:27.5564Z",
+        "role" : "user",
+        "total_unread_count" : 0,
+        "online" : true,
+    }
+}


### PR DESCRIPTION
**This PR**:
- exposes `addReaction/deleteReaction` by `MessageController`
- updates `MessageDTO` and `ChatMessage` to have reactions info
- introduces DTO and model for `MessageReaction`
- introduces generic `MessageReactionPayload` and makes use of it
- introduce `MessageReactionsMiddleware` that listens for reaction events and updated the database accordingly

