### PR TITLE
Fix internal properties that should've been public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Upcoming
 
 ### 🔄 Changed
+- `membership` attribute in `Channel` is now public [#574](https://github.com/GetStream/stream-chat-swift/issues/574)
+
+### 🐞 Fixed
+- `MembersQueryResponse.member` is now public [#574](https://github.com/GetStream/stream-chat-swift/issues/574)
 
 # [2.4.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.4.1)
 _October 23, 2020_

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -77,7 +77,7 @@ public final class Channel: Codable {
     /// Checks if the channel is frozen.
     public let frozen: Bool
     /// The current user is a member of the channel. If not, it will be nil.
-    var membership: Member?
+    public internal(set) var membership: Member?
     /// A list of channel members.
     public internal(set) var members = Set<Member>()
     

--- a/Sources/Client/Model/Channel/ChannelResponse.swift
+++ b/Sources/Client/Model/Channel/ChannelResponse.swift
@@ -148,5 +148,5 @@ public enum InviteAnswer: String {
 }
 
 public struct MembersQueryResponse: Decodable {
-    let members: [Member]
+    public let members: [Member]
 }


### PR DESCRIPTION
`Channel.membership` and `MembersQueryResponse.members` should've been public from the get-go