### PR TITLE
MessageComposerView prototype

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageComposerView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageComposerView.swift
@@ -1,0 +1,193 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+open class ChatChannelMessageComposerView<ExtraData: UIExtraDataTypes>: UIView {
+    // MARK: - Properties
+    
+    public var buttonHeight: CGFloat = 20
+    
+    public let uiConfig: UIConfig<ExtraData>
+    
+    public weak var owningVC: UIViewController?
+    
+    // MARK: - Subviews
+    
+    public lazy var imagePicker: UIImagePickerController = {
+        let picker = UIImagePickerController()
+        picker.mediaTypes = ["public.image", "public.movie"]
+        picker.sourceType = .photoLibrary
+        return picker
+    }()
+
+    public private(set) lazy var container = ContainerStackView().withoutAutoresizingMaskConstraints
+    
+    public private(set) lazy var replyView: UIView = .init()
+    
+    public private(set) lazy var attachmentsView: MessageComposerAttachmentsView<ExtraData> = .init(uiConfig: uiConfig)
+    
+    public private(set) lazy var messageInputView: ChatChannelMessageInputView<ExtraData> = .init(uiConfig: uiConfig)
+    
+    public private(set) lazy var sendButton: UIButton = {
+        let button = UIButton().withoutAutoresizingMaskConstraints
+        if #available(iOS 13.0, *) {
+            button.setImage(UIImage(systemName: "arrow.up.circle.fill"), for: .normal)
+        }
+        button.widthAnchor.constraint(equalTo: button.heightAnchor, multiplier: 1).isActive = true
+        return button
+    }()
+        
+    public private(set) lazy var searchButton: UIButton = {
+        let button = UIButton().withoutAutoresizingMaskConstraints
+        if #available(iOS 13.0, *) {
+            button.setImage(UIImage(systemName: "magnifyingglass"), for: .normal)
+        }
+        button.widthAnchor.constraint(equalTo: button.heightAnchor, multiplier: 1).isActive = true
+        return button
+    }()
+    
+    public private(set) lazy var attachmentButton: UIButton = {
+        let button = UIButton().withoutAutoresizingMaskConstraints
+        if #available(iOS 13.0, *) {
+            button.setImage(UIImage(systemName: "paperclip"), for: .normal)
+        }
+        button.addTarget(self, action: #selector(attachmentButtonHandler), for: .touchUpInside)
+        button.widthAnchor.constraint(equalTo: button.heightAnchor, multiplier: 1).isActive = true
+        return button
+    }()
+    
+    @objc func attachmentButtonHandler() {
+        invalidateIntrinsicContentSize()
+
+        owningVC?.present(imagePicker, animated: true)
+    }
+    
+    public private(set) lazy var boltButton: UIButton = {
+        let button = UIButton().withoutAutoresizingMaskConstraints
+        if #available(iOS 13.0, *) {
+            button.setImage(UIImage(systemName: "bolt.fill"), for: .normal)
+        }
+        button.widthAnchor.constraint(equalTo: button.heightAnchor, multiplier: 1).isActive = true
+        return button
+    }()
+    
+    public private(set) lazy var suggestionsViewController: MessageComposerSuggestionsViewController<ExtraData> = {
+        .init(uiConfig: uiConfig)
+    }()
+    
+    // MARK: - Init
+    
+    public required init(
+        uiConfig: UIConfig<ExtraData> = .default
+    ) {
+        self.uiConfig = uiConfig
+        
+        super.init(frame: .zero)
+        
+        commonInit()
+    }
+    
+    public required init?(coder: NSCoder) {
+        uiConfig = .default
+        
+        super.init(coder: coder)
+        
+        commonInit()
+    }
+    
+    public func commonInit() {
+        embed(container)
+
+        setupAppearance()
+        setupLayout()
+    }
+    
+    // MARK: - Public
+    
+    open func setupAppearance() {
+        if #available(iOS 13.0, *) {
+            backgroundColor = .systemBackground
+        } else {
+            backgroundColor = .white
+        }
+    }
+    
+    open func setupLayout() {
+        container.preservesSuperviewLayoutMargins = true
+        container.isLayoutMarginsRelativeArrangement = true
+        
+        container.centerContainerStackView.spacing = UIStackView.spacingUseSystem
+        
+        container.centerStackView.isHidden = false
+        container.centerStackView.axis = .vertical
+        container.centerStackView.alignment = .fill
+        container.centerStackView.addArrangedSubview(replyView)
+        
+        container.centerStackView.addArrangedSubview(attachmentsView)
+        attachmentsView.heightAnchor.constraint(equalToConstant: 80).isActive = true
+        
+        container.centerStackView.addArrangedSubview(messageInputView)
+        messageInputView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        
+        container.rightStackView.isHidden = false
+        container.rightStackView.alignment = .center
+        container.rightStackView.spacing = UIStackView.spacingUseSystem
+        searchButton.isHidden = true
+        container.rightStackView.addArrangedSubview(searchButton)
+        container.rightStackView.addArrangedSubview(sendButton)
+        
+        container.leftStackView.isHidden = false
+        container.leftStackView.alignment = .center
+        container.leftStackView.spacing = UIStackView.spacingUseSystem
+        container.leftStackView.addArrangedSubview(attachmentButton)
+        boltButton.isHidden = true
+        container.leftStackView.addArrangedSubview(boltButton)
+        
+        searchButton.widthAnchor.constraint(equalToConstant: buttonHeight).isActive = true
+        sendButton.widthAnchor.constraint(equalToConstant: buttonHeight).isActive = true
+        attachmentButton.widthAnchor.constraint(equalToConstant: buttonHeight).isActive = true
+        boltButton.widthAnchor.constraint(equalToConstant: buttonHeight).isActive = true
+
+        attachmentsView.isHidden = true
+        attachmentsView.composer = self
+
+        addObserver(self, forKeyPath: "safeAreaInsets", options: .new, context: nil)
+        messageInputView.textView.addObserver(self, forKeyPath: "contentSize", options: .new, context: nil)
+    }
+    
+    // MARK: - Overrides
+    
+    override open var intrinsicContentSize: CGSize {
+        let size = CGSize(
+            width: superview?.bounds.width ?? super.intrinsicContentSize.width,
+            height: container.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
+        )
+        return size
+    }
+    
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+                
+        container.centerStackView.clipsToBounds = true
+        container.centerStackView.layer.cornerRadius = 20
+        container.centerStackView.layer.borderWidth = 2
+        container.centerStackView.layer.borderColor = UIColor.systemGray.cgColor
+    }
+    
+    // There are some issues with new-style KVO so that is something that will need attention later.
+    // swiftlint:disable block_based_kvo
+    override open func observeValue(
+        forKeyPath keyPath: String?,
+        of object: Any?,
+        change: [NSKeyValueChangeKey: Any]?,
+        context: UnsafeMutableRawPointer?
+    ) {
+        if object as AnyObject? === messageInputView.textView, keyPath == "contentSize" {
+            invalidateIntrinsicContentSize()
+        } else if object as AnyObject? === self, keyPath == "safeAreaInsets" {
+            invalidateIntrinsicContentSize()
+        }
+    }
+}

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageInputView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageInputView.swift
@@ -1,0 +1,127 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+open class ChatChannelMessageInputView<ExtraData: UIExtraDataTypes>: UIView, UITextViewDelegate {
+    // MARK: - Properties
+    
+    public let uiConfig: UIConfig<ExtraData>
+    
+    public var textViewDidChange: ((String?) -> Void)?
+    
+    public var textViewDidEndEditing: ((String?) -> Void)?
+    
+    var numberOfLines: Int {
+        guard let font = textView.font else { return 0 }
+        let textHeight = textView.contentSize.height - textView.textContainerInset.top - textView.textContainerInset.bottom
+        return Int(textHeight / font.lineHeight)
+    }
+    
+    var calculatedHeight: CGFloat {
+        textView.contentSize.height // + safeAreaInsets.bottom
+    }
+    
+    // MARK: - Subviews
+    
+    public private(set) lazy var container = ContainerStackView().withoutAutoresizingMaskConstraints
+        
+    public private(set) lazy var textView = UITextView().withoutAutoresizingMaskConstraints
+    
+    public private(set) lazy var slashCommandView: MessageInputSlashCommandView = .init()
+    
+    public private(set) lazy var rightAccessoryButton: UIButton = {
+        let button = UIButton().withoutAutoresizingMaskConstraints
+        if #available(iOS 13.0, *) {
+            button.setImage(UIImage(systemName: "xmark.circle"), for: .normal)
+        }
+        button.addTarget(self, action: #selector(hideSlashCommand), for: .touchUpInside)
+        button.widthAnchor.constraint(equalTo: button.heightAnchor, multiplier: 1).isActive = true
+        return button
+    }()
+    
+    @objc func hideSlashCommand() {
+        rightAccessoryButton.isHidden = true
+        container.leftStackView.isHidden = true
+    }
+    
+    // MARK: - Init
+    
+    public required init(
+        uiConfig: UIConfig<ExtraData> = .default
+    ) {
+        self.uiConfig = uiConfig
+        
+        super.init(frame: .zero)
+        
+        commonInit()
+    }
+    
+    public required init?(coder: NSCoder) {
+        uiConfig = .default
+        
+        super.init(coder: coder)
+        
+        commonInit()
+    }
+    
+    public func commonInit() {
+        embed(container)
+        
+        setupAppearance()
+        setupLayout()
+    }
+    
+    // MARK: - Overrides
+    
+    override open var intrinsicContentSize: CGSize {
+        CGSize(width: super.intrinsicContentSize.width, height: calculatedHeight)
+    }
+    
+    // MARK: - Public
+    
+    open func setupAppearance() {
+        textView.text = "Hi"
+        textView.delegate = self
+    }
+    
+    open func setupLayout() {
+        container.preservesSuperviewLayoutMargins = true
+        container.isLayoutMarginsRelativeArrangement = true
+        container.spacing = UIStackView.spacingUseSystem
+        
+        container.leftStackView.alignment = .center
+        container.leftStackView.addArrangedSubview(slashCommandView)
+        slashCommandView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        
+        textView.isScrollEnabled = false
+        textView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        
+        container.centerStackView.isHidden = false
+        container.centerStackView.addArrangedSubview(textView)
+        
+        container.rightStackView.isHidden = false
+        container.rightStackView.alignment = .center
+        container.rightStackView.addArrangedSubview(rightAccessoryButton)
+        rightAccessoryButton.widthAnchor.constraint(equalToConstant: 20).isActive = true
+        
+        rightAccessoryButton.isHidden = true
+    }
+    
+    // MARK: - UITextViewDelegate
+    
+    public func textViewDidChange(_ textView: UITextView) {
+        textViewDidChange?(textView.text)
+        if textView.text == "\\giphy" {
+            textView.text = ""
+            slashCommandView.command = .giphy
+            container.leftStackView.isHidden = false
+            rightAccessoryButton.isHidden = false
+        }
+    }
+    
+    public func textViewDidEndEditing(_ textView: UITextView) {
+        textViewDidEndEditing?(textView.text)
+    }
+}

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposerAttachmentCellView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposerAttachmentCellView.swift
@@ -1,0 +1,48 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+open class MessageComposerAttachmentsCellView: UIView {
+    var deleteClosure: (() -> Void)?
+    
+    public private(set) lazy var imageView: UIImageView = .init()
+
+    public private(set) lazy var closeButton: UIButton = {
+        let button = UIButton()
+        button.pin(anchors: [.width, .height], to: 15)
+        button.layer.cornerRadius = 7.5
+        button.backgroundColor = .init(red: 0, green: 0, blue: 0, alpha: 0.4)
+        button.setTitle("𝗑", for: .normal)
+        button.addTarget(self, action: #selector(deleteAttachmentTapped), for: .touchUpInside)
+        return button
+    }()
+
+    public required init(image: UIImage, deleteClosure: @escaping () -> Void) {
+        super.init(frame: .zero)
+        commonInit(with: image)
+        self.deleteClosure = deleteClosure
+    }
+
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit(with: UIImage())
+    }
+
+    func commonInit(with image: UIImage) {
+        pin(anchors: [.width, .height], to: 50)
+        layer.masksToBounds = true
+        layer.cornerRadius = 5
+
+        addSubview(imageView)
+        addSubview(closeButton)
+        imageView.pin(to: self)
+        closeButton.pin(anchors: [.top, .right], to: self)
+        imageView.image = image
+    }
+
+    @objc func deleteAttachmentTapped() {
+        deleteClosure?()
+    }
+}

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposerAttachmentsView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposerAttachmentsView.swift
@@ -1,0 +1,108 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+open class MessageComposerAttachmentsView<ExtraData: UIExtraDataTypes>: UIView,
+    UICollectionViewDelegate,
+    UICollectionViewDataSource {
+    // MARK: - Properties
+
+    public weak var composer: UIView?
+    public let uiConfig: UIConfig<ExtraData>
+    
+    var attachments: [UIImage] = []
+    
+    // MARK: - Subviews
+    
+    public private(set) lazy var flowLayout: UICollectionViewFlowLayout = {
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.itemSize = .init(width: 50, height: 70)
+        flowLayout.sectionInset = .init(top: 20, left: 10, bottom: 10, right: 10)
+        flowLayout.minimumInteritemSpacing = 10
+        flowLayout.scrollDirection = .horizontal
+        
+        return flowLayout
+    }()
+    
+    public private(set) lazy var collectionView: UICollectionView = .init(frame: .zero, collectionViewLayout: flowLayout)
+
+    // MARK: - Init
+    
+    public required init(
+        uiConfig: UIConfig<ExtraData> = .default
+    ) {
+        self.uiConfig = uiConfig
+        
+        super.init(frame: .zero)
+        
+        commonInit()
+    }
+    
+    public required init?(coder: NSCoder) {
+        uiConfig = .default
+        
+        super.init(coder: coder)
+        
+        commonInit()
+    }
+    
+    public func commonInit() {
+        embed(collectionView)
+        
+        setupAppearance()
+        setupCollectionView()
+    }
+    
+    // MARK: - Public
+    
+    open func setupAppearance() {
+        collectionView.backgroundColor = .clear
+        collectionView.showsHorizontalScrollIndicator = false
+    }
+    
+    open func setupCollectionView() {
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "Cell")
+    }
+    
+    // MARK: - Actions
+    
+    public func insertNewItem(with image: UIImage) {
+        attachments.append(image)
+        collectionView.reloadData()
+        if !attachments.isEmpty {
+            isHidden = false
+        }
+    }
+
+    public func remove(at index: Int) {
+        attachments.remove(at: index)
+        collectionView.reloadData()
+        if attachments.isEmpty {
+            isHidden = true
+            composer?.invalidateIntrinsicContentSize()
+        }
+    }
+    
+    // MARK: - UICollectionView
+    
+    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        attachments.count
+    }
+    
+    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath)
+        let imageView = MessageComposerAttachmentsCellView(
+            image: attachments[indexPath.row],
+            deleteClosure: { [weak self] in
+                self?.remove(at: indexPath.row)
+                collectionView.reloadItems(at: collectionView.indexPathsForVisibleItems)
+            }
+        )
+        cell.embed(imageView)
+        return cell
+    }
+}

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposerSuggestionsViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposerSuggestionsViewController.swift
@@ -1,0 +1,186 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+open class MessageComposerSuggestionsViewController<ExtraData: UIExtraDataTypes>: UIViewController,
+    UITableViewDelegate,
+    UITableViewDataSource {
+    // MARK: - Property
+    
+    public weak var owningViewController: UIViewController?
+
+    public let uiConfig: UIConfig<ExtraData>
+    
+    public var suggestions: [String] = ["Brian", "David", "Pavel"] {
+        didSet {
+            updateContent()
+        }
+    }
+    
+    public var position: CGPoint = CGPoint(x: 0, y: 300) {
+        didSet {
+            updateContent()
+        }
+    }
+    
+    public var maxHeight: CGFloat = 300.0 {
+        didSet {
+            updateContent()
+        }
+    }
+    
+    public var calculatedHeight: CGFloat {
+        min(CGFloat(40 * suggestions.count), maxHeight)
+    }
+    
+    // MARK: - Subviews
+    
+    public private(set) lazy var tableView = UITableView().withoutAutoresizingMaskConstraints
+    
+    // MARK: - Init
+    
+    public required init(
+        uiConfig: UIConfig<ExtraData> = .default
+    ) {
+        self.uiConfig = uiConfig
+
+        super.init(nibName: nil, bundle: nil)
+        
+        commonInit()
+    }
+    
+    public required init?(coder: NSCoder) {
+        uiConfig = .default
+        
+        super.init(coder: coder)
+        
+        commonInit()
+    }
+    
+    public func commonInit() {
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
+        modalPresentationStyle = .custom
+        modalTransitionStyle = .crossDissolve
+    }
+    
+    // MARK: - Overrides
+    
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.embed(tableView)
+        
+        setupAppearance()
+        setupLayout()
+    }
+    
+    override open func updateViewConstraints() {
+        widthConstraint?.constant = UIScreen.main.bounds.width
+        heightConstraint?.constant = calculatedHeight
+        
+        positionXConstraint?.constant = position.x
+        positionYConstraint?.constant = position.y
+        
+        super.updateViewConstraints()
+    }
+    
+    // MARK: - Public
+    
+    open func setupAppearance() {
+        view.backgroundColor = .clear
+        tableView.backgroundColor = .white
+        tableView.estimatedRowHeight = 40
+        tableView.showsVerticalScrollIndicator = false
+    }
+    
+    var heightConstraint: NSLayoutConstraint?
+    var widthConstraint: NSLayoutConstraint?
+    var positionXConstraint: NSLayoutConstraint?
+    var positionYConstraint: NSLayoutConstraint?
+    
+    open func setupLayout() {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        
+        heightConstraint = .init(
+            item: tableView,
+            attribute: .height,
+            relatedBy: .equal,
+            toItem: nil,
+            attribute: .notAnAttribute,
+            multiplier: 1,
+            constant: 300
+        )
+        
+        widthConstraint = .init(
+            item: tableView,
+            attribute: .width,
+            relatedBy: .equal,
+            toItem: nil,
+            attribute: .notAnAttribute,
+            multiplier: 1,
+            constant: UIScreen.main.bounds.width
+        )
+        
+        positionXConstraint = .init(
+            item: tableView,
+            attribute: .centerX,
+            relatedBy: .equal,
+            toItem: view,
+            attribute: .centerX,
+            multiplier: 1,
+            constant: 200
+        )
+        
+        positionYConstraint = .init(
+            item: tableView,
+            attribute: .centerY,
+            relatedBy: .equal,
+            toItem: view,
+            attribute: .centerY,
+            multiplier: 1,
+            constant: 200
+        )
+        
+        let constraints = [heightConstraint, widthConstraint, positionXConstraint, positionYConstraint].compactMap { $0 }
+        NSLayoutConstraint.activate(constraints)
+        
+        updateContent()
+    }
+    
+    open func updateContent() {
+        tableView.reloadData()
+        
+        view.setNeedsUpdateConstraints()
+        view.layoutIfNeeded()
+    }
+        
+    public func show() {
+        guard let owner = owningViewController else { return }
+        owningViewController?.addChild(self)
+        owner.view.addSubview(view)
+        didMove(toParent: owner)
+    }
+    
+    public func dismiss() {
+        removeFromParent()
+        view.removeFromSuperview()
+    }
+    
+    // MARK: - UITableView
+    
+    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        suggestions.count
+    }
+    
+    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell")!
+        cell.textLabel?.text = suggestions[indexPath.row]
+        
+        return cell
+    }
+}

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageInputSlashCommandView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageInputSlashCommandView.swift
@@ -1,0 +1,105 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+open class MessageInputSlashCommandView: UIView {
+    // MARK: - Underlying types
+    
+    public enum Command: String {
+        case giphy
+    }
+    
+    // MARK: - Properties
+        
+    override open var intrinsicContentSize: CGSize {
+        container.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+    }
+    
+    public var command: Command = .giphy {
+        didSet {
+            updateContent()
+        }
+    }
+    
+    // MARK: - Subviews
+    
+    private lazy var container = ContainerStackView().withoutAutoresizingMaskConstraints
+    
+    private lazy var commandLabel = UILabel().withoutAutoresizingMaskConstraints
+    
+    private lazy var iconView = UIImageView().withoutAutoresizingMaskConstraints
+    
+    // MARK: - Init
+    
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+    
+    private func commonInit() {
+        embed(container)
+        
+        setupLayout()
+        setupAppearance()
+        updateContent()
+    }
+    
+    // MARK: - Layout
+    
+    override open func invalidateIntrinsicContentSize() {
+        super.invalidateIntrinsicContentSize()
+        
+        commandLabel.invalidateIntrinsicContentSize()
+    }
+    
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+        
+        invalidateIntrinsicContentSize()
+        
+        layer.cornerRadius = intrinsicContentSize.height / 2
+    }
+    
+    // MARK: - Public
+    
+    open func setupAppearance() {
+        layer.masksToBounds = true
+        backgroundColor = .systemPurple
+        commandLabel.textColor = .white
+        commandLabel.font = UIFont.preferredFont(forTextStyle: .caption1).bold()
+        commandLabel.adjustsFontForContentSizeCategory = true
+        commandLabel.textAlignment = .center
+        
+        if #available(iOS 13.0, *) {
+            iconView.image = UIImage(systemName: "bolt.fill")
+            iconView.tintColor = .white
+        }
+    }
+    
+    open func setupLayout() {
+        container.preservesSuperviewLayoutMargins = true
+        container.isLayoutMarginsRelativeArrangement = true
+        
+        container.spacing = UIStackView.spacingUseSystem
+                
+        container.leftStackView.isHidden = false
+        container.leftStackView.addArrangedSubview(iconView)
+        
+        container.rightStackView.isHidden = false
+        container.rightStackView.addArrangedSubview(commandLabel)
+        
+        iconView.contentMode = .scaleAspectFit
+        iconView.heightAnchor.constraint(equalToConstant: commandLabel.font.pointSize).isActive = true
+    }
+    
+    open func updateContent() {
+        commandLabel.text = command.rawValue.uppercased()
+    }
+}

