### PR TITLE
[CIS-435] Switch from autolayout to frame based layout for message list collection view

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelCollectionViewLayout.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelCollectionViewLayout.swift
@@ -5,63 +5,75 @@
 import Foundation
 import UIKit
 
-open class ChatChannelCollectionViewLayout: UICollectionViewFlowLayout {
-    // MARK: - Init & Deinit
-    
-    override public init() {
+public struct ChatChannelCollectionViewLayoutModel {
+    public var forWidth: CGFloat
+    public var itemHeights: [CGFloat]
+
+    public static let zero = ChatChannelCollectionViewLayoutModel(forWidth: 0, itemHeights: [])
+}
+
+public protocol ChatChannelCollectionViewLayoutDelegate: AnyObject {
+    func createLayoutModel() -> ChatChannelCollectionViewLayoutModel
+}
+
+open class ChatChannelCollectionViewLayout: UICollectionViewLayout {
+    var layoutModel: ChatChannelCollectionViewLayoutModel = .zero
+    var contentSize: CGSize = .zero
+    var attributes: [UICollectionViewLayoutAttributes] = []
+    var interItemSpacing: CGFloat = 8
+
+    open weak var delegate: ChatChannelCollectionViewLayoutDelegate?
+
+    // MARK: - Lifecycle
+
+    override public required init() {
         super.init()
         commonInit()
     }
-    
+
     public required init?(coder: NSCoder) {
         super.init(coder: coder)
         commonInit()
     }
-    
-    private func commonInit() {
-        minimumInteritemSpacing = 0
-        minimumLineSpacing = 4
+
+    private func commonInit() {}
+
+    // MARK: - Layout
+
+    override open var collectionViewContentSize: CGSize { contentSize }
+
+    override open func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+        layoutModel.forWidth != newBounds.width
     }
-    
-    // MARK: - Overrides
-    
+
     override open func prepare() {
         super.prepare()
-        
-        estimatedItemSize = .init(
-            width: collectionView?.bounds.width ?? 0,
-            height: 60
-        )
-        if collectionView!.contentSize == .zero {
-            let newOffset = CGPoint(x: 0, y: collectionViewContentSize.height)
-            collectionView?.contentOffset = newOffset
+        guard let delegate = delegate else { return }
+        layoutModel = delegate.createLayoutModel()
+        let width = layoutModel.forWidth
+        var offset: CGFloat = 0
+        var attributes: [UICollectionViewLayoutAttributes] = []
+        // latest message has ip = {0;0}, but must be bottom one, so we iterate in reverse order
+        for (idx, height) in layoutModel.itemHeights.enumerated().reversed() {
+            let attribute = UICollectionViewLayoutAttributes(forCellWith: IndexPath(item: idx, section: 0))
+            attribute.frame = CGRect(x: 0, y: offset, width: width, height: height)
+            attributes.append(attribute)
+            offset += height
+            if idx > 0 {
+                offset += interItemSpacing
+            }
         }
+        // attributes are added from old message to new message, need to reverse it to achieve
+        // `attributes[idx].indexPath.item == idx`
+        self.attributes = attributes.reversed()
+        contentSize = CGSize(width: width, height: offset)
     }
 
     override open func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
-        let contentSize = collectionViewContentSize
-        let portalRect = CGRect(
-            x: rect.origin.x,
-            y: contentSize.height - rect.origin.y - rect.height,
-            width: rect.width,
-            height: rect.height
-        )
-        return super.layoutAttributesForElements(in: portalRect)?
-            .map(flip(_:))
+        attributes.filter { $0.frame.intersects(rect) }
     }
 
     override open func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
-        super.layoutAttributesForItem(at: indexPath).map(flip(_:))
-    }
-
-    private func flip(_ attribute: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
-        let contentSize = collectionViewContentSize
-        attribute.frame = CGRect(
-            x: attribute.frame.origin.x,
-            y: contentSize.height - attribute.frame.origin.y - attribute.frame.height,
-            width: attribute.frame.width,
-            height: attribute.frame.height
-        )
-        return attribute
+        attributes[indexPath.item]
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelCollectionViewLayout.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelCollectionViewLayout.swift
@@ -7,9 +7,9 @@ import UIKit
 
 public struct ChatChannelCollectionViewLayoutModel {
     public var forWidth: CGFloat
-    public var itemHeights: [CGFloat]
+    public var itemsData: [(height: CGFloat, bottomMargin: CGFloat)]
 
-    public static let zero = ChatChannelCollectionViewLayoutModel(forWidth: 0, itemHeights: [])
+    public static let zero = ChatChannelCollectionViewLayoutModel(forWidth: 0, itemsData: [])
 }
 
 public protocol ChatChannelCollectionViewLayoutDelegate: AnyObject {
@@ -20,7 +20,6 @@ open class ChatChannelCollectionViewLayout: UICollectionViewLayout {
     var layoutModel: ChatChannelCollectionViewLayoutModel = .zero
     var contentSize: CGSize = .zero
     var attributes: [UICollectionViewLayoutAttributes] = []
-    var interItemSpacing: CGFloat = 8
 
     open weak var delegate: ChatChannelCollectionViewLayoutDelegate?
 
@@ -54,14 +53,12 @@ open class ChatChannelCollectionViewLayout: UICollectionViewLayout {
         var offset: CGFloat = 0
         var attributes: [UICollectionViewLayoutAttributes] = []
         // latest message has ip = {0;0}, but must be bottom one, so we iterate in reverse order
-        for (idx, height) in layoutModel.itemHeights.enumerated().reversed() {
+        for (idx, (height, bottomMargin)) in layoutModel.itemsData.enumerated().reversed() {
             let attribute = UICollectionViewLayoutAttributes(forCellWith: IndexPath(item: idx, section: 0))
             attribute.frame = CGRect(x: 0, y: offset, width: width, height: height)
             attributes.append(attribute)
             offset += height
-            if idx > 0 {
-                offset += interItemSpacing
-            }
+            offset += bottomMargin
         }
         // attributes are added from old message to new message, need to reverse it to achieve
         // `attributes[idx].indexPath.item == idx`

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -20,12 +20,8 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
         layout.delegate = self
         let collection = uiConfig.messageList.collectionView.init(layout: layout)
         collection.register(
-            СhatIncomingMessageCollectionViewCell<ExtraData>.self,
-            forCellWithReuseIdentifier: СhatIncomingMessageCollectionViewCell<ExtraData>.reuseId
-        )
-        collection.register(
-            СhatOutgoingMessageCollectionViewCell<ExtraData>.self,
-            forCellWithReuseIdentifier: СhatOutgoingMessageCollectionViewCell<ExtraData>.reuseId
+            СhatMessageCollectionViewCell<ExtraData>.self,
+            forCellWithReuseIdentifier: СhatMessageCollectionViewCell<ExtraData>.reuseId
         )
         collection.showsHorizontalScrollIndicator = false
         collection.dataSource = self
@@ -34,7 +30,7 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
         return collection
     }()
 
-    let cellSizer = СhatMessageCollectionViewCellLayoutManager<ExtraData>()
+    lazy var cellSizer = СhatMessageCollectionViewCell<ExtraData>.LayoutProvider(uiConfig: uiConfig, parent: nil)
 
     private var navbarListener: ChatChannelNavigationBarListener<ExtraData>?
     private var activePopup: ChatMessagePopupViewController<ExtraData>?
@@ -196,18 +192,10 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
     ) -> UICollectionViewCell {
         let message = messageGroupPart(at: indexPath)
 
-        let cell: СhatMessageCollectionViewCell<ExtraData>
-        if message.isSentByCurrentUser {
-            cell = collectionView.dequeueReusableCell(
-                withReuseIdentifier: СhatOutgoingMessageCollectionViewCell<ExtraData>.reuseId,
-                for: indexPath
-            ) as! СhatOutgoingMessageCollectionViewCell<ExtraData>
-        } else {
-            cell = collectionView.dequeueReusableCell(
-                withReuseIdentifier: СhatIncomingMessageCollectionViewCell<ExtraData>.reuseId,
-                for: indexPath
-            ) as! СhatIncomingMessageCollectionViewCell<ExtraData>
-        }
+        let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: СhatMessageCollectionViewCell<ExtraData>.reuseId,
+            for: indexPath
+        ) as! СhatMessageCollectionViewCell<ExtraData>
 
         cell.layout = cellSizer.layoutForCell(with: message, limitedBy: collectionView.bounds.width)
         cell.message = message

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -17,6 +17,7 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
         
     public private(set) lazy var collectionView: UICollectionView = {
         let layout = uiConfig.messageList.collectionLayout.init()
+        layout.delegate = self
         let collection = uiConfig.messageList.collectionView.init(layout: layout)
         collection.register(
             СhatIncomingMessageCollectionViewCell<ExtraData>.self,
@@ -33,6 +34,8 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
         return collection
     }()
 
+    let cellSizer = СhatMessageCollectionViewCellLayoutManager<ExtraData>()
+
     private var navbarListener: ChatChannelNavigationBarListener<ExtraData>?
     private var activePopup: ChatMessagePopupViewController<ExtraData>?
     
@@ -47,6 +50,12 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
 
         installLongPress()
         setupMessageComposer()
+    }
+
+    override open func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        let rect = CGRect(x: 0, y: collectionView.contentSize.height - 1, width: 1, height: 1)
+        collectionView.scrollRectToVisible(rect, animated: false)
     }
 
     override open func setUpLayout() {
@@ -200,6 +209,7 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
             ) as! СhatIncomingMessageCollectionViewCell<ExtraData>
         }
 
+        cell.layout = cellSizer.layoutForCell(with: message, limitedBy: collectionView.bounds.width)
         cell.message = message
 
         return cell
@@ -265,6 +275,18 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
     }
 }
 
+// MARK: - ChatChannelCollectionViewLayoutDelegate
+
+extension ChatChannelVC: ChatChannelCollectionViewLayoutDelegate {
+    public func createLayoutModel() -> ChatChannelCollectionViewLayoutModel {
+        let width = collectionView.bounds.width
+        let heights = (0..<controller.messages.count)
+            .map { messageGroupPart(at: IndexPath(item: $0, section: 0)) }
+            .map { cellSizer.heightForCell(with: $0, limitedBy: width) }
+        return ChatChannelCollectionViewLayoutModel(forWidth: width, itemHeights: heights)
+    }
+}
+
 // MARK: - _ChatChannelControllerDelegate
 
 extension ChatChannelVC: _ChatChannelControllerDelegate {
@@ -272,6 +294,8 @@ extension ChatChannelVC: _ChatChannelControllerDelegate {
         _ channelController: _ChatChannelController<ExtraData>,
         didUpdateMessages changes: [ListChange<_ChatMessage<ExtraData>>]
     ) {
+        // in ideal world, we would recalculate layoutModel for new data right here
+        // and set layoutModel inside batchUpdates. But right now let's roll with what we got
         collectionView.performBatchUpdates({
             for change in changes {
                 switch change {

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -280,10 +280,13 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
 extension ChatChannelVC: ChatChannelCollectionViewLayoutDelegate {
     public func createLayoutModel() -> ChatChannelCollectionViewLayoutModel {
         let width = collectionView.bounds.width
-        let heights = (0..<controller.messages.count)
+        let data = (0..<controller.messages.count)
             .map { messageGroupPart(at: IndexPath(item: $0, section: 0)) }
-            .map { cellSizer.heightForCell(with: $0, limitedBy: width) }
-        return ChatChannelCollectionViewLayoutModel(forWidth: width, itemHeights: heights)
+            .map { (
+                height: cellSizer.heightForCell(with: $0, limitedBy: width),
+                bottomMargin: $0.isLastInGroup ? CGFloat(8) : CGFloat(2)
+            ) }
+        return ChatChannelCollectionViewLayoutModel(forWidth: width, itemsData: data)
     }
 }
 

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageBubbleView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageBubbleView.swift
@@ -70,21 +70,21 @@ open class ChatMessageBubbleView<ExtraData: UIExtraDataTypes>: View, UIConfigPro
 
         borderLayer.frame = layer.bounds
 
-        guard let layout = layout else { return }
-
-        textView.isHidden = layout.text == nil
-        if let frame = layout.text {
+        textView.isHidden = layout?.text == nil
+        if let frame = layout?.text {
             textView.frame = frame
         }
 
-        repliedMessageView?.isHidden = layout.repliedMessage == nil
-        if let frame = layout.repliedMessage {
+        repliedMessageView?.isHidden = layout?.repliedMessage == nil
+        if let frame = layout?.repliedMessage {
             repliedMessageView?.frame = frame
         }
-        repliedMessageView?.layout = layout.repliesMessageLayout as? ChatRepliedMessageContentView<ExtraData>.Layout
+        repliedMessageView?.layout = layout?.repliesMessageLayout as? ChatRepliedMessageContentView<ExtraData>.Layout
 
-        zip(attachments, layout.attachments).forEach {
-            $0.frame = $1
+        if let attachmentFrames = layout?.attachments {
+            zip(attachments, attachmentFrames).forEach {
+                $0.frame = $1
+            }
         }
     }
 

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageBubbleView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageBubbleView.swift
@@ -6,6 +6,19 @@ import StreamChat
 import UIKit
 
 open class ChatMessageBubbleView<ExtraData: UIExtraDataTypes>: View, UIConfigProvider {
+    struct Layout {
+        let text: CGRect?
+        let repliedMessage: CGRect?
+        /// must be ChatRepliedMessageContentView<ExtraData>.Layout?
+        /// but it's circular dependency, swift confused
+        let repliesMessageLayout: Any?
+        let attachments: [CGRect]
+    }
+
+    var layout: Layout? {
+        didSet { setNeedsLayout() }
+    }
+    
     public var message: _ChatMessageGroupPart<ExtraData>? {
         didSet { updateContent() }
     }
@@ -13,13 +26,8 @@ open class ChatMessageBubbleView<ExtraData: UIExtraDataTypes>: View, UIConfigPro
     public let showRepliedMessage: Bool
     
     // MARK: - Subviews
-    
-    public private(set) lazy var stackView: UIStackView = {
-        let stack = UIStackView()
-        stack.axis = .vertical
-        stack.spacing = UIStackView.spacingUseSystem
-        return stack
-    }()
+
+    public private(set) var attachments: [UIView] = []
     
     public private(set) lazy var textView: UITextView = {
         let textView = UITextView()
@@ -35,9 +43,9 @@ open class ChatMessageBubbleView<ExtraData: UIExtraDataTypes>: View, UIConfigPro
         return textView
     }()
 
-    public private(set) lazy var repliedMessageView = showRepliedMessage ?
-        uiConfig.messageList.messageContentSubviews.repliedMessageContentView.init().withoutAutoresizingMaskConstraints :
-        nil
+    public private(set) lazy var repliedMessageView = showRepliedMessage
+        ? uiConfig.messageList.messageContentSubviews.repliedMessageContentView.init()
+        : nil
     
     public private(set) lazy var borderLayer = CAShapeLayer()
 
@@ -60,7 +68,24 @@ open class ChatMessageBubbleView<ExtraData: UIExtraDataTypes>: View, UIConfigPro
     override open func layoutSubviews() {
         super.layoutSubviews()
 
-        borderLayer.frame = bounds
+        borderLayer.frame = layer.bounds
+
+        guard let layout = layout else { return }
+
+        textView.isHidden = layout.text == nil
+        if let frame = layout.text {
+            textView.frame = frame
+        }
+
+        repliedMessageView?.isHidden = layout.repliedMessage == nil
+        if let frame = layout.repliedMessage {
+            repliedMessageView?.frame = frame
+        }
+        repliedMessageView?.layout = layout.repliesMessageLayout as? ChatRepliedMessageContentView<ExtraData>.Layout
+
+        zip(attachments, layout.attachments).forEach {
+            $0.frame = $1
+        }
     }
 
     override public func defaultAppearance() {
@@ -71,22 +96,16 @@ open class ChatMessageBubbleView<ExtraData: UIExtraDataTypes>: View, UIConfigPro
 
     override open func setUpLayout() {
         layer.addSublayer(borderLayer)
-
-        addSubview(stackView)
-        stackView.pin(to: layoutMarginsGuide)
-
-        if let repliedMessageView = repliedMessageView {
-            stackView.addArrangedSubview(repliedMessageView)
+        if let reply = repliedMessageView {
+            addSubview(reply)
         }
-        stackView.addArrangedSubview(textView)
+        addSubview(textView)
     }
 
     override open func updateContent() {
         repliedMessageView?.message = message?.parentMessage
-        repliedMessageView?.isHidden = message?.parentMessageState == nil
 
         textView.text = message?.text
-        textView.isHidden = message?.text.isEmpty ?? true
 
         borderLayer.maskedCorners = corners
         borderLayer.isHidden = message == nil
@@ -97,6 +116,8 @@ open class ChatMessageBubbleView<ExtraData: UIExtraDataTypes>: View, UIConfigPro
 
         backgroundColor = message?.isSentByCurrentUser == true ? .outgoingMessageBubbleBackground : .incomingMessageBubbleBackground
         layer.maskedCorners = corners
+
+        // add attachments subviews
     }
     
     // MARK: - Private
@@ -119,5 +140,93 @@ open class ChatMessageBubbleView<ExtraData: UIExtraDataTypes>: View, UIConfigPro
         }
         
         return roundedCorners
+    }
+}
+
+class ChatMessageBubbleViewLayoutManager<ExtraData: UIExtraDataTypes> {
+    let textView: UITextView = {
+        let textView = UITextView()
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.font = .preferredFont(forTextStyle: .body)
+        textView.adjustsFontForContentSizeCategory = true
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        return textView
+    }()
+
+    /// reply sizer depends on bubble sizer, circle dependency
+    /// but bubble inside reply don't need reply sizer so it should be fine as long as you not access it unless needed
+    lazy var replySizer = ChatRepliedMessageContentViewLayoutManager<ExtraData>()
+
+    func heightForView(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGFloat {
+        sizeForView(with: data, limitedBy: width).height
+    }
+
+    func sizeForView(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGSize {
+        let margins: CGFloat = 8
+        let workWidth = width - 2 * margins
+
+        var spacings = margins
+
+        var replySize: CGSize = .zero
+        if data.parentMessageState != nil {
+            replySize = replySizer.sizeForView(with: data.parentMessage, limitedBy: workWidth)
+            spacings += margins
+        }
+
+        // put attachments here
+
+        var textSize: CGSize = .zero
+        if !data.text.isEmpty {
+            textSize = {
+                textView.text = data.message.text
+                return textView.sizeThatFits(CGSize(width: workWidth, height: .greatestFiniteMagnitude))
+            }()
+            spacings += margins
+        }
+        
+        let width = 2 * margins + max(replySize.width, textSize.width)
+        let height = spacings + replySize.height + textSize.height
+        return CGSize(width: max(width, 32), height: max(height, 32))
+    }
+
+    func layoutForView(
+        with data: _ChatMessageGroupPart<ExtraData>,
+        of size: CGSize
+    ) -> ChatMessageBubbleView<ExtraData>.Layout {
+        let margins: CGFloat = 8
+        let workWidth = size.width - 2 * margins
+        var offsetY = margins
+
+        var replyFrame: CGRect?
+        var replyLayout: ChatRepliedMessageContentView<ExtraData>.Layout?
+        if data.parentMessageState != nil {
+            let replySize = replySizer.sizeForView(with: data.parentMessage, limitedBy: workWidth)
+            replyLayout = replySizer.layoutForView(with: data.parentMessage, of: replySize)
+            replyFrame = CGRect(origin: CGPoint(x: margins, y: offsetY), size: replySize)
+            offsetY += replySize.height
+            offsetY += margins
+        }
+
+        // put attachments here
+
+        let textSize: CGSize = {
+            textView.text = data.message.text
+            return textView.sizeThatFits(CGSize(width: workWidth, height: .greatestFiniteMagnitude))
+        }()
+        var textFrame: CGRect?
+        if !data.text.isEmpty {
+            textFrame = CGRect(origin: CGPoint(x: margins, y: offsetY), size: textSize)
+            offsetY += textSize.height
+            offsetY += margins
+        }
+
+        return ChatMessageBubbleView.Layout(
+            text: textFrame,
+            repliedMessage: replyFrame,
+            repliesMessageLayout: replyLayout,
+            attachments: []
+        )
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageCollectionViewCell.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageCollectionViewCell.swift
@@ -6,6 +6,11 @@ import StreamChat
 import UIKit
 
 class СhatMessageCollectionViewCell<ExtraData: UIExtraDataTypes>: UICollectionViewCell, UIConfigProvider {
+    struct Layout {}
+    var layout: Layout? {
+        didSet { setNeedsLayout() }
+    }
+
     var message: _ChatMessageGroupPart<ExtraData>? {
         didSet { updateContent() }
     }
@@ -84,5 +89,36 @@ class СhatOutgoingMessageCollectionViewCell<ExtraData: UIExtraDataTypes>: Сhat
         super.setUpLayout()
 
         messageView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor).isActive = true
+    }
+}
+
+class СhatMessageCollectionViewCellLayoutManager<ExtraData: UIExtraDataTypes> {
+    /// As all mad scientists we need lab rats to conduct our experiments.
+    /// But as we know, lab rats never survive to the end.
+    private let labRat: СhatMessageCollectionViewCell<ExtraData> = {
+        let dumbContainer = UIView()
+        let rat = СhatMessageCollectionViewCell<ExtraData>(frame: .zero)
+        /// fire didMoveToSuperview
+        dumbContainer.addSubview(rat)
+        return rat
+    }()
+
+    func heightForCell(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGFloat {
+        sizeForCell(with: data, limitedBy: width).height
+    }
+
+    func sizeForCell(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGSize {
+        let attributes = UICollectionViewLayoutAttributes(forCellWith: IndexPath(item: 0, section: 0))
+        attributes.frame = CGRect(x: 0, y: 0, width: width, height: 3000)
+        labRat.message = data
+        let preference = labRat.preferredLayoutAttributesFitting(attributes)
+        return preference.frame.size
+    }
+
+    func layoutForCell(
+        with data: _ChatMessageGroupPart<ExtraData>,
+        limitedBy width: CGFloat
+    ) -> СhatMessageCollectionViewCell<ExtraData>.Layout {
+        СhatMessageCollectionViewCell.Layout()
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageCollectionViewCell.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageCollectionViewCell.swift
@@ -6,7 +6,11 @@ import StreamChat
 import UIKit
 
 class СhatMessageCollectionViewCell<ExtraData: UIExtraDataTypes>: UICollectionViewCell, UIConfigProvider {
-    struct Layout {}
+    struct Layout {
+        let messageView: CGRect?
+        let messageViewLayout: ChatMessageContentView<ExtraData>.Layout?
+    }
+
     var layout: Layout? {
         didSet { setNeedsLayout() }
     }
@@ -17,7 +21,7 @@ class СhatMessageCollectionViewCell<ExtraData: UIExtraDataTypes>: UICollectionV
     
     // MARK: - Subviews
 
-    public private(set) lazy var messageView = uiConfig.messageList.messageContentView.init().withoutAutoresizingMaskConstraints
+    public private(set) lazy var messageView = uiConfig.messageList.messageContentView.init()
     
     // MARK: - Lifecycle
 
@@ -30,14 +34,18 @@ class СhatMessageCollectionViewCell<ExtraData: UIExtraDataTypes>: UICollectionV
         updateContent()
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard let layout = layout else { return }
+        messageView.isHidden = layout.messageView == nil
+        if let messageFrame = layout.messageView {
+            messageView.frame = messageFrame
+        }
+        messageView.layout = layout.messageViewLayout
+    }
+
     func setUpLayout() {
         contentView.addSubview(messageView)
-
-        NSLayoutConstraint.activate([
-            messageView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            messageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            messageView.widthAnchor.constraint(lessThanOrEqualTo: contentView.widthAnchor, multiplier: 0.75)
-        ])
     }
 
     func updateContent() {
@@ -51,74 +59,43 @@ class СhatMessageCollectionViewCell<ExtraData: UIExtraDataTypes>: UICollectionV
 
         message = nil
     }
-    
-    override func preferredLayoutAttributesFitting(
-        _ layoutAttributes: UICollectionViewLayoutAttributes
-    ) -> UICollectionViewLayoutAttributes {
-        let preferredAttributes = super.preferredLayoutAttributesFitting(layoutAttributes)
-        
-        let targetSize = CGSize(
-            width: layoutAttributes.frame.width,
-            height: UIView.layoutFittingCompressedSize.height
-        )
-        
-        preferredAttributes.frame.size = contentView.systemLayoutSizeFitting(
-            targetSize,
-            withHorizontalFittingPriority: .required,
-            verticalFittingPriority: .fittingSizeLevel
-        )
-        
-        return preferredAttributes
-    }
 }
 
 class СhatIncomingMessageCollectionViewCell<ExtraData: UIExtraDataTypes>: СhatMessageCollectionViewCell<ExtraData> {
     static var reuseId: String { String(describing: self) }
-
-    override func setUpLayout() {
-        super.setUpLayout()
-
-        messageView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor).isActive = true
-    }
 }
 
 class СhatOutgoingMessageCollectionViewCell<ExtraData: UIExtraDataTypes>: СhatMessageCollectionViewCell<ExtraData> {
     static var reuseId: String { String(describing: self) }
-
-    override func setUpLayout() {
-        super.setUpLayout()
-
-        messageView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor).isActive = true
-    }
 }
 
 class СhatMessageCollectionViewCellLayoutManager<ExtraData: UIExtraDataTypes> {
-    /// As all mad scientists we need lab rats to conduct our experiments.
-    /// But as we know, lab rats never survive to the end.
-    private let labRat: СhatMessageCollectionViewCell<ExtraData> = {
-        let dumbContainer = UIView()
-        let rat = СhatMessageCollectionViewCell<ExtraData>(frame: .zero)
-        /// fire didMoveToSuperview
-        dumbContainer.addSubview(rat)
-        return rat
-    }()
+    let contentSizer = ChatMessageContentViewLayoutManager<ExtraData>()
 
     func heightForCell(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGFloat {
         sizeForCell(with: data, limitedBy: width).height
     }
 
     func sizeForCell(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGSize {
-        let attributes = UICollectionViewLayoutAttributes(forCellWith: IndexPath(item: 0, section: 0))
-        attributes.frame = CGRect(x: 0, y: 0, width: width, height: 3000)
-        labRat.message = data
-        let preference = labRat.preferredLayoutAttributesFitting(attributes)
-        return preference.frame.size
+        let workWidth = width * 0.75
+        let height = contentSizer.heightForView(with: data, limitedBy: workWidth)
+        return CGSize(width: width, height: height)
     }
 
     func layoutForCell(
         with data: _ChatMessageGroupPart<ExtraData>,
         limitedBy width: CGFloat
     ) -> СhatMessageCollectionViewCell<ExtraData>.Layout {
-        СhatMessageCollectionViewCell.Layout()
+        let workWidth = width * 0.75
+        let margin: CGFloat = 8
+        let size = contentSizer.sizeForView(with: data, limitedBy: workWidth)
+        let layout = contentSizer.layoutForView(with: data, of: size)
+        let originX = data.isSentByCurrentUser
+            ? width - size.width - margin
+            : margin
+        return СhatMessageCollectionViewCell.Layout(
+            messageView: CGRect(origin: CGPoint(x: originX, y: 0), size: size),
+            messageViewLayout: layout
+        )
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageContentView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageContentView.swift
@@ -56,27 +56,26 @@ open class ChatMessageContentView<ExtraData: UIExtraDataTypes>: View, UIConfigPr
 
     override open func layoutSubviews() {
         super.layoutSubviews()
-        guard let layout = layout else { return }
 
-        messageBubbleView.isHidden = layout.messageBubble == nil
-        if let frame = layout.messageBubble {
+        messageBubbleView.isHidden = layout?.messageBubble == nil
+        if let frame = layout?.messageBubble {
             messageBubbleView.frame = frame
         }
-        messageBubbleView.layout = layout.messageBubbleLayout
+        messageBubbleView.layout = layout?.messageBubbleLayout
 
-        messageMetadataView.isHidden = layout.messageMetadata == nil
-        if let frame = layout.messageMetadata {
+        messageMetadataView.isHidden = layout?.messageMetadata == nil
+        if let frame = layout?.messageMetadata {
             messageMetadataView.frame = frame
         }
-        messageMetadataView.layout = layout.messageMetadataLayout
+        messageMetadataView.layout = layout?.messageMetadataLayout
 
-        authorAvatarView.isHidden = layout.authorAvatar == nil
-        if let frame = layout.authorAvatar {
+        authorAvatarView.isHidden = layout?.authorAvatar == nil
+        if let frame = layout?.authorAvatar {
             authorAvatarView.frame = frame
         }
 
-        messageReactionsView.isHidden = layout.reactions == nil
-        if let frame = layout.reactions {
+        messageReactionsView.isHidden = layout?.reactions == nil
+        if let frame = layout?.reactions {
             messageReactionsView.frame = frame
         }
     }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageContentView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageContentView.swift
@@ -6,6 +6,19 @@ import StreamChat
 import UIKit
 
 open class ChatMessageContentView<ExtraData: UIExtraDataTypes>: View, UIConfigProvider {
+    struct Layout {
+        let messageBubble: CGRect?
+        let messageBubbleLayout: ChatMessageBubbleView<ExtraData>.Layout?
+        let messageMetadata: CGRect?
+        let messageMetadataLayout: ChatMessageMetadataView<ExtraData>.Layout?
+        let authorAvatar: CGRect?
+        let reactions: CGRect?
+    }
+
+    var layout: Layout? {
+        didSet { setNeedsLayout() }
+    }
+
     public var message: _ChatMessageGroupPart<ExtraData>? {
         didSet { updateContent() }
     }
@@ -17,28 +30,20 @@ open class ChatMessageContentView<ExtraData: UIExtraDataTypes>: View, UIConfigPr
         .messageContentSubviews
         .bubbleView
         .init(showRepliedMessage: true)
-        .withoutAutoresizingMaskConstraints
 
     public private(set) lazy var messageMetadataView = uiConfig
         .messageList
         .messageContentSubviews
         .metadataView
         .init()
-        .withoutAutoresizingMaskConstraints
     
     public private(set) lazy var authorAvatarView = uiConfig
         .messageList
         .messageContentSubviews
         .authorAvatarView
         .init()
-        .withoutAutoresizingMaskConstraints
 
     let messageReactionsView = ChatMessageReactionsView().withoutAutoresizingMaskConstraints
-
-    private var incomingMessageGroupPartConstraints: [NSLayoutConstraint] = []
-    private var incomingMessageGroupFooterConstraints: [NSLayoutConstraint] = []
-    private var outgoingMessageGroupPartConstraints: [NSLayoutConstraint] = []
-    private var outgoingMessageGroupFooterConstraints: [NSLayoutConstraint] = []
 
     // MARK: - Overrides
 
@@ -47,61 +52,33 @@ open class ChatMessageContentView<ExtraData: UIExtraDataTypes>: View, UIConfigPr
         addSubview(messageMetadataView)
         addSubview(authorAvatarView)
         addSubview(messageReactionsView)
+    }
 
-        incomingMessageGroupPartConstraints = [
-            messageBubbleView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 40),
-            messageBubbleView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            messageBubbleView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            
-            messageReactionsView.topAnchor.constraint(equalTo: topAnchor),
-            messageReactionsView.bottomAnchor.constraint(equalTo: messageBubbleView.topAnchor),
-            messageReactionsView.centerXAnchor.constraint(equalTo: messageBubbleView.trailingAnchor),
-            messageReactionsView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor)
-        ]
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+        guard let layout = layout else { return }
 
-        incomingMessageGroupFooterConstraints = [
-            authorAvatarView.widthAnchor.constraint(equalToConstant: 32),
-            authorAvatarView.heightAnchor.constraint(equalToConstant: 32),
-            authorAvatarView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            authorAvatarView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        messageBubbleView.isHidden = layout.messageBubble == nil
+        if let frame = layout.messageBubble {
+            messageBubbleView.frame = frame
+        }
+        messageBubbleView.layout = layout.messageBubbleLayout
 
-            messageBubbleView.leadingAnchor.constraint(equalToSystemSpacingAfter: authorAvatarView.trailingAnchor, multiplier: 1),
-            messageBubbleView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            
-            messageMetadataView.topAnchor.constraint(equalToSystemSpacingBelow: messageBubbleView.bottomAnchor, multiplier: 1),
-            messageMetadataView.leadingAnchor.constraint(equalTo: messageBubbleView.leadingAnchor),
-            messageMetadataView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            
-            messageReactionsView.topAnchor.constraint(equalTo: topAnchor),
-            messageReactionsView.bottomAnchor.constraint(equalTo: messageBubbleView.topAnchor),
-            messageReactionsView.centerXAnchor.constraint(equalTo: messageBubbleView.trailingAnchor),
-            messageReactionsView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor)
-        ]
+        messageMetadataView.isHidden = layout.messageMetadata == nil
+        if let frame = layout.messageMetadata {
+            messageMetadataView.frame = frame
+        }
+        messageMetadataView.layout = layout.messageMetadataLayout
 
-        outgoingMessageGroupPartConstraints = [
-            messageBubbleView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            messageBubbleView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            messageBubbleView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            
-            messageReactionsView.topAnchor.constraint(equalTo: topAnchor),
-            messageReactionsView.bottomAnchor.constraint(equalTo: messageBubbleView.topAnchor),
-            messageReactionsView.centerXAnchor.constraint(equalTo: messageBubbleView.leadingAnchor),
-            messageReactionsView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
-        ]
+        authorAvatarView.isHidden = layout.authorAvatar == nil
+        if let frame = layout.authorAvatar {
+            authorAvatarView.frame = frame
+        }
 
-        outgoingMessageGroupFooterConstraints = [
-            messageBubbleView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            messageBubbleView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            
-            messageMetadataView.topAnchor.constraint(equalToSystemSpacingBelow: messageBubbleView.bottomAnchor, multiplier: 1),
-            messageMetadataView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            messageMetadataView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            
-            messageReactionsView.topAnchor.constraint(equalTo: topAnchor),
-            messageReactionsView.bottomAnchor.constraint(equalTo: messageBubbleView.topAnchor),
-            messageReactionsView.centerXAnchor.constraint(equalTo: messageBubbleView.leadingAnchor),
-            messageReactionsView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
-        ]
+        messageReactionsView.isHidden = layout.reactions == nil
+        if let frame = layout.reactions {
+            messageReactionsView.frame = frame
+        }
     }
 
     override open func updateContent() {
@@ -120,53 +97,104 @@ open class ChatMessageContentView<ExtraData: UIExtraDataTypes>: View, UIConfigPr
         } else {
             authorAvatarView.imageView.image = placeholder
         }
+    }
+}
 
-        authorAvatarView.isHidden = message?.isSentByCurrentUser == true || message?.isLastInGroup == false
-        messageMetadataView.isHidden = message?.isLastInGroup == false
-        activateNecessaryConstraints()
+class ChatMessageContentViewLayoutManager<ExtraData: UIExtraDataTypes> {
+    let bubbleSizer = ChatMessageBubbleViewLayoutManager<ExtraData>()
+    let metadataSizer = ChatMessageMetadataViewLayoutManager<ExtraData>()
+    private let reactions = ChatMessageReactionsView()
+
+    func heightForView(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGFloat {
+        sizeForView(with: data, limitedBy: width).height
     }
 
-    // MARK: - Private
-    
-    private func activateNecessaryConstraints() {
-        let constraintsToDeactivate: [NSLayoutConstraint]
-        let constraintsToActivate: [NSLayoutConstraint]
+    func sizeForView(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGSize {
+        let isSentByCurrentUser = data.isSentByCurrentUser
+        let avatarSize = isSentByCurrentUser ? .zero : CGSize(width: 32, height: 32)
+        let reactionsSize = sizeForReactions(with: data, limitedBy: width)
+        let bubbleLeading: CGFloat = isSentByCurrentUser ? 0 : 40
 
-        switch (message?.isSentByCurrentUser, message?.isLastInGroup) {
-        case (true, true):
-            constraintsToDeactivate =
-                outgoingMessageGroupPartConstraints +
-                incomingMessageGroupPartConstraints +
-                incomingMessageGroupFooterConstraints
-            constraintsToActivate = outgoingMessageGroupFooterConstraints
-        case (true, false):
-            constraintsToDeactivate =
-                outgoingMessageGroupFooterConstraints +
-                incomingMessageGroupPartConstraints +
-                incomingMessageGroupFooterConstraints
-            constraintsToActivate = outgoingMessageGroupPartConstraints
-        case (false, true):
-            constraintsToDeactivate =
-                outgoingMessageGroupPartConstraints +
-                outgoingMessageGroupFooterConstraints +
-                incomingMessageGroupPartConstraints
-            constraintsToActivate = incomingMessageGroupFooterConstraints
-        case (false, false):
-            constraintsToDeactivate =
-                outgoingMessageGroupPartConstraints +
-                outgoingMessageGroupFooterConstraints +
-                incomingMessageGroupFooterConstraints
-            constraintsToActivate = incomingMessageGroupPartConstraints
-        default:
-            constraintsToDeactivate =
-                incomingMessageGroupPartConstraints +
-                incomingMessageGroupFooterConstraints +
-                outgoingMessageGroupPartConstraints +
-                outgoingMessageGroupFooterConstraints
-            constraintsToActivate = []
+        var height = reactionsSize?.height ?? 0
+
+        let bubbleSize = bubbleSizer.sizeForView(with: data, limitedBy: width - bubbleLeading)
+        var nonAvatarWidth = bubbleSize.width
+        height += bubbleSize.height
+
+        let metadataSize = metadataSizer.sizeForView(with: data, limitedBy: width - bubbleLeading)
+        if data.isLastInGroup {
+            height += 8
+            height += metadataSize.height
+            nonAvatarWidth = max(nonAvatarWidth, metadataSize.width)
         }
-        
-        constraintsToDeactivate.forEach { $0.isActive = false }
-        constraintsToActivate.forEach { $0.isActive = true }
+
+        height = max(avatarSize.height, height)
+        let width = bubbleLeading + nonAvatarWidth
+        return CGSize(width: width, height: height)
+    }
+
+    func layoutForView(
+        with data: _ChatMessageGroupPart<ExtraData>,
+        of size: CGSize
+    ) -> ChatMessageContentView<ExtraData>.Layout {
+        let width = size.width
+        let height = size.height
+
+        let isSentByCurrentUser = data.isSentByCurrentUser
+        let isLastInGroup = data.isLastInGroup
+        let spacing: CGFloat = 8
+
+        // sizes
+        let avatarSize = isSentByCurrentUser ? .zero : CGSize(width: 32, height: 32)
+        let reactionsSize = sizeForReactions(with: data, limitedBy: width)
+        let avatarMaxX = isSentByCurrentUser ? 0 : avatarSize.width + spacing
+        let bubbleSize = bubbleSizer.sizeForView(with: data, limitedBy: width - avatarMaxX)
+        let metadataSize = metadataSizer.sizeForView(with: data, limitedBy: width - avatarMaxX)
+
+        // frames
+        let avatarFrame: CGRect? = {
+            guard !isSentByCurrentUser, isLastInGroup else { return nil }
+            return CGRect(origin: CGPoint(x: 0, y: height - avatarSize.height), size: avatarSize)
+        }()
+
+        let reactionsBottom: CGFloat = reactionsSize?.height ?? 0
+        let bubbleLeading = isSentByCurrentUser
+            ? width - bubbleSize.width
+            : avatarMaxX
+        let bubbleFrame = CGRect(origin: CGPoint(x: bubbleLeading, y: reactionsBottom), size: bubbleSize)
+
+        let reactionFrame: CGRect? = reactionsSize.map { size in
+            let originX: CGFloat = isSentByCurrentUser
+                ? min(bubbleFrame.minX - size.width / 2, width - size.width)
+                : max(bubbleFrame.maxX - size.width / 2, 0)
+            return CGRect(origin: CGPoint(x: originX, y: 0), size: size)
+        }
+
+        let metadataFrame: CGRect? = {
+            guard isLastInGroup else { return nil }
+            let originX = isSentByCurrentUser
+                ? width - metadataSize.width
+                : bubbleLeading
+            return CGRect(
+                origin: CGPoint(x: originX, y: bubbleFrame.maxY + 8),
+                size: metadataSize
+            )
+        }()
+
+        return ChatMessageContentView.Layout(
+            messageBubble: bubbleFrame,
+            messageBubbleLayout: bubbleSizer.layoutForView(with: data, of: bubbleSize),
+            messageMetadata: metadataFrame,
+            messageMetadataLayout: metadataFrame == nil ? nil : metadataSizer.layoutForView(with: data, of: metadataSize),
+            authorAvatar: avatarFrame,
+            reactions: reactionFrame
+        )
+    }
+
+    func sizeForReactions(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGSize? {
+        guard !data.message.reactionScores.isEmpty else { return nil }
+        reactions.style = data.isSentByCurrentUser ? .smallOutgoing : .smallIncoming
+        reactions.reload(from: data.message)
+        return reactions.systemLayoutSizeFitting(CGSize(width: width, height: 300))
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageMetadataView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageMetadataView.swift
@@ -6,6 +6,14 @@ import StreamChat
 import UIKit
 
 open class ChatMessageMetadataView<ExtraData: UIExtraDataTypes>: View {
+    struct Layout {
+        let timestamp: CGRect?
+    }
+
+    var layout: Layout? {
+        didSet { setNeedsLayout() }
+    }
+
     public var message: _ChatMessageGroupPart<ExtraData>? {
         didSet { updateContent() }
     }
@@ -21,15 +29,53 @@ open class ChatMessageMetadataView<ExtraData: UIExtraDataTypes>: View {
     
     // MARK: - Overrides
 
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+
+        if let frame = layout?.timestamp {
+            timestampLabel.frame = frame
+            timestampLabel.isHidden = false
+        } else {
+            timestampLabel.isHidden = true
+        }
+    }
+
     override public func defaultAppearance() {
         timestampLabel.textColor = .messageTimestamp
     }
 
     override open func setUpLayout() {
-        embed(timestampLabel)
+        addSubview(timestampLabel)
     }
 
     override open func updateContent() {
         timestampLabel.text = message?.createdAt.getFormattedDate(format: "hh:mm a")
+    }
+}
+
+class ChatMessageMetadataViewLayoutManager<ExtraData: UIExtraDataTypes> {
+    let label: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .footnote)
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    func heightForView(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGFloat {
+        sizeForView(with: data, limitedBy: width).height
+    }
+
+    func sizeForView(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGSize {
+        label.text = data.message.createdAt.getFormattedDate(format: "hh:mm a")
+        return label.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
+    }
+
+    func layoutForView(
+        with data: _ChatMessageGroupPart<ExtraData>,
+        of size: CGSize
+    ) -> ChatMessageMetadataView<ExtraData>.Layout {
+        ChatMessageMetadataView.Layout(
+            timestamp: CGRect(origin: .zero, size: size)
+        )
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageMetadataView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageMetadataView.swift
@@ -53,29 +53,24 @@ open class ChatMessageMetadataView<ExtraData: UIExtraDataTypes>: View {
     }
 }
 
-class ChatMessageMetadataViewLayoutManager<ExtraData: UIExtraDataTypes> {
-    let label: UILabel = {
-        let label = UILabel()
-        label.font = .preferredFont(forTextStyle: .footnote)
-        label.adjustsFontForContentSizeCategory = true
-        return label
-    }()
+extension ChatMessageMetadataView {
+    class LayoutProvider: ConfiguredLayoutProvider<ExtraData> {
+        let label: UILabel = ChatMessageMetadataView().timestampLabel
 
-    func heightForView(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGFloat {
-        sizeForView(with: data, limitedBy: width).height
-    }
+        func heightForView(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGFloat {
+            sizeForView(with: data, limitedBy: width).height
+        }
 
-    func sizeForView(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGSize {
-        label.text = data.message.createdAt.getFormattedDate(format: "hh:mm a")
-        return label.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
-    }
+        func sizeForView(with data: _ChatMessageGroupPart<ExtraData>, limitedBy width: CGFloat) -> CGSize {
+            label.text = data.message.createdAt.getFormattedDate(format: "hh:mm a")
+            return label.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
+        }
 
-    func layoutForView(
-        with data: _ChatMessageGroupPart<ExtraData>,
-        of size: CGSize
-    ) -> ChatMessageMetadataView<ExtraData>.Layout {
-        ChatMessageMetadataView.Layout(
-            timestamp: CGRect(origin: .zero, size: size)
-        )
+        func layoutForView(
+            with data: _ChatMessageGroupPart<ExtraData>,
+            of size: CGSize
+        ) -> Layout {
+            Layout(timestamp: CGRect(origin: .zero, size: size))
+        }
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageReactionsView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageReactionsView.swift
@@ -150,7 +150,9 @@ class ChatMessageReactionsView: UIView {
         content.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor).isActive = true
         content.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor).isActive = true
         content.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor).isActive = true
-        content.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor).isActive = true
+        let bottom = content.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor)
+        bottom.priority = UILayoutPriority(999)
+        bottom.isActive = true
         layer.borderWidth = 1
         updateStyle()
     }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatRepliedMessageContentView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatRepliedMessageContentView.swift
@@ -33,21 +33,20 @@ open class ChatRepliedMessageContentView<ExtraData: UIExtraDataTypes>: View {
 
     override open func layoutSubviews() {
         super.layoutSubviews()
-        guard let layout = layout else { return }
 
-        messageBubbleView.isHidden = layout.messageBubble == nil
-        if let frame = layout.messageBubble {
+        messageBubbleView.isHidden = layout?.messageBubble == nil
+        if let frame = layout?.messageBubble {
             messageBubbleView.frame = frame
         }
-        messageBubbleView.layout = layout.messageBubbleLayout
+        messageBubbleView.layout = layout?.messageBubbleLayout
 
-        authorAvatarView.isHidden = layout.authorAvatar == nil
-        if let frame = layout.authorAvatar {
+        authorAvatarView.isHidden = layout?.authorAvatar == nil
+        if let frame = layout?.authorAvatar {
             authorAvatarView.frame = frame
         }
 
-        loadingView.isHidden = layout.loading == nil
-        if let frame = layout.loading {
+        loadingView.isHidden = layout?.loading == nil
+        if let frame = layout?.loading {
             loadingView.frame = frame
         }
     }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatRepliedMessageContentView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatRepliedMessageContentView.swift
@@ -6,6 +6,17 @@ import StreamChat
 import UIKit
 
 open class ChatRepliedMessageContentView<ExtraData: UIExtraDataTypes>: View {
+    struct Layout {
+        let messageBubble: CGRect?
+        let messageBubbleLayout: ChatMessageBubbleView<ExtraData>.Layout?
+        let authorAvatar: CGRect?
+        let loading: CGRect?
+    }
+
+    var layout: Layout? {
+        didSet { setNeedsLayout() }
+    }
+
     public var message: _ChatMessage<ExtraData>? {
         didSet { updateContent() }
     }
@@ -13,53 +24,44 @@ open class ChatRepliedMessageContentView<ExtraData: UIExtraDataTypes>: View {
     // MARK: - Subviews
 
     public private(set) lazy var messageBubbleView = ChatMessageBubbleView<ExtraData>(showRepliedMessage: false)
-        .withoutAutoresizingMaskConstraints
 
     public private(set) lazy var authorAvatarView = AvatarView()
-        .withoutAutoresizingMaskConstraints
 
     public private(set) lazy var loadingView = LoadingView()
 
-    private var avatarOnTheLeftConstraints: [NSLayoutConstraint] = []
-    private var avatarOnTheRightConstraints: [NSLayoutConstraint] = []
-
     // MARK: - Overrides
+
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+        guard let layout = layout else { return }
+
+        messageBubbleView.isHidden = layout.messageBubble == nil
+        if let frame = layout.messageBubble {
+            messageBubbleView.frame = frame
+        }
+        messageBubbleView.layout = layout.messageBubbleLayout
+
+        authorAvatarView.isHidden = layout.authorAvatar == nil
+        if let frame = layout.authorAvatar {
+            authorAvatarView.frame = frame
+        }
+
+        loadingView.isHidden = layout.loading == nil
+        if let frame = layout.loading {
+            loadingView.frame = frame
+        }
+    }
 
     override open func setUpLayout() {
         addSubview(authorAvatarView)
         addSubview(messageBubbleView)
-        embed(loadingView)
-
-        avatarOnTheLeftConstraints = [
-            authorAvatarView.widthAnchor.constraint(equalToConstant: 24),
-            authorAvatarView.heightAnchor.constraint(equalToConstant: 24),
-            authorAvatarView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            authorAvatarView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            
-            messageBubbleView.topAnchor.constraint(equalTo: topAnchor),
-            messageBubbleView.leadingAnchor.constraint(equalToSystemSpacingAfter: authorAvatarView.trailingAnchor, multiplier: 1),
-            messageBubbleView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            messageBubbleView.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ]
-
-        avatarOnTheRightConstraints = [
-            messageBubbleView.topAnchor.constraint(equalTo: topAnchor),
-            messageBubbleView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            messageBubbleView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            
-            authorAvatarView.widthAnchor.constraint(equalToConstant: 24),
-            authorAvatarView.heightAnchor.constraint(equalToConstant: 24),
-            authorAvatarView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            authorAvatarView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            authorAvatarView.leadingAnchor.constraint(equalToSystemSpacingAfter: messageBubbleView.trailingAnchor, multiplier: 1)
-        ]
+        addSubview(loadingView)
     }
 
     override open func updateContent() {
         messageBubbleView.message = message.flatMap {
             .init(message: $0, parentMessageState: nil, isLastInGroup: true)
         }
-        messageBubbleView.isHidden = message == nil
 
         let placeholder = UIImage(named: "pattern1", in: .streamChatUI)
         if let imageURL = message?.author.imageURL {
@@ -67,13 +69,8 @@ open class ChatRepliedMessageContentView<ExtraData: UIExtraDataTypes>: View {
         } else {
             authorAvatarView.imageView.image = placeholder
         }
-        authorAvatarView.isHidden = message == nil
 
-        loadingView.isHidden = message != nil
         loadingView.isLoading = message == nil
-
-        avatarOnTheLeftConstraints.forEach { $0.isActive = (message?.isSentByCurrentUser == false) }
-        avatarOnTheRightConstraints.forEach { $0.isActive = (message?.isSentByCurrentUser == true) }
     }
 }
 
@@ -120,5 +117,68 @@ extension ChatRepliedMessageContentView {
         override public func defaultAppearance() {
             activityIndicator.style = .gray
         }
+    }
+}
+
+class ChatRepliedMessageContentViewLayoutManager<ExtraData: UIExtraDataTypes> {
+    let bubbleSizer = ChatMessageBubbleViewLayoutManager<ExtraData>()
+
+    func heightForView(with data: _ChatMessage<ExtraData>?, limitedBy width: CGFloat) -> CGFloat {
+        sizeForView(with: data, limitedBy: width).height
+    }
+
+    func sizeForView(with data: _ChatMessage<ExtraData>?, limitedBy width: CGFloat) -> CGSize {
+        guard let message = data else {
+            return CGSize(width: width, height: 60)
+        }
+        let spacing: CGFloat = 8
+        let avatarSize = CGSize(width: 24, height: 24)
+        let group = _ChatMessageGroupPart(message: message, parentMessageState: nil, isLastInGroup: true)
+        let bubbleSize = bubbleSizer.sizeForView(with: group, limitedBy: width - avatarSize.width - spacing)
+        let height = max(avatarSize.height, bubbleSize.height)
+        return CGSize(width: avatarSize.width + spacing + bubbleSize.width, height: height)
+    }
+
+    func layoutForView(
+        with data: _ChatMessage<ExtraData>?,
+        of size: CGSize
+    ) -> ChatRepliedMessageContentView<ExtraData>.Layout {
+        let width = size.width
+        let height = size.height
+        guard let message = data else {
+            let loadingFrame = CGRect(x: (width - 60) / 2, y: 0, width: 60, height: 60)
+            return ChatRepliedMessageContentView.Layout(
+                messageBubble: nil,
+                messageBubbleLayout: nil,
+                authorAvatar: nil,
+                loading: loadingFrame
+            )
+        }
+        let spacing: CGFloat = 8
+        let avatarSize = CGSize(width: 24, height: 24)
+        let isSentByCurrentUser = message.isSentByCurrentUser
+        let avatarOffsetX = isSentByCurrentUser
+            ? width - avatarSize.width
+            : 0
+
+        let group = _ChatMessageGroupPart(message: message, parentMessageState: nil, isLastInGroup: true)
+        let bubbleSize = bubbleSizer.sizeForView(with: group, limitedBy: width - avatarSize.width - spacing)
+
+        let avatarFrame = CGRect(origin: CGPoint(x: avatarOffsetX, y: height - avatarSize.height), size: avatarSize)
+
+        let bubbleOffsetX = isSentByCurrentUser
+            ? 0
+            : avatarFrame.maxX + spacing
+        let bubbleFrame = CGRect(
+            origin: CGPoint(x: bubbleOffsetX, y: max(0, height - bubbleSize.height)),
+            size: bubbleSize
+        )
+
+        return ChatRepliedMessageContentView.Layout(
+            messageBubble: bubbleFrame,
+            messageBubbleLayout: bubbleSizer.layoutForView(with: group, of: bubbleSize),
+            authorAvatar: avatarFrame,
+            loading: nil
+        )
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/ConfiguredLayoutProvider.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ConfiguredLayoutProvider.swift
@@ -1,0 +1,25 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Object responsible for calculation of view sizes + frames of its subviews
+/// Shouldn't be used. Only subclassed.
+open class ConfiguredLayoutProvider<ExtraData: UIExtraDataTypes> {
+    var parent: ConfiguredLayoutProvider<ExtraData>?
+    private var _uiConfig: UIConfig<ExtraData>?
+    var uiConfig: UIConfig<ExtraData> {
+        get {
+            _uiConfig ?? parent?.uiConfig ?? UIConfig<ExtraData>.default
+        }
+        set {
+            _uiConfig = newValue
+        }
+    }
+
+    init(uiConfig: UIConfig<ExtraData>? = nil, parent: ConfiguredLayoutProvider<ExtraData>? = nil) {
+        _uiConfig = uiConfig
+        self.parent = parent
+    }
+}

--- a/Sources_v3/StreamChatUI/UIConfig.swift
+++ b/Sources_v3/StreamChatUI/UIConfig.swift
@@ -80,6 +80,9 @@ public extension UIConfig {
         public var collectionView: ChatChannelCollectionView.Type = ChatChannelCollectionView.self
         public var collectionLayout: ChatChannelCollectionViewLayout.Type = ChatChannelCollectionViewLayout.self
         public var minTimeInvteralBetweenMessagesInGroup: TimeInterval = 10
+        public var defaultMargins: CGFloat = 8
+        /// in (0;1] range
+        public var maxMessageWidth: CGFloat = 0.75
         public var messageContentView: ChatMessageContentView<ExtraData>.Type = ChatMessageContentView<ExtraData>.self
         public var messageContentSubviews = MessageContentViewSubviews()
     }

--- a/Sources_v3/StreamChatUI/UIConfig.swift
+++ b/Sources_v3/StreamChatUI/UIConfig.swift
@@ -78,7 +78,7 @@ public extension UIConfig {
 public extension UIConfig {
     struct MessageListUI {
         public var collectionView: ChatChannelCollectionView.Type = ChatChannelCollectionView.self
-        public var collectionLayout: UICollectionViewLayout.Type = ChatChannelCollectionViewLayout.self
+        public var collectionLayout: ChatChannelCollectionViewLayout.Type = ChatChannelCollectionViewLayout.self
         public var minTimeInvteralBetweenMessagesInGroup: TimeInterval = 10
         public var messageContentView: ChatMessageContentView<ExtraData>.Type = ChatMessageContentView<ExtraData>.self
         public var messageContentSubviews = MessageContentViewSubviews()

--- a/Sources_v3/StreamChatUI/Utils/UIColor+Extensions.swift
+++ b/Sources_v3/StreamChatUI/Utils/UIColor+Extensions.swift
@@ -35,7 +35,7 @@ extension UIColor {
     static let outgoingMessageBubbleBackground = UIColor(rgb: 0xe5e5e5)
     static let outgoingMessageBubbleBorder = outgoingMessageBubbleBackground
     static let incomingMessageBubbleBackground = white
-    static let incomingMessageBubbleBorder = UIColor.black.withAlphaComponent(0.08)
+    static let incomingMessageBubbleBorder = UIColor(red: 20, green: 20, blue: 20)
     static let chatBackground = UIColor(rgb: 0xfcfcfc)
     static let messageTimestamp = UIColor.lightGray
 }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -498,6 +498,7 @@
 		DB70CFF425701FE500DDF436 /* ChatChannelNavigationBarListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB70CFF325701FE500DDF436 /* ChatChannelNavigationBarListener.swift */; };
 		DB70CFFB25702EB900DDF436 /* ChatMessagePopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB70CFFA25702EB900DDF436 /* ChatMessagePopupViewController.swift */; };
 		DB70D002257119C500DDF436 /* ChatMessageReactionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */; };
+		DB781C9825790A1B00E5FDB5 /* ConfiguredLayoutProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB781C9725790A1B00E5FDB5 /* ConfiguredLayoutProvider.swift */; };
 		E759AC4D256E694F00341865 /* OnlineIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */; };
 		F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */; };
 		F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */; };
@@ -1115,6 +1116,7 @@
 		DB70CFF325701FE500DDF436 /* ChatChannelNavigationBarListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelNavigationBarListener.swift; sourceTree = "<group>"; };
 		DB70CFFA25702EB900DDF436 /* ChatMessagePopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessagePopupViewController.swift; sourceTree = "<group>"; };
 		DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageReactionsView.swift; sourceTree = "<group>"; };
+		DB781C9725790A1B00E5FDB5 /* ConfiguredLayoutProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfiguredLayoutProvider.swift; sourceTree = "<group>"; };
 		E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineIndicatorView.swift; sourceTree = "<group>"; };
 		F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints_Tests.swift; sourceTree = "<group>"; };
 		F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Mock.swift; sourceTree = "<group>"; };
@@ -1299,13 +1301,13 @@
 				79088331254876C100896F03 /* ChatChannelCollectionView.swift */,
 				79088330254876C100896F03 /* ChatChannelCollectionViewLayout.swift */,
 				7908832E254876C100896F03 /* ChatMessageCollectionViewCell.swift */,
+				DB781C9725790A1B00E5FDB5 /* ConfiguredLayoutProvider.swift */,
 				88A8CF15256E7BDA004EA4C7 /* ChatMessageContentView.swift */,
 				88A8CF1F256E7C06004EA4C7 /* ChatMessageBubbleView.swift */,
 				88A8CF25256E7C31004EA4C7 /* ChatMessageMetadataView.swift */,
 				88A8CF0A256E7AC8004EA4C7 /* ChatMessageGroupPart.swift */,
 				88BC8907256E90A1009C5554 /* ChatRepliedMessageContentView.swift */,
 				DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */,
-				79088333254876C200896F03 /* ChatChannelNavigationBar.swift */,
 				22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */,
 				22ADD681256C40410098EFEB /* ChatChannelMessageComposerView.swift */,
 				221742D4256DC97F005B257C /* MessageComposerAttachmentsView.swift */,
@@ -2753,13 +2755,11 @@
 				228190EB256733420048D7C6 /* UIFont+Extensions.swift in Sources */,
 				888123D2255D430B00070D5A /* UIView+Extensions.swift in Sources */,
 				224FF6872562F55F00725DD1 /* Date+Extensions.swift in Sources */,
-				7908833E254876F900896F03 /* ChatChannelCollectionViewDataSource.swift in Sources */,
 				22ADD682256C40410098EFEB /* ChatChannelMessageComposerView.swift in Sources */,
 				8850FE91256558B200C8D534 /* ChatRouter.swift in Sources */,
 				DB70CFF425701FE500DDF436 /* ChatChannelNavigationBarListener.swift in Sources */,
 				88A8CF0B256E7AC8004EA4C7 /* ChatMessageGroupPart.swift in Sources */,
 				88BC8908256E90A1009C5554 /* ChatRepliedMessageContentView.swift in Sources */,
-				790883522548771100896F03 /* ChatChannelNavigationBar.swift in Sources */,
 				22FF4365256E943F00133910 /* MessageComposerSuggestionsViewController.swift in Sources */,
 				22A0921725682880001FE9F0 /* ChatNavigationBar.swift in Sources */,
 				7952764A255D86BD008531E8 /* UIExtraData.swift in Sources */,
@@ -2773,9 +2773,10 @@
 				221742D5256DC97F005B257C /* MessageComposerAttachmentsView.swift in Sources */,
 				885B3D7D25642B88003E6BDF /* CreateNewChannelButton.swift in Sources */,
 				792DD9D9256BC542001DB91B /* BaseViews.swift in Sources */,
+				DB781C9825790A1B00E5FDB5 /* ConfiguredLayoutProvider.swift in Sources */,
 				79088334254876EA00896F03 /* ChatChannelVC.swift in Sources */,
 				228DC80E25704B410080A49F /* MessageComposerAttachmentCellView.swift in Sources */,
-				79088334254876EA00896F03 /* ChatChannelViewController.swift in Sources */,
+				79088334254876EA00896F03 /* ChatChannelVC.swift in Sources */,
 				790882DF25486B6800896F03 /* ChatChannelListVC.swift in Sources */,
 				79D86E832562BAB900DCD1D2 /* AppearanceSetting.swift in Sources */,
 				792DD9FB256E67C6001DB91B /* UIConfigProvider.swift in Sources */,


### PR DESCRIPTION
For fast and smooth scrolling experience we decided to go for frame based layout for message cells. To achieve it we have:
- `ChatChannelCollectionViewLayout` - collection view layout that precalculate frames for all items in collection view
- `ChatChannelCollectionViewLayoutModel` - DTO containing desire heights for all items in collection view
- `ChatChannelCollectionViewLayoutDelegate` - delegate responsible for calculation of `ChatChannelCollectionViewLayoutModel` for current data, right now it's `ChatChannelVC`
- `ConfiguredLayoutProvider` - abstract class for layout calculators, provide access for `UIConfig`
- `View.LayoutProvider ` - brain of layout. Calculates size for cell + frames for cell subviews
- `View.Layout` - DTO that contains frames for views subviews. If frame is `nil` subview should be hidden