### PR TITLE
Add option to disable scroll to bottom when new messages are received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
-### 🔄 Changed
+### ✅ Added
+- `ChatViewController.scrollOnNewData` to specify whether the messages table view should scroll down on any new message. Defaults to `true`. `false` will still scroll down when data is authored by the current user.
 
 # [2.5.0](https://github.com/GetStream/stream-chat-swift/releases/tag/2.5.0)
 _November 26, 2020_

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -58,7 +58,14 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
     private var needsToReload = true
     /// A reaction view.
     weak var reactionsView: ReactionsView?
-    var scrollEnabled: Bool { reactionsView == nil }
+
+    /// Whether the table view should scroll when data is added to the table view
+    var canScroll: Bool { reactionsView == nil && (isAtBottom || scrollOnNewData) }
+    /// Whether the table view is scrolled all the way down
+    var isAtBottom: Bool { tableView.contentOffset.y >= (tableView.contentSize.height - tableView.frame.size.height) }
+    /// Whether to scroll to bottom when any new data is added to the bottom of the table view. Defaults to `true`. `false` will still scroll when data is authored by the current user.
+    public var scrollOnNewData: Bool = true
+    
     /// A composer view.
     public private(set) lazy var composerView = createComposerView()
     var keyboardIsVisible = false
@@ -206,7 +213,7 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
         markReadIfPossible()
         
         if let presenter = presenter, (needsToReload || presenter.items != items) {
-            let scrollToBottom = items.isEmpty || (scrollEnabled && tableView.bottomContentOffset < bottomThreshold)
+            let scrollToBottom = items.isEmpty || (canScroll && tableView.bottomContentOffset < bottomThreshold)
             refreshTableView(scrollToBottom: scrollToBottom, animated: false)
         }
     }
@@ -457,7 +464,7 @@ extension ChatViewController {
             
             tableView.reloadData()
             
-            if scrollToRow >= 0 && (isLoading || scrollEnabled) {
+            if scrollToRow >= 0 && (isLoading || canScroll) {
                 tableView.scrollToRowIfPossible(at: scrollToRow, animated: false)
             }
             
@@ -493,7 +500,7 @@ extension ChatViewController {
                     + minMessageHeight
             }
             
-            let needsToScroll = forceToScroll || (scrollEnabled && (effectiveContentHeight >= tableView.frame.height))
+            let needsToScroll = forceToScroll || (canScroll && (effectiveContentHeight >= tableView.frame.height))
             
             if forceToScroll {
                 reactionsView?.dismiss()

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -63,7 +63,8 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
     var canScroll: Bool { reactionsView == nil && (isAtBottom || scrollOnNewData) }
     /// Whether the table view is scrolled all the way down
     var isAtBottom: Bool { tableView.contentOffset.y >= (tableView.contentSize.height - tableView.frame.size.height) }
-    /// Whether to scroll to bottom when any new data is added to the bottom of the table view. Defaults to `true`. `false` will still scroll when data is authored by the current user.
+    /// Whether to scroll to bottom when any new data is added to the bottom of the table view. Defaults to `true`.
+    /// `false` will still scroll when data is authored by the current user.
     public var scrollOnNewData: Bool = true
     
     /// A composer view.


### PR DESCRIPTION
The table view always scrolls to the bottom when new messages are received. This can be annoying if you're looking at older messages and the channel is very active. I added an option `scrollOnNewData` that when set to `false` disables this behavior. If it's false, the table view will only scroll if it's already at the bottom.

Decided to rename `scrollEnabled` to `canScroll` so it reads better as a passive computed property.