### PR TITLE
[CIS-475] Replies UI in MessageComposer

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageComposerView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageComposerView.swift
@@ -16,9 +16,13 @@ open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: UIInputVie
     
     // MARK: - Subviews
 
-    public private(set) lazy var container = ContainerStackView().withoutAutoresizingMaskConstraints
+    public private(set) lazy var container = ContainerStackView()
+        .withoutAutoresizingMaskConstraints
     
-    public private(set) lazy var replyView: UIView = .init()
+    public private(set) lazy var replyView = uiConfig
+        .messageComposer
+        .replyBubbleView.init()
+        .withoutAutoresizingMaskConstraints
     
     public private(set) lazy var attachmentsView: MessageComposerAttachmentsView<ExtraData> = uiConfig
         .messageComposer
@@ -155,8 +159,9 @@ open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: UIInputVie
         container.centerStackView.isHidden = false
         container.centerStackView.axis = .vertical
         container.centerStackView.alignment = .fill
-        container.centerStackView.addArrangedSubview(replyView)
         
+        replyView.isHidden = true
+        container.centerStackView.addArrangedSubview(replyView)
         container.centerStackView.addArrangedSubview(attachmentsView)
         attachmentsView.heightAnchor.constraint(equalToConstant: attachmentsViewHeight).isActive = true
         
@@ -173,6 +178,12 @@ open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: UIInputVie
         container.leftStackView.addArrangedSubview(shrinkInputButton)
         container.leftStackView.addArrangedSubview(attachmentButton)
         container.leftStackView.addArrangedSubview(commandsButton)
