### PR TITLE
Minor SDK Fixes 

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageGiphyView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageGiphyView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Nuke
@@ -59,7 +59,7 @@ open class ChatMessageGiphyView<ExtraData: ExtraDataTypes>: View, UIConfigProvid
         loadingIndicator.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
     }
 
-    override open func defaultAppearance() {
+    override public func defaultAppearance() {
         super.defaultAppearance()
         backgroundColor = .clear
     }
@@ -120,7 +120,7 @@ extension ChatMessageGiphyView {
             contentStack.pin(to: layoutMarginsGuide)
         }
 
-        override open func defaultAppearance() {
+        override public func defaultAppearance() {
             super.defaultAppearance()
 
             backgroundColor = UIColor.black.withAlphaComponent(0.6)

--- a/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageImageGallery.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageImageGallery.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -103,7 +103,7 @@ open class ChatMessageImageGallery<ExtraData: ExtraDataTypes>: View, UIConfigPro
         ])
     }
 
-    override open func defaultAppearance() {
+    override public func defaultAppearance() {
         moreImagesOverlay.textColor = .white
         moreImagesOverlay.backgroundColor = uiConfig.colorPalette.galleryMoreImagesOverlayBackground
     }

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessage/ChatMessageThreadInfoView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessage/ChatMessageThreadInfoView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -25,7 +25,7 @@ open class ChatMessageThreadArrowView<ExtraData: ExtraDataTypes>: View, UIConfig
         }
     }
 