--- a/Sources_v3/StreamChatUI/Common Views/ContainerStackView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/ContainerStackView.swift
@@ -12,6 +12,8 @@ public class ContainerStackView: UIStackView {
     public let leftStackView = UIStackView()
     public let rightStackView = UIStackView()
     public let centerStackView = UIStackView()
+    
+    public let centerContainerStackView = UIStackView()
         
     // MARK: - Init
 
@@ -31,7 +33,6 @@ public class ContainerStackView: UIStackView {
         alignment = .fill
         translatesAutoresizingMaskIntoConstraints = false
         
-        let centerContainerStackView = UIStackView()
         centerContainerStackView.distribution = .fill
         centerContainerStackView.axis = .horizontal
         centerContainerStackView.alignment = .fill

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2210525F256FE16600A5F0DB /* MessageInputSlashCommandView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2210525E256FE16600A5F0DB /* MessageInputSlashCommandView.swift */; };
+		221742D5256DC97F005B257C /* MessageComposerAttachmentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221742D4256DC97F005B257C /* MessageComposerAttachmentsView.swift */; };
 		2229C6D9256562AC00C56B63 /* ChatMessageAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2229C6D8256562AC00C56B63 /* ChatMessageAttachment.swift */; };
 		2229C6DF256562DB00C56B63 /* AttachmentPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2229C6DE256562DB00C56B63 /* AttachmentPayload.swift */; };
 		2245B2B625602465006A612D /* ChatChannelAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2245B2B525602465006A612D /* ChatChannelAvatarView.swift */; };
