### PR TITLE
[CIS-437] Add initial `StreamChatTestTools`

### DIFF
--- a/DemoApp/DemoUsers.swift
+++ b/DemoApp/DemoUsers.swift
@@ -4,8 +4,6 @@
 
 import Foundation
 
-// swiftlint:disable line_length
-
 let apiKeyString = "q95x9hkbyd6p"
 
 struct UserCredentials {

--- a/Sources_v3/StreamChatTestTools/ChatClient_Mock.swift
+++ b/Sources_v3/StreamChatTestTools/ChatClient_Mock.swift
@@ -1,0 +1,49 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+
+public extension _ChatClient {
+    /// Create a new instance of mock `_ChatClient`
+    static func mock() -> _ChatClient {
+        var config = ChatClientConfig(apiKey: .init("--== Mock ChatClient ==--"))
+        config.isLocalStorageEnabled = false
+        
+        return .init(
+            config: config,
+            workerBuilders: [],
+            environment: .init(
+                apiClientBuilder: APIClient_Mock.init,
+                webSocketClientBuilder: {
+                    WebSocketClient_Mock(
+                        connectEndpoint: $0,
+                        sessionConfiguration: $1,
+                        requestEncoder: $2,
+                        eventDecoder: $3,
+                        eventNotificationCenter: $4,
+                        internetConnection: $5
+                    )
+                }
+            )
+        )
+    }
+}
+
+// ===== TEMP =====
+
+class APIClient_Mock: APIClient {
+    override func request<Response>(
+        endpoint: Endpoint<Response>,
+        completion: @escaping (Result<Response, Error>) -> Void
+    ) where Response: Decodable {
+        // Do nothing for now
+    }
+}
+
+class WebSocketClient_Mock: WebSocketClient {
+    override func connect() {
+        // Do nothing for now
+    }
+}

--- a/Sources_v3/StreamChatTestTools/Controllers/ChannelListController_Mock.swift
+++ b/Sources_v3/StreamChatTestTools/Controllers/ChannelListController_Mock.swift
@@ -1,0 +1,48 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+
+public class ChatChannelListController_Mock<ExtraData: ExtraDataTypes>: _ChatChannelListController<ExtraData> {
+    /// Creates a new mock instance of `ChatChannelListController`.
+    public static func mock() -> ChatChannelListController_Mock<ExtraData> {
+        .init(query: .init(filter: .equal(.memberCount, to: 0)), client: .mock())
+    }
+    
+    public private(set) var channels_mock: [_ChatChannel<ExtraData>]?
+    override public var channels: [_ChatChannel<ExtraData>] {
+        channels_mock ?? super.channels
+    }
+    
+    public private(set) var state_mock: State?
+    override public var state: DataController.State {
+        get { state_mock ?? super.state }
+        set { super.state = newValue }
+    }
+}
+
+public extension ChatChannelListController_Mock {
+    /// Simulates the initial conditions. Setting these values doesn't trigger any observer callback.
+    func simulateInitial(channels: [_ChatChannel<ExtraData>], state: DataController.State) {
+        channels_mock = channels
+        state_mock = state
+    }
+    
+    /// Simulates changes in the channels array. Observers are notified with the provided `changes` value.
+    func simulate(channels: [_ChatChannel<ExtraData>], changes: [ListChange<_ChatChannel<ExtraData>>]) {
+        channels_mock = channels
+        delegateCallback {
+            $0.controller(self, didChangeChannels: changes)
+        }
+    }
+    
+    /// Simulates changes of `state`. Observers are notified with the new value.
+    func simulate(state: DataController.State) {
+        state_mock = state
+        delegateCallback {
+            $0.controller(self, didChangeState: state)
+        }
+    }
+}

--- a/Sources_v3/StreamChatTestTools/Controllers/ChatChannelController_Mock.swift
+++ b/Sources_v3/StreamChatTestTools/Controllers/ChatChannelController_Mock.swift
@@ -1,0 +1,77 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+
+public class ChatChannelController_Mock<ExtraData: ExtraDataTypes>: _ChatChannelController<ExtraData> {
+    /// Creates a new mock instance of `ChatChannelController`.
+    public static func mock() -> ChatChannelController_Mock<ExtraData> {
+        .init(channelQuery: .init(cid: try! .init(cid: "Mock:Channel")), client: .mock())
+    }
+    
+    public private(set) var channel_mock: _ChatChannel<ExtraData>?
+    override public var channel: _ChatChannel<ExtraData>? {
+        channel_mock ?? super.channel
+    }
+    
+    public private(set) var messages_mock: [_ChatMessage<ExtraData>]?
+    override public var messages: [_ChatMessage<ExtraData>] {
+        messages_mock ?? super.messages
+    }
+
+    public private(set) var state_mock: State?
+    override public var state: DataController.State {
+        get { state_mock ?? super.state }
+        set { super.state = newValue }
+    }
+}
+
+public extension ChatChannelController_Mock {
+    /// Simulates the initial conditions. Setting these values doesn't trigger any observer callback.
+    func simulateInitial(channel: _ChatChannel<ExtraData>, messages: [_ChatMessage<ExtraData>], state: DataController.State) {
+        channel_mock = channel
+        messages_mock = messages
+        state_mock = state
+    }
+    
+    /// Simulates a change of the `channel` value. Observers are notified with the provided `change` value. If `typingMembers`
+    /// value is explicitly provided, `didChangeTypingMembers` is called, too.
+    func simulate(
+        channel: _ChatChannel<ExtraData>?,
+        change: EntityChange<_ChatChannel<ExtraData>>,
+        typingMembers: Set<_ChatChannelMember<ExtraData.User>>?
+    ) {
+        channel_mock = channel
+        delegateCallback {
+            $0.channelController(self, didUpdateChannel: change)
+            if let typingMembers = typingMembers {
+                $0.channelController(self, didChangeTypingMembers: typingMembers)
+            }
+        }
+    }
+    
+    /// Simulates changes in the `messages` array. Observers are notified with the provided `changes` value.
+    func simulate(messages: [_ChatMessage<ExtraData>], changes: [ListChange<_ChatMessage<ExtraData>>]) {
+        messages_mock = messages
+        delegateCallback {
+            $0.channelController(self, didUpdateMessages: changes)
+        }
+    }
+    
+    /// Simulates a received member event.
+    func simulate(memberEvent: MemberEvent) {
+        delegateCallback {
+            $0.channelController(self, didReceiveMemberEvent: memberEvent)
+        }
+    }
+    
+    /// Simulates changes of `state`. Observers are notified with the new value.
+    func simulate(state: DataController.State) {
+        state_mock = state
+        delegateCallback {
+            $0.controller(self, didChangeState: state)
+        }
+    }
+}

--- a/Sources_v3/StreamChatTestTools/Controllers/ChatMessageController_Mock.swift
+++ b/Sources_v3/StreamChatTestTools/Controllers/ChatMessageController_Mock.swift
@@ -1,0 +1,62 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+
+public class ChatMessageController_Mock<ExtraData: ExtraDataTypes>: _ChatMessageController<ExtraData> {
+    /// Creates a new mock instance of `ChatMessageController`.
+    public static func mock() -> _ChatMessageController<ExtraData> {
+        .init(client: .mock(), cid: try! .init(cid: "Mock:Channel"), messageId: "MockMessage")
+    }
+    
+    public private(set) var message_mock: _ChatMessage<ExtraData>?
+    override public var message: _ChatMessage<ExtraData>? {
+        message_mock ?? super.message
+    }
+
+    public private(set) var replies_mock: [_ChatMessage<ExtraData>]?
+    override public var replies: [_ChatMessage<ExtraData>] {
+        replies_mock ?? super.replies
+    }
+
+    public private(set) var state_mock: State?
+    override public var state: DataController.State {
+        get { state_mock ?? super.state }
+        set { super.state = newValue }
+    }
+}
+
+public extension ChatMessageController_Mock {
+    /// Simulates the initial conditions. Setting these values doesn't trigger any observer callback.
+    func simulateInitial(message: _ChatMessage<ExtraData>, replies: [_ChatMessage<ExtraData>], state: DataController.State) {
+        message_mock = message
+        replies_mock = replies
+        state_mock = state
+    }
+    
+    /// Simulates a change of the `message` value. Observers are notified with the provided `change` value.
+    func simulate(message: _ChatMessage<ExtraData>?, change: EntityChange<_ChatMessage<ExtraData>>) {
+        message_mock = message
+        delegateCallback {
+            $0.messageController(self, didChangeMessage: change)
+        }
+    }
+    
+    /// Simulates changes in the `replies` array. Observers are notified with the provided `changes` value.
+    func simulate(replies: [_ChatMessage<ExtraData>], changes: [ListChange<_ChatMessage<ExtraData>>]) {
+        replies_mock = replies
+        delegateCallback {
+            $0.messageController(self, didChangeReplies: changes)
+        }
+    }
+    
+    /// Simulates changes of `state`. Observers are notified with the new value.
+    func simulate(state: DataController.State) {
+        state_mock = state
+        delegateCallback {
+            $0.controller(self, didChangeState: state)
+        }
+    }
+}

--- a/Sources_v3/StreamChatTestTools/Info.plist
+++ b/Sources_v3/StreamChatTestTools/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Sources_v3/StreamChatTestTools/Models/ChatChannelMember_Mock.swift
+++ b/Sources_v3/StreamChatTestTools/Models/ChatChannelMember_Mock.swift
@@ -1,0 +1,43 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+
+public extension _ChatChannelMember {
+    /// Creates a new `_ChatChannelMember` object from the provided data.
+    static func mock(
+        id: String,
+        isOnline: Bool,
+        isBanned: Bool,
+        userRole: UserRole,
+        userCreatedAt: Date,
+        userUpdatedAt: Date,
+        lastActiveAt: Date?,
+        extraData: ExtraData,
+        memberRole: MemberRole,
+        memberCreatedAt: Date,
+        memberUpdatedAt: Date,
+        isInvited: Bool,
+        inviteAcceptedAt: Date?,
+        inviteRejectedAt: Date?
+    ) -> _ChatChannelMember {
+        .init(
+            id: id,
+            isOnline: isOnline,
+            isBanned: isBanned,
+            userRole: userRole,
+            userCreatedAt: userCreatedAt,
+            userUpdatedAt: userUpdatedAt,
+            lastActiveAt: lastActiveAt,
+            extraData: extraData,
+            memberRole: memberRole,
+            memberCreatedAt: memberCreatedAt,
+            memberUpdatedAt: memberUpdatedAt,
+            isInvited: isInvited,
+            inviteAcceptedAt: inviteAcceptedAt,
+            inviteRejectedAt: inviteRejectedAt
+        )
+    }
+}

--- a/Sources_v3/StreamChatTestTools/Models/ChatChannel_Mock.swift
+++ b/Sources_v3/StreamChatTestTools/Models/ChatChannel_Mock.swift
@@ -1,0 +1,101 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+
+public extension ChannelConfig {
+    /// Creates a new `ChannelConfig` object from the provided data.
+    static func mock(
+        reactionsEnabled: Bool = false,
+        typingEventsEnabled: Bool = false,
+        readEventsEnabled: Bool = false,
+        connectEventsEnabled: Bool = false,
+        uploadsEnabled: Bool = false,
+        repliesEnabled: Bool = false,
+        searchEnabled: Bool = false,
+        mutesEnabled: Bool = false,
+        urlEnrichmentEnabled: Bool = false,
+        messageRetention: String = "",
+        maxMessageLength: Int = 0,
+        commands: [Command] = [],
+        createdAt: Date = .init(),
+        updatedAt: Date = .init()
+    ) -> Self {
+        self.init(
+            reactionsEnabled: reactionsEnabled,
+            typingEventsEnabled: typingEventsEnabled,
+            readEventsEnabled: readEventsEnabled,
+            connectEventsEnabled: connectEventsEnabled,
+            uploadsEnabled: uploadsEnabled,
+            repliesEnabled: repliesEnabled,
+            searchEnabled: searchEnabled,
+            mutesEnabled: mutesEnabled,
+            urlEnrichmentEnabled: urlEnrichmentEnabled,
+            messageRetention: messageRetention,
+            maxMessageLength: maxMessageLength,
+            commands: commands,
+            createdAt: createdAt,
+            updatedAt: updatedAt
+        )
+    }
+}
+
+public extension _ChatChannelRead {
+    /// Creates a new `_ChatChannelRead` object from the provided data.
+    static func mock(
+        lastReadAt: Date,
+        unreadMessagesCount: Int,
+        user: _ChatUser<ExtraData.User>
+    ) -> Self {
+        .init(
+            lastReadAt: lastReadAt,
+            unreadMessagesCount: unreadMessagesCount,
+            user: user
+        )
+    }
+}
+
+public extension _ChatChannel {
+    /// Creates a new `_ChatChannel` object from the provided data.
+    static func mock(
+        cid: ChannelId,
+        lastMessageAt: Date? = nil,
+        createdAt: Date = .init(),
+        updatedAt: Date = .init(),
+        deletedAt: Date? = nil,
+        createdBy: _ChatUser<ExtraData.User>? = nil,
+        config: ChannelConfig = .mock(),
+        isFrozen: Bool = false,
+        members: Set<_ChatChannelMember<ExtraData.User>> = [],
+        currentlyTypingMembers: Set<_ChatChannelMember<ExtraData.User>> = [],
+        watchers: Set<_ChatUser<ExtraData.User>> = [],
+        unreadCount: ChannelUnreadCount = .noUnread,
+        watcherCount: Int = 0,
+        memberCount: Int = 0,
+        reads: [_ChatChannelRead<ExtraData>] = [],
+        extraData: ExtraData.Channel,
+        latestMessages: [_ChatMessage<ExtraData>] = []
+    ) -> Self {
+        self.init(
+            cid: cid,
+            lastMessageAt: lastMessageAt,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deletedAt: deletedAt,
+            createdBy: createdBy,
+            config: config,
+            isFrozen: isFrozen,
+            members: members,
+            currentlyTypingMembers: currentlyTypingMembers,
+            watchers: watchers,
+            unreadCount: unreadCount,
+            watcherCount: watcherCount,
+            memberCount: memberCount,
+            reads: reads,
+            extraData: extraData,
+            latestMessages: latestMessages
+        )
+    }
+}

--- a/Sources_v3/StreamChatTestTools/Models/ChatMessage_Mock.swift
+++ b/Sources_v3/StreamChatTestTools/Models/ChatMessage_Mock.swift
@@ -1,0 +1,63 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+
+public extension _ChatMessage {
+    /// Creates a new `_ChatMessage` object from the provided data.
+    static func mock(
+        id: MessageId,
+        text: String,
+        type: MessageType = .reply,
+        author: _ChatUser<ExtraData.User>,
+        command: String? = nil,
+        createdAt: Date = .init(),
+        locallyCreatedAt: Date? = nil,
+        updatedAt: Date = .init(),
+        deletedAt: Date? = nil,
+        arguments: String? = nil,
+        parentMessageId: MessageId? = nil,
+        showReplyInChannel: Bool = false,
+        replyCount: Int = 0,
+        extraData: ExtraData.Message = .defaultValue,
+        isSilent: Bool = false,
+        reactionScores: [MessageReactionType: Int] = [:],
+        mentionedUsers: Set<_ChatUser<ExtraData.User>> = [],
+        attachments: Set<_ChatMessageAttachment<ExtraData>> = [],
+        latestReplies: [_ChatMessage<ExtraData>] = [],
+        localState: LocalMessageState? = nil,
+        isFlaggedByCurrentUser: Bool = false,
+        latestReactions: Set<_ChatMessageReaction<ExtraData>> = [],
+        currentUserReactions: Set<_ChatMessageReaction<ExtraData>> = [],
+        isSentByCurrentUser: Bool = false
+    ) -> Self {
+        .init(
+            id: id,
+            text: text,
+            type: type,
+            command: command,
+            createdAt: createdAt,
+            locallyCreatedAt: locallyCreatedAt,
+            updatedAt: updatedAt,
+            deletedAt: deletedAt,
+            arguments: arguments,
+            parentMessageId: parentMessageId,
+            showReplyInChannel: showReplyInChannel,
+            replyCount: replyCount,
+            extraData: extraData,
+            isSilent: isSilent,
+            reactionScores: reactionScores,
+            author: author,
+            mentionedUsers: mentionedUsers,
+            attachments: attachments,
+            latestReplies: latestReplies,
+            localState: localState,
+            isFlaggedByCurrentUser: isFlaggedByCurrentUser,
+            latestReactions: latestReactions,
+            currentUserReactions: currentUserReactions,
+            isSentByCurrentUser: isSentByCurrentUser
+        )
+    }
+}

--- a/Sources_v3/StreamChatTestTools/Models/ChatUser_Mock.swift
+++ b/Sources_v3/StreamChatTestTools/Models/ChatUser_Mock.swift
@@ -1,0 +1,35 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+
+public extension _ChatUser {
+    /// Creates a new `_ChatUser` object from the provided data.
+    static func mock(
+        id: UserId,
+        isOnline: Bool = false,
+        isBanned: Bool = false,
+        isFlaggedByCurrentUser: Bool = false,
+        userRole: UserRole = .user,
+        createdAt: Date = .init(),
+        updatedAt: Date = .init(),
+        lastActiveAt: Date? = nil,
+        teams: [String] = [],
+        extraData: ExtraData = .defaultValue
+    ) -> _ChatUser {
+        .init(
+            id: id,
+            isOnline: isOnline,
+            isBanned: isBanned,
+            isFlaggedByCurrentUser: isFlaggedByCurrentUser,
+            userRole: userRole,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            lastActiveAt: lastActiveAt,
+            teams: teams,
+            extraData: extraData
+        )
+    }
+}

--- a/Sources_v3/StreamChatTestTools/StreamChatTestTools.h
+++ b/Sources_v3/StreamChatTestTools/StreamChatTestTools.h
@@ -1,0 +1,19 @@
+//
+//  StreamChatTestTools.h
+//  StreamChatTestTools
+//
+//  Created by Vojta on 02/12/2020.
+//  Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for StreamChatTestTools.
+FOUNDATION_EXPORT double StreamChatTestToolsVersionNumber;
+
+//! Project version string for StreamChatTestTools.
+FOUNDATION_EXPORT const unsigned char StreamChatTestToolsVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <StreamChatTestTools/PublicHeader.h>
+
+

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC_Tests.swift
@@ -1,0 +1,46 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import StreamChatTestTools
+@testable import StreamChatUI
+import XCTest
+
+// ====== Example test only ====
+
+class ChatChannelVC_Tests: XCTestCase {
+    var vc: ChatChannelVC<DefaultUIExtraData>!
+    var channelController: ChatChannelController_Mock<DefaultUIExtraData>!
+    
+    override func setUp() {
+        super.setUp()
+        channelController = .mock()
+        vc = ChatChannelVC()
+        vc.controller = channelController
+        
+        // Load default data
+        let cid = ChannelId(type: .messaging, id: "test")
+        let message: _ChatMessage<DefaultUIExtraData> = .mock(
+            id: UUID().uuidString,
+            text: "This is a test message",
+            author: .init(id: "luke", name: "Luke Skywalker", imageURL: nil)
+        )
+        let channel: _ChatChannel<DefaultUIExtraData> = .mock(cid: cid, extraData: .init(name: "Family chat", imageURL: nil))
+        
+        channelController.simulateInitial(channel: channel, messages: [message], state: .remoteDataFetched)
+    }
+    
+    override func tearDown() {
+        vc = nil
+        channelController = nil
+
+        super.tearDown()
+    }
+    
+    func test_allMessagesAreLoaded() {
+        // load view
+        vc.loadViewIfNeeded()
+        XCTAssertEqual(vc.collectionView.numberOfItems(inSection: 0), 1)
+    }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		792A4F492480107A00EAF71D /* Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F452480107A00EAF71D /* Sorting.swift */; };
 		792A4F4B248010A600EAF71D /* QueryOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F4A248010A600EAF71D /* QueryOptions.swift */; };
 		792A4F4D248011E500EAF71D /* ChannelListQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A4F4C248011E500EAF71D /* ChannelListQuery.swift */; };
