### PR TITLE
[CIS-520] Attachment actions (LLC)

### DIFF
--- a/Sources_v3/StreamChat/APIClient/Endpoints/MessageEndpoints.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/MessageEndpoints.swift
@@ -77,6 +77,24 @@ extension Endpoint {
             body: nil
         )
     }
+
+    static func dispatchEphemeralMessageAction<ExtraData: ExtraDataTypes>(
+        cid: ChannelId,
+        messageId: MessageId,
+        action: AttachmentAction
+    ) -> Endpoint<WrappedMessagePayload<ExtraData>> {
+        .init(
+            path: messageId.actionPath,
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: AttachmentActionRequestBody(
+                cid: cid,
+                messageId: messageId,
+                action: action
+            )
+        )
+    }
 }
 
 private extension MessageId {
@@ -90,5 +108,9 @@ private extension MessageId {
     
     var reactionsPath: String {
         path.appending("/reaction")
+    }
+
+    var actionPath: String {
+        path.appending("/action")
     }
 }

--- a/Sources_v3/StreamChat/APIClient/Endpoints/MessageEndpoints_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/MessageEndpoints_Tests.swift
@@ -134,4 +134,38 @@ final class MessageEndpoints_Tests: XCTestCase {
         // Assert endpoint is built correctly
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
     }
+
+    func test_sendMessageAction_buildsCorrectly() {
+        let cid: ChannelId = .unique
+        let messageId: MessageId = .unique
+        let action = AttachmentAction(
+            name: .unique,
+            value: .unique,
+            style: .primary,
+            type: .button,
+            text: .unique
+        )
+
+        let expectedEndpoint = Endpoint<WrappedMessagePayload<DefaultExtraData>>(
+            path: "messages/\(messageId)/action",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: AttachmentActionRequestBody(
+                cid: cid,
+                messageId: messageId,
+                action: action
+            )
+        )
+
+        // Build endpoint.
+        let endpoint: Endpoint<WrappedMessagePayload<DefaultExtraData>> = .dispatchEphemeralMessageAction(
+            cid: cid,
+            messageId: messageId,
+            action: action
+        )
+
+        // Assert endpoint is built correctly
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
 }

--- a/Sources_v3/StreamChat/APIClient/Endpoints/Requests/AttachmentActionRequestBody.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/Requests/AttachmentActionRequestBody.swift
@@ -1,0 +1,28 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The type describes the outgoing JSON to `message/{id}/action` endpoint
+struct AttachmentActionRequestBody: Encodable {
+    private enum CodingKeys: String, CodingKey {
+        case channelId = "id"
+        case channelType = "type"
+        case messageId = "message_id"
+        case data = "form_data"
+    }
+
+    let cid: ChannelId
+    let messageId: MessageId
+    let action: AttachmentAction
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(cid.id, forKey: .channelId)
+        try container.encode(cid.type, forKey: .channelType)
+        try container.encode(messageId, forKey: .messageId)
+        try container.encode([action.name: action.value], forKey: .data)
+    }
+}

--- a/Sources_v3/StreamChat/APIClient/Endpoints/Requests/AttachmentActionRequestBody_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/Requests/AttachmentActionRequestBody_Tests.swift
@@ -1,0 +1,38 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class AttachmentActionRequestBody_Tests: XCTestCase {
+    func test_body_isBuiltAndEncodedCorrectly() throws {
+        let cid: ChannelId = .unique
+        let messageId: MessageId = .unique
+        let action = AttachmentAction(
+            name: .unique,
+            value: .unique,
+            style: .primary,
+            type: .button,
+            text: .unique
+        )
+
+        // Build the body.
+        let body = AttachmentActionRequestBody(
+            cid: cid,
+            messageId: messageId,
+            action: action
+        )
+
+        // Encode the body.
+        let json = try JSONEncoder.default.encode(body)
+
+        // Assert encoding is correct.
+        AssertJSONEqual(json, [
+            "id": cid.id,
+            "type": cid.type.rawValue,
+            "message_id": messageId,
+            "form_data": [action.name: action.value]
+        ])
+    }
+}

--- a/Sources_v3/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources_v3/StreamChat/Controllers/MessageController/MessageController.swift
@@ -362,6 +362,19 @@ public extension _ChatMessageController {
             }
         }
     }
+    
+    /// Executes the provided action on the message this controller manages.
+    /// - Parameters:
+    ///   - action: The action to take.
+    ///   - completion: The completion. Will be called on a **callbackQueue** when the operation is finished.
+    ///                 If operation fails, the completion is called with the error.
+    func dispatchEphemeralMessageAction(_ action: AttachmentAction, completion: ((Error?) -> Void)? = nil) {
+        messageUpdater.dispatchEphemeralMessageAction(cid: cid, messageId: messageId, action: action) { error in
+            self.callback {
+                completion?(error)
+            }
+        }
+    }
 }
 
 // MARK: - Environment

