### PR TITLE
Make ChatClient init available from extensions

### DIFF
--- a/Sources_v3/StreamChat/ChatClient.swift
+++ b/Sources_v3/StreamChat/ChatClient.swift
@@ -215,7 +215,6 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
     ///
     /// - Parameter config: The config object for the `Client`. See `ChatClientConfig` for all configuration options.
     ///
-    @available(iOSApplicationExtension, unavailable)
     public convenience init(config: ChatClientConfig) {
         // All production workers
         let workerBuilders: [WorkerBuilder] = [


### PR DESCRIPTION
It would be good to be able to use the SDK from extensions like Widget. It seems to work properly. If there are concerns about data consistency maybe we can limit some other way than blocking the SDK altogether ?

<img width="197" alt="Screen Shot 2021-01-05 at 11 27 39" src="https://user-images.githubusercontent.com/5606812/103658274-c1596400-4f49-11eb-870b-95ca48efb0d1.png">