+		792A71AD2577E0510082498D /* ChatChannelVC_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793061812577C557005CF846 /* ChatChannelVC_Tests.swift */; };
 		792AF91624D812440010097B /* EntityDatabaseObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792AF91524D812440010097B /* EntityDatabaseObserver.swift */; };
 		792B805024D95B5D00C2963E /* Cached.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792B804F24D95B5D00C2963E /* Cached.swift */; };
 		792B805224D95D4300C2963E /* Cached_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792B805124D95D4300C2963E /* Cached_Tests.swift */; };
@@ -117,6 +118,16 @@
 		792FCB4924A3BF38000290C7 /* OptionSet+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */; };
 		792FCB4B24A3D52A000290C7 /* DatabaseSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4A24A3D52A000290C7 /* DatabaseSession.swift */; };
 		792FCB4D24A3D56D000290C7 /* DatabaseSession_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FCB4C24A3D56D000290C7 /* DatabaseSession_Tests.swift */; };
+		793060EF25778897005CF846 /* StreamChatTestTools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 793060E625778896005CF846 /* StreamChatTestTools.framework */; };
+		793060F625778897005CF846 /* StreamChatTestTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 793060E825778896005CF846 /* StreamChatTestTools.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7930610F25778C37005CF846 /* ChannelListController_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7930610E25778C37005CF846 /* ChannelListController_Mock.swift */; };
+		79306136257798FC005CF846 /* ChatChannel_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79306135257798FC005CF846 /* ChatChannel_Mock.swift */; };
+		7930614E2577A1AF005CF846 /* ChatUser_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7930614D2577A1AE005CF846 /* ChatUser_Mock.swift */; };
+		793061572577A336005CF846 /* ChatChannelMember_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793061562577A336005CF846 /* ChatChannelMember_Mock.swift */; };
+		793061602577A39D005CF846 /* ChatMessage_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7930615F2577A39D005CF846 /* ChatMessage_Mock.swift */; };
+		793061692577B511005CF846 /* ChatChannelController_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793061682577B511005CF846 /* ChatChannelController_Mock.swift */; };
+		793061722577BB48005CF846 /* ChatMessageController_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793061712577BB48005CF846 /* ChatMessageController_Mock.swift */; };
+		793061A12577C8B4005CF846 /* ChatClient_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793061A02577C8B4005CF846 /* ChatClient_Mock.swift */; };
 		7931818C24FD2660002F8C84 /* ChannelListController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7931818B24FD2660002F8C84 /* ChannelListController+Combine.swift */; };
 		7931818E24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7931818D24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift */; };
 		793305F3256FD24500FBB586 /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = 793305F2256FD24500FBB586 /* Nuke */; settings = {ATTRIBUTES = (Required, ); }; };
