### PR TITLE
[CIS-350][CIS-427][CIS-359] Fix failing LLC tests

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -11,15 +11,21 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Cache RubyGems
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       id: rubygem-cache
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: ${{ runner.os }}-gem-
-    - name: Install RubyGems
-      if: steps.rubygem-cache.outputs.cache-hit != 'true'
-      run: bundle install
+    - name: Cache Mint
+      uses: actions/cache@v2
+      id: mint-cache
+      with:
+        path: /usr/local/lib/mint
+        key: ${{ runner.os }}-mint-${{ hashFiles('./Mintfile') }}
+        restore-keys: ${{ runner.os }}-mint-
+    - name: Run bootstrap.sh
+      run: ./bootstrap.sh
     - name: Run Stress Tests
       run: bundle exec fastlane stress_test_v3
 
@@ -29,15 +35,21 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Cache RubyGems
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       id: rubygem-cache
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: ${{ runner.os }}-gem-
-    - name: Install RubyGems
-      if: steps.rubygem-cache.outputs.cache-hit != 'true'
-      run: bundle install
+    - name: Cache Mint
+      uses: actions/cache@v2
+      id: mint-cache
+      with:
+        path: /usr/local/lib/mint
+        key: ${{ runner.os }}-mint-${{ hashFiles('./Mintfile') }}
+        restore-keys: ${{ runner.os }}-mint-
+    - name: Run bootstrap.sh
+      run: ./bootstrap.sh
     - name: Run Stress Tests
       run: bundle exec fastlane stress_test_v3_release
 
@@ -53,9 +65,15 @@ jobs:
         path: vendor/bundle
         key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: ${{ runner.os }}-gem-
-    - name: Install RubyGems
-      if: steps.rubygem-cache.outputs.cache-hit != 'true'
-      run: bundle install
+    - name: Cache Mint
+      uses: actions/cache@v2
+      id: mint-cache
+      with:
+        path: /usr/local/lib/mint
+        key: ${{ runner.os }}-mint-${{ hashFiles('./Mintfile') }}
+        restore-keys: ${{ runner.os }}-mint-
+    - name: Run bootstrap.sh
+      run: ./bootstrap.sh
     - name: Install iOS11.4 runtime
       run: bundle exec xcversion simulators --install='iOS 11.4'
     - name: Run v3 Tests (Debug - iOS 11.4)

--- a/Sources_v3/StreamChat/APIClient/APIClient_Mock.swift
+++ b/Sources_v3/StreamChat/APIClient/APIClient_Mock.swift
@@ -50,7 +50,7 @@ class APIClientMock: APIClient {
     ) where Response: Decodable {
         request_endpoint = AnyEndpoint(endpoint)
         request_completion = completion
-        request_allRecordedCalls.append((request_endpoint!, request_completion!))
+        _request_allRecordedCalls.mutate { $0.append((request_endpoint!, request_completion!)) }
     }
 
     override func uploadFile(
@@ -63,7 +63,7 @@ class APIClientMock: APIClient {
         uploadFile_multipartFormData = multipartFormData
         uploadFile_progress = progress
         uploadFile_completion = completion
-        request_allRecordedCalls.append((AnyEndpoint(uploadFile_endpoint!), uploadFile_completion!))
+        _request_allRecordedCalls.mutate { $0.append((AnyEndpoint(uploadFile_endpoint!), uploadFile_completion!)) }
     }
 }
 

