### PR TITLE
[CIS-499] User Search Controller

### DIFF
--- a/Sources_v3/StreamChat/Controllers/SearchControllers/UserSearchController.swift
+++ b/Sources_v3/StreamChat/Controllers/SearchControllers/UserSearchController.swift
@@ -1,0 +1,326 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+extension _ChatClient {
+    /// Creates a new `_ChatUserSearchController` with the provided user query.
+    ///
+    /// - Parameter query: The query specify the filter and sorting of the users the controller should fetch.
+    ///
+    /// - Returns: A new instance of `_ChatUserSearchController`.
+    ///
+    public func userSearchController() -> _ChatUserSearchController<ExtraData> {
+        .init(client: self)
+    }
+}
+
+/// `_ChatUserSearchController` is a controller class which allows observing a list of chat users based on the provided query.
+///
+/// Learn more about `_ChatUserSearchController` and its usage in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#user-list).
+///
+/// - Note: `ChatUserSearchController` is a typealias of `_ChatUserSearchController` with default extra data. If you're using
+/// custom extra data, create your own typealias of `_ChatUserSearchController`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public typealias ChatUserSearchController = _ChatUserSearchController<DefaultExtraData>
+
+public class _ChatUserSearchController<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
+    /// The `ChatClient` instance this controller belongs to.
+    public let client: _ChatClient<ExtraData>
+    
+    /// Filter hash this controller observes.
+    let explicitFilterHash = UUID().uuidString
+    
+    lazy var query: UserListQuery<ExtraData.User> = {
+        // Filter is just a mock, explicit hash will override it
+        var query = UserListQuery<ExtraData.User>(filter: .exists(.id))
+        // Setting `shouldBeObserved` to false prevents NewUserQueryUpdater to pick this query up
+        query.shouldBeUpdatedInBackground = false
+        // The initial DB fetch will return 0 users and this is expected
+        // In the future we'll implement DB search too
+        query.filter?.explicitHash = explicitFilterHash
+        
+        return query
+    }()
+    
+    /// Copy of last search query made, used for getting next page.
+    var lastQuery: UserListQuery<ExtraData.User>?
+    
+    /// The users matching the query of this controller.
+    ///
+    /// To observe changes of the users, set your class as a delegate of this controller or use the provided
+    /// `Combine` publishers.
+    ///
+    public var users: [_ChatUser<ExtraData.User>] { userListObserver.items }
+    
+    lazy var userQueryUpdater = self.environment
+        .userQueryUpdaterBuilder(
+            client.databaseContainer,
+            client.webSocketClient,
+            client.apiClient
+        )
+    
+    /// Used for observing the database for changes.
+    lazy var userListObserver: ListDatabaseObserver<_ChatUser<ExtraData.User>, UserDTO> = {
+        let request = UserDTO.userListFetchRequest(query: query)
+        
+        let observer = self.environment.createUserListDatabaseObserver(
+            client.databaseContainer.viewContext,
+            request,
+            { $0.asModel() }
+        )
+        
+        observer.onChange = { [unowned self] changes in
+            self.delegateCallback {
+                $0.controller(self, didChangeUsers: changes)
+            }
+        }
+        
+        do {
+            try observer.startObserving()
+            state = .localDataFetched
+        } catch {
+            state = .localDataFetchFailed(ClientError(with: error))
+            log.error("Failed to perform fetch request with error: \(error). This is an internal error.")
+        }
+        
+        return observer
+    }()
+    
+    /// A type-erased delegate.
+    var multicastDelegate: MulticastDelegate<AnyUserSearchControllerDelegate<ExtraData>> = .init() {
+        didSet {
+            stateMulticastDelegate.mainDelegate = multicastDelegate.mainDelegate
+            stateMulticastDelegate.additionalDelegates = multicastDelegate.additionalDelegates
+            
+            // After setting delegate local changes will be fetched and observed.
+            startUserListObserver()
+        }
+    }
+    
+    private let environment: Environment
+    
+    init(client: _ChatClient<ExtraData>, environment: Environment = .init()) {
+        self.client = client
+        self.environment = environment
+    }
+    
+    deinit {
+        let query = self.query
+        client.databaseContainer.write { session in
+            session.deleteQuery(query)
+        }
+    }
+    
+    /// Initializing of `userListObserver` will start local data observing.
+    /// In most cases it will be done by accessing `users` but it's possible that only
+    /// changes will be observed.
+    private func startUserListObserver() {
+        _ = userListObserver
+    }
+    
+    /// Sets the provided object as a delegate of this controller.
+    ///
+    /// - Note: If you don't use custom extra data types, you can set the delegate directly using `controller.delegate = self`.
+    /// Due to the current limits of Swift and the way it handles protocols with associated types, it's required to use this
+    /// method to set the delegate, if you're using custom extra data types.
+    ///
+    /// - Parameter delegate: The object used as a delegate. It's referenced weakly, so you need to keep the object
+    /// alive if you want keep receiving updates.
+    ///
+    public func setDelegate<Delegate: _ChatUserSearchControllerDelegate>(_ delegate: Delegate)
+        where Delegate.ExtraData == ExtraData {
+        multicastDelegate.mainDelegate = AnyUserSearchControllerDelegate(delegate)
+    }
+    
+    /// Searches users for the given term.
+    ///
+    /// When this function is called, `users` property of this controller will refresh with new users matching the term.
+    /// The delegate function `didChangeUsers` will also be called.
+    ///
+    /// - Note: Currently, no local data will be searched, only remote data will be queried.
+    ///
+    /// - Parameters:
+    ///   - term: Search term.
+    ///   - completion: Called when the controller has finished fetching remote data.
+    ///   If the data fetching fails, the error variable contains more details about the problem.
+    public func search(term: String, completion: ((_ error: Error?) -> Void)? = nil) {
+        var query = UserListQuery<ExtraData.User>(filter: .or([
+            .autocomplete(.name, text: term),
+            .autocomplete(.id, text: term)
+        ]))
+        query.filter?.explicitHash = explicitFilterHash
+        // We don't need to set `shouldBeObserved = false` since this is done when we first init the query
+        // with this filter hash (see `userListQueryUpdater` above)
+        
+        lastQuery = query
+        
+        userQueryUpdater.update(userListQuery: query, policy: .replace) { [weak self] error in
+            guard let self = self else { return }
+            self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
+            self.callback { completion?(error) }
+        }
+    }
+    
+    /// Loads next users from backend.
+    ///
+    /// - Parameters:
+    ///   - limit: Limit for page size.
+    ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    ///                 If request fails, the completion will be called with an error.
+    ///
+    func loadNextUsers(
+        limit: Int = 25,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        guard let lastQuery = lastQuery else {
+            completion?(ClientError("You should make a search before calling for next page."))
+            return
+        }
+        
+        var updatedQuery = lastQuery
+        updatedQuery.pagination = Pagination(pageSize: limit, offset: users.count)
+        userQueryUpdater.update(userListQuery: updatedQuery) { [weak self] error in
+            self?.callback { completion?(error) }
+        }
+    }
+}
+
+extension _ChatUserSearchController {
+    struct Environment {
+        var userQueryUpdaterBuilder: (
+            _ database: DatabaseContainer,
+            _ webSocketClient: WebSocketClient,
+            _ apiClient: APIClient
+        ) -> UserListUpdater<ExtraData.User> = UserListUpdater.init
+        
+        var createUserListDatabaseObserver: (
+            _ context: NSManagedObjectContext,
+            _ fetchRequest: NSFetchRequest<UserDTO>,
+            _ itemCreator: @escaping (UserDTO) -> _ChatUser<ExtraData.User>?
+        )
+            -> ListDatabaseObserver<_ChatUser<ExtraData.User>, UserDTO> = {
+                ListDatabaseObserver(context: $0, fetchRequest: $1, itemCreator: $2)
+            }
+    }
+}
+
+extension _ChatUserSearchController where ExtraData == DefaultExtraData {
+    /// Set the delegate of `UserListController` to observe the changes in the system.
+    ///
+    /// - Note: The delegate can be set directly only if you're **not** using custom extra data types. Due to the current
+    /// limits of Swift and the way it handles protocols with associated types, it's required to use `setDelegate` method
+    /// instead to set the delegate, if you're using custom extra data types.
+    public weak var delegate: ChatUserSearchControllerDelegate? {
+        get { multicastDelegate.mainDelegate?.wrappedDelegate as? ChatUserSearchControllerDelegate }
+        set { multicastDelegate.mainDelegate = AnyUserSearchControllerDelegate(newValue) }
+    }
+}
+
+/// `ChatUserSearchController` uses this protocol to communicate changes to its delegate.
+///
+/// If you're **not** using custom extra data types, you can use a convenience version of this protocol
+/// named `ChatUserSearchControllerDelegate`, which hides the generic types, and make the usage easier.
+///
+public protocol _ChatUserSearchControllerDelegate: DataControllerStateDelegate {
+    associatedtype ExtraData: ExtraDataTypes
+    
+    /// The controller changed the list of observed users.
+    ///
+    /// - Parameters:
+    ///   - controller: The controller emitting the change callback.
+    ///   - changes: The change to the list of users.
+    ///
+    func controller(
+        _ controller: _ChatUserSearchController<ExtraData>,
+        didChangeUsers changes: [ListChange<_ChatUser<ExtraData.User>>]
+    )
+}
+
+public extension _ChatUserSearchControllerDelegate {
+    func controller(
+        _ controller: _ChatUserSearchController<ExtraData>,
+        didChangeUsers changes: [ListChange<_ChatUser<ExtraData.User>>]
+    ) {}
+}
+
+/// `ChatUserSearchController` uses this protocol to communicate changes to its delegate.
+///
+/// This protocol can be used only when no custom extra data are specified. If you're using custom extra data types,
+/// please use `_ChatUserSearchControllerDelegate` instead.
+///
+public protocol ChatUserSearchControllerDelegate: DataControllerStateDelegate {
+    /// The controller changed the list of observed users.
+    ///
+    /// - Parameters:
+    ///   - controller: The controller emitting the change callback.
+    ///   - changes: The change to the list of users.
+    ///
+    func controller(
+        _ controller: ChatUserSearchController,
+        didChangeUsers changes: [ListChange<ChatUser>]
+    )
+}
+
+public extension ChatUserSearchControllerDelegate {
+    func controller(
+        _ controller: ChatUserSearchController,
+        didChangeUsers changes: [ListChange<ChatUser>]
+    ) {}
+}
+
+// MARK: - Delegate type eraser
+
+class AnyUserSearchControllerDelegate<ExtraData: ExtraDataTypes>: _ChatUserSearchControllerDelegate {
+    private var _controllerDidChangeUsers: (_ChatUserSearchController<ExtraData>, [ListChange<_ChatUser<ExtraData.User>>])
+        -> Void
+    private var _controllerDidChangeState: (DataController, DataController.State) -> Void
+    
+    weak var wrappedDelegate: AnyObject?
+    
+    init(
+        wrappedDelegate: AnyObject?,
+        controllerDidChangeState: @escaping (DataController, DataController.State) -> Void,
+        controllerDidChangeUsers: @escaping (_ChatUserSearchController<ExtraData>, [ListChange<_ChatUser<ExtraData.User>>])
+            -> Void
+    ) {
+        self.wrappedDelegate = wrappedDelegate
+        _controllerDidChangeState = controllerDidChangeState
+        _controllerDidChangeUsers = controllerDidChangeUsers
+    }
+    
+    func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        _controllerDidChangeState(controller, state)
+    }
+    
+    func controller(
+        _ controller: _ChatUserSearchController<ExtraData>,
+        didChangeUsers changes: [ListChange<_ChatUser<ExtraData.User>>]
+    ) {
+        _controllerDidChangeUsers(controller, changes)
+    }
+}
+
+extension AnyUserSearchControllerDelegate {
+    convenience init<Delegate: _ChatUserSearchControllerDelegate>(_ delegate: Delegate) where Delegate.ExtraData == ExtraData {
+        self.init(
+            wrappedDelegate: delegate,
+            controllerDidChangeState: { [weak delegate] in delegate?.controller($0, didChangeState: $1) },
+            controllerDidChangeUsers: { [weak delegate] in delegate?.controller($0, didChangeUsers: $1) }
+        )
+    }
+}
+
+extension AnyUserSearchControllerDelegate where ExtraData == DefaultExtraData {
+    convenience init(_ delegate: ChatUserSearchControllerDelegate?) {
+        self.init(
+            wrappedDelegate: delegate,
+            controllerDidChangeState: { [weak delegate] in delegate?.controller($0, didChangeState: $1) },
+            controllerDidChangeUsers: { [weak delegate] in delegate?.controller($0, didChangeUsers: $1) }
+        )
+    }
+}

