### PR TITLE
Make file preview layout less dynamic, to prevent layout loop

### DIFF
--- a/DemoApp/ChatPresenter.swift
+++ b/DemoApp/ChatPresenter.swift
@@ -9,7 +9,7 @@ import UIKit
 extension UIViewController {
     // TODO: Where to put this???
     func presentChat(userCredentials: UserCredentials) {
-        LogConfig.level = .debug
+        LogConfig.level = .error
         
         // Create client
         let config = ChatClientConfig(apiKey: .init(userCredentials.apiKey))

--- a/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatFileAttachmentListView+ItemView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatFileAttachmentListView+ItemView.swift
@@ -9,8 +9,11 @@ extension ChatFileAttachmentListView {
     open class ItemView: ChatMessageAttachmentInfoView<ExtraData> {
         // MARK: - Subviews
 
-        public private(set) lazy var fileIconImageView = UIImageView()
-            .withoutAutoresizingMaskConstraints
+        public private(set) lazy var fileIconImageView: UIImageView = {
+            let imageView = UIImageView().withoutAutoresizingMaskConstraints
+            imageView.contentMode = .center
+            return imageView
+        }()
 
         // MARK: - Overrides
 
@@ -29,9 +32,8 @@ extension ChatFileAttachmentListView {
 
             NSLayoutConstraint.activate([
                 fileIconImageView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-                fileIconImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
-                fileIconImageView.topAnchor.constraint(greaterThanOrEqualTo: layoutMarginsGuide.topAnchor),
-                fileIconImageView.bottomAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.bottomAnchor),
+                fileIconImageView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+                fileIconImageView.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
                 
                 actionIconImageView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
                 actionIconImageView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessage/ChatMessageContentView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessage/ChatMessageContentView.swift
@@ -205,9 +205,9 @@ open class ChatMessageContentView<ExtraData: ExtraDataTypes>: View, UIConfigProv
         }
 
         if message?.deletedAt == nil, !(message?.reactionScores.isEmpty ?? true) {
-            toActivate.append(bubbleToReactionsConstraint!)
+//            toActivate.append(bubbleToReactionsConstraint!)
         } else {
-            toDeactivate.append(bubbleToReactionsConstraint!)
+//            toDeactivate.append(bubbleToReactionsConstraint!)
         }
         
         if message?.isLastInGroup == true {

--- a/StreamChat_v3.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
+++ b/StreamChat_v3.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:StreamChat_v3.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-UIViewLayoutFeedbackLoopDebuggingThreshold 100"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Looks like our layout was too dynamic and layout engine goes mad with it. Specifically:
- `ChatFileAttachmentListView.ItemView` 2 components that limit min height, positioned in the middle, nothing to limit max size
- `ChatMessageContentView.messageReactionsView` in general bad constraints. Will be reworked with reactions tail update