### PR TITLE
[CIS-498] Layout feedback loop in composer

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageComposerView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageComposerView.swift
@@ -5,10 +5,7 @@
 import StreamChat
 import UIKit
 
-open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: UIInputView,
-    UIConfigProvider,
-    Customizable,
-    AppearanceSetting {
+open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
     // MARK: - Properties
     
     public var attachmentsViewHeight: CGFloat = .zero
@@ -67,30 +64,9 @@ open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: UIInputVie
         .withoutAutoresizingMaskConstraints
     
     public private(set) lazy var titleLabel: UILabel = UILabel().withoutAutoresizingMaskConstraints
-    
-    // MARK: - Init
-    
-    public required init() {
-        super.init(frame: .zero, inputViewStyle: .default)
-    }
-    
-    public required init?(coder: NSCoder) {
-        super.init(coder: coder)
-    }
-    
+
     // MARK: - Overrides
-    
-    override open func didMoveToSuperview() {
-        super.didMoveToSuperview()
-        guard superview != nil else { return }
-        
-        setUp()
-        (self as! Self).applyDefaultAppearance()
-        setUpAppearance()
-        setUpLayout()
-        updateContent()
-    }
-    
+
     override open var intrinsicContentSize: CGSize {
         let size = CGSize(
             width: UIView.noIntrinsicMetric,
@@ -98,12 +74,8 @@ open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: UIInputVie
         )
         return size
     }
-    
-    // MARK: - Public
 
-    open func setUp() {}
-    
-    open func defaultAppearance() {
+    override open func defaultAppearance() {
         attachmentsViewHeight = 80
         stateIconHeight = 40
         
@@ -136,10 +108,8 @@ open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: UIInputVie
         titleLabel.font = .preferredFont(forTextStyle: .headline)
         titleLabel.adjustsFontForContentSizeCategory = true
     }
-    
-    open func setUpAppearance() {}
-    
-    open func setUpLayout() {
+
+    override open func setUpLayout() {
         embed(container)
         
         preservesSuperviewLayoutMargins = true
@@ -167,6 +137,7 @@ open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: UIInputVie
         
         container.centerStackView.addArrangedSubview(messageInputView)
         messageInputView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        messageInputView.setContentCompressionResistancePriority(.required, for: .vertical)
         
         container.rightStackView.isHidden = false
         container.rightStackView.alignment = .center
@@ -188,6 +159,4 @@ open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: UIInputVie
         attachmentsView.isHidden = true
         shrinkInputButton.isHidden = true
     }
-    
-    open func updateContent() {}
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposerInputAccessoryViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposerInputAccessoryViewController.swift
@@ -128,7 +128,9 @@ open class MessageComposerInputAccessoryViewController<ExtraData: ExtraDataTypes
     }
     
     func setupInputView() {
-        inputView = composerView
+        inputView?.embed(composerView)
+        inputView?.translatesAutoresizingMaskIntoConstraints = false
+        inputView?.allowsSelfSizing = true
         
         composerView.messageInputView.textView.delegate = self
         


### PR DESCRIPTION
# What is this PR
This PR Fixes layout feedback loop caused by mainly setting `composerView` instead of `inputView` inside `MessageComposerInputAccessoryViewController`. It does 2 things:
- Makes `composerView` subview to inputView, removing the `UIInputView` constraints as subclass. 
- Fixes compression resistance vertical priority for the `messageInputView` so `intrinsicSize` is always known.

# How to test this 
1. Run the application with `-UIViewLayoutFeedbackLoopDebuggingThreshold 100` argument.
2. Try to use the chat as usually.
3. The app should not crash on the argument or the layout shouldn't be somehow broken (except for resizing the textView on deletion the text) 

# Important note
As far as my progress goes, `UIInputViewController` is broken and should not be used so we should fallback to using `inputView`.

This error is thrown in the callstack, while the inputView is first responder and you present something over full screen and then it goes back, somehow the `ViewWillAppear` happens on `UIInputViewController` subclass while the view is actually disappearing this causes this strange behavior which also happens to make composer not showing from time to time and throws assert failure: 

`[Assert] UITextEffectsWindow should not become key. Please file a bug to Keyboard | iOS with this call stack`

In near future I will file a radar, which is closely tight with this one: https://openradar.appspot.com/30064691 