### PR TITLE
[CIS-462] Add UI for threads in message cell

### DIFF
--- a/Sources_v3/StreamChatUI/.swiftgen.yml
+++ b/Sources_v3/StreamChatUI/.swiftgen.yml
@@ -1,5 +1,7 @@
 strings:
-  inputs: Resources/en.lproj/Localizable.strings
+  inputs:
+    - Resources/en.lproj/Localizable.strings
+    - Resources/en.lproj/Localizable.stringsdict
   outputs:
     - templateName: structured-swift5
       output: Generated/L10n.swift

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -129,6 +129,10 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
             )
         )
     }
+
+    func showThread(for message: _ChatMessageGroupPart<ExtraData>?) {
+        debugPrint(message as Any)
+    }
     
     // MARK: - ChatChannelMessageComposerView
     
@@ -163,6 +167,7 @@ open class ChatChannelVC<ExtraData: UIExtraDataTypes>: ViewController,
             ) as! СhatIncomingMessageCollectionViewCell<ExtraData>
         }
 
+        cell.messageView.onThreadTap = { [weak self] in self?.showThread(for: $0) }
         cell.message = message
 
         return cell

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageBubbleView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageBubbleView.swift
@@ -209,7 +209,9 @@ open class ChatMessageBubbleView<ExtraData: UIExtraDataTypes>: View, UIConfigPro
             .layerMaxXMinYCorner,
             .layerMaxXMaxYCorner
         ]
-        
+
+        guard message?.isPartOfThread == false else { return roundedCorners }
+
         switch (message?.isLastInGroup, message?.isSentByCurrentUser) {
         case (true, true):
             roundedCorners.remove(.layerMaxXMaxYCorner)

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageContentView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageContentView.swift
@@ -10,6 +10,8 @@ open class ChatMessageContentView<ExtraData: UIExtraDataTypes>: View, UIConfigPr
         didSet { updateContentIfNeeded() }
     }
 
+    public var onThreadTap: (_ChatMessageGroupPart<ExtraData>?) -> Void = { _ in }
+
     // MARK: - Subviews
 
     public private(set) lazy var messageBubbleView = uiConfig
@@ -35,49 +37,93 @@ open class ChatMessageContentView<ExtraData: UIExtraDataTypes>: View, UIConfigPr
 
     let messageReactionsView = ChatMessageReactionsView().withoutAutoresizingMaskConstraints
 
+    public private(set) lazy var threadArrowView = uiConfig
+        .messageList
+        .messageContentSubviews
+        .threadArrowView
+        .init()
+        .withoutAutoresizingMaskConstraints
+
+    public private(set) lazy var threadView = uiConfig
+        .messageList
+        .messageContentSubviews
+        .threadInfoView
+        .init()
+        .withoutAutoresizingMaskConstraints
+
     private var incomingMessageConstraints: [NSLayoutConstraint] = []
     private var outgoingMessageConstraints: [NSLayoutConstraint] = []
     private var bubbleToReactionsConstraint: NSLayoutConstraint?
     private var bubbleToMetadataConstraint: NSLayoutConstraint?
 
+    private var incomingMessageIsThreadConstraints: [NSLayoutConstraint] = []
+    private var outgoingMessageIsThreadConstraints: [NSLayoutConstraint] = []
+
     // MARK: - Overrides
