### PR TITLE
[CIS-550] MessageComposer basic animation

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatReplyBubbleView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatReplyBubbleView.swift
@@ -55,6 +55,7 @@ open class ChatReplyBubbleView<ExtraData: ExtraDataTypes>: View, UIConfigProvide
         textView.backgroundColor = .clear
         textView.font = .preferredFont(forTextStyle: .footnote)
         textView.textContainerInset = .zero
+        textView.textColor = uiConfig.colorPalette.text
 
         authorAvatarView.contentMode = .scaleAspectFit
         

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerInputContainerView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerInputContainerView.swift
@@ -87,7 +87,7 @@ open class MessageComposerInputContainerView<ExtraData: ExtraDataTypes>: UIView 
     }
 
     public func setSlashCommandViews(hidden: Bool) {
-        container.rightStackView.isHidden = hidden
-        container.leftStackView.isHidden = hidden
+        container.rightStackView.setAnimatedly(hidden: hidden)
+        container.leftStackView.setAnimatedly(hidden: hidden)
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerSendButton.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerSendButton.swift
@@ -24,10 +24,14 @@ open class MessageComposerSendButton<ExtraData: ExtraDataTypes>: ChatSquareButto
     
     override open var isEnabled: Bool {
         didSet {
+            var transformToApply: CGAffineTransform
             if isEnabled, mode == .new {
-                transform = CGAffineTransform(rotationAngle: -CGFloat.pi / 2.0)
+                transformToApply = CGAffineTransform(rotationAngle: -CGFloat.pi / 2.0)
             } else {
-                transform = .identity
+                transformToApply = .identity
+            }
+            Animate {
+                self.transform = transformToApply
             }
         }
     }
@@ -43,18 +47,24 @@ open class MessageComposerSendButton<ExtraData: ExtraDataTypes>: ChatSquareButto
         switch mode {
         case .new:
             let normalStateImage = UIImage(named: "sendMessageArrow", in: .streamChatUI)
-            setImage(normalStateImage, for: .normal)
+            setImageWithAnimation(normalStateImage, for: .normal)
             
             let buttonColor: UIColor = uiConfig.colorPalette.messageComposerButton
             let disabledStateImage = UIImage(named: "sendMessageArrow", in: .streamChatUI)?.tinted(with: buttonColor)
-            setImage(disabledStateImage, for: .disabled)
+            setImageWithAnimation(disabledStateImage, for: .disabled)
         case .edit:
             let normalStateImage = UIImage(named: "editMessageCheckmark", in: .streamChatUI)
-            setImage(normalStateImage, for: .normal)
+            setImageWithAnimation(normalStateImage, for: .normal)
             
             let buttonColor: UIColor = uiConfig.colorPalette.messageComposerButton
             let disabledStateImage = UIImage(named: "editMessageCheckmark", in: .streamChatUI)?.tinted(with: buttonColor)
-            setImage(disabledStateImage, for: .disabled)
+            setImageWithAnimation(disabledStateImage, for: .disabled)
         }
+    }
+    
+    private func setImageWithAnimation(_ image: UIImage?, for state: UIControl.State) {
+        UIView.transition(with: self, duration: 0.3, options: .transitionCrossDissolve, animations: {
+            self.setImage(image, for: state)
+        }, completion: nil)
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerView.swift
@@ -130,6 +130,7 @@ open class MessageComposerView<ExtraData: ExtraDataTypes>: View,
         dismissButton.setImage(dismissIcon, for: .normal)
         
         titleLabel.textAlignment = .center
+        titleLabel.textColor = uiConfig.colorPalette.text
         titleLabel.font = .preferredFont(forTextStyle: .headline)
         titleLabel.adjustsFontForContentSizeCategory = true
     }

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerView.swift
@@ -138,9 +138,7 @@ open class MessageComposerView<ExtraData: ExtraDataTypes>: View,
     override open func setUpLayout() {
         super.setUpLayout()
         embed(container)
-        
-        preservesSuperviewLayoutMargins = true
-        
+                
         container.preservesSuperviewLayoutMargins = true
         container.isLayoutMarginsRelativeArrangement = true
         

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerViewController.swift
@@ -46,6 +46,7 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
             composerView.commandsButton.isHidden = !isEmpty
             composerView.shrinkInputButton.isHidden = isEmpty
             composerView.sendButton.isEnabled = !isEmpty
+            updateSendButton()
         }
     }
     
