### PR TITLE
Change the workaround solution for encoding `+` in URLs

### DIFF
--- a/Sources_v3/StreamChat/APIClient/RequestEncoder_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/RequestEncoder_Tests.swift
@@ -163,8 +163,13 @@ class RequestEncoder_Tests: XCTestCase {
         let user1JSON = try JSONDecoder.default.decode(TestUser.self, from: user1String.data(using: .utf8)!)
         XCTAssertEqual(user1JSON, TestUser(name: "Luke", age: 22))
         
-        // Check the + sign is encoded properly in query
-        XCTAssert(urlComponents.url!.query!.contains("%22name%22%3A%22Leia%20is%20the%20best%21%20%2B%20%E2%99%A5%EF%B8%8F%22"))
+        let user2String = try XCTUnwrap(urlComponents.queryItems?["user2"])
+        let user2JSON = try JSONDecoder.default.decode(TestUser.self, from: user2String.data(using: .utf8)!)
+        XCTAssertEqual(user2JSON, TestUser(name: "Leia is the best! + ♥️", age: 22))
+        
+        // Check the + sign is encoded properly in the query
+        XCTAssertFalse(urlComponents.url!.query!.contains("+"))
+        XCTAssertTrue(urlComponents.url!.query!.contains("%2B"))
     }
     
     func test_encodingGETRequestBody_withQueryItems() throws {


### PR DESCRIPTION
This is a different solution for the current v3 workaround for the incorrect¹ encoding of the `+` character in the URL query. The description of the problem and other solutions can be found here https://stackoverflow.com/questions/43052657/encode-using-urlcomponents-in-swift .

@cardoso, thank you for fixing this! Great work. I just took your solution and tests and made it fit a tiny bit better into the rest of the SDK.

---
¹ _Technically, the encoding is actually correct, `+` is an allowed character in the URL query, it's just not understood as `+`_.