### PR TITLE
[CIS-474] Presenting Suggestions on ChatVC

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatVC.swift
@@ -16,6 +16,9 @@ open class ChatVC<ExtraData: ExtraDataTypes>: ViewController,
 
     public var channelController: _ChatChannelController<ExtraData>!
 
+    public private(set) lazy var suggestionsViewController: MessageComposerSuggestionsViewController<ExtraData> =
+        uiConfig.messageComposer.suggestionsViewController.init()
+
     // TODO: composer input must be able to distinguish between channel message send and thread message send
     public private(set) lazy var messageInputAccessoryViewController: MessageComposerInputAccessoryViewController<ExtraData> = {
         let inputAccessoryVC = MessageComposerInputAccessoryViewController<ExtraData>()
@@ -23,7 +26,7 @@ open class ChatVC<ExtraData: ExtraDataTypes>: ViewController,
         // `inputAccessoryViewController` is part of `_UIKeyboardWindowScene` so we need to manually pass
         // tintColor down that `inputAccessoryViewController` view hierarchy.
         inputAccessoryVC.view.tintColor = view.tintColor
-
+        inputAccessoryVC.suggestionsPresenter = self
         return inputAccessoryVC
     }()
 
@@ -155,5 +158,24 @@ open class ChatVC<ExtraData: ExtraDataTypes>: ViewController,
     
     public func chatMessageListVC(_ vc: ChatMessageListVC<ExtraData>, didTapOnEdit message: _ChatMessage<ExtraData>) {
         messageInputAccessoryViewController.state = .edit(message)
+    }
+}
+
+// MARK: - SuggestionsViewControllerPresenter
+
+extension ChatVC: SuggestionsViewControllerPresenter {
+    public var isSuggestionControllerPresented: Bool {
+        suggestionsViewController.isPresented
+    }
+
+    public func showSuggestionsViewController(with state: SuggestionsViewControllerState, onSelectItem: ((Int) -> Void)) {
+        suggestionsViewController.state = state
+        addChildViewController(suggestionsViewController, targetView: view)
+        suggestionsViewController.bottomAnchorView = messageInputAccessoryViewController.composerView
+    }
+
+    public func dismissSuggestionsViewController() {
+        suggestionsViewController.removeFromParent()
+        suggestionsViewController.view.removeFromSuperview()
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposerSuggestionsViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposerSuggestionsViewController.swift
@@ -24,13 +24,6 @@ open class MessageComposerSuggestionsViewController<ExtraData: ExtraDataTypes>: 
     UIConfigProvider,
     UICollectionViewDelegate,
     UICollectionViewDataSource {
-    // MARK: - Underlying types
-
-    public enum State {
-        case commands([Command])
-        case mentions([String])
-    }
-
     // MARK: - Property
 
     private var frameObserver: NSKeyValueObservation?

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposerSuggestionsViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposerSuggestionsViewController.swift
@@ -9,16 +9,23 @@ open class MessageComposerSuggestionsViewController<ExtraData: ExtraDataTypes>: 
     UIConfigProvider,
     UICollectionViewDelegate,
     UICollectionViewDataSource {
-    var heightConstraint: NSLayoutConstraint?
-    
     // MARK: - Underlying types
-    
+
     public enum State {
         case commands([Command])
         case mentions([String])
     }
 
     // MARK: - Property
+
+    private var frameObserver: NSKeyValueObservation?
+
+    /// View to which the suggestions should be pinned.
+    /// This view should be assigned as soon as instance of this
+    /// class is instantiated, because we set observer to
+    /// the bottomAnchorView as soon as we compute the height of the
+    /// contentSize of the nested collectionView
+    public var bottomAnchorView: UIView?
     
     public var state: State? {
         didSet {
@@ -42,12 +49,9 @@ open class MessageComposerSuggestionsViewController<ExtraData: ExtraDataTypes>: 
         .init(layout: uiConfig.messageComposer.suggestionsCollectionViewLayout.init())
         .withoutAutoresizingMaskConstraints
 
-    // MARK: - Overrides
+    open private(set) lazy var containerView: UIView = UIView().withoutAutoresizingMaskConstraints
 
-    override open func viewDidLoad() {
-        super.viewDidLoad()
-        view.embed(collectionView)
-    }
+    // MARK: - Overrides
 
     override open func setUp() {
         super.setUp()
@@ -61,18 +65,6 @@ open class MessageComposerSuggestionsViewController<ExtraData: ExtraDataTypes>: 
             uiConfig.messageComposer.suggestionsMentionCollectionViewCell,
             forCellWithReuseIdentifier: uiConfig.messageComposer.suggestionsMentionCollectionViewCell.reuseId
         )
-        
-        collectionViewHeightObserver = collectionView.observe(
-            \.contentSize,
-            options: [.new],
-            changeHandler: { [weak self] _, change in
-                DispatchQueue.main.async {
-                    guard let self = self, let newSize = change.newValue else { return }
-                    self.heightConstraint?.constant = newSize.height
-                    self.view.setNeedsLayout()
-                }
-            }
-        )
     }
 
     override public func setUpAppearance() {
@@ -81,23 +73,55 @@ open class MessageComposerSuggestionsViewController<ExtraData: ExtraDataTypes>: 
     }
 
     override public func setUpLayout() {
-        view.translatesAutoresizingMaskIntoConstraints = false
+        view.embed(containerView)
+        containerView.embed(
+            collectionView,
+            insets: .init(
+                top: 0,
+                leading: containerView.directionalLayoutMargins.leading,
+                bottom: 0,
+                trailing: containerView.directionalLayoutMargins.trailing
+            )
+        )
 
-        heightConstraint = collectionView.heightAnchor.constraint(equalToConstant: 0)
-
-        let constraints = [heightConstraint].compactMap { $0 }
-
-        NSLayoutConstraint.activate(constraints)
+        collectionViewHeightObserver = collectionView.observe(
+            \.contentSize,
+            options: [.new],
+            changeHandler: { [weak self] _, change in
+                DispatchQueue.main.async {
+                    guard let newSize = change.newValue, newSize.height < 300 else {
+                        // TODO: Compute size better according to 4 cells.
+                        self?.view.frame.size.height = 300
+                        self?.updateViewFrame()
+                        return
+                    }
+                    self?.view.frame.size.height = newSize.height
+                    self?.updateViewFrame()
+                }
+            }
+        )
         updateContent()
-    }
-
-    override open func updateViewConstraints() {
-        super.updateViewConstraints()
-        heightConstraint?.constant = collectionView.contentSize.height
     }
 
     override open func updateContent() {
         collectionView.reloadData()
+    }
+
+    // MARK: - Private
+
+    private func updateViewFrame() {
+        frameObserver = bottomAnchorView?.observe(
+            \.bounds,
+            options: [.new, .initial],
+            changeHandler: { [weak self] bottomAnchoredView, change in
+                DispatchQueue.main.async {
+                    guard let self = self, let changedFrame = change.newValue else { return }
+
+                    let newFrame = bottomAnchoredView.convert(changedFrame, to: nil)
+                    self.view.frame.origin.y = newFrame.minY - self.view.frame.height
+                }
+            }
+        )
     }
 
     // MARK: - UICollectionView

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposerSuggestionsViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposerSuggestionsViewController.swift
@@ -5,6 +5,21 @@
 import StreamChat
 import UIKit
 
+public protocol SuggestionsViewControllerPresenter: class {
+    func showSuggestionsViewController(
+        with state: SuggestionsViewControllerState,
+        onSelectItem: ((Int) -> Void)
+    )
+    func dismissSuggestionsViewController()
+
+    var isSuggestionControllerPresented: Bool { get }
+}
+
+public enum SuggestionsViewControllerState {
+    case commands([Command])
+    case mentions([String])
+}
+
 open class MessageComposerSuggestionsViewController<ExtraData: ExtraDataTypes>: ViewController,
     UIConfigProvider,
     UICollectionViewDelegate,
@@ -27,7 +42,7 @@ open class MessageComposerSuggestionsViewController<ExtraData: ExtraDataTypes>: 
     /// contentSize of the nested collectionView
     public var bottomAnchorView: UIView?
     
-    public var state: State? {
+    public var state: SuggestionsViewControllerState? {
         didSet {
             updateContentIfNeeded()
         }


### PR DESCRIPTION
# What this PR does
- Presents SuggestionsViewController on ChatVC as a child VIewController, this eliminates problems with strange behaviour while adding it as VC on custom Window or child of `InputAccessoryViewController`. Also resizes and moves according to position of inputView. 
# How to test this
- Go to chat and run suggestions either with the flash button or with typing `/`, see if this works for you 
