### PR TITLE
[CIS-496] Preview URL for attachments

### DIFF
--- a/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/AttachmentPayload.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/AttachmentPayload.swift
@@ -35,8 +35,10 @@ struct AttachmentPayload<ExtraData: AttachmentExtraData>: Decodable {
     let actions: [AttachmentAction]
     /// A URL. Depends on type of the attachment (e.g. some asset URL, enriched URL, tappable title URL)
     let url: URL?
-    /// An image preview URL.
+    /// An image URL.
     let imageURL: URL?
+    /// An image preview URL.
+    let imagePreviewURL: URL?
     /// A file description (see `AttachmentFile`).
     let file: AttachmentFile?
     /// An extra data for the attachment.
@@ -63,12 +65,14 @@ struct AttachmentPayload<ExtraData: AttachmentExtraData>: Decodable {
         title: String,
         url: URL? = nil,
         imageURL: URL? = nil,
+        imagePreviewURL: URL?,
         file: AttachmentFile? = nil,
         extraData: ExtraData = .defaultValue
     ) {
         self.type = type
         self.url = url
         self.imageURL = imageURL
+        self.imagePreviewURL = imagePreviewURL
         self.title = title
         self.file = file
         self.extraData = extraData
@@ -95,6 +99,10 @@ struct AttachmentPayload<ExtraData: AttachmentExtraData>: Decodable {
             try container.decodeIfPresent(String.self, forKey: .image)
                 ?? container.decodeIfPresent(String.self, forKey: .imageURL)
                 ?? container.decodeIfPresent(String.self, forKey: .thumbURL)
+        )
+
+        imagePreviewURL = AttachmentPayload.fixedURL(
+            try container.decodeIfPresent(String.self, forKey: .thumbURL)
         )
         
         // Parse URL.

--- a/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/AttachmentPayload_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/AttachmentPayload_Tests.swift
@@ -17,6 +17,7 @@ final class AttachmentPayload_Tests: XCTestCase {
         XCTAssertEqual(payload.type, .youtube)
         XCTAssertEqual(payload.url, URL(string: "https://www.youtube.com/embed/ZXBcwyMUrcU"))
         XCTAssertEqual(payload.imageURL, URL(string: "https://i.ytimg.com/vi/ZXBcwyMUrcU/maxresdefault.jpg"))
+        XCTAssertEqual(payload.imagePreviewURL, URL(string: "https://i.ytimg.com/vi/ZXBcwyMUrcU/maxresdefault_preview.jpg"))
         XCTAssertEqual(payload.extraData, .defaultValue)
     }
 
@@ -31,6 +32,7 @@ final class AttachmentPayload_Tests: XCTestCase {
         XCTAssertEqual(payload.type, .youtube)
         XCTAssertEqual(payload.url, URL(string: "https://www.youtube.com/embed/ZXBcwyMUrcU"))
         XCTAssertEqual(payload.imageURL, URL(string: "https://i.ytimg.com/vi/ZXBcwyMUrcU/maxresdefault.jpg"))
+        XCTAssertEqual(payload.imagePreviewURL, URL(string: "https://i.ytimg.com/vi/ZXBcwyMUrcU/maxresdefault_preview.jpg"))
         
         // Assert `AttachmentPayload`s `ExtraData` is deserialized correctly
         XCTAssertEqual(payload.extraData.countdown, 120)

--- a/Sources_v3/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -21,8 +21,10 @@ class AttachmentDTO: NSManagedObject {
     @NSManaged var actions: Data?
     /// A URL.
     @NSManaged var url: URL?
-    /// An image preview URL.
+    /// An image URL.
     @NSManaged var imageURL: URL?
+    /// An image preview URL.
+    @NSManaged var imagePreviewURL: URL?
     /// A file description (see `AttachmentFile`).
     @NSManaged var file: Data?
     /// An extra data for the attachment.
@@ -64,6 +66,7 @@ extension NSManagedObjectContext: AttachmentDatabaseSession {
         dto.actions = payload.actions.isEmpty ? nil : try JSONEncoder.stream.encode(payload.actions)
         dto.url = payload.url
         dto.imageURL = payload.imageURL
+        dto.imagePreviewURL = payload.imagePreviewURL
         dto.file = payload.file == nil ? nil : try JSONEncoder.stream.encode(payload.file)
         dto.extraData = try JSONEncoder.default.encode(payload.extraData)
         

--- a/Sources_v3/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -101,6 +101,7 @@ extension NSManagedObjectContext: AttachmentDatabaseSession {
         dto.actions = attachment.actions.isEmpty ? nil : try JSONEncoder.stream.encode(attachment.actions)
         dto.url = attachment.url
         dto.imageURL = attachment.imageURL
+        dto.imagePreviewURL = attachment.imagePreviewURL
         dto.file = attachment.file == nil ? nil : try JSONEncoder.stream.encode(attachment.file)
         dto.extraData = try JSONEncoder.default.encode(attachment.extraData)
         
@@ -152,6 +153,7 @@ private extension _ChatMessageAttachment {
             actions: dto.decoded([AttachmentAction].self, from: dto.actions) ?? [],
             url: dto.url,
             imageURL: dto.imageURL,
+            imagePreviewURL: dto.imagePreviewURL,
             file: dto.decoded(AttachmentFile.self, from: dto.file),
             extraData: extraData
         )

--- a/Sources_v3/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
@@ -120,6 +120,7 @@ class AttachmentDTO_Tests: XCTestCase {
         XCTAssertEqual(attachment.actions, modelAttachment?.actions)
         XCTAssertEqual(attachment.author, modelAttachment?.author)
         XCTAssertEqual(attachment.imageURL, modelAttachment?.imageURL)
+        XCTAssertEqual(attachment.imagePreviewURL, modelAttachment?.imagePreviewURL)
         XCTAssertEqual(attachment.url, modelAttachment?.url)
         XCTAssertEqual(attachment.extraData, modelAttachment?.extraData)
     }

--- a/Sources_v3/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
@@ -30,6 +30,7 @@ class AttachmentDTO_Tests: XCTestCase {
         XCTAssertEqual(attachment.title, loadedAttachment?.title)
         XCTAssertEqual(attachment.author, loadedAttachment?.author)
         XCTAssertEqual(attachment.imageURL, loadedAttachment?.imageURL)
+        XCTAssertEqual(attachment.imagePreviewURL, loadedAttachment?.imagePreviewURL)
         XCTAssertEqual(attachment.url, loadedAttachment?.url)
     }
     
@@ -66,6 +67,7 @@ class AttachmentDTO_Tests: XCTestCase {
         XCTAssertEqual(attachment.title, loadedAttachment?.title)
         XCTAssertEqual(attachment.author, loadedAttachment?.author)
         XCTAssertEqual(attachment.imageURL, loadedAttachment?.imageURL)
+        XCTAssertEqual(attachment.imagePreviewURL, loadedAttachment?.imagePreviewURL)
         XCTAssertEqual(attachment.url, loadedAttachment?.url)
         
         // Assert extra data is saved correctly

--- a/Sources_v3/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources_v3/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -6,6 +6,7 @@
         <attribute name="author" optional="YES" attributeType="String"/>
         <attribute name="extraData" optional="YES" attributeType="Binary"/>
         <attribute name="file" optional="YES" attributeType="Binary"/>
+        <attribute name="imagePreviewURL" optional="YES" attributeType="URI"/>
         <attribute name="imageURL" optional="YES" attributeType="URI"/>
         <attribute name="text" optional="YES" attributeType="String"/>
         <attribute name="title" attributeType="String"/>

--- a/Sources_v3/StreamChat/Models/Attachment.swift
+++ b/Sources_v3/StreamChat/Models/Attachment.swift
@@ -37,8 +37,10 @@ public struct _ChatMessageAttachment<ExtraData: ExtraDataTypes>: Hashable {
     public let actions: [AttachmentAction]
     /// A URL. Depends on type of the attachment (e.g. some asset URL, enriched URL, title URL)
     public let url: URL?
-    /// An image preview URL.
+    /// An image URL.
     public let imageURL: URL?
+    /// An image preview URL.
+    public let imagePreviewURL: URL?
     /// A file description (see `AttachmentFile`).
     public let file: AttachmentFile?
     /// An extra data for the attachment.
@@ -52,6 +54,7 @@ public struct _ChatMessageAttachment<ExtraData: ExtraDataTypes>: Hashable {
         actions: [AttachmentAction],
         url: URL?,
         imageURL: URL?,
+        imagePreviewURL: URL?,
         file: AttachmentFile?,
         extraData: ExtraData.Attachment
     ) {
@@ -62,6 +65,7 @@ public struct _ChatMessageAttachment<ExtraData: ExtraDataTypes>: Hashable {
         self.actions = actions
         self.url = url
         self.imageURL = imageURL
+        self.imagePreviewURL = imagePreviewURL
         self.file = file
         self.extraData = extraData
     }

--- a/Tests_v3/Dummy data/AttachmentPayload.swift
+++ b/Tests_v3/Dummy data/AttachmentPayload.swift
@@ -12,6 +12,7 @@ extension AttachmentPayload {
         title: String = .unique,
         url: URL? = URL(string: "https://getstream.io/some.jpg"),
         imageURL: URL? = URL(string: "https://getstream.io/some.jpg"),
+        imagePreviewURL: URL? = URL(string: "https://getstream.io/some_preview.jpg"),
         file: AttachmentFile? = .init(type: .gif, size: 1024, mimeType: "image/gif"),
         extraData: T = .defaultValue
     ) -> AttachmentPayload<T> {
@@ -20,6 +21,7 @@ extension AttachmentPayload {
             title: title,
             url: url,
             imageURL: imageURL,
+            imagePreviewURL: imagePreviewURL,
             file: file,
             extraData: extraData
         )

--- a/Tests_v3/Dummy data/ChatMessageAttachment.swift
+++ b/Tests_v3/Dummy data/ChatMessageAttachment.swift
@@ -14,6 +14,7 @@ extension _ChatMessageAttachment {
         type: AttachmentType = .image,
         url: URL? = URL(string: "https://getstream.io/some.jpg"),
         imageURL: URL? = URL(string: "https://getstream.io/some.jpg"),
+        imagePreviewURL: URL? = URL(string: "https://getstream.io/some_preview.jpg"),
         file: AttachmentFile? = .init(type: .gif, size: 1024, mimeType: "image/gif"),
         extraData: T.Attachment = .defaultValue
     ) -> _ChatMessageAttachment<T> {
@@ -23,8 +24,9 @@ extension _ChatMessageAttachment {
             text: .unique,
             type: .image,
             actions: [],
-            url: URL(string: "https://getstream.io/some.jpg"),
-            imageURL: URL(string: "https://getstream.io/some.jpg"),
+            url: url,
+            imageURL: imageURL,
+            imagePreviewURL: imagePreviewURL,
             file: nil,
             extraData: .defaultValue
         )

--- a/Tests_v3/MockEnpointResponses/Attachment/AttachmentPayload+CustomExtraData.json
+++ b/Tests_v3/MockEnpointResponses/Attachment/AttachmentPayload+CustomExtraData.json
@@ -6,7 +6,7 @@
   "text" : "For more information, follow The Weeknd on Twitter: http:\/\/twitter.com\/theweeknd",
   "type" : "video",
   "title_link" : "https:\/\/www.youtube.com\/watch?v=ZXBcwyMUrcU",
-  "thumb_url" : "https:\/\/i.ytimg.com\/vi\/ZXBcwyMUrcU\/maxresdefault.jpg",
+  "thumb_url" : "https:\/\/i.ytimg.com\/vi\/ZXBcwyMUrcU\/maxresdefault_preview.jpg",
   "asset_url" : "https:\/\/www.youtube.com\/embed\/ZXBcwyMUrcU",
   "countdown_due" : 120
 }

--- a/Tests_v3/MockEnpointResponses/Attachment/AttachmentPayload+NoExtraData.json
+++ b/Tests_v3/MockEnpointResponses/Attachment/AttachmentPayload+NoExtraData.json
@@ -6,6 +6,6 @@
   "text" : "For more information, follow The Weeknd on Twitter: http:\/\/twitter.com\/theweeknd",
   "type" : "video",
   "title_link" : "https:\/\/www.youtube.com\/watch?v=ZXBcwyMUrcU",
-  "thumb_url" : "https:\/\/i.ytimg.com\/vi\/ZXBcwyMUrcU\/maxresdefault.jpg",
+  "thumb_url" : "https:\/\/i.ytimg.com\/vi\/ZXBcwyMUrcU\/maxresdefault_preview.jpg",
   "asset_url" : "https:\/\/www.youtube.com\/embed\/ZXBcwyMUrcU"
 }


### PR DESCRIPTION
**This PR** adds `imagePreviewURL` to attachment payload, DTO, and model types