### PR TITLE
Add path and path ignore params to PR workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'Sources/**' # Only run if a file outside /Sources changes (anything outside v2 is assumed to be v3)
   release:
     types:
       - created

--- a/.github/workflows/ci_v2.yml
+++ b/.github/workflows/ci_v2.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'Sources/**' # Only run if a file in /Sources changes (v2 folder)
   release:
     types:
       - created


### PR DESCRIPTION
Initially it was only added for push: main workflows, which caused PR workflows to run unnecessarily