### PR TITLE
[CIS-480] Add placeholder to `ChatChannelMessageInputTextView`

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageInputTextView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageInputTextView.swift
@@ -1,0 +1,79 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+open class ChatChannelMessageInputTextView<ExtraData: UIExtraDataTypes>: UITextView,
+    AppearanceSetting,
+    Customizable,
+    UIConfigProvider
+{
+    // MARK: - Subviews
+    
+    public lazy var placeholderLabel: UILabel = UILabel().withoutAutoresizingMaskConstraints
+    
+    // MARK: - Overrides
+    
+    override public var text: String! {
+        didSet {
+            textDidChange()
+        }
+    }
+    
+    override public var attributedText: NSAttributedString! {
+        didSet {
+            textDidChange()
+        }
+    }
+    
+    override open func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        guard superview != nil else { return }
+        
+        setUp()
+        (self as! Self).applyDefaultAppearance()
+        setUpAppearance()
+        setUpLayout()
+        updateContent()
+    }
+    
+    // MARK: Public
+    
+    open func defaultAppearance() {
+        font = .preferredFont(forTextStyle: .callout)
+        textContainer.lineFragmentPadding = 10
+        
+        placeholderLabel.font = font
+        placeholderLabel.textColor = uiConfig.colorPalette.messageComposerPlaceholder
+        placeholderLabel.textAlignment = .center
+    }
+    
+    open func setUp() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(textDidChange),
+            name: UITextView.textDidChangeNotification,
+            object: nil
+        )
+    }
+    
+    open func setUpAppearance() {}
+    
+    open func setUpLayout() {
+        embed(placeholderLabel, insets: .init(
+            top: .zero,
+            leading: textContainer.lineFragmentPadding,
+            bottom: .zero,
+            trailing: .zero
+        ))
+        placeholderLabel.pin(anchors: [.centerY], to: self)
+    }
+    
+    open func updateContent() {}
+    
+    @objc func textDidChange() {
+        delegate?.textViewDidChange?(self)
+        placeholderLabel.isHidden = !text.isEmpty
+    }
+}

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageInputView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageInputView.swift
@@ -4,14 +4,6 @@
 
 import UIKit
 
