### PR TITLE
Fix UserListUpdater flaky test

### DIFF
--- a/Sources_v3/StreamChat/Workers/UserListUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/UserListUpdater_Tests.swift
@@ -187,11 +187,14 @@ class UserListUpdater_Tests: StressTestCase {
             // At this point, DB write should have completed
             
             // Assert the data is stored in the DB
-            let user: ChatUser? = self.database.viewContext.user(id: dummyUserId)?.asModel()
-        
-            XCTAssert(user != nil)
+            // We call this block in `main` queue since we need to access `viewContext`
+            DispatchQueue.main.sync {
+                let user: ChatUser? = self.database.viewContext.user(id: dummyUserId)?.asModel()
             
-            completionCalled = true
+                XCTAssert(user != nil)
+                
+                completionCalled = true
+            }
         })
         
         // Simulate API response with user data


### PR DESCRIPTION
`test_updateCompletion_calledAfterDBWriteCompletes` was flaky since listUpdater.update makes a database.write call, which calls writableContext.perform , and in the same perform block accessing viewContext crashes. but using same context (writableContext ) works flawless. So we need to call `viewContext` in main queue
