### PR TITLE
Replace UIInputAccessoryView with UIInputAccessoryViewController

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageComposerView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageComposerView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-open class ChatChannelMessageComposerView<ExtraData: UIExtraDataTypes>: UIView {
+open class ChatChannelMessageComposerView<ExtraData: UIExtraDataTypes>: UIInputView {
     // MARK: - Properties
     
     public var buttonHeight: CGFloat = 20
@@ -84,7 +84,7 @@ open class ChatChannelMessageComposerView<ExtraData: UIExtraDataTypes>: UIView {
     ) {
         self.uiConfig = uiConfig
         
-        super.init(frame: .zero)
+        super.init(frame: .zero, inputViewStyle: .default)
         
         commonInit()
     }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -14,6 +14,8 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
     // MARK: - Properties
     
     public var controller: _ChatChannelController<ExtraData>!
+
+    lazy var messageInputAccessoryViewController = { MessageComposerInputAccessoryViewController() }()
         
     public private(set) lazy var collectionView: UICollectionView = {
         let layout = uiConfig.messageList.collectionLayout.init()
@@ -135,34 +137,10 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
     
     var composerView = ChatChannelMessageComposerView<DefaultUIExtraData>(uiConfig: .default)
 
-    override open var inputAccessoryView: UIView? {
-        guard presentedViewController?.isBeingDismissed != false else {
-            return nil
-        }
-        
-        composerView.translatesAutoresizingMaskIntoConstraints = false
-        composerView.layoutMargins = view.layoutMargins
-        composerView.directionalLayoutMargins = systemMinimumLayoutMargins
-        
-        composerView.owningVC = self
-        composerView.suggestionsViewController.owningViewController = self
-        
-        composerView.messageInputView.textViewDidChange = { [weak self] text in
-            self?.controller.sendKeystrokeEvent()
-            if text?.first == "\\" || text?.first == "@" {
-                self?.composerView.suggestionsViewController.show()
-            } else {
-                self?.composerView.suggestionsViewController.dismiss()
-            }
-        }
-        
-        composerView.messageInputView.textViewDidEndEditing = { [weak self] _ in
-            self?.controller.sendStopTypingEvent()
-        }
-        
-        return composerView
+    override open var inputAccessoryViewController: UIInputViewController? {
+        messageInputAccessoryViewController
     }
-    
+
     public func imagePickerController(
         _ picker: UIImagePickerController,
         didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposerInputAccessoryViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposerInputAccessoryViewController.swift
@@ -1,0 +1,36 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+class MessageComposerInputAccessoryViewController: UIInputViewController {
+    var composerView = ChatChannelMessageComposerView<DefaultUIExtraData>(uiConfig: .default).withoutAutoresizingMaskConstraints
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        inputView = composerView
+
+        guard let inputView = inputView else { return }
+        composerView.messageInputView.textView.delegate = self
+
+        composerView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        composerView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        composerView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        composerView.topAnchor.constraint(equalTo: inputView.topAnchor).isActive = true
+    }
+}
+
+// MARK: - UITextViewDelegate
+
+extension MessageComposerInputAccessoryViewController: UITextViewDelegate {
+    func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
+        composerView.messageInputView.textView.inputAccessoryView = view
+        return true
+    }
+
+    func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
+        composerView.messageInputView.textView.inputAccessoryView = nil
+        return true
+    }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -498,6 +498,7 @@
 		DB70CFF425701FE500DDF436 /* ChatChannelNavigationBarListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB70CFF325701FE500DDF436 /* ChatChannelNavigationBarListener.swift */; };
 		DB70CFFB25702EB900DDF436 /* ChatMessagePopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB70CFFA25702EB900DDF436 /* ChatMessagePopupViewController.swift */; };
 		DB70D002257119C500DDF436 /* ChatMessageReactionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */; };
+		E73A8B2B2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73A8B2A2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift */; };
 		E759AC4D256E694F00341865 /* OnlineIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */; };
 		F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */; };
 		F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */; };
