### PR TITLE
Fix plus signs in User fields becoming spaces in the set user request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix plus signs in User fields becoming spaces in the set user request, preventing names with + signs, base64 custom fields, etc. [#572](https://github.com/GetStream/stream-chat-swift/issues/572)
 
 # [2.4.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.4.1)
 _October 23, 2020_

--- a/Sources/Client/Client/Client+WebSocket.swift
+++ b/Sources/Client/Client/Client+WebSocket.swift
@@ -28,18 +28,16 @@ extension Client {
         
         let jsonData = try JSONEncoder.default.encode(jsonParameter)
         
-        if let jsonString = String(data: jsonData, encoding: .utf8) {
-            urlComponents.queryItems?.append(URLQueryItem(name: "json", value: jsonString))
-        } else {
-            logger?.log("❌ Can't create a JSON parameter string from the json: \(jsonParameter)", level: .error)
-        }
-        
-        guard let url = urlComponents.url else {
+        guard
+            let url = urlComponents.url,
+            let jsonString = String(data: jsonData, encoding: .utf8)?.addingPercentEncoding(withAllowedCharacters: .alphanumerics),
+            let urlWithJson = URL(string: "\(url.absoluteString)&json=\(jsonString)")
+        else {
             logger?.log("❌ Bad URL: \(urlComponents)", level: .error)
             throw ClientError.invalidURL(urlComponents.description)
         }
-        
-        var request = URLRequest(url: url)
+
+        var request = URLRequest(url: urlWithJson)
         request.allHTTPHeaderFields = authHeaders(token: token)
         return request
     }

--- a/Sources_v3/StreamChat/APIClient/RequestEncoder.swift
+++ b/Sources_v3/StreamChat/APIClient/RequestEncoder.swift
@@ -196,7 +196,17 @@ struct DefaultRequestEncoder: RequestEncoder {
         }
         
         log.assert(request.url != nil, "Request URL must not be `nil`.")
-        request.url = try request.url!.appendingQueryItems(bodyQueryItems)
+        request.url = bodyQueryItems.reduce(request.url) { url, item in
+            guard var urlString = url?.absoluteString else { return url }
+            
+            urlString += "&\(item.name)"
+            
+            if let value = item.value?.addingPercentEncoding(withAllowedCharacters: .alphanumerics) {
+                urlString += "=\(value)"
+            }
+            
+            return URL(string: urlString)
+        }
     }
 }
 

--- a/Sources_v3/StreamChat/APIClient/RequestEncoder_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/RequestEncoder_Tests.swift
@@ -163,9 +163,8 @@ class RequestEncoder_Tests: XCTestCase {
         let user1JSON = try JSONDecoder.default.decode(TestUser.self, from: user1String.data(using: .utf8)!)
         XCTAssertEqual(user1JSON, TestUser(name: "Luke", age: 22))
         
-        let user2String = try XCTUnwrap(urlComponents.queryItems?["user2"])
-        let user2JSON = try JSONDecoder.default.decode(TestUser.self, from: user2String.data(using: .utf8)!)
-        XCTAssertEqual(user2JSON, TestUser(name: "Leia is the best! + ♥️", age: 22))
+        // Check the + sign is encoded properly in query
+        XCTAssert(urlComponents.url!.query!.contains("%22name%22%3A%22Leia%20is%20the%20best%21%20%2B%20%E2%99%A5%EF%B8%8F%22"))
     }
     
     func test_encodingGETRequestBody_withQueryItems() throws {

--- a/Sources_v3/StreamChat/APIClient/RequestEncoder_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/RequestEncoder_Tests.swift
@@ -71,7 +71,7 @@ class RequestEncoder_Tests: XCTestCase {
         XCTAssertEqual(request.allHTTPHeaderFields?["Stream-Auth-Type"], "anonymous")
     }
     
-    func test_endpointRequiringConectionId() throws {
+    func test_endpointRequiringConnectionId() throws {
         // Prepare an endpoint that requires connection id
         let endpoint = Endpoint<Data>(
             path: .unique,
@@ -148,7 +148,8 @@ class RequestEncoder_Tests: XCTestCase {
             requiresConnectionId: false,
             body: [
                 "user1": TestUser(name: "Luke", age: 22),
-                "user2": TestUser(name: "Leia", age: 22)
+                // Test non-alphanumeric characters, too
+                "user2": TestUser(name: "Leia is the best! + ♥️", age: 22)
             ]
         )
         
@@ -164,7 +165,7 @@ class RequestEncoder_Tests: XCTestCase {
         
         let user2String = try XCTUnwrap(urlComponents.queryItems?["user2"])
         let user2JSON = try JSONDecoder.default.decode(TestUser.self, from: user2String.data(using: .utf8)!)
-        XCTAssertEqual(user2JSON, TestUser(name: "Leia", age: 22))
+        XCTAssertEqual(user2JSON, TestUser(name: "Leia is the best! + ♥️", age: 22))
     }
     
     func test_encodingGETRequestBody_withQueryItems() throws {


### PR DESCRIPTION
The default encoding when building the query parameter with `URLQueryItem` will not encode the + symbols, thus making them become spaces. I fixed it by appending the `json` query parameter manually with the proper percent encoding to include the plus sign.

This can be specially annoying if a field is a base64 string, like an encoded public key, but it's also preventing creating a user with a plus in the name which is valid in other clients such as the JS client.

Example:
mhPcgwhH8L8FqFni20qLZ/bIHbwleWvaqm+zcByNp4FWQj0ufl8H9cHV/pbAYo74gCEUdH/MxXdtX+SmW2o3Rg==
becomes
mhPcgwhH8L8FqFni20qLZ/bIHbwleWvaqm zcByNp4FWQj0ufl8H9cHV/pbAYo74gCEUdH/MxXdtX SmW2o3Rg==
which is invalid base64