### PR TITLE
Don't adjust composer when keyboard is floating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🔄 Changed
 - `showWebView` function in `ChatViewController` can be overridden. 
   This function will be called when a user taps on a link in a message, or an attachment which isn't an image (such as a video or a file) [#589](https://github.com/GetStream/stream-chat-swift/issues/589)
+  
+### 🐞 Fixed
+- Fixed floating / undocked keyboard in iPad causing message composer to take a wrong height. Now it stays at the bottom. [#597](https://github.com/GetStream/stream-chat-swift/pull/597)
 
 # [2.4.2](https://github.com/GetStream/stream-chat-swift/releases/tag/2.4.2)
 _November 13, 2020_

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
@@ -47,22 +47,22 @@ extension Reactive where Base: ChatViewController {
             
             var contentOffset = CGPoint.zero
             
-            let contentHeight = chatViewController.tableView.contentSize.height
-                + chatViewController.tableView.contentInset.top
-                + chatViewController.tableView.contentInset.bottom
-            
-            let tableHeight = chatViewController.tableView.bounds.height - keyboardNotification.height
-            
-            if keyboardNotification.animation != nil,
-                keyboardNotification.isVisible,
-                !chatViewController.keyboardIsVisible,
-                tableHeight < contentHeight {
-                contentOffset = chatViewController.tableView.contentOffset
-                contentOffset.y += min(bottom, contentHeight - tableHeight)
-            }
-            
             if keyboardNotification.isFloating {
                 bottom = 0
+            } else {
+                let contentHeight = chatViewController.tableView.contentSize.height
+                    + chatViewController.tableView.contentInset.top
+                    + chatViewController.tableView.contentInset.bottom
+                
+                let tableHeight = chatViewController.tableView.bounds.height - keyboardNotification.height
+                
+                if keyboardNotification.animation != nil,
+                    keyboardNotification.isVisible,
+                    !chatViewController.keyboardIsVisible,
+                    tableHeight < contentHeight {
+                    contentOffset = chatViewController.tableView.contentOffset
+                    contentOffset.y += min(bottom, contentHeight - tableHeight)
+                }
             }
             
             func animations() {

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Composer.swift
@@ -61,6 +61,10 @@ extension Reactive where Base: ChatViewController {
                 contentOffset.y += min(bottom, contentHeight - tableHeight)
             }
             
+            if keyboardNotification.isFloating {
+                bottom = 0
+            }
+            
             func animations() {
                 chatViewController.view.removeAllAnimations()
                 chatViewController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottom, right: 0)

--- a/Sources/UI/Extensions/Keyboard.swift
+++ b/Sources/UI/Extensions/Keyboard.swift
@@ -26,7 +26,7 @@ struct Keyboard {
             .panGesture()
             .when(.began, .changed, .ended)
             .withLatestFrom(keyboardNotifications) { ($0, $1) }
-            .filter { $1.height > 0 }
+            .filter { $1.height > 0 && $1.isDocked }
             .compactMap { KeyboardNotification(panGesture: $0, with: $1) }
         
         notification = Observable.merge(viewPan, keyboardNotifications)
@@ -72,11 +72,15 @@ struct KeyboardNotification: Equatable {
     }
     
     var isFloating: Bool {
-        return height > (frame?.height ?? 0)
+        return UIDevice.current.userInterfaceIdiom == .pad && height > (frame?.height ?? 0)
     }
     
     var isHidden: Bool {
         return !isVisible
+    }
+    
+    var isDocked: Bool {
+        return !isFloating
     }
     
     init(_ notification: Notification) {

--- a/Sources/UI/Extensions/Keyboard.swift
+++ b/Sources/UI/Extensions/Keyboard.swift
@@ -71,6 +71,10 @@ struct KeyboardNotification: Equatable {
         return height > 0
     }
     
+    var isFloating: Bool {
+        return height > (frame?.height ?? 0)
+    }
+    
     var isHidden: Bool {
         return !isVisible
     }

--- a/Sources/UI/Extensions/Keyboard.swift
+++ b/Sources/UI/Extensions/Keyboard.swift
@@ -56,12 +56,13 @@ struct KeyboardNotification: Equatable {
         }
     }
     
+    let screenBounds = UIScreen.main.bounds
     let frame: CGRect?
     let animation: Animation?
     
     var height: CGFloat {
         if let frame = frame {
-            return UIScreen.main.bounds.height - frame.origin.y
+            return screenBounds.height - frame.origin.y
         }
         
         return 0
@@ -87,7 +88,7 @@ struct KeyboardNotification: Equatable {
         if let frame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
             if frame.origin.y < 0 {
                 var newFrame = frame
-                newFrame.origin.y = UIScreen.main.bounds.height - newFrame.height
+                newFrame.origin.y = screenBounds.height - newFrame.height
                 self.frame = newFrame
             } else {
                 self.frame = frame
@@ -106,14 +107,14 @@ struct KeyboardNotification: Equatable {
         
         guard case .changed = panGesture.state,
             let window = UIApplication.shared.windows.first,
-            frame.origin.y < UIScreen.main.bounds.height else {
+            frame.origin.y < screenBounds.height else {
                 return nil
                 
         }
         
         let origin = panGesture.location(in: window)
         var newFrame = frame
-        newFrame.origin.y = max(origin.y, UIScreen.main.bounds.height - frame.height)
+        newFrame.origin.y = max(origin.y, screenBounds.height - frame.height)
         
         self.frame = newFrame
         animation = nil


### PR DESCRIPTION
iOS doesn't let us know if the composer is floating, but if the keyboard frame height is lower than the distance from the bottom of the screen to the keyboard's y origin, then it seems safe to say it's floating. 

Additional bug fix: KeyboardNotification calculations were incorrect if the screen rotated. Fixed this by storing the current screen bounds on initialization. 