### PR TITLE
Sample v3: Use non-inverted LazyVStack in SwiftUI sample's ChatView

### DIFF
--- a/Sample_v3/Base.lproj/Main.storyboard
+++ b/Sample_v3/Base.lproj/Main.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
@@ -203,11 +203,13 @@ struct ChannelListView: View {
     }
     
     private func chatView(for index: Int) -> ChatView {
-        ChatView(
-            channel: channelList.controller.client.channelController(
-                for: channelList.channels[index].cid
-            ).observableObject
+        let channelController = channelList.controller.client.channelController(
+            for: channelList.channels[index].cid
         )
+        
+        channelController.listOrdering = .bottomToTop
+        
+        return ChatView(channel: channelController.observableObject)
     }
     
     private func openDirectMessages(with userId: UserId) {

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChatScrollView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChatScrollView.swift
@@ -4,7 +4,8 @@
 
 import SwiftUI
 
-@available(iOS 13, *)
+/// `ChatScrollView` implements the bottom-to-top scrolling behavior common to chats.
+@available(iOS 14, *)
 struct ChatScrollView<Content>: View where Content: View {
     var content: () -> Content
 
@@ -90,7 +91,7 @@ extension ViewHeightKey: ViewModifier {
     }
 }
 
-@available(iOS 13, *)
+@available(iOS 14, *)
 extension View {
     func onKeyboardAppear(_ callback: @escaping () -> Void) -> some View {
         onAppear {

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChatScrollView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChatScrollView.swift
@@ -1,0 +1,103 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import SwiftUI
+
+@available(iOS 13, *)
+struct ChatScrollView<Content>: View where Content: View {
+    var content: () -> Content
+
+    @State private var contentHeight: CGFloat = .zero
+    @State private var contentOffset: CGFloat = .zero
+    @State private var scrollOffset: CGFloat = .zero
+
+    var body: some View {
+        GeometryReader { geometry in
+            self.vertical(geometry: geometry)
+        }
+        .clipped()
+    }
+
+    private func vertical(geometry: GeometryProxy) -> some View {
+        VStack {
+            content()
+        }
+        .modifier(ViewHeightKey())
+        .onPreferenceChange(ViewHeightKey.self) {
+            self.updateHeight(with: $0, outerHeight: geometry.size.height)
+        }
+        .frame(height: geometry.size.height, alignment: .bottom)
+        .offset(y: contentOffset + scrollOffset)
+        .animation(.easeInOut)
+        .background(Color.white)
+        .gesture(
+            DragGesture()
+                .onChanged { self.onDragChanged($0) }
+                .onEnded { self.onDragEnded($0, outerHeight: geometry.size.height) }
+        )
+    }
+
+    private func onDragChanged(_ value: DragGesture.Value) {
+        scrollOffset = value.location.y - value.startLocation.y
+    }
+
+    private func onDragEnded(_ value: DragGesture.Value, outerHeight: CGFloat) {
+        let scrollOffset = value.predictedEndLocation.y - value.startLocation.y
+
+        updateOffset(with: scrollOffset, outerHeight: outerHeight)
+        self.scrollOffset = 0
+    }
+
+    private func updateHeight(with height: CGFloat, outerHeight: CGFloat) {
+        let delta = contentHeight - height
+        contentHeight = height
+        if abs(contentOffset) > .zero {
+            updateOffset(with: delta, outerHeight: outerHeight)
+        }
+    }
+
+    private func updateOffset(with delta: CGFloat, outerHeight: CGFloat) {
+        let topLimit = contentHeight - outerHeight
+
+        if topLimit < .zero {
+            contentOffset = .zero
+        } else {
+            var proposedOffset = contentOffset + delta
+            if proposedOffset < .zero {
+                proposedOffset = 0
+            } else if proposedOffset > topLimit {
+                proposedOffset = topLimit
+            }
+            contentOffset = proposedOffset
+        }
+    }
+}
+
+struct ViewHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat { 0 }
+    static func reduce(value: inout Value, nextValue: () -> Value) {
+        value = value + nextValue()
+    }
+}
+
+@available(iOS 13, *)
+extension ViewHeightKey: ViewModifier {
+    func body(content: Content) -> some View {
+        content.background(GeometryReader { proxy in
+            Color.clear.preference(key: Self.self, value: proxy.size.height)
+        })
+    }
+}
+
+@available(iOS 13, *)
+extension View {
+    func onKeyboardAppear(_ callback: @escaping () -> Void) -> some View {
+        onAppear {
+            NotificationCenter.default
+                .addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: .main) { _ in
+                    callback()
+                }
+        }
+    }
+}

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChatScrollView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChatScrollView.swift
@@ -31,7 +31,6 @@ struct ChatScrollView<Content>: View where Content: View {
         .frame(height: geometry.size.height, alignment: .bottom)
         .offset(y: contentOffset + scrollOffset)
         .animation(.easeInOut)
-        .background(Color.white)
         .gesture(
             DragGesture()
                 .onChanged { self.onDragChanged($0) }

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
@@ -48,12 +48,17 @@ struct ChatView: View {
     }
     
     func messageList() -> some View {
-        List(channel.messages, id: \.self) { message in
-            self.messageView(for: message)
+        ChatScrollView {
+            ScrollViewReader { scrollView in
+                LazyVStack(alignment: .leading) {
+                    ForEach(channel.messages, id: \.self) { message in
+                        self.messageView(for: message)
+                    }
+                }.onKeyboardAppear {
+                    scrollView.scrollTo(channel.messages[0])
+                }
+            }
         }
-        /// Flipping `List` upside down so messages are displayed from bottom to top.
-        .scaleEffect(x: 1, y: -1, anchor: .center)
-        .offset(x: 0, y: 2)
     }
     
     func messageView(for message: ChatMessage) -> some View {
@@ -70,14 +75,13 @@ struct ChatView: View {
         }
         
         return text
+            .padding()
             .contextMenu {
                 messageContextMenu(for: message)
             }
-            /// We have flipped `List` with messages upside down so now we need to flip each message view.
-            .scaleEffect(x: 1, y: -1, anchor: .center)
             /// Load next more messages when the last is shown.
             .onAppear {
-                if (self.channel.messages.last == message) {
+                if (self.channel.messages.first == message) {
                     self.channel.controller.loadPreviousMessages()
                 }
             }

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
@@ -55,6 +55,8 @@ struct ChatView: View {
                         self.messageView(for: message)
                     }
                 }.onKeyboardAppear {
+                    /// When the keyboard appears, we scroll to the latest message.
+                    /// This resembles the behavior in Apple's Messages app.
                     scrollView.scrollTo(channel.messages[0])
                 }
             }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		805A11492506FBBD0089DFC4 /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805A11472506FBB30089DFC4 /* UIViewController+Alert.swift */; };
 		80C6026F2514281000A6B714 /* UITableViewController+Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */; };
 		80C6027B25157E4D00A6B714 /* View+AlertTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */; };
+		80D880432546553500908B7B /* ChatScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D880422546553500908B7B /* ChatScrollView.swift */; };
 		8819DFCF2525F3C600FD1A50 /* UserUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFCE2525F3C600FD1A50 /* UserUpdater.swift */; };
 		8819DFD52525F49D00FD1A50 /* UserController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFD42525F49D00FD1A50 /* UserController.swift */; };
 		8819DFDE252622D900FD1A50 /* ModerationEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFDD252622D900FD1A50 /* ModerationEndpoints_Tests.swift */; };
