### PR TITLE
[CIS-423] Container cell

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListCollectionViewCell.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListCollectionViewCell.swift
@@ -6,13 +6,10 @@ import Foundation
 import UIKit
 
 open class ChatChannelListCollectionViewCell<ExtraData: UIExtraDataTypes>: UICollectionViewCell {
-    
     // MARK: - Properties
-    
-    var uiConfig: UIConfig<ExtraData> = .default
-    
+        
     public private(set) lazy var channelView: ChatChannelView<ExtraData> = {
-        let view = uiConfig.channelList.channelView.init(uiConfig: uiConfig)
+        let view = uiConfig(ExtraData.self).channelList.channelView.init()
         contentView.embed(view)
         return view
     }()

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -11,7 +11,11 @@ open class ChatChannelListVC<ExtraData: UIExtraDataTypes>: UIViewController,
     // MARK: - Properties
     
     public var controller: _ChatChannelListController<ExtraData>!
-    public var uiConfig: UIConfig<ExtraData> = .default
+    
+    public var uiConfig: UIConfig<ExtraData> {
+        get { view.uiConfig(ExtraData.self) }
+        set { view.register(config: newValue) }
+    }
     
     public private(set) lazy var router = uiConfig.navigation.channelListRouter.init(rootViewController: self)
     
@@ -32,7 +36,7 @@ open class ChatChannelListVC<ExtraData: UIExtraDataTypes>: UIViewController,
     }()
     
     public private(set) lazy var userAvatarView: CurrentChatUserAvatarView<ExtraData> = {
-        let avatar = uiConfig.currentUser.currentUserViewAvatarView.init(uiConfig: uiConfig)
+        let avatar = uiConfig.currentUser.currentUserViewAvatarView.init()
         avatar.controller = controller.client.currentUserController()
         avatar.translatesAutoresizingMaskIntoConstraints = false
         avatar.addTarget(self, action: #selector(didTapOnCurrentUserAvatar), for: .touchUpInside)
@@ -66,8 +70,7 @@ open class ChatChannelListVC<ExtraData: UIExtraDataTypes>: UIViewController,
             withReuseIdentifier: "Cell",
             for: indexPath
         ) as! ChatChannelListCollectionViewCell<ExtraData>
-    
-        cell.uiConfig = uiConfig
+        
         cell.channelView.channel = controller.channels[indexPath.row]
         
         return cell

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelView.swift
@@ -17,9 +17,7 @@ open class ChatChannelView<ExtraData: UIExtraDataTypes>: UIView, AppearanceSetti
     }
     
     // MARK: - Properties
-    
-    public let uiConfig: UIConfig<ExtraData>
-    
+        
     public var channel: _ChatChannel<ExtraData>? {
         didSet { updateContent() }
     }
@@ -33,7 +31,7 @@ open class ChatChannelView<ExtraData: UIExtraDataTypes>: UIView, AppearanceSetti
     }()
     
     public private(set) lazy var channelAvatarView: AvatarView = {
-        let avatar = uiConfig.channelList.avatarView.init()
+        let avatar = uiConfig(ExtraData.self).channelList.avatarView.init()
         avatar.translatesAutoresizingMaskIntoConstraints = false
         return avatar
     }()
@@ -69,28 +67,9 @@ open class ChatChannelView<ExtraData: UIExtraDataTypes>: UIView, AppearanceSetti
     
     // MARK: - Init
     