+        
+        [shrinkInputButton, attachmentButton, commandsButton, sendButton, dismissButton]
+            .forEach { button in
+                button.pin(anchors: [.width], to: button.intrinsicContentSize.width)
+                button.pin(anchors: [.height], to: button.intrinsicContentSize.height)
+            }
 
         attachmentsView.isHidden = true
         shrinkInputButton.isHidden = true

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageInputView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageInputView.swift
@@ -10,20 +10,6 @@ open class ChatChannelMessageInputView<ExtraData: ExtraDataTypes>: UIView {
     
     public let uiConfig: UIConfig<ExtraData>
     
-    public var textViewHeight: CGFloat {
-        guard let font = textView.font, let text = textView.text else { return 0 }
-
-        let width = textView.frame.width - textView.textContainerInset.right - textView.textContainerInset.left
-        let constraintRect = CGSize(width: width, height: .greatestFiniteMagnitude)
-        let boundingBox = text.boundingRect(
-            with: constraintRect,
-            options: .usesLineFragmentOrigin,
-            attributes: [.font: font],
-            context: nil
-        )
-        return boundingBox.height
-    }
-    
     // MARK: - Subviews
     
     public private(set) lazy var container = ContainerStackView().withoutAutoresizingMaskConstraints
@@ -72,7 +58,7 @@ open class ChatChannelMessageInputView<ExtraData: ExtraDataTypes>: UIView {
     // MARK: - Overrides
     
     override open var intrinsicContentSize: CGSize {
-        CGSize(width: UIView.noIntrinsicMetric, height: textViewHeight)
+        CGSize(width: UIView.noIntrinsicMetric, height: textView.calculatedTextHeight())
     }
     
     // MARK: - Public

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -259,8 +259,8 @@ open class ChatChannelVC<ExtraData: ExtraDataTypes>: ViewController,
         var actions: [ChatMessageActionItem] = []
 
         actions.append(.inlineReply { [weak self] in
-            debugPrint("inline reply")
             self?.dismiss(animated: true)
+            self?.messageInputAccessoryViewController.state = .reply(message)
         })
 
         actions.append(.threadReply { [weak self] in

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatReplyBubbleView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatReplyBubbleView.swift
@@ -1,0 +1,158 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+open class ChatReplyBubbleView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+    // MARK: - Properties
+    
+    public var avatarViewWidth: CGFloat = 24
+    public var attachmentPreviewWidth: CGFloat = 34
+    
+    public var message: _ChatMessage<ExtraData>? {
+        didSet {
+            updateContentIfNeeded()
+        }
+    }
+    
+    lazy var textViewHeightConstraint = textView.heightAnchor.constraint(greaterThanOrEqualToConstant: .zero)
+    
+    // MARK: - Subviews
+    
+    public private(set) lazy var container = ContainerStackView()
+        .withoutAutoresizingMaskConstraints
+    
+    public private(set) lazy var authorAvatarView = uiConfig
+        .messageComposer
+        .replyBubbleAvatarView.init()
+        .withoutAutoresizingMaskConstraints
+    
+    public private(set) lazy var attachmentPreview = UIImageView()
+        .withoutAutoresizingMaskConstraints
+
+    public private(set) lazy var textView = UITextView()
+        .withoutAutoresizingMaskConstraints
+    
+    // MARK: - Public
+    
+    override open func setUp() {
+        super.setUp()
+        
+        textView.isEditable = false
+        textView.dataDetectorTypes = .link
+        textView.isScrollEnabled = false
+        textView.adjustsFontForContentSizeCategory = true
+        textView.isUserInteractionEnabled = false
+    }
+    
+    override open func defaultAppearance() {
+        textView.textContainer.maximumNumberOfLines = 6
+        textView.textContainer.lineBreakMode = .byTruncatingTail
+        textView.textContainer.lineFragmentPadding = .zero
+        
+        textView.backgroundColor = .clear
+        textView.font = .preferredFont(forTextStyle: .footnote)
+        textView.textContainerInset = .zero
+
+        authorAvatarView.contentMode = .scaleAspectFit
+        
+        attachmentPreview.layer.cornerRadius = attachmentPreviewWidth / 4
+        attachmentPreview.layer.masksToBounds = true
+        
+        container.centerStackView.layer.cornerRadius = 16
+        container.centerStackView.layer.borderWidth = 1
+        container.centerStackView.layer.borderColor = uiConfig.colorPalette.messageComposerBorder.cgColor
+        container.centerStackView.layer.masksToBounds = true
+    }
+    
+    override open func setUpLayout() {
+        embed(container)
+        
+        preservesSuperviewLayoutMargins = true
+        
+        container.preservesSuperviewLayoutMargins = true
+        container.isLayoutMarginsRelativeArrangement = true
+        
+        container.leftStackView.isHidden = false
+        container.leftStackView.addArrangedSubview(authorAvatarView)
+        authorAvatarView.widthAnchor.constraint(equalToConstant: avatarViewWidth).isActive = true
+        authorAvatarView.heightAnchor.constraint(equalTo: authorAvatarView.widthAnchor, multiplier: 1).isActive = true
+        
+        container.centerContainerStackView.spacing = UIStackView.spacingUseSystem
+        container.centerContainerStackView.alignment = .bottom
+        
+        container.centerStackView.isLayoutMarginsRelativeArrangement = true
+        container.centerStackView.layoutMargins = layoutMargins
+        
+        container.centerStackView.isHidden = false
+        container.centerStackView.spacing = UIStackView.spacingUseSystem
+        container.centerStackView.alignment = .top
+        container.centerStackView.addArrangedSubview(attachmentPreview)
+
+        attachmentPreview.widthAnchor.constraint(equalToConstant: attachmentPreviewWidth).isActive = true
+        attachmentPreview.heightAnchor.constraint(equalTo: attachmentPreview.widthAnchor, multiplier: 1).isActive = true
+
+        container.centerStackView.addArrangedSubview(textView)
+        textViewHeightConstraint.isActive = true
+        
+        container.centerStackView.layer.maskedCorners = [
+            .layerMinXMinYCorner,
+            .layerMaxXMinYCorner,
+            .layerMaxXMaxYCorner
+        ]
+    }
+    
+    override open func updateContent() {
+        guard let message = message else { return }
+        
+        let placeholder = UIImage(named: "pattern1", in: .streamChatUI)
+        if let imageURL = message.author.imageURL {
+            authorAvatarView.imageView.setImage(from: imageURL, placeholder: placeholder)
+        } else {
+            authorAvatarView.imageView.image = placeholder
+        }
+        
+        textView.text = message.text
+        
+        updateAttachmentPreview(for: message)
+        
+        textViewHeightConstraint.constant = textView.calculatedTextHeight()
+    }
+    
+    // MARK: - Helpers
+    
+    func updateAttachmentPreview(for message: _ChatMessage<ExtraData>) {
+        // TODO: Take last attachment when they'll be ordered.
+        guard let attachment = message.attachments.first else {
+            attachmentPreview.image = nil
+            attachmentPreview.isHidden = true
+            return
+        }
+        
+        switch attachment.type {
+        case .file:
+            // TODO: Question for designers.
+            // I'm not sure if it will be possible to provide specific icon for all file formats
+            // so probably we should stick to some generic like other apps do.
+            print("set file icon")
+            attachmentPreview.isHidden = false
+            attachmentPreview.contentMode = .scaleAspectFit
+        default:
+            if let previewURL = attachment.imagePreviewURL ?? attachment.imageURL {
+                attachmentPreview.setImage(from: previewURL)
+                attachmentPreview.isHidden = false
+                attachmentPreview.contentMode = .scaleAspectFill
+                // TODO: When we will have attachment examples we will set smth
+                // different for different types.
+                if message.text.isEmpty, attachment.type == .image {
+                    textView.text = "Photo"
+                }
+            } else {
+                attachmentPreview.image = nil
+                attachmentPreview.isHidden = true
+            }
+        }
+    }
+}

--- a/Sources_v3/StreamChatUI/UIConfig.swift
+++ b/Sources_v3/StreamChatUI/UIConfig.swift
@@ -171,6 +171,8 @@ public extension UIConfig {
         public var sendButton: MessageComposerSendButton<ExtraData>.Type = MessageComposerSendButton<ExtraData>.self
         public var composerButton: ChatSquareButton<ExtraData>.Type = ChatSquareButton<ExtraData>.self
         public var textView: ChatChannelMessageInputTextView<ExtraData>.Type = ChatChannelMessageInputTextView<ExtraData>.self
+        public var replyBubbleView: ChatReplyBubbleView<ExtraData>.Type = ChatReplyBubbleView.self
+        public var replyBubbleAvatarView: AvatarView.Type = AvatarView.self
         public var suggestionsViewController: MessageComposerSuggestionsViewController<ExtraData>.Type =
             MessageComposerSuggestionsViewController<ExtraData>.self
         public var suggestionsCollectionView: MessageComposerSuggestionsCollectionView.Type =

--- a/Sources_v3/StreamChatUI/Utils/UITextView+Extensions.swift
+++ b/Sources_v3/StreamChatUI/Utils/UITextView+Extensions.swift
@@ -1,0 +1,31 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+extension UITextView {
+    ///
+    /// Reference:
+    /// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/TextLayout/Tasks/StringHeight.html
+    ///
+    func calculatedTextHeight() -> CGFloat {
+        let textStorage = NSTextStorage(string: text)
+        let width = frame.width - textContainerInset.right - textContainerInset.left
+        let customTextContainer = NSTextContainer(size: .init(width: width, height: CGFloat.greatestFiniteMagnitude))
+        let layoutManager = NSLayoutManager()
+        
+        layoutManager.addTextContainer(customTextContainer)
+        
+        textStorage.addLayoutManager(layoutManager)
+        textStorage.addAttribute(.font, value: font!, range: .init(0..<textStorage.length))
+        
+        customTextContainer.lineFragmentPadding = textContainer.lineFragmentPadding
+        customTextContainer.maximumNumberOfLines = textContainer.maximumNumberOfLines
+        customTextContainer.lineBreakMode = textContainer.lineBreakMode
+        
+        layoutManager.glyphRange(for: customTextContainer)
+        
+        return layoutManager.usedRect(for: customTextContainer).size.height
+    }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		226C438D25802AAD008B3648 /* ChatChannelMessageInputTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226C438C25802AAD008B3648 /* ChatChannelMessageInputTextView.swift */; };
 		22753599257C442300D1FDB6 /* MessageComposerSendButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22753598257C442300D1FDB6 /* MessageComposerSendButton.swift */; };
 		228190EB256733420048D7C6 /* UIFont+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228190EA256733420048D7C6 /* UIFont+Extensions.swift */; };
+		228C7EE52583AF4800AAE9E3 /* UITextView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228C7EE42583AF4800AAE9E3 /* UITextView+Extensions.swift */; };
 		228DC80E25704B410080A49F /* MessageComposerAttachmentCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */; };
 		22A0921725682880001FE9F0 /* ChatNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A0921625682880001FE9F0 /* ChatNavigationBar.swift */; };
 		22ADD67C256BF1550098EFEB /* ChatChannelMessageInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */; };
