### PR TITLE
[CIS-552] Fix composer resizing

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageListVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageListVC.swift
@@ -270,8 +270,10 @@ open class ChatMessageListVC<ExtraData: ExtraDataTypes>: ViewController,
         _ vc: ChatMessageActionsVC<ExtraData>,
         didTapOnInlineReplyFor message: _ChatMessage<ExtraData>
     ) {
-        delegate?.didTapOnInlineReply?(self, message)
-        dismiss(animated: true)
+        dismiss(animated: true) { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.didTapOnInlineReply?(self, message)
+        }
     }
 
     open func chatMessageActionsVC(
@@ -285,8 +287,10 @@ open class ChatMessageListVC<ExtraData: ExtraDataTypes>: ViewController,
         _ vc: ChatMessageActionsVC<ExtraData>,
         didTapOnEdit message: _ChatMessage<ExtraData>
     ) {
-        delegate?.didTapOnEdit?(self, message)
-        dismiss(animated: true)
+        dismiss(animated: true) { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.didTapOnEdit?(self, message)
+        }
     }
 
     open func chatMessageActionsVCDidFinish(_ vc: ChatMessageActionsVC<ExtraData>) {

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerInputTextView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerInputTextView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -10,6 +10,10 @@ open class MessageComposerInputTextView<ExtraData: ExtraDataTypes>: UITextView,
     Customizable,
     UIConfigProvider
 {
+    // MARK: - Properties
+            
+    lazy var textViewHeightConstraint = heightAnchor.constraint(equalToConstant: .zero)
+    
     // MARK: - Subviews
     
     public lazy var placeholderLabel: UILabel = UILabel().withoutAutoresizingMaskConstraints
@@ -72,6 +76,10 @@ open class MessageComposerInputTextView<ExtraData: ExtraDataTypes>: UITextView,
             trailing: .zero
         ))
         placeholderLabel.pin(anchors: [.centerY], to: self)
+        
+        isScrollEnabled = false
+        
+        textViewHeightConstraint.isActive = true
     }
     
     open func updateContent() {}
@@ -79,5 +87,7 @@ open class MessageComposerInputTextView<ExtraData: ExtraDataTypes>: UITextView,
     @objc func textDidChange() {
         delegate?.textViewDidChange?(self)
         placeholderLabel.isHidden = !text.isEmpty
+        textViewHeightConstraint.constant = calculatedTextHeight() + textContainerInset.bottom + textContainerInset.top
+        layoutIfNeeded()
     }
 }

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -144,7 +144,7 @@ open class MessageComposerView<ExtraData: ExtraDataTypes>: View,
         
         container.spacing = UIStackView.spacingUseSystem
         
-        container.topStackView.alignment = .center
+        container.topStackView.alignment = .fill
         container.topStackView.addArrangedSubview(stateIcon)
         container.topStackView.addArrangedSubview(titleLabel)
         container.topStackView.addArrangedSubview(dismissButton)

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -110,6 +110,7 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
             composerView.replyView.setAnimatedly(hidden: true)
             composerView.container.topStackView.setAnimatedly(hidden: true)
             composerView.messageInputView.setSlashCommandViews(hidden: true)
+            composerView.invalidateIntrinsicContentSize()
         case let .slashCommand(command):
             textView.text = ""
             textView.placeholderLabel.text = command.name.firstUppercased
@@ -124,6 +125,7 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
             composerView.container.topStackView.setAnimatedly(hidden: false)
             composerView.replyView.setAnimatedly(hidden: false)
             composerView.replyView.message = messageToReply
+            composerView.invalidateIntrinsicContentSize()
         case let .edit(message):
             composerView.sendButton.mode = .edit
             composerView.titleLabel.text = L10n.Composer.Title.edit
@@ -132,6 +134,7 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
             composerView.stateIcon.image = image
             composerView.container.topStackView.setAnimatedly(hidden: false)
             textView.text = message.text
+            composerView.invalidateIntrinsicContentSize()
         }
         
         if let memberCount = controller?.channel?.memberCount,

--- a/Sources_v3/StreamChatUI/Utils/UITextView+Extensions.swift
+++ b/Sources_v3/StreamChatUI/Utils/UITextView+Extensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import UIKit
@@ -10,7 +10,9 @@ extension UITextView {
     /// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/TextLayout/Tasks/StringHeight.html
     ///
     func calculatedTextHeight() -> CGFloat {
-        let textStorage = NSTextStorage(string: text)
+        // Height is not calculated correctly with empty text
+        let string: String = text.isEmpty ? " " : text
+        let textStorage = NSTextStorage(string: string)
         let width = frame.width - textContainerInset.right - textContainerInset.left
         let customTextContainer = NSTextContainer(size: .init(width: width, height: CGFloat.greatestFiniteMagnitude))
         let layoutManager = NSLayoutManager()


### PR DESCRIPTION
**In this PR:**

- Fix occasional feedback loop on setting replies and message to edit
- Fix height of `MessageComposerInputTextView`
- Adjust `MessageComposerInputContainerView` according to UI framework guidlines and fix height
- Fix ambiguity in `topStackView` `intrinsicContentSize`
- Fix composer size reset after major layout changes


https://user-images.githubusercontent.com/10098359/103549249-59524180-4ea7-11eb-8a25-56ae1bd681fb.MP4