--- a/Sources_v3/StreamChat/ChatClient_Tests.swift
+++ b/Sources_v3/StreamChat/ChatClient_Tests.swift
@@ -492,12 +492,15 @@ extension ChatClient_Tests {
 private struct Queue<Element> {
     @Atomic private var storage = [Element]()
     mutating func push(_ element: Element) {
-        storage.append(element)
+        _storage.mutate { $0.append(element) }
     }
     
     mutating func pop() -> Element? {
-        let first = storage.first
-        storage = Array(storage.dropFirst())
+        var first: Element?
+        _storage.mutate { storage in
+            first = storage.first
+            storage = Array(storage.dropFirst())
+        }
         return first
     }
 }

--- a/Sources_v3/StreamChat/Controllers/EntityDatabaseObserver.swift
+++ b/Sources_v3/StreamChat/Controllers/EntityDatabaseObserver.swift
@@ -95,17 +95,7 @@ class EntityDatabaseObserver<Item, DTO: NSManagedObject> {
         }
     
     /// Used for observing the changes in the DB.
-    private(set) lazy var frc: NSFetchedResultsController<DTO> = self.fetchedResultsControllerType
-        .init(
-            fetchRequest: self.request,
-            managedObjectContext: self.context,
-            sectionNameKeyPath: nil,
-            cacheName: nil
-        )
-    
-    /// The `NSFetchedResultsController` subclass the observe uses to create its FRC. You can inject your custom subclass
-    /// in the initializer if needed, i.e. when testing.
-    let fetchedResultsControllerType: NSFetchedResultsController<DTO>.Type
+    private(set) var frc: NSFetchedResultsController<DTO>!
     
     let itemCreator: (DTO) -> Item?
     let request: NSFetchRequest<DTO>
@@ -136,7 +126,12 @@ class EntityDatabaseObserver<Item, DTO: NSManagedObject> {
         self.context = context
         request = fetchRequest
         self.itemCreator = itemCreator
-        self.fetchedResultsControllerType = fetchedResultsControllerType
+        frc = fetchedResultsControllerType.init(
+            fetchRequest: request,
+            managedObjectContext: self.context,
+            sectionNameKeyPath: nil,
+            cacheName: nil
+        )
         
         _item.computeValue = { [unowned self] in
             guard let fetchedObjects = self.frc.fetchedObjects else { return nil }

--- a/Sources_v3/StreamChat/Controllers/ListDatabaseObserver.swift
+++ b/Sources_v3/StreamChat/Controllers/ListDatabaseObserver.swift
@@ -93,23 +93,13 @@ class ListDatabaseObserver<Item, DTO: NSManagedObject> {
         ListChangeAggregator<DTO, Item>(itemCreator: self.itemCreator)
     
     /// Used for observing the changes in the DB.
-    private(set) lazy var frc: NSFetchedResultsController<DTO> = self.fetchedResultsControllerType
-        .init(
-            fetchRequest: self.request,
-            managedObjectContext: self.context,
-            sectionNameKeyPath: nil,
-            cacheName: nil
-        )
-    
-    /// The `NSFetchedResultsController` subclass the observe uses to create its FRC. You can inject your custom subclass
-    /// in the initializer if needed, i.e. when testing.
-    let fetchedResultsControllerType: NSFetchedResultsController<DTO>.Type
+    private(set) var frc: NSFetchedResultsController<DTO>!
     
     let itemCreator: (DTO) -> Item?
     let request: NSFetchRequest<DTO>
     let context: NSManagedObjectContext
     
-    /// When called, release the nofication observers
+    /// When called, release the notification observers
     var releaseNotificationObservers: (() -> Void)?
     
     /// Creates a new `ListObserver`.
@@ -134,7 +124,12 @@ class ListDatabaseObserver<Item, DTO: NSManagedObject> {
         self.context = context
         request = fetchRequest
         self.itemCreator = itemCreator
-        self.fetchedResultsControllerType = fetchedResultsControllerType
+        frc = fetchedResultsControllerType.init(
+            fetchRequest: request,
+            managedObjectContext: self.context,
+            sectionNameKeyPath: nil,
+            cacheName: nil
+        )
         
         _items.computeValue = { [unowned self] in (self.frc.fetchedObjects ?? []).lazy.compactMap(self.itemCreator) }
 

--- a/Sources_v3/StreamChat/Controllers/SearchControllers/UserSearchController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/SearchControllers/UserSearchController_Tests.swift
@@ -93,7 +93,9 @@ class UserSearchController_Tests: StressTestCase {
         XCTAssert(controller.users.isEmpty)
         
         // Assert that state is updated
-        XCTAssertEqual(delegate.state, .localDataFetched)
+        XCTAssertEqual(controller.state, .localDataFetched)
+        // Delegate is updated on a different queue so we have to use AssertAsync
+        AssertAsync.willBeEqual(delegate.state, .localDataFetched)
         
         // Make a search
         controller.search(term: "test")

--- a/Sources_v3/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -65,7 +65,7 @@ class AttachmentDTO: NSManagedObject {
             return existing
         }
         
-        let new = AttachmentDTO(context: context)
+        let new = NSEntityDescription.insertNewObject(forEntityName: Self.entityName, into: context) as! AttachmentDTO
         new.attachmentID = id
         return new
     }

--- a/Sources_v3/StreamChatUI/AppearanceSetting.swift
+++ b/Sources_v3/StreamChatUI/AppearanceSetting.swift
@@ -30,18 +30,27 @@ public extension AppearanceSetting {
 /// An object describing the default appearance of the view. Be aware that the appearance object is generic-type-specific,
 /// in other words: `MyView<A>.defaultAppearance != MyView<V>.defaultAppearance`.
 private func fetchDefaultAppearance<T: AppearanceSetting>(_ key: String) -> Appearance<T> {
-    if let existing = _AppearanceStorage.shared.appearances[key] as? Appearance<T> {
+    if let existing = _AppearanceStorage.shared.appearance(for: key) as? Appearance<T> {
         return existing
     } else {
         let appearance = Appearance<T>()
-        _AppearanceStorage.shared.appearances[key] = appearance
+        _AppearanceStorage.shared.setAppearance(appearance, for: key)
         return appearance
     }
 }
 
 private class _AppearanceStorage {
     static let shared = _AppearanceStorage()
-    @Atomic var appearances: [String: Any] = [:]
+    
+    fileprivate func setAppearance(_ appearance: Any, for key: String) {
+        _appearances.mutate { $0[key] = appearance }
+    }
+    
+    fileprivate func appearance(for key: String) -> Any? {
+        appearances[key]
+    }
+    
+    @Atomic private var appearances: [String: Any] = [:]
 }
 
 public class Appearance<Root: AnyObject> {

--- a/Tests_v3/StreamChatTests/StreamChatStressTestPlan.xctestplan
+++ b/Tests_v3/StreamChatTests/StreamChatStressTestPlan.xctestplan
@@ -19,11 +19,6 @@
   },
   "testTargets" : [
     {
-      "skippedTests" : [
-        "ChatClient_Tests",
-        "MessageSender_Tests",
-        "MessageUpdater_Tests"
-      ],
       "target" : {
         "containerPath" : "container:StreamChat_v3.xcodeproj",
         "identifier" : "799C9450247D59B1001F1104",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,7 +4,7 @@ default_platform :ios
 require 'json'
 
 # The number of times the stress test suite is ran
-stress_tests_cycles = 25
+stress_tests_cycles = 10
 
 before_all do
   if is_ci


### PR DESCRIPTION
This PR fixes many different problems with the stability of our SDK:

- CoreData was complaining about us using an incorrect initializer for `AttachmentDTO`. See the commit description for more details.

- I fixed the incorrect usage of `@Atomic` with collections (CIS-427)

- Fixed a race condition of removing notifications in `deinit`

- Fixed DB observer's `startObserving` method not being thread safe

This should also fix out test suite, so I re-enabled it. Let's see :)

I put the new findings to our [Writing stable unit tests](https://github.com/GetStream/stream-chat-swift/wiki/Writing-stable-unit-tests-checklist) checklist.

---

This PR also closes CIS-427 and CIS-359.