### PR TITLE
[CIS-539] Switch from `inputAccessoryView` to custom one for message composer

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageComposerView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatChannelMessageComposerView.swift
@@ -5,10 +5,8 @@
 import StreamChat
 import UIKit
 
-open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: UIInputView,
-    UIConfigProvider,
-    Customizable,
-    AppearanceSetting {
+open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: View,
+    UIConfigProvider {
     // MARK: - Properties
     
     public var attachmentsViewHeight: CGFloat = .zero
@@ -68,16 +66,6 @@ open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: UIInputVie
     
     public private(set) lazy var titleLabel: UILabel = UILabel().withoutAutoresizingMaskConstraints
     
-    // MARK: - Init
-    
-    public required init() {
-        super.init(frame: .zero, inputViewStyle: .default)
-    }
-    
-    public required init?(coder: NSCoder) {
-        super.init(coder: coder)
-    }
-    
     // MARK: - Overrides
     
     override open func didMoveToSuperview() {
@@ -100,10 +88,9 @@ open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: UIInputVie
     }
     
     // MARK: - Public
-
-    open func setUp() {}
     
-    open func defaultAppearance() {
+    override open func defaultAppearance() {
+        super.defaultAppearance()
         attachmentsViewHeight = 80
         stateIconHeight = 40
         
@@ -137,9 +124,8 @@ open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: UIInputVie
         titleLabel.adjustsFontForContentSizeCategory = true
     }
     
-    open func setUpAppearance() {}
-    
-    open func setUpLayout() {
+    override open func setUpLayout() {
+        super.setUpLayout()
         embed(container)
         
         preservesSuperviewLayoutMargins = true
@@ -188,6 +174,4 @@ open class ChatChannelMessageComposerView<ExtraData: ExtraDataTypes>: UIInputVie
         attachmentsView.isHidden = true
         shrinkInputButton.isHidden = true
     }
-    
-    open func updateContent() {}
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatVC.swift
@@ -50,6 +50,8 @@ open class ChatVC<ExtraData: ExtraDataTypes>: ViewController,
         super.setUp()
         
         messageComposerViewController.controller = channelController
+        messageComposerViewController.suggestionsPresenter = self
+        
         messageList.delegate = .wrap(self)
         messageList.dataSource = .wrap(self)
         

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposerViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposerViewController.swift
@@ -5,10 +5,8 @@
 import StreamChat
 import UIKit
 
-open class MessageComposerInputAccessoryViewController<ExtraData: ExtraDataTypes>: UIInputViewController,
+open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewController,
     UIConfigProvider,
-    Customizable,
-    AppearanceSetting,
     UITextViewDelegate,
     UIImagePickerControllerDelegate,
     UIDocumentPickerDelegate,
@@ -63,27 +61,15 @@ open class MessageComposerInputAccessoryViewController<ExtraData: ExtraDataTypes
     }()
     
     // MARK: Setup
-    
-    override open func viewDidLoad() {
-        super.viewDidLoad()
-        
-        setUp()
-        (self as! Self).applyDefaultAppearance()
-        setUpAppearance()
-        setUpLayout()
-        updateContent()
-    }
-    
-    open func setUp() {
+
+    override open func setUp() {
+        super.setUp()
         setupInputView()
         observeSizeChanges()
     }
-    
-    open func defaultAppearance() {}
-    
-    open func setUpAppearance() {}
-    
-    open func updateContent() {
+
+    override open func updateContent() {
+        super.updateContent()
         switch state {
         case .initial:
             textView.text = ""
@@ -125,7 +111,7 @@ open class MessageComposerInputAccessoryViewController<ExtraData: ExtraDataTypes
     }
     
     func setupInputView() {
-        inputView = composerView
+        view.embed(composerView)
         
         composerView.messageInputView.textView.delegate = self
         
@@ -141,8 +127,6 @@ open class MessageComposerInputAccessoryViewController<ExtraData: ExtraDataTypes
         composerView.dismissButton.addTarget(self, action: #selector(resetState), for: .touchUpInside)
         composerView.attachmentsView.didTapRemoveItemButton = { [weak self] index in self?.imageAttachments.remove(at: index) }
     }
-    
-    open func setUpLayout() {}
     
     public func observeSizeChanges() {
         composerView.addObserver(self, forKeyPath: "safeAreaInsets", options: .new, context: nil)
@@ -295,20 +279,11 @@ open class MessageComposerInputAccessoryViewController<ExtraData: ExtraDataTypes
 
     // MARK: - UITextViewDelegate
     
-    public func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
-        composerView.messageInputView.textView.inputAccessoryView = view
-        return true
-    }
-
-    public func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
-        composerView.messageInputView.textView.inputAccessoryView = nil
-        return true
-    }
-    
     public func textViewDidChange(_ textView: UITextView) {
         isEmpty = textView.text.replacingOccurrences(of: " ", with: "").isEmpty
         replaceTextWithSlashCommandViewIfNeeded()
         promptSuggestionIfNeeded(for: textView.text)
+        composerView.invalidateIntrinsicContentSize()
     }
 
     // MARK: - UIImagePickerControllerDelegate

--- a/Sources_v3/StreamChatUI/UIConfig.swift
+++ b/Sources_v3/StreamChatUI/UIConfig.swift
@@ -217,6 +217,8 @@ public extension UIConfig {
 
 public extension UIConfig {
     struct MessageComposer {
+        public var messageComposerViewController: MessageComposerViewController<ExtraData>.Type =
+            MessageComposerViewController<ExtraData>.self
         public var messageComposerView: ChatChannelMessageComposerView<ExtraData>.Type =
             ChatChannelMessageComposerView<ExtraData>.self
         public var messageInputView: ChatChannelMessageInputView<ExtraData>.Type = ChatChannelMessageInputView<ExtraData>.self

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -564,7 +564,7 @@
 		DBC8A5762581476E00B20A82 /* ChatMessageListVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC8A5752581476E00B20A82 /* ChatMessageListVC.swift */; };
 		DBF12128258BAFC1001919C6 /* OnlyLinkTappableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF12127258BAFC1001919C6 /* OnlyLinkTappableTextView.swift */; };
 		E701201E2583EBD50036DACD /* CALayer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70120152583EBC90036DACD /* CALayer+Extensions.swift */; };
-		E73A8B2B2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73A8B2A2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift */; };
+		E73A8B2B2578EB2B00FBDC56 /* MessageComposerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73A8B2A2578EB2B00FBDC56 /* MessageComposerViewController.swift */; };
 		E759AC4D256E694F00341865 /* OnlineIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */; };
 		E79AC10A25831A1500C3CE5D /* MessageComposerMentionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AC10625831A1100C3CE5D /* MessageComposerMentionCollectionViewCell.swift */; };
 		E79AC10B25831A1500C3CE5D /* MessageComposerCommandCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AC10725831A1500C3CE5D /* MessageComposerCommandCollectionViewCell.swift */; };
@@ -1281,7 +1281,7 @@
 		DBC8A5752581476E00B20A82 /* ChatMessageListVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListVC.swift; sourceTree = "<group>"; };
 		DBF12127258BAFC1001919C6 /* OnlyLinkTappableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlyLinkTappableTextView.swift; sourceTree = "<group>"; };
 		E70120152583EBC90036DACD /* CALayer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+Extensions.swift"; sourceTree = "<group>"; };
-		E73A8B2A2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageComposerInputAccessoryViewController.swift; sourceTree = "<group>"; };
+		E73A8B2A2578EB2B00FBDC56 /* MessageComposerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageComposerViewController.swift; sourceTree = "<group>"; };
 		E759AC4C256E694F00341865 /* OnlineIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineIndicatorView.swift; sourceTree = "<group>"; };
 		E79AC10625831A1100C3CE5D /* MessageComposerMentionCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageComposerMentionCollectionViewCell.swift; sourceTree = "<group>"; };
 		E79AC10725831A1500C3CE5D /* MessageComposerCommandCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageComposerCommandCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -1509,7 +1509,7 @@
 				228DC80D25704B410080A49F /* MessageComposerAttachmentCellView.swift */,
 				2210525E256FE16600A5F0DB /* MessageInputSlashCommandView.swift */,
 				22FF4364256E943F00133910 /* MessageComposerSuggestionsViewController.swift */,
-				E73A8B2A2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift */,
+				E73A8B2A2578EB2B00FBDC56 /* MessageComposerViewController.swift */,
 				E79AC10725831A1500C3CE5D /* MessageComposerCommandCollectionViewCell.swift */,
 				E79AC10625831A1100C3CE5D /* MessageComposerMentionCollectionViewCell.swift */,
 				E79AC10825831A1500C3CE5D /* MessageComposerSuggestionsCollectionView.swift */,
@@ -3245,7 +3245,7 @@
 				8850B92A255C286B003AED69 /* UIConfig.swift in Sources */,
 				790882ED25486B6D00896F03 /* ChatChannelListCollectionViewDataSource.swift in Sources */,
 				E79AC10D25831A1500C3CE5D /* MessageComposerSuggestionsCollectionViewLayout.swift in Sources */,
-				E73A8B2B2578EB2B00FBDC56 /* MessageComposerInputAccessoryViewController.swift in Sources */,
+				E73A8B2B2578EB2B00FBDC56 /* MessageComposerViewController.swift in Sources */,
 				8800A26F258A04D5006D64C4 /* ChatAttachmentPreviewVC.swift in Sources */,
 				228C7F022584132F00AAE9E3 /* ChatReplyBubbleView.swift in Sources */,
 				885B3D7725642B3D003E6BDF /* CurrentChatUserAvatarView.swift in Sources */,


### PR DESCRIPTION
**In this PR:**

- Switch from `inputAccessoryView` to custom one for message composer

kudos to @ManWithBear for helping with that

![ezgif com-video-to-gif-3](https://user-images.githubusercontent.com/10098359/102918209-cb2d9280-4486-11eb-89ec-f3c3d2f7c1e0.gif)