### PR TITLE
[CIS-450] Photo gallery

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -223,7 +223,10 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
         return .init(
             message: message,
             parentMessageState: parentMessageState,
-            isLastInGroup: isLastInGroup
+            isLastInGroup: isLastInGroup,
+            didTapOnAttachment: { attachment in
+                debugPrint(attachment)
+            }
         )
     }
 

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageGroupPart.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageGroupPart.swift
@@ -9,6 +9,7 @@ public struct _ChatMessageGroupPart<ExtraData: ExtraDataTypes> {
     public let message: _ChatMessage<ExtraData>
     public let parentMessageState: ParentMessageState?
     public let isLastInGroup: Bool
+    public let didTapOnAttachment: ((_ChatMessageAttachment<ExtraData>) -> Void)?
 
     public var parentMessage: _ChatMessage<ExtraData>? {
         switch parentMessageState {

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageImageGallery.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageImageGallery.swift
@@ -1,0 +1,233 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Nuke
+import StreamChat
+import UIKit
+
+open class ChatMessageImageGallery<ExtraData: UIExtraDataTypes>: View, UIConfigProvider {
+    public var data: Data? {
+        didSet { updateContentIfNeeded() }
+    }
+
+    // MARK: - Subviews
+
+    public private(set) lazy var previews = [
+        createImagePreview(),
+        createImagePreview(),
+        createImagePreview(),
+        createImagePreview()
+    ]
+
+    public private(set) lazy var moreImagesOverlay: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .largeTitle).bold()
+        label.adjustsFontForContentSizeCategory = true
+        label.textAlignment = .center
+        return label.withoutAutoresizingMaskConstraints
+    }()
+
+    private var layouts: [[NSLayoutConstraint]] = []
+
+    // MARK: - Overrides
+
+    override open func setUpLayout() {
+        previews.forEach(addSubview)
+        addSubview(moreImagesOverlay)
+
+        let anchorSpacing = -uiConfig.messageList.messageContentSubviews.imageGalleryInteritemSpacing / 2
+
+        layouts = [
+            [
+                previews[0].leadingAnchor.constraint(equalTo: leadingAnchor),
+                previews[0].topAnchor.constraint(equalTo: topAnchor),
+                previews[0].bottomAnchor.constraint(equalTo: bottomAnchor),
+                previews[0].trailingAnchor.constraint(equalTo: trailingAnchor)
+            ],
+            [
+                previews[0].leadingAnchor.constraint(equalTo: leadingAnchor),
+                previews[0].topAnchor.constraint(equalTo: topAnchor),
+                previews[0].bottomAnchor.constraint(equalTo: bottomAnchor),
+                previews[0].widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.5, constant: anchorSpacing),
+                
+                previews[1].trailingAnchor.constraint(equalTo: trailingAnchor),
+                previews[1].topAnchor.constraint(equalTo: topAnchor),
+                previews[1].bottomAnchor.constraint(equalTo: bottomAnchor),
+                previews[1].widthAnchor.constraint(equalTo: previews[0].widthAnchor)
+            ],
+            [
+                previews[0].leadingAnchor.constraint(equalTo: leadingAnchor),
+                previews[0].topAnchor.constraint(equalTo: topAnchor),
+                previews[0].bottomAnchor.constraint(equalTo: bottomAnchor),
+                previews[0].widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.5, constant: anchorSpacing),
+                
+                previews[1].topAnchor.constraint(equalTo: topAnchor),
+                previews[1].trailingAnchor.constraint(equalTo: trailingAnchor),
+                previews[1].heightAnchor.constraint(equalTo: heightAnchor, multiplier: 0.5, constant: anchorSpacing),
+                previews[1].widthAnchor.constraint(equalTo: previews[0].widthAnchor),
+                
+                previews[2].trailingAnchor.constraint(equalTo: previews[1].trailingAnchor),
+                previews[2].heightAnchor.constraint(equalTo: previews[1].heightAnchor),
+                previews[2].widthAnchor.constraint(equalTo: previews[1].widthAnchor),
+                previews[2].bottomAnchor.constraint(equalTo: bottomAnchor)
+            ],
+            [
+                previews[0].leadingAnchor.constraint(equalTo: leadingAnchor),
+                previews[0].topAnchor.constraint(equalTo: topAnchor),
+                previews[0].widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.5, constant: anchorSpacing),
+                previews[0].heightAnchor.constraint(equalTo: widthAnchor, multiplier: 0.5, constant: anchorSpacing),
+                
+                previews[1].topAnchor.constraint(equalTo: topAnchor),
+                previews[1].trailingAnchor.constraint(equalTo: trailingAnchor),
+                previews[1].heightAnchor.constraint(equalTo: previews[0].heightAnchor),
+                previews[1].widthAnchor.constraint(equalTo: previews[0].widthAnchor),
+                
+                previews[2].leadingAnchor.constraint(equalTo: leadingAnchor),
+                previews[2].heightAnchor.constraint(equalTo: previews[0].heightAnchor),
+                previews[2].widthAnchor.constraint(equalTo: previews[0].widthAnchor),
+                previews[2].bottomAnchor.constraint(equalTo: bottomAnchor),
+                
+                previews[3].trailingAnchor.constraint(equalTo: trailingAnchor),
+                previews[3].heightAnchor.constraint(equalTo: previews[0].heightAnchor),
+                previews[3].widthAnchor.constraint(equalTo: previews[0].widthAnchor),
+                previews[3].bottomAnchor.constraint(equalTo: bottomAnchor)
+            ]
+        ]
+
+        NSLayoutConstraint.activate([
+            moreImagesOverlay.leadingAnchor.constraint(equalTo: previews[3].leadingAnchor),
+            moreImagesOverlay.trailingAnchor.constraint(equalTo: previews[3].trailingAnchor),
+            moreImagesOverlay.topAnchor.constraint(equalTo: previews[3].topAnchor),
+            moreImagesOverlay.bottomAnchor.constraint(equalTo: previews[3].bottomAnchor),
+            widthAnchor.constraint(equalTo: heightAnchor)
+        ])
+    }
+
+    override open func defaultAppearance() {
+        moreImagesOverlay.textColor = .white
+        moreImagesOverlay.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+    }
+
+    override open func updateContent() {
+        for (index, itemPreview) in previews.enumerated() {
+            let attachment = data?.attachments[safe: index]
+
+            itemPreview.isHidden = attachment == nil
+            itemPreview.previewURL = attachment?.imagePreviewURL ?? attachment?.imageURL
+            itemPreview.didTap = attachment.flatMap { image in
+                { [weak self] in
+                    self?.data?.didTapOnAttachment?(image)
+                }
+            }
+        }
+
+        let visiblePreviewsCount = previews.filter { !$0.isHidden }.count
+        layouts.flatMap { $0 }.forEach { $0.isActive = false }
+        layouts[max(visiblePreviewsCount - 1, 0)].forEach { $0.isActive = true }
+
+        let otherImagesCount = (data?.attachments.count ?? 0) - previews.count
+        moreImagesOverlay.isHidden = otherImagesCount <= 0
+        moreImagesOverlay.text = "+\(otherImagesCount)"
+    }
+
+    // MARK: - Private
+
+    private func createImagePreview() -> ImagePreview {
+        uiConfig
+            .messageList
+            .messageContentSubviews
+            .imageGalleryItem
+            .init()
+            .withoutAutoresizingMaskConstraints
+    }
+}
+
+// MARK: - Data
+
+extension ChatMessageImageGallery {
+    public struct Data {
+        public let attachments: [_ChatMessageAttachment<ExtraData>]
+        public let didTapOnAttachment: ((_ChatMessageAttachment<ExtraData>) -> Void)?
+
+        public init(
+            attachments: [_ChatMessageAttachment<ExtraData>],
+            didTapOnAttachment: ((_ChatMessageAttachment<ExtraData>) -> Void)?
+        ) {
+            self.attachments = attachments
+            self.didTapOnAttachment = didTapOnAttachment
+        }
+    }
+}
+
+// MARK: - ImagePreview
+
+extension ChatMessageImageGallery {
+    open class ImagePreview: View {
+        public var previewURL: URL? {
+            didSet { updateContentIfNeeded() }
+        }
+
+        public var didTap: (() -> Void)?
+
+        private var imageTask: ImageTask? {
+            didSet { oldValue?.cancel() }
+        }
+
+        // MARK: - Subviews
+
+        public private(set) lazy var imageView: UIImageView = {
+            let imageView = UIImageView()
+            imageView.contentMode = .scaleAspectFill
+            imageView.layer.masksToBounds = true
+            return imageView.withoutAutoresizingMaskConstraints
+        }()
+
+        public private(set) lazy var activityIndicator: UIActivityIndicatorView = {
+            let indicator = UIActivityIndicatorView()
+            indicator.hidesWhenStopped = true
+            indicator.style = .gray
+            return indicator.withoutAutoresizingMaskConstraints
+        }()
+
+        // MARK: - Overrides
+
+        override open func setUp() {
+            super.setUp()
+            
+            let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapHandler(_:)))
+            addGestureRecognizer(tapRecognizer)
+        }
+
+        override open func setUpLayout() {
+            embed(imageView)
+            embed(activityIndicator)
+        }
+
+        override open func updateContent() {
+            if let url = previewURL {
+                activityIndicator.startAnimating()
+                imageTask = loadImage(with: url, options: .shared, into: imageView, completion: { [weak self] _ in
+                    self?.activityIndicator.stopAnimating()
+                    self?.imageTask = nil
+                })
+            } else {
+                activityIndicator.stopAnimating()
+                imageView.image = nil
+                imageTask = nil
+            }
+        }
+
+        // MARK: - Actions
+
+        @objc open func tapHandler(_ recognizer: UITapGestureRecognizer) {
+            didTap?()
+        }
+
+        // MARK: - Init & Deinit
+
+        deinit {
+            imageTask?.cancel()
+        }
+    }
+}

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatRepliedMessageContentView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatRepliedMessageContentView.swift
@@ -57,7 +57,7 @@ open class ChatRepliedMessageContentView<ExtraData: UIExtraDataTypes>: View {
 
     override open func updateContent() {
         messageBubbleView.message = message.flatMap {
-            .init(message: $0, parentMessageState: nil, isLastInGroup: true)
+            .init(message: $0, parentMessageState: nil, isLastInGroup: true, didTapOnAttachment: nil)
         }
         messageBubbleView.isHidden = message == nil
 

--- a/Sources_v3/StreamChatUI/UIConfig.swift
+++ b/Sources_v3/StreamChatUI/UIConfig.swift
@@ -104,5 +104,9 @@ public extension UIConfig {
         public var metadataView: ChatMessageMetadataView<ExtraData>.Type = ChatMessageMetadataView<ExtraData>.self
         public var repliedMessageContentView: ChatRepliedMessageContentView<ExtraData>.Type =
             ChatRepliedMessageContentView<ExtraData>.self
+        public var imageGallery: ChatMessageImageGallery<ExtraData>.Type = ChatMessageImageGallery<ExtraData>.self
+        public var imageGalleryItem: ChatMessageImageGallery<ExtraData>.ImagePreview.Type =
+            ChatMessageImageGallery<ExtraData>.ImagePreview.self
+        public var imageGalleryInteritemSpacing: CGFloat = 2
     }
 }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -305,6 +305,7 @@
 		8837C63A2539B4A600D8FE86 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8837C6392539B4A600D8FE86 /* Date+Extensions.swift */; };
 		8837C6442539C17A00D8FE86 /* ChannelMember+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8837C6432539C17A00D8FE86 /* ChannelMember+Extensions.swift */; };
 		8837C66C2539E50500D8FE86 /* MemberListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8837C66B2539E50500D8FE86 /* MemberListView.swift */; };
