### PR TITLE
Implement User online indicator on ChannelListItemView

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
@@ -17,6 +17,10 @@ open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
     public var channel: _ChatChannel<ExtraData>? {
         didSet { updateContent() }
     }
+
+    public var currentUserId: UserId? {
+        didSet { updateContent() }
+    }
     
     override open var intrinsicContentSize: CGSize {
         .init(width: 56, height: 56)
@@ -41,7 +45,7 @@ open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
         }
 
         if channel.isDirectMessageChannel,
-            let member = channel.cachedMembers.first(where: { $0.isOnline }),
+            let member = channel.cachedMembers.first(where: { $0.isOnline && $0.id != currentUserId }),
             member.isOnline {
             onlineIndicatorView.availabilityStatus = .online
         }

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
@@ -40,6 +40,12 @@ open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
             return
         }
 
+        if channel.isDirectMessageChannel,
+            let member = channel.cachedMembers.first(where: { $0.isOnline }),
+            member.isOnline {
+            onlineIndicatorView.availabilityStatus = .online
+        }
+
         if let imageURL = channel.imageURL {
             imageView.setImage(from: imageURL)
         } else {

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
@@ -7,7 +7,13 @@ import UIKit
 
 open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
     // MARK: - Properties
-    
+
+    public let onlineIndicatorView: OnlineIndicatorView = {
+        let indicator = OnlineIndicatorView()
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        return indicator
+    }()
+
     public var channel: _ChatChannel<ExtraData>? {
         didSet { updateContent() }
     }
@@ -21,6 +27,9 @@ open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
     override open func setupLayout() {
         widthAnchor.constraint(equalTo: heightAnchor, multiplier: 1).isActive = true
         embed(imageView)
+
+        addSubview(onlineIndicatorView)
+        onlineIndicatorView.pin(anchors: [.top, .right], to: self)
     }
     
     // MARK: - Public
@@ -30,7 +39,7 @@ open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
             imageView.image = nil
             return
         }
-        
+
         if let imageURL = channel.imageURL {
             imageView.setImage(from: imageURL)
         } else {

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -25,6 +25,8 @@ open class ChatChannelListItemView<ExtraData: UIExtraDataTypes>: UIView, Appeara
             updateContent()
         }
     }
+
+    public var currentUserId: UserId?
     
     // MARK: - Subviews
     
@@ -54,10 +56,12 @@ open class ChatChannelListItemView<ExtraData: UIExtraDataTypes>: UIView, Appeara
     
     public required init(
         channel: _ChatChannel<ExtraData>? = nil,
+        currentUserId: UserId? = nil,
         uiConfig: UIConfig<ExtraData> = .default
     ) {
         self.channel = channel
         self.uiConfig = uiConfig
+        self.currentUserId = currentUserId
         
         super.init(frame: .zero)
         
@@ -67,6 +71,7 @@ open class ChatChannelListItemView<ExtraData: UIExtraDataTypes>: UIView, Appeara
     public required init?(coder: NSCoder) {
         uiConfig = .default
         channel = nil
+        currentUserId = nil
         
         super.init(coder: coder)
         
@@ -164,6 +169,7 @@ open class ChatChannelListItemView<ExtraData: UIExtraDataTypes>: UIView, Appeara
         // Avatar
         
         avatarView.channel = channel
+        avatarView.currentUserId = currentUserId
         
         // UnreadCount
         

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -69,6 +69,7 @@ open class ChatChannelListVC<ExtraData: UIExtraDataTypes>: UIViewController,
     
         cell.uiConfig = uiConfig
         cell.channelView.channel = controller.channels[indexPath.row]
+        cell.channelView.currentUserId = controller.client.currentUserId
         
         return cell
     }

--- a/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
@@ -1,0 +1,92 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+open class OnlineIndicatorView: UIView {
+    public enum AvailabilityStatus {
+        case online
+        case offline
+        case unknown
+
+        var color: UIColor {
+            switch self {
+            case .online:
+                return .systemGreen
+            case .offline:
+                return .systemRed
+            case .unknown:
+                return .systemGray
+            }
+        }
+    }
+
+    open var defaultIntrinsicContentSize: CGSize?
+    override open var intrinsicContentSize: CGSize {
+        defaultIntrinsicContentSize ?? super.intrinsicContentSize
+    }
+
+    public var availabilityStatus: AvailabilityStatus? = .offline {
+        didSet { layoutSubviews() }
+    }
+
+    // MARK: - Init
+
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        applyDefaultAppearance()
+        if #available(iOS 13.0, *) {
+            self.backgroundColor = .systemBackground // What if cell background is different??
+        } else {
+            backgroundColor = .white
+        }
+    }
+
+    // MARK: - Layout
+
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+        layer.cornerRadius = bounds.width / 2
+        clipsToBounds = true
+        drawIndicatorDot(with: availabilityStatus)
+    }
+
+    // MARK: - Private
+
+    private func drawIndicatorDot(with status: AvailabilityStatus?) {
+        guard let status = status, status != .unknown else {
+            isHidden = true
+            return
+        }
+        isHidden = false
+
+        let indicatorLayer = CAShapeLayer()
+        indicatorLayer.path = UIBezierPath(
+            arcCenter: CGPoint(x: bounds.width / 2, y: bounds.height / 2),
+            radius: 4,
+            startAngle: CGFloat(0),
+            endAngle: CGFloat.pi * 2,
+            clockwise: true
+        )
+        .cgPath
+        // UIBezierPath(ovalIn: CGRect(origin: self.bounds.origin, size: size)).cgPath
+        indicatorLayer.fillColor = status.color.cgColor
+        layer.addSublayer(indicatorLayer)
+    }
+}
+
+extension OnlineIndicatorView: AppearanceSetting {
+    public static func initialAppearanceSetup(_ view: OnlineIndicatorView) {
+        view.defaultIntrinsicContentSize = .init(width: 14, height: 14)
+    }
+}