@@ -19,6 +20,7 @@
 		224FF6972562F5AE00725DD1 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224FF6962562F5AE00725DD1 /* Bundle+Extensions.swift */; };
 		224FF69D2562F5D100725DD1 /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224FF69C2562F5D100725DD1 /* UIImage+Extensions.swift */; };
 		228190EB256733420048D7C6 /* UIFont+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228190EA256733420048D7C6 /* UIFont+Extensions.swift */; };
+		228DC80E25704B410080A49F /* MessageComposerAttachmentCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */; };
 		22A0921725682880001FE9F0 /* ChatNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A0921625682880001FE9F0 /* ChatNavigationBar.swift */; };
 		7900452625374CA20096ECA1 /* User+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900452525374CA20096ECA1 /* User+SwiftUI.swift */; };
 		7908820625432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
@@ -599,6 +601,7 @@
 
 /* Begin PBXFileReference section */
 		2210525E256FE16600A5F0DB /* MessageInputSlashCommandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageInputSlashCommandView.swift; sourceTree = "<group>"; };
+		221742D4256DC97F005B257C /* MessageComposerAttachmentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerAttachmentsView.swift; sourceTree = "<group>"; };
 		2229C6D8256562AC00C56B63 /* ChatMessageAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageAttachment.swift; sourceTree = "<group>"; };
 		2229C6DE256562DB00C56B63 /* AttachmentPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentPayload.swift; sourceTree = "<group>"; };
 		2245B2B525602465006A612D /* ChatChannelAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelAvatarView.swift; sourceTree = "<group>"; };
@@ -610,6 +613,7 @@
 		224FF6962562F5AE00725DD1 /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
 		224FF69C2562F5D100725DD1 /* UIImage+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
 		228190EA256733420048D7C6 /* UIFont+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extensions.swift"; sourceTree = "<group>"; };
+		228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerAttachmentCellView.swift; sourceTree = "<group>"; };
 		22A0921625682880001FE9F0 /* ChatNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatNavigationBar.swift; sourceTree = "<group>"; };
 		7900452525374CA20096ECA1 /* User+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+SwiftUI.swift"; sourceTree = "<group>"; };
 		790881FD25432B7200896F03 /* StreamChatUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1296,6 +1300,8 @@
 				88BC8907256E90A1009C5554 /* ChatRepliedMessageContentView.swift */,
 				DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */,
 				79088333254876C200896F03 /* ChatChannelNavigationBar.swift */,