@@ -578,6 +589,13 @@
 			remoteGlobalIDString = 790881FC25432B7200896F03;
 			remoteInfo = StreamChatUI;
 		};
+		793060F025778897005CF846 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8AD5EC8622E9A3E8005CFAC9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 793060E525778896005CF846;
+			remoteInfo = StreamChatTestTools;
+		};
 		799C9457247D59B1001F1104 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8AD5EC8622E9A3E8005CFAC9 /* Project object */;
@@ -719,6 +737,20 @@
 		792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OptionSet+Extensions.swift"; sourceTree = "<group>"; };
 		792FCB4A24A3D52A000290C7 /* DatabaseSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSession.swift; sourceTree = "<group>"; };
 		792FCB4C24A3D56D000290C7 /* DatabaseSession_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSession_Tests.swift; sourceTree = "<group>"; };
+		793060E625778896005CF846 /* StreamChatTestTools.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatTestTools.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		793060E825778896005CF846 /* StreamChatTestTools.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StreamChatTestTools.h; sourceTree = "<group>"; };
+		793060E925778896005CF846 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		793060EE25778897005CF846 /* StreamChatTestToolsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatTestToolsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		793060F525778897005CF846 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7930610E25778C37005CF846 /* ChannelListController_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListController_Mock.swift; sourceTree = "<group>"; };
+		79306135257798FC005CF846 /* ChatChannel_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannel_Mock.swift; sourceTree = "<group>"; };
+		7930614D2577A1AE005CF846 /* ChatUser_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatUser_Mock.swift; sourceTree = "<group>"; };
+		793061562577A336005CF846 /* ChatChannelMember_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelMember_Mock.swift; sourceTree = "<group>"; };
+		7930615F2577A39D005CF846 /* ChatMessage_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage_Mock.swift; sourceTree = "<group>"; };
+		793061682577B511005CF846 /* ChatChannelController_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelController_Mock.swift; sourceTree = "<group>"; };
+		793061712577BB48005CF846 /* ChatMessageController_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageController_Mock.swift; sourceTree = "<group>"; };
+		793061812577C557005CF846 /* ChatChannelVC_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelVC_Tests.swift; sourceTree = "<group>"; };
+		793061A02577C8B4005CF846 /* ChatClient_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatClient_Mock.swift; sourceTree = "<group>"; };
 		7931818B24FD2660002F8C84 /* ChannelListController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelListController+Combine.swift"; sourceTree = "<group>"; };
 		7931818D24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelListController+Combine_Tests.swift"; sourceTree = "<group>"; };
 		79330603256FEBE600FBB586 /* AdvancedOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedOptionsViewController.swift; sourceTree = "<group>"; };
@@ -1193,6 +1225,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		793060E325778896005CF846 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		793060EB25778897005CF846 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				793060EF25778897005CF846 /* StreamChatTestTools.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		799C9418247D2F80001F1104 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1294,6 +1341,7 @@
 			isa = PBXGroup;
 			children = (
 				7908832D254876C100896F03 /* ChatChannelVC.swift */,