-    override open func defaultAppearance() {
+    override public func defaultAppearance() {
         shape.contentsScale = layer.contentsScale
         shape.strokeColor = uiConfig.colorPalette.incomingMessageBubbleBorder.cgColor
         shape.fillColor = nil

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessageListVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessageListVC.swift
@@ -99,7 +99,7 @@ open class ChatMessageListVC<ExtraData: ExtraDataTypes>: ViewController,
 
         view.addSubview(collectionView)
         collectionView.pin(to: view.safeAreaLayoutGuide)
-        collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
+        collectionView.contentInset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
     }
 
     override public func defaultAppearance() {

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatReplyBubbleView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatReplyBubbleView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -47,7 +47,7 @@ open class ChatReplyBubbleView<ExtraData: ExtraDataTypes>: View, UIConfigProvide
         textView.isUserInteractionEnabled = false
     }
     
-    override open func defaultAppearance() {
+    override public func defaultAppearance() {
         textView.textContainer.maximumNumberOfLines = 6
         textView.textContainer.lineBreakMode = .byTruncatingTail
         textView.textContainer.lineFragmentPadding = .zero

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerCommandCollectionViewCell.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerCommandCollectionViewCell.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -21,7 +21,7 @@ open class MessageComposerCommandCellView<ExtraData: ExtraDataTypes>: View, UICo
 
     // MARK: - Appearance
 
-    override open func defaultAppearance() {
+    override public func defaultAppearance() {
         backgroundColor = uiConfig.colorPalette.generalBackground
 
         commandNameLabel.font = UIFont.preferredFont(forTextStyle: .footnote).bold

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerMentionCollectionViewCell.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerMentionCollectionViewCell.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -27,7 +27,7 @@ open class MessageComposerMentionCellView<ExtraData: ExtraDataTypes>: View, UICo
 
     // MARK: - Appearance
 
-    override open func defaultAppearance() {
+    override public func defaultAppearance() {
         backgroundColor = uiConfig.colorPalette.generalBackground
         usernameLabel.font = UIFont.preferredFont(forTextStyle: .footnote).bold
 

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerSuggestionsViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerSuggestionsViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -52,12 +52,12 @@ open class MessageComposerSuggestionsViewController<ExtraData: ExtraDataTypes>: 
         collectionView.delegate = self
     }
 
-    override public func setUpAppearance() {
+    override open func setUpAppearance() {
         view.backgroundColor = .clear
         view.layer.addShadow(color: uiConfig.colorPalette.shadow)
     }
 
-    override public func setUpLayout() {
+    override open func setUpLayout() {
         view.embed(containerView)
         containerView.embed(
             collectionView,

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerView.swift
@@ -100,7 +100,7 @@ open class MessageComposerView<ExtraData: ExtraDataTypes>: View,
     
     // MARK: - Public
     
-    override open func defaultAppearance() {
+    override public func defaultAppearance() {
         super.defaultAppearance()
         stateIconHeight = 40
         

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatSwipeableListItemView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatSwipeableListItemView.swift
@@ -21,7 +21,7 @@ open class ChatSwipeableListItemView<ExtraData: ExtraDataTypes>: View, UIConfigP
 
     // MARK: - View
 
-    override public func setUpLayout() {
+    override open func setUpLayout() {
         super.setUpLayout()
         addSubview(cellContentView)
         cellContentView.pin(anchors: [.top, .bottom, .width], to: self)
@@ -43,7 +43,7 @@ open class ChatSwipeableListItemView<ExtraData: ExtraDataTypes>: View, UIConfigP
         trailingConstraint?.isActive = true
     }
 
-    override public func setUp() {
+    override open func setUp() {
         super.setUp()
 
         deleteButton.addTarget(self, action: #selector(didTapDelete), for: .touchUpInside)

--- a/Sources_v3/StreamChatUI/Common Views/ChatSquareButton.swift
+++ b/Sources_v3/StreamChatUI/Common Views/ChatSquareButton.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -16,7 +16,7 @@ open class ChatSquareButton<ExtraData: ExtraDataTypes>: Button, UIConfigProvider
         defaultIntrinsicContentSize ?? super.intrinsicContentSize
     }
     
-    override open func defaultAppearance() {
+    override public func defaultAppearance() {
         defaultIntrinsicContentSize = .init(width: 40, height: 40)
         imageView?.contentMode = .scaleAspectFit
     }

--- a/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
+++ b/Sources_v3/StreamChatUI/Common Views/OnlineIndicatorView.swift
@@ -8,7 +8,7 @@ import UIKit
 open class OnlineIndicatorView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
     // MARK: - Customizable
 
-    override public func setUpLayout() {
+    override open func setUpLayout() {
         super.setUpLayout()
         heightAnchor.constraint(equalTo: widthAnchor).isActive = true
     }

--- a/Sources_v3/StreamChatUI/MessageActionsPopup/MessageActionsView+ActionButton.swift
+++ b/Sources_v3/StreamChatUI/MessageActionsPopup/MessageActionsView+ActionButton.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import UIKit
@@ -12,7 +12,7 @@ extension MessageActionsView {
 
         // MARK: Overrides
 
-        override open func defaultAppearance() {
+        override public func defaultAppearance() {
             backgroundColor = uiConfig.colorPalette.generalBackground
             titleLabel?.font = UIFont.preferredFont(forTextStyle: .headline).bold
             contentEdgeInsets = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)

--- a/Sources_v3/StreamChatUI/MessageActionsPopup/MessageActionsView.swift
+++ b/Sources_v3/StreamChatUI/MessageActionsPopup/MessageActionsView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -23,7 +23,7 @@ open class MessageActionsView<ExtraData: ExtraDataTypes>: View, UIConfigProvider
 
     // MARK: Overrides
 
-    override open func defaultAppearance() {
+    override public func defaultAppearance() {
         layer.cornerRadius = 16
         layer.masksToBounds = true
         backgroundColor = uiConfig.colorPalette.outgoingMessageBubbleBorder

--- a/Sources_v3/StreamChatUI/UIConfig.swift
+++ b/Sources_v3/StreamChatUI/UIConfig.swift
@@ -123,6 +123,8 @@ public extension UIConfig {
     struct ChannelListUI {
         public var channelCollectionView: ChatChannelListCollectionView.Type = ChatChannelListCollectionView.self
         public var channelCollectionLayout: UICollectionViewLayout.Type = ChatChannelListCollectionViewLayout.self
+        public var channelListSwipeableItemView: ChatSwipeableListItemView<ExtraData>.Type =
+            ChatSwipeableListItemView<ExtraData>.self
         public var channelListItemView: ChatChannelListItemView<ExtraData>.Type = ChatChannelListItemView<ExtraData>.self
         public var channelViewCell: ChatChannelListCollectionViewCell<ExtraData>.Type =
             ChatChannelListCollectionViewCell<ExtraData>.self


### PR DESCRIPTION
# What does this PR do:
- Fix of Access Modifiers for `View` subclasses / `Customizable` implementations  across the SDK usage, i.e. now functions that should be public are public, functions that should be open (everything except `defaultAppearance`) are open 🎊 .
- Adds `SwipeableListItemView` to `UIConfig`.
- Adds 8 points inset from top to Message List UI.

Main thing to test in here is the inset (check if autoscroll to bottom works properly), other things should be clear. :) 