+				221742D4256DC97F005B257C /* MessageComposerAttachmentsView.swift */,
+				228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */,
 				2210525E256FE16600A5F0DB /* MessageInputSlashCommandView.swift */,
 			);
 			path = ChatChannel;
@@ -2751,9 +2757,12 @@
 				8850B914255C1F77003AED69 /* NameAndImageProviding.swift in Sources */,
 				88A8CF26256E7C31004EA4C7 /* ChatMessageMetadataView.swift in Sources */,
 				7908834D2548770C00896F03 /* ChatMessageCollectionViewCell.swift in Sources */,
+				221742D5256DC97F005B257C /* MessageComposerAttachmentsView.swift in Sources */,
 				885B3D7D25642B88003E6BDF /* CreateNewChannelButton.swift in Sources */,
 				792DD9D9256BC542001DB91B /* BaseViews.swift in Sources */,
 				79088334254876EA00896F03 /* ChatChannelVC.swift in Sources */,
+				228DC80E25704B410080A49F /* MessageComposerAttachmentCellView.swift in Sources */,
+				79088334254876EA00896F03 /* ChatChannelViewController.swift in Sources */,
 				790882DF25486B6800896F03 /* ChatChannelListVC.swift in Sources */,
 				79D86E832562BAB900DCD1D2 /* AppearanceSetting.swift in Sources */,
 				792DD9FB256E67C6001DB91B /* UIConfigProvider.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		228190EB256733420048D7C6 /* UIFont+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228190EA256733420048D7C6 /* UIFont+Extensions.swift */; };
 		228DC80E25704B410080A49F /* MessageComposerAttachmentCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */; };
 		22A0921725682880001FE9F0 /* ChatNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A0921625682880001FE9F0 /* ChatNavigationBar.swift */; };
