### PR TITLE
Improve thread arrow aligment with message border

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageBubbleView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageBubbleView.swift
@@ -68,8 +68,9 @@ open class ChatMessageBubbleView<ExtraData: ExtraDataTypes>: View, UIConfigProvi
     override public func defaultAppearance() {
         layer.cornerRadius = 16
         layer.masksToBounds = true
+        borderLayer.contentsScale = layer.contentsScale
         borderLayer.cornerRadius = 16
-        borderLayer.borderWidth = 1 / UIScreen.main.scale
+        borderLayer.borderWidth = 1
     }
 
     override open func setUpLayout() {

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageThreadInfoView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageThreadInfoView.swift
@@ -26,9 +26,10 @@ open class ChatMessageThreadArrowView<ExtraData: ExtraDataTypes>: View, UIConfig
     }
 
     override open func defaultAppearance() {
+        shape.contentsScale = layer.contentsScale
         shape.strokeColor = uiConfig.colorPalette.incomingMessageBubbleBorder.cgColor
         shape.fillColor = nil
-        shape.lineWidth = 1.0 / UIScreen.main.scale
+        shape.lineWidth = 1.0
     }
 
     public var isLeftToRight: Bool {
@@ -40,8 +41,9 @@ open class ChatMessageThreadArrowView<ExtraData: ExtraDataTypes>: View, UIConfig
     override open func draw(_ rect: CGRect) {
         let corner: CGFloat = 16
         let height = bounds.height
+        let lineCenter = shape.lineWidth / 2
 
-        let startX = isLeftToRight ? 0 : bounds.width
+        let startX = isLeftToRight ? lineCenter : (bounds.width - lineCenter)
         let endX = isLeftToRight ? corner : (bounds.width - corner)
 
         let path = CGMutablePath()


### PR DESCRIPTION
Designs in Figma are made in "points" resolution -> 1pt border should be 1pt border in our project.

Arrow was drawing outside it borders, which lead to small misalignment with message bubble

![Screenshot 2020-12-17 at 17 54 13](https://user-images.githubusercontent.com/6978940/102517998-06981d80-4091-11eb-8202-f0d85004d400.png)
<img width="255" alt="Screenshot 2020-12-17 at 17 55 51" src="https://user-images.githubusercontent.com/6978940/102518155-36dfbc00-4091-11eb-9b2e-16d6acdc7c1e.png">