--- a/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
@@ -17,7 +17,12 @@ open class OnlineIndicatorView: UIView {
 
         var color: UIColor {
             switch self {
-            case .online: return .systemGreen
+            case .online:
+                if #available(iOS 13, *) {
+                    return .systemGreen
+                } else {
+                    return .green
+                }
             case .none: fatalError("You should never request the color for none status.")
             }
         }

--- a/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
@@ -70,18 +70,17 @@ open class OnlineIndicatorView: UIView {
             return
         }
         isHidden = false
+        let indicatorLayer = CALayer()
+        indicatorLayer.masksToBounds = true
 
-        let indicatorLayer = CAShapeLayer()
-        indicatorLayer.path = UIBezierPath(
-            arcCenter: CGPoint(x: bounds.width / 2, y: bounds.height / 2),
-            radius: 4,
-            startAngle: CGFloat(0),
-            endAngle: CGFloat.pi * 2,
-            clockwise: true
+        indicatorLayer.frame = CGRect(
+            origin: .zero,
+            size: CGSize(width: 8, height: 8)
         )
-        .cgPath
+        indicatorLayer.cornerRadius = 4
 
-        indicatorLayer.fillColor = status.color.cgColor
+        indicatorLayer.position = CGPoint(x: layer.bounds.midX, y: layer.bounds.midY)
+        indicatorLayer.backgroundColor = status.color.cgColor
         layer.addSublayer(indicatorLayer)
     }
 }

--- a/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
@@ -4,20 +4,21 @@
 
 import UIKit
 
+/// View indicating whether the user is online or not.
+/// This view is meant to be the green dot on the `ChatChannelAvatarView` indicating that
+/// the user is online, should work only for 1-1 Chat and currently shown only green when online.
 open class OnlineIndicatorView: UIView {
+    /// Enum describing current status of the user inside the chat,
+    /// currently, we are indicating just state:
+    /// - online: Uses green color when the user is online
     public enum AvailabilityStatus {
         case online
-        case offline
-        case unknown
+        case none
 
         var color: UIColor {
             switch self {
-            case .online:
-                return .systemGreen
-            case .offline:
-                return .systemRed
-            case .unknown:
-                return .systemGray
+            case .online: return .systemGreen
+            case .none: fatalError("You should never request the color for none status.")
             }
         }
     }
@@ -27,7 +28,7 @@ open class OnlineIndicatorView: UIView {
         defaultIntrinsicContentSize ?? super.intrinsicContentSize
     }
 
-    public var availabilityStatus: AvailabilityStatus? = .offline {
+    public var availabilityStatus: AvailabilityStatus = .none {
         didSet { layoutSubviews() }
     }
 
@@ -64,7 +65,7 @@ open class OnlineIndicatorView: UIView {
     // MARK: - Private
 
     private func drawIndicatorDot(with status: AvailabilityStatus?) {
-        guard let status = status, status != .unknown else {
+        guard let status = status, status != .none else {
             isHidden = true
             return
         }
@@ -79,7 +80,7 @@ open class OnlineIndicatorView: UIView {
             clockwise: true
         )
         .cgPath
-        // UIBezierPath(ovalIn: CGRect(origin: self.bounds.origin, size: size)).cgPath
+
         indicatorLayer.fillColor = status.color.cgColor
         layer.addSublayer(indicatorLayer)
     }

--- a/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
@@ -47,7 +47,7 @@ open class OnlineIndicatorView: UIView {
     private func commonInit() {
         applyDefaultAppearance()
         if #available(iOS 13.0, *) {
-            self.backgroundColor = .systemBackground // What if cell background is different??
+            backgroundColor = .systemBackground // What if cell background is different??
         } else {
             backgroundColor = .white
         }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -474,6 +474,7 @@
 		DAFAD6A124DC476A0043ED06 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFAD6A024DC476A0043ED06 /* Result+Extensions.swift */; };
 		DAFAD6A324DD8E1A0043ED06 /* ChannelEditDetailPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFAD6A224DD8E1A0043ED06 /* ChannelEditDetailPayload.swift */; };
 		DAFC1D4724F50C5C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFC1D4524F50C2C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift */; };
+		E726C524256BDC7C003704DE /* OnlineIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E726C523256BDC7C003704DE /* OnlineIndicatorView.swift */; };
 		F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */; };
 		F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */; };
 		F61D7C3524FFA6FD00188A0E /* MessageUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3424FFA6FD00188A0E /* MessageUpdater_Tests.swift */; };
