### PR TITLE
[CIS-481] Logic -> `MessageComposerInputAccessoryViewController`

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageComposerView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageComposerView.swift
@@ -10,17 +10,8 @@ open class ChatChannelMessageComposerView<ExtraData: UIExtraDataTypes>: UIInputV
     public var buttonHeight: CGFloat = 20
     
     public let uiConfig: UIConfig<ExtraData>
-    
-    public weak var owningVC: UIViewController?
-    
+        
     // MARK: - Subviews
-    
-    public lazy var imagePicker: UIImagePickerController = {
-        let picker = UIImagePickerController()
-        picker.mediaTypes = ["public.image", "public.movie"]
-        picker.sourceType = .photoLibrary
-        return picker
-    }()
 
     public private(set) lazy var container = ContainerStackView().withoutAutoresizingMaskConstraints
     
@@ -53,17 +44,10 @@ open class ChatChannelMessageComposerView<ExtraData: UIExtraDataTypes>: UIInputV
         if #available(iOS 13.0, *) {
             button.setImage(UIImage(systemName: "paperclip"), for: .normal)
         }
-        button.addTarget(self, action: #selector(attachmentButtonHandler), for: .touchUpInside)
         button.widthAnchor.constraint(equalTo: button.heightAnchor, multiplier: 1).isActive = true
         return button
     }()
-    
-    @objc func attachmentButtonHandler() {
-        invalidateIntrinsicContentSize()
 
-        owningVC?.present(imagePicker, animated: true)
-    }
-    
     public private(set) lazy var boltButton: UIButton = {
         let button = UIButton().withoutAutoresizingMaskConstraints
         if #available(iOS 13.0, *) {
@@ -71,10 +55,6 @@ open class ChatChannelMessageComposerView<ExtraData: UIExtraDataTypes>: UIInputV
         }
         button.widthAnchor.constraint(equalTo: button.heightAnchor, multiplier: 1).isActive = true
         return button
-    }()
-    
-    public private(set) lazy var suggestionsViewController: MessageComposerSuggestionsViewController<ExtraData> = {
-        .init(uiConfig: uiConfig)
     }()
     
     // MARK: - Init
@@ -151,7 +131,6 @@ open class ChatChannelMessageComposerView<ExtraData: UIExtraDataTypes>: UIInputV
         boltButton.widthAnchor.constraint(equalToConstant: buttonHeight).isActive = true
 
         attachmentsView.isHidden = true
-        attachmentsView.composer = self
 
         addObserver(self, forKeyPath: "safeAreaInsets", options: .new, context: nil)
         messageInputView.textView.addObserver(self, forKeyPath: "contentSize", options: .new, context: nil)