@@ -90,6 +91,8 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
         case .initial:
             textView.text = ""
             textView.placeholderLabel.text = L10n.Composer.Placeholder.message
+            imageAttachments = []
+            documentAttachments = []
             composerView.replyView.message = nil
             composerView.sendButton.mode = .new
             composerView.documentAttachmentsView.isHidden = true
@@ -185,17 +188,12 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
         }
     }
     
-    // MARK: Button actions
+    // MARK: Actions
     
     @objc func sendMessage() {
-        guard let text = composerView.messageInputView.textView.text,
-            !text.replacingOccurrences(of: " ", with: "").isEmpty
-        else { return }
-        
         switch state {
         case .initial:
-            // TODO: Attachments
-            createNewMessage(text: text)
+            createNewMessage(text: textView.text)
         case .reply:
             // TODO:
             // 1. Attachments
@@ -208,9 +206,9 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
                 messageId: messageToEdit.id
             )
             // TODO: Adjust LLC to edit attachments also
-            messageController?.editMessage(text: text)
+            messageController?.editMessage(text: textView.text)
         case let .slashCommand(command):
-            createNewMessage(text: "/\(command.name) " + text)
+            createNewMessage(text: "/\(command.name) " + textView.text)
         }
         
         state = .initial
@@ -283,6 +281,10 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
         state = .initial
     }
     
+    func updateSendButton() {
+        composerView.sendButton.isEnabled = !isEmpty || !imageAttachments.isEmpty || !documentAttachments.isEmpty
+    }
+
     // MARK: Suggestions
 
     public func showSuggestionsViewController(for kind: SuggestionKind, onSelectItem: @escaping ((Int) -> Void)) {
@@ -373,6 +375,7 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
         composerView.imageAttachmentsView.isHidden = imageAttachments.isEmpty
         composerView.imageAttachmentsView.invalidateIntrinsicContentSize()
         composerView.invalidateIntrinsicContentSize()
+        updateSendButton()
     }
     
     func didUpdateDocumentAttachments() {
@@ -382,6 +385,7 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
         composerView.documentAttachmentsView.isHidden = documentAttachments.isEmpty
         composerView.documentAttachmentsView.invalidateIntrinsicContentSize()
         composerView.invalidateIntrinsicContentSize()
+        updateSendButton()
     }
     
     // MARK: UITextView

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerViewController.swift
@@ -42,10 +42,7 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
     
     var isEmpty: Bool = true {
         didSet {
-            composerView.attachmentButton.isHidden = !isEmpty
-            composerView.commandsButton.isHidden = !isEmpty
-            composerView.shrinkInputButton.isHidden = isEmpty
-            composerView.sendButton.isEnabled = !isEmpty
+            setInput(shrinked: isEmpty)
             updateSendButton()
         }
     }
@@ -97,8 +94,8 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
             composerView.sendButton.mode = .new
             composerView.documentAttachmentsView.isHidden = true
             composerView.imageAttachmentsView.isHidden = true
-            composerView.replyView.isHidden = true
-            composerView.container.topStackView.isHidden = true
+            composerView.replyView.setAnimatedly(hidden: true)
+            composerView.container.topStackView.setAnimatedly(hidden: true)
             composerView.messageInputView.setSlashCommandViews(hidden: true)
         case let .slashCommand(command):
             textView.text = ""
@@ -111,8 +108,8 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
             let image = UIImage(named: "replyArrow", in: .streamChatUI)?
                 .tinted(with: uiConfig.colorPalette.messageComposerStateIcon)
             composerView.stateIcon.image = image