+
+    override open func setUp() {
+        super.setUp()
+        threadView.addTarget(self, action: #selector(didTapOnThread), for: .touchUpInside)
+    }
 
     override open func setUpLayout() {
         addSubview(messageBubbleView)
         addSubview(messageMetadataView)
         addSubview(authorAvatarView)
         addSubview(messageReactionsView)
+        addSubview(threadArrowView)
+        addSubview(threadView)
+
+        incomingMessageIsThreadConstraints = [
+            threadView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            messageMetadataView.leadingAnchor.constraint(equalToSystemSpacingAfter: threadView.trailingAnchor, multiplier: 1)
+        ]
+
+        outgoingMessageIsThreadConstraints = [
+            threadView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            threadView.leadingAnchor.constraint(equalToSystemSpacingAfter: messageMetadataView.trailingAnchor, multiplier: 1)
+        ]
 
         NSLayoutConstraint.activate([
             authorAvatarView.widthAnchor.constraint(equalToConstant: 32),
             authorAvatarView.heightAnchor.constraint(equalToConstant: 32),
             authorAvatarView.leadingAnchor.constraint(equalTo: leadingAnchor),
             authorAvatarView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            
+
             messageReactionsView.topAnchor.constraint(equalTo: topAnchor),
             messageReactionsView.bottomAnchor.constraint(equalTo: messageBubbleView.topAnchor),
-            
+
             messageBubbleView.trailingAnchor.constraint(equalTo: trailingAnchor),
             messageBubbleView.topAnchor.constraint(equalTo: topAnchor).with(priority: .defaultHigh),
             messageBubbleView.bottomAnchor.constraint(equalTo: bottomAnchor).with(priority: .defaultHigh),
 
             messageMetadataView.heightAnchor.constraint(equalToConstant: 16),
-            messageMetadataView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            messageMetadataView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            threadArrowView.widthAnchor.constraint(equalToConstant: 16),
+            threadArrowView.topAnchor.constraint(equalTo: messageBubbleView.centerYAnchor),
+            threadArrowView.bottomAnchor.constraint(equalTo: threadView.centerYAnchor),
+
+            threadView.topAnchor.constraint(equalToSystemSpacingBelow: messageBubbleView.bottomAnchor, multiplier: 1)
         ])
 
         incomingMessageConstraints = [
             messageReactionsView.centerXAnchor.constraint(equalTo: messageBubbleView.trailingAnchor),
-            messageMetadataView.leadingAnchor.constraint(equalTo: messageBubbleView.leadingAnchor),
+            messageMetadataView.leadingAnchor.constraint(equalTo: messageBubbleView.leadingAnchor).with(priority: .defaultHigh),
             messageBubbleView.leadingAnchor.constraint(
                 equalToSystemSpacingAfter: authorAvatarView.trailingAnchor,
                 multiplier: 1
-            )
+            ),
+            threadArrowView.leadingAnchor.constraint(equalTo: messageBubbleView.leadingAnchor),
+            threadView.leadingAnchor.constraint(equalTo: threadArrowView.trailingAnchor)
         ]
 
         outgoingMessageConstraints = [
             messageReactionsView.centerXAnchor.constraint(equalTo: messageBubbleView.leadingAnchor),
-            messageMetadataView.trailingAnchor.constraint(equalTo: messageBubbleView.trailingAnchor),
-            messageBubbleView.leadingAnchor.constraint(equalTo: leadingAnchor)
+            messageMetadataView.trailingAnchor.constraint(equalTo: messageBubbleView.trailingAnchor).with(priority: .defaultHigh),
+            messageBubbleView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            threadArrowView.trailingAnchor.constraint(equalTo: messageBubbleView.trailingAnchor),
+            threadView.trailingAnchor.constraint(equalTo: threadArrowView.leadingAnchor)
         ]
 
         bubbleToReactionsConstraint = messageBubbleView.topAnchor.constraint(
@@ -90,14 +136,26 @@ open class ChatMessageContentView<ExtraData: UIExtraDataTypes>: View, UIConfigPr
     }
 
     override open func updateContent() {
+        let isOutgoing = message?.isSentByCurrentUser ?? false
+        let isPartOfThread = message?.isPartOfThread ?? false
+
         messageBubbleView.message = message
         messageMetadataView.message = message
-        if message?.isSentByCurrentUser ?? false {
+        threadView.message = message
+
+        if isOutgoing {
             messageReactionsView.style = .smallOutgoing
+            threadArrowView.direction = .toLeading
         } else {
             messageReactionsView.style = .smallIncoming
+            threadArrowView.direction = .toTrailing
         }
         messageReactionsView.reload(from: message?.message)
+
+        threadView.isHidden = !isPartOfThread
+        threadArrowView.isHidden = !isPartOfThread
+        outgoingMessageIsThreadConstraints.forEach { $0.isActive = isPartOfThread && isOutgoing }
+        incomingMessageIsThreadConstraints.forEach { $0.isActive = isPartOfThread && !isOutgoing }
 
         let placeholder = UIImage(named: "pattern1", in: .streamChatUI)
         if let imageURL = message?.author.imageURL {
@@ -106,13 +164,19 @@ open class ChatMessageContentView<ExtraData: UIExtraDataTypes>: View, UIConfigPr
             authorAvatarView.imageView.image = placeholder
         }
 
-        incomingMessageConstraints.forEach { $0.isActive = message?.isSentByCurrentUser == false }
-        outgoingMessageConstraints.forEach { $0.isActive = message?.isSentByCurrentUser == true }
+        incomingMessageConstraints.forEach { $0.isActive = !isOutgoing }
+        outgoingMessageConstraints.forEach { $0.isActive = isOutgoing }
         bubbleToReactionsConstraint?.isActive = message?.deletedAt == nil && !(message?.reactionScores.isEmpty ?? true)
         bubbleToMetadataConstraint?.isActive = message?.isLastInGroup == true
 
-        authorAvatarView.isVisible = message?.isSentByCurrentUser == false && message?.isLastInGroup == true
+        authorAvatarView.isVisible = !isOutgoing && message?.isLastInGroup == true
         messageMetadataView.isVisible = bubbleToMetadataConstraint?.isActive ?? false
         messageReactionsView.isVisible = bubbleToReactionsConstraint?.isActive ?? false
+    }
+
+    // MARK: - Actions
+
+    @objc func didTapOnThread() {
+        onThreadTap(message)
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageGroupPart.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageGroupPart.swift
@@ -19,6 +19,12 @@ public struct _ChatMessageGroupPart<ExtraData: ExtraDataTypes> {
             return nil
         }
     }
+
+    public var isPartOfThread: Bool {
+        let isThreadStart = message.replyCount > 0
+        let isReplyInChannel = message.parentMessageId != nil && message.showReplyInChannel
+        return isThreadStart || isReplyInChannel
+    }
 }
 
 extension _ChatMessageGroupPart {

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageThreadInfoView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageThreadInfoView.swift
@@ -1,0 +1,92 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+open class ChatMessageThreadInfoView<ExtraData: UIExtraDataTypes>: Control, UIConfigProvider {
+    public var message: _ChatMessageGroupPart<ExtraData>? {
+        didSet { updateContentIfNeeded() }
+    }
+
+    public private(set) lazy var avatarView = AvatarView().withoutAutoresizingMaskConstraints
+    public private(set) lazy var replyCountLabel: UILabel = {
+        let label = UILabel().withoutAutoresizingMaskConstraints
+        label.font = .preferredFont(forTextStyle: .footnote)
+        label.adjustsFontForContentSizeCategory = true
+        label.text = L10n.Message.Threads.reply
+        label.textColor = tintColor
+        return label
+    }()
+
+    public private(set) lazy var stack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [avatarView, replyCountLabel]).withoutAutoresizingMaskConstraints
+        stack.distribution = .fill
+        stack.alignment = .center
+        stack.axis = .horizontal
+        stack.spacing = UIStackView.spacingUseSystem
+        return stack
+    }()
+
+    // MARK: - Overrides
+
+    override open var isHighlighted: Bool {
+        didSet { updateAppearance() }
+    }
+
+    override open func tintColorDidChange() {
+        super.tintColorDidChange()
+        updateAppearance()
+    }
+
+    override open func setUpLayout() {
+        super.setUpLayout()
+        embed(stack)
+        avatarView.widthAnchor.constraint(equalToConstant: 16).isActive = true
+        avatarView.heightAnchor.constraint(equalToConstant: 16).with(priority: .defaultHigh).isActive = true
+        replyCountLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        replyCountLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+    }
+
+    override open func updateContent() {
+        super.updateContent()
+        if message?.parentMessageId == nil {
+            updateForThreadStart()
+        } else {
+            updateForThreadReply()
+        }
+        updateAppearance()
+    }
+
+    // MARK: - State configurations
+
+    open func updateAppearance() {
+        if isHighlighted {
+            replyCountLabel.textColor = uiConfig.colorPalette.highlightedColorForColor(tintColor)
+        } else {
+            replyCountLabel.textColor = tintColor
+        }
+    }
+
+    open func updateForThreadStart() {
+        if let latestReplyAuthorAvatar = message?.latestReplies.first?.author.imageURL {
+            avatarView.isHidden = false
+            avatarView.imageView.setImage(from: latestReplyAuthorAvatar)
+        } else {
+            avatarView.isHidden = true
+            avatarView.imageView.image = nil
+        }
+        if let replyCount = message?.replyCount {
+            replyCountLabel.text = L10n.Message.Threads.count(replyCount)
+        } else {
+            replyCountLabel.text = L10n.Message.Threads.reply
+        }
+    }
+
+    open func updateForThreadReply() {
+        avatarView.isHidden = true
+        avatarView.imageView.image = nil
+        replyCountLabel.text = L10n.Message.Threads.reply
+    }
+}

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageThreadInfoView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageThreadInfoView.swift
@@ -5,6 +5,59 @@
 import StreamChat
 import UIKit
 