@@ -161,7 +140,7 @@ open class ChatChannelMessageComposerView<ExtraData: UIExtraDataTypes>: UIInputV
     
     override open var intrinsicContentSize: CGSize {
         let size = CGSize(
-            width: superview?.bounds.width ?? super.intrinsicContentSize.width,
+            width: .zero,
             height: container.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
         )
         return size

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageInputView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageInputView.swift
@@ -4,14 +4,10 @@
 
 import UIKit
 
-open class ChatChannelMessageInputView<ExtraData: UIExtraDataTypes>: UIView, UITextViewDelegate {
+open class ChatChannelMessageInputView<ExtraData: UIExtraDataTypes>: UIView {
     // MARK: - Properties
     
     public let uiConfig: UIConfig<ExtraData>
-    
-    public var textViewDidChange: ((String?) -> Void)?
-    
-    public var textViewDidEndEditing: ((String?) -> Void)?
     
     var numberOfLines: Int {
         guard let font = textView.font else { return 0 }
@@ -36,15 +32,9 @@ open class ChatChannelMessageInputView<ExtraData: UIExtraDataTypes>: UIView, UIT
         if #available(iOS 13.0, *) {
             button.setImage(UIImage(systemName: "xmark.circle"), for: .normal)
         }
-        button.addTarget(self, action: #selector(hideSlashCommand), for: .touchUpInside)
         button.widthAnchor.constraint(equalTo: button.heightAnchor, multiplier: 1).isActive = true
         return button
     }()
-    
-    @objc func hideSlashCommand() {
-        rightAccessoryButton.isHidden = true
-        container.leftStackView.isHidden = true
-    }
     
     // MARK: - Init
     
@@ -83,7 +73,6 @@ open class ChatChannelMessageInputView<ExtraData: UIExtraDataTypes>: UIView, UIT
     
     open func setupAppearance() {
         textView.text = "Hi"
-        textView.delegate = self
     }
     
     open func setupLayout() {
@@ -107,21 +96,5 @@ open class ChatChannelMessageInputView<ExtraData: UIExtraDataTypes>: UIView, UIT
         rightAccessoryButton.widthAnchor.constraint(equalToConstant: 20).isActive = true
         
         rightAccessoryButton.isHidden = true
-    }
-    
-    // MARK: - UITextViewDelegate
-    
-    public func textViewDidChange(_ textView: UITextView) {
-        textViewDidChange?(textView.text)
-        if textView.text == "\\giphy" {
-            textView.text = ""
-            slashCommandView.command = .giphy
-            container.leftStackView.isHidden = false
-            rightAccessoryButton.isHidden = false
-        }
-    }
-    
-    public func textViewDidEndEditing(_ textView: UITextView) {
-        textViewDidEndEditing?(textView.text)
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -15,7 +15,9 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
     
     public var controller: _ChatChannelController<ExtraData>!
 
-    lazy var messageInputAccessoryViewController = { MessageComposerInputAccessoryViewController() }()
+    public private(set) lazy var messageInputAccessoryViewController: MessageComposerInputAccessoryViewController<ExtraData> = {
+        .init()
+    }()
         
     public private(set) lazy var collectionView: UICollectionView = {
         let layout = uiConfig.messageList.collectionLayout.init()
@@ -48,7 +50,7 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
         navigationItem.largeTitleDisplayMode = .never
 
         installLongPress()
-        setupMessageComposer()
+        messageInputAccessoryViewController.controller = controller
     }
 
     override open func setUpLayout() {
@@ -96,11 +98,6 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress(_:)))
         collectionView.addGestureRecognizer(longPress)
     }
-    
-    func setupMessageComposer() {
-        composerView.sendButton.addTarget(self, action: #selector(sendMessage), for: .touchUpInside)
-        composerView.imagePicker.delegate = self
-    }
 
     // MARK: - Actions
 
@@ -121,36 +118,12 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
         }
     }
     
-    @objc func sendMessage(_ sender: Any) {
-        guard let text = composerView.messageInputView.textView.text else {
-            return
-        }
-        
-        controller?.createNewMessage(text: text)
-        
-        composerView.messageInputView.textView.text = ""
-    }
-    
     // MARK: - ChatChannelMessageComposerView
     
     override open var canBecomeFirstResponder: Bool { true }
     
-    var composerView = ChatChannelMessageComposerView<DefaultUIExtraData>(uiConfig: .default)
-
     override open var inputAccessoryViewController: UIInputViewController? {
         messageInputAccessoryViewController
-    }
-
-    public func imagePickerController(
-        _ picker: UIImagePickerController,
-        didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
-    ) {
-        guard let selectedImage = info[.originalImage] as? UIImage else { return }
-        
-        composerView.attachmentsView.insertNewItem(with: selectedImage)
-        picker.dismiss(animated: true) {
-            self.composerView.attachmentsView.isHidden = false
-        }
     }
     
     // MARK: - UICollectionViewDataSource

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposerAttachmentsView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposerAttachmentsView.swift
@@ -9,10 +9,15 @@ open class MessageComposerAttachmentsView<ExtraData: UIExtraDataTypes>: UIView,
     UICollectionViewDataSource {
     // MARK: - Properties
 
-    public weak var composer: UIView?
     public let uiConfig: UIConfig<ExtraData>
     
-    var attachments: [UIImage] = []
+    var previews: [UIImage] = [] {
+        didSet {
+            collectionView.reloadData()
+        }
+    }
+    
+    var didTapRemoveItemButton: ((Int) -> Void)?
     
     // MARK: - Subviews
     
@@ -68,37 +73,18 @@ open class MessageComposerAttachmentsView<ExtraData: UIExtraDataTypes>: UIView,
         collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "Cell")
     }
     
