### PR TITLE
[CIS-555] Make ChatClient available in app extensions

### DIFF
--- a/Sources_v3/StreamChat/ChatClient.swift
+++ b/Sources_v3/StreamChat/ChatClient.swift
@@ -120,7 +120,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
     }()
     
     /// The `WebSocketClient` instance `Client` uses to communicate with Stream WS servers.
-    lazy var webSocketClient: WebSocketClient = {
+    lazy var webSocketClient: WebSocketClient? = {
         // Create a connection request
         let webSocketEndpoint: Endpoint<EmptyResponse> = .webSocketConnect(
             userId: self.currentUserId,
@@ -142,7 +142,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
             internetConnection
         )
         
-        webSocketClient.connectionStateDelegate = self
+        webSocketClient?.connectionStateDelegate = self
         
         return webSocketClient
     }()
@@ -269,6 +269,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         self.workerBuilders = workerBuilders
         
         createBackgroundWorkers()
+        createWebSocketClient()
     }
     
     deinit {
@@ -297,6 +298,13 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
             builder(self.databaseContainer, self.webSocketClient, self.apiClient)
         }
     }
+    
+    /// Before CIS-555, `webSocketClient` was initialized in `createBackgroundWorkers` in `init` since it was passed
+    /// to the background workers. Now, background workers do not access `webSocketClient` and it's not being
+    /// initialized in `init`, so we initialize it here explicitly.
+    private func createWebSocketClient() {
+        _ = webSocketClient
+    }
 }
 
 extension _ChatClient {
@@ -315,7 +323,7 @@ extension _ChatClient {
             _ eventDecoder: AnyEventDecoder,
             _ notificationCenter: EventNotificationCenter,
             _ internetConnection: InternetConnection
-        ) -> WebSocketClient = {
+        ) -> WebSocketClient? = {
             WebSocketClient(
                 connectEndpoint: $0,
                 sessionConfiguration: $1,

--- a/Sources_v3/StreamChat/ChatClient.swift
+++ b/Sources_v3/StreamChat/ChatClient.swift
@@ -295,7 +295,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
     
     func createBackgroundWorkers() {
         backgroundWorkers = workerBuilders.map { builder in
-            builder(self.databaseContainer, self.webSocketClient, self.apiClient)
+            builder(self.databaseContainer, self.apiClient)
         }
     }
     

--- a/Sources_v3/StreamChat/ChatClient_Mock.swift
+++ b/Sources_v3/StreamChat/ChatClient_Mock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -10,6 +10,7 @@ extension ChatClient {
         ChatClient(
             config: .init(apiKey: .init(.unique)),
             workerBuilders: [],
+            eventWorkerBuilders: [],
             environment: .mock
         )
     }

--- a/Sources_v3/StreamChat/ChatClient_Mock.swift
+++ b/Sources_v3/StreamChat/ChatClient_Mock.swift
@@ -42,7 +42,9 @@ extension _ChatClient.Environment where ExtraData == DefaultExtraData {
                     internetConnection: $5
                 )
             },
-            databaseContainerBuilder: { try! DatabaseContainerMock(kind: $0, shouldFlushOnStart: $1) },
+            databaseContainerBuilder: {
+                try! DatabaseContainerMock(kind: $0, shouldFlushOnStart: $1, shouldResetEphemeralValuesOnStart: $2)
+            },
             requestEncoderBuilder: DefaultRequestEncoder.init,
             requestDecoderBuilder: DefaultRequestDecoder.init,
             eventDecoderBuilder: EventDecoder.init,

--- a/Sources_v3/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources_v3/StreamChat/Config/ChatClientConfig.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -50,12 +50,20 @@ public struct ChatClientConfig {
     /// refreshed.
     public var tokenProvider: TokenProvider?
     
+    /// Flag for setting a ChatClient instance in connection-less mode.
+    /// A connection-less client is not able to connect to websocket and will not
+    /// receive websocket events. It can still observe and mutate database.
+    /// This flag is automatically set to `false` for app extensions
+    /// **Warning**: There should be at max 1 active client at the same time, else it can lead to undefined behavior.
+    public var isClientInActiveMode: Bool
+    
     /// Creates a new instance of `ChatClientConfig`.
     ///
     /// - Parameter apiKey: The API key of the chat app the `ChatClient` connects to.
     ///
     public init(apiKey: APIKey) {
         self.apiKey = apiKey
+        isClientInActiveMode = !Bundle.main.isAppExtension
     }
 }
 

--- a/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -187,13 +187,11 @@ public class _ChatChannelController<ExtraData: ExtraDataTypes>: DataController, 
     /// The worker used to fetch the remote data and communicate with servers.
     private lazy var updater: ChannelUpdater<ExtraData> = self.environment.channelUpdaterBuilder(
         client.databaseContainer,
-        client.webSocketClient,
         client.apiClient
     )
     
     private lazy var eventSender: EventSender<ExtraData> = self.environment.eventSenderBuilder(
         client.databaseContainer,
-        client.webSocketClient,
         client.apiClient
     )
     
@@ -769,13 +767,11 @@ extension _ChatChannelController {
     struct Environment {
         var channelUpdaterBuilder: (
             _ database: DatabaseContainer,
-            _ webSocketClient: WebSocketClient,
             _ apiClient: APIClient
         ) -> ChannelUpdater<ExtraData> = ChannelUpdater.init
         
         var eventSenderBuilder: (
             _ database: DatabaseContainer,
-            _ webSocketClient: WebSocketClient,
             _ apiClient: APIClient
         ) -> EventSender<ExtraData> = EventSender.init
     }

--- a/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -368,7 +368,9 @@ public class _ChatChannelController<ExtraData: ExtraDataTypes>: DataController, 
 
     private func setupEventObservers(for cid: ChannelId) {
         eventObservers.removeAll()
-        let center = client.webSocketClient.eventNotificationCenter
+        // We can't setup event observers in connectionless mode
+        guard let webSocketClient = client.webSocketClient else { return }
+        let center = webSocketClient.eventNotificationCenter
         eventObservers = [
             MemberEventObserver(notificationCenter: center, cid: cid) { [unowned self] event in
                 self.delegateCallback {

--- a/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -496,7 +496,7 @@ class ChannelController_Tests: StressTestCase {
         // Send notification with event happened in the observed channel
         let event = TestMemberEvent(cid: controller.channelQuery.cid!, userId: .unique)
         let notification = Notification(newEventReceived: event, sender: self)
-        client.webSocketClient.eventNotificationCenter.post(notification)
+        client.webSocketClient!.eventNotificationCenter.post(notification)
         
         // Assert the event is received
         AssertAsync.willBeEqual(delegate.didReceiveMemberEvent_event as? TestMemberEvent, event)
@@ -512,7 +512,7 @@ class ChannelController_Tests: StressTestCase {
         // Send notification with event happened in the observed channel
         let event = TestMemberEvent(cid: controller.cid!, userId: .unique)
         let notification = Notification(newEventReceived: event, sender: self)
-        client.webSocketClient.eventNotificationCenter.post(notification)
+        client.webSocketClient!.eventNotificationCenter.post(notification)
         
         // Assert the event is received
         AssertAsync.willBeEqual(delegate.didReceiveMemberEvent_event as? TestMemberEvent, event)
@@ -1737,11 +1737,11 @@ private class TestEnvironment {
     
     lazy var environment: ChatChannelController.Environment = .init(
         channelUpdaterBuilder: { [unowned self] in
-            self.channelUpdater = ChannelUpdaterMock(database: $0, webSocketClient: $1, apiClient: $2)
+            self.channelUpdater = ChannelUpdaterMock(database: $0, apiClient: $1)
             return self.channelUpdater!
         },
         eventSenderBuilder: { [unowned self] in
-            self.eventSender = EventSenderMock(database: $0, webSocketClient: $1, apiClient: $2)
+            self.eventSender = EventSenderMock(database: $0, apiClient: $1)
             return self.eventSender!
         }
     )

--- a/Sources_v3/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources_v3/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -56,7 +56,6 @@ public class _ChatChannelListController<ExtraData: ExtraDataTypes>: DataControll
     private lazy var worker: ChannelListUpdater<ExtraData> = self.environment
         .channelQueryUpdaterBuilder(
             client.databaseContainer,
-            client.webSocketClient,
             client.apiClient
         )
 
@@ -184,7 +183,6 @@ extension _ChatChannelListController {
     struct Environment {
         var channelQueryUpdaterBuilder: (
             _ database: DatabaseContainer,
-            _ webSocketClient: WebSocketClient,
             _ apiClient: APIClient
         ) -> ChannelListUpdater<ExtraData> = ChannelListUpdater.init
 

--- a/Sources_v3/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -391,8 +391,7 @@ private class TestEnvironment {
         .init(channelQueryUpdaterBuilder: { [unowned self] in
             self.channelListUpdater = ChannelListUpdaterMock(
                 database: $0,
-                webSocketClient: $1,
-                apiClient: $2
+                apiClient: $1
             )
             return self.channelListUpdater!
         })

--- a/Sources_v3/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources_v3/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -133,6 +133,12 @@ public class _CurrentChatUserController<ExtraData: ExtraDataTypes>: Controller, 
         extraData: ExtraData.User? = nil,
         completion: @escaping (Error?) -> Void
     ) {
+        // Setting a new user is not possible in connectionless mode
+        guard let webSocketClient = client.webSocketClient else {
+            completion(ClientError.ClientIsNotInActiveMode())
+            return
+        }
+        
         // Reset the current token
         client.currentToken = nil
         
@@ -178,6 +184,12 @@ public extension _CurrentChatUserController {
     /// called with an error.
     ///
     func connect(completion: ((Error?) -> Void)? = nil) {
+        // Connecting is not possible in connectionless mode (duh)
+        guard let webSocketClient = client.webSocketClient else {
+            completion?(ClientError.ClientIsNotInActiveMode())
+            return
+        }
+        
         guard client.connectionId == nil else {
             log.warning("The client is already connected. Skipping the `connect` call.")
             completion?(nil)
@@ -204,6 +216,12 @@ public extension _CurrentChatUserController {
     /// Disconnects the chat client the controller represents from the chat servers. No further updates from the servers
     /// are received.
     func disconnect() {
+        // Disconnecting is not possible in connectionless mode (duh)
+        guard let webSocketClient = client.webSocketClient else {
+            log.error(ClientError.ClientIsNotInActiveMode().localizedDescription)
+            return
+        }
+        
         // Disconnect the web socket
         client.webSocketClient.disconnect(source: .userInitiated)
         

--- a/Sources_v3/StreamChat/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -133,8 +133,8 @@ final class CurrentUserController_Tests: StressTestCase {
         XCTAssertTrue(delegate.didUpdateConnectionStatus_statuses.isEmpty)
         
         // Simulate connection status updates.
-        client.webSocketClient.simulateConnectionStatus(.connecting)
-        client.webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        client.webSocketClient?.simulateConnectionStatus(.connecting)
+        client.webSocketClient?.simulateConnectionStatus(.connected(connectionId: .unique))
         
         // Assert updates are received
         AssertAsync.willBeEqual(delegate.didUpdateConnectionStatus_statuses, [.connecting, .connected])
@@ -244,7 +244,7 @@ final class CurrentUserController_Tests: StressTestCase {
     
     func test_setAnonymousUser() {
         let oldUserId = client.currentUserId
-        let oldWSConnectEndpoint = client.webSocketClient.connectEndpoint
+        let oldWSConnectEndpoint = client.webSocketClient!.connectEndpoint
 
         // Set up a new anonymous user
         var setUserCompletionCalled = false
@@ -258,11 +258,11 @@ final class CurrentUserController_Tests: StressTestCase {
             Assert.willBeTrue(self.client.mockDatabaseContainer.flush_called == true)
 
             // WebSocketClient connect endpoint is updated
-            Assert.willBeTrue(AnyEndpoint(oldWSConnectEndpoint) != AnyEndpoint(self.client.webSocketClient.connectEndpoint))
+            Assert.willBeTrue(AnyEndpoint(oldWSConnectEndpoint) != AnyEndpoint(self.client.webSocketClient!.connectEndpoint))
 
             // New user id is used in `TypingStartCleanupMiddleware`
             Assert.willBeTrue(
-                self.client.webSocketClient.typingMiddleware?.excludedUserIds().contains(self.client.currentUserId) == true
+                self.client.webSocketClient!.typingMiddleware?.excludedUserIds().contains(self.client.currentUserId) == true
             )
 
             // WebSocketClient connect is called
@@ -273,7 +273,7 @@ final class CurrentUserController_Tests: StressTestCase {
         XCTAssertFalse(setUserCompletionCalled)
 
         // Simulate successful connection
-        client.webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        client.webSocketClient!.simulateConnectionStatus(.connected(connectionId: .unique))
 
         // Check the completion is called
         AssertAsync.willBeTrue(setUserCompletionCalled)
@@ -318,7 +318,7 @@ final class CurrentUserController_Tests: StressTestCase {
     }
 
     func test_setUser() {
-        let oldWSConnectEndpoint = client.webSocketClient.connectEndpoint
+        let oldWSConnectEndpoint = client.webSocketClient!.connectEndpoint
 
         let newUserId: UserId = .unique
         let newUserToken: Token = .unique
@@ -341,11 +341,11 @@ final class CurrentUserController_Tests: StressTestCase {
             Assert.willBeTrue(self.client.mockDatabaseContainer.flush_called == true)
 
             // WebSocketClient connect endpoint is updated
-            Assert.willBeTrue(AnyEndpoint(oldWSConnectEndpoint) != AnyEndpoint(self.client.webSocketClient.connectEndpoint))
+            Assert.willBeTrue(AnyEndpoint(oldWSConnectEndpoint) != AnyEndpoint(self.client.webSocketClient!.connectEndpoint))
 
             // New user id is used in `TypingStartCleanupMiddleware`
             Assert.willBeTrue(
-                self.client.webSocketClient.typingMiddleware?.excludedUserIds().contains(newUserId) == true
+                self.client.webSocketClient!.typingMiddleware?.excludedUserIds().contains(newUserId) == true
             )
 
             // WebSocketClient connect is called
@@ -357,10 +357,10 @@ final class CurrentUserController_Tests: StressTestCase {
 
         // Simulate a health check event with the current user data
         // This should trigger the middlewares and save the current user data to DB
-        client.webSocketClient.webSocketDidReceiveMessage(healthCheckEventJSON(userId: newUserId))
+        client.webSocketClient!.webSocketDidReceiveMessage(healthCheckEventJSON(userId: newUserId))
 
         // Simulate successful connection
-        client.webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        client.webSocketClient!.simulateConnectionStatus(.connected(connectionId: .unique))
 
         var currentUser: CurrentUserDTO? {
             client.databaseContainer.viewContext.currentUser()
@@ -435,7 +435,7 @@ final class CurrentUserController_Tests: StressTestCase {
     }
 
     func test_setGuestUser() {
-        let oldWSConnectEndpoint = client.webSocketClient.connectEndpoint
+        let oldWSConnectEndpoint = client.webSocketClient!.connectEndpoint
 
         let newUserToken: Token = .unique
         let newUserExtraData = DefaultExtraData.User.defaultValue
@@ -466,7 +466,7 @@ final class CurrentUserController_Tests: StressTestCase {
 
             // New user id is used in `TypingStartCleanupMiddleware`
             Assert.willBeTrue(
-                self.client.webSocketClient.typingMiddleware?.excludedUserIds().contains(newUser.userId) == true
+                self.client.webSocketClient!.typingMiddleware?.excludedUserIds().contains(newUser.userId) == true
             )
 
             // Make sure `guest` endpoint is called
@@ -496,7 +496,7 @@ final class CurrentUserController_Tests: StressTestCase {
             Assert.willBeEqual(self.client.provideToken(), newUserToken)
 
             // WebSocketClient connect endpoint is updated
-            Assert.willBeTrue(AnyEndpoint(oldWSConnectEndpoint) != AnyEndpoint(self.client.webSocketClient.connectEndpoint))
+            Assert.willBeTrue(AnyEndpoint(oldWSConnectEndpoint) != AnyEndpoint(self.client.webSocketClient!.connectEndpoint))
 
             // WebSocketClient connect is called
             Assert.willBeEqual(self.client.mockWebSocketClient.connect_calledCounter, 1)
@@ -504,10 +504,10 @@ final class CurrentUserController_Tests: StressTestCase {
 
         // Simulate a health check event with the current user data
         // This should trigger the middlewares and save the current user data to DB
-        client.webSocketClient.webSocketDidReceiveMessage(healthCheckEventJSON(userId: newUser.userId))
+        client.webSocketClient!.webSocketDidReceiveMessage(healthCheckEventJSON(userId: newUser.userId))
 
         // Simulate successful connection
-        client.webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        client.webSocketClient!.simulateConnectionStatus(.connected(connectionId: .unique))
         
         var currentUser: CurrentUserDTO? {
             client.databaseContainer.viewContext.currentUser()
@@ -528,7 +528,7 @@ final class CurrentUserController_Tests: StressTestCase {
         controller.setAnonymousUser(completion: { _ in setUserCompletionCalled = true })
 
         // Simulate successful connection
-        client.webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        client.webSocketClient!.simulateConnectionStatus(.connected(connectionId: .unique))
 
         // Wait for the connection to succeed
         AssertAsync.willBeTrue(setUserCompletionCalled)
@@ -542,7 +542,7 @@ final class CurrentUserController_Tests: StressTestCase {
         XCTAssertEqual(client.mockWebSocketClient.disconnect_calledCounter, 1)
 
         // Simulate WS disconnecting
-        client.webSocketClient.simulateConnectionStatus(.disconnected(error: nil))
+        client.webSocketClient!.simulateConnectionStatus(.disconnected(error: nil))
 
         // Call connect again and assert WS connect is called
         var connectCompletionCalled = false
@@ -557,7 +557,7 @@ final class CurrentUserController_Tests: StressTestCase {
         controller = nil
 
         // Simulate successful connection
-        client.webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        client.webSocketClient!.simulateConnectionStatus(.connected(connectionId: .unique))
         client.mockAPIClient.cleanUp()
         
         AssertAsync.willBeTrue(connectCompletionCalled)

--- a/Sources_v3/StreamChat/Controllers/MemberController/MemberController.swift
+++ b/Sources_v3/StreamChat/Controllers/MemberController/MemberController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -139,7 +139,6 @@ public class _ChatChannelMemberController<ExtraData: ExtraDataTypes>: DataContro
     private func createMemberUpdater() -> ChannelMemberUpdater {
         environment.memberUpdaterBuilder(
             client.databaseContainer,
-            client.webSocketClient,
             client.apiClient
         )
     }
@@ -147,7 +146,6 @@ public class _ChatChannelMemberController<ExtraData: ExtraDataTypes>: DataContro
     private func createMemberListUpdater() -> ChannelMemberListUpdater<ExtraData> {
         environment.memberListUpdaterBuilder(
             client.databaseContainer,
-            client.webSocketClient,
             client.apiClient
         )
     }
@@ -211,13 +209,11 @@ extension _ChatChannelMemberController {
     struct Environment {
         var memberUpdaterBuilder: (
             _ database: DatabaseContainer,
-            _ webSocketClient: WebSocketClient,
             _ apiClient: APIClient
         ) -> ChannelMemberUpdater = ChannelMemberUpdater.init
         
         var memberListUpdaterBuilder: (
             _ database: DatabaseContainer,
-            _ webSocketClient: WebSocketClient,
             _ apiClient: APIClient
         ) -> ChannelMemberListUpdater<ExtraData> = ChannelMemberListUpdater.init
         

--- a/Sources_v3/StreamChat/Controllers/MemberController/MemberController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/MemberController/MemberController_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -445,16 +445,14 @@ private class TestEnvironment {
         memberUpdaterBuilder: { [unowned self] in
             self.memberUpdater = .init(
                 database: $0,
-                webSocketClient: $1,
-                apiClient: $2
+                apiClient: $1
             )
             return self.memberUpdater!
         },
         memberListUpdaterBuilder: { [unowned self] in
             self.memberListUpdater = .init(
                 database: $0,
-                webSocketClient: $1,
-                apiClient: $2
+                apiClient: $1
             )
             return self.memberListUpdater!
         },

--- a/Sources_v3/StreamChat/Controllers/MemberListController/MemberListController.swift
+++ b/Sources_v3/StreamChat/Controllers/MemberListController/MemberListController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -117,7 +117,6 @@ public class _ChatChannelMemberListController<ExtraData: ExtraDataTypes>: DataCo
     private func createMemberListUpdater() -> ChannelMemberListUpdater<ExtraData> {
         environment.memberListUpdaterBuilder(
             client.databaseContainer,
-            client.webSocketClient,
             client.apiClient
         )
     }
@@ -179,7 +178,6 @@ extension _ChatChannelMemberListController {
     struct Environment {
         var memberListUpdaterBuilder: (
             _ database: DatabaseContainer,
-            _ webSocketClient: WebSocketClient,
             _ apiClient: APIClient
         ) -> ChannelMemberListUpdater<ExtraData> = ChannelMemberListUpdater.init
 

--- a/Sources_v3/StreamChat/Controllers/MemberListController/MemberListController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/MemberListController/MemberListController_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -459,8 +459,7 @@ private class TestEnvironment {
         memberListUpdaterBuilder: { [unowned self] in
             self.memberListUpdater = .init(
                 database: $0,
-                webSocketClient: $1,
-                apiClient: $2
+                apiClient: $1
             )
             return self.memberListUpdater!
         },

--- a/Sources_v3/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources_v3/StreamChat/Controllers/MessageController/MessageController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -120,7 +120,6 @@ public class _ChatMessageController<ExtraData: ExtraDataTypes>: DataController, 
     /// The worker used to fetch the remote data and communicate with servers.
     private lazy var messageUpdater: MessageUpdater<ExtraData> = environment.messageUpdaterBuilder(
         client.databaseContainer,
-        client.webSocketClient,
         client.apiClient
     )
 
@@ -390,7 +389,6 @@ extension _ChatMessageController {
         
         var messageUpdaterBuilder: (
             _ database: DatabaseContainer,
-            _ webSocketClient: WebSocketClient,
             _ apiClient: APIClient
         ) -> MessageUpdater<ExtraData> = MessageUpdater.init
     }

--- a/Sources_v3/StreamChat/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/MessageController/MessageController_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -1155,7 +1155,7 @@ private class TestEnvironment {
                 return self.messageObserver!
             },
             messageUpdaterBuilder: { [unowned self] in
-                self.messageUpdater = MessageUpdaterMock(database: $0, webSocketClient: $1, apiClient: $2)
+                self.messageUpdater = MessageUpdaterMock(database: $0, apiClient: $1)
                 return self.messageUpdater
             }
         )

--- a/Sources_v3/StreamChat/Controllers/SearchControllers/UserSearchController.swift
+++ b/Sources_v3/StreamChat/Controllers/SearchControllers/UserSearchController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -60,7 +60,6 @@ public class _ChatUserSearchController<ExtraData: ExtraDataTypes>: DataControlle
     lazy var userQueryUpdater = self.environment
         .userQueryUpdaterBuilder(
             client.databaseContainer,
-            client.webSocketClient,
             client.apiClient
         )
     
@@ -199,7 +198,6 @@ extension _ChatUserSearchController {
     struct Environment {
         var userQueryUpdaterBuilder: (
             _ database: DatabaseContainer,
-            _ webSocketClient: WebSocketClient,
             _ apiClient: APIClient
         ) -> UserListUpdater<ExtraData.User> = UserListUpdater.init
         

--- a/Sources_v3/StreamChat/Controllers/SearchControllers/UserSearchController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/SearchControllers/UserSearchController_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -433,8 +433,7 @@ private class TestEnvironment {
         .init(userQueryUpdaterBuilder: { [unowned self] in
             self.userListUpdater = UserListUpdaterMock(
                 database: $0,
-                webSocketClient: $1,
-                apiClient: $2
+                apiClient: $1
             )
             return self.userListUpdater!
         })

--- a/Sources_v3/StreamChat/Controllers/UserController/UserController.swift
+++ b/Sources_v3/StreamChat/Controllers/UserController/UserController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -129,7 +129,6 @@ public class _ChatUserController<ExtraData: ExtraDataTypes>: DataController, Del
     private func createUserUpdater() -> UserUpdater<ExtraData> {
         environment.userUpdaterBuilder(
             client.databaseContainer,
-            client.webSocketClient,
             client.apiClient
         )
     }
@@ -208,7 +207,6 @@ extension _ChatUserController {
     struct Environment {
         var userUpdaterBuilder: (
             _ database: DatabaseContainer,
-            _ webSocketClient: WebSocketClient,
             _ apiClient: APIClient
         ) -> UserUpdater<ExtraData> = UserUpdater.init
         

--- a/Sources_v3/StreamChat/Controllers/UserController/UserController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/UserController/UserController_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -572,8 +572,7 @@ private class TestEnvironment {
         userUpdaterBuilder: { [unowned self] in
             self.userUpdater = .init(
                 database: $0,
-                webSocketClient: $1,
-                apiClient: $2
+                apiClient: $1
             )
             return self.userUpdater!
         },

--- a/Sources_v3/StreamChat/Controllers/UserListController/UserListController.swift
+++ b/Sources_v3/StreamChat/Controllers/UserListController/UserListController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -56,7 +56,6 @@ public class _ChatUserListController<ExtraData: ExtraDataTypes>: DataController,
     private lazy var worker: UserListUpdater<ExtraData.User> = self.environment
         .userQueryUpdaterBuilder(
             client.databaseContainer,
-            client.webSocketClient,
             client.apiClient
         )
 
@@ -172,7 +171,6 @@ extension _ChatUserListController {
     struct Environment {
         var userQueryUpdaterBuilder: (
             _ database: DatabaseContainer,
-            _ webSocketClient: WebSocketClient,
             _ apiClient: APIClient
         ) -> UserListUpdater<ExtraData.User> = UserListUpdater.init
 

--- a/Sources_v3/StreamChat/Controllers/UserListController/UserListController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/UserListController/UserListController_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -337,8 +337,7 @@ private class TestEnvironment {
         .init(userQueryUpdaterBuilder: { [unowned self] in
             self.userListUpdater = UserListUpdaterMock(
                 database: $0,
-                webSocketClient: $1,
-                apiClient: $2
+                apiClient: $1
             )
             return self.userListUpdater!
         })

--- a/Sources_v3/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseContainer.swift
@@ -265,9 +265,7 @@ class DatabaseContainer: NSPersistentContainer {
             throw error
         }
     }
-}
-
-extension DatabaseContainer {
+    
     /// Iterates over all items and if the DTO conforms to `EphemeralValueContainers` calls `resetEphemeralValues()` on
     /// every object.
     func resetEphemeralValues() {

--- a/Sources_v3/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseContainer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -77,7 +77,13 @@ class DatabaseContainer: NSPersistentContainer {
     ///   - completion: Called when the container finishes its initialization. If the initialization fails, called
     ///   with an error.
     ///
-    init(kind: Kind, shouldFlushOnStart: Bool = false, modelName: String = "StreamChatModel", bundle: Bundle? = nil) throws {
+    init(
+        kind: Kind,
+        shouldFlushOnStart: Bool = false,
+        shouldResetEphemeralValuesOnStart: Bool = true,
+        modelName: String = "StreamChatModel",
+        bundle: Bundle? = nil
+    ) throws {
         // It's safe to unwrap the following values because this is not settable by users and it's always a programmer error.
         let bundle = bundle ?? Bundle(for: DatabaseContainer.self)
         let modelURL = bundle.url(forResource: modelName, withExtension: "momd")!
@@ -115,7 +121,9 @@ class DatabaseContainer: NSPersistentContainer {
         
         setupLoggerForDatabaseChanges()
         
-        resetEphemeralValues()
+        if shouldResetEphemeralValuesOnStart {
+            resetEphemeralValues()
+        }
     }
     
     deinit {

--- a/Sources_v3/StreamChat/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseContainer_Mock.swift
@@ -14,6 +14,7 @@ class DatabaseContainerMock: DatabaseContainer {
     @Atomic var flush_called = false
     @Atomic var recreatePersistentStore_called = false
     @Atomic var recreatePersistentStore_errorResponse: Error?
+    @Atomic var resetEphemeralValues_called = false
     
     convenience init() {
         try! self.init(kind: .inMemory)
@@ -58,6 +59,11 @@ class DatabaseContainerMock: DatabaseContainer {
         } else {
             super.write(actions, completion: completion)
         }
+    }
+    
+    override func resetEphemeralValues() {
+        resetEphemeralValues_called = true
+        super.resetEphemeralValues()
     }
 }
 

--- a/Sources_v3/StreamChat/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseContainer_Mock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -22,11 +22,18 @@ class DatabaseContainerMock: DatabaseContainer {
     override init(
         kind: DatabaseContainer.Kind,
         shouldFlushOnStart: Bool = false,
+        shouldResetEphemeralValuesOnStart: Bool = true,
         modelName: String = "StreamChatModel",
         bundle: Bundle? = nil
     ) throws {
         init_kind = kind
-        try super.init(kind: kind, shouldFlushOnStart: shouldFlushOnStart, modelName: modelName, bundle: bundle)
+        try super.init(
+            kind: kind,
+            shouldFlushOnStart: shouldFlushOnStart,
+            shouldResetEphemeralValuesOnStart: shouldResetEphemeralValuesOnStart,
+            modelName: modelName,
+            bundle: bundle
+        )
     }
     
     override func removeAllData(force: Bool = true) throws {

--- a/Sources_v3/StreamChat/Database/DatabaseContainer_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseContainer_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -117,6 +117,9 @@ class DatabaseContainer_Tests: StressTestCase {
             modelName: "TestDataModel",
             bundle: Bundle(for: DatabaseContainer_Tests.self)
         )
+        
+        // Assert `resetEphemeralValues` is called on DatabaseContainer
+        XCTAssert((newDatabase as! DatabaseContainerMock).resetEphemeralValues_called)
 
         let testObject2 = try newDatabase.viewContext
             .fetch(NSFetchRequest<TestManagedObject>(entityName: "TestManagedObject"))
@@ -126,6 +129,20 @@ class DatabaseContainer_Tests: StressTestCase {
         
         // Wait for the new DB instance to be released
         AssertAsync.canBeReleased(&newDatabase)
+    }
+    
+    func test_databaseContainer_doesntCallsResetEphemeralValues_whenFlagIsSetToFalse() throws {
+        // Create a new on-disc database with the test data model
+        let dbURL = URL.newTemporaryFileURL()
+        let database = try DatabaseContainerMock(
+            kind: .onDisk(databaseFileURL: dbURL),
+            shouldResetEphemeralValuesOnStart: false,
+            modelName: "TestDataModel",
+            bundle: Bundle(for: DatabaseContainer_Tests.self)
+        )
+        
+        // Assert `resetEphemeralValues` is not called on DatabaseContainer
+        XCTAssertFalse(database.resetEphemeralValues_called)
     }
     
     func test_databaseContainer_removesAllData_whenShouldFlushOnStartIsTrue() throws {

--- a/Sources_v3/StreamChat/Workers/Background/AttachmentUploader.swift
+++ b/Sources_v3/StreamChat/Workers/Background/AttachmentUploader.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -26,14 +26,14 @@ class AttachmentUploader<ExtraData: ExtraDataTypes>: Worker {
 
     var minSignificantUploadingProgressChange: Double = 0.05
 
-    override init(database: DatabaseContainer, webSocketClient: WebSocketClient, apiClient: APIClient) {
+    override init(database: DatabaseContainer, apiClient: APIClient) {
         observer = .init(
             context: database.backgroundReadOnlyContext,
             fetchRequest: AttachmentDTO.pendingUploadFetchRequest(),
             itemCreator: { $0 }
         )
 
-        super.init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        super.init(database: database, apiClient: apiClient)
 
         startObserving()
     }

--- a/Sources_v3/StreamChat/Workers/Background/AttachmentUploader_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/Background/AttachmentUploader_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -21,7 +21,7 @@ final class AttachmentUploader_Tests: StressTestCase {
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
         database = DatabaseContainerMock()
-        uploader = AttachmentUploader(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        uploader = AttachmentUploader(database: database, apiClient: apiClient)
     }
 
     override func tearDown() {

--- a/Sources_v3/StreamChat/Workers/Background/ChannelWatchStateUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/Background/ChannelWatchStateUpdater_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -23,7 +23,7 @@ class ChannelWatchStateUpdater_Tests: StressTestCase {
         
         channelWatchStateUpdater = ChannelWatchStateUpdater(
             database: database,
-            webSocketClient: webSocketClient,
+            eventNotificationCenter: webSocketClient.eventNotificationCenter,
             apiClient: apiClient
         )
     }

--- a/Sources_v3/StreamChat/Workers/Background/MessageEditor.swift
+++ b/Sources_v3/StreamChat/Workers/Background/MessageEditor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -23,14 +23,14 @@ class MessageEditor<ExtraData: ExtraDataTypes>: Worker {
     
     private let observer: ListDatabaseObserver<MessageDTO, MessageDTO>
 
-    override init(database: DatabaseContainer, webSocketClient: WebSocketClient, apiClient: APIClient) {
+    override init(database: DatabaseContainer, apiClient: APIClient) {
         observer = .init(
             context: database.backgroundReadOnlyContext,
             fetchRequest: MessageDTO.messagesPendingSyncFetchRequest(),
             itemCreator: { $0 }
         )
         
-        super.init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        super.init(database: database, apiClient: apiClient)
         
         startObserving()
     }

--- a/Sources_v3/StreamChat/Workers/Background/MessageEditor_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/Background/MessageEditor_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -21,7 +21,7 @@ final class MessageEditor_Tests: StressTestCase {
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
         database = try! DatabaseContainerMock(kind: .inMemory)
-        editor = MessageEditor(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        editor = MessageEditor(database: database, apiClient: apiClient)
     }
     
     override func tearDown() {

--- a/Sources_v3/StreamChat/Workers/Background/MessageSender.swift
+++ b/Sources_v3/StreamChat/Workers/Background/MessageSender.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -37,8 +37,8 @@ class MessageSender<ExtraData: ExtraDataTypes>: Worker {
         attributes: [.concurrent]
     )
     
-    override init(database: DatabaseContainer, webSocketClient: WebSocketClient, apiClient: APIClient) {
-        super.init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+    override init(database: DatabaseContainer, apiClient: APIClient) {
+        super.init(database: database, apiClient: apiClient)
 
         // We need to initialize the observer synchronously
         _ = observer

--- a/Sources_v3/StreamChat/Workers/Background/MessageSender_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/Background/MessageSender_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -23,7 +23,7 @@ class MessageSender_Tests: StressTestCase {
         apiClient = APIClientMock()
         database = try! DatabaseContainerMock(kind: .inMemory)
         
-        sender = MessageSender(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        sender = MessageSender(database: database, apiClient: apiClient)
         
         cid = .unique
         

--- a/Sources_v3/StreamChat/Workers/Background/MissingEventsPublisher_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/Background/MissingEventsPublisher_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -24,7 +24,7 @@ final class MissingEventsPublisher_Tests: StressTestCase {
         
         publisher = MissingEventsPublisher(
             database: database,
-            webSocketClient: webSocketClient,
+            eventNotificationCenter: webSocketClient.eventNotificationCenter,
             apiClient: apiClient
         )
     }

--- a/Sources_v3/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -18,7 +18,6 @@ final class NewChannelQueryUpdater<ExtraData: ExtraDataTypes>: Worker {
     private lazy var channelListUpdater: ChannelListUpdater<ExtraData> = self.environment
         .createChannelListUpdater(
             database,
-            webSocketClient,
             apiClient
         )
     
@@ -38,15 +37,15 @@ final class NewChannelQueryUpdater<ExtraData: ExtraDataTypes>: Worker {
         return []
     }
     
-    init(database: DatabaseContainer, webSocketClient: WebSocketClient, apiClient: APIClient, env: Environment) {
+    init(database: DatabaseContainer, apiClient: APIClient, env: Environment) {
         environment = env
-        super.init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        super.init(database: database, apiClient: apiClient)
         
         startObserving()
     }
     
-    override convenience init(database: DatabaseContainer, webSocketClient: WebSocketClient, apiClient: APIClient) {
-        self.init(database: database, webSocketClient: webSocketClient, apiClient: apiClient, env: .init())
+    override convenience init(database: DatabaseContainer, apiClient: APIClient) {
+        self.init(database: database, apiClient: apiClient, env: .init())
     }
     
     private func startObserving() {
@@ -112,7 +111,6 @@ extension NewChannelQueryUpdater {
     struct Environment {
         var createChannelListUpdater: (
             _ database: DatabaseContainer,
-            _ webSocketClient: WebSocketClient,
             _ apiClient: APIClient
         ) -> ChannelListUpdater<ExtraData> = ChannelListUpdater.init
     }

--- a/Sources_v3/StreamChat/Workers/Background/NewChannelQueryUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/Background/NewChannelQueryUpdater_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -26,7 +26,6 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
         
         newChannelQueryUpdater = NewChannelQueryUpdater(
             database: database,
-            webSocketClient: webSocketClient,
             apiClient: apiClient,
             env: env.environment
         )
@@ -76,7 +75,6 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
         // Create `newChannelQueryUpdater`
         newChannelQueryUpdater = NewChannelQueryUpdater(
             database: database,
-            webSocketClient: webSocketClient,
             apiClient: apiClient,
             env: env.environment
         )
@@ -120,8 +118,7 @@ private class TestEnvironment {
     lazy var environment = NewChannelQueryUpdater<DefaultExtraData>.Environment(createChannelListUpdater: { [unowned self] in
         self.channelQueryUpdater = ChannelListUpdaterMock(
             database: $0,
-            webSocketClient: $1,
-            apiClient: $2
+            apiClient: $1
         )
         return self.channelQueryUpdater!
     })

--- a/Sources_v3/StreamChat/Workers/Background/NewUserQueryUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/Background/NewUserQueryUpdater.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -18,7 +18,6 @@ final class NewUserQueryUpdater<ExtraData: UserExtraData>: Worker {
     private lazy var userListUpdater: UserListUpdater<ExtraData> = self.environment
         .createUserListUpdater(
             database,
-            webSocketClient,
             apiClient
         )
     
@@ -38,15 +37,15 @@ final class NewUserQueryUpdater<ExtraData: UserExtraData>: Worker {
         return []
     }
     
-    init(database: DatabaseContainer, webSocketClient: WebSocketClient, apiClient: APIClient, env: Environment) {
+    init(database: DatabaseContainer, apiClient: APIClient, env: Environment) {
         environment = env
-        super.init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        super.init(database: database, apiClient: apiClient)
         
         startObserving()
     }
     
-    override convenience init(database: DatabaseContainer, webSocketClient: WebSocketClient, apiClient: APIClient) {
-        self.init(database: database, webSocketClient: webSocketClient, apiClient: apiClient, env: .init())
+    override convenience init(database: DatabaseContainer, apiClient: APIClient) {
+        self.init(database: database, apiClient: apiClient, env: .init())
     }
     
     private func startObserving() {
@@ -113,7 +112,6 @@ extension NewUserQueryUpdater {
     struct Environment {
         var createUserListUpdater: (
             _ database: DatabaseContainer,
-            _ webSocketClient: WebSocketClient,
             _ apiClient: APIClient
         ) -> UserListUpdater<ExtraData> = UserListUpdater.init
     }

--- a/Sources_v3/StreamChat/Workers/Background/NewUserQueryUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/Background/NewUserQueryUpdater_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -26,7 +26,6 @@ class NewUserQueryUpdater_Tests: StressTestCase {
         
         newUserQueryUpdater = NewUserQueryUpdater(
             database: database,
-            webSocketClient: webSocketClient,
             apiClient: apiClient,
             env: env.environment
         )
@@ -76,7 +75,6 @@ class NewUserQueryUpdater_Tests: StressTestCase {
         // Create `newUserQueryUpdater`
         newUserQueryUpdater = NewUserQueryUpdater(
             database: database,
-            webSocketClient: webSocketClient,
             apiClient: apiClient,
             env: env.environment
         )
@@ -141,8 +139,7 @@ private class TestEnvironment {
     lazy var environment = NewUserQueryUpdater<DefaultExtraData.User>.Environment(createUserListUpdater: { [unowned self] in
         self.userQueryUpdater = UserListUpdaterMock(
             database: $0,
-            webSocketClient: $1,
-            apiClient: $2
+            apiClient: $1
         )
         return self.userQueryUpdater!
     })

--- a/Sources_v3/StreamChat/Workers/ChannelListUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelListUpdater_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -19,7 +19,7 @@ class ChannelListUpdater_Tests: StressTestCase {
         apiClient = APIClientMock()
         database = try! DatabaseContainer(kind: .inMemory)
         
-        listUpdater = ChannelListUpdater(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        listUpdater = ChannelListUpdater(database: database, apiClient: apiClient)
     }
     
     override func tearDown() {

--- a/Sources_v3/StreamChat/Workers/ChannelMemberListUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelMemberListUpdater_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -21,7 +21,7 @@ final class ChannelMemberListUpdater_Tests: StressTestCase {
         database = DatabaseContainerMock()
         query = ChannelMemberListQuery(cid: .unique, filter: .query(.id, text: "Luke"))
 
-        listUpdater = .init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        listUpdater = .init(database: database, apiClient: apiClient)
     }
     
     override func tearDown() {

--- a/Sources_v3/StreamChat/Workers/ChannelMemberUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelMemberUpdater_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -21,7 +21,7 @@ final class ChannelMemberUpdater_Tests: StressTestCase {
         apiClient = APIClientMock()
         database = DatabaseContainerMock()
         
-        updater = .init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        updater = .init(database: database, apiClient: apiClient)
     }
     
     override func tearDown() {

--- a/Sources_v3/StreamChat/Workers/ChannelUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelUpdater_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -21,7 +21,7 @@ class ChannelUpdater_Tests: StressTestCase {
         apiClient = APIClientMock()
         database = try! DatabaseContainerMock(kind: .inMemory)
         
-        channelUpdater = ChannelUpdater(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        channelUpdater = ChannelUpdater(database: database, apiClient: apiClient)
     }
     
     override func tearDown() {

--- a/Sources_v3/StreamChat/Workers/EventSender_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/EventSender_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -24,7 +24,7 @@ class EventSender_Tests: StressTestCase {
         time = VirtualTime()
         VirtualTimeTimer.time = time
         
-        eventSender = EventSender(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        eventSender = EventSender(database: database, apiClient: apiClient)
         eventSender.timer = VirtualTimeTimer.self
     }
     

--- a/Sources_v3/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -22,7 +22,7 @@ final class MessageUpdater_Tests: StressTestCase {
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
         database = try! DatabaseContainerMock(kind: .inMemory)
-        messageUpdater = MessageUpdater(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        messageUpdater = MessageUpdater(database: database, apiClient: apiClient)
     }
     
     override func tearDown() {

--- a/Sources_v3/StreamChat/Workers/UserListUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/UserListUpdater_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -19,7 +19,7 @@ class UserListUpdater_Tests: StressTestCase {
         apiClient = APIClientMock()
         database = try! DatabaseContainer(kind: .inMemory)
         
-        listUpdater = UserListUpdater(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        listUpdater = UserListUpdater(database: database, apiClient: apiClient)
     }
     
     override func tearDown() {

--- a/Sources_v3/StreamChat/Workers/UserUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/UserUpdater_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -23,7 +23,7 @@ final class UserUpdater_Tests: StressTestCase {
         apiClient = APIClientMock()
         database = DatabaseContainerMock()
         
-        userUpdater = .init(database: database, webSocketClient: webSocketClient, apiClient: apiClient)
+        userUpdater = .init(database: database, apiClient: apiClient)
     }
     
     override func tearDown() {

--- a/Sources_v3/StreamChat/Workers/Worker.swift
+++ b/Sources_v3/StreamChat/Workers/Worker.swift
@@ -7,19 +7,18 @@ import Foundation
 
 typealias WorkerBuilder = (
     _ database: DatabaseContainer,
-    _ webSocketClient: WebSocketClient,
+    _ apiClient: APIClient
+) -> Worker
     _ apiClient: APIClient
 ) -> Worker
 
 // This is a super-class instead of protocol because we need to be sure, `unowned` is used for socket client and api client
 class Worker: NSObject { // TODO: remove NSObject
     unowned let database: DatabaseContainer
-    unowned let webSocketClient: WebSocketClient
     unowned let apiClient: APIClient
     
-    init(database: DatabaseContainer, webSocketClient: WebSocketClient, apiClient: APIClient) {
+    init(database: DatabaseContainer, apiClient: APIClient) {
         self.database = database
-        self.webSocketClient = webSocketClient
         self.apiClient = apiClient
         super.init()
     }

--- a/Sources_v3/StreamChat/Workers/Worker.swift
+++ b/Sources_v3/StreamChat/Workers/Worker.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -9,6 +9,10 @@ typealias WorkerBuilder = (
     _ database: DatabaseContainer,
     _ apiClient: APIClient
 ) -> Worker
+
+typealias EventWorkerBuilder = (
+    _ database: DatabaseContainer,
+    _ eventNotificationCenter: EventNotificationCenter,
     _ apiClient: APIClient
 ) -> Worker
 
@@ -21,5 +25,18 @@ class Worker: NSObject { // TODO: remove NSObject
         self.database = database
         self.apiClient = apiClient
         super.init()
+    }
+}
+
+class EventWorker: Worker {
+    unowned let eventNotificationCenter: EventNotificationCenter
+    
+    init(
+        database: DatabaseContainer,
+        eventNotificationCenter: EventNotificationCenter,
+        apiClient: APIClient
+    ) {
+        self.eventNotificationCenter = eventNotificationCenter
+        super.init(database: database, apiClient: apiClient)
     }
 }


### PR DESCRIPTION
### ~Open~ Answered Questions
1. `isConnectionless` naming :)
> We decided to go with `isClientInActiveMode`, thinking that Client can be active vs passive 
1. Should we allow creation of connectionless clients for main app? Or full client in app extensions? (basically making `isConnectionless` a parameter)
> Why not? Good as long as we document it properly ¯\_(ツ)_/¯ 
1. For operations available to connectionless client but doesn't make sense (`connect`, `disconnect`, `setUser`) should we:
```swift
completion?(ClientError.ClientInConnectionlessMode())
```
or
```swift
log.warning("The client is in connectionless mode. Skipping the `connect` call.")
completion?(nil)
```
> Error returning approach is better