### PR TITLE
[CIS-541] Make `StreamChat` usable from app extensions

### DIFF
--- a/Sources_v3/StreamChat/ChatClient.swift
+++ b/Sources_v3/StreamChat/ChatClient.swift
@@ -215,6 +215,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
     ///
     /// - Parameter config: The config object for the `Client`. See `ChatClientConfig` for all configuration options.
     ///
+    @available(iOSApplicationExtension, unavailable)
     public convenience init(config: ChatClientConfig) {
         // All production workers
         let workerBuilders: [WorkerBuilder] = [

--- a/Sources_v3/StreamChat/Utils/BundleExtensions.swift
+++ b/Sources_v3/StreamChat/Utils/BundleExtensions.swift
@@ -14,4 +14,11 @@ extension Bundle {
     var name: String? {
         object(forInfoDictionaryKey: kCFBundleNameKey as String) as? String
     }
+    
+    /// Returns `true` if the bundle path has `appex` suffix. When used for the `main` bundle, it can help you to
+    /// identify if the executable is an app or an app extension.
+    var isAppExtension: Bool {
+        let bundlePathExtension: String = bundleURL.pathExtension
+        return bundlePathExtension == "appex"
+    }
 }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -4264,6 +4264,7 @@
 		799C9421247D2F80001F1104 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -4291,6 +4292,7 @@
 		799C9422247D2F80001F1104 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -4584,6 +4586,7 @@
 		A57E5C7524C6FA3900187DC2 /* ReleaseTests */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
This PR is a part of the changes needed to enable notification extensions for `StreamChat`. The extension is needed to support our new backend service for push notifications.

### Changes
- `StreamChat` is marked as `APPLICATION_EXTENSION_API_ONLY` which means you can use it safely from app extensions.
- Accessing `UIApplication.shared` directly is no longer possible so I put it behind a check.
 
*However,* it can lead to issues if we run the full client from extensions. It would create a new web socket connection, mark the user as `online`, start background workers, etc. For these reasons, I made it not possible to actually create a client instance from extensions yet. Our notification extension will expose only safe API, not the full client, for the reasons above.

In general, we should make it possible to create a `ChatClient` instance in extensions eventually. However, this task will not be trivial.