+		22ADD67C256BF1550098EFEB /* ChatChannelMessageInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */; };
 		7900452625374CA20096ECA1 /* User+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900452525374CA20096ECA1 /* User+SwiftUI.swift */; };
 		7908820625432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
 		7908821225432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
@@ -615,6 +616,7 @@
 		228190EA256733420048D7C6 /* UIFont+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extensions.swift"; sourceTree = "<group>"; };
 		228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerAttachmentCellView.swift; sourceTree = "<group>"; };
 		22A0921625682880001FE9F0 /* ChatNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatNavigationBar.swift; sourceTree = "<group>"; };
+		22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelMessageInputView.swift; sourceTree = "<group>"; };
 		7900452525374CA20096ECA1 /* User+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+SwiftUI.swift"; sourceTree = "<group>"; };
 		790881FD25432B7200896F03 /* StreamChatUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7908820525432B7200896F03 /* StreamChatUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1300,6 +1302,7 @@
 				88BC8907256E90A1009C5554 /* ChatRepliedMessageContentView.swift */,
 				DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */,
 				79088333254876C200896F03 /* ChatChannelNavigationBar.swift */,
+				22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */,
 				221742D4256DC97F005B257C /* MessageComposerAttachmentsView.swift */,
 				228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */,
 				2210525E256FE16600A5F0DB /* MessageInputSlashCommandView.swift */,