--- a/Sources_v3/StreamChat/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseContainer_Mock.swift
@@ -135,12 +135,14 @@ extension DatabaseContainer {
         cid: ChannelId = .unique,
         text: String = .unique,
         attachments: [AttachmentPayload<DefaultExtraData.Attachment>] = [],
-        localState: LocalMessageState? = nil
+        localState: LocalMessageState? = nil,
+        type: MessageType? = nil
     ) throws {
         try writeSynchronously { session in
             try session.saveChannel(payload: XCTestCase().dummyPayload(with: cid))
             
             let message: MessagePayload<DefaultExtraData> = .dummy(
+                type: type,
                 messageId: id,
                 attachments: attachments,
                 authorUserId: authorId,

--- a/Sources_v3/StreamChat/Models/Attachment.swift
+++ b/Sources_v3/StreamChat/Models/Attachment.swift
@@ -168,6 +168,9 @@ public struct AttachmentAction: Codable, Hashable {
         self.type = type
         self.text = text
     }
+
+    /// Check if the action is cancel button.
+    public var isCancel: Bool { value.lowercased() == "cancel" }
     
     /// An attachment action type, e.g. button.
     public enum ActionType: String, Codable {

--- a/Sources_v3/StreamChat/Models/Attachment_Tests.swift
+++ b/Sources_v3/StreamChat/Models/Attachment_Tests.swift
@@ -46,6 +46,36 @@ class Attachment_Tests: XCTestCase {
         // Assert object encoded and decoded correctly
         XCTAssertEqual(action, decoded)
     }
+
+    func test_cancelAction_isDetected() throws {
+        let cancelActions = [
+            AttachmentAction(
+                name: .unique,
+                value: "cancel",
+                style: .default,
+                type: .button,
+                text: .unique
+            ),
+            AttachmentAction(
+                name: .unique,
+                value: "CANCEL",
+                style: .default,
+                type: .button,
+                text: .unique
+            ),
+            AttachmentAction(
+                name: .unique,
+                value: "Cancel",
+                style: .default,
+                type: .button,
+                text: .unique
+            )
+        ]
+
+        for action in cancelActions {
+            XCTAssertTrue(action.isCancel)
+        }
+    }
     
     func test_file_encodedAndDecodedCorrectly() throws {
         let file: AttachmentFile = .init(

--- a/Sources_v3/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/Sources_v3/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -53,6 +53,11 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
 
     @Atomic var resendMessage_messageId: MessageId?
     @Atomic var resendMessage_completion: ((Error?) -> Void)?
+
+    @Atomic var dispatchEphemeralMessageAction_cid: ChannelId?
+    @Atomic var dispatchEphemeralMessageAction_messageId: MessageId?
+    @Atomic var dispatchEphemeralMessageAction_action: AttachmentAction?
+    @Atomic var dispatchEphemeralMessageAction_completion: ((Error?) -> Void)?
     
     // Cleans up all recorded values
     func cleanUp() {
@@ -102,6 +107,11 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
 
         resendMessage_messageId = nil
         resendMessage_completion = nil
+
+        dispatchEphemeralMessageAction_cid = nil
+        dispatchEphemeralMessageAction_messageId = nil
+        dispatchEphemeralMessageAction_action = nil
+        dispatchEphemeralMessageAction_completion = nil
     }
     
     override func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Error?) -> Void)? = nil) {
@@ -197,5 +207,17 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
     ) {
         restartFailedAttachmentUploading_id = id
         restartFailedAttachmentUploading_completion = completion
+    }
+    
+    override func dispatchEphemeralMessageAction(
+        cid: ChannelId,
+        messageId: MessageId,
+        action: AttachmentAction,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        dispatchEphemeralMessageAction_cid = cid
+        dispatchEphemeralMessageAction_messageId = messageId
+        dispatchEphemeralMessageAction_action = action
+        dispatchEphemeralMessageAction_completion = completion
     }
 }

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -332,6 +332,8 @@
 		88381E77258259C70047A6A3 /* FileUploadPayload.json in Resources */ = {isa = PBXBuildFile; fileRef = 88381E76258259C70047A6A3 /* FileUploadPayload.json */; };
 		88381E8725825A240047A6A3 /* AttachmentEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88381E8625825A240047A6A3 /* AttachmentEndpoints_Tests.swift */; };
 		883998212576397900294DB9 /* ChatMessageImageGallery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883998202576397900294DB9 /* ChatMessageImageGallery.swift */; };
+		884C61222594A449008B70DC /* AttachmentActionRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884C61212594A449008B70DC /* AttachmentActionRequestBody.swift */; };
+		884C612A2594A7DB008B70DC /* AttachmentActionRequestBody_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884C61292594A7DB008B70DC /* AttachmentActionRequestBody_Tests.swift */; };
 		8850B92A255C286B003AED69 /* UIConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8850B929255C286B003AED69 /* UIConfig.swift */; };
 		8850B93C255C3168003AED69 /* ContainerStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8850B93B255C3168003AED69 /* ContainerStackView.swift */; };
 		8850B946255C3B41003AED69 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8850B945255C3B41003AED69 /* AvatarView.swift */; };