--- a/Sources_v3/StreamChat/Controllers/SearchControllers/UserSearchController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/SearchControllers/UserSearchController_Tests.swift
@@ -1,0 +1,355 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+import XCTest
+
+class UserSearchController_Tests: StressTestCase {
+    fileprivate var env: TestEnvironment!
+    
+    var client: ChatClient!
+    
+    var controller: ChatUserSearchController!
+    var controllerCallbackQueueID: UUID!
+    /// Workaround for uwrapping **controllerCallbackQueueID!** in each closure that captures it
+    private var callbackQueueID: UUID { controllerCallbackQueueID }
+    
+    override func setUp() {
+        super.setUp()
+        
+        env = TestEnvironment()
+        client = _ChatClient.mock
+        controller = ChatUserSearchController(client: client, environment: env.environment)
+        controllerCallbackQueueID = UUID()
+        controller.callbackQueue = .testQueue(withId: controllerCallbackQueueID)
+    }
+    
+    override func tearDown() {
+        controllerCallbackQueueID = nil
+        
+        AssertAsync {
+            Assert.canBeReleased(&controller)
+            Assert.canBeReleased(&client)
+            Assert.canBeReleased(&env)
+        }
+        
+        super.tearDown()
+    }
+    
+    func test_clientIsCorrect() {
+        let controller = client.userSearchController()
+        XCTAssert(controller.client === client)
+    }
+    
+    func test_userListIsEmpty_beforeSearch() throws {
+        // Save a new user to DB, so DB is not empty
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveUser(payload: self.dummyUser, query: nil)
+        }
+        
+        // Assert that controller users is empty
+        XCTAssert(controller.users.isEmpty)
+    }
+    
+    func test_search_callsUserQueryUpdater() {
+        let queueId = UUID()
+        controller.callbackQueue = .testQueue(withId: queueId)
+        
+        // Simulate `search` calls and catch the completion
+        var completionCalled = false
+        controller.search(term: "test") { error in
+            XCTAssertNil(error)
+            AssertTestQueue(withId: queueId)
+            completionCalled = true
+        }
+        
+        // Assert the updater is called with the query
+        XCTAssertEqual(
+            env.userListUpdater?.update_queries.first?.filter?.filterHash,
+            controller.query.filter?.filterHash
+        )
+        // Completion shouldn't be called yet
+        XCTAssertFalse(completionCalled)
+        
+        // Simulate successful update
+        env.userListUpdater!.update_completion?(nil)
+        
+        // Completion should be called
+        AssertAsync.willBeTrue(completionCalled)
+    }
+    
+    func test_searchResult_isReported() throws {
+        // Set the delegate
+        let delegate = TestDelegate(expectedQueueId: controllerCallbackQueueID)
+        controller.delegate = delegate
+        
+        // Assert the delegate is assigned correctly. We should test this because of the type-erasing we
+        // do in the controller.
+        XCTAssert(controller.delegate === delegate)
+        
+        // Assert that controller users is empty
+        XCTAssert(controller.users.isEmpty)
+        
+        // Assert that state is updated
+        XCTAssertEqual(delegate.state, .localDataFetched)
+        
+        // Make a search
+        controller.search(term: "test")
+        
+        // Simulate DB update
+        let userId = UserId.unique
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveUser(payload: self.dummyUser(id: userId), query: self.controller.query)
+        }
+        
+        // Simulate network call response
+        env.userListUpdater?.update_completion?(nil)
+        
+        let user: ChatUser = client.databaseContainer.viewContext.user(id: userId)!.asModel()
+        
+        AssertAsync.willBeEqual(controller.users.count, 1)
+        // Check if delegate method is called
+        AssertAsync.willBeEqual(delegate.didChangeUsers_changes, [.insert(user, index: [0, 0])])
+    }
+    
+    func test_newlyMatchedUser_isReportedAsInserted() throws {
+        // Add user to DB before searching
+        let userId = UserId.unique
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveUser(payload: self.dummyUser(id: userId), query: nil)
+        }
+        
+        // Set the delegate
+        let delegate = TestDelegate(expectedQueueId: controllerCallbackQueueID)
+        controller.delegate = delegate
+        
+        // Make a search
+        controller.search(term: "test")
+        
+        // Simulate DB update
+        try client.databaseContainer.writeSynchronously { session in
+            // This will actually link the existing user to controller's query, not insert a new one
+            try session.saveUser(payload: self.dummyUser(id: userId), query: self.controller.query)
+        }
+        
+        // Simulate network call response
+        env.userListUpdater?.update_completion?(nil)
+        
+        let user: ChatUser = client.databaseContainer.viewContext.user(id: userId)!.asModel()
+        
+        // Check if delegate method is called
+        AssertAsync.willBeEqual(delegate.didChangeUsers_changes, [.insert(user, index: [0, 0])])
+    }
+    
+    func test_whenNewSearchIsMade_oldUsersAreNotLinked() throws {
+        // For this test, we need to check if `.replace` update policy is correctly passed to
+        // the updater instance
+        
+        // Set the delegate
+        let delegate = TestDelegate(expectedQueueId: controllerCallbackQueueID)
+        controller.delegate = delegate
+        
+        // Make a search
+        controller.search(term: "test")
+        
+        // Assert the correct update policy is passed
+        XCTAssertEqual(env.userListUpdater!.update_policy, .replace)
+        
+        // Simulate DB update
+        let userId = UserId.unique
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveUser(payload: self.dummyUser(id: userId), query: self.controller.query)
+        }
+        
+        // Simulate update call response
+        env.userListUpdater?.update_completion?(nil)
+        
+        let user: ChatUser = client.databaseContainer.viewContext.user(id: userId)!.asModel()
+        
+        // Check if delegate method is called
+        AssertAsync.willBeEqual(delegate.didChangeUsers_changes, [.insert(user, index: [0, 0])])
+        
+        // Make another search
+        controller.search(term: "newTest")
+        
+        // Simulate DB update
+        // This is the expected behavior of UserListUpdater under `.replace` update policy
+        let newUserId = UserId.unique
+        try client.databaseContainer.writeSynchronously { session in
+            let dto = try session.saveQuery(query: self.controller.query)
+            dto?.users.removeAll()
+            try session.saveUser(payload: self.dummyUser(id: newUserId), query: self.controller.query)
+        }
+        
+        // Simulate network call response
+        env.userListUpdater?.update_completion?(nil)
+        
+        let newUser: ChatUser = client.databaseContainer.viewContext.user(id: newUserId)!.asModel()
+        
+        // Check if the old user is still matching the new search query (shouldn't)
+        XCTAssertEqual(controller.users.count, 1)
+        // Check if delegate method is called
+        AssertAsync.willBeEqual(delegate.didChangeUsers_changes, [.remove(user, index: [0, 0]), .insert(newUser, index: [0, 0])])
+    }
+    
+    func test_searchError_isPropagated() {
+        let testError = TestError()
+        
+        // Make a search
+        var reportedError: Error?
+        controller.search(term: "test") { error in
+            reportedError = error
+        }
+        
+        // Simulate network call response
+        env.userListUpdater?.update_completion?(testError)
+        
+        AssertAsync.willBeEqual(reportedError as? TestError, testError)
+    }
+    
+    func test_nextResultPage_isLoaded() throws {
+        // Set the delegate
+        let delegate = TestDelegate(expectedQueueId: controllerCallbackQueueID)
+        controller.delegate = delegate
+        
+        // Make a search
+        controller.search(term: "test")
+        
+        // Simulate DB update
+        // We use random character and not `.unique` for userId
+        // Since we'll generate a smaller id for next user's id
+        // so that insertion will be [0,1] and not [0,0]
+        let userId = "def".randomElement()!.description
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveUser(payload: self.dummyUser(id: userId), query: self.controller.query)
+        }
+        
+        // Simulate update call response
+        env.userListUpdater?.update_completion?(nil)
+        
+        let user: ChatUser = client.databaseContainer.viewContext.user(id: userId)!.asModel()
+        
+        // Check if delegate method is called
+        AssertAsync.willBeEqual(delegate.didChangeUsers_changes, [.insert(user, index: [0, 0])])
+        
+        // Load next page
+        controller.loadNextUsers()
+        
+        // Simulate DB update
+        let newUserId = "abc".randomElement()!.description
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveUser(payload: self.dummyUser(id: newUserId), query: self.controller.query)
+        }
+        
+        // Simulate network call response
+        env.userListUpdater?.update_completion?(nil)
+        
+        let newUser: ChatUser = client.databaseContainer.viewContext.user(id: newUserId)!.asModel()
+        
+        // Check if the old user is still matching the new search query (it should - since this is new page)
+        XCTAssertEqual(controller.users.count, 2)
+        // Check if delegate method is called, for new users' insert
+        AssertAsync.willBeEqual(delegate.didChangeUsers_changes, [.insert(newUser, index: [0, 1])])
+    }
+    
+    func test_nextResultsPage_cantBeCalledBeforeSearch() {
+        var reportedError: Error?
+        controller.loadNextUsers { error in
+            reportedError = error
+        }
+        
+        // Assert updater is not called
+        XCTAssertNil(env.userListUpdater?.update_completion)
+        
+        // Assert an error is reported
+        AssertAsync.willBeFalse(reportedError == nil)
+    }
+    
+    func test_controllerQueryRemoved_whenControllerIsDeallocated() throws {
+        // Assert that controller users is empty
+        // Calling `users` property starts observing DB too
+        XCTAssert(controller.users.isEmpty)
+        
+        // Make a search
+        controller.search(term: "test")
+        
+        // Simulate DB update
+        let userId = UserId.unique
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveUser(payload: self.dummyUser(id: userId), query: self.controller.query)
+        }
+        
+        // Simulate network call response
+        env.userListUpdater?.update_completion?(nil)
+        
+        var user: ChatUser? { client.databaseContainer.viewContext.user(id: userId)!.asModel() }
+        
+        // Check if user is reported
+        AssertAsync.willBeEqual(controller.users.first, user)
+        
+        let filterHash = controller.query.filter!.filterHash
+        // Deallocate controller
+        controller = nil
+        
+        // Assert query doesn't exist in DB anymore
+        AssertAsync.willBeNil(client.databaseContainer.viewContext.userListQuery(filterHash: filterHash))
+        
+        // Assert the user is still here
+        AssertAsync.staysTrue(user != nil)
+    }
+}
+
+private class TestEnvironment {
+    @Atomic var userListUpdater: UserListUpdaterMock<DefaultExtraData.User>?
+    
+    lazy var environment: ChatUserSearchController.Environment =
+        .init(userQueryUpdaterBuilder: { [unowned self] in
+            self.userListUpdater = UserListUpdaterMock(
+                database: $0,
+                webSocketClient: $1,
+                apiClient: $2
+            )
+            return self.userListUpdater!
+        })
+}
+
+// A concrete `UserSearchControllerDelegate` implementation allowing capturing the delegate calls
+private class TestDelegate: QueueAwareDelegate, ChatUserSearchControllerDelegate {
+    @Atomic var state: DataController.State?
+    @Atomic var didChangeUsers_changes: [ListChange<ChatUser>]?
+    
+    func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        self.state = state
+        validateQueue()
+    }
+    
+    func controller(
+        _ controller: _ChatUserSearchController<DefaultExtraData>,
+        didChangeUsers changes: [ListChange<ChatUser>]
+    ) {
+        didChangeUsers_changes = changes
+        print("### CHANGE \(changes) ids \(changes.map(\.item.id))")
+        validateQueue()
+    }
+}
+
+// A concrete `_ChatUserSearchControllerDelegate` implementation allowing capturing the delegate calls.
+private class TestDelegateGeneric: QueueAwareDelegate, _ChatUserSearchControllerDelegate {
+    @Atomic var state: DataController.State?
+    @Atomic var didChangeUsers_changes: [ListChange<ChatUser>]?
+    
+    func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        self.state = state
+        validateQueue()
+    }
+    
+    func controller(
+        _ controller: _ChatUserSearchController<DefaultExtraData>,
+        didChangeUsers changes: [ListChange<ChatUser>]
+    ) {
+        didChangeUsers_changes = changes
+        validateQueue()
+    }
+}

