### PR TITLE
[CIS-416] Explore lazy setup for views

### DIFF
--- a/Sample_v3/AppDelegate.swift
+++ b/Sample_v3/AppDelegate.swift
@@ -27,7 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         LogStore.registerShared()
         
-        setupAppearance()
+        setUpAppearance()
 
         return true
     }
@@ -52,7 +52,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
     
-    private func setupAppearance() {
+    private func setUpAppearance() {
         UIConfig<DefaultExtraData>.default.navigation.channelListRouter = MyChatChannelListRouter.self
         ChatChannelListCollectionView.appearance().backgroundColor = .white
     }

--- a/Sample_v3/AppDelegate.swift
+++ b/Sample_v3/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         LogConfig.showDate = false
         LogConfig.showFunctionName = false
         
-        LogConfig.level = .debug
+        LogConfig.level = .warning
         
         LogStore.registerShared()
         

--- a/Sample_v3/LoginViewController.swift
+++ b/Sample_v3/LoginViewController.swift
@@ -127,14 +127,20 @@ extension LoginViewController {
             alert(title: "Swift 5.3 required", message: "The app needs to be compiled with Swift 5.3 or above.")
             #endif
         case streamDesignCell:
+            
             let channelList = ChatChannelListVC<DefaultExtraData>()
+            
             channelList.controller = channelListController
-        
+            
             // An example of change default appearance
-            ChatChannelListItemView<DefaultExtraData>.defaultAppearance.addRule {
-                $0.unreadCountView.backgroundColor = .systemPink
+            ChatChannelListItemView<DefaultExtraData>.defaultAppearance {
+                $0.backgroundColor = .yellow
             }
 
+            ChatChannelListVC<DefaultExtraData>.defaultAppearance {
+                $0.title = "Custom title"
+            }
+            
             let navigation = UINavigationController(
                 navigationBarClass: channelList.uiConfig.navigation.navigationBar.self,
                 toolbarClass: nil

--- a/Sources_v3/StreamChatUI/AppearanceSetting.swift
+++ b/Sources_v3/StreamChatUI/AppearanceSetting.swift
@@ -8,33 +8,38 @@ import UIKit
 /// Used to define the default appearance for views.
 public protocol AppearanceSetting: AnyObject {
     /// Objects must implement this method and apply the default configuration on the provided object.
-    static func initialAppearanceSetup(_ view: Self)
+    func defaultAppearance()
 }
 
-extension AppearanceSetting {
-    /// An object describing the default appearance of the view. Be aware that the appearance object is generic-type-specific,
-    /// in other words: `MyView<A>.defaultAppearance != MyView<V>.defaultAppearance`.
-    public static var defaultAppearance: Appearance<Self> {
-        get {
-            let key = String(describing: Self.self)
-            if let existing = _AppearanceStorage.shared.appearances[key] as? Appearance<Self> {
-                return existing
-            } else {
-                let appearance = Appearance<Self>()
-                appearance.rules.append { Self.initialAppearanceSetup($0) }
-                _AppearanceStorage.shared.appearances[key] = appearance
-                return appearance
-            }
-        }
+public extension AppearanceSetting {
+    func defaultAppearance() { /* default empty implementation */ }
+}
 
-        set {
-            let key = String(describing: Self.self)
-            _AppearanceStorage.shared.appearances[key] = newValue
-        }
-    }
-    
+public extension AppearanceSetting {
+    /// Applies the default appearance specified by the type, including the custom rules set using the `defaultAppearance` API.
     func applyDefaultAppearance() {
-        Self.defaultAppearance.rules.forEach { $0(self) }
+        defaultAppearance()
+        let appearance: Appearance<Self> = Self.defaultAppearance
+        appearance.rules.forEach { $0(self) }
+    }
+}
+
+public extension AppearanceSetting {
+    static var defaultAppearance: Appearance<Self> {
+        let key = String(describing: self)
+        return fetchDefaultAppearance(key)
+    }
+}
+
+/// An object describing the default appearance of the view. Be aware that the appearance object is generic-type-specific,
+/// in other words: `MyView<A>.defaultAppearance != MyView<V>.defaultAppearance`.
+private func fetchDefaultAppearance<T: AppearanceSetting>(_ key: String) -> Appearance<T> {
+    if let existing = _AppearanceStorage.shared.appearances[key] as? Appearance<T> {
+        return existing
+    } else {
+        let appearance = Appearance<T>()
+        _AppearanceStorage.shared.appearances[key] = appearance
+        return appearance
     }
 }
 
@@ -48,5 +53,9 @@ public class Appearance<Root: AnyObject> {
 
     public func addRule(_ rule: @escaping (Root) -> Void) {
         rules.append(rule)
+    }
+    
+    public func callAsFunction(_ rule: @escaping (Root) -> Void) {
+        addRule(rule)
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
@@ -18,14 +18,15 @@ open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
     
     // MARK: - Overrides
     
-    override open func setupLayout() {
+    override open func setUpLayout() {
+        super.setUpLayout()
+        
         widthAnchor.constraint(equalTo: heightAnchor, multiplier: 1).isActive = true
-        embed(imageView)
     }
     
     // MARK: - Public
     
-    open func updateContent() {
+    override open func updateContent() {
         guard let channel = channel else {
             imageView.image = nil
             return

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -5,17 +5,15 @@
 import StreamChat
 import UIKit
 
-open class ChatChannelListItemView<ExtraData: UIExtraDataTypes>: UIView, AppearanceSetting {
-    // MARK: - Default Appearance
-    
-    public class func initialAppearanceSetup(_ view: ChatChannelListItemView<ExtraData>) {
+open class ChatChannelListItemView<ExtraData: UIExtraDataTypes>: View {
+    public func defaultAppearance() {
         if #available(iOS 13, *) {
-            view.backgroundColor = .systemBackground
+            backgroundColor = .systemBackground
         } else {
-            view.backgroundColor = .white // Should be add custom support for dark theme?
+            backgroundColor = .white // Should be add custom support for dark theme?
         }
     }
-    
+
     // MARK: - Properties
     
     public let uiConfig: UIConfig<ExtraData>
@@ -74,17 +72,12 @@ open class ChatChannelListItemView<ExtraData: UIExtraDataTypes>: UIView, Appeara
     }
     
     public func commonInit() {
-        embed(container)
-        
-        applyDefaultAppearance()
-        setupAppearance()
-        setupLayout()
         updateContent()
     }
     
     // MARK: - Public
     
-    open func setupAppearance() {
+    override open func setUpAppearance() {
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.font = .preferredFont(forTextStyle: .headline)
         
@@ -97,7 +90,8 @@ open class ChatChannelListItemView<ExtraData: UIExtraDataTypes>: UIView, Appeara
         timestampLabel.font = .preferredFont(forTextStyle: .subheadline)
     }
     
-    open func setupLayout() {
+    override open func setUpLayout() {
+        embed(container)
         container.preservesSuperviewLayoutMargins = true
         container.isLayoutMarginsRelativeArrangement = true
                 
@@ -152,7 +146,7 @@ open class ChatChannelListItemView<ExtraData: UIExtraDataTypes>: UIView, Appeara
         avatarView.widthAnchor.constraint(equalToConstant: avatarView.intrinsicContentSize.width).isActive = true
     }
     
-    open func updateContent() {
+    override open func updateContent() {
         // Title
         
         titleLabel.text = channel?.displayName

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -5,7 +5,7 @@
 import StreamChat
 import UIKit
 
-open class ChatChannelListItemView<ExtraData: UIExtraDataTypes>: View {
+open class ChatChannelListItemView<ExtraData: UIExtraDataTypes>: View, UIConfigProvider {
     public func defaultAppearance() {
         if #available(iOS 13, *) {
             backgroundColor = .systemBackground
@@ -15,8 +15,6 @@ open class ChatChannelListItemView<ExtraData: UIExtraDataTypes>: View {
     }
 
     // MARK: - Properties
-    
-    public let uiConfig: UIConfig<ExtraData>
     
     public var channel: _ChatChannel<ExtraData>? {
         didSet {
@@ -55,24 +53,16 @@ open class ChatChannelListItemView<ExtraData: UIExtraDataTypes>: View {
         uiConfig: UIConfig<ExtraData> = .default
     ) {
         self.channel = channel
-        self.uiConfig = uiConfig
         
         super.init(frame: .zero)
         
-        commonInit()
+        self.uiConfig = uiConfig
     }
     
     public required init?(coder: NSCoder) {
-        uiConfig = .default
         channel = nil
         
         super.init(coder: coder)
-        
-        commonInit()
-    }
-    
-    public func commonInit() {
-        updateContent()
     }
     
     // MARK: - Public

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -7,8 +7,8 @@ import UIKit
 
 open class ChatChannelListVC<ExtraData: UIExtraDataTypes>: ViewController,
     UICollectionViewDataSource,
-    UICollectionViewDelegate {
-    
+    UICollectionViewDelegate,
+    UIConfigProvider {
     public func defaultAppearance() {
         title = "Stream Chat"
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: userAvatarView)
@@ -18,7 +18,6 @@ open class ChatChannelListVC<ExtraData: UIExtraDataTypes>: ViewController,
     // MARK: - Properties
     
     public var controller: _ChatChannelListController<ExtraData>!
-    public var uiConfig: UIConfig<ExtraData> = .default
     
     public private(set) lazy var router = uiConfig.navigation.channelListRouter.init(rootViewController: self)
     

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -5,9 +5,16 @@
 import StreamChat
 import UIKit
 
-open class ChatChannelListVC<ExtraData: UIExtraDataTypes>: UIViewController,
+open class ChatChannelListVC<ExtraData: UIExtraDataTypes>: ViewController,
     UICollectionViewDataSource,
     UICollectionViewDelegate {
+    
+    public func defaultAppearance() {
+        title = "Stream Chat"
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: userAvatarView)
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: createNewChannelButton)
+    }
+    
     // MARK: - Properties
     
     public var controller: _ChatChannelListController<ExtraData>!
@@ -45,8 +52,6 @@ open class ChatChannelListVC<ExtraData: UIExtraDataTypes>: UIViewController,
         super.viewDidLoad()
         
         view.embed(collectionView)
-        
-        applyDefaultAppearance()
         
         controller.setDelegate(self)
         controller.synchronize()
@@ -122,15 +127,5 @@ extension ChatChannelListVC: _ChatChannelListControllerDelegate {
                 }
             }
         }, completion: nil)
-    }
-}
-
-// MARK: - AppearanceSetting
-
-extension ChatChannelListVC: AppearanceSetting {
-    public static func initialAppearanceSetup(_ controller: ChatChannelListVC<ExtraData>) {
-        controller.title = "Stream Chat"
-        controller.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: controller.userAvatarView)
-        controller.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: controller.createNewChannelButton)
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatReadStatusCheckmarkView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatReadStatusCheckmarkView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-open class ChatReadStatusCheckmarkView: UIView {
+open class ChatReadStatusCheckmarkView: View {
     public enum Status {
         case read, unread, empty
     }
@@ -51,23 +51,21 @@ open class ChatReadStatusCheckmarkView: UIView {
     }
     
     private func commonInit() {
-        embed(imageView)
-        setupLayout()
-        setupAppearance()
         updateContent()
     }
     
     // MARK: - Public
     
-    open func setupAppearance() {
+    override open func setUpAppearance() {
         imageView.contentMode = .scaleAspectFit
     }
     
-    open func setupLayout() {
+    override open func setUpLayout() {
+        embed(imageView)
         widthAnchor.constraint(equalTo: heightAnchor, multiplier: 1).isActive = true
     }
     
-    open func updateContent() {
+    override open func updateContent() {
         switch status {
         case .empty:
             imageView.image = nil

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatUnreadCountView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatUnreadCountView.swift
@@ -5,7 +5,7 @@
 import StreamChat
 import UIKit
 
-open class ChatUnreadCountView: UIView {
+open class ChatUnreadCountView: View {
     // MARK: - Properties
     
     public var inset: CGFloat = 3
@@ -39,8 +39,6 @@ open class ChatUnreadCountView: UIView {
     }
     
     private func commonInit() {
-        setupLayout()
-        setupAppearance()
         updateContent()
     }
     
@@ -62,7 +60,7 @@ open class ChatUnreadCountView: UIView {
     
     // MARK: - Public
     
-    open func setupAppearance() {
+    override open func setUpAppearance() {
         layer.masksToBounds = true
         backgroundColor = .systemRed
         unreadCountLabel.textColor = .white
@@ -71,12 +69,12 @@ open class ChatUnreadCountView: UIView {
         unreadCountLabel.textAlignment = .center
     }
     
-    open func setupLayout() {
+    override open func setUpLayout() {
         embed(unreadCountLabel, insets: .init(top: inset, leading: inset, bottom: inset, trailing: inset))
         setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
     }
     
-    open func updateContent() {
+    override open func updateContent() {
         isHidden = unreadCount.mentionedMessages == 0 && unreadCount.messages == 0
         unreadCountLabel.text = String(unreadCount.messages)
     }

--- a/Sources_v3/StreamChatUI/Common Views/AvatarView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/AvatarView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-open class AvatarView: UIView {
+open class AvatarView: View {
     // MARK: - Subviews
     
     public let imageView: UIImageView = {
@@ -20,24 +20,6 @@ open class AvatarView: UIView {
         defaultIntrinsicContentSize ?? imageView.intrinsicContentSize
     }
     
-    // MARK: - Init
-    
-    override public init(frame: CGRect) {
-        super.init(frame: frame)
-        commonInit()
-    }
-    
-    public required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        commonInit()
-    }
-    
-    private func commonInit() {
-        applyDefaultAppearance()
-        setupLayout()
-        setupAppearance()
-    }
-    
     // MARK: - Layout
     
     override open func layoutSubviews() {
@@ -47,23 +29,19 @@ open class AvatarView: UIView {
     }
     
     // MARK: - Public
+
+    public func defaultAppearance() {
+        defaultIntrinsicContentSize = .init(width: 40, height: 40)
+    }
     
-    open func setupAppearance() {
+    override open func setUpAppearance() {
         imageView.contentMode = .scaleAspectFit
         imageView.clipsToBounds = true
     }
     
-    open func setupLayout() {
+    override open func setUpLayout() {
         imageView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         imageView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         embed(imageView)
-    }
-}
-
-// MARK: - AppearanceSetting
-
-extension AvatarView: AppearanceSetting {
-    public class func initialAppearanceSetup(_ view: AvatarView) {
-        view.defaultIntrinsicContentSize = .init(width: 40, height: 40)
     }
 }

--- a/Sources_v3/StreamChatUI/Common Views/BaseViews.swift
+++ b/Sources_v3/StreamChatUI/Common Views/BaseViews.swift
@@ -1,0 +1,108 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+// Just a protocol to formalize the methods required
+public protocol Customizable {
+    /// Main point of customization for appearance.
+    ////Calling super implementation is not necessary nor encouraged.
+    func setUpAppearance()
+    
+    /// Main point of customization for appearance.
+    /// Calling super implementation is not necessary nor encouraged.
+    func setUpLayout()
+    
+    /// Main point of updating views with the latest data.
+    /// Calling super implementation is not necessary nor encouraged.
+    func updateContent()
+}
+
+/// Base class for overridable views StreamChatUI provides.
+/// All conformers will have StreamChatUI appearance settings by default.
+open class View: UIView, AppearanceSetting, Customizable {
+    override open func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        guard superview != nil else { return }
+        
+        (self as! Self).applyDefaultAppearance()
+        setUpAppearance()
+        setUpLayout()
+        updateContent()
+    }
+    
+    open func setUpAppearance() { /* default empty implementation */ }
+    open func setUpLayout() { /* default empty implementation */ }
+    open func updateContent() { /* default empty implementation */ }
+}
+
+/// Base class for overridable views StreamChatUI provides.
+/// All conformers will have StreamChatUI appearance settings by default.
+open class Control: UIControl, AppearanceSetting, Customizable {
+    override open func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        guard superview != nil else { return }
+        
+        (self as! Self).applyDefaultAppearance()
+        setUpAppearance()
+        setUpLayout()
+        updateContent()
+    }
+    
+    open func setUpAppearance() { /* default empty implementation */ }
+    open func setUpLayout() { /* default empty implementation */ }
+    open func updateContent() { /* default empty implementation */ }
+}
+
+/// Base class for overridable views StreamChatUI provides.
+/// All conformers will have StreamChatUI appearance settings by default.
+open class Button: UIButton, AppearanceSetting, Customizable {
+    override open func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        guard superview != nil else { return }
+        
+        (self as! Self).applyDefaultAppearance()
+        setUpAppearance()
+        setUpLayout()
+        updateContent()
+    }
+    
+    open func setUpAppearance() { /* default empty implementation */ }
+    open func setUpLayout() { /* default empty implementation */ }
+    open func updateContent() { /* default empty implementation */ }
+}
+
+/// Base class for overridable views StreamChatUI provides.
+/// All conformers will have StreamChatUI appearance settings by default.
+open class NavigationBar: UINavigationBar, AppearanceSetting, Customizable {
+    override open func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        guard superview != nil else { return }
+        
+        (self as! Self).applyDefaultAppearance()
+        setUpAppearance()
+        setUpLayout()
+        updateContent()
+    }
+    
+    open func setUpAppearance() { /* default empty implementation */ }
+    open func setUpLayout() { /* default empty implementation */ }
+    open func updateContent() { /* default empty implementation */ }
+}
+
+open class ViewController: UIViewController, AppearanceSetting, Customizable {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        
+        (self as! Self).applyDefaultAppearance()
+        setUpAppearance()
+        setUpLayout()
+        updateContent()
+    }
+    
+    open func setUpAppearance() { /* default empty implementation */ }
+    open func setUpLayout() { /* default empty implementation */ }
+    open func updateContent() { /* default empty implementation */ }
+}

--- a/Sources_v3/StreamChatUI/Common Views/ChatNavigationBar.swift
+++ b/Sources_v3/StreamChatUI/Common Views/ChatNavigationBar.swift
@@ -5,24 +5,10 @@
 import StreamChat
 import UIKit
 
-open class ChatNavigationBar: UINavigationBar {
-    override public init(frame: CGRect) {
-        super.init(frame: frame)
-        applyDefaultAppearance()
-    }
-    
-    public required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        applyDefaultAppearance()
-    }
-}
-
-// MARK: - AppearanceSetting
- 
-extension ChatNavigationBar: AppearanceSetting {
-    public static func initialAppearanceSetup(_ bar: ChatNavigationBar) {
+open class ChatNavigationBar: NavigationBar {
+    public func defaultAppearance() {
         let backIcon = UIImage(named: "icn_back", in: Bundle(for: Self.self), compatibleWith: nil)
-        bar.backIndicatorTransitionMaskImage = backIcon
-        bar.backIndicatorImage = backIcon
+        backIndicatorTransitionMaskImage = backIcon
+        backIndicatorImage = backIcon
     }
 }

--- a/Sources_v3/StreamChatUI/Common Views/CreateNewChannelButton.swift
+++ b/Sources_v3/StreamChatUI/Common Views/CreateNewChannelButton.swift
@@ -22,11 +22,9 @@ open class CreateNewChannelButton: Button {
     
     override public init(frame: CGRect) {
         super.init(frame: frame)
-//        applyDefaultAppearance()
     }
     
     public required init?(coder: NSCoder) {
         super.init(coder: coder)
-//        applyDefaultAppearance()
     }
 }

--- a/Sources_v3/StreamChatUI/Common Views/CreateNewChannelButton.swift
+++ b/Sources_v3/StreamChatUI/Common Views/CreateNewChannelButton.swift
@@ -5,9 +5,14 @@
 import StreamChat
 import UIKit
 
-open class CreateNewChannelButton: UIButton {
+open class CreateNewChannelButton: Button {
     // MARK: - Overrides
     
+    public func defaultAppearance() {
+        defaultIntrinsicContentSize = .init(width: 44, height: 44)
+        setImage(UIImage(named: "icn_new_chat", in: Bundle(for: Self.self), compatibleWith: nil), for: .normal)
+    }
+
     open var defaultIntrinsicContentSize: CGSize?
     override open var intrinsicContentSize: CGSize {
         defaultIntrinsicContentSize ?? super.intrinsicContentSize
@@ -17,20 +22,11 @@ open class CreateNewChannelButton: UIButton {
     
     override public init(frame: CGRect) {
         super.init(frame: frame)
-        applyDefaultAppearance()
+//        applyDefaultAppearance()
     }
     
     public required init?(coder: NSCoder) {
         super.init(coder: coder)
-        applyDefaultAppearance()
-    }
-}
-
-// MARK: - AppearanceSetting
-
-extension CreateNewChannelButton: AppearanceSetting {
-    public static func initialAppearanceSetup(_ button: CreateNewChannelButton) {
-        button.defaultIntrinsicContentSize = .init(width: 44, height: 44)
-        button.setImage(UIImage(named: "icn_new_chat", in: Bundle(for: Self.self), compatibleWith: nil), for: .normal)
+//        applyDefaultAppearance()
     }
 }

--- a/Sources_v3/StreamChatUI/Common Views/CurrentChatUserAvatarView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/CurrentChatUserAvatarView.swift
@@ -5,10 +5,8 @@
 import StreamChat
 import UIKit
 
-open class CurrentChatUserAvatarView<ExtraData: UIExtraDataTypes>: Control {
+open class CurrentChatUserAvatarView<ExtraData: UIExtraDataTypes>: Control, UIConfigProvider {
     // MARK: - Properties
-    
-    public let uiConfig: UIConfig<ExtraData>
     
     public var controller: _CurrentChatUserController<ExtraData>? {
         didSet {
@@ -54,19 +52,12 @@ open class CurrentChatUserAvatarView<ExtraData: UIExtraDataTypes>: Control {
     // MARK: - Init
     
     public required init(uiConfig: UIConfig<ExtraData> = .default) {
-        self.uiConfig = uiConfig
         super.init(frame: .zero)
-        commonInit()
+        self.uiConfig = uiConfig
     }
     
     public required init?(coder: NSCoder) {
-        uiConfig = .default
         super.init(coder: coder)
-        commonInit()
-    }
-    
-    private func commonInit() {
-        updateContent()
     }
 
     // MARK: - Content

--- a/Sources_v3/StreamChatUI/Common Views/CurrentChatUserAvatarView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/CurrentChatUserAvatarView.swift
@@ -5,7 +5,7 @@
 import StreamChat
 import UIKit
 
-open class CurrentChatUserAvatarView<ExtraData: UIExtraDataTypes>: UIControl {
+open class CurrentChatUserAvatarView<ExtraData: UIExtraDataTypes>: Control {
     // MARK: - Properties
     
     public let uiConfig: UIConfig<ExtraData>
@@ -26,6 +26,10 @@ open class CurrentChatUserAvatarView<ExtraData: UIExtraDataTypes>: UIControl {
     }()
     
     // MARK: - Overrides
+    
+    public func defaultAppearance() {
+        defaultIntrinsicContentSize = .init(width: 28, height: 28)
+    }
     
     open var defaultIntrinsicContentSize: CGSize?
     override open var intrinsicContentSize: CGSize {
@@ -62,26 +66,23 @@ open class CurrentChatUserAvatarView<ExtraData: UIExtraDataTypes>: UIControl {
     }
     
     private func commonInit() {
-        applyDefaultAppearance()
-        setupAppearance()
-        setupLayout()
         updateContent()
     }
 
     // MARK: - Content
     
-    open func setupAppearance() {
+    override open func setUpAppearance() {
         avatarView.isUserInteractionEnabled = false
     }
     
-    open func setupLayout() {
+    override open func setUpLayout() {
         widthAnchor.constraint(equalTo: heightAnchor).isActive = true
         avatarView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         avatarView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         embed(avatarView)
     }
     
-    @objc open func updateContent() {
+    @objc override open func updateContent() {
         if let imageURL = controller?.currentUser?.imageURL {
             avatarView.imageView.setImage(from: imageURL)
         } else {
@@ -89,14 +90,6 @@ open class CurrentChatUserAvatarView<ExtraData: UIExtraDataTypes>: UIControl {
         }
         
         alpha = state == .normal ? 1 : 0.5
-    }
-}
-
-// MARK: - AppearanceSetting
-
-extension CurrentChatUserAvatarView: AppearanceSetting {
-    public static func initialAppearanceSetup(_ view: CurrentChatUserAvatarView<ExtraData>) {
-        view.defaultIntrinsicContentSize = .init(width: 28, height: 28)
     }
 }
 

--- a/Sources_v3/StreamChatUI/Utils/UIConfigProvider.swift
+++ b/Sources_v3/StreamChatUI/Utils/UIConfigProvider.swift
@@ -1,0 +1,108 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+// MARK: - Stored property in UIView required to make this work
+
+private extension UIView {
+    static var anyUIConfigKey: UInt8 = 0
+    
+    var anyUIConfig: Any? {
+        get { objc_getAssociatedObject(self, &Self.anyUIConfigKey) as? String }
+        set { objc_setAssociatedObject(self, &Self.anyUIConfigKey, newValue, .OBJC_ASSOCIATION_RETAIN) }
+    }
+}
+
+// MARK: - Protocols
+
+public protocol GenericUIConfigProvider: AnyObject {
+    func register<T: UIExtraDataTypes>(config: UIConfig<T>)
+    func uiConfig<T: UIExtraDataTypes>(_ type: T.Type) -> UIConfig<T>
+}
+
+public protocol UIConfigProvider: GenericUIConfigProvider {
+    associatedtype ExtraData: UIExtraDataTypes
+    var uiConfig: UIConfig<ExtraData> { get set }
+}
+
+// MARK: - Protocol extensions for UIView
+
+public extension GenericUIConfigProvider where Self: UIView {
+    func register<T: UIExtraDataTypes>(config: UIConfig<T>) {
+        anyUIConfig = config
+    }
+    
+    func uiConfig<T: UIExtraDataTypes>(_ type: T.Type = T.self) -> UIConfig<T> {
+        // We have a config registered, return it
+        if let config = anyUIConfig as? UIConfig<T> {
+            return config
+        }
+        
+        // Walk up the superview chain until we find a config provider
+        // Skip non-providers
+        var _superview = superview
+        while _superview != nil {
+            if let _superview = _superview as? GenericUIConfigProvider {
+                return _superview.uiConfig(type)
+            } else {
+                _superview = _superview?.superview
+            }
+        }
+        
+        // No parent provider found, return default config
+        return .default
+    }
+}
+
+extension UIConfigProvider where Self: UIView {
+    public var uiConfig: UIConfig<ExtraData> {
+        get {
+            uiConfig(ExtraData.self)
+        }
+        set {
+            register(config: newValue)
+        }
+    }
+}
+
+// MARK: - Protocol extensions for UIViewController
+
+public extension GenericUIConfigProvider where Self: UIViewController {
+    func register<T: UIExtraDataTypes>(config: UIConfig<T>) {
+        view.anyUIConfig = config
+    }
+    
+    func uiConfig<T: UIExtraDataTypes>(_ type: T.Type = T.self) -> UIConfig<T> {
+        // We have a config registered, return it
+        if let config = view.anyUIConfig as? UIConfig<T> {
+            return config
+        }
+        
+        // Walk up the superview chain until we find a config provider
+        // Skip non-providers
+        var _superview = view.superview
+        while _superview != nil {
+            if let _superview = _superview as? GenericUIConfigProvider {
+                return _superview.uiConfig(type)
+            } else {
+                _superview = _superview?.superview
+            }
+        }
+        
+        // No parent provider found, return default config
+        return .default
+    }
+}
+
+extension UIConfigProvider where Self: UIViewController {
+    public var uiConfig: UIConfig<ExtraData> {
+        get {
+            uiConfig(ExtraData.self)
+        }
+        set {
+            register(config: newValue)
+        }
+    }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		792B805424D95FC700C2963E /* RandomDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792B805324D95FC700C2963E /* RandomDispatchQueue.swift */; };
 		792CA62624CEE93700D70A5E /* ChannelListUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F1A247FE84900EAF71D /* ChannelListUpdater.swift */; };
 		792DD9D9256BC542001DB91B /* BaseViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792DD9D8256BC542001DB91B /* BaseViews.swift */; };
+		792DD9FB256E67C6001DB91B /* UIConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792DD9FA256E67C6001DB91B /* UIConfigProvider.swift */; };
 		792FCB4524A33B5B000290C7 /* EventDataProcessorMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4424A33B5B000290C7 /* EventDataProcessorMiddleware.swift */; };
 		792FCB4724A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4624A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift */; };
 		792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */; };
@@ -671,6 +672,7 @@
 		792B805124D95D4300C2963E /* Cached_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cached_Tests.swift; sourceTree = "<group>"; };
 		792B805324D95FC700C2963E /* RandomDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomDispatchQueue.swift; sourceTree = "<group>"; };
 		792DD9D8256BC542001DB91B /* BaseViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViews.swift; sourceTree = "<group>"; };
+		792DD9FA256E67C6001DB91B /* UIConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfigProvider.swift; sourceTree = "<group>"; };
 		792FCB4424A33B5B000290C7 /* EventDataProcessorMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDataProcessorMiddleware.swift; sourceTree = "<group>"; };
 		792FCB4624A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDataProcessorMiddleware_Tests.swift; sourceTree = "<group>"; };
 		792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OptionSet+Extensions.swift"; sourceTree = "<group>"; };
@@ -1884,6 +1886,7 @@
 				224FF6962562F5AE00725DD1 /* Bundle+Extensions.swift */,
 				224FF69C2562F5D100725DD1 /* UIImage+Extensions.swift */,
 				228190EA256733420048D7C6 /* UIFont+Extensions.swift */,
+				792DD9FA256E67C6001DB91B /* UIConfigProvider.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2615,6 +2618,7 @@
 				79088334254876EA00896F03 /* ChatChannelViewController.swift in Sources */,
 				790882DF25486B6800896F03 /* ChatChannelListVC.swift in Sources */,
 				79D86E832562BAB900DCD1D2 /* AppearanceSetting.swift in Sources */,
+				792DD9FB256E67C6001DB91B /* UIConfigProvider.swift in Sources */,
 				790882FD25486BFD00896F03 /* ChatChannelListCollectionViewCell.swift in Sources */,
 				790882D625486B4A00896F03 /* ChatChannelListCollectionViewLayout.swift in Sources */,
 				790882F725486B8000896F03 /* ChatChannelListCollectionViewDelegate.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		792B805224D95D4300C2963E /* Cached_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792B805124D95D4300C2963E /* Cached_Tests.swift */; };
 		792B805424D95FC700C2963E /* RandomDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792B805324D95FC700C2963E /* RandomDispatchQueue.swift */; };
 		792CA62624CEE93700D70A5E /* ChannelListUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F1A247FE84900EAF71D /* ChannelListUpdater.swift */; };
+		792DD9D9256BC542001DB91B /* BaseViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792DD9D8256BC542001DB91B /* BaseViews.swift */; };
 		792FCB4524A33B5B000290C7 /* EventDataProcessorMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4424A33B5B000290C7 /* EventDataProcessorMiddleware.swift */; };
 		792FCB4724A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4624A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift */; };
 		792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */; };
@@ -669,6 +670,7 @@
 		792B804F24D95B5D00C2963E /* Cached.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cached.swift; sourceTree = "<group>"; };
 		792B805124D95D4300C2963E /* Cached_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cached_Tests.swift; sourceTree = "<group>"; };
 		792B805324D95FC700C2963E /* RandomDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomDispatchQueue.swift; sourceTree = "<group>"; };
+		792DD9D8256BC542001DB91B /* BaseViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViews.swift; sourceTree = "<group>"; };
 		792FCB4424A33B5B000290C7 /* EventDataProcessorMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDataProcessorMiddleware.swift; sourceTree = "<group>"; };
 		792FCB4624A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDataProcessorMiddleware_Tests.swift; sourceTree = "<group>"; };
 		792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OptionSet+Extensions.swift"; sourceTree = "<group>"; };
@@ -1894,6 +1896,7 @@
 				885B3D7625642B3D003E6BDF /* CurrentChatUserAvatarView.swift */,
 				885B3D7C25642B88003E6BDF /* CreateNewChannelButton.swift */,
 				22A0921625682880001FE9F0 /* ChatNavigationBar.swift */,
+				792DD9D8256BC542001DB91B /* BaseViews.swift */,
 			);
 			path = "Common Views";
 			sourceTree = "<group>";
@@ -2608,6 +2611,7 @@
 				8850B914255C1F77003AED69 /* NameAndImageProviding.swift in Sources */,
 				7908834D2548770C00896F03 /* ChatMessageCollectionViewCell.swift in Sources */,
 				885B3D7D25642B88003E6BDF /* CreateNewChannelButton.swift in Sources */,
+				792DD9D9256BC542001DB91B /* BaseViews.swift in Sources */,
 				79088334254876EA00896F03 /* ChatChannelViewController.swift in Sources */,
 				790882DF25486B6800896F03 /* ChatChannelListVC.swift in Sources */,
 				79D86E832562BAB900DCD1D2 /* AppearanceSetting.swift in Sources */,


### PR DESCRIPTION
### Main issue
Views are doing layout/setup operations in `commonInit`, which is called on `init`. These operations can be expensive, and cause performance issues [we don't have numbers yet]. We're searching for a way to "lazily" do these operations.
Comment which started the discussion: https://github.com/GetStream/stream-chat-swift/pull/577#discussion_r522078499

### Secondary issue
As #596 explores, passing `config` from views to subviews & initiating correct views from config:
> I pin hopes on this approach since it is similar to environment variables in SwiftUI, can be applied for all the views and helps to avoid storing let config + init(config). **The problem is that we create subviews from the inside of view's init and at this point the view itself hasn't yet had a superview -> there is no view hierarchy to search the uiConfig<ExtraData> for.**

So we need a way to lazily do the `setupAppearance`/`setupLayout` operations, in which subviews will be created. No subviews will be touched (hence, created) during init, or before having a subview.

### Solutions explored
- `layoutSubviews`
This is part of render loop, which will be called 120 times per second. Apple generally suggest not overriding this, because low performance code in this function can cause rendering issues. If we were to use this, we'd have to do:
```swift
var didLayoutSubviews = false
override func layoutSubviews() {
  super.layoutSubviews()
  guard !didLayoutSubviews else { return }
  // our code here, to be run 1 time only
  setupLayout()
  setupAppearance()
  didLayoutSubviews = true
}
```
which is considered a code smell.
Another big issue with this approach, since `setupLayout` and `setupAppearance` is `open`, users will be able to override these, and any costly operations users implement will cause performance issues.

- `updateConstraints`
The same findings as above. `updateConstraints` is also part of render loop, being called before `layoutSubviews`.

- `didMoveToSuperview`
This is the closest callback we have in UIKit to what we actually need. It's being called whenever view's `superview` property changes.

So I came up with the `OverridableView` base class that ensures `setupLayout` and `setupAppearance` are called in the correct order when the view has a valid superview, and subclasses only need to override these 2 functions to setup themselves.
Also has the added benefit of calling `applyDefaultAppearance` in the correct place.

### Open points
1. Since `CurrentUserAvatarView` is `UIControl` rather than `UIView`, we need another base class for it, `OverridableControl`. How can we avoid this? 2 base classes basically the same, yet we need 2 different classes.
1. Should `OverridableView` also conform to `AppearanceSetting`? I thought this was a nice addition - in the worst case where the view doesn't need Appearance configurability, it doesn't need to do anything - default implementation is provided.
1. Should `updateContent` also be part of base class?