@@ -1115,6 +1116,7 @@
 		DB70CFF325701FE500DDF436 /* ChatChannelNavigationBarListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelNavigationBarListener.swift; sourceTree = "<group>"; };
 		DB70CFFA25702EB900DDF436 /* ChatMessagePopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessagePopupViewController.swift; sourceTree = "<group>"; };
 		DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageReactionsView.swift; sourceTree = "<group>"; };
+		E73A8B2A2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageComposerInputAccessoryViewController.swift; sourceTree = "<group>"; };
 		E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineIndicatorView.swift; sourceTree = "<group>"; };
 		F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints_Tests.swift; sourceTree = "<group>"; };
 		F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Mock.swift; sourceTree = "<group>"; };
@@ -1305,13 +1307,13 @@
 				88A8CF0A256E7AC8004EA4C7 /* ChatMessageGroupPart.swift */,
 				88BC8907256E90A1009C5554 /* ChatRepliedMessageContentView.swift */,
 				DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */,
-				79088333254876C200896F03 /* ChatChannelNavigationBar.swift */,
 				22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */,
 				22ADD681256C40410098EFEB /* ChatChannelMessageComposerView.swift */,
 				221742D4256DC97F005B257C /* MessageComposerAttachmentsView.swift */,
 				228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */,
 				2210525E256FE16600A5F0DB /* MessageInputSlashCommandView.swift */,
 				22FF4364256E943F00133910 /* MessageComposerSuggestionsViewController.swift */,
+				E73A8B2A2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift */,
 			);
 			path = ChatChannel;
 			sourceTree = "<group>";
@@ -2753,13 +2755,11 @@
 				228190EB256733420048D7C6 /* UIFont+Extensions.swift in Sources */,
 				888123D2255D430B00070D5A /* UIView+Extensions.swift in Sources */,
 				224FF6872562F55F00725DD1 /* Date+Extensions.swift in Sources */,
-				7908833E254876F900896F03 /* ChatChannelCollectionViewDataSource.swift in Sources */,
 				22ADD682256C40410098EFEB /* ChatChannelMessageComposerView.swift in Sources */,
 				8850FE91256558B200C8D534 /* ChatRouter.swift in Sources */,
 				DB70CFF425701FE500DDF436 /* ChatChannelNavigationBarListener.swift in Sources */,
 				88A8CF0B256E7AC8004EA4C7 /* ChatMessageGroupPart.swift in Sources */,
 				88BC8908256E90A1009C5554 /* ChatRepliedMessageContentView.swift in Sources */,
-				790883522548771100896F03 /* ChatChannelNavigationBar.swift in Sources */,
 				22FF4365256E943F00133910 /* MessageComposerSuggestionsViewController.swift in Sources */,
 				22A0921725682880001FE9F0 /* ChatNavigationBar.swift in Sources */,
 				7952764A255D86BD008531E8 /* UIExtraData.swift in Sources */,
@@ -2775,7 +2775,7 @@
 				792DD9D9256BC542001DB91B /* BaseViews.swift in Sources */,
 				79088334254876EA00896F03 /* ChatChannelVC.swift in Sources */,
 				228DC80E25704B410080A49F /* MessageComposerAttachmentCellView.swift in Sources */,
-				79088334254876EA00896F03 /* ChatChannelViewController.swift in Sources */,
+				79088334254876EA00896F03 /* ChatChannelVC.swift in Sources */,
 				790882DF25486B6800896F03 /* ChatChannelListVC.swift in Sources */,
 				79D86E832562BAB900DCD1D2 /* AppearanceSetting.swift in Sources */,
 				792DD9FB256E67C6001DB91B /* UIConfigProvider.swift in Sources */,
@@ -2794,6 +2794,7 @@
 				79088343254876FE00896F03 /* ChatChannelCollectionViewLayout.swift in Sources */,
 				8850B92A255C286B003AED69 /* UIConfig.swift in Sources */,
 				790882ED25486B6D00896F03 /* ChatChannelListCollectionViewDataSource.swift in Sources */,
+				E73A8B2B2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift in Sources */,
 				885B3D7725642B3D003E6BDF /* CurrentChatUserAvatarView.swift in Sources */,
 				224FF6912562F58F00725DD1 /* UIColor+Extensions.swift in Sources */,
 				79088339254876F200896F03 /* ChatChannelCollectionView.swift in Sources */,


### PR DESCRIPTION
# What this PR Does
- Replaces implementation of `ChatChannelMessageComposerView` which was implemented just as `accessoryInputView` to implementation which now has `UIInputViewController` to holds the `inputView` since this is for us better way to implement complex logic with the `ChatChannelMessageComposerView`. Also changes `ChatChannelMessageComposerView` to subclass `UIInputView` instead.
# How to test this
- Start the v3 app, go to some random chat and expect the composerView to be there and behave the same way it did in the first implementation.

Note: This PR is for us to move on and implement the logic into this separate viewController.