-    // MARK: - Actions
-    
-    public func insertNewItem(with image: UIImage) {
-        attachments.append(image)
-        collectionView.reloadData()
-        if !attachments.isEmpty {
-            isHidden = false
-        }
-    }
-
-    public func remove(at index: Int) {
-        attachments.remove(at: index)
-        collectionView.reloadData()
-        if attachments.isEmpty {
-            isHidden = true
-            composer?.invalidateIntrinsicContentSize()
-        }
-    }
-    
     // MARK: - UICollectionView
     
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        attachments.count
+        previews.count
     }
     
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath)
         let imageView = MessageComposerAttachmentsCellView(
-            image: attachments[indexPath.row],
+            image: previews[indexPath.row],
             deleteClosure: { [weak self] in
-                self?.remove(at: indexPath.row)
+                self?.didTapRemoveItemButton?(indexPath.row)
                 collectionView.reloadItems(at: collectionView.indexPathsForVisibleItems)
             }
         )

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposerInputAccessoryViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposerInputAccessoryViewController.swift
@@ -2,35 +2,161 @@
 // Copyright © 2020 Stream.io Inc. All rights reserved.
 //
 
+import StreamChat
 import UIKit
 
-class MessageComposerInputAccessoryViewController: UIInputViewController {
-    var composerView = ChatChannelMessageComposerView<DefaultUIExtraData>(uiConfig: .default).withoutAutoresizingMaskConstraints
-
-    override func viewDidLoad() {
+open class MessageComposerInputAccessoryViewController<ExtraData: UIExtraDataTypes>: UIInputViewController,
+    UIConfigProvider,
+    UITextViewDelegate,
+    UIImagePickerControllerDelegate,
+    UIDocumentPickerDelegate,
+    UINavigationControllerDelegate {
+    // MARK: - Properties
+    
+    var controller: _ChatChannelController<ExtraData>!
+    
+    // MARK: - Subviews
+        
+    public private(set) lazy var composerView: ChatChannelMessageComposerView<ExtraData> = {
+        ChatChannelMessageComposerView<ExtraData>(uiConfig: uiConfig).withoutAutoresizingMaskConstraints
+    }()
+    
+    public private(set) lazy var suggestionsViewController: MessageComposerSuggestionsViewController<ExtraData> = {
+        .init(uiConfig: uiConfig)
+    }()
+    
+    public private(set) lazy var imagePicker: UIImagePickerController = {
+        let picker = UIImagePickerController()
+        picker.mediaTypes = ["public.image", "public.movie"]
+        picker.sourceType = .photoLibrary
+        picker.delegate = self
+        return picker
+    }()
+    
+    // MARK: Setup
+    
+    override open func viewDidLoad() {
         super.viewDidLoad()
+        
+        setupInputView()
+        setUpLayout()
+    }
+    
+    func setupInputView() {
         inputView = composerView
-
-        guard let inputView = inputView else { return }
+        
         composerView.messageInputView.textView.delegate = self
-
+        composerView.attachmentButton.addTarget(self, action: #selector(showImagePicker), for: .touchUpInside)
+        composerView.sendButton.addTarget(self, action: #selector(sendMessage), for: .touchUpInside)
+        composerView.messageInputView.rightAccessoryButton.addTarget(
+            self,
+            action: #selector(dismissSlashCommand),
+            for: .touchUpInside
+        )
+        
+        composerView.attachmentsView.didTapRemoveItemButton = { [weak self] index in self?.imageAttachments.remove(at: index) }
+    }
+    
+    public func setUpLayout() {
+        guard let inputView = inputView else { return }
+        
         composerView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         composerView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
         composerView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
         composerView.topAnchor.constraint(equalTo: inputView.topAnchor).isActive = true
     }
-}
-
-// MARK: - UITextViewDelegate
-
-extension MessageComposerInputAccessoryViewController: UITextViewDelegate {
-    func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
+    
+    // MARK: Button actions
+    
+    @objc func sendMessage() {
+        guard let text = composerView.messageInputView.textView.text,
+            !text.replacingOccurrences(of: " ", with: "").isEmpty
+        else { return }
+        
+        controller?.createNewMessage(text: text)
+        composerView.messageInputView.textView.text = ""
+    }
+    
+    @objc func showImagePicker() {
+        present(imagePicker, animated: true, completion: nil)
+    }
+    
+    @objc func dismissSlashCommand() {
+        composerView.messageInputView.rightAccessoryButton.isHidden = true
+        composerView.messageInputView.container.leftStackView.isHidden = true
+    }
+    
+    // MARK: Suggestions
+    
+    func showSuggestionsViewController() {
+        addChild(suggestionsViewController)
+        view.addSubview(suggestionsViewController.view)
+        suggestionsViewController.didMove(toParent: self)
+    }
+    
+    func dismissSuggestionsViewController() {
+        suggestionsViewController.removeFromParent()
+        suggestionsViewController.view.removeFromSuperview()
+    }
+    
+    // MARK: Attachments
+    
+    var imageAttachments: [UIImage] = [] {
+        didSet {
+            didUpdateImageAttachments()
+        }
+    }
+    
+    func didUpdateImageAttachments() {
+        composerView.attachmentsView.previews = imageAttachments
+        composerView.attachmentsView.isHidden = imageAttachments.isEmpty
+        composerView.invalidateIntrinsicContentSize()
+    }
+    
+    // MARK: UITextView
+    
+    func promptSuggestionIfNeeded(for textView: UITextView) {
+        if textView.text == "\\" {
+            showSuggestionsViewController()
+        }
+    }
+    
+    func replaceTextWithSlashCommandViewIfNeeded(for textView: UITextView) {
+        if textView.text == "\\giphy" {
+            textView.text = ""
+            composerView.messageInputView.slashCommandView.command = .giphy
+            composerView.messageInputView.container.leftStackView.isHidden = false
+            composerView.messageInputView.rightAccessoryButton.isHidden = false
+            dismissSuggestionsViewController()
+        }
+    }
+    
+    // MARK: - UITextViewDelegate
+    
+    public func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
         composerView.messageInputView.textView.inputAccessoryView = view
         return true
     }
 
-    func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
+    public func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
         composerView.messageInputView.textView.inputAccessoryView = nil
         return true
+    }
+    
+    public func textViewDidChange(_ textView: UITextView) {
+        promptSuggestionIfNeeded(for: textView)
+        replaceTextWithSlashCommandViewIfNeeded(for: textView)
+    }
+
+    // MARK: - UIImagePickerControllerDelegate
+    
+    public func imagePickerController(
+        _ picker: UIImagePickerController,
+        didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+    ) {
+        guard let selectedImage = info[.originalImage] as? UIImage else { return }
+        
+        imageAttachments.append(selectedImage)
+        picker.dismiss(animated: true, completion: nil)
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposerSuggestionsViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposerSuggestionsViewController.swift
@@ -8,8 +8,6 @@ open class MessageComposerSuggestionsViewController<ExtraData: UIExtraDataTypes>
     UITableViewDelegate,
     UITableViewDataSource {
     // MARK: - Property
-    
-    public weak var owningViewController: UIViewController?
 
     public let uiConfig: UIConfig<ExtraData>
     
@@ -157,18 +155,6 @@ open class MessageComposerSuggestionsViewController<ExtraData: UIExtraDataTypes>
         
         view.setNeedsUpdateConstraints()
         view.layoutIfNeeded()
-    }
-        
-    public func show() {
-        guard let owner = owningViewController else { return }
-        owningViewController?.addChild(self)
-        owner.view.addSubview(view)
-        didMove(toParent: owner)
-    }
-    
-    public func dismiss() {
-        removeFromParent()
-        view.removeFromSuperview()
     }
     
     // MARK: - UITableView


### PR DESCRIPTION
**In this PR:** 

Intermediate PR with moving logic to `MessageComposerInputAccessoryViewController` and getting rid of passing the parent `UIView` or `UIViewController` down the hierarchy. 