@@ -685,6 +686,7 @@
 		226C438C25802AAD008B3648 /* ChatChannelMessageInputTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelMessageInputTextView.swift; sourceTree = "<group>"; };
 		22753598257C442300D1FDB6 /* MessageComposerSendButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerSendButton.swift; sourceTree = "<group>"; };
 		228190EA256733420048D7C6 /* UIFont+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extensions.swift"; sourceTree = "<group>"; };
+		228C7EE42583AF4800AAE9E3 /* UITextView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+Extensions.swift"; sourceTree = "<group>"; };
 		228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerAttachmentCellView.swift; sourceTree = "<group>"; };
 		22A0921625682880001FE9F0 /* ChatNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatNavigationBar.swift; sourceTree = "<group>"; };
 		22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelMessageInputView.swift; sourceTree = "<group>"; };
@@ -2154,6 +2156,7 @@
 				882AE123257A7FFE004095B3 /* UIViewController+Extensions.swift */,
 				88D88F85257F9AA700AFE2A2 /* NSLayoutConstraint+Extensions.swift */,
 				795296C02582494000435B2E /* UIConfigProvider_Tests.swift */,
+				228C7EE42583AF4800AAE9E3 /* UITextView+Extensions.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3056,6 +3059,7 @@
 				E701201E2583EBD50036DACD /* CALayer+Extensions.swift in Sources */,
 				DB70CFF425701FE500DDF436 /* ChatChannelNavigationBarListener.swift in Sources */,
 				88A8CF0B256E7AC8004EA4C7 /* ChatMessageGroupPart.swift in Sources */,