@@ -2786,6 +2789,7 @@
 				79088339254876F200896F03 /* ChatChannelCollectionView.swift in Sources */,
 				2210525F256FE16600A5F0DB /* MessageInputSlashCommandView.swift in Sources */,
 				224FF6972562F5AE00725DD1 /* Bundle+Extensions.swift in Sources */,
+				22ADD67C256BF1550098EFEB /* ChatChannelMessageInputView.swift in Sources */,
 				224FF69D2562F5D100725DD1 /* UIImage+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		228DC80E25704B410080A49F /* MessageComposerAttachmentCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */; };
 		22A0921725682880001FE9F0 /* ChatNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A0921625682880001FE9F0 /* ChatNavigationBar.swift */; };
 		22ADD67C256BF1550098EFEB /* ChatChannelMessageInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */; };
+		22ADD682256C40410098EFEB /* ChatChannelMessageComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22ADD681256C40410098EFEB /* ChatChannelMessageComposerView.swift */; };
 		7900452625374CA20096ECA1 /* User+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900452525374CA20096ECA1 /* User+SwiftUI.swift */; };
 		7908820625432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
 		7908821225432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
@@ -617,6 +618,7 @@
 		228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerAttachmentCellView.swift; sourceTree = "<group>"; };
 		22A0921625682880001FE9F0 /* ChatNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatNavigationBar.swift; sourceTree = "<group>"; };
 		22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelMessageInputView.swift; sourceTree = "<group>"; };
+		22ADD681256C40410098EFEB /* ChatChannelMessageComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelMessageComposerView.swift; sourceTree = "<group>"; };
 		7900452525374CA20096ECA1 /* User+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+SwiftUI.swift"; sourceTree = "<group>"; };
 		790881FD25432B7200896F03 /* StreamChatUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7908820525432B7200896F03 /* StreamChatUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1303,6 +1305,7 @@
 				DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */,
 				79088333254876C200896F03 /* ChatChannelNavigationBar.swift */,
 				22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */,
