### PR TITLE
Fix markRead requests failing

### DIFF
--- a/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
+++ b/Sample_v3/Samples/SimpleChat/SimpleChatViewController.swift
@@ -37,6 +37,16 @@ final class SimpleChatViewController: UITableViewController, ChatChannelControll
         }
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        channelController.markRead { error in
+            if let error = error {
+                print("Error marking the channel read:", error)
+            }
+        }
+    }
+    
     // MARK: - ChannelControllerDelegate
 
     ///

--- a/Sources_v3/StreamChat/APIClient/Endpoints/Endpoint.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/Endpoint.swift
@@ -20,3 +20,7 @@ enum EndpointMethod: String {
 
 /// A type representing empty response of an Endpoint.
 public struct EmptyResponse: Decodable {}
+
+/// A type representing empty body for `.post` Endpoints.
+/// Our backend currently expects a body (not `nil`), even if it's empty.
+struct EmptyBody: Codable, Equatable {}

--- a/Sources_v3/StreamChat/APIClient/RequestEncoder.swift
+++ b/Sources_v3/StreamChat/APIClient/RequestEncoder.swift
@@ -167,9 +167,10 @@ struct DefaultRequestEncoder: RequestEncoder {
     
     private func encodePOSTRequestBody<T: Decodable>(request: inout URLRequest, endpoint: Endpoint<T>) throws {
         log.assert(endpoint.method == .post, "Request method is \(endpoint.method) but must be POST.")
-        guard let body = endpoint.body else { return }
-        
-        request.httpBody = try JSONEncoder.stream.encode(AnyEncodable(body))
+        // If the endpoint doesn't contain a body, we should encode an empty body
+        // since backends expects it
+        let body = try JSONEncoder.stream.encode(AnyEncodable(endpoint.body ?? EmptyBody()))
+        request.httpBody = body
     }
     
     private func encodeJSONToQueryItems(request: inout URLRequest, data: Encodable) throws {

--- a/Sources_v3/StreamChat/APIClient/RequestEncoder_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/RequestEncoder_Tests.swift
@@ -139,6 +139,29 @@ class RequestEncoder_Tests: XCTestCase {
         XCTAssertEqual(serializedBody, endpoint.body as! TestUser)
     }
     
+    func test_encodingRequestWithoutBody_POST() throws {
+        // Our backend expects all POST requests will have a body, even if empty
+        // nil body is not acceptable (causes invalid json - 400 error)
+        
+        // Prepare a POST endpoint with JSON body
+        let endpoint = Endpoint<Data>(
+            path: .unique,
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: nil
+        )
+        
+        // Encode the request and wait for the result
+        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        
+        // Check the body is present (and empty)
+        let body = try XCTUnwrap(request.httpBody)
+        let serializedBody = try JSONDecoder.stream.decode(EmptyBody.self, from: body)
+        
+        XCTAssertEqual(serializedBody, EmptyBody())
+    }
+    
     func test_encodingRequestBody_GET() throws {
         // Prepare a GET endpoint with JSON body
         let endpoint = Endpoint<Data>(


### PR DESCRIPTION
They were failing since backend expects a valid body (not nil) for post requests