-    public required init(
-        channel: _ChatChannel<ExtraData>? = nil,
-        uiConfig: UIConfig<ExtraData> = .default
-    ) {
-        self.channel = channel
-        self.uiConfig = uiConfig
+    override open func didMoveToSuperview() {
+        super.didMoveToSuperview()
         
-        super.init(frame: .zero)
-        
-        commonInit()
-    }
-    
-    public required init?(coder: NSCoder) {
-        uiConfig = .default
-        channel = nil
-        
-        super.init(coder: coder)
-        
-        commonInit()
-    }
-    
-    public func commonInit() {
         embed(container)
         // TODO: This should be called before `setupAppearance` is called but it doesn't have to be called in `init`
         applyDefaultAppearance()
@@ -134,6 +113,8 @@ open class ChatChannelView<ExtraData: UIExtraDataTypes>: UIView, AppearanceSetti
     }
     
     open func updateContent() {
+        guard superview != nil else { return }
+        
         channelNameLabel.text = channel?.displayName
         
         if let imageURL = channel?.imageURL {

--- a/Sources_v3/StreamChatUI/Common Views/CurrentChatUserAvatarView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/CurrentChatUserAvatarView.swift
@@ -7,9 +7,7 @@ import UIKit
 
 open class CurrentChatUserAvatarView<ExtraData: UIExtraDataTypes>: UIControl {
     // MARK: - Properties
-    
-    public let uiConfig: UIConfig<ExtraData>
-    
+        
     public var controller: _CurrentChatUserController<ExtraData>? {
         didSet {
             controller?.setDelegate(self)
@@ -20,7 +18,7 @@ open class CurrentChatUserAvatarView<ExtraData: UIExtraDataTypes>: UIControl {
     // MARK: - Subviews
     
     public private(set) lazy var avatarView: AvatarView = {
-        let avatar = uiConfig.currentUser.avatarView.init()
+        let avatar = uiConfig(ExtraData.self).currentUser.avatarView.init()
         avatar.translatesAutoresizingMaskIntoConstraints = false
         return avatar
     }()
@@ -49,19 +47,9 @@ open class CurrentChatUserAvatarView<ExtraData: UIExtraDataTypes>: UIControl {
     
     // MARK: - Init
     
-    public required init(uiConfig: UIConfig<ExtraData> = .default) {
-        self.uiConfig = uiConfig
-        super.init(frame: .zero)
-        commonInit()
-    }
-    
-    public required init?(coder: NSCoder) {
-        uiConfig = .default
-        super.init(coder: coder)
-        commonInit()
-    }
-    
-    private func commonInit() {
+    override open func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        
         applyDefaultAppearance()
         setupAppearance()
         setupLayout()
@@ -82,6 +70,8 @@ open class CurrentChatUserAvatarView<ExtraData: UIExtraDataTypes>: UIControl {
     }
     
     @objc open func updateContent() {
+        guard superview != nil else { return }
+
         if let imageURL = controller?.currentUser?.imageURL {
             avatarView.imageView.setImage(from: imageURL)
         } else {

--- a/Sources_v3/StreamChatUI/Utils/UIView+UIConfig.swift
+++ b/Sources_v3/StreamChatUI/Utils/UIView+UIConfig.swift
@@ -1,0 +1,34 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+// MARK: - Backing type-erased config
+
+private extension UIView {
+    static var anyUIConfigKey: UInt8 = 0
+    
+    var anyUIConfig: Any? {
+        get { objc_getAssociatedObject(self, &Self.anyUIConfigKey) as? String }
+        set { objc_setAssociatedObject(self, &Self.anyUIConfigKey, newValue, .OBJC_ASSOCIATION_RETAIN) }
+    }
+}
+
+// MARK: - Public config API
+
+public extension UIView {
+    func register<T: UIExtraDataTypes>(config: UIConfig<T>) {
+        anyUIConfig = config
+    }
+    
+    func uiConfig<T: UIExtraDataTypes>(_ type: T.Type = T.self) -> UIConfig<T> {
+        if let config = anyUIConfig as? UIConfig<T> {
+            return config
+        } else if let superview = superview {
+            return superview.uiConfig(type)
+        } else {
+            return .default
+        }
+    }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 		8850FE91256558B200C8D534 /* ChatRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8850FE90256558B200C8D534 /* ChatRouter.swift */; };
 		885B3D7725642B3D003E6BDF /* CurrentChatUserAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 885B3D7625642B3D003E6BDF /* CurrentChatUserAvatarView.swift */; };
 		885B3D7D25642B88003E6BDF /* CreateNewChannelButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 885B3D7C25642B88003E6BDF /* CreateNewChannelButton.swift */; };
+		88771850256804A2001BE7F0 /* UIView+UIConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8877184F256804A2001BE7F0 /* UIView+UIConfig.swift */; };
 		888123D2255D430B00070D5A /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888123D1255D430B00070D5A /* UIView+Extensions.swift */; };
 		888123E0255D4D2100070D5A /* UIImageView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888123DF255D4D2100070D5A /* UIImageView+Extensions.swift */; };
 		888E8C36252B2AAF00195E03 /* UserController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888E8C35252B2AAF00195E03 /* UserController+SwiftUI.swift */; };
@@ -835,6 +836,7 @@
 		8850FE90256558B200C8D534 /* ChatRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRouter.swift; sourceTree = "<group>"; };
 		885B3D7625642B3D003E6BDF /* CurrentChatUserAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentChatUserAvatarView.swift; sourceTree = "<group>"; };
 		885B3D7C25642B88003E6BDF /* CreateNewChannelButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNewChannelButton.swift; sourceTree = "<group>"; };
+		8877184F256804A2001BE7F0 /* UIView+UIConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+UIConfig.swift"; sourceTree = "<group>"; };
 		888123D1255D430B00070D5A /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		888123DF255D4D2100070D5A /* UIImageView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extensions.swift"; sourceTree = "<group>"; };
 		888E8C35252B2AAF00195E03 /* UserController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserController+SwiftUI.swift"; sourceTree = "<group>"; };
@@ -1856,6 +1858,7 @@
 				888123D1255D430B00070D5A /* UIView+Extensions.swift */,
 				888123DF255D4D2100070D5A /* UIImageView+Extensions.swift */,
 				8850FE90256558B200C8D534 /* ChatRouter.swift */,
+				8877184F256804A2001BE7F0 /* UIView+UIConfig.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2560,6 +2563,7 @@
 				8850B914255C1F77003AED69 /* NameAndImageProviding.swift in Sources */,
 				7908834D2548770C00896F03 /* ChatMessageCollectionViewCell.swift in Sources */,
 				7908830325486CA700896F03 /* ChatNavigationBar.swift in Sources */,
+				88771850256804A2001BE7F0 /* UIView+UIConfig.swift in Sources */,
 				885B3D7D25642B88003E6BDF /* CreateNewChannelButton.swift in Sources */,
 				79088334254876EA00896F03 /* ChatChannelViewController.swift in Sources */,
 				790882DF25486B6800896F03 /* ChatChannelListVC.swift in Sources */,


### PR DESCRIPTION
### Problem description

We would like to instantiate `ChatChannelView<ExtraData>` and add to cell view hierarchy when the cell is created. To instantiate `ChatChannelView<ExtraData>` of the correct type, the type should be taken from `UIConfig<ExtraData>` (as it can be overridden). We cannot create custom `init(uiConfig: UIConfig<ExtraData>)` for the cell and invoke it since the cells are created inside the `UICollectionView` via `init(frame: CGRect)/init(coder: )`.

### Possible solutions:
1. have a generic cell + stored `var uiConfig<ExtraData> = .default`
2. have a generic cell + computed `uiConfig<ExtraData>` and iterate up by view hierarchy searching for ancestor that provides `UIConfig<ExtraData>`
3. have a non-generic cell with `content: UIView?` and let the controller do the rest

### Solutions issues:
1. when we have stored config we have to make sure `cell.uiConfig = controller.uiConfig` happens before the  `ChatChannelView<ExtraData>` is created. Otherwise we risk to create another `ChatChannelView<ExtraData>` from default config other than from controller's config
2. I pin hopes on this approach since it is similar to environment variables in `SwiftUI`, can be applied for all the views and helps to avoid storing `let config + init(config)`. The problem is that we create subviews from the inside of view's `init` and at this point the view itself hasn't yet had a superview -> there is no view hierarchy to search the `uiConfig<ExtraData>` for.
3. The type of content view is not fixed to any specific one. On the other hand, it allows the cell to be reused in other collections (not only channel-list)
