### PR TITLE
Enable bouncing on small content message list

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageListVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageListVC.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageListVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageListVC.swift
@@ -67,6 +67,7 @@ open class ChatMessageListVC<ExtraData: ExtraDataTypes>: ViewController,
         collection.register(incomingCell, forCellWithReuseIdentifier: incomingCell.reuseId)
         collection.register(outgoingCell, forCellWithReuseIdentifier: outgoingCell.reuseId)
         collection.showsHorizontalScrollIndicator = false
+        collection.alwaysBounceVertical = true
         collection.keyboardDismissMode = .onDrag
         collection.dataSource = self
         collection.delegate = self


### PR DESCRIPTION
#### Instance Property
# alwaysBounceVertical
A Boolean value that determines whether bouncing always occurs when vertical scrolling reaches the end of the content.

### Declaration
```
var alwaysBounceVertical: Bool { get set }
```
### Discussion
If this property is set to `true` and bounces is `true`, vertical dragging is allowed even if the content is smaller than the bounds of the scroll view. The default value is `false`.