-open class ChatChannelMessageInputTextView: UITextView {
-    override public var text: String? {
-        didSet {
-            delegate?.textViewDidChange?(self)
-        }
-    }
-}
-
 open class ChatChannelMessageInputView<ExtraData: UIExtraDataTypes>: UIView {
     // MARK: - Properties
     
@@ -35,7 +27,7 @@ open class ChatChannelMessageInputView<ExtraData: UIExtraDataTypes>: UIView {
     
     public private(set) lazy var container = ContainerStackView().withoutAutoresizingMaskConstraints
         
-    public private(set) lazy var textView: ChatChannelMessageInputTextView = {
+    public private(set) lazy var textView: ChatChannelMessageInputTextView<ExtraData> = {
         uiConfig.messageComposer.textView.init().withoutAutoresizingMaskConstraints
     }()
     

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposerInputAccessoryViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposerInputAccessoryViewController.swift
@@ -55,7 +55,7 @@ open class MessageComposerInputAccessoryViewController<ExtraData: UIExtraDataTyp
         .withoutAutoresizingMaskConstraints
     
     /// Convenience getter for underlying `textView`.
-    public var textView: UITextView {
+    public var textView: ChatChannelMessageInputTextView<ExtraData> {
         composerView.messageInputView.textView
     }
     
@@ -96,6 +96,7 @@ open class MessageComposerInputAccessoryViewController<ExtraData: UIExtraDataTyp
         switch state {
         case .initial:
             textView.text = ""
+            textView.placeholderLabel.text = L10n.Composer.Placeholder.message
             state = .empty(isEmpty: true)
             messageToEdit = nil
             replyMessage = nil
@@ -111,6 +112,7 @@ open class MessageComposerInputAccessoryViewController<ExtraData: UIExtraDataTyp
             composerView.shrinkInputButton.isHidden = isEmpty
         case let .slashCommand(command):
             textView.text = ""
+            textView.placeholderLabel.text = L10n.Composer.Placeholder.giphy
             composerView.messageInputView.slashCommandView.command = command
             composerView.messageInputView.setSlashCommandViews(hidden: false)
             dismissSuggestionsViewController()

--- a/Sources_v3/StreamChatUI/Generated/L10n.swift
+++ b/Sources_v3/StreamChatUI/Generated/L10n.swift
@@ -1,3 +1,7 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
 // swiftlint:disable all
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
@@ -10,86 +14,96 @@ import Foundation
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
+    internal enum Alert {
+        internal enum Actions {
+            /// Cancel
+            internal static let cancel = L10n.tr("Localizable", "alert.actions.cancel")
+            /// Delete
+            internal static let delete = L10n.tr("Localizable", "alert.actions.delete")
+        }
+    }
 
-  internal enum Alert {
-    internal enum Actions {
-      /// Cancel
-      internal static let cancel = L10n.tr("Localizable", "alert.actions.cancel")
-      /// Delete
-      internal static let delete = L10n.tr("Localizable", "alert.actions.delete")
-    }
-  }
+    internal enum Composer {
+        internal enum Placeholder {
+            /// Search GIFs
+            internal static let giphy = L10n.tr("Localizable", "composer.placeholder.giphy")
+            /// Send a message
+            internal static let message = L10n.tr("Localizable", "composer.placeholder.message")
+        }
 
-  internal enum Composer {
-    internal enum Title {
-      /// Edit Message
-      internal static let edit = L10n.tr("Localizable", "composer.title.edit")
-      /// Reply to Message
-      internal static let reply = L10n.tr("Localizable", "composer.title.reply")
+        internal enum Title {
+            /// Edit Message
+            internal static let edit = L10n.tr("Localizable", "composer.title.edit")
+            /// Reply to Message
+            internal static let reply = L10n.tr("Localizable", "composer.title.reply")
+        }
     }
-  }
 
-  internal enum Message {
-    /// Message deleted
-    internal static let deletedMessagePlaceholder = L10n.tr("Localizable", "message.deleted-message-placeholder")
-    /// Only visible to you
-    internal static let onlyVisibleToYou = L10n.tr("Localizable", "message.only-visible-to-you")
-    internal enum Actions {
-      /// Copy Message
-      internal static let copy = L10n.tr("Localizable", "message.actions.copy")
-      /// Delete Message
-      internal static let delete = L10n.tr("Localizable", "message.actions.delete")
-      /// Edit Message
-      internal static let edit = L10n.tr("Localizable", "message.actions.edit")
-      /// Reply
-      internal static let inlineReply = L10n.tr("Localizable", "message.actions.inline-reply")
-      /// Thread Reply
-      internal static let threadReply = L10n.tr("Localizable", "message.actions.thread-reply")
-      /// Block User
-      internal static let userBlock = L10n.tr("Localizable", "message.actions.user-block")
-      /// Mute User
-      internal static let userMute = L10n.tr("Localizable", "message.actions.user-mute")
-      /// Unblock User
-      internal static let userUnblock = L10n.tr("Localizable", "message.actions.user-unblock")
-      /// Unmute User
-      internal static let userUnmute = L10n.tr("Localizable", "message.actions.user-unmute")
-      internal enum Delete {
-        /// Are you sure you want to permanently delete this message?
-        internal static let confirmationMessage = L10n.tr("Localizable", "message.actions.delete.confirmation-message")
-        /// Delete Message
-        internal static let confirmationTitle = L10n.tr("Localizable", "message.actions.delete.confirmation-title")
-      }
+    internal enum Message {
+        /// Message deleted
+        internal static let deletedMessagePlaceholder = L10n.tr("Localizable", "message.deleted-message-placeholder")
+        /// Only visible to you
+        internal static let onlyVisibleToYou = L10n.tr("Localizable", "message.only-visible-to-you")
+        internal enum Actions {
+            /// Copy Message
+            internal static let copy = L10n.tr("Localizable", "message.actions.copy")
+            /// Delete Message
+            internal static let delete = L10n.tr("Localizable", "message.actions.delete")
+            /// Edit Message
+            internal static let edit = L10n.tr("Localizable", "message.actions.edit")
+            /// Reply
+            internal static let inlineReply = L10n.tr("Localizable", "message.actions.inline-reply")
+            /// Thread Reply
+            internal static let threadReply = L10n.tr("Localizable", "message.actions.thread-reply")
+            /// Block User
+            internal static let userBlock = L10n.tr("Localizable", "message.actions.user-block")
+            /// Mute User
+            internal static let userMute = L10n.tr("Localizable", "message.actions.user-mute")
+            /// Unblock User
+            internal static let userUnblock = L10n.tr("Localizable", "message.actions.user-unblock")
+            /// Unmute User
+            internal static let userUnmute = L10n.tr("Localizable", "message.actions.user-unmute")
+            internal enum Delete {
+                /// Are you sure you want to permanently delete this message?
+                internal static let confirmationMessage = L10n.tr("Localizable", "message.actions.delete.confirmation-message")
+                /// Delete Message
+                internal static let confirmationTitle = L10n.tr("Localizable", "message.actions.delete.confirmation-title")
+            }
+        }
+
+        internal enum Threads {
+            /// Plural format key: "%#@replies@"
+            internal static func count(_ p1: Int) -> String {
+                L10n.tr("Localizable", "message.threads.count", p1)
+            }
+
+            /// Thread Reply
+            internal static let reply = L10n.tr("Localizable", "message.threads.reply")
+        }
     }
-    internal enum Threads {
-      /// Plural format key: "%#@replies@"
-      internal static func count(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "message.threads.count", p1)
-      }
-      /// Thread Reply
-      internal static let reply = L10n.tr("Localizable", "message.threads.reply")
-    }
-  }
 }
+
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
 
 // MARK: - Implementation Details
 
 extension L10n {
-  private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
-    let format = BundleToken.bundle.localizedString(forKey: key, value: nil, table: table)
-    return String(format: format, locale: Locale.current, arguments: args)
-  }
+    private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
+        let format = BundleToken.bundle.localizedString(forKey: key, value: nil, table: table)
+        return String(format: format, locale: Locale.current, arguments: args)
+    }
 }
 
 // swiftlint:disable convenience_type
 private final class BundleToken {
-  static let bundle: Bundle = {
-    #if SWIFT_PACKAGE
-    return Bundle.module
-    #else
-    return Bundle(for: BundleToken.self)
-    #endif
-  }()
+    static let bundle: Bundle = {
+        #if SWIFT_PACKAGE
+        return Bundle.module
+        #else
+        return Bundle(for: BundleToken.self)
+        #endif
+    }()
 }
+
 // swiftlint:enable convenience_type

--- a/Sources_v3/StreamChatUI/Resources/en.lproj/Localizable.strings
+++ b/Sources_v3/StreamChatUI/Resources/en.lproj/Localizable.strings
@@ -24,3 +24,5 @@
 
 "composer.title.edit" = "Edit Message";
 "composer.title.reply" = "Reply to Message";
+"composer.placeholder.message" = "Send a message";
+"composer.placeholder.giphy" = "Search GIFs";

--- a/Sources_v3/StreamChatUI/UIConfig.swift
+++ b/Sources_v3/StreamChatUI/UIConfig.swift
@@ -54,6 +54,7 @@ public extension UIConfig {
         public var messageComposerBackground: UIColor = .white
         public var messageComposerButton: UIColor = .streamGray
         public var messageComposerStateIcon: UIColor = .streamGrayGainsboro
+        public var messageComposerPlaceholder: UIColor = .streamGray
 
         public var generalBackground: UIColor = UIColor(rgb: 0xfcfcfc)
         public var popupDimmedBackground: UIColor = UIColor.black.withAlphaComponent(0.2)
@@ -154,7 +155,7 @@ public extension UIConfig {
         public var attachmentsView: MessageComposerAttachmentsView<ExtraData>.Type = MessageComposerAttachmentsView<ExtraData>.self
         public var sendButton: MessageComposerSendButton<ExtraData>.Type = MessageComposerSendButton<ExtraData>.self
         public var composerButton: ChatSquareButton<ExtraData>.Type = ChatSquareButton<ExtraData>.self
-        public var textView: ChatChannelMessageInputTextView.Type = ChatChannelMessageInputTextView.self
+        public var textView: ChatChannelMessageInputTextView<ExtraData>.Type = ChatChannelMessageInputTextView<ExtraData>.self
     }
 }
 

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		224FF6972562F5AE00725DD1 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224FF6962562F5AE00725DD1 /* Bundle+Extensions.swift */; };
 		224FF69D2562F5D100725DD1 /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224FF69C2562F5D100725DD1 /* UIImage+Extensions.swift */; };
 		225DDDFC25799270009C280A /* ChatSquareButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225DDDFB25799270009C280A /* ChatSquareButton.swift */; };