@@ -1058,6 +1059,7 @@
 		DAFAD6A024DC476A0043ED06 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		DAFAD6A224DD8E1A0043ED06 /* ChannelEditDetailPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelEditDetailPayload.swift; sourceTree = "<group>"; };
 		DAFC1D4524F50C2C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewChannelQueryUpdater_Tests.swift; sourceTree = "<group>"; };
+		E726C523256BDC7C003704DE /* OnlineIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineIndicatorView.swift; sourceTree = "<group>"; };
 		F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints_Tests.swift; sourceTree = "<group>"; };
 		F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Mock.swift; sourceTree = "<group>"; };
 		F61D7C3424FFA6FD00188A0E /* MessageUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Tests.swift; sourceTree = "<group>"; };
@@ -1891,6 +1893,7 @@
 			children = (
 				8850B93B255C3168003AED69 /* ContainerStackView.swift */,
 				8850B945255C3B41003AED69 /* AvatarView.swift */,
+				E726C523256BDC7C003704DE /* OnlineIndicatorView.swift */,
 				885B3D7625642B3D003E6BDF /* CurrentChatUserAvatarView.swift */,
 				885B3D7C25642B88003E6BDF /* CreateNewChannelButton.swift */,
 				22A0921625682880001FE9F0 /* ChatNavigationBar.swift */,
@@ -2599,6 +2602,7 @@
 				224FF6812562F2E900725DD1 /* ChatUnreadCountView.swift in Sources */,
 				224FF67B2562F1EA00725DD1 /* ChatReadStatusCheckmarkView.swift in Sources */,
 				2245B2B625602465006A612D /* ChatChannelAvatarView.swift in Sources */,
+				E726C524256BDC7C003704DE /* OnlineIndicatorView.swift in Sources */,
 				888123E0255D4D2100070D5A /* UIImageView+Extensions.swift in Sources */,
 				8850B93C255C3168003AED69 /* ContainerStackView.swift in Sources */,
 				79088343254876FE00896F03 /* ChatChannelCollectionViewLayout.swift in Sources */,
@@ -3094,7 +3098,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = D48F367GRM;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3124,7 +3128,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = D48F367GRM;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3152,7 +3156,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = D48F367GRM;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3243,7 +3247,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = D48F367GRM;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = Sample_v3/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3267,7 +3271,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = D48F367GRM;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = Sample_v3/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3291,7 +3295,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = D48F367GRM;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3318,7 +3322,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = D48F367GRM;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3342,7 +3346,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = D48F367GRM;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = Tests_v3/StreamChatTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3361,7 +3365,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = D48F367GRM;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = Tests_v3/StreamChatTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3611,7 +3615,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = D48F367GRM;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3636,7 +3640,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = D48F367GRM;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = Tests_v3/StreamChatTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3657,7 +3661,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = D48F367GRM;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = Sample_v3/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -474,7 +474,7 @@
 		DAFAD6A124DC476A0043ED06 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFAD6A024DC476A0043ED06 /* Result+Extensions.swift */; };
 		DAFAD6A324DD8E1A0043ED06 /* ChannelEditDetailPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFAD6A224DD8E1A0043ED06 /* ChannelEditDetailPayload.swift */; };
 		DAFC1D4724F50C5C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFC1D4524F50C2C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift */; };
-		E726C524256BDC7C003704DE /* OnlineIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E726C523256BDC7C003704DE /* OnlineIndicatorView.swift */; };
+		E7FDC8A3256C753100B882D4 /* OnlineIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7FDC8A2256C753100B882D4 /* OnlineIndicatorView.swift */; };
 		F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */; };
 		F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */; };
 		F61D7C3524FFA6FD00188A0E /* MessageUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3424FFA6FD00188A0E /* MessageUpdater_Tests.swift */; };
