### PR TITLE
[CIS-392] Safe sorting option for queries

### DIFF
--- a/Sources_v3/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources_v3/StreamChat/Query/ChannelListQuery.swift
@@ -102,7 +102,7 @@ public struct ChannelListQuery<ExtraData: ChannelExtraData>: Encodable {
         messagesLimit: Int = .messagesPageSize
     ) {
         self.filter = filter
-        self.sort = sort
+        self.sort = sort.appendingCidSortingKey()
         pagination = Pagination(pageSize: pageSize)
         self.messagesLimit = messagesLimit
     }

--- a/Sources_v3/StreamChat/Query/ChannelListQuery_Tests.swift
+++ b/Sources_v3/StreamChat/Query/ChannelListQuery_Tests.swift
@@ -39,4 +39,22 @@ final class ChannelListFilterScope_Tests: XCTestCase {
             Filter<ChannelListFilterScope<NoExtraData>>.in(.members, values: ids)
         )
     }
+    
+    func test_safeSorting_added() {
+        // Sortings without safe option
+        let sortings: [[Sorting<ChannelListSortingKey>]] = [
+            [.init(key: .createdAt)],
+            [.init(key: .updatedAt), .init(key: .memberCount)]
+        ]
+        
+        // Create queries with sortings
+        let queries = sortings.map {
+            ChannelListQuery<DefaultExtraData.Channel>(filter: .containMembers(userIds: [.unique]), sort: $0)
+        }
+        
+        // Assert safe sorting option is added
+        queries.forEach {
+            XCTAssertEqual($0.sort.last?.key, Sorting<ChannelListSortingKey>(key: .cid).key)
+        }
+    }
 }

--- a/Sources_v3/StreamChat/Query/Sorting/ChannelListSortingKey.swift
+++ b/Sources_v3/StreamChat/Query/Sorting/ChannelListSortingKey.swift
@@ -47,3 +47,15 @@ extension ChannelListSortingKey {
         .init(key: rawValue, ascending: isAscending)
     }
 }
+
+/// In case elements have same or `nil` target sorting values it's not possible to guarantee that order of elements will be the same
+/// all the time. So we need to additionally provide safe sorting option.
+extension Array where Element == Sorting<ChannelListSortingKey> {
+    func appendingCidSortingKey() -> [Sorting<ChannelListSortingKey>] {
+        guard !contains(where: { $0.key == .cid }), !isEmpty else {
+            return self
+        }
+        
+        return self + [.init(key: .cid)]
+    }
+}

--- a/Sources_v3/StreamChat/Query/Sorting/ChannelListSortingKey.swift
+++ b/Sources_v3/StreamChat/Query/Sorting/ChannelListSortingKey.swift
@@ -16,6 +16,9 @@ public enum ChannelListSortingKey: String, SortingKey {
     case lastMessageAt
     /// Sort channels by number of members.
     case memberCount
+    /// Sort channels by `cid`.
+    /// **Note**: This sorting option can extend your response waiting time if used as primary one.
+    case cid
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
@@ -27,6 +30,7 @@ public enum ChannelListSortingKey: String, SortingKey {
         case .updatedAt: value = "updated_at"
         case .lastMessageAt: value = "last_message_at"
         case .memberCount: value = "member_count"
+        case .cid: value = "cid"
         }
         
         try container.encode(value)

--- a/Sources_v3/StreamChat/Query/Sorting/UserListSortingKey.swift
+++ b/Sources_v3/StreamChat/Query/Sorting/UserListSortingKey.swift
@@ -40,3 +40,15 @@ extension UserListSortingKey {
         .init(key: rawValue, ascending: isAscending)
     }
 }
+
+/// In case elements have same or `nil` target sorting values it's not possible to guarantee that order of elements will be the same
+/// all the time. So we need to additionally provide safe sorting option.
+extension Array where Element == Sorting<UserListSortingKey> {
+    func appendingIdSortingKey() -> [Sorting<UserListSortingKey>] {
+        guard !contains(where: { $0.key == .id }), !isEmpty else {
+            return self
+        }
+        
+        return self + [.init(key: .id)]
+    }
+}

--- a/Sources_v3/StreamChat/Query/UserListQuery.swift
+++ b/Sources_v3/StreamChat/Query/UserListQuery.swift
@@ -89,7 +89,7 @@ public struct UserListQuery<ExtraData: UserExtraData>: Encodable {
         pageSize: Int = .usersPageSize
     ) {
         self.filter = filter
-        self.sort = sort
+        self.sort = sort.appendingIdSortingKey()
         pagination = Pagination(pageSize: pageSize)
     }
     

--- a/Sources_v3/StreamChat/Query/UserListQuery_Tests.swift
+++ b/Sources_v3/StreamChat/Query/UserListQuery_Tests.swift
@@ -51,7 +51,7 @@ class UserListQuery_Tests: XCTestCase {
             "presence": true,
             "limit": 23,
             "filter_conditions": ["id": ["$eq": "luke"]],
-            "sort": [["field": "last_active", "direction": -1]]
+            "sort": [["field": "last_active", "direction": -1], ["field": "id", "direction": -1]]
         ]
 
         let expectedJSON = try JSONSerialization.data(withJSONObject: expectedData, options: [])
@@ -72,5 +72,21 @@ class UserListQuery_Tests: XCTestCase {
     
         // Assert queries match
         AssertJSONEqual(actualJSON, expectedJSON)
+    }
+    
+    func test_safeSorting_added() {
+        // Sortings without safe option
+        let sortings: [[Sorting<UserListSortingKey>]] = [
+            [.init(key: .lastActivityAt)],
+            [.init(key: .lastActivityAt), .init(key: .isBanned)]
+        ]
+        
+        // Create queries with sortings
+        let queries = sortings.map { UserListQuery<DefaultExtraData.User>(sort: $0) }
+        
+        // Assert safe sorting option is added
+        queries.forEach {
+            XCTAssertEqual($0.sort.last?.key, Sorting<UserListSortingKey>(key: .id).key)
+        }
     }
 }


### PR DESCRIPTION
**In this PR:**

- Add `cid` sorting key to `ChannelListSortingKey`
- Add safe sorting option to `ChannelListQuery`
- Add safe sorting option to `UserListQuery`

_`ChannelMemberListQuery` is left out cause there is no safe sorting option available._