+		226C438D25802AAD008B3648 /* ChatChannelMessageInputTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226C438C25802AAD008B3648 /* ChatChannelMessageInputTextView.swift */; };
 		22753599257C442300D1FDB6 /* MessageComposerSendButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22753598257C442300D1FDB6 /* MessageComposerSendButton.swift */; };
 		228190EB256733420048D7C6 /* UIFont+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228190EA256733420048D7C6 /* UIFont+Extensions.swift */; };
 		228DC80E25704B410080A49F /* MessageComposerAttachmentCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */; };
@@ -648,6 +649,7 @@
 		224FF6962562F5AE00725DD1 /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
 		224FF69C2562F5D100725DD1 /* UIImage+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
 		225DDDFB25799270009C280A /* ChatSquareButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSquareButton.swift; sourceTree = "<group>"; };
+		226C438C25802AAD008B3648 /* ChatChannelMessageInputTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelMessageInputTextView.swift; sourceTree = "<group>"; };
 		22753598257C442300D1FDB6 /* MessageComposerSendButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerSendButton.swift; sourceTree = "<group>"; };
 		228190EA256733420048D7C6 /* UIFont+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extensions.swift"; sourceTree = "<group>"; };
 		228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerAttachmentCellView.swift; sourceTree = "<group>"; };
@@ -1395,6 +1397,7 @@
 				E73A8B2A2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift */,
 				883998202576397900294DB9 /* ChatMessageImageGallery.swift */,
 				22753598257C442300D1FDB6 /* MessageComposerSendButton.swift */,