@@ -1059,7 +1059,7 @@
 		DAFAD6A024DC476A0043ED06 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		DAFAD6A224DD8E1A0043ED06 /* ChannelEditDetailPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelEditDetailPayload.swift; sourceTree = "<group>"; };
 		DAFC1D4524F50C2C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewChannelQueryUpdater_Tests.swift; sourceTree = "<group>"; };
-		E726C523256BDC7C003704DE /* OnlineIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineIndicatorView.swift; sourceTree = "<group>"; };
+		E7FDC8A2256C753100B882D4 /* OnlineIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnlineIndicatorView.swift; sourceTree = "<group>"; };
 		F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints_Tests.swift; sourceTree = "<group>"; };
 		F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Mock.swift; sourceTree = "<group>"; };
 		F61D7C3424FFA6FD00188A0E /* MessageUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Tests.swift; sourceTree = "<group>"; };
@@ -1893,10 +1893,10 @@
 			children = (
 				8850B93B255C3168003AED69 /* ContainerStackView.swift */,
 				8850B945255C3B41003AED69 /* AvatarView.swift */,
-				E726C523256BDC7C003704DE /* OnlineIndicatorView.swift */,
 				885B3D7625642B3D003E6BDF /* CurrentChatUserAvatarView.swift */,
 				885B3D7C25642B88003E6BDF /* CreateNewChannelButton.swift */,
 				22A0921625682880001FE9F0 /* ChatNavigationBar.swift */,
+				E7FDC8A2256C753100B882D4 /* OnlineIndicatorView.swift */,
 			);
 			path = "Common Views";
 			sourceTree = "<group>";
@@ -2602,7 +2602,7 @@
 				224FF6812562F2E900725DD1 /* ChatUnreadCountView.swift in Sources */,
 				224FF67B2562F1EA00725DD1 /* ChatReadStatusCheckmarkView.swift in Sources */,
 				2245B2B625602465006A612D /* ChatChannelAvatarView.swift in Sources */,
-				E726C524256BDC7C003704DE /* OnlineIndicatorView.swift in Sources */,
+				E7FDC8A3256C753100B882D4 /* OnlineIndicatorView.swift in Sources */,
 				888123E0255D4D2100070D5A /* UIImageView+Extensions.swift in Sources */,
 				8850B93C255C3168003AED69 /* ContainerStackView.swift in Sources */,
 				79088343254876FE00896F03 /* ChatChannelCollectionViewLayout.swift in Sources */,
@@ -3098,7 +3098,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DEVELOPMENT_TEAM = D48F367GRM;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3128,7 +3128,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DEVELOPMENT_TEAM = D48F367GRM;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3156,7 +3156,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DEVELOPMENT_TEAM = D48F367GRM;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3247,7 +3247,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DEVELOPMENT_TEAM = D48F367GRM;
 				INFOPLIST_FILE = Sample_v3/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3271,7 +3271,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DEVELOPMENT_TEAM = D48F367GRM;
 				INFOPLIST_FILE = Sample_v3/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3295,7 +3295,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DEVELOPMENT_TEAM = D48F367GRM;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3322,7 +3322,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DEVELOPMENT_TEAM = D48F367GRM;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3346,7 +3346,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DEVELOPMENT_TEAM = D48F367GRM;
 				INFOPLIST_FILE = Tests_v3/StreamChatTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3365,7 +3365,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DEVELOPMENT_TEAM = D48F367GRM;
 				INFOPLIST_FILE = Tests_v3/StreamChatTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3615,7 +3615,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DEVELOPMENT_TEAM = D48F367GRM;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -3640,7 +3640,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DEVELOPMENT_TEAM = D48F367GRM;
 				INFOPLIST_FILE = Tests_v3/StreamChatTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3661,7 +3661,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DEVELOPMENT_TEAM = D48F367GRM;
 				INFOPLIST_FILE = Sample_v3/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
# What this PR does
Implements small view on `ChatChannelAvatarView` which indicates whether the user is online or not. This small indicator should be visible only on direct 1-1 Channels.

# How to test this

Fire up the test StreamChat UI and run the **Stream Design** sample. In code, you can check whether those online indicator statuses match the given status:

1. The channel mock is 1-1
2. The channel mock has 1 other user than you and he is online
3. Check if the view matches the designs

Possible issues: The `OnlineIndicatorView` uses now `.systemBackground` background color to cut out the indicator according to designs. `ChatChannelListItemView` sets the same background color. Should we somehow connect this to always to point to same color? 