@@ -1042,6 +1044,8 @@
 		88381E76258259C70047A6A3 /* FileUploadPayload.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = FileUploadPayload.json; sourceTree = "<group>"; };
 		88381E8625825A240047A6A3 /* AttachmentEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentEndpoints_Tests.swift; sourceTree = "<group>"; };
 		883998202576397900294DB9 /* ChatMessageImageGallery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageImageGallery.swift; sourceTree = "<group>"; };
+		884C61212594A449008B70DC /* AttachmentActionRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentActionRequestBody.swift; sourceTree = "<group>"; };
+		884C61292594A7DB008B70DC /* AttachmentActionRequestBody_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentActionRequestBody_Tests.swift; sourceTree = "<group>"; };
 		8850B929255C286B003AED69 /* UIConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfig.swift; sourceTree = "<group>"; };
 		8850B93B255C3168003AED69 /* ContainerStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerStackView.swift; sourceTree = "<group>"; };
 		8850B945255C3B41003AED69 /* AvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
@@ -2646,6 +2650,8 @@
 				88EA9AE725471EF4007EE76B /* MessageReactionRequestPayload_Tests.swift */,
 				DA4971202547699E00AC68C2 /* AttachmentRequestBody.swift */,
 				DA49713D2548AFF700AC68C2 /* AttachmentRequestBody_Tests.swift */,
+				884C61212594A449008B70DC /* AttachmentActionRequestBody.swift */,
+				884C61292594A7DB008B70DC /* AttachmentActionRequestBody_Tests.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -3563,6 +3569,7 @@
 				79280F7A248918FD00CDEB89 /* StarscreamWebSocketEngine.swift in Sources */,
 				7964F3A4249A0ACF002A09EC /* ChannelListQueryDTO.swift in Sources */,
 				79280F3F2484E3BA00CDEB89 /* ClientError.swift in Sources */,
+				884C61222594A449008B70DC /* AttachmentActionRequestBody.swift in Sources */,
 				DAFAD6A124DC476A0043ED06 /* Result+Extensions.swift in Sources */,
 				DAF8359924F8042D00392699 /* TypingEventObserver.swift in Sources */,
 				794927ED249E0BE2009D7EB7 /* ExtraData.swift in Sources */,
@@ -3794,6 +3801,7 @@
 				8819DFDE252622D900FD1A50 /* ModerationEndpoints_Tests.swift in Sources */,
 				F65D9093250A5CD4000B8CEB /* WebSocketConnectEndpoint_Tests.swift in Sources */,
 				790A4C4A252DDD50001F4A23 /* DeviceEndpoints_Tests.swift in Sources */,
+				884C612A2594A7DB008B70DC /* AttachmentActionRequestBody_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests_v3/Shared/TemporaryData.swift
+++ b/Tests_v3/Shared/TemporaryData.swift
@@ -31,6 +31,19 @@ extension String {
     static var unique: String { UUID().uuidString }
 }
 
+extension AttachmentAction {
+    /// Returns a new unique action
+    static var unique: Self {
+        .init(
+            name: .unique,
+            value: .unique,
+            style: .primary,
+            type: .button,
+            text: .unique
+        )
+    }
+}
+
 extension AttachmentId {
     /// Returns a new unique id
     static var unique: Self {

--- a/Tests_v3/StreamChatTests/Dummy data/MessagePayload.swift
+++ b/Tests_v3/StreamChatTests/Dummy data/MessagePayload.swift
@@ -8,6 +8,7 @@ import Foundation
 extension MessagePayload {
     /// Creates a dummy `MessagePayload` with the given `messageId` and `userId` of the author.
     static func dummy<T: ExtraDataTypes>(
+        type: MessageType? = nil,
         messageId: MessageId,
         parentId: MessageId? = nil,
         showReplyInChannel: Bool = false,
@@ -25,7 +26,7 @@ extension MessagePayload {
     ) -> MessagePayload<T> where T.User == DefaultExtraData.User {
         .init(
             id: messageId,
-            type: parentId == nil ? .regular : .reply,
+            type: type ?? (parentId == nil ? .regular : .reply),
             user: UserPayload.dummy(userId: authorUserId) as UserPayload<T.User>,
             createdAt: .unique,
             updatedAt: .unique,


### PR DESCRIPTION
**This PR** adds LLC support for message actions:
- exposes `dispatchEphemeralMessageAction ` by `ChatMessageController`
- exposes `dispatchEphemeralMessageAction ` by `MessageUpdater`
- introduces `AttachmentActionRequestBody` type
- introduces `dispatchEphemeralMessageAction ` endpoint

**Notes and possible improvement directions:**
1. If user sends `/giphy cat` and then `/giphy wow` they will see 2 ephemeral messages in channel one for each `/giphy` command. In **v2** there's always a single ephemeral message which is updated to reflect the latest command
2. When **Cancel** action is chosen the ephemeral message is `softly` deleted -> it's content changes to `Message deleted` and stays in a channel which is not nice but cannot be fixed at this point (it is part of global issue with deletions and relationships becoming `nil` which leads to crash when parsing the model from DTO)