@@ -722,6 +723,7 @@
 		805A11472506FBB30089DFC4 /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewController+Cells.swift"; sourceTree = "<group>"; };
 		80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AlertTextField.swift"; sourceTree = "<group>"; };
+		80D880422546553500908B7B /* ChatScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScrollView.swift; sourceTree = "<group>"; };
 		8819DFCE2525F3C600FD1A50 /* UserUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater.swift; sourceTree = "<group>"; };
 		8819DFD42525F49D00FD1A50 /* UserController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserController.swift; sourceTree = "<group>"; };
 		8819DFDD252622D900FD1A50 /* ModerationEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModerationEndpoints_Tests.swift; sourceTree = "<group>"; };
@@ -1613,6 +1615,7 @@
 		8008C19724F7EE0300F5BCCE /* SwiftUISimpleChat */ = {
 			isa = PBXGroup;
 			children = (
+				80D880422546553500908B7B /* ChatScrollView.swift */,
 				8008C19824F7EE5B00F5BCCE /* ChannelListView.swift */,
 				DA4EE5D2252CB64900CB26D4 /* UserListView.swift */,
 				8837C66B2539E50500D8FE86 /* MemberListView.swift */,
@@ -2327,6 +2330,7 @@
 				804B127224E712F5002B00EA /* SimpleChatViewController.swift in Sources */,
 				8837C66C2539E50500D8FE86 /* MemberListView.swift in Sources */,
 				DA84071325250E23005A0F62 /* SimpleUsersViewController.swift in Sources */,
+				80D880432546553500908B7B /* ChatScrollView.swift in Sources */,
 				DA4EE5C5252C777A00CB26D4 /* CombineSimpleUsersViewController.swift in Sources */,
 				DAD8A8A52507E1C800D05282 /* CombineSimpleChatViewController.swift in Sources */,
 				80C6026F2514281000A6B714 /* UITableViewController+Cells.swift in Sources */,


### PR DESCRIPTION
This PR reworks the approach in the SwiftUI sample's chat view to use the .bottomToTop list ordering in ChatController and use a LazyVStack with a custom ScrollView wrapper instead of an inverted List which was causing visual glitches in the context menu.

#no_changelog