+		883998212576397900294DB9 /* ChatMessageImageGallery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883998202576397900294DB9 /* ChatMessageImageGallery.swift */; };
 		8850B914255C1F77003AED69 /* NameAndImageProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8850B906255C1DE0003AED69 /* NameAndImageProviding.swift */; };
 		8850B92A255C286B003AED69 /* UIConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8850B929255C286B003AED69 /* UIConfig.swift */; };
 		8850B93C255C3168003AED69 /* ContainerStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8850B93B255C3168003AED69 /* ContainerStackView.swift */; };
@@ -934,6 +935,7 @@
 		8837C6392539B4A600D8FE86 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
 		8837C6432539C17A00D8FE86 /* ChannelMember+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelMember+Extensions.swift"; sourceTree = "<group>"; };
 		8837C66B2539E50500D8FE86 /* MemberListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemberListView.swift; sourceTree = "<group>"; };
+		883998202576397900294DB9 /* ChatMessageImageGallery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageImageGallery.swift; sourceTree = "<group>"; };
 		8850B906255C1DE0003AED69 /* NameAndImageProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameAndImageProviding.swift; sourceTree = "<group>"; };
 		8850B929255C286B003AED69 /* UIConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfig.swift; sourceTree = "<group>"; };
 		8850B93B255C3168003AED69 /* ContainerStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerStackView.swift; sourceTree = "<group>"; };
@@ -1380,6 +1382,7 @@
 				2210525E256FE16600A5F0DB /* MessageInputSlashCommandView.swift */,
 				22FF4364256E943F00133910 /* MessageComposerSuggestionsViewController.swift */,
 				E73A8B2A2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift */,
