### PR TITLE
[CIS-502] Prevent user from overscrolling out of visible content

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelCollectionViewLayout.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelCollectionViewLayout.swift
@@ -5,10 +5,17 @@
 import Foundation
 import UIKit
 
+/// This layout flips items such that item at indexPath 0-0 appears at the bottom of collectionView,
+/// while last item appears first.
+///
+/// Such approach comes with self-sizing cell issue: when you scroll to "estimated" cell bottom anchor, cell size calculated
+/// and you may jump right into middle of cell, because `collectionViewContentSize` have been changed,
+/// while `contentOffset` stay same.
+/// To fight it we lock `collectionViewContentSize`, now newly calculated cell "expands" up into invisible yet area, removing jumps.
 open class ChatChannelCollectionViewLayout: UICollectionViewFlowLayout {
     // MARK: - Init & Deinit
     
-    override public init() {
+    override public required init() {
         super.init()
         commonInit()
     }
@@ -22,8 +29,24 @@ open class ChatChannelCollectionViewLayout: UICollectionViewFlowLayout {
         minimumInteritemSpacing = 0
         minimumLineSpacing = 4
     }
+
+    open var zeroOffset: CGPoint {
+        CGPoint(
+            x: 0,
+            y: collectionViewContentSize.height - realContentSize.height
+        )
+    }
+
+    open var realContentSize: CGSize {
+        super.collectionViewContentSize
+    }
     
     // MARK: - Overrides
+
+    override open var collectionViewContentSize: CGSize {
+        let size = super.collectionViewContentSize
+        return CGSize(width: size.width, height: 100_000)
+    }
     
     override open func prepare() {
         super.prepare()
@@ -32,10 +55,6 @@ open class ChatChannelCollectionViewLayout: UICollectionViewFlowLayout {
             width: collectionView?.bounds.width ?? 0,
             height: 60
         )
-        if collectionView!.contentSize == .zero {
-            let newOffset = CGPoint(x: 0, y: collectionViewContentSize.height)
-            collectionView?.contentOffset = newOffset
-        }
     }
 
     override open func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
@@ -53,6 +72,32 @@ open class ChatChannelCollectionViewLayout: UICollectionViewFlowLayout {
     override open func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
         super.layoutAttributesForItem(at: indexPath).map(flip(_:))
     }
+
+    override open func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint) -> CGPoint {
+        // Content offset may be zero only when view just loaded for first time and needs to be scrolled to bottom
+        if proposedContentOffset == .zero {
+            return CGPoint(
+                x: 0,
+                y: collectionViewContentSize.height - (collectionView?.bounds.height ?? 0)
+            )
+        }
+        if proposedContentOffset.y < zeroOffset.y {
+            return zeroOffset
+        }
+        return super.targetContentOffset(forProposedContentOffset: proposedContentOffset)
+    }
+
+    override open func targetContentOffset(
+        forProposedContentOffset proposedContentOffset: CGPoint,
+        withScrollingVelocity velocity: CGPoint
+    ) -> CGPoint {
+        if proposedContentOffset.y < zeroOffset.y {
+            return zeroOffset
+        }
+        return super.targetContentOffset(forProposedContentOffset: proposedContentOffset, withScrollingVelocity: velocity)
+    }
+
+    // MARK: - Dark Magic
 
     private func flip(_ attribute: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
         let contentSize = collectionViewContentSize

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -18,10 +18,13 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
     public private(set) lazy var messageInputAccessoryViewController: MessageComposerInputAccessoryViewController<ExtraData> = {
         .init()
     }()
-        
+
+    public private(set) lazy var collectionViewLayout: ChatChannelCollectionViewLayout = uiConfig
+        .messageList
+        .collectionLayout
+        .init()
     public private(set) lazy var collectionView: UICollectionView = {
-        let layout = uiConfig.messageList.collectionLayout.init()
-        let collection = uiConfig.messageList.collectionView.init(layout: layout)
+        let collection = uiConfig.messageList.collectionView.init(layout: collectionViewLayout)
         collection.register(
             СhatIncomingMessageCollectionViewCell<ExtraData>.self,
             forCellWithReuseIdentifier: СhatIncomingMessageCollectionViewCell<ExtraData>.reuseId
@@ -172,11 +175,12 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
     }
     
     // MARK: - UIScrollViewDelegate
-    
+
     public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        guard scrollView.contentOffset.y <= 0 else { return }
-        
-        controller.loadNextMessages()
+        let realOffset = collectionView.contentOffset.y - collectionViewLayout.zeroOffset.y
+        if realOffset < uiConfig.messageList.offsetToPreloadMoreMessages {
+            controller.loadNextMessages()
+        }
     }
     
     // MARK: - Private

--- a/Sources_v3/StreamChatUI/UIConfig.swift
+++ b/Sources_v3/StreamChatUI/UIConfig.swift
@@ -79,8 +79,10 @@ public extension UIConfig {
 public extension UIConfig {
     struct MessageListUI {
         public var collectionView: ChatChannelCollectionView.Type = ChatChannelCollectionView.self
-        public var collectionLayout: UICollectionViewLayout.Type = ChatChannelCollectionViewLayout.self
+        public var collectionLayout: ChatChannelCollectionViewLayout.Type = ChatChannelCollectionViewLayout.self
         public var minTimeInvteralBetweenMessagesInGroup: TimeInterval = 10
+        /// Vertical contentOffset for message list, when next message batch should be requested
+        public var offsetToPreloadMoreMessages: CGFloat = 100
         public var messageContentView: ChatMessageContentView<ExtraData>.Type = ChatMessageContentView<ExtraData>.self
         public var messageContentSubviews = MessageContentViewSubviews()
         public var messageAvailableReactions: [MessageReactionType] = [


### PR DESCRIPTION
CollectionViewLayout flip comes with self-sizing cell issue: when you scroll to "estimated" cell bottom anchor, cell size calculated and you may jump right into middle of cell, because `collectionViewContentSize` have been changed, while `contentOffset` stay same.
To fight it we lock `collectionViewContentSize` to super big number simulating "infinite scroll", now newly calculated cell "expands" up into invisible yet area, removing jumps.