--- a/Sources_v3/StreamChat/Database/DTOs/UserListQueryDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/UserListQueryDTO.swift
@@ -61,4 +61,18 @@ extension NSManagedObjectContext {
         
         return newDTO
     }
+    
+    func deleteQuery<ExtraData: UserExtraData>(_ query: UserListQuery<ExtraData>) {
+        guard let filterHash = query.filter?.filterHash else {
+            // A query without a filter is not saved in DB.
+            return
+        }
+        
+        guard let existingDTO = UserListQueryDTO.load(filterHash: filterHash, context: self) else {
+            // This query doesn't exist in DB.
+            return
+        }
+        
+        delete(existingDTO)
+    }
 }

--- a/Sources_v3/StreamChat/Database/DatabaseSession.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseSession.swift
@@ -12,6 +12,11 @@ protocol UserDatabaseSession {
     @discardableResult
     func saveUser<ExtraData: UserExtraData>(payload: UserPayload<ExtraData>, query: UserListQuery<ExtraData>?) throws -> UserDTO
     
+    /// Saves the provided query to the DB. Return's the matching `UserListQueryDTO` if the save was successful. Throws an error
+    /// if the save fails.
+    @discardableResult
+    func saveQuery<ExtraData: UserExtraData>(query: UserListQuery<ExtraData>) throws -> UserListQueryDTO?
+    
     /// Fetches `UserDTO` with the given `id` from the DB. Returns `nil` if no `UserDTO` matching the `id` exists.
     func user(id: UserId) -> UserDTO?
 }

