### PR TITLE
[CIS-518] Restart attachment uploading API

### DIFF
--- a/Sources_v3/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources_v3/StreamChat/Controllers/MessageController/MessageController.swift
@@ -336,6 +336,22 @@ public extension _ChatMessageController {
             }
         }
     }
+    
+    /// Updates local state of attachment with provided `id` to be enqueued by attachment uploader.
+    /// - Parameters:
+    ///   - id: The attachment identifier.
+    ///   - completion: The completion. Will be called on a **callbackQueue** when the database operation is finished.
+    ///                 If operation fails, the completion will be called with an error.
+    func restartFailedAttachmentUploading(
+        with id: AttachmentId,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        messageUpdater.restartFailedAttachmentUploading(with: id) { error in
+            self.callback {
+                completion?(error)
+            }
+        }
+    }
 }
 
 // MARK: - Environment

--- a/Sources_v3/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -276,3 +276,17 @@ extension LocalAttachmentState {
         }
     }
 }
+
+extension ClientError {
+    class AttachmentDoesNotExist: ClientError {
+        init(id: AttachmentId) {
+            super.init("There is no `AttachmentDTO` instance in the DB matching id: \(id).")
+        }
+    }
+
+    class AttachmentEditing: ClientError {
+        init(id: AttachmentId, reason: String) {
+            super.init("`AttachmentDTO` with id: \(id) can't be edited (\(reason))")
+        }
+    }
+}

--- a/Sources_v3/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/Sources_v3/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -47,6 +47,9 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
     @Atomic var deleteReaction_type: MessageReactionType?
     @Atomic var deleteReaction_messageId: MessageId?
     @Atomic var deleteReaction_completion: ((Error?) -> Void)?
+
+    @Atomic var restartFailedAttachmentUploading_id: AttachmentId?
+    @Atomic var restartFailedAttachmentUploading_completion: ((Error?) -> Void)?
     
     // Cleans up all recorded values
     func cleanUp() {
@@ -90,6 +93,9 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         deleteReaction_type = nil
         deleteReaction_messageId = nil
         deleteReaction_completion = nil
+
+        restartFailedAttachmentUploading_id = nil
+        restartFailedAttachmentUploading_completion = nil
     }
     
     override func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Error?) -> Void)? = nil) {
@@ -172,5 +178,13 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         deleteReaction_type = type
         deleteReaction_messageId = messageId
         deleteReaction_completion = completion
+    }
+
+    override func restartFailedAttachmentUploading(
+        with id: AttachmentId,
+        completion: @escaping (Error?) -> Void
+    ) {
+        restartFailedAttachmentUploading_id = id
+        restartFailedAttachmentUploading_completion = completion
     }
 }


### PR DESCRIPTION
**This PR:**
- exposes restart attachment uploading API by `ChatMessageController`
- exposes restart attachment uploading API by `MessageUpdater`
- introduces `AttachmentDoesNotExist` and `AttachmentEditing` error types