+open class ChatMessageThreadArrowView: View, UIConfigProvider {
+    public typealias ExtraData = DefaultUIExtraData
+
+    public enum Direction {
+        case toTrailing
+        case toLeading
+    }
+
+    override public class var layerClass: AnyClass {
+        CAShapeLayer.self
+    }
+
+    public var shape: CAShapeLayer {
+        layer as! CAShapeLayer
+    }
+
+    public var direction: Direction = .toTrailing {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+
+    override open func defaultAppearance() {
+        shape.strokeColor = uiConfig.colorPalette.incomingMessageBubbleBorder.cgColor
+        shape.fillColor = nil
+        shape.lineWidth = 1.0 / UIScreen.main.scale
+    }
+
+    public var isLeftToRight: Bool {
+        let isLeftToRightWithTrailing = direction == .toTrailing && traitCollection.layoutDirection == .leftToRight
+        let isRightToLeftWithLeading = direction == .toLeading && traitCollection.layoutDirection == .rightToLeft
+        return isLeftToRightWithTrailing || isRightToLeftWithLeading
+    }
+
+    override open func draw(_ rect: CGRect) {
+        let corner: CGFloat = 16
+        let height = bounds.height
+
+        let startX = isLeftToRight ? 0 : bounds.width
+        let endX = isLeftToRight ? corner : (bounds.width - corner)
+
+        let path = CGMutablePath()
+        path.move(to: CGPoint(x: startX, y: 0))
+        path.addLine(to: CGPoint(x: startX, y: height - corner))
+        path.addQuadCurve(
+            to: CGPoint(x: endX, y: height),
+            control: CGPoint(x: startX, y: height)
+        )
+        shape.path = path
+        super.draw(rect)
+    }
+}
+
 open class ChatMessageThreadInfoView<ExtraData: UIExtraDataTypes>: Control, UIConfigProvider {
     public var message: _ChatMessageGroupPart<ExtraData>? {
         didSet { updateContentIfNeeded() }

--- a/Sources_v3/StreamChatUI/Generated/L10n.swift
+++ b/Sources_v3/StreamChatUI/Generated/L10n.swift
@@ -51,6 +51,14 @@ internal enum L10n {
         internal static let confirmationTitle = L10n.tr("Localizable", "message.actions.delete.confirmation-title")
       }
     }
+    internal enum Threads {
+      /// Plural format key: "%#@replies@"
+      internal static func count(_ p1: Int) -> String {
+        return L10n.tr("Localizable", "message.threads.count", p1)
+      }
+      /// Thread Reply
+      internal static let reply = L10n.tr("Localizable", "message.threads.reply")
+    }
   }
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length

--- a/Sources_v3/StreamChatUI/Resources/en.lproj/Localizable.strings
+++ b/Sources_v3/StreamChatUI/Resources/en.lproj/Localizable.strings
@@ -14,6 +14,8 @@
 "message.actions.user-unmute" = "Unmute User";
 "message.actions.user-mute" = "Mute User";
 
+"message.threads.reply" = "Thread Reply";
+
 "alert.actions.cancel" = "Cancel";
 "alert.actions.delete" = "Delete";
 

--- a/Sources_v3/StreamChatUI/Resources/en.lproj/Localizable.stringsdict
+++ b/Sources_v3/StreamChatUI/Resources/en.lproj/Localizable.stringsdict
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>message.threads.count</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@replies@</string>
+		<key>replies</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d Thread Reply</string>
+			<key>other</key>
+			<string>%d Thread Replies</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Sources_v3/StreamChatUI/UIConfig.swift
+++ b/Sources_v3/StreamChatUI/UIConfig.swift
@@ -136,6 +136,8 @@ public extension UIConfig {
         public var imageGalleryInteritemSpacing: CGFloat = 2
         public var onlyVisibleForCurrentUserIndicator: ChatMessageOnlyVisibleForCurrentUserIndicator.Type =
             ChatMessageOnlyVisibleForCurrentUserIndicator.self
+        public var threadArrowView: ChatMessageThreadArrowView.Type = ChatMessageThreadArrowView.self
+        public var threadInfoView: ChatMessageThreadInfoView<ExtraData>.Type = ChatMessageThreadInfoView<ExtraData>.self
     }
 }
 

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -520,6 +520,7 @@
 		DB70CFFB25702EB900DDF436 /* ChatMessagePopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB70CFFA25702EB900DDF436 /* ChatMessagePopupViewController.swift */; };
 		DB70D002257119C500DDF436 /* ChatMessageReactionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */; };
 		DBC8A4BB257E5BFB00B20A82 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DBC8A4BD257E5BFB00B20A82 /* Localizable.stringsdict */; };
