### PR TITLE
Fix "typo" in default implementation of lowlevel controller delegates

### DIFF
--- a/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -874,7 +874,7 @@ public extension _ChatChannelControllerDelegate {
     ) {}
     
     func channelController(
-        _ channelController: ChatChannelController,
+        _ channelController: _ChatChannelController<ExtraData>,
         didUpdateMessages changes: [ListChange<_ChatMessage<ExtraData>>]
     ) {}
 

--- a/Sources_v3/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources_v3/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -259,7 +259,7 @@ public protocol _ChatChannelListControllerDelegate: DataControllerStateDelegate 
 
 public extension _ChatChannelListControllerDelegate {
     func controller(
-        _ controller: _ChatChannelListController<DefaultExtraData>,
+        _ controller: _ChatChannelListController<ExtraData>,
         didChangeChannels changes: [ListChange<_ChatChannel<ExtraData>>]
     ) {}
 }

--- a/Sources_v3/StreamChat/Controllers/UserListController/UserListController.swift
+++ b/Sources_v3/StreamChat/Controllers/UserListController/UserListController.swift
@@ -247,7 +247,7 @@ public protocol _ChatUserListControllerDelegate: DataControllerStateDelegate {
 
 public extension _ChatUserListControllerDelegate {
     func controller(
-        _ controller: _ChatUserListController<DefaultExtraData>,
+        _ controller: _ChatUserListController<ExtraData>,
         didChangeUsers changes: [ListChange<_ChatUser<ExtraData.User>>]
     ) {}
 }


### PR DESCRIPTION
We dropped a guard and copypaste demons find a way in our codebase.
With power granted to me by supreme leader @VojtaStavik I banish them for good! 