### PR TITLE
Fix db crash on user change

### DIFF
--- a/Sources_v3/StreamChat/Workers/Background/AttachmentUploader.swift
+++ b/Sources_v3/StreamChat/Workers/Background/AttachmentUploader.swift
@@ -52,6 +52,8 @@ class AttachmentUploader<ExtraData: ExtraDataTypes>: Worker {
     }
 
     private func handleChanges(changes: [ListChange<AttachmentDTO>]) {
+        guard !changes.isEmpty else { return }
+        
         var wasEmpty: Bool!
         _pendingAttachmentIDs.mutate { pendingAttachmentIDs in
             wasEmpty = pendingAttachmentIDs.isEmpty

--- a/Sources_v3/StreamChat/Workers/Background/MessageEditor.swift
+++ b/Sources_v3/StreamChat/Workers/Background/MessageEditor.swift
@@ -49,6 +49,8 @@ class MessageEditor<ExtraData: ExtraDataTypes>: Worker {
     }
     
     private func handleChanges(changes: [ListChange<MessageDTO>]) {
+        guard !changes.isEmpty else { return }
+        
         _pendingMessageIDs.mutate { pendingMessageIDs in
             let wasEmpty = pendingMessageIDs.isEmpty
             changes.pendingEditMessageIDs.forEach { pendingMessageIDs.insert($0) }

--- a/Sources_v3/StreamChat/Workers/ChannelListUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelListUpdater.swift
@@ -18,19 +18,17 @@ class ChannelListUpdater<ExtraData: ExtraDataTypes>: Worker {
                 switch result {
                 case let .success(channelListPayload):
                     self.database.write { session in
-                        do {
-                            try channelListPayload.channels.forEach {
-                                try session.saveChannel(payload: $0, query: channelListQuery)
-                            }
-                            
-                            completion?(nil)
-                            
-                        } catch {
+                        try channelListPayload.channels.forEach {
+                            try session.saveChannel(payload: $0, query: channelListQuery)
+                        }
+                    } completion: { error in
+                        if let error = error {
                             log.error("Failed to save `ChannelListPayload` to the database. Error: \(error)")
                             completion?(error)
+                        } else {
+                            completion?(nil)
                         }
                     }
-                    
                 case let .failure(error):
                     completion?(error)
                 }

--- a/Sources_v3/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelUpdater.swift
@@ -25,7 +25,8 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
                 channelCreatedCallback?(payload.channel.cid)
                 self.database.write { (session) in
                     try session.saveChannel(payload: payload)
-                    completion?(nil)
+                } completion: { error in
+                    completion?(error)
                 }
             } catch {
                 completion?(error)


### PR DESCRIPTION
### Issue description

We were removing `persistentStore` in `removeAllData` when we detected a new user login, but this causes crashes if there are ongoing `write` actions accessing the said store.

### Details

When we initialize the `DatabaseContainer` first, we reset ephemeral values with `resetEphemeralValues` async func:
```swift
/// Iterates over all items and if the DTO conforms to `EphemeralValueContainers` calls `resetEphemeralValues()` on
/// every object.
func resetEphemeralValues() {
    write({ session in
        let session = session as! NSManagedObjectContext
        
        try self.managedObjectModel.entities.forEach { entityDescription in
            guard let entityName = entityDescription.name else { return }
            let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: entityName)
            let entities = try session.fetch(fetchRequest) as? [EphemeralValuesContainer]
            entities?.forEach { $0.resetEphemeralValues() }
        }
    }, completion: { error in
        if let error = error {
            log.error("Error resetting ephemeral values: \(error)")
        } else {
            log.debug("Ephemeral values reset.")
        }
    })
}
```
which doesn't complete immediately.

When there's a new user detected, we reset all db, in `prepareEnvironmentForNewUser`:
```swift
// Reset all existing data if the new user is not the same as the last logged-in one
if client.databaseContainer.viewContext.currentUser()?.user.id != userId {
    // Re-create backgroundWorker's so their ongoing requests won't affect database state
    client.createBackgroundWorkers()

    do {
        // Reset all existing local data
        try client.databaseContainer.removeAllData(force: true)

    } catch {
        completion(error)
    }
}
```

When these 2 called back to back, we were removing the `persistentStore` while there's an ongoing write on it, so it caused the crash.

Moreover, `AttachmentUploader` and `MesageEditor` was calling `database.write` unnecessarily (while there are no pending items)

### Discussion

While testing the new login times, I didn't realize considerable delay/lag caused by `perform -> performAsync` change, though I don't have concrete numbers.

The changes in `ChannelUpdater` and `ChannelListUpdater` were trials on resolving the crashes, in the end it turned out they didn't have anything to do with it, but they are required for consistency among uploaders, so I've kept it.