### PR TITLE
[CIS-519] Disable all interactions with message textview except links

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageBubbleView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageBubbleView.swift
@@ -22,7 +22,7 @@ open class ChatMessageBubbleView<ExtraData: ExtraDataTypes>: View, UIConfigProvi
         .withoutAutoresizingMaskConstraints
 
     public private(set) lazy var textView: UITextView = {
-        let textView = UITextView()
+        let textView = OnlyLinkTappableTextView()
         textView.isEditable = false
         textView.dataDetectorTypes = .link
         textView.isScrollEnabled = false
@@ -31,7 +31,6 @@ open class ChatMessageBubbleView<ExtraData: ExtraDataTypes>: View, UIConfigProvi
         textView.adjustsFontForContentSizeCategory = true
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
-        textView.isUserInteractionEnabled = false
         return textView.withoutAutoresizingMaskConstraints
     }()
 

--- a/Sources_v3/StreamChatUI/Common Views/OnlyLinkTappableTextView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/OnlyLinkTappableTextView.swift
@@ -1,0 +1,20 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+/// Text View that ignore all user interactions except touches on links
+class OnlyLinkTappableTextView: UITextView {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        if let range = characterRange(at: point),
+            !range.isEmpty,
+            let position = closestPosition(to: point, within: range),
+            let styles = textStyling(at: position, in: .forward),
+            styles[.link] != nil {
+            return super.hitTest(point, with: event)
+        } else {
+            return nil
+        }
+    }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -543,9 +543,10 @@
 		DB9A3D662582783F00555D36 /* ChatVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9A3D652582783F00555D36 /* ChatVC.swift */; };
 		DBC8A4BB257E5BFB00B20A82 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DBC8A4BD257E5BFB00B20A82 /* Localizable.stringsdict */; };
 		DBC8A4C6257E696900B20A82 /* ChatMessageThreadInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC8A4C5257E696900B20A82 /* ChatMessageThreadInfoView.swift */; };
-		E701201E2583EBD50036DACD /* CALayer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70120152583EBC90036DACD /* CALayer+Extensions.swift */; };
 		DBC8A564258113F700B20A82 /* ChatThreadVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC8A563258113F700B20A82 /* ChatThreadVC.swift */; };
 		DBC8A5762581476E00B20A82 /* ChatMessageListVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC8A5752581476E00B20A82 /* ChatMessageListVC.swift */; };
+		DBF12128258BAFC1001919C6 /* OnlyLinkTappableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF12127258BAFC1001919C6 /* OnlyLinkTappableTextView.swift */; };
+		E701201E2583EBD50036DACD /* CALayer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70120152583EBC90036DACD /* CALayer+Extensions.swift */; };
 		E73A8B2B2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73A8B2A2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift */; };
 		E759AC4D256E694F00341865 /* OnlineIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */; };
 		E79AC10A25831A1500C3CE5D /* MessageComposerMentionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AC10625831A1100C3CE5D /* MessageComposerMentionCollectionViewCell.swift */; };
@@ -1242,9 +1243,10 @@
 		DB9A3D652582783F00555D36 /* ChatVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatVC.swift; sourceTree = "<group>"; };
 		DBC8A4BC257E5BFB00B20A82 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DBC8A4C5257E696900B20A82 /* ChatMessageThreadInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageThreadInfoView.swift; sourceTree = "<group>"; };
-		E70120152583EBC90036DACD /* CALayer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+Extensions.swift"; sourceTree = "<group>"; };
 		DBC8A563258113F700B20A82 /* ChatThreadVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThreadVC.swift; sourceTree = "<group>"; };
 		DBC8A5752581476E00B20A82 /* ChatMessageListVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListVC.swift; sourceTree = "<group>"; };
+		DBF12127258BAFC1001919C6 /* OnlyLinkTappableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlyLinkTappableTextView.swift; sourceTree = "<group>"; };
+		E70120152583EBC90036DACD /* CALayer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+Extensions.swift"; sourceTree = "<group>"; };
 		E73A8B2A2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageComposerInputAccessoryViewController.swift; sourceTree = "<group>"; };
 		E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineIndicatorView.swift; sourceTree = "<group>"; };
 		E79AC10625831A1100C3CE5D /* MessageComposerMentionCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageComposerMentionCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -2227,6 +2229,7 @@
 			isa = PBXGroup;
 			children = (
 				8850B93B255C3168003AED69 /* ContainerStackView.swift */,
+				DBF12127258BAFC1001919C6 /* OnlyLinkTappableTextView.swift */,
 				8850B945255C3B41003AED69 /* AvatarView.swift */,
 				885B3D7625642B3D003E6BDF /* CurrentChatUserAvatarView.swift */,
 				885B3D7C25642B88003E6BDF /* CreateNewChannelButton.swift */,
@@ -3158,6 +3161,7 @@
 				790882D625486B4A00896F03 /* ChatChannelListCollectionViewLayout.swift in Sources */,
 				790882F725486B8000896F03 /* ChatChannelListCollectionViewDelegate.swift in Sources */,
 				8850B946255C3B41003AED69 /* AvatarView.swift in Sources */,
+				DBF12128258BAFC1001919C6 /* OnlyLinkTappableTextView.swift in Sources */,
 				E79AC10B25831A1500C3CE5D /* MessageComposerCommandCollectionViewCell.swift in Sources */,
 				224FF6812562F2E900725DD1 /* ChatUnreadCountView.swift in Sources */,
 				224FF67B2562F1EA00725DD1 /* ChatReadStatusCheckmarkView.swift in Sources */,


### PR DESCRIPTION
Links were broken because to allow long press for message popup I disabled user interactions on text view.
If we just enable user interactions back, then on long press, user will select text inside text view instead of opening  message popup.

To disable press interception we have next options:
1. Use `UIGestureRecognaizerDelegate.gestureRecognizer(_:shouldRecognizeSimultaneouslyWith:)` and try to find which gesture recognizers in textview are responsible for links actions and for other actions.
This approach is unstable and rely on implementation details of text view
2. Override `hitTest` to skip all touches outside of link bounds.
Nice, simple, and elegant solution.
3. Intercept touches in some middle layer (e.g. view on top of text view) and pass only touches on links. 
Dirty, affect hierarchy, otherwise similar to 2
4. Disable `isSelectable`, add custom gesture recognizer on text view and check if is's inside link bounds.
Missing a lot of system features.