+		DBC8A4C6257E696900B20A82 /* ChatMessageThreadInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC8A4C5257E696900B20A82 /* ChatMessageThreadInfoView.swift */; };
 		E73A8B2B2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73A8B2A2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift */; };
 		E759AC4D256E694F00341865 /* OnlineIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */; };
 		F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */; };
@@ -1167,6 +1168,7 @@
 		DB70CFFA25702EB900DDF436 /* ChatMessagePopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessagePopupViewController.swift; sourceTree = "<group>"; };
 		DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageReactionsView.swift; sourceTree = "<group>"; };
 		DBC8A4BC257E5BFB00B20A82 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		DBC8A4C5257E696900B20A82 /* ChatMessageThreadInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageThreadInfoView.swift; sourceTree = "<group>"; };
 		E73A8B2A2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageComposerInputAccessoryViewController.swift; sourceTree = "<group>"; };
 		E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineIndicatorView.swift; sourceTree = "<group>"; };
 		F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints_Tests.swift; sourceTree = "<group>"; };
@@ -1374,6 +1376,7 @@
 				79088330254876C100896F03 /* ChatChannelCollectionViewLayout.swift */,
 				7908832E254876C100896F03 /* ChatMessageCollectionViewCell.swift */,
 				88A8CF15256E7BDA004EA4C7 /* ChatMessageContentView.swift */,