-            composerView.container.topStackView.isHidden = false
-            composerView.replyView.isHidden = false
+            composerView.container.topStackView.setAnimatedly(hidden: false)
+            composerView.replyView.setAnimatedly(hidden: false)
             composerView.replyView.message = messageToReply
         case let .edit(message):
             composerView.sendButton.mode = .edit
@@ -120,7 +117,7 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
             let image = UIImage(named: "editPencil", in: .streamChatUI)?
                 .tinted(with: uiConfig.colorPalette.messageComposerStateIcon)
             composerView.stateIcon.image = image
-            composerView.container.topStackView.isHidden = false
+            composerView.container.topStackView.setAnimatedly(hidden: false)
             textView.text = message.text
         }
         
@@ -264,9 +261,13 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
     }
     
     @objc func shrinkInput() {
-        composerView.attachmentButton.isHidden = false
-        composerView.commandsButton.isHidden = false
-        composerView.shrinkInputButton.isHidden = true
+        setInput(shrinked: true)
+    }
+    
+    func setInput(shrinked: Bool) {
+        composerView.attachmentButton.setAnimatedly(hidden: !shrinked)
+        composerView.commandsButton.setAnimatedly(hidden: !shrinked)
+        composerView.shrinkInputButton.setAnimatedly(hidden: shrinked)
     }
     
     @objc func showAvailableCommands() {
@@ -284,7 +285,7 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
     func updateSendButton() {
         composerView.sendButton.isEnabled = !isEmpty || !imageAttachments.isEmpty || !documentAttachments.isEmpty
     }
-
+    
     // MARK: Suggestions
 
     public func showSuggestionsViewController(for kind: SuggestionKind, onSelectItem: @escaping ((Int) -> Void)) {
@@ -372,7 +373,7 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
     
     func didUpdateImageAttachments() {
         composerView.imageAttachmentsView.images = imageAttachments.map(\.preview)
-        composerView.imageAttachmentsView.isHidden = imageAttachments.isEmpty
+        composerView.imageAttachmentsView.setAnimatedly(hidden: imageAttachments.isEmpty)
         composerView.imageAttachmentsView.invalidateIntrinsicContentSize()
         composerView.invalidateIntrinsicContentSize()
         updateSendButton()
@@ -382,7 +383,7 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
         composerView.documentAttachmentsView.documents = documentAttachments.map {
             ($0.preview, $0.localURL.lastPathComponent, $0.size)
         }
-        composerView.documentAttachmentsView.isHidden = documentAttachments.isEmpty
+        composerView.documentAttachmentsView.setAnimatedly(hidden: documentAttachments.isEmpty)
         composerView.documentAttachmentsView.invalidateIntrinsicContentSize()
         composerView.invalidateIntrinsicContentSize()
         updateSendButton()
@@ -431,8 +432,6 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
         showSuggestionsViewController(
             for: .mention,
             onSelectItem: { [weak self] _ in
-                print(text)
-                print(self?.textView.text)
                 self?.textView.text = self?.textView.text.appending("@ \(text)")
                 self?.state = .initial
             }

--- a/Sources_v3/StreamChatUI/Utils/Animation.swift
+++ b/Sources_v3/StreamChatUI/Utils/Animation.swift
@@ -1,0 +1,23 @@
+//
+// Copyright © 2020 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+func Animate(_ actions: @escaping () -> Void, completion: ((Bool) -> Void)? = nil) {
+    guard !UIAccessibility.isReduceMotionEnabled else {
+        actions()
+        completion?(true)
+        return
+    }
+    
+    UIView.animate(
+        withDuration: 0.25,
+        delay: 0,
+        usingSpringWithDamping: 0.8,
+        initialSpringVelocity: 4,
+        options: .curveEaseInOut,
+        animations: actions,
+        completion: completion
+    )
+}

--- a/Sources_v3/StreamChatUI/Utils/UIView+Extensions.swift
+++ b/Sources_v3/StreamChatUI/Utils/UIView+Extensions.swift
@@ -51,6 +51,15 @@ extension UIView {
         get { !isHidden }
         set { isHidden = !newValue }
     }
+    
+    func setAnimatedly(hidden: Bool) {
+        Animate({
+            self.alpha = hidden ? 0.0 : 1.0
+            self.isHidden = hidden
+        }) { _ in
+            self.isHidden = hidden
+        }
+    }
 }
 
 enum LayoutAnchorName {

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		22ADD682256C40410098EFEB /* MessageComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22ADD681256C40410098EFEB /* MessageComposerView.swift */; };
 		22C23506259A257B00DC805A /* MessageComposerDocumentAttachmentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C23505259A257B00DC805A /* MessageComposerDocumentAttachmentsView.swift */; };
 		22C2350E259A25A300DC805A /* MessageComposerImageAttachmentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C2350D259A25A300DC805A /* MessageComposerImageAttachmentsView.swift */; };
