### PR TITLE
Add online indicator for 1-1 Chat avatars

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
@@ -31,7 +31,7 @@ open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
     
     // MARK: - Public
     
-    open override func updateContent() {
+    override open func updateContent() {
         guard let channel = channelAndUserId.channel else {
             imageView.image = nil
             return

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
@@ -31,7 +31,7 @@ open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
     
     // MARK: - Public
     
-    open func updateContent() {
+    open override func updateContent() {
         guard let channel = channelAndUserId.channel else {
             imageView.image = nil
             return

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
@@ -8,6 +8,8 @@ import UIKit
 open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
     // MARK: - Properties
 
+    lazy var onlineIndicatorView = OnlineIndicatorView().withoutAutoresizingMaskConstraints
+
     public var channelAndUserId: (channel: _ChatChannel<ExtraData>?, currentUserId: UserId?) {
         didSet { updateContent() }
     }
@@ -22,6 +24,9 @@ open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
         super.setUpLayout()
         
         widthAnchor.constraint(equalTo: heightAnchor, multiplier: 1).isActive = true
+        embed(imageView)
+        addSubview(onlineIndicatorView)
+        onlineIndicatorView.pin(anchors: [.top, .right], to: self)
     }
     
     // MARK: - Public
@@ -32,6 +37,15 @@ open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
             return
         }
 
+        if  channel.isDirectMessageChannel,
+            let currentUserId = channelAndUserId.currentUserId,
+            let otherMember = channel.cachedMembers.first(where: { $0.id == currentUserId}),
+            otherMember.isOnline {
+            onlineIndicatorView.isHidden = false
+        } else {
+            onlineIndicatorView.isHidden = true
+        }
+        
         if let imageURL = channel.imageURL {
             imageView.setImage(from: imageURL)
         } else {

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
@@ -8,7 +8,7 @@ import UIKit
 open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
     // MARK: - Properties
 
-    lazy var onlineIndicatorView = OnlineIndicatorView().withoutAutoresizingMaskConstraints
+    public lazy var onlineIndicatorView = OnlineIndicatorView().withoutAutoresizingMaskConstraints
 
     public var channelAndUserId: (channel: _ChatChannel<ExtraData>?, currentUserId: UserId?) {
         didSet { updateContent() }
@@ -41,6 +41,15 @@ open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
             let currentUserId = channelAndUserId.currentUserId,
             let otherMember = channel.cachedMembers.first(where: { $0.id == currentUserId}),
             otherMember.isOnline {
+
+            let fallbackBackgroundColor: UIColor
+            if #available(iOS 13.0, *) {
+                fallbackBackgroundColor = UIColor.systemBackground
+            } else {
+                fallbackBackgroundColor = .white
+            }
+
+            onlineIndicatorView.borderColor = backgroundColor ?? fallbackBackgroundColor
             onlineIndicatorView.isHidden = false
         } else {
             onlineIndicatorView.isHidden = true

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelAvatarView.swift
@@ -7,8 +7,8 @@ import UIKit
 
 open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
     // MARK: - Properties
-    
-    public var channel: _ChatChannel<ExtraData>? {
+
+    public var channelAndUserId: (channel: _ChatChannel<ExtraData>?, currentUserId: UserId?) {
         didSet { updateContent() }
     }
     
@@ -26,12 +26,12 @@ open class ChatChannelAvatarView<ExtraData: UIExtraDataTypes>: AvatarView {
     
     // MARK: - Public
     
-    override open func updateContent() {
-        guard let channel = channel else {
+    open func updateContent() {
+        guard let channel = channelAndUserId.channel else {
             imageView.image = nil
             return
         }
-        
+
         if let imageURL = channel.imageURL {
             imageView.setImage(from: imageURL)
         } else {

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -16,7 +16,7 @@ open class ChatChannelListItemView<ExtraData: UIExtraDataTypes>: View, UIConfigP
 
     // MARK: - Properties
     
-    public let uiConfig: UIConfig<ExtraData>
+    public var uiConfig: UIConfig<ExtraData>
 
     public var channelAndUserId: (channel: _ChatChannel<ExtraData>?, currentUserId: UserId?) {
         didSet {

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -72,7 +72,7 @@ open class ChatChannelListVC<ExtraData: UIExtraDataTypes>: ViewController,
         ) as! ChatChannelListCollectionViewCell<ExtraData>
     
         cell.uiConfig = uiConfig
-        cell.channelView.channel = controller.channels[indexPath.row]
+        cell.channelView.channelAndUserId = (controller.channels[indexPath.row], controller.client.currentUserId)
         
         return cell
     }

--- a/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
@@ -21,6 +21,10 @@ class OnlineIndicatorView: UIView {
         layer.cornerRadius = bounds.width / 2
         layer.borderWidth = 2
         layer.backgroundColor = fillColor.cgColor
-        layer.borderColor = UIColor.white.cgColor
+        if #available(iOS 13.0, *) {
+            layer.borderColor = UIColor.systemBackground.cgColor
+        } else {
+            layer.borderColor = UIColor.white.cgColor
+        }
     }
 }

--- a/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
@@ -1,0 +1,26 @@
+//
+//  OnlineIndicatorView.swift
+//  StreamChatUI
+//
+//  Created by Dominik Bucher on 25/11/2020.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+class OnlineIndicatorView: UIView {
+    public var fillColor: UIColor = .green {
+        didSet { layer.borderColor = fillColor.cgColor }
+    }
+    public var defaultDiameter: CGFloat = 14
+    override var intrinsicContentSize: CGSize {
+        .init(width: defaultDiameter, height: defaultDiameter)
+    }
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.cornerRadius = bounds.width / 2
+        layer.borderWidth = 2
+        layer.backgroundColor = fillColor.cgColor
+        layer.borderColor = UIColor.white.cgColor
+    }
+}

--- a/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
@@ -8,23 +8,30 @@
 
 import UIKit
 
-class OnlineIndicatorView: UIView {
-    public var fillColor: UIColor = .green {
-        didSet { layer.borderColor = fillColor.cgColor }
+open class OnlineIndicatorView: UIView {
+    static var greenColor: UIColor {
+        if #available(iOS 13.0, *) {
+            return .systemGreen
+        } else {
+            return .green
+        }
+    }
+
+    public var borderColor: UIColor = .white {
+        didSet { layer.borderColor = borderColor.cgColor }
+    }
+    public var fillColor: UIColor = OnlineIndicatorView.greenColor {
+        didSet { layer.backgroundColor = fillColor.cgColor }
     }
     public var defaultDiameter: CGFloat = 14
-    override var intrinsicContentSize: CGSize {
+    override open var intrinsicContentSize: CGSize {
         .init(width: defaultDiameter, height: defaultDiameter)
     }
-    override func layoutSubviews() {
+    override open func layoutSubviews() {
         super.layoutSubviews()
         layer.cornerRadius = bounds.width / 2
         layer.borderWidth = 2
         layer.backgroundColor = fillColor.cgColor
-        if #available(iOS 13.0, *) {
-            layer.borderColor = UIColor.systemBackground.cgColor
-        } else {
-            layer.borderColor = UIColor.white.cgColor
-        }
+        layer.borderColor = borderColor.cgColor
     }
 }

--- a/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
@@ -9,18 +9,11 @@
 import UIKit
 
 open class OnlineIndicatorView: UIView {
-    static var greenColor: UIColor {
-        if #available(iOS 13.0, *) {
-            return .systemGreen
-        } else {
-            return .green
-        }
-    }
 
     public var borderColor: UIColor = .white {
         didSet { layer.borderColor = borderColor.cgColor }
     }
-    public var fillColor: UIColor = OnlineIndicatorView.greenColor {
+    public var fillColor: UIColor = .systemGreen {
         didSet { layer.backgroundColor = fillColor.cgColor }
     }
     public var defaultDiameter: CGFloat = 14

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -476,6 +476,7 @@
 		DAFAD6A124DC476A0043ED06 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFAD6A024DC476A0043ED06 /* Result+Extensions.swift */; };
 		DAFAD6A324DD8E1A0043ED06 /* ChannelEditDetailPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFAD6A224DD8E1A0043ED06 /* ChannelEditDetailPayload.swift */; };
 		DAFC1D4724F50C5C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFC1D4524F50C2C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift */; };
+		E759AC4D256E694F00341865 /* OnlineIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */; };
 		F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */; };
 		F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */; };
 		F61D7C3524FFA6FD00188A0E /* MessageUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3424FFA6FD00188A0E /* MessageUpdater_Tests.swift */; };
@@ -1062,6 +1063,7 @@
 		DAFAD6A024DC476A0043ED06 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		DAFAD6A224DD8E1A0043ED06 /* ChannelEditDetailPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelEditDetailPayload.swift; sourceTree = "<group>"; };
 		DAFC1D4524F50C2C00CE2DD8 /* NewChannelQueryUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewChannelQueryUpdater_Tests.swift; sourceTree = "<group>"; };
+		E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineIndicatorView.swift; sourceTree = "<group>"; };
 		F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints_Tests.swift; sourceTree = "<group>"; };
 		F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Mock.swift; sourceTree = "<group>"; };
 		F61D7C3424FFA6FD00188A0E /* MessageUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Tests.swift; sourceTree = "<group>"; };
@@ -1900,6 +1902,7 @@
 				885B3D7C25642B88003E6BDF /* CreateNewChannelButton.swift */,
 				22A0921625682880001FE9F0 /* ChatNavigationBar.swift */,
 				792DD9D8256BC542001DB91B /* BaseViews.swift */,
+				E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */,
 			);
 			path = "Common Views";
 			sourceTree = "<group>";
@@ -2626,6 +2629,7 @@
 				224FF6812562F2E900725DD1 /* ChatUnreadCountView.swift in Sources */,
 				224FF67B2562F1EA00725DD1 /* ChatReadStatusCheckmarkView.swift in Sources */,
 				2245B2B625602465006A612D /* ChatChannelAvatarView.swift in Sources */,
+				E759AC4D256E694F00341865 /* OnlineIndicatorView.swift in Sources */,
 				888123E0255D4D2100070D5A /* UIImageView+Extensions.swift in Sources */,
 				8850B93C255C3168003AED69 /* ContainerStackView.swift in Sources */,
 				79088343254876FE00896F03 /* ChatChannelCollectionViewLayout.swift in Sources */,


### PR DESCRIPTION
# What this PR does
Implements small view on `ChatChannelAvatarView` which indicates whether the user is online or not. This small indicator should be visible only on direct 1-1 Channels.

# How to test this

Fire up the test StreamChat UI and run the **Stream Design** sample. In code, you can check whether those online indicator statuses match the given status:

1. The channel mock is 1-1
2. The channel mock has 1 other user than you and he is online
3. Check if the view matches the designs