### PR TITLE
Add CI v2 workflow and separate v2/v3 CIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'Sources/**' # Only run if a file outside /Sources changes (anything outside v2 is assumed to be v3)
   pull_request:
     branches:
       - main
@@ -12,43 +14,9 @@ on:
       - created
 
 env:
-  carthage-cache-dir: 'carthage-cache-29102020' # When you change carthage cache directory, please append the date
+  carthage-cache-dir: 'carthage-cache-14122020' # When you change carthage cache directory, please append the date
 
 jobs:
-  build-and-test:
-    name: Build and Test v2
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Cache Carthage dependencies
-      uses: actions/cache@v2
-      id: carthage-cache
-      with:
-        path: Carthage
-        key: ${{ runner.os }}-${{ env.carthage-cache-dir }}-${{ hashFiles('**/Cartfile.resolved') }}
-    - name: Cache RubyGems
-      uses: actions/cache@v2
-      id: rubygem-cache
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: ${{ runner.os }}-gem-
-    - name: Cache Mint
-      uses: actions/cache@v2
-      id: mint-cache
-      with:
-        path: /usr/local/lib/mint
-        key: ${{ runner.os }}-mint-${{ hashFiles('./Mintfile') }}
-        restore-keys: ${{ runner.os }}-mint-
-    - name: Run bootstrap.sh
-      run: ./bootstrap.sh    
-    - name: Install Carthage dependencies
-      run: bundle exec fastlane carthage_bootstrap
-    - name: Build all targets
-      run: bundle exec fastlane build_for_testing
-    - name: Run all tests
-      run: bundle exec fastlane test_without_building
-
   run-danger:
     name: Run Danger
     runs-on: macos-latest
@@ -74,84 +42,6 @@ jobs:
         run: bundle exec danger
         env:
           GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
-
-  test-carthage-integration:
-    name: Test Carthage integration
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Cache Carthage dependencies
-      uses: actions/cache@v2
-      id: carthage-cache
-      with:
-        path: Carthage
-        key: ${{ runner.os }}-${{ env.carthage-cache-dir }}-${{ hashFiles('**/Cartfile.resolved') }}
-    - name: Cache RubyGems
-      uses: actions/cache@v2
-      id: rubygem-cache
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: ${{ runner.os }}-gem-
-    - name: Cache Mint
-      uses: actions/cache@v2
-      id: mint-cache
-      with:
-        path: /usr/local/lib/mint
-        key: ${{ runner.os }}-mint-${{ hashFiles('./Mintfile') }}
-        restore-keys: ${{ runner.os }}-mint-
-    - name: Run bootstrap.sh
-      run: ./bootstrap.sh
-    - name: Test Carthage integration
-      run: bundle exec fastlane test_carthage_integration
-
-  test-cocoapods-integration:
-    name: Test CocoaPods integration
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Cache RubyGems
-      uses: actions/cache@v2
-      id: rubygem-cache
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: ${{ runner.os }}-gem-
-    - name: Cache Mint
-      uses: actions/cache@v2
-      id: mint-cache
-      with:
-        path: /usr/local/lib/mint
-        key: ${{ runner.os }}-mint-${{ hashFiles('./Mintfile') }}
-        restore-keys: ${{ runner.os }}-mint-
-    - name: Run bootstrap.sh
-      run: ./bootstrap.sh
-    - name: Test Cocoapods integration
-      run: bundle exec fastlane test_cocoapods_integration
-
-  test-spm-integration:
-    name: Test SPM integration
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Cache RubyGems
-      uses: actions/cache@v2
-      id: rubygem-cache
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: ${{ runner.os }}-gem-
-    - name: Cache Mint
-      uses: actions/cache@v2
-      id: mint-cache
-      with:
-        path: /usr/local/lib/mint
-        key: ${{ runner.os }}-mint-${{ hashFiles('./Mintfile') }}
-        restore-keys: ${{ runner.os }}-mint-
-    - name: Run bootstrap.sh
-      run: ./bootstrap.sh
-    - name: Test SPM integration
-      run: bundle exec fastlane test_spm_integration  
       
   build-and-test-v3-debug:
     name: Run v3 Tests (Debug)