+				22ADD681256C40410098EFEB /* ChatChannelMessageComposerView.swift */,
 				221742D4256DC97F005B257C /* MessageComposerAttachmentsView.swift */,
 				228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */,
 				2210525E256FE16600A5F0DB /* MessageInputSlashCommandView.swift */,
@@ -2747,6 +2750,8 @@
 				228190EB256733420048D7C6 /* UIFont+Extensions.swift in Sources */,
 				888123D2255D430B00070D5A /* UIView+Extensions.swift in Sources */,
 				224FF6872562F55F00725DD1 /* Date+Extensions.swift in Sources */,
+				7908833E254876F900896F03 /* ChatChannelCollectionViewDataSource.swift in Sources */,
+				22ADD682256C40410098EFEB /* ChatChannelMessageComposerView.swift in Sources */,
 				8850FE91256558B200C8D534 /* ChatRouter.swift in Sources */,
 				DB70CFF425701FE500DDF436 /* ChatChannelNavigationBarListener.swift in Sources */,
 				88A8CF0B256E7AC8004EA4C7 /* ChatMessageGroupPart.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		22A0921725682880001FE9F0 /* ChatNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A0921625682880001FE9F0 /* ChatNavigationBar.swift */; };
 		22ADD67C256BF1550098EFEB /* ChatChannelMessageInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */; };
 		22ADD682256C40410098EFEB /* ChatChannelMessageComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22ADD681256C40410098EFEB /* ChatChannelMessageComposerView.swift */; };
+		22FF4365256E943F00133910 /* MessageComposerSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FF4364256E943F00133910 /* MessageComposerSuggestionsViewController.swift */; };
 		7900452625374CA20096ECA1 /* User+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900452525374CA20096ECA1 /* User+SwiftUI.swift */; };
 		7908820625432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
 		7908821225432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