+				226C438C25802AAD008B3648 /* ChatChannelMessageInputTextView.swift */,
 			);
 			path = ChatChannel;
 			sourceTree = "<group>";
@@ -3017,6 +3020,7 @@
 				7952764A255D86BD008531E8 /* UIExtraData.swift in Sources */,
 				88A8CF20256E7C06004EA4C7 /* ChatMessageBubbleView.swift in Sources */,
 				88A8CF16256E7BDA004EA4C7 /* ChatMessageContentView.swift in Sources */,
+				226C438D25802AAD008B3648 /* ChatChannelMessageInputTextView.swift in Sources */,
 				88D88F86257F9AA700AFE2A2 /* NSLayoutConstraint+Extensions.swift in Sources */,
 				88F8366D2578D1C60039AEC8 /* MessageActionsView.swift in Sources */,
 				8850FE87256558A200C8D534 /* ChatChannelListRouter.swift in Sources */,


### PR DESCRIPTION
In this PR: 
- Add placeholder to `ChatChannelMessageInputTextView`

Should be merged after https://github.com/GetStream/stream-chat-swift/pull/629.

<img width="300" alt="Screenshot 2020-12-08 at 22 54 56" src="https://user-images.githubusercontent.com/10098359/101546460-1a64c500-39a9-11eb-910c-89f278411398.png">
<img width="300" alt="Screenshot 2020-12-08 at 22 55 03" src="https://user-images.githubusercontent.com/10098359/101546465-1c2e8880-39a9-11eb-9e6c-80b3aa2834fe.png">
<img width="300" alt="Screenshot 2020-12-08 at 22 55 11" src="https://user-images.githubusercontent.com/10098359/101546470-1cc71f00-39a9-11eb-917c-93f5e8cb82cd.png">
<img width="300" alt="Screenshot 2020-12-08 at 22 55 22" src="https://user-images.githubusercontent.com/10098359/101546474-1d5fb580-39a9-11eb-9941-9cc400200984.png">