--- a/Sources_v3/StreamChat/Database/DatabaseSession.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseSession.swift
@@ -19,6 +19,9 @@ protocol UserDatabaseSession {
     
     /// Fetches `UserDTO` with the given `id` from the DB. Returns `nil` if no `UserDTO` matching the `id` exists.
     func user(id: UserId) -> UserDTO?
+    
+    /// Removes the specified query from DB.
+    func deleteQuery<ExtraData: UserExtraData>(_ query: UserListQuery<ExtraData>)
 }
 
 protocol CurrentUserDatabaseSession {

--- a/Sources_v3/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources_v3/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -243,6 +243,7 @@
     <entity name="UserListQueryDTO" representedClassName="UserListQueryDTO" syncable="YES">
         <attribute name="filterHash" attributeType="String"/>
         <attribute name="filterJSONData" attributeType="Binary"/>
+        <attribute name="shouldBeUpdatedInBackground" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
         <relationship name="users" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="queries" inverseEntity="UserDTO"/>
         <fetchIndex name="filterHash">
             <fetchIndexElement property="filterHash" type="Binary" order="ascending"/>
@@ -266,6 +267,6 @@
         <element name="MessageReactionDTO" positionX="9" positionY="153" width="128" height="163"/>
         <element name="TeamDTO" positionX="0" positionY="0" width="128" height="88"/>
         <element name="UserDTO" positionX="0" positionY="0" width="128" height="344"/>
-        <element name="UserListQueryDTO" positionX="9" positionY="153" width="128" height="88"/>
+        <element name="UserListQueryDTO" positionX="9" positionY="153" width="128" height="103"/>
     </elements>
 </model>

--- a/Sources_v3/StreamChat/Query/UserListQuery.swift
+++ b/Sources_v3/StreamChat/Query/UserListQuery.swift
@@ -64,7 +64,7 @@ public struct UserListQuery<ExtraData: UserExtraData>: Encodable {
     }
     
     /// A filter for the query (see `Filter`).
-    public let filter: Filter<UserListFilterScope<ExtraData>>?
+    public var filter: Filter<UserListFilterScope<ExtraData>>?
     
     /// A sorting for the query (see `Sorting`).
     public let sort: [Sorting<UserListSortingKey>]

--- a/Sources_v3/StreamChat/Query/UserListQuery.swift
+++ b/Sources_v3/StreamChat/Query/UserListQuery.swift
@@ -75,6 +75,10 @@ public struct UserListQuery<ExtraData: UserExtraData>: Encodable {
     /// Query options. By default the query options contain `presence`.
     var options: QueryOptions = [.presence]
     
+    /// Indicates if the query should be observed for new users.
+    /// If set to true, newly created users in the database are automatically included in the query if they fit the predicate.
+    var shouldBeUpdatedInBackground = true
+    
     /// Init a users query.
     /// - Parameters:
     ///   - filter: a users filter. Empty filter will return all users.

--- a/Sources_v3/StreamChat/Workers/Background/NewUserQueryUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/Background/NewUserQueryUpdater.swift
@@ -30,7 +30,7 @@ final class NewUserQueryUpdater<ExtraData: UserExtraData>: Worker {
     private var queries: [UserListQueryDTO] {
         do {
             let queries = try database.backgroundReadOnlyContext
-                .fetch(NSFetchRequest<UserListQueryDTO>(entityName: UserListQueryDTO.entityName))
+                .fetch(UserListQueryDTO.observedQueries())
             return queries
         } catch {
             log.error("Internal error: Failed to fetch [UserListQueryDTO]: \(error)")

--- a/Sources_v3/StreamChat/Workers/UserListUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/UserListUpdater.swift
@@ -6,19 +6,33 @@ import CoreData
 
 /// Makes a users query call to the backend and updates the local storage with the results.
 class UserListUpdater<ExtraData: UserExtraData>: Worker {
+    /// Defines the update policy for this worker.
+    enum UpdatePolicy {
+        /// The resulting user set of the query will be merged with the existing user set.
+        case merge
+        /// The resulting user set of the query will replace the existing user set.
+        case replace
+    }
+
     /// Makes a users query call to the backend and updates the local storage with the results.
     ///
     /// - Parameters:
     ///   - userListQuery: The users query used in the request
+    ///   - policy: The update policy for the resulting user set. See `UpdatePolicy`
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     ///
-    func update(userListQuery: UserListQuery<ExtraData>, completion: ((Error?) -> Void)? = nil) {
+    func update(userListQuery: UserListQuery<ExtraData>, policy: UpdatePolicy = .merge, completion: ((Error?) -> Void)? = nil) {
         apiClient
             .request(endpoint: .users(query: userListQuery)) { (result: Result<UserListPayload<ExtraData>, Error>) in
                 switch result {
                 case let .success(userListPayload):
                     self.database.write { session in
                         do {
+                            if case .replace = policy {
+                                let dto = try session.saveQuery(query: userListQuery)
+                                dto?.users.removeAll()
+                            }
+                            
                             try userListPayload.users.forEach {
                                 try session.saveUser(payload: $0, query: userListQuery)
                             }

--- a/Sources_v3/StreamChat/Workers/UserListUpdater_Mock.swift
+++ b/Sources_v3/StreamChat/Workers/UserListUpdater_Mock.swift
@@ -8,10 +8,16 @@ import XCTest
 /// Mock implementation of UserListUpdater
 class UserListUpdaterMock<ExtraData: UserExtraData>: UserListUpdater<ExtraData> {
     @Atomic var update_queries: [UserListQuery<ExtraData>] = []
+    @Atomic var update_policy: UpdatePolicy?
     @Atomic var update_completion: ((Error?) -> Void)?
         
-    override func update(userListQuery: UserListQuery<ExtraData>, completion: ((Error?) -> Void)? = nil) {
+    override func update(
+        userListQuery: UserListQuery<ExtraData>,
+        policy: UpdatePolicy = .merge,
+        completion: ((Error?) -> Void)? = nil
+    ) {
         _update_queries.mutate { $0.append(userListQuery) }
+        update_policy = policy
         update_completion = completion
     }
 }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		794927F3249E3F77009D7EB7 /* NotificationAddedToChannel.json in Resources */ = {isa = PBXBuildFile; fileRef = 794927EE249E3D37009D7EB7 /* NotificationAddedToChannel.json */; };
 		795296C12582494000435B2E /* UIConfigProvider_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795296C02582494000435B2E /* UIConfigProvider_Tests.swift */; };
 		795296FC258264A100435B2E /* UserSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795296FB258264A100435B2E /* UserSearchController.swift */; };
+		795297062583B52000435B2E /* UserSearchController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795297052583B52000435B2E /* UserSearchController_Tests.swift */; };
 		7952B3B324D4560E00AC53D4 /* ChannelController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7952B3B224D314B100AC53D4 /* ChannelController_Tests.swift */; };
 		7952B3B524D45DA300AC53D4 /* ChannelUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7952B3B424D45D9400AC53D4 /* ChannelUpdater_Tests.swift */; };
 		7962958C248147430078EB53 /* BaseURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7962958B248147430078EB53 /* BaseURL.swift */; };
@@ -829,6 +830,7 @@
 		794927F0249E3DE6009D7EB7 /* EventPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventPayload_Tests.swift; sourceTree = "<group>"; };
 		795296C02582494000435B2E /* UIConfigProvider_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfigProvider_Tests.swift; sourceTree = "<group>"; };
 		795296FB258264A100435B2E /* UserSearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSearchController.swift; sourceTree = "<group>"; };
+		795297052583B52000435B2E /* UserSearchController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSearchController_Tests.swift; sourceTree = "<group>"; };
 		7952B3B224D314B100AC53D4 /* ChannelController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelController_Tests.swift; sourceTree = "<group>"; };
 		7952B3B424D45D9400AC53D4 /* ChannelUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelUpdater_Tests.swift; sourceTree = "<group>"; };
 		7962958B248147430078EB53 /* BaseURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseURL.swift; sourceTree = "<group>"; };
@@ -1749,6 +1751,7 @@
 			isa = PBXGroup;
 			children = (
 				795296FB258264A100435B2E /* UserSearchController.swift */,
+				795297052583B52000435B2E /* UserSearchController_Tests.swift */,
 			);
 			path = SearchControllers;
 			sourceTree = "<group>";
@@ -3483,6 +3486,7 @@
 				DA84074B2526417B005A0F62 /* JSONEncoder+Extensions.swift in Sources */,
 				88381E6E258259310047A6A3 /* FileUploadPayload_Tests.swift in Sources */,
 				F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */,
+				795297062583B52000435B2E /* UserSearchController_Tests.swift in Sources */,
 				DA958D5425309918005D23FA /* Sorting_Tests.swift in Sources */,
 				DA497180254AE0B200AC68C2 /* Attachment_Tests.swift in Sources */,
 				F62BE7872506525700D13B86 /* MissingEventsRequestBody_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		794927ED249E0BE2009D7EB7 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794927EC249E0BE2009D7EB7 /* ExtraData.swift */; };
 		794927F3249E3F77009D7EB7 /* NotificationAddedToChannel.json in Resources */ = {isa = PBXBuildFile; fileRef = 794927EE249E3D37009D7EB7 /* NotificationAddedToChannel.json */; };
 		795296C12582494000435B2E /* UIConfigProvider_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795296C02582494000435B2E /* UIConfigProvider_Tests.swift */; };
+		795296FC258264A100435B2E /* UserSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795296FB258264A100435B2E /* UserSearchController.swift */; };
 		7952B3B324D4560E00AC53D4 /* ChannelController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7952B3B224D314B100AC53D4 /* ChannelController_Tests.swift */; };
 		7952B3B524D45DA300AC53D4 /* ChannelUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7952B3B424D45D9400AC53D4 /* ChannelUpdater_Tests.swift */; };
 		7962958C248147430078EB53 /* BaseURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7962958B248147430078EB53 /* BaseURL.swift */; };
