### PR TITLE
V2: prevent crash on inconsistent row deletion in ChatViewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🐞 Fixed
 - Fixed thread's parent message not receiving updates [#656](https://github.com/GetStream/stream-chat-swift/issues/656)
 - Fixed being able to open reactions view without connection [#662](https://github.com/GetStream/stream-chat-swift/issues/662)
+- Fixed rare crash on row deletion in ChatViewController [#701](https://github.com/GetStream/stream-chat-swift/pull/701)
 
 # [2.6.1](https://github.com/GetStream/stream-chat-swift/releases/tag/2.6.1)
 _December 17, 2020_

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -548,8 +548,15 @@ extension ChatViewController {
         case let .itemRemoved(row, items):
             self.items = items
             
-            UIView.performWithoutAnimation {
-                tableView.deleteRows(at: [.row(row)], with: .none)
+            let rowsToDelete = [IndexPath.row(row)]
+            
+            if previousRowCount - rowsToDelete.count == items.count {
+                UIView.performWithoutAnimation {
+                    tableView.deleteRows(at: rowsToDelete, with: .none)
+                }
+            } else {
+                ClientLogger.log("⚠️", level: .error, "Inconsistent table view update. Recovering by reloading the table view.")
+                tableView.reloadData()
             }
             
         case .footerUpdated:


### PR DESCRIPTION
Added the same fallback that is on row insertion