### PR TITLE
Delete most of Swiftlint warnings

### DIFF
--- a/Sample_v3/AppDelegate.swift
+++ b/Sample_v3/AppDelegate.swift
@@ -48,7 +48,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     @available(iOS 13.0, *)
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // If any sessions were discarded while the application was not running, this will be called shortly
+        // after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
     

--- a/Sample_v3/Configuration.swift
+++ b/Sample_v3/Configuration.swift
@@ -5,8 +5,8 @@
 import Foundation
 import StreamChat
 
-struct Configuration {
-    struct PersistenceKeys {
+enum Configuration {
+    enum PersistenceKeys {
         static let apiKey = "apiKey"
         static let userId = "userId"
         static let userName = "userName"
@@ -16,7 +16,7 @@ struct Configuration {
         static let shouldFlushLocalStorageOnStart = "shouldFlushLocalStorageOnStart"
     }
     
-    struct DefaultValues {
+    enum DefaultValues {
         static let apiKey = "qk4nn7rpcn75"
         static let userId = TestUser.defaults[0].id
         static let userName = TestUser.defaults[0].name
@@ -35,17 +35,17 @@ struct Configuration {
             [
                 TestUser(
                     name: "Broken Waterfall",
-                    id: "broken-waterfall-5",
+                    id: "broken-waterfall-5", // swiftlint:disable:next line_length
                     token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.d1xKTlD_D0G-VsBoDBNbaLjO-2XWNA8rlTm4ru4sMHg"
                 ),
                 TestUser(
                     name: "Suspicious Coyote",
-                    id: "suspicious-coyote-3",
+                    id: "suspicious-coyote-3", // swiftlint:disable:next line_length
                     token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoic3VzcGljaW91cy1jb3lvdGUtMyJ9.xVaBHFTexlYPEymPmlgIYCM5M_iQVHrygaGS1QhkaEE"
                 ),
                 TestUser(
                     name: "Steep Moon",
-                    id: "steep-moon-9",
+                    id: "steep-moon-9", // swiftlint:disable:next line_length
                     token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoic3RlZXAtbW9vbi05In0.xwGjOwnTy3r4o2owevNTyzZLWMsMh_bK7e5s1OQ2zXU"
                 )
             ]

--- a/Sample_v3/ConfigurationViewController.swift
+++ b/Sample_v3/ConfigurationViewController.swift
@@ -40,7 +40,8 @@ class ConfigurationViewController: UITableViewController {
         case 2:
             tokenTypeSegmentedControl.selectedSegmentIndex = 2
             jwtTextField.isEnabled = false
-            if token != "" {
+            if let token = token,
+                !token.isEmpty {
                 tableView.deleteRows(at: [jwtCellIndexPath], with: .top)
             }
             jwtTextField.text = .development

--- a/Sample_v3/Extensions/UITableViewController+KeyboardAvoidance.swift
+++ b/Sample_v3/Extensions/UITableViewController+KeyboardAvoidance.swift
@@ -52,7 +52,7 @@ extension UITableViewController {
         return view.frame.intersection(keyboardView.frame).height
     }
     
-    private struct AssociatedKeys {
+    private enum AssociatedKeys {
         static var keyboardHeight = "keyboardHeight"
     }
 

--- a/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChannelMembersViewController.swift
+++ b/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChannelMembersViewController.swift
@@ -21,11 +21,12 @@ class CombineSimpleChannelMembersViewController: UITableViewController {
     /// # memberListController
     ///
     ///
-    ///  The property below holds the `ChatChannelMemberListController` object.
-    ///  It is used to make calls to the Stream Chat API and to listen to the events.
-    ///  After it is set, we are subscribing to `Publishers` from `ChatChannelMemberListController.BasePublisher` to receive updates.
-    ///  Publishers functionality is identical to methods of `ChatChannelMemberListControllerDelegate`.
-    ///  Also we need to call `memberListController.synchronize()` to update local data with remote one.
+    /// The property below holds the `ChatChannelMemberListController` object.
+    /// It is used to make calls to the Stream Chat API and to listen to the events.
+    /// After it is set, we are subscribing to `Publishers` from `ChatChannelMemberListController.BasePublisher`
+    /// to receive updates.
+    /// Publishers functionality is identical to methods of `ChatChannelMemberListControllerDelegate`.
+    /// Also we need to call `memberListController.synchronize()` to update local data with remote one.
     ///
     var memberListController: ChatChannelMemberListController! {
         didSet {
@@ -54,8 +55,10 @@ class CombineSimpleChannelMembersViewController: UITableViewController {
         /// You can use it for presenting some loading indicator.
         /// While using `Combine` publishers, the initial `state` of the contraller will be `.localDataFetched`
         /// (or `localDataFetchFailed` in case of some internal error with DB, it should be very rare case).
-        /// It means that if there is some local data is stored in DB related to this controller, it will be available from the start. After calling `memberListController.synchronize()`
-        /// the controller will try to update local data with remote one and change it's state to `.remoteDataFetched` (or `.remoteDataFetchFailed` in case of failed API request).
+        /// It means that if there is some local data is stored in DB related to this controller,
+        /// it will be available from the start. After calling `memberListController.synchronize()`
+        /// the controller will try to update local data with remote one and change it's state to `.remoteDataFetched`
+        /// (or `.remoteDataFetchFailed` in case of failed API request).
         ///
         memberListController
             .statePublisher
@@ -165,7 +168,8 @@ class CombineSimpleChannelMembersViewController: UITableViewController {
     ///
     /// # cellForRowAt
     ///
-    /// The method below returns a cell configured based on the member in position `indexPath.row` of `memberListController.members`.
+    /// The method below returns a cell configured based on the member in
+    /// position `indexPath.row` of `memberListController.members`.
     ///
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let member = memberListController.members[indexPath.row]

--- a/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChannelsViewController.swift
+++ b/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChannelsViewController.swift
@@ -9,7 +9,8 @@ import UIKit
 ///
 /// # CombineSimpleChannelsViewController
 ///
-/// A `UITableViewController` subclass that displays and manages the list of channels.  It uses the `ChannelListController`  class to make calls to the Stream Chat API
+/// A `UITableViewController` subclass that displays and manages the list of channels.
+/// It uses the `ChannelListController`  class to make calls to the Stream Chat API
 /// and listens to events by subscribing to its combine publishers.
 ///
 @available(iOS 13, *)
@@ -19,12 +20,13 @@ class CombineSimpleChannelsViewController: UITableViewController {
     ///
     /// # channelListController
     ///
-    ///  The property below holds the `ChannelListController` object.  It is used to make calls to the Stream Chat API and to listen to the events related to the channels list.
-    ///  After it is set, we are subscribing to `Publishers` from `ChannelListController.BasePublisher` to receive updates.
-    ///  `Publishers` functionality is identical to methods from `ChannelListControllerDelegate`.
-    ///  Also we need to call `channelListController.synchronize()` to update local data with remote one.
-    ///  Additionally, `channelListController.client` holds a reference to the `ChatClient` which created this instance.
-    ///  It can be used to create other controllers.
+    /// The property below holds the `ChannelListController` object.
+    /// It is used to make calls to the Stream Chat API and to listen to the events related to the channels list.
+    /// After it is set, we are subscribing to `Publishers` from `ChannelListController.BasePublisher` to receive updates.
+    /// `Publishers` functionality is identical to methods from `ChannelListControllerDelegate`.
+    /// Also we need to call `channelListController.synchronize()` to update local data with remote one.
+    /// Additionally, `channelListController.client` holds a reference to the `ChatClient` which created this instance.
+    /// It can be used to create other controllers.
     var channelListController: ChatChannelListController! {
         didSet {
             subscribeToCombinePublishers()
@@ -61,8 +63,10 @@ class CombineSimpleChannelsViewController: UITableViewController {
         /// You can use it for presenting some loading indicator.
         /// While using `Combine` publishers, the initial `state` of the contraller will be `.localDataFetched`
         /// (or `localDataFetchFailed` in case of some internal error with DB, it should be very rare case).
-        /// It means that if there is some local data is stored in DB related to this controller, it will be available from the start. After calling `channelListController.synchronize()`
-        /// the controller will try to update local data with remote one and change it's state to `.remoteDataFetched` (or `.remoteDataFetchFailed` in case of failed API request).
+        /// It means that if there is some local data is stored in DB related to this controller,
+        ///  it will be available from the start. After calling `channelListController.synchronize()`
+        /// the controller will try to update local data with remote one and change it's state to `.remoteDataFetched`
+        /// (or `.remoteDataFetchFailed` in case of failed API request).
         ///
         channelListController
             .statePublisher
@@ -105,14 +109,16 @@ class CombineSimpleChannelsViewController: UITableViewController {
     // MARK: - UITableViewDataSource
 
     ///
-    /// The methods below are part of the `UITableViewDataSource` protocol and will be called when the `UITableView` needs information which will be given by the
+    /// The methods below are part of the `UITableViewDataSource` protocol and will be called when
+    /// the `UITableView` needs information which will be given by the
     /// `channelListController` object.
     ///
     
     ///
     /// # numberOfRowsInSection
     ///
-    /// The method below returns the current loaded channels count `channelListController.channels.count`. It will increase as more channels are loaded or decrease as
+    /// The method below returns the current loaded channels count `channelListController.channels.count`.
+    /// It will increase as more channels are loaded or decrease as
     /// channels are deleted.
     ///
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -122,7 +128,8 @@ class CombineSimpleChannelsViewController: UITableViewController {
     ///
     /// # cellForRowAt
     ///
-    /// The method below returns a cell configured based on the channel in position `indexPath.row` of `channelListController.channels`.
+    /// The method below returns a cell configured based on the channel in
+    /// position `indexPath.row` of `channelListController.channels`.
     ///
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let channel = channelListController.channels[indexPath.row]
@@ -147,14 +154,16 @@ class CombineSimpleChannelsViewController: UITableViewController {
     // MARK: - UITableViewDelegate
 
     ///
-    /// The methods below are part of the `UITableViewDelegate` protocol and will be called when some event happened in the `UITableView`  which will cause some action
+    /// The methods below are part of the `UITableViewDelegate` protocol and will be called when
+    /// some event happened in the `UITableView`  which will cause some action
     /// done by the `channelController` object.
     ///
     
     ///
     /// # willDisplay
     ///
-    /// The method below handles the case when the last cell in the channels list is displayed by calling `channelListController.loadNextChannels()` to fetch more
+    /// The method below handles the case when the last cell in the channels list is displayed by
+    /// calling `channelListController.loadNextChannels()` to fetch more
     /// channels.
     ///
     override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
@@ -177,7 +186,8 @@ class CombineSimpleChannelsViewController: UITableViewController {
         switch editingStyle {
         case .delete:
             let channelId = channelListController.channels[indexPath.row].cid
-            /// After successful channel deletion you will receive updates from `channelsChangesPublisher` and channel will be removed from `tableView`.
+            /// After successful channel deletion you will receive updates from `channelsChangesPublisher`
+            /// and channel will be removed from `tableView`.
             chatClient.channelController(for: channelId).deleteChannel()
         default: return
         }
@@ -186,13 +196,15 @@ class CombineSimpleChannelsViewController: UITableViewController {
     // MARK: - Actions
 
     ///
-    /// The methods below are called when the user presses some button to open the settings screen or create a channel, or long presses a channel cell in the table view.
+    /// The methods below are called when the user presses some button to open
+    /// the settings screen or create a channel, or long presses a channel cell in the table view.
     ///
     
     ///
     /// # handleSettingsButton
     ///
-    /// The method below is called when the user taps the settings button. Before presenting the view controller, `settingsViewController.currentUserController` is set
+    /// The method below is called when the user taps the settings button.
+    /// Before presenting the view controller, `settingsViewController.currentUserController` is set
     /// so that view controller can get information and take actions that affect the current user.
     ///
     @objc
@@ -211,7 +223,8 @@ class CombineSimpleChannelsViewController: UITableViewController {
     ///
     /// # handleAddChannelButton
     ///
-    /// The method below is called when the user taps the add channel button. It creates the channel by calling `chatClient.channelController(createChannelWithId: ...)`
+    /// The method below is called when the user taps the add channel button. It creates the channel
+    /// by calling `chatClient.channelController(createChannelWithId: ...)`
     ///
     @objc
     func handleAddChannelButton(_ sender: Any) {
@@ -272,9 +285,11 @@ class CombineSimpleChannelsViewController: UITableViewController {
     ///
     /// # handleLongPress
     ///
-    /// The method below handles long press on channel cells by displaying a `UIAlertController` with many actions that can be taken on the `channelController` such
-    /// as `updateChannel`, `muteChannel`, `unmuteChannel`, ``showChannel`, and `hideChannel`.
-    /// After succesfull channel modifcation you will receive updates from `channelsChangesPublisher` so you will be able to update your UI.
+    /// The method below handles long press on channel cells by displaying a `UIAlertController` with many
+    /// actions that can be taken on the `channelController`
+    /// such as `updateChannel`, `muteChannel`, `unmuteChannel`, ``showChannel`, and `hideChannel`.
+    /// After succesfull channel modifcation you will receive updates from `channelsChangesPublisher`
+    /// so you will be able to update your UI.
     /// (e.g. show "mute" icon in `UITableViewCell`)
     ///
     @objc
@@ -322,7 +337,8 @@ class CombineSimpleChannelsViewController: UITableViewController {
     ///
     /// # prepareForSegue
     ///
-    /// The method below handles the segue to `CombineSimpleChatViewController`. It passes down to it a reference to a `ChannelController` for the respective channel so it
+    /// The method below handles the segue to `CombineSimpleChatViewController`.
+    /// It passes down to it a reference to a `ChannelController` for the respective channel so it
     /// can display and manage it.
     ///
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChatViewController.swift
+++ b/Sample_v3/Samples/CombineSimpleChat/CombineSimpleChatViewController.swift
@@ -9,7 +9,8 @@ import UIKit
 ///
 /// # CombineSimpleChatViewController
 ///
-/// A `UITableViewController` subclass that displays and manages a channel.  It uses the `ChannelController`  class to make calls to the Stream Chat API and listens to
+/// A `UITableViewController` subclass that displays and manages a channel.
+/// It uses the `ChannelController`  class to make calls to the Stream Chat API and listens to
 /// events by conforming to `ChannelControllerDelegate`.
 ///
 @available(iOS 13, *)
@@ -20,10 +21,11 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
     /// # channelController
     ///
     ///
-    ///  The property below holds the `ChannelController` object.  It is used to make calls to the Stream Chat API and to listen to the events.
-    ///  After it is set, we are subscribing to `Publishers` from `ChannelController.BasePublisher` to receive updates.
-    ///  `Publishers` functionality is identical to methods of `ChannelControllerDelegate`.
-    ///  Also we need to call `channelController.synchronize()` to update local data with remote one.
+    /// The property below holds the `ChannelController` object.
+    /// It is used to make calls to the Stream Chat API and to listen to the events.
+    /// After it is set, we are subscribing to `Publishers` from `ChannelController.BasePublisher` to receive updates.
+    /// `Publishers` functionality is identical to methods of `ChannelControllerDelegate`.
+    /// Also we need to call `channelController.synchronize()` to update local data with remote one.
     ///
     var channelController: ChatChannelController! {
         didSet {
@@ -57,7 +59,8 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
         
         ///
         /// This subscription updates the view controller's `title` and its `navigationItem.prompt` to display the count of channel
-        /// members and the count of online members or typing members if any. When the channel is deleted, this view controller is dismissed.
+        /// members and the count of online members or typing members if any.
+        /// When the channel is deleted, this view controller is dismissed.
         ///
         let updatedChannel = channelController
             .channelChangePublisher
@@ -148,8 +151,10 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
         /// You can use it for presenting some loading indicator.
         /// While using `Combine` publishers, the initial `state` of the contraller will be `.localDataFetched`
         /// (or `localDataFetchFailed` in case of some internal error with DB, it should be very rare case).
-        /// It means that if there is some local data stored in DB related to this controller, it will be available from the start. After calling `channelController.synchronize()`
-        /// the controller will try to update local data with remote one and change it's state to `.remoteDataFetched` (or `.remoteDataFetchFailed` in case of failed API request).
+        /// It means that if there is some local data stored in DB related to this controller,
+        /// it will be available from the start. After calling `channelController.synchronize()`
+        /// the controller will try to update local data with remote one and change it's state to `.remoteDataFetched`
+        /// (or `.remoteDataFetchFailed` in case of failed API request).
         ///
         channelController
             .statePublisher
@@ -162,14 +167,16 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
     // MARK: - UITableViewDataSource
 
     ///
-    /// The methods below are part of the `UITableViewDataSource` protocol and will be called when the `UITableView` needs information which will be given by the
+    /// The methods below are part of the `UITableViewDataSource` protocol and will be
+    /// called when the `UITableView` needs information which will be given by the
     /// `channelController` object.
     ///
     
     ///
     /// # numberOfRowsInSection
     ///
-    /// The method below returns the current loaded message count `channelController.messages.count`. It will increase as more messages are loaded or decrease as
+    /// The method below returns the current loaded message count `channelController.messages.count`.
+    /// It will increase as more messages are loaded or decrease as
     /// messages are deleted.
     ///
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -179,8 +186,9 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
     ///
     /// # cellForRowAt
     ///
-    /// The method below returns a cell configured based on the message in position `indexPath.row` of `channelController.messages`. It also highlights the cell based
-    /// on the message's `localState` which when different from `nil` means some local work is being done on it which is not completed yet.
+    /// The method below returns a cell configured based on the message in position `indexPath.row` of `channelController.messages`.
+    /// It also highlights the cell based on the message's `localState` which when different from `nil`
+    /// means some local work is being done on it which is not completed yet.
     ///
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let message = channelController.messages[indexPath.row]
@@ -204,15 +212,16 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
     // MARK: - UITableViewDelegate
 
     ///
-    /// The methods below are part of the `UITableViewDelegate` protocol and will be called when some event happened in the `UITableView`  which will cause some action
+    /// The methods below are part of the `UITableViewDelegate` protocol and will be called when some event
+    ///  happened in the `UITableView`  which will cause some action
     /// done by the `channelController` object.
     ///
     
     ///
     /// # willDisplay
     ///
-    /// The method below handles the case when the last cell in the message list is displayed by calling `channelController?.loadNextMessages()` to fetch more
-    /// messages.
+    /// The method below handles the case when the last cell in the message list is displayed
+    /// by calling `channelController?.loadNextMessages()` to fetch more messages.
     ///
     override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         let lastSection = tableView.numberOfSections - 1
@@ -283,7 +292,8 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
     ///
     /// # contextMenuConfigurationForRowAt
     ///
-    /// The method below returns the context menu with actions that can be taken on the message such as deleting and editing, or on the message's author such as banning and
+    /// The method below returns the context menu with actions that can be taken on the message
+    /// such as deleting and editing, or on the message's author such as banning and
     /// unbanning.
     ///
     @available(iOS 13, *)
@@ -362,7 +372,8 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
     ///
     /// # sendMessageButtonTapped
     ///
-    /// The method below is called when the user taps the send button. To send the message, `channelController?.createNewMessage(text:)` is called.
+    /// The method below is called when the user taps the send button. To send the message,
+    /// `channelController?.createNewMessage(text:)` is called.
     ///
     @objc func sendMessageButtonTapped(_ sender: Any) {
         guard let text = composerView.textView.text else {
@@ -377,7 +388,8 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
     ///
     /// # showChannelActionsAlert
     ///
-    /// The method below displays a `UIAlertController` with many actions that can be taken on the `channelController` such as `addMembers`, `removeMembers`,
+    /// The method below displays a `UIAlertController` with many actions that can be
+    /// taken on the `channelController` such as `addMembers`, `removeMembers`,
     /// and `deleteChannel`.
     ///
     @objc func showChannelActionsAlert() {
@@ -420,14 +432,16 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
     // MARK: - UITextViewDelegate
 
     ///
-    /// The methods below are part of the `UITextViewDelegate` protocol and will be called when some event happened in the  `ComposerView`'s `UITextView`  which will
+    /// The methods below are part of the `UITextViewDelegate`
+    /// protocol and will be called when some event happened in the `ComposerView`'s `UITextView`  which will
     /// cause some action done by the `channelController` object.
     ///
     
     ///
     /// # textViewDidChange
     ///
-    /// The method below handles changes to the `ComposerView`'s `UITextView` by calling `channelController.keystroke()` to send typing events to the channel so
+    /// The method below handles changes to the `ComposerView`'s `UITextView`
+    /// by calling `channelController.keystroke()` to send typing events to the channel so
     /// other users will know the current user is typing.
     ///
     func textViewDidChange(_ textView: UITextView) {
@@ -437,7 +451,8 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
     ///
     /// # textViewDidChange
     ///
-    /// The method below handles the end of `ComposerView`'s `UITextView` editing by calling `channelController.stopTyping()` to immediately stop the typing
+    /// The method below handles the end of `ComposerView`'s `UITextView` editing
+    ///  by calling `channelController.stopTyping()` to immediately stop the typing
     /// events so other users will know the current user stopped typing.
     ///
     func textViewDidEndEditing(_ textView: UITextView) {

--- a/Sample_v3/Samples/CombineSimpleChat/CombineSimpleUsersViewController.swift
+++ b/Sample_v3/Samples/CombineSimpleChat/CombineSimpleUsersViewController.swift
@@ -9,7 +9,8 @@ import UIKit
 ///
 /// # CombineSimpleUsersViewController
 ///
-/// A `UITableViewController` subclass that displays and manages the list of users.  It uses the `ChatUserListController`  class to make calls to the Stream Chat API
+/// A `UITableViewController` subclass that displays and manages the list of users.
+/// It uses the `ChatUserListController`  class to make calls to the Stream Chat API
 /// and listens to events by conforming to `ChatUserListControllerDelegate`.
 ///
 @available(iOS 13, *)
@@ -19,10 +20,11 @@ class CombineSimpleUsersViewController: UITableViewController, ChatUserListContr
     ///
     /// # userListController
     ///
-    ///  The property below holds the `ChatUserListController` object.  It is used to make calls to the Stream Chat API and to listen to the events related to the users list.
-    ///  After it is set, we are subscribing to `Publishers` from `ChatUserListController.BasePublisher` to receive updates.
-    ///  `Publishers` functionality is identical to methods of `ChatUserListControllerDelegate`.
-    ///  Also we need to call `userListController.synchronize()` to update local data with remote one.
+    /// The property below holds the `ChatUserListController` object.
+    /// It is used to make calls to the Stream Chat API and to listen to the events related to the users list.
+    /// After it is set, we are subscribing to `Publishers` from `ChatUserListController.BasePublisher` to receive updates.
+    /// `Publishers` functionality is identical to methods of `ChatUserListControllerDelegate`.
+    /// Also we need to call `userListController.synchronize()` to update local data with remote one.
     ///
     var userListController: ChatUserListController! {
         didSet {
@@ -51,8 +53,10 @@ class CombineSimpleUsersViewController: UITableViewController, ChatUserListContr
         /// You can use it for presenting some loading indicator.
         /// While using `Combine` publishers, the initial `state` of the contraller will be `.localDataFetched`
         /// (or `localDataFetchFailed` in case of some internal error with DB, it should be very rare case).
-        /// It means that if there is some local data is stored in DB related to this controller, it will be available from the start. After calling `userListController.synchronize()`
-        /// the controller will try to update local data with remote one and change it's state to `.remoteDataFetched` (or `.remoteDataFetchFailed` in case of failed API request).
+        /// It means that if there is some local data is stored in DB related to this controller,
+        /// it will be available from the start. After calling `userListController.synchronize()`
+        /// the controller will try to update local data with remote one and change it's state to `.remoteDataFetched`
+        /// (or `.remoteDataFetchFailed` in case of failed API request).
         ///
         userListController
             .statePublisher
@@ -105,7 +109,8 @@ class CombineSimpleUsersViewController: UITableViewController, ChatUserListContr
     ///
     /// # handleLongPress
     ///
-    /// The method below handles long press on user cells by displaying a `UIAlertController` with actions that can be taken on the `userController`. (`mute` and `unmute`)
+    /// The method below handles long press on user cells by displaying a `UIAlertController`
+    /// with actions that can be taken on the `userController`. (`mute` and `unmute`)
     @objc func handleLongPress(_ gestureRecognizer: UILongPressGestureRecognizer) {
         guard
             let indexPath = tableView.indexPathForRow(at: gestureRecognizer.location(in: tableView)),
@@ -135,14 +140,16 @@ class CombineSimpleUsersViewController: UITableViewController, ChatUserListContr
     // MARK: - UITableViewDataSource
 
     ///
-    /// The methods below are part of the `UITableViewDataSource` protocol and will be called when the `UITableView` needs information which will be given by the
+    /// The methods below are part of the `UITableViewDataSource` protocol and will be called when the `UITableView`
+    /// needs information which will be given by the
     /// `userListController` object.
     ///
     
     ///
     /// # numberOfRowsInSection
     ///
-    /// The method below returns the current loaded users count `userListController.users.count`. It will increase as more users are loaded or decrease as
+    /// The method below returns the current loaded users count `userListController.users.count`.
+    /// It will increase as more users are loaded or decrease as
     /// users are deleted.
     ///
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -159,7 +166,7 @@ class CombineSimpleUsersViewController: UITableViewController, ChatUserListContr
         
         var cell = tableView.dequeueReusableCell(withIdentifier: "Cell")
         
-        if (!(cell != nil)) {
+        if cell == nil {
             cell = UITableViewCell(style: .default, reuseIdentifier: "Cell")
         }
         
@@ -185,7 +192,8 @@ class CombineSimpleUsersViewController: UITableViewController, ChatUserListContr
     ///
     /// # willDisplay
     ///
-    /// The method below handles the case when the last cell in the users list is displayed by calling `userListController.loadNextChannels()` to fetch more
+    /// The method below handles the case when the last cell in the users list is displayed by
+    /// calling `userListController.loadNextChannels()` to fetch more
     /// users.
     ///
     override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
@@ -212,6 +220,7 @@ class CombineSimpleUsersViewController: UITableViewController, ChatUserListContr
     )
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         tableView.addGestureRecognizer(longPressRecognizer)
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .done,

--- a/Sample_v3/Samples/SimpleChat/SimpleChannelMembersViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChannelMembersViewController.swift
@@ -18,10 +18,14 @@ class SimpleChannelMembersViewController: UITableViewController, ChatChannelMemb
     ///
     /// # memberListController
     ///
-    ///  The property below holds the `ChatChannelMemberListController` object.  It is used to make calls to the Stream Chat API and to listen to the events related to the users list.
-    ///  After it is set, `memberListController.delegate` needs to receive a reference to a `ChatChannelMemberListControllerDelegate`, which, in this case, is `self`. After the
-    ///  delegate is set,`memberListController.synchronize()` must be called to start listening to events related to the users list. Additionally,
-    ///  `memberListController.client` holds a reference to the `ChatClient` which created this instance. It can be used to create other controllers.
+    /// The property below holds the `ChatChannelMemberListController` object.
+    /// It is used to make calls to the Stream Chat API and to listen to the events related to the users list.
+    /// After it is set, `memberListController.delegate` needs to receive a reference to a
+    /// `ChatChannelMemberListControllerDelegate`, which, in this case, is `self`.
+    /// After the delegate is set,`memberListController.synchronize()` must be called to start listening to
+    ///  events related to the users list. Additionally,
+    /// `memberListController.client` holds a reference to the `ChatClient`
+    /// which created this instance. It can be used to create other controllers.
     ///
     var memberListController: ChatChannelMemberListController! {
         didSet {
@@ -33,14 +37,16 @@ class SimpleChannelMembersViewController: UITableViewController, ChatChannelMemb
     // MARK: - ChatChannelMemberListControllerDelegate
 
     ///
-    /// The methods below are part of the `ChatChannelMemberListControllerDelegate` protocol and will be called when events happen in the channel member list. In order for these updates to
+    /// The methods below are part of the `ChatChannelMemberListControllerDelegate`
+    /// protocol and will be called when events happen in the channel member list. In order for these updates to
     /// happen, `memberListController.delegate` must be equal `self` and `memberListController.synchronize()` must be called.
     ///
     
     ///
     /// # didChangeMembers
     ///
-    /// The method below receives the `changes` that happen in the list of channel members and updates the `UITableView` accordingly.
+    /// The method below receives the `changes` that happen in
+    /// the list of channel members and updates the `UITableView` accordingly.
     ///
     func memberListController(
         _ controller: ChatChannelMemberListController,
@@ -134,7 +140,8 @@ class SimpleChannelMembersViewController: UITableViewController, ChatChannelMemb
     ///
     /// # cellForRowAt
     ///
-    /// The method below returns a cell configured based on the member in position `indexPath.row` of `memberListController.members`.
+    /// The method below returns a cell configured based on the member in position `indexPath.row`
+    /// of `memberListController.members`.
     ///
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let member = memberListController.members[indexPath.row]

--- a/Sample_v3/Samples/SimpleChat/SimpleChannelsViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChannelsViewController.swift
@@ -9,7 +9,8 @@ import UIKit
 ///
 /// # SimpleChannelsViewController
 ///
-/// A `UITableViewController` subclass that displays and manages the list of channels.  It uses the `ChannelListController`  class to make calls to the Stream Chat API
+/// A `UITableViewController` subclass that displays and manages the list of channels.
+/// It uses the `ChannelListController`  class to make calls to the Stream Chat API
 /// and listens to events by conforming to `ChannelListControllerDelegate`.
 ///
 class SimpleChannelsViewController: UITableViewController, ChatChannelListControllerDelegate {
@@ -18,10 +19,13 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
     ///
     /// # channelListController
     ///
-    ///  The property below holds the `ChannelListController` object.  It is used to make calls to the Stream Chat API and to listen to the events related to the channels list.
-    ///  After it is set, `channelListController.delegate` needs to receive a reference to a `ChannelListControllerDelegate`, which, in this case, is `self`. After the
-    ///  delegate is set,`channelListController.synchronize()` must be called to start listening to events related to the channel list. Additionally,
-    ///  `channelListController.client` holds a reference to the `ChatClient` which created this instance. It can be used to create other controllers.
+    /// The property below holds the `ChannelListController` object.
+    /// It is used to make calls to the Stream Chat API and to listen to the events related to the channels list.
+    /// After it is set, `channelListController.delegate` needs to receive a reference to a `ChannelListControllerDelegate`,
+    /// which, in this case, is `self`. After the delegate is set,`channelListController.synchronize()`
+    /// must be called to start listening to events related to the channel list.
+    ///  Additionally, `channelListController.client` holds a reference to the
+    /// `ChatClient` which created this instance. It can be used to create other controllers.
     ///
     var channelListController: ChatChannelListController! {
         didSet {
@@ -42,7 +46,8 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
     // MARK: - ChannelControllerDelegate
 
     ///
-    /// The methods below are part of the `ChannelListControllerDelegate` protocol and will be called when events happen in the channel list. In order for these updates to
+    /// The methods below are part of the `ChannelListControllerDelegate` protocol and will be called
+    /// when events happen in the channel list. In order for these updates to
     /// happen, `channelListController.delegate` must be equal `self` and `channelListController.synchronize()` must be called.
     ///
     
@@ -76,14 +81,16 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
     // MARK: - UITableViewDataSource
 
     ///
-    /// The methods below are part of the `UITableViewDataSource` protocol and will be called when the `UITableView` needs information which will be given by the
+    /// The methods below are part of the `UITableViewDataSource` protocol and will be called when the
+    /// `UITableView` needs information which will be given by the
     /// `channelListController` object.
     ///
     
     ///
     /// # numberOfRowsInSection
     ///
-    /// The method below returns the current loaded channels count `channelListController.channels.count`. It will increase as more channels are loaded or decrease as
+    /// The method below returns the current loaded channels count `channelListController.channels.count`.
+    /// It will increase as more channels are loaded or decrease as
     /// channels are deleted.
     ///
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -93,7 +100,8 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
     ///
     /// # cellForRowAt
     ///
-    /// The method below returns a cell configured based on the channel in position `indexPath.row` of `channelListController.channels`.
+    /// The method below returns a cell configured based on the channel in position `indexPath.row`
+    /// of `channelListController.channels`.
     ///
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let channel = channelListController.channels[indexPath.row]
@@ -118,14 +126,16 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
     // MARK: - UITableViewDelegate
 
     ///
-    /// The methods below are part of the `UITableViewDelegate` protocol and will be called when some event happened in the `UITableView`  which will cause some action
+    /// The methods below are part of the `UITableViewDelegate` protocol and will be called
+    /// when some event happened in the `UITableView`  which will cause some action
     /// done by the `channelController` object.
     ///
     
     ///
     /// # willDisplay
     ///
-    /// The method below handles the case when the last cell in the channels list is displayed by calling `channelListController.loadNextChannels()` to fetch more
+    /// The method below handles the case when the last cell in the channels list is displayed by
+    /// calling `channelListController.loadNextChannels()` to fetch more
     /// channels.
     ///
     override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
@@ -157,13 +167,15 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
     // MARK: - Actions
 
     ///
-    /// The methods below are called when the user presses some button to open the settings screen or create a channel, or long presses a channel cell in the table view.
+    /// The methods below are called when the user presses some button to open the settings screen or create a channel,
+    /// or long presses a channel cell in the table view.
     ///
     
     ///
     /// # handleSettingsButton
     ///
-    /// The method below is called when the user taps the settings button. Before presenting the view controller, `settingsViewController.currentUserController` is set
+    /// The method below is called when the user taps the settings button.
+    /// Before presenting the view controller, `settingsViewController.currentUserController` is set
     /// so that view controller can get information and take actions that affect the current user.
     ///
     @objc func handleSettingsButton(_ sender: Any) {
@@ -181,7 +193,8 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
     ///
     /// # handleAddChannelButton
     ///
-    /// The method below is called when the user taps the add channel button. It creates the channel by calling `chatClient.channelController(createChannelWithId: ...)`
+    /// The method below is called when the user taps the add channel button.
+    /// It creates the channel by calling `chatClient.channelController(createChannelWithId: ...)`
     ///
     @objc func handleAddChannelButton(_ sender: Any) {
         let id = UUID().uuidString
@@ -241,7 +254,8 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
     ///
     /// # handleLongPress
     ///
-    /// The method below handles long press on channel cells by displaying a `UIAlertController` with many actions that can be taken on the `channelController` such
+    /// The method below handles long press on channel cells by displaying a `UIAlertController`
+    /// with many actions that can be taken on the `channelController` such
     /// as `updateChannel`, `muteChannel`, `unmuteChannel`, ``showChannel`, and `hideChannel`.
     ///
     @objc func handleLongPress(_ gestureRecognizer: UILongPressGestureRecognizer) {
@@ -286,7 +300,8 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
     ///
     /// # prepareForSegue
     ///
-    /// The method below handles the segue to `SimpleChatViewController`. It passes down to it a reference to a `ChannelController` for the respective channel so it
+    /// The method below handles the segue to `SimpleChatViewController`.
+    /// It passes down to it a reference to a `ChannelController` for the respective channel so it
     /// can display and manage it.
     ///
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
@@ -8,7 +8,8 @@ import UIKit
 ///
 /// # SimpleChatViewController
 ///
-/// A `UITableViewController` subclass that displays and manages a channel.  It uses the `ChannelController`  class to make calls to the Stream Chat API and listens to
+/// A `UITableViewController` subclass that displays and manages a channel.
+/// It uses the `ChannelController`  class to make calls to the Stream Chat API and listens to
 /// events by conforming to `ChannelControllerDelegate`.
 ///
 final class SimpleChatViewController: UITableViewController, ChatChannelControllerDelegate, UITextViewDelegate {
@@ -17,10 +18,13 @@ final class SimpleChatViewController: UITableViewController, ChatChannelControll
     ///
     /// # channelController
     ///
-    ///  The property below holds the `ChannelController` object.  It is used to make calls to the Stream Chat API and to listen to the events. After it is set,
-    ///  `channelController.delegate` needs to receive a reference to a `ChannelControllerDelegate`, which, in this case, is `self`. After the delegate is set,
-    ///  `channelController.synchronize()` must be called to start listening to events related to the channel. Additionally, `channelController.client` holds a
-    ///  reference to the `ChatClient` which created this instance. It can be used to create other controllers.
+    /// The property below holds the `ChannelController` object.
+    /// It is used to make calls to the Stream Chat API and to listen to the events. After it is set,
+    /// `channelController.delegate` needs to receive a reference to a `ChannelControllerDelegate`,
+    /// which, in this case, is `self`. After the delegate is set,
+    /// `channelController.synchronize()` must be called to start listening to events related to the channel.
+    /// Additionally, `channelController.client` holds a
+    /// reference to the `ChatClient` which created this instance. It can be used to create other controllers.
     ///
     var channelController: ChatChannelController! {
         didSet {
@@ -36,7 +40,8 @@ final class SimpleChatViewController: UITableViewController, ChatChannelControll
     // MARK: - ChannelControllerDelegate
 
     ///
-    /// The methods below are part of the `ChannelControllerDelegate` protocol and will be called when events happen in the channel. In order for these updates to happen,
+    /// The methods below are part of the `ChannelControllerDelegate` protocol and will be called
+    /// when events happen in the channel. In order for these updates to happen,
     /// `channelController.delegate` must be equal `self` and `channelController.synchronize()` must be called.
     ///
     
@@ -67,7 +72,8 @@ final class SimpleChatViewController: UITableViewController, ChatChannelControll
     ///
     /// # didUpdateChannel
     ///
-    /// The method below reacts to changes in the `Channel` entity. It updates the view controller's `title` and its `navigationItem.prompt` to display the count of channel
+    /// The method below reacts to changes in the `Channel` entity.
+    /// It updates the view controller's `title` and its `navigationItem.prompt` to display the count of channel
     /// members and the count of online members. When the channel is deleted, this view controller is dismissed.
     ///
     func channelController(_ channelController: ChatChannelController, didUpdateChannel channel: EntityChange<ChatChannel>) {
@@ -96,14 +102,16 @@ final class SimpleChatViewController: UITableViewController, ChatChannelControll
     // MARK: - UITableViewDataSource
 
     ///
-    /// The methods below are part of the `UITableViewDataSource` protocol and will be called when the `UITableView` needs information which will be given by the
+    /// The methods below are part of the `UITableViewDataSource` protocol and will be called
+    /// when the `UITableView` needs information which will be given by the
     /// `channelController` object.
     ///
     
     ///
     /// # numberOfRowsInSection
     ///
-    /// The method below returns the current loaded message count `channelController.messages.count`. It will increase as more messages are loaded or decrease as
+    /// The method below returns the current loaded message count `channelController.messages.count`.
+    /// It will increase as more messages are loaded or decrease as
     /// messages are deleted.
     ///
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -113,8 +121,9 @@ final class SimpleChatViewController: UITableViewController, ChatChannelControll
     ///
     /// # cellForRowAt
     ///
-    /// The method below returns a cell configured based on the message in position `indexPath.row` of `channelController.messages`. It also highlights the cell based
-    /// on the message's `localState` which when different from `nil` means some local work is being done on it which is not completed yet.
+    /// The method below returns a cell configured based on the message in position `indexPath.row` of `channelController.messages`.
+    /// It also highlights the cell based on the message's `localState` which
+    /// when different from `nil` means some local work is being done on it which is not completed yet.
     ///
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let message = channelController.messages[indexPath.row]
@@ -145,14 +154,16 @@ final class SimpleChatViewController: UITableViewController, ChatChannelControll
     // MARK: - UITableViewDelegate
 
     ///
-    /// The methods below are part of the `UITableViewDelegate` protocol and will be called when some event happened in the `UITableView`  which will cause some action
+    /// The methods below are part of the `UITableViewDelegate` protocol and will be called
+    /// when some event happened in the `UITableView`  which will cause some action
     /// done by the `channelController` object.
     ///
     
     ///
     /// # willDisplay
     ///
-    /// The method below handles the case when the last cell in the message list is displayed by calling `channelController?.loadNextMessages()` to fetch more
+    /// The method below handles the case when the last cell in the message list is
+    /// displayed by calling `channelController?.loadNextMessages()` to fetch more
     /// messages.
     ///
     override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
@@ -224,8 +235,8 @@ final class SimpleChatViewController: UITableViewController, ChatChannelControll
     ///
     /// # contextMenuConfigurationForRowAt
     ///
-    /// The method below returns the context menu with actions that can be taken on the message such as deleting and editing, or on the message's author such as banning and
-    /// unbanning.
+    /// The method below returns the context menu with actions that can be taken on the message
+    /// such as deleting and editing, or on the message's author such as banning and unbanning.
     ///
     @available(iOS 13, *)
     override func tableView(
@@ -365,7 +376,8 @@ final class SimpleChatViewController: UITableViewController, ChatChannelControll
     ///
     /// # sendMessageButtonTapped
     ///
-    /// The method below is called when the user taps the send button. To send the message, `channelController?.createNewMessage(text:)` is called.
+    /// The method below is called when the user taps the send button. To send the message,
+    /// `channelController?.createNewMessage(text:)` is called.
     ///
     @objc func sendMessageButtonTapped(_ sender: Any) {
         guard let text = composerView.textView.text else {
@@ -380,7 +392,8 @@ final class SimpleChatViewController: UITableViewController, ChatChannelControll
     ///
     /// # showChannelActionsAlert
     ///
-    /// The method below displays a `UIAlertController` with many actions that can be taken on the `channelController` such as `addMembers`, `removeMembers`,
+    /// The method below displays a `UIAlertController` with many actions that can be taken on the
+    /// `channelController` such as `addMembers`, `removeMembers`,
     /// and `deleteChannel`.
     ///
     @objc func showChannelActionsAlert() {
@@ -421,14 +434,16 @@ final class SimpleChatViewController: UITableViewController, ChatChannelControll
     // MARK: - UITextViewDelegate
 
     ///
-    /// The methods below are part of the `UITextViewDelegate` protocol and will be called when some event happened in the  `ComposerView`'s `UITextView`  which will
+    /// The methods below are part of the `UITextViewDelegate` protocol
+    /// and will be called when some event happened in the  `ComposerView`'s `UITextView`  which will
     /// cause some action done by the `channelController` object.
     ///
     
     ///
     /// # textViewDidChange
     ///
-    /// The method below handles changes to the `ComposerView`'s `UITextView` by calling `channelController.keystroke()` to send typing events to the channel so
+    /// The method below handles changes to the `ComposerView`'s `UITextView`
+    /// by calling `channelController.keystroke()` to send typing events to the channel so
     /// other users will know the current user is typing.
     ///
     func textViewDidChange(_ textView: UITextView) {
@@ -438,7 +453,8 @@ final class SimpleChatViewController: UITableViewController, ChatChannelControll
     ///
     /// # textViewDidChange
     ///
-    /// The method below handles the end of `ComposerView`'s `UITextView` editing by calling `channelController.stopTyping()` to immediately stop the typing
+    /// The method below handles the end of `ComposerView`'s `UITextView` editing
+    /// by calling `channelController.stopTyping()` to immediately stop the typing
     /// events so other users will know the current user stopped typing.
     ///
     func textViewDidEndEditing(_ textView: UITextView) {

--- a/Sample_v3/Samples/SimpleChat/SimpleUsersViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleUsersViewController.swift
@@ -8,7 +8,8 @@ import UIKit
 ///
 /// # SimpleUsersViewController
 ///
-/// A `UITableViewController` subclass that displays and manages the list of users.  It uses the `ChatUserListController`  class to make calls to the Stream Chat API
+/// A `UITableViewController` subclass that displays and manages the list of users.
+/// It uses the `ChatUserListController`  class to make calls to the Stream Chat API
 /// and listens to events by conforming to `ChatUserListControllerDelegate`.
 ///
 class SimpleUsersViewController: UITableViewController, ChatUserListControllerDelegate {
@@ -17,10 +18,13 @@ class SimpleUsersViewController: UITableViewController, ChatUserListControllerDe
     ///
     /// # userListController
     ///
-    ///  The property below holds the `ChatUserListController` object.  It is used to make calls to the Stream Chat API and to listen to the events related to the users list.
-    ///  After it is set, `userListController.delegate` needs to receive a reference to a `ChatUserListControllerDelegate`, which, in this case, is `self`. After the
-    ///  delegate is set,`userListController.synchronize()` must be called to start listening to events related to the users list. Additionally,
-    ///  `userListController.client` holds a reference to the `ChatClient` which created this instance. It can be used to create other controllers.
+    /// The property below holds the `ChatUserListController` object.
+    /// It is used to make calls to the Stream Chat API and to listen to the events related to the users list.
+    /// After it is set, `userListController.delegate` needs to receive a reference to a `ChatUserListControllerDelegate`,
+    /// which, in this case, is `self`. After the
+    /// delegate is set,`userListController.synchronize()` must be called to start listening to events
+    /// related to the users list. Additionally,`userListController.client` holds a reference to the `ChatClient`
+    /// which created this instance. It can be used to create other controllers.
     ///
     var userListController: ChatUserListController! {
         didSet {
@@ -42,7 +46,8 @@ class SimpleUsersViewController: UITableViewController, ChatUserListControllerDe
     ///
     /// # handleLongPress
     ///
-    /// The method below handles long press on user cells by displaying a `UIAlertController` with actions that can be taken on the `userController`. (`mute` and `unmute`)
+    /// The method below handles long press on user cells by displaying a `UIAlertController`
+    /// with actions that can be taken on the `userController`. (`mute` and `unmute`)
     @objc func handleLongPress(_ gestureRecognizer: UILongPressGestureRecognizer) {
         guard
             let indexPath = tableView.indexPathForRow(at: gestureRecognizer.location(in: tableView)),
@@ -72,7 +77,8 @@ class SimpleUsersViewController: UITableViewController, ChatUserListControllerDe
     // MARK: - ChatUserControllerDelegate
 
     ///
-    /// The methods below are part of the `ChatUserListControllerDelegate` protocol and will be called when events happen in the user list. In order for these updates to
+    /// The methods below are part of the `ChatUserListControllerDelegate` protocol and will be called when
+    /// events happen in the user list. In order for these updates to
     /// happen, `userListController.delegate` must be equal `self` and `userListController.synchronize()` must be called.
     ///
     
@@ -106,14 +112,16 @@ class SimpleUsersViewController: UITableViewController, ChatUserListControllerDe
     // MARK: - UITableViewDataSource
 
     ///
-    /// The methods below are part of the `UITableViewDataSource` protocol and will be called when the `UITableView` needs information which will be given by the
+    /// The methods below are part of the `UITableViewDataSource` protocol and will be called when the
+    /// `UITableView` needs information which will be given by the
     /// `userListController` object.
     ///
     
     ///
     /// # numberOfRowsInSection
     ///
-    /// The method below returns the current loaded users count `userListController.users.count`. It will increase as more users are loaded or decrease as
+    /// The method below returns the current loaded users count `userListController.users.count`.
+    /// It will increase as more users are loaded or decrease as
     /// users are deleted.
     ///
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -130,7 +138,7 @@ class SimpleUsersViewController: UITableViewController, ChatUserListControllerDe
         
         var cell = tableView.dequeueReusableCell(withIdentifier: "Cell")
         
-        if (!(cell != nil)) {
+        if cell == nil {
             cell = UITableViewCell(style: .default, reuseIdentifier: "Cell")
         }
         
@@ -156,7 +164,8 @@ class SimpleUsersViewController: UITableViewController, ChatUserListControllerDe
     ///
     /// # willDisplay
     ///
-    /// The method below handles the case when the last cell in the users list is displayed by calling `userListController.loadNextUsers()` to fetch more
+    /// The method below handles the case when the last cell in the users list is displayed by
+    /// calling `userListController.loadNextUsers()` to fetch more
     /// users.
     ///
     override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
@@ -183,6 +192,7 @@ class SimpleUsersViewController: UITableViewController, ChatUserListControllerDe
     )
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         tableView.addGestureRecognizer(longPressRecognizer)
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .done,

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChannelListView.swift
@@ -100,7 +100,8 @@ struct ChannelListView: View {
         ])
     }
     
-    /// Add channel button. To create new channel we need to get a new `ChannelController` with `chatClient.channelController(createChannelWithId: ...)`
+    /// Add channel button. To create new channel we need to get a new `ChannelController`
+    /// with `chatClient.channelController(createChannelWithId: ...)`
     /// and call `synchronize()` on it.
     var addChannelButton: some View {
         Button(action: {

--- a/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
+++ b/Sample_v3/Samples/SwiftUISimpleChat/ChatView.swift
@@ -85,7 +85,7 @@ struct ChatView: View {
             }
             /// Load next more messages when the last is shown.
             .onAppear {
-                if (self.channel.messages.first == message) {
+                if self.channel.messages.first == message {
                     self.channel.controller.loadPreviousMessages()
                 }
             }

--- a/Sample_v3/SceneDelegate.swift
+++ b/Sample_v3/SceneDelegate.swift
@@ -11,7 +11,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, UISplitViewControllerDe
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        // This delegate does not imply the connecting scene or session are new
+        // (see `application:configurationForConnectingSceneSession` instead).
         guard let window = window else { return }
         guard let splitViewController = window.rootViewController as? UISplitViewController else { return }
         guard let navigationController = splitViewController.viewControllers.last as? UINavigationController else { return }
@@ -24,7 +25,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, UISplitViewControllerDe
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
+        // The scene may re-connect later, as its session was not neccessarily discarded
+        // (see `application:didDiscardSceneSessions` instead).
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {

--- a/Sources/UI/Chat/Composer/ComposerView+Images.swift
+++ b/Sources/UI/Chat/Composer/ComposerView+Images.swift
@@ -106,7 +106,7 @@ extension ComposerView: UICollectionViewDataSource, UICollectionViewDelegate {
             
             uploadManager?.startUploading(item: item)
                 .observeOn(MainScheduler.instance)
-                .do(onError: { [weak cell] error in cell?.updateForError() },
+                .do(onError: { [weak cell] _ in cell?.updateForError() },
                     onCompleted: { [weak self, weak cell] in
                         cell?.updateForProgress(1)
                         self?.updateSendButton()

--- a/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
+++ b/Tests/Client/Custom Assertions/AssertNetworkRequest.swift
@@ -8,7 +8,6 @@
 import XCTest
 @testable import StreamChatClient
 
-
 extension AssertAsync {
     /// Synchronously waits for a network request that matches its properties with the given parameters.
     ///
@@ -75,14 +74,12 @@ extension Assert {
                                file: StaticString = #file,
                                line: UInt = #line) -> Assertion {
         
-        
         return Assert.willBeTrue(RequestRecorderURLProtocol.recordedRequests.contains {
             $0.matches(method, path, headers, queryParameters, body).isSuccess
         }, message: failureMessage(method, path, headers, queryParameters, body),
            file: file,
            line: line)
     }
-    
     
     /// Failure message displayed in the network request assertion
     private static func failureMessage(_ method: Endpoint.Method,
@@ -274,7 +271,7 @@ private extension Data {
         let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
         while input.hasBytesAvailable {
             let read = input.read(buffer, maxLength: bufferSize)
-            if (read == 0) {
+            if read == 0 {
                 break  // added
             }
             append(buffer, count: read)

--- a/Tests/Client/Integration Tests/TestCase.swift
+++ b/Tests/Client/Integration Tests/TestCase.swift
@@ -28,7 +28,7 @@ class TestCase: XCTestCase {
         }
         
         isClientReady = true
-        ClientLogger.log = { icon, date, level, message in print(icon, message) }
+        ClientLogger.log = { icon, _, _, message in print(icon, message) }
         
         Client.configureShared(.init(
             apiKey: Self.apiKey,

--- a/Tests/Client/Unit Tests/AtomicTests.swift
+++ b/Tests/Client/Unit Tests/AtomicTests.swift
@@ -111,7 +111,7 @@ class AtomicTests: XCTestCase {
         atomicValue.set("Luke")
         XCTAssertEqual(atomicValue.get(), "Luke")
         
-        atomicValue.update { (current) -> String? in
+        atomicValue.update { (_) -> String? in
             XCTAssertEqual(atomicValue.get(), "Luke")
             return nil
         }

--- a/Tests/Client/Unit Tests/Channel+SetupTests.swift
+++ b/Tests/Client/Unit Tests/Channel+SetupTests.swift
@@ -67,7 +67,7 @@ final class Channel_SetupTests: XCTestCase {
     }
 }
 
-fileprivate struct MockNamingStrategy: ChannelNamingStrategy {
+private struct MockNamingStrategy: ChannelNamingStrategy {
     func name(for currentUser: User, members: [User]) -> String? {
         "\(members.count)"
     }

--- a/Tests/Client/Unit Tests/WebSocket/WebSocketEventsMock.swift
+++ b/Tests/Client/Unit Tests/WebSocket/WebSocketEventsMock.swift
@@ -13,28 +13,28 @@ extension Dictionary {
     /// Helper function to create a `health.check` event JSON with the given `userId` and `connectId`.
     static func healthCheckEvent(userId: String, connectionId: String) -> [String: Any] {
         [
-            "created_at" : "2020-05-02T13:21:03.862065063Z",
-            "me" : [
-                "id" : userId,
-                "banned" : false,
-                "unread_channels" : 0,
-                "mutes" : [],
-                "last_active" : "2020-05-02T13:21:03.849219Z",
-                "created_at" : "2019-06-05T15:01:52.847807Z",
-                "devices" : [],
-                "invisible" : false,
-                "unread_count" : 0,
-                "channel_mutes" : [],
-                "image" : "https://i.imgur.com/EgEPqWZ.jpg",
-                "updated_at" : "2020-05-02T13:21:03.855468Z",
-                "role" : "user",
-                "total_unread_count" : 0,
-                "online" : true,
-                "name" : "Steep Moon",
-                "test" : 1
+            "created_at": "2020-05-02T13:21:03.862065063Z",
+            "me": [
+                "id": userId,
+                "banned": false,
+                "unread_channels": 0,
+                "mutes": [],
+                "last_active": "2020-05-02T13:21:03.849219Z",
+                "created_at": "2019-06-05T15:01:52.847807Z",
+                "devices": [],
+                "invisible": false,
+                "unread_count": 0,
+                "channel_mutes": [],
+                "image": "https://i.imgur.com/EgEPqWZ.jpg",
+                "updated_at": "2020-05-02T13:21:03.855468Z",
+                "role": "user",
+                "total_unread_count": 0,
+                "online": true,
+                "name": "Steep Moon",
+                "test": 1
             ],
-            "type" : "health.check",
-            "connection_id" : connectionId
+            "type": "health.check",
+            "connection_id": connectionId
         ]
     }
     

--- a/Tests/Client/Unit Tests/WebSocket/WebSocketProviderMock.swift
+++ b/Tests/Client/Unit Tests/WebSocket/WebSocketProviderMock.swift
@@ -15,7 +15,7 @@ final class WebSocketProviderMock: WebSocketProvider {
     
     var callbackQueue: DispatchQueue
     
-    var delegate: WebSocketProviderDelegate?
+    weak var delegate: WebSocketProviderDelegate?
 
     /// How many times was `connect()` called
     var connectCalledCount = 0

--- a/Tests_v3/Mock Network/AssertNetworkRequest.swift
+++ b/Tests_v3/Mock Network/AssertNetworkRequest.swift
@@ -133,7 +133,7 @@ private extension Data {
         let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
         while input.hasBytesAvailable {
             let read = input.read(buffer, maxLength: bufferSize)
-            if (read == 0) {
+            if read == 0 {
                 break // added
             }
             append(buffer, count: read)


### PR DESCRIPTION
# What does this PR do
Clears most Swiftlint warnings across the project. I ran `swiftlint autocorrect` to fix some issues which Swiftlint could fix on it own. I also went through files with documentation and splitted the documentation on newLines so we don't get any `line_length` swiftlint rule (It was faster than figure out some automation thing)
# How to test this
 You can run the project go through it, run tests and see if anything is broken, but it really shouldn't be
# Where to start
 Some place worth a logic check are: 

- `ConfigurationViewController.swift` -> `isEmpty` condition
- `WebSocketProviderMock.swift` -> Possibly if the delegate is explicitly not meant to be weak (I don't see any reason) 
- `SimpleUsersViewController.swift`  -> `super.viewDidLoad`, was this intentional?
-  `CombineSimpleUsersViewController.swift` -> `super.viewDidLoad`, was this intentional?

The rest is just documentation, you can suggest if you want the rest of warnings (4) but I believe they are not important for now. At least now you don't see tons of warnings about `line_length` :) 