+				DBC8A4C5257E696900B20A82 /* ChatMessageThreadInfoView.swift */,
 				88A8CF1F256E7C06004EA4C7 /* ChatMessageBubbleView.swift */,
 				88A8CF25256E7C31004EA4C7 /* ChatMessageMetadataView.swift */,
 				88A8CF0A256E7AC8004EA4C7 /* ChatMessageGroupPart.swift */,
@@ -3039,6 +3042,7 @@
 				790882ED25486B6D00896F03 /* ChatChannelListCollectionViewDataSource.swift in Sources */,
 				E73A8B2B2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift in Sources */,
 				885B3D7725642B3D003E6BDF /* CurrentChatUserAvatarView.swift in Sources */,
+				DBC8A4C6257E696900B20A82 /* ChatMessageThreadInfoView.swift in Sources */,
 				224FF6912562F58F00725DD1 /* UIColor+Extensions.swift in Sources */,
 				79088339254876F200896F03 /* ChatChannelCollectionView.swift in Sources */,
 				883998212576397900294DB9 /* ChatMessageImageGallery.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 		DB70CFF425701FE500DDF436 /* ChatChannelNavigationBarListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB70CFF325701FE500DDF436 /* ChatChannelNavigationBarListener.swift */; };
 		DB70CFFB25702EB900DDF436 /* ChatMessagePopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB70CFFA25702EB900DDF436 /* ChatMessagePopupViewController.swift */; };
 		DB70D002257119C500DDF436 /* ChatMessageReactionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */; };