+				793061812577C557005CF846 /* ChatChannelVC_Tests.swift */,
 				DB70CFFA25702EB900DDF436 /* ChatMessagePopupViewController.swift */,
 				DB70CFF325701FE500DDF436 /* ChatChannelNavigationBarListener.swift */,
 				79088331254876C100896F03 /* ChatChannelCollectionView.swift */,
@@ -1305,7 +1353,6 @@
 				88A8CF0A256E7AC8004EA4C7 /* ChatMessageGroupPart.swift */,
 				88BC8907256E90A1009C5554 /* ChatRepliedMessageContentView.swift */,
 				DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */,
-				79088333254876C200896F03 /* ChatChannelNavigationBar.swift */,
 				22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */,
 				22ADD681256C40410098EFEB /* ChatChannelMessageComposerView.swift */,
 				221742D4256DC97F005B257C /* MessageComposerAttachmentsView.swift */,
@@ -1526,6 +1573,47 @@
 			path = DemoApp;
 			sourceTree = "<group>";
 		};
+		793060E725778896005CF846 /* StreamChatTestTools */ = {
+			isa = PBXGroup;
+			children = (
+				793061A02577C8B4005CF846 /* ChatClient_Mock.swift */,
+				7930610D25778BC4005CF846 /* Controllers */,
+				7930613E25779900005CF846 /* Models */,
+				793060E825778896005CF846 /* StreamChatTestTools.h */,
+				793060E925778896005CF846 /* Info.plist */,
+			);
+			path = StreamChatTestTools;
+			sourceTree = "<group>";
+		};
+		793060F225778897005CF846 /* StreamChatTestToolsTests */ = {
+			isa = PBXGroup;
+			children = (
+				793060F525778897005CF846 /* Info.plist */,
+			);
+			path = StreamChatTestToolsTests;
+			sourceTree = "<group>";
+		};
+		7930610D25778BC4005CF846 /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				7930610E25778C37005CF846 /* ChannelListController_Mock.swift */,
+				793061682577B511005CF846 /* ChatChannelController_Mock.swift */,
+				793061712577BB48005CF846 /* ChatMessageController_Mock.swift */,
+			);
+			path = Controllers;
+			sourceTree = "<group>";
+		};
+		7930613E25779900005CF846 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				79306135257798FC005CF846 /* ChatChannel_Mock.swift */,
+				7930614D2577A1AE005CF846 /* ChatUser_Mock.swift */,
+				793061562577A336005CF846 /* ChatChannelMember_Mock.swift */,
+				7930615F2577A39D005CF846 /* ChatMessage_Mock.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		7962958A2481473A0078EB53 /* Config */ = {
 			isa = PBXGroup;
 			children = (
@@ -1669,6 +1757,7 @@
 			isa = PBXGroup;
 			children = (
 				790881AB254327C800896F03 /* StreamChat */,
+				793060E725778896005CF846 /* StreamChatTestTools */,
 				7908823025432C6400896F03 /* StreamChatUI */,
 			);
 			indentWidth = 4;
@@ -1815,6 +1904,7 @@
 		799C9452247D59B1001F1104 /* Tests_v3 */ = {
 			isa = PBXGroup;
 			children = (
+				793060F225778897005CF846 /* StreamChatTestToolsTests */,
 				7908824625432CC600896F03 /* StreamChatTests */,
 				7908823925432C9000896F03 /* StreamChatUITests */,
 				790B9E2E24DC21C5005455AA /* Dummy data */,
@@ -2163,6 +2253,8 @@
 				790881FD25432B7200896F03 /* StreamChatUI.framework */,
 				7908820525432B7200896F03 /* StreamChatUITests.xctest */,
 				792DDA57256FB69E001DB91B /* DemoApp.app */,
+				793060E625778896005CF846 /* StreamChatTestTools.framework */,
+				793060EE25778897005CF846 /* StreamChatTestToolsTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2358,6 +2450,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		793060E125778896005CF846 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				793060F625778897005CF846 /* StreamChatTestTools.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		799C9416247D2F80001F1104 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -2453,6 +2553,42 @@
 			productReference = 792DDA57256FB69E001DB91B /* DemoApp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		793060E525778896005CF846 /* StreamChatTestTools */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 793060FD25778897005CF846 /* Build configuration list for PBXNativeTarget "StreamChatTestTools" */;
+			buildPhases = (
+				793060E125778896005CF846 /* Headers */,
+				793060E225778896005CF846 /* Sources */,
+				793060E325778896005CF846 /* Frameworks */,
+				793060E425778896005CF846 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StreamChatTestTools;
+			productName = StreamChatTestTools;
+			productReference = 793060E625778896005CF846 /* StreamChatTestTools.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		793060ED25778897005CF846 /* StreamChatTestToolsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 793060FE25778897005CF846 /* Build configuration list for PBXNativeTarget "StreamChatTestToolsTests" */;
+			buildPhases = (
+				793060EA25778897005CF846 /* Sources */,
+				793060EB25778897005CF846 /* Frameworks */,
+				793060EC25778897005CF846 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				793060F125778897005CF846 /* PBXTargetDependency */,
+			);
+			name = StreamChatTestToolsTests;
+			productName = StreamChatTestToolsTests;
+			productReference = 793060EE25778897005CF846 /* StreamChatTestToolsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		799C941A247D2F80001F1104 /* StreamChat */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 799C9420247D2F80001F1104 /* Build configuration list for PBXNativeTarget "StreamChat" */;
@@ -2516,6 +2652,13 @@
 					792DDA56256FB69E001DB91B = {
 						CreatedOnToolsVersion = 12.2;
 					};
+					793060E525778896005CF846 = {
+						CreatedOnToolsVersion = 12.2;
+						LastSwiftMigration = 1220;
+					};
+					793060ED25778897005CF846 = {
+						CreatedOnToolsVersion = 12.2;
+					};
 					799C941A247D2F80001F1104 = {
 						CreatedOnToolsVersion = 11.4.1;
 						LastSwiftMigration = 1140;
@@ -2545,6 +2688,8 @@
 				792A4F21247FF01800EAF71D /* Sample */,
 				799C941A247D2F80001F1104 /* StreamChat */,
 				799C9450247D59B1001F1104 /* StreamChatTests */,
+				793060E525778896005CF846 /* StreamChatTestTools */,
+				793060ED25778897005CF846 /* StreamChatTestToolsTests */,
 				790881FC25432B7200896F03 /* StreamChatUI */,
 				7908820425432B7200896F03 /* StreamChatUITests */,
 				792DDA56256FB69E001DB91B /* DemoApp */,
@@ -2589,6 +2734,20 @@
 				792DDA66256FB69F001DB91B /* LaunchScreen.storyboard in Resources */,
 				792DDA63256FB69F001DB91B /* Assets.xcassets in Resources */,
 				792DDA61256FB69E001DB91B /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		793060E425778896005CF846 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		793060EC25778897005CF846 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2753,13 +2912,11 @@
 				228190EB256733420048D7C6 /* UIFont+Extensions.swift in Sources */,
 				888123D2255D430B00070D5A /* UIView+Extensions.swift in Sources */,
 				224FF6872562F55F00725DD1 /* Date+Extensions.swift in Sources */,
-				7908833E254876F900896F03 /* ChatChannelCollectionViewDataSource.swift in Sources */,
 				22ADD682256C40410098EFEB /* ChatChannelMessageComposerView.swift in Sources */,
 				8850FE91256558B200C8D534 /* ChatRouter.swift in Sources */,
 				DB70CFF425701FE500DDF436 /* ChatChannelNavigationBarListener.swift in Sources */,
 				88A8CF0B256E7AC8004EA4C7 /* ChatMessageGroupPart.swift in Sources */,
 				88BC8908256E90A1009C5554 /* ChatRepliedMessageContentView.swift in Sources */,
-				790883522548771100896F03 /* ChatChannelNavigationBar.swift in Sources */,
 				22FF4365256E943F00133910 /* MessageComposerSuggestionsViewController.swift in Sources */,
 				22A0921725682880001FE9F0 /* ChatNavigationBar.swift in Sources */,
 				7952764A255D86BD008531E8 /* UIExtraData.swift in Sources */,
@@ -2775,7 +2932,7 @@
 				792DD9D9256BC542001DB91B /* BaseViews.swift in Sources */,
 				79088334254876EA00896F03 /* ChatChannelVC.swift in Sources */,
 				228DC80E25704B410080A49F /* MessageComposerAttachmentCellView.swift in Sources */,
-				79088334254876EA00896F03 /* ChatChannelViewController.swift in Sources */,
+				79088334254876EA00896F03 /* ChatChannelVC.swift in Sources */,
 				790882DF25486B6800896F03 /* ChatChannelListVC.swift in Sources */,
 				79D86E832562BAB900DCD1D2 /* AppearanceSetting.swift in Sources */,
 				792DD9FB256E67C6001DB91B /* UIConfigProvider.swift in Sources */,
@@ -2808,6 +2965,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				792A71AD2577E0510082498D /* ChatChannelVC_Tests.swift in Sources */,
 				7908823C25432C9000896F03 /* StreamChatUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2864,6 +3022,28 @@
 				792DDA5C256FB69E001DB91B /* SceneDelegate.swift in Sources */,
 				7933060B256FF94800FBB586 /* ChatPresenter.swift in Sources */,
 				79330604256FEBE600FBB586 /* AdvancedOptionsViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		793060E225778896005CF846 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				793061A12577C8B4005CF846 /* ChatClient_Mock.swift in Sources */,
+				793061602577A39D005CF846 /* ChatMessage_Mock.swift in Sources */,
+				7930610F25778C37005CF846 /* ChannelListController_Mock.swift in Sources */,
+				793061572577A336005CF846 /* ChatChannelMember_Mock.swift in Sources */,
+				793061692577B511005CF846 /* ChatChannelController_Mock.swift in Sources */,
+				793061722577BB48005CF846 /* ChatMessageController_Mock.swift in Sources */,
+				7930614E2577A1AF005CF846 /* ChatUser_Mock.swift in Sources */,
+				79306136257798FC005CF846 /* ChatChannel_Mock.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		793060EA25778897005CF846 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3270,6 +3450,11 @@
 			target = 790881FC25432B7200896F03 /* StreamChatUI */;
 			targetProxy = 792DDA71256FB6AD001DB91B /* PBXContainerItemProxy */;
 		};
+		793060F125778897005CF846 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 793060E525778896005CF846 /* StreamChatTestTools */;
+			targetProxy = 793060F025778897005CF846 /* PBXContainerItemProxy */;
+		};
 		799C9458247D59B1001F1104 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 799C941A247D2F80001F1104 /* StreamChat */;
@@ -3566,6 +3751,147 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.stream.DemoApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = ReleaseTests;
+		};
+		793060F725778897005CF846 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Sources_v3/StreamChatTestTools/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatTestTools;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		793060F825778897005CF846 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Sources_v3/StreamChatTestTools/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatTestTools;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		793060F925778897005CF846 /* ReleaseTests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Sources_v3/StreamChatTestTools/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatTestTools;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = ReleaseTests;
+		};
+		793060FA25778897005CF846 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				INFOPLIST_FILE = StreamChatTestToolsTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatTestToolsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		793060FB25778897005CF846 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				INFOPLIST_FILE = StreamChatTestToolsTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatTestToolsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		793060FC25778897005CF846 /* ReleaseTests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = EHV7XZLAHA;
+				INFOPLIST_FILE = StreamChatTestToolsTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.getstream.StreamChatTestToolsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4001,6 +4327,26 @@
 				792DDA68256FB69F001DB91B /* Debug */,
 				792DDA69256FB69F001DB91B /* Release */,
 				792DDA6A256FB69F001DB91B /* ReleaseTests */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		793060FD25778897005CF846 /* Build configuration list for PBXNativeTarget "StreamChatTestTools" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				793060F725778897005CF846 /* Debug */,
+				793060F825778897005CF846 /* Release */,
+				793060F925778897005CF846 /* ReleaseTests */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		793060FE25778897005CF846 /* Build configuration list for PBXNativeTarget "StreamChatTestToolsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				793060FA25778897005CF846 /* Debug */,
+				793060FB25778897005CF846 /* Release */,
+				793060FC25778897005CF846 /* ReleaseTests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/StreamChat_v3.xcodeproj/xcshareddata/xcschemes/StreamChatUI.xcscheme
+++ b/StreamChat_v3.xcodeproj/xcshareddata/xcschemes/StreamChatUI.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7908820425432B7200896F03"
+               BuildableName = "StreamChatUITests.xctest"
+               BlueprintName = "StreamChatUITests"
+               ReferencedContainer = "container:StreamChat_v3.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Tests_v3/StreamChatTestToolsTests/Info.plist
+++ b/Tests_v3/StreamChatTestToolsTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
### In this PR:

This is the initial PR of `StreamChatTestTools`. Currently, this new framework is meant to be used only internally for better testing of StreamChatUI. Eventually (planned for Q1), it will be available for our customers too to test their own UI.

**Features:**
- It's possible to create model objects without the DB using the `.mock(...)` static method.
- It's possible to create mock controllers and simulate their behavior using `simulate(....)` methods.

I also added an example test for `ChatChannelVC` to showcase how the usage.