@@ -619,6 +620,7 @@
 		22A0921625682880001FE9F0 /* ChatNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatNavigationBar.swift; sourceTree = "<group>"; };
 		22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelMessageInputView.swift; sourceTree = "<group>"; };
 		22ADD681256C40410098EFEB /* ChatChannelMessageComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelMessageComposerView.swift; sourceTree = "<group>"; };
+		22FF4364256E943F00133910 /* MessageComposerSuggestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerSuggestionsViewController.swift; sourceTree = "<group>"; };
 		7900452525374CA20096ECA1 /* User+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+SwiftUI.swift"; sourceTree = "<group>"; };
 		790881FD25432B7200896F03 /* StreamChatUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7908820525432B7200896F03 /* StreamChatUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1309,6 +1311,7 @@
 				221742D4256DC97F005B257C /* MessageComposerAttachmentsView.swift */,
 				228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */,
 				2210525E256FE16600A5F0DB /* MessageInputSlashCommandView.swift */,
+				22FF4364256E943F00133910 /* MessageComposerSuggestionsViewController.swift */,
 			);
 			path = ChatChannel;
 			sourceTree = "<group>";
@@ -2756,6 +2759,8 @@
 				DB70CFF425701FE500DDF436 /* ChatChannelNavigationBarListener.swift in Sources */,
 				88A8CF0B256E7AC8004EA4C7 /* ChatMessageGroupPart.swift in Sources */,
 				88BC8908256E90A1009C5554 /* ChatRepliedMessageContentView.swift in Sources */,
+				790883522548771100896F03 /* ChatChannelNavigationBar.swift in Sources */,
+				22FF4365256E943F00133910 /* MessageComposerSuggestionsViewController.swift in Sources */,
 				22A0921725682880001FE9F0 /* ChatNavigationBar.swift in Sources */,
 				7952764A255D86BD008531E8 /* UIExtraData.swift in Sources */,
 				88A8CF20256E7C06004EA4C7 /* ChatMessageBubbleView.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2210525F256FE16600A5F0DB /* MessageInputSlashCommandView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2210525E256FE16600A5F0DB /* MessageInputSlashCommandView.swift */; };
 		2229C6D9256562AC00C56B63 /* ChatMessageAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2229C6D8256562AC00C56B63 /* ChatMessageAttachment.swift */; };
 		2229C6DF256562DB00C56B63 /* AttachmentPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2229C6DE256562DB00C56B63 /* AttachmentPayload.swift */; };
 		2245B2B625602465006A612D /* ChatChannelAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2245B2B525602465006A612D /* ChatChannelAvatarView.swift */; };
@@ -597,6 +598,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2210525E256FE16600A5F0DB /* MessageInputSlashCommandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageInputSlashCommandView.swift; sourceTree = "<group>"; };
 		2229C6D8256562AC00C56B63 /* ChatMessageAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageAttachment.swift; sourceTree = "<group>"; };
 		2229C6DE256562DB00C56B63 /* AttachmentPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentPayload.swift; sourceTree = "<group>"; };
 		2245B2B525602465006A612D /* ChatChannelAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelAvatarView.swift; sourceTree = "<group>"; };
@@ -1293,6 +1295,8 @@
 				88A8CF0A256E7AC8004EA4C7 /* ChatMessageGroupPart.swift */,
 				88BC8907256E90A1009C5554 /* ChatRepliedMessageContentView.swift */,
 				DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */,
+				79088333254876C200896F03 /* ChatChannelNavigationBar.swift */,
+				2210525E256FE16600A5F0DB /* MessageInputSlashCommandView.swift */,
 			);
 			path = ChatChannel;
 			sourceTree = "<group>";
@@ -2771,6 +2775,7 @@
 				885B3D7725642B3D003E6BDF /* CurrentChatUserAvatarView.swift in Sources */,
 				224FF6912562F58F00725DD1 /* UIColor+Extensions.swift in Sources */,
 				79088339254876F200896F03 /* ChatChannelCollectionView.swift in Sources */,
+				2210525F256FE16600A5F0DB /* MessageInputSlashCommandView.swift in Sources */,
 				224FF6972562F5AE00725DD1 /* Bundle+Extensions.swift in Sources */,
 				224FF69D2562F5D100725DD1 /* UIImage+Extensions.swift in Sources */,
 			);


### PR DESCRIPTION
**In this PR:** 

- Expose underlying container in `ContainerStackView`
- Introduce `MessageInputSlashCommandView`
- Introduce `MessageComposerAttachmentsView`
- Introduce `ChatChannelMessageInputView`
- Introduce `ChatChannelMessageComposerView`
- Introduce `MessageComposerSuggestionsViewController`
- Use `ChatChannelMessageComposerView` in `SimpleChatViewController`