+				883998202576397900294DB9 /* ChatMessageImageGallery.swift */,
 			);
 			path = ChatChannel;
 			sourceTree = "<group>";
@@ -3030,6 +3033,7 @@
 				885B3D7725642B3D003E6BDF /* CurrentChatUserAvatarView.swift in Sources */,
 				224FF6912562F58F00725DD1 /* UIColor+Extensions.swift in Sources */,
 				79088339254876F200896F03 /* ChatChannelCollectionView.swift in Sources */,
+				883998212576397900294DB9 /* ChatMessageImageGallery.swift in Sources */,
 				2210525F256FE16600A5F0DB /* MessageInputSlashCommandView.swift in Sources */,
 				882AE057257A176A004095B3 /* ChatChannelRouter.swift in Sources */,
 				882AE124257A7FFE004095B3 /* UIViewController+Extensions.swift in Sources */,


### PR DESCRIPTION
**This PR:**
- introduces `ChatMessageImageGallery` type for displaying attachment image previews
- shows `ChatMessageImageGallery` to message bubble
- adjusts message bubble layout depending on message content
- photo gallery can have **1...4** previews, if more images are attached the `+N` overlay is shown on the last preview
- loading indicator is shown when the preview is being loaded

Screenshots:
![Simulator Screen Shot - iPhone 11 - 2020-12-04 at 12 33 55](https://user-images.githubusercontent.com/12818985/101147652-b8653200-362d-11eb-9c5f-1d1b50374be0.png)
![Simulator Screen Shot - iPhone 11 - 2020-12-04 at 12 34 08](https://user-images.githubusercontent.com/12818985/101147669-bd29e600-362d-11eb-85c7-f59502532d82.png)
![Simulator Screen Shot - iPhone 11 - 2020-12-04 at 12 38 45](https://user-images.githubusercontent.com/12818985/101147671-bdc27c80-362d-11eb-854f-7c2ad12bf157.png)
