### PR TITLE
Fix UIConfig not being passed down for VCs

### DIFF
--- a/Sources_v3/StreamChatUI/UIConfig.swift
+++ b/Sources_v3/StreamChatUI/UIConfig.swift
@@ -12,6 +12,8 @@ public struct UIConfig<ExtraData: ExtraDataTypes> {
     public var currentUser = CurrentUserUI()
     public var navigation = Navigation()
     public var colorPalette = ColorPalette()
+    
+    public init() {}
 }
 
 // MARK: - UIConfig + Default

--- a/Sources_v3/StreamChatUI/Utils/UIConfigProvider_Tests.swift
+++ b/Sources_v3/StreamChatUI/Utils/UIConfigProvider_Tests.swift
@@ -1,0 +1,104 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamChat
+@testable import StreamChatUI
+import XCTest
+
+class UIConfigProvider_Tests: XCTestCase {
+    typealias ExtraData = DefaultExtraData
+    
+    func test_uiConfig_passedDownToSubview() {
+        let parentView = TestView<ExtraData>()
+        let subView = TestView<ExtraData>()
+        
+        var uiConfig = UIConfig<ExtraData>()
+        // Set some random subclass to check if the config is passed down
+        uiConfig.channelList.newChannelButton = TestButton.self
+        
+        parentView.addSubview(subView)
+        parentView.uiConfig = uiConfig
+        
+        // We can only compare string descriptions, which should be good enough
+        XCTAssertEqual(
+            String(describing: subView.uiConfig.channelList.newChannelButton),
+            String(describing: uiConfig.channelList.newChannelButton)
+        )
+    }
+    
+    func test_uiConfig_passedDown_ignoringNonProviders() {
+        let parentView = TestView<ExtraData>()
+        let intermediateView = UIView()
+        let subView = TestView<ExtraData>()
+        
+        var uiConfig = UIConfig<ExtraData>()
+        // Set some random subclass to check if the config is passed down
+        uiConfig.channelList.newChannelButton = TestButton.self
+        
+        parentView.addSubview(intermediateView)
+        intermediateView.addSubview(subView)
+        parentView.uiConfig = uiConfig
+        
+        // We can only compare string descriptions, which should be good enough
+        XCTAssertEqual(
+            String(describing: subView.uiConfig.channelList.newChannelButton),
+            String(describing: uiConfig.channelList.newChannelButton)
+        )
+    }
+    
+    func test_uiConfig_passedDownToVCView() {
+        let vc = TestViewController<ExtraData>()
+        
+        var uiConfig = UIConfig<ExtraData>()
+        // Set some random subclass to check if the config is passed down
+        uiConfig.channelList.newChannelButton = TestButton.self
+        
+        vc.uiConfig = uiConfig
+        
+        // Force to call viewDidLoad
+        vc.loadViewIfNeeded()
+        
+        // We can only compare string descriptions, which should be good enough
+        XCTAssertEqual(
+            String(describing: vc.subView.uiConfig.channelList.newChannelButton),
+            String(describing: uiConfig.channelList.newChannelButton)
+        )
+    }
+    
+    func test_vcSubviews_initedFromConfig() {
+        let vc = TestViewController<ExtraData>()
+        
+        var uiConfig = UIConfig<ExtraData>()
+        // Set some random subclass to check if the config is passed down
+        uiConfig.channelList.newChannelButton = TestButton.self
+        
+        vc.uiConfig = uiConfig
+        
+        // Force to call viewDidLoad
+        vc.loadViewIfNeeded()
+        
+        // We can only compare string descriptions, which should be good enough
+        XCTAssertEqual(
+            String(describing: type(of: vc.testButton)),
+            String(describing: uiConfig.channelList.newChannelButton)
+        )
+    }
+}
+
+private class TestView<ExtraData: ExtraDataTypes>: UIView, UIConfigProvider {}
+
+private class TestViewController<ExtraData: ExtraDataTypes>: UIViewController, UIConfigProvider {
+    let subView = TestView<ExtraData>()
+    lazy var testButton = uiConfig.channelList.newChannelButton.init()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.addSubview(subView)
+        view.addSubview(testButton)
+    }
+}
+
+private class TestButton: CreateNewChannelButton {}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		793C14DC24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793C14DB24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift */; };
 		794927ED249E0BE2009D7EB7 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794927EC249E0BE2009D7EB7 /* ExtraData.swift */; };
 		794927F3249E3F77009D7EB7 /* NotificationAddedToChannel.json in Resources */ = {isa = PBXBuildFile; fileRef = 794927EE249E3D37009D7EB7 /* NotificationAddedToChannel.json */; };
+		795296C12582494000435B2E /* UIConfigProvider_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795296C02582494000435B2E /* UIConfigProvider_Tests.swift */; };
 		7952B3B324D4560E00AC53D4 /* ChannelController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7952B3B224D314B100AC53D4 /* ChannelController_Tests.swift */; };
 		7952B3B524D45DA300AC53D4 /* ChannelUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7952B3B424D45D9400AC53D4 /* ChannelUpdater_Tests.swift */; };
 		7962958C248147430078EB53 /* BaseURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7962958B248147430078EB53 /* BaseURL.swift */; };
@@ -776,6 +777,7 @@
 		794927EC249E0BE2009D7EB7 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
 		794927EE249E3D37009D7EB7 /* NotificationAddedToChannel.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = NotificationAddedToChannel.json; sourceTree = "<group>"; };
 		794927F0249E3DE6009D7EB7 /* EventPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventPayload_Tests.swift; sourceTree = "<group>"; };
+		795296C02582494000435B2E /* UIConfigProvider_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfigProvider_Tests.swift; sourceTree = "<group>"; };
 		7952B3B224D314B100AC53D4 /* ChannelController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelController_Tests.swift; sourceTree = "<group>"; };
 		7952B3B424D45D9400AC53D4 /* ChannelUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelUpdater_Tests.swift; sourceTree = "<group>"; };
 		7962958B248147430078EB53 /* BaseURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseURL.swift; sourceTree = "<group>"; };
@@ -2104,6 +2106,7 @@
 				88EF29FE2571288600B06EF1 /* Array+Extensions.swift */,
 				882AE123257A7FFE004095B3 /* UIViewController+Extensions.swift */,
 				88D88F85257F9AA700AFE2A2 /* NSLayoutConstraint+Extensions.swift */,
+				795296C02582494000435B2E /* UIConfigProvider_Tests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3061,6 +3064,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				795296C12582494000435B2E /* UIConfigProvider_Tests.swift in Sources */,
 				792A71AD2577E0510082498D /* ChatChannelVC_Tests.swift in Sources */,
 				7908823C25432C9000896F03 /* StreamChatUITests.swift in Sources */,
 			);


### PR DESCRIPTION
### Problem

If we use the VC's `view` property for storing/getting `uiConfig`, we'll assume by the time we need it, `view` will be initialised.

In the old impl, when we call:
```swift
chatList.uiConfig = uiConfig
```
we call `register`, which in turn does:
```
func register<T: ExtraDataTypes>(config: UIConfig<T>) {
        view.anyUIConfig = config
}
```
which accesses `view` so `loadView` and `viewDidLoad` gets called. This initializes all subviews of the VC _before actually assigning_ `uiConfig`

So we need to be able to assign `uiConfig` before initializing `view`