+				228C7EE52583AF4800AAE9E3 /* UITextView+Extensions.swift in Sources */,
 				225DDDFC25799270009C280A /* ChatSquareButton.swift in Sources */,
 				88BC8908256E90A1009C5554 /* ChatRepliedMessageContentView.swift in Sources */,
 				22FF4365256E943F00133910 /* MessageComposerSuggestionsViewController.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		22753599257C442300D1FDB6 /* MessageComposerSendButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22753598257C442300D1FDB6 /* MessageComposerSendButton.swift */; };
 		228190EB256733420048D7C6 /* UIFont+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228190EA256733420048D7C6 /* UIFont+Extensions.swift */; };
 		228C7EE52583AF4800AAE9E3 /* UITextView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228C7EE42583AF4800AAE9E3 /* UITextView+Extensions.swift */; };
+		228C7F022584132F00AAE9E3 /* ChatReplyBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228C7F012584132F00AAE9E3 /* ChatReplyBubbleView.swift */; };
 		228DC80E25704B410080A49F /* MessageComposerAttachmentCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */; };
 		22A0921725682880001FE9F0 /* ChatNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A0921625682880001FE9F0 /* ChatNavigationBar.swift */; };
 		22ADD67C256BF1550098EFEB /* ChatChannelMessageInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */; };
@@ -687,6 +688,7 @@
 		22753598257C442300D1FDB6 /* MessageComposerSendButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerSendButton.swift; sourceTree = "<group>"; };
 		228190EA256733420048D7C6 /* UIFont+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extensions.swift"; sourceTree = "<group>"; };
 		228C7EE42583AF4800AAE9E3 /* UITextView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+Extensions.swift"; sourceTree = "<group>"; };
+		228C7F012584132F00AAE9E3 /* ChatReplyBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatReplyBubbleView.swift; sourceTree = "<group>"; };
 		228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerAttachmentCellView.swift; sourceTree = "<group>"; };
 		22A0921625682880001FE9F0 /* ChatNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatNavigationBar.swift; sourceTree = "<group>"; };
 		22ADD67B256BF1550098EFEB /* ChatChannelMessageInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelMessageInputView.swift; sourceTree = "<group>"; };
@@ -1440,6 +1442,7 @@
 				E79AC10925831A1500C3CE5D /* MessageComposerSuggestionsCollectionViewLayout.swift */,
 				22753598257C442300D1FDB6 /* MessageComposerSendButton.swift */,
 				226C438C25802AAD008B3648 /* ChatChannelMessageInputTextView.swift */,
+				228C7F012584132F00AAE9E3 /* ChatReplyBubbleView.swift */,
 			);
 			path = ChatChannel;
 			sourceTree = "<group>";
@@ -3104,6 +3107,7 @@
 				790882ED25486B6D00896F03 /* ChatChannelListCollectionViewDataSource.swift in Sources */,
 				E79AC10D25831A1500C3CE5D /* MessageComposerSuggestionsCollectionViewLayout.swift in Sources */,
 				E73A8B2B2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift in Sources */,
+				228C7F022584132F00AAE9E3 /* ChatReplyBubbleView.swift in Sources */,
 				885B3D7725642B3D003E6BDF /* CurrentChatUserAvatarView.swift in Sources */,
 				DBC8A4C6257E696900B20A82 /* ChatMessageThreadInfoView.swift in Sources */,
 				224FF6912562F58F00725DD1 /* UIColor+Extensions.swift in Sources */,


### PR DESCRIPTION
In this PR:

- Improve `UITextView` text height calculation
- Introduce `ChatReplyBubbleView`
- Make use of `ChatReplyBubbleView` in `ChatChannelMessageComposerView`
- Adjust `MessageComposerInputAccessoryViewController.State` and add test reply functionality

<img width="300" alt="Screenshot 2020-12-12 at 18 04 50" src="https://user-images.githubusercontent.com/10098359/101990146-59469380-3ca5-11eb-8f03-c7b79b677d9f.png">
<img width="300" alt="Screenshot 2020-12-12 at 18 05 09" src="https://user-images.githubusercontent.com/10098359/101990148-5a77c080-3ca5-11eb-8663-e6976bcae6ec.png">
<img width="300" alt="Screenshot 2020-12-12 at 18 05 52" src="https://user-images.githubusercontent.com/10098359/101990150-5c418400-3ca5-11eb-9f55-3a44336a7006.png">