+		22C2359A259CA87B00DC805A /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C23599259CA87B00DC805A /* Animation.swift */; };
 		22FF4365256E943F00133910 /* MessageComposerSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FF4364256E943F00133910 /* MessageComposerSuggestionsViewController.swift */; };
 		7900452625374CA20096ECA1 /* User+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900452525374CA20096ECA1 /* User+SwiftUI.swift */; };
 		7908820625432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
@@ -755,6 +756,7 @@
 		22ADD681256C40410098EFEB /* MessageComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerView.swift; sourceTree = "<group>"; };
 		22C23505259A257B00DC805A /* MessageComposerDocumentAttachmentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerDocumentAttachmentsView.swift; sourceTree = "<group>"; };
 		22C2350D259A25A300DC805A /* MessageComposerImageAttachmentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerImageAttachmentsView.swift; sourceTree = "<group>"; };
+		22C23599259CA87B00DC805A /* Animation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
 		22FF4364256E943F00133910 /* MessageComposerSuggestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerSuggestionsViewController.swift; sourceTree = "<group>"; };
 		7900452525374CA20096ECA1 /* User+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+SwiftUI.swift"; sourceTree = "<group>"; };
 		790881FD25432B7200896F03 /* StreamChatUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2302,6 +2304,8 @@
 				228C7EE42583AF4800AAE9E3 /* UITextView+Extensions.swift */,
 				2241167F258A91280034184D /* String+Extensions.swift */,
 				88A11B092590AFBB0000AC24 /* ChatMessage+Extensions.swift */,
+				880656F8259A2C0800E31D23 /* ChatMessageAttachment+Extensions.swift */,
+				22C23599259CA87B00DC805A /* Animation.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3350,6 +3354,7 @@
 				885B3D7725642B3D003E6BDF /* CurrentChatUserAvatarView.swift in Sources */,
 				DBC8A4C6257E696900B20A82 /* ChatMessageThreadInfoView.swift in Sources */,
 				224FF6912562F58F00725DD1 /* UIColor+Extensions.swift in Sources */,
+				22C2359A259CA87B00DC805A /* Animation.swift in Sources */,
 				79088339254876F200896F03 /* ChatChannelCollectionView.swift in Sources */,
 				88CABC8E25936E440061BB67 /* ChatMessageReactionsBubbleTail.swift in Sources */,
 				883998212576397900294DB9 /* ChatMessageImageGallery.swift in Sources */,


### PR DESCRIPTION
**In this PR:**

- Update `textColor` with `ColorPalette`
- Fix sendting attachments without text
- Remove left and right extra insets for `MessageComposerView`
- Add basic animation to `MessageComposer`

_Note: haven't succeeded in animating intrinsicContentSize change on textView height expand._

https://user-images.githubusercontent.com/10098359/103308065-d9912680-4a11-11eb-9fe6-c75591f47073.mp4