+		DBC8A4BB257E5BFB00B20A82 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DBC8A4BD257E5BFB00B20A82 /* Localizable.stringsdict */; };
 		E73A8B2B2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73A8B2A2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift */; };
 		E759AC4D256E694F00341865 /* OnlineIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */; };
 		F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */; };
@@ -1165,6 +1166,7 @@
 		DB70CFF325701FE500DDF436 /* ChatChannelNavigationBarListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelNavigationBarListener.swift; sourceTree = "<group>"; };
 		DB70CFFA25702EB900DDF436 /* ChatMessagePopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessagePopupViewController.swift; sourceTree = "<group>"; };
 		DB70D001257119C500DDF436 /* ChatMessageReactionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageReactionsView.swift; sourceTree = "<group>"; };
+		DBC8A4BC257E5BFB00B20A82 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		E73A8B2A2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageComposerInputAccessoryViewController.swift; sourceTree = "<group>"; };
 		E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineIndicatorView.swift; sourceTree = "<group>"; };
 		F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints_Tests.swift; sourceTree = "<group>"; };
@@ -2168,6 +2170,7 @@
 			children = (
 				88E779B12563FA6B00BA79B6 /* Assets.xcassets */,
 				882AE0F1257A652A004095B3 /* Localizable.strings */,
+				DBC8A4BD257E5BFB00B20A82 /* Localizable.stringsdict */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -2764,6 +2767,7 @@
 			files = (
 				88F0D74B257E50B200F4B050 /* Assets.xcassets in Resources */,
 				88F0D743257E50B000F4B050 /* Localizable.strings in Resources */,
+				DBC8A4BB257E5BFB00B20A82 /* Localizable.stringsdict in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3589,6 +3593,14 @@
 				882AE0F0257A652A004095B3 /* en */,
 			);
 			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		DBC8A4BD257E5BFB00B20A82 /* Localizable.stringsdict */ = {
+			isa = PBXVariantGroup;
+			children = (
+				DBC8A4BC257E5BFB00B20A82 /* en */,
+			);
+			name = Localizable.stringsdict;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */


### PR DESCRIPTION
Adds info about number of replies to message bubble + api to open thread

Points of interest:
- `ChatMessageThreadArrowView` - dummy view that just draw reply tail for message bubble
- `ChatMessageThreadInfoView` - view that contains information about replies count and latest replier avatar
- `ChatMessageContentView` layout approach starts breaking up, since amount of states for message grows exponentially (now we on `incoming/outgoing`, `group body / footer`, part of reply or not, 8 total states).
<img width="348" alt="threadReplies" src="https://user-images.githubusercontent.com/6978940/101360416-e781da80-389d-11eb-8a07-30f80de92c9c.png">
<img width="365" alt="outgoingAvatar" src="https://user-images.githubusercontent.com/6978940/101387140-58d18580-38be-11eb-92fa-a0c41a06dc81.png">
<img width="360" alt="incomingAvatar" src="https://user-images.githubusercontent.com/6978940/101387150-5bcc7600-38be-11eb-89e7-822b8d859933.png">