@@ -827,6 +828,7 @@
 		794927EE249E3D37009D7EB7 /* NotificationAddedToChannel.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = NotificationAddedToChannel.json; sourceTree = "<group>"; };
 		794927F0249E3DE6009D7EB7 /* EventPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventPayload_Tests.swift; sourceTree = "<group>"; };
 		795296C02582494000435B2E /* UIConfigProvider_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfigProvider_Tests.swift; sourceTree = "<group>"; };
+		795296FB258264A100435B2E /* UserSearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSearchController.swift; sourceTree = "<group>"; };
 		7952B3B224D314B100AC53D4 /* ChannelController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelController_Tests.swift; sourceTree = "<group>"; };
 		7952B3B424D45D9400AC53D4 /* ChannelUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelUpdater_Tests.swift; sourceTree = "<group>"; };
 		7962958B248147430078EB53 /* BaseURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseURL.swift; sourceTree = "<group>"; };
@@ -1743,6 +1745,14 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		795296FA2582648F00435B2E /* SearchControllers */ = {
+			isa = PBXGroup;
+			children = (
+				795296FB258264A100435B2E /* UserSearchController.swift */,
+			);
+			path = SearchControllers;
+			sourceTree = "<group>";
+		};
 		7962958A2481473A0078EB53 /* Config */ = {
 			isa = PBXGroup;
 			children = (
@@ -2019,6 +2029,7 @@
 				DAD539DA250B8A9C00CFC649 /* Controller.swift */,
 				79280F4E2485308100CDEB89 /* DataController.swift */,
 				8A0D64AD24E5853F0017A3C0 /* DataController_Tests.swift */,
+				795296FA2582648F00435B2E /* SearchControllers */,
 				8819DFD32525F48800FD1A50 /* UserController */,
 				888E8C53252B522F00195E03 /* MemberController */,
 				88D85DA5252F3C0900AE1030 /* MemberListController */,
@@ -3323,6 +3334,7 @@
 				79877A272498E50D00015F8B /* MemberModelDTO.swift in Sources */,
 				7962958C248147430078EB53 /* BaseURL.swift in Sources */,
 				8A0C3BD424C1DF2100CAFD19 /* MessageEvents.swift in Sources */,
+				795296FC258264A100435B2E /* UserSearchController.swift in Sources */,
 				79CD959224F9380B00E87377 /* MulticastDelegate.swift in Sources */,
 				7964F3BC249A5E60002A09EC /* RequestEncoder.swift in Sources */,
 				79896D64250A63A200BA8F1C /* ChannelReadUpdaterMiddleware.swift in Sources */,


### PR DESCRIPTION
### Idea:
SearchController creates a unique query and observes DB for updates to this query. Whenever the developer calls `search(text)` searchController will update this query (in DB) and will report results to the user. In `deinit`, searchController will remove this query from DB. 
The developer will always get `.insert(item` changes, never `.update`) (will be tested)
Additionally, this query will not be observed by `NewUserQueryUpdater` since it's an "ephemeral" query.