### PR TITLE
Fix layout loop in composer command view

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerInputSlashCommandView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerInputSlashCommandView.swift
@@ -66,7 +66,6 @@ open class MessageInputSlashCommandView<ExtraData: ExtraDataTypes>: View, UIConf
         container.rightStackView.addArrangedSubview(commandLabel)
         
         iconView.contentMode = .scaleAspectFit
-        iconView.heightAnchor.pin(equalToConstant: commandLabel.font.pointSize).isActive = true
     }
     
     override open func updateContent() {


### PR DESCRIPTION
Composer view layout is confusing and hard to understand. So I have no idea why exactly this loop happen and why removing this constraint fixes it.
But looks like it helped.