### PR TITLE
Fix images are not being attached to message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🐞 Fixed
 - `MembersQueryResponse.member` is now public [#574](https://github.com/GetStream/stream-chat-swift/issues/574)
 - Fix plus signs in User fields becoming spaces in the set user request, preventing names with + signs, base64 custom fields, etc. [#572](https://github.com/GetStream/stream-chat-swift/issues/572)
+- Fix images and files are not being send. This was a bug introduced in 2.4.1, now resolved [#585](https://github.com/GetStream/stream-chat-swift/issues/585)
 
 # [2.4.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.4.1)
 _October 23, 2020_

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
@@ -189,10 +189,6 @@ extension ChatViewController {
             composerEditingContainerView.animate(show: false)
         }
         
-        // We don't want users to send the same message multiple times
-        // in case their internet is slow and message isn't sent immediately
-        composerView.reset()
-        
         presenter?.rx.send(text: text,
                            showReplyInChannel: composerView.alsoSendToChannelButton.isSelected,
                            parseMentionedUsers: parseMentionedUsersOnSend)
@@ -206,6 +202,10 @@ extension ChatViewController {
                     self?.show(error: $0)
                 })
             .disposed(by: disposeBag)
+        
+        // We don't want users to send the same message multiple times
+        // in case their internet is slow and message isn't sent immediately
+        composerView.reset()
     }
     
     private func findCommand(in text: String) -> String? {


### PR DESCRIPTION
If we reset composerView before calling presenter.send, the attachments will be reset and never sent
Fixes #584 