--- a/.github/workflows/ci_v2.yml
+++ b/.github/workflows/ci_v2.yml
@@ -1,0 +1,156 @@
+name: CI v2
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Sources/**' # Only run if a file in /Sources changes (v2 folder)
+  pull_request:
+    branches:
+      - main
+  release:
+    types:
+      - created
+
+env:
+  carthage-cache-dir: 'carthage-cache-14122020' # When you change carthage cache directory, please append the date
+
+jobs:
+  build-and-test:
+    name: Build and Test v2
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Cache Carthage dependencies
+      uses: actions/cache@v2
+      id: carthage-cache
+      with:
+        path: Carthage
+        key: ${{ runner.os }}-${{ env.carthage-cache-dir }}-${{ hashFiles('**/Cartfile.resolved') }}
+    - name: Cache RubyGems
+      uses: actions/cache@v2
+      id: rubygem-cache
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: ${{ runner.os }}-gem-
+    - name: Cache Mint
+      uses: actions/cache@v2
+      id: mint-cache
+      with:
+        path: /usr/local/lib/mint
+        key: ${{ runner.os }}-mint-${{ hashFiles('./Mintfile') }}
+        restore-keys: ${{ runner.os }}-mint-
+    - name: Run bootstrap.sh
+      run: ./bootstrap.sh    
+    - name: Install Carthage dependencies
+      run: bundle exec fastlane carthage_bootstrap
+    - name: Build all targets
+      run: bundle exec fastlane build_for_testing
+    - name: Run all tests
+      run: bundle exec fastlane test_without_building
+
+  run-danger:
+    name: Run Danger
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Cache RubyGems
+        uses: actions/cache@v2
+        id: rubygem-cache
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: ${{ runner.os }}-gem-
+      - name: Cache Mint
+        uses: actions/cache@v2
+        id: mint-cache
+        with:
+          path: /usr/local/lib/mint
+          key: ${{ runner.os }}-mint-${{ hashFiles('./Mintfile') }}
+          restore-keys: ${{ runner.os }}-mint-
+      - name: Run bootstrap.sh
+        run: ./bootstrap.sh
+      - name: Run Danger
+        run: bundle exec danger
+        env:
+          GITHUB_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+
+  test-carthage-integration:
+    name: Test Carthage integration
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Cache Carthage dependencies
+      uses: actions/cache@v2
+      id: carthage-cache
+      with:
+        path: Carthage
+        key: ${{ runner.os }}-${{ env.carthage-cache-dir }}-${{ hashFiles('**/Cartfile.resolved') }}
+    - name: Cache RubyGems
+      uses: actions/cache@v2
+      id: rubygem-cache
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: ${{ runner.os }}-gem-
+    - name: Cache Mint
+      uses: actions/cache@v2
+      id: mint-cache
+      with:
+        path: /usr/local/lib/mint
+        key: ${{ runner.os }}-mint-${{ hashFiles('./Mintfile') }}
+        restore-keys: ${{ runner.os }}-mint-
+    - name: Run bootstrap.sh
+      run: ./bootstrap.sh
+    - name: Test Carthage integration
+      run: bundle exec fastlane test_carthage_integration
+
+  test-cocoapods-integration:
+    name: Test CocoaPods integration
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Cache RubyGems
+      uses: actions/cache@v2
+      id: rubygem-cache
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: ${{ runner.os }}-gem-
+    - name: Cache Mint
+      uses: actions/cache@v2
+      id: mint-cache
+      with:
+        path: /usr/local/lib/mint
+        key: ${{ runner.os }}-mint-${{ hashFiles('./Mintfile') }}
+        restore-keys: ${{ runner.os }}-mint-
+    - name: Run bootstrap.sh
+      run: ./bootstrap.sh
+    - name: Test Cocoapods integration
+      run: bundle exec fastlane test_cocoapods_integration
+
+  test-spm-integration:
+    name: Test SPM integration
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Cache RubyGems
+      uses: actions/cache@v2
+      id: rubygem-cache
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: ${{ runner.os }}-gem-
+    - name: Cache Mint
+      uses: actions/cache@v2
+      id: mint-cache
+      with:
+        path: /usr/local/lib/mint
+        key: ${{ runner.os }}-mint-${{ hashFiles('./Mintfile') }}
+        restore-keys: ${{ runner.os }}-mint-
+    - name: Run bootstrap.sh
+      run: ./bootstrap.sh
+    - name: Test SPM integration
+      run: bundle exec fastlane test_spm_integration  


### PR DESCRIPTION
Also update the carthage key, in the hopes that this will resolve the caching issue

No longer our v2 jobs will run unnecessarily