### PR TITLE
[CIS-574] Token based user setting

### DIFF
--- a/DemoApp/ChatPresenter.swift
+++ b/DemoApp/ChatPresenter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -10,24 +10,14 @@ extension UIViewController {
     // TODO: Where to put this???
     func presentChat(userCredentials: UserCredentials) {
         LogConfig.level = .error
+
+        // Create a token
+        let token = try! Token(rawValue: userCredentials.token)
         
         // Create client
         let config = ChatClientConfig(apiKey: .init(userCredentials.apiKey))
-        let client = ChatClient(config: config)
-        
-        // Log in the current user
-        let currentUserController = client.currentUserController()
-        currentUserController.setUser(
-            userId: userCredentials.id,
-            name: userCredentials.name,
-            imageURL: userCredentials.avatarURL,
-            token: userCredentials.token
-        ) { error in
-            if let error = error {
-                print("User login failed: \(error)")
-            }
-        }
-        
+        let client = ChatClient(config: config, tokenProvider: .static(token))
+
         // Config
         var uiConfig = UIConfig<DefaultExtraData>()
         uiConfig.navigation.channelListRouter = DemoChatChannelListRouter.self

--- a/Sample_v3/Configuration.swift
+++ b/Sample_v3/Configuration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -29,7 +29,7 @@ enum Configuration {
     struct TestUser {
         let name: String
         let id: String
-        let token: String
+        let token: Token
         
         static var defaults: [Self] {
             [
@@ -162,8 +162,17 @@ enum Configuration {
     }
 
     static var token: Token? {
-        get { UserDefaults.standard.string(forKey: "token") ?? DefaultValues.token }
-        set { UserDefaults.standard.setValue(newValue, forKey: PersistenceKeys.token) }
+        get {
+            guard
+                let rawValue = UserDefaults.standard.string(forKey: PersistenceKeys.token),
+                let token = try? Token(rawValue: rawValue)
+            else {
+                return DefaultValues.token
+            }
+
+            return token
+        }
+        set { UserDefaults.standard.setValue(newValue?.rawValue, forKey: PersistenceKeys.token) }
     }
     
     static var isLocalStorageEnabled: Bool {

--- a/Sample_v3/ConfigurationViewController.swift
+++ b/Sample_v3/ConfigurationViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -33,22 +33,21 @@ class ConfigurationViewController: UITableViewController {
         case 1:
             tokenTypeSegmentedControl.selectedSegmentIndex = 1
             jwtTextField.isEnabled = false
-            if token != .development {
+            if tableView.numberOfRows(inSection: 0) > 4 {
                 tableView.deleteRows(at: [jwtCellIndexPath], with: .top)
             }
-            jwtTextField.text = nil
+            token = nil
         case 2:
             tokenTypeSegmentedControl.selectedSegmentIndex = 2
             jwtTextField.isEnabled = false
-            if let token = token,
-                !token.isEmpty {
+            if tableView.numberOfRows(inSection: 0) > 4 {
                 tableView.deleteRows(at: [jwtCellIndexPath], with: .top)
             }
-            jwtTextField.text = .development
+            token = .development(userId: userId)
         default:
             tokenTypeSegmentedControl.selectedSegmentIndex = 0
             jwtTextField.isEnabled = true
-            jwtTextField.text = Configuration.TestUser.defaults.first(where: { $0.id == userId })?.token ?? ""
+            token = Configuration.TestUser.defaults.first(where: { $0.id == userId })?.token
             tableView.insertRows(at: [jwtCellIndexPath], with: .top)
         }
         
@@ -155,8 +154,8 @@ extension ConfigurationViewController {
     }
 
     var token: Token? {
-        get { jwtTextField.text ?? "" }
-        set { jwtTextField.text = newValue }
+        get { try? Token(rawValue: jwtTextField.text ?? "") }
+        set { jwtTextField.text = newValue?.rawValue }
     }
     
     var isLocalStorageEnabled: Bool {

--- a/Sources_v3/StreamChat/APIClient/Endpoints/Endpoint.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/Endpoint.swift
@@ -9,7 +9,24 @@ struct Endpoint<ResponseType: Decodable> {
     let method: EndpointMethod
     let queryItems: Encodable?
     let requiresConnectionId: Bool
+    let requiresToken: Bool
     let body: Encodable?
+
+    init(
+        path: String,
+        method: EndpointMethod,
+        queryItems: Encodable? = nil,
+        requiresConnectionId: Bool = false,
+        requiresToken: Bool = true,
+        body: Encodable? = nil
+    ) {
+        self.path = path
+        self.method = method
+        self.queryItems = queryItems
+        self.requiresConnectionId = requiresConnectionId
+        self.requiresToken = requiresToken
+        self.body = body
+    }
 }
 
 enum EndpointMethod: String {

--- a/Sources_v3/StreamChat/APIClient/Endpoints/GuestEndpoints.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/GuestEndpoints.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -21,6 +21,7 @@ extension Endpoint {
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
+            requiresToken: false,
             body: ["user": GuestUserTokenRequestPayload(
                 userId: userId,
                 name: name,

--- a/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/GuestUserTokenPayload.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/GuestUserTokenPayload.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -12,4 +12,24 @@ struct GuestUserTokenPayload<ExtraData: UserExtraData>: Decodable {
 
     let user: CurrentUserPayload<ExtraData>
     let token: Token
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let user = try container.decode(CurrentUserPayload<ExtraData>.self, forKey: .user)
+        let token = try container.decode(Token.self, forKey: .token)
+
+        guard user.id == token.userId else {
+            throw ClientError.InvalidToken("Token has different user_id")
+        }
+
+        self.init(user: user, token: token)
+    }
+
+    init(
+        user: CurrentUserPayload<ExtraData>,
+        token: Token
+    ) {
+        self.user = user
+        self.token = token
+    }
 }

--- a/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/GuestUserTokenPayload_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/Payloads/GuestUserTokenPayload_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -9,14 +9,19 @@ final class GuestUserTokenPayload_Tests: XCTestCase {
     let guestUserDefaultExtraDataJSON = XCTestCase.mockData(fromFile: "GuestUser+DefaultExtraData")
     let guestUserNoExtraDataJSON = XCTestCase.mockData(fromFile: "GuestUser+NoExtraData")
     let guestUserCustomExtraDataJSON = XCTestCase.mockData(fromFile: "GuestUser+CustomExtraData")
-    
+    let guestUserInvalidTokenJSON = XCTestCase.mockData(fromFile: "GuestUser+InvalidToken")
+
     func test_guestUserDefaultExtraData_isSerialized() throws {
         let payload = try JSONDecoder.default.decode(
             GuestUserTokenPayload<DefaultExtraData.User>.self,
             from: guestUserDefaultExtraDataJSON
         )
-        
-        XCTAssertEqual(payload.token, "123")
+
+        XCTAssertEqual(
+            payload.token,
+            // swiftlint:disable:next line_length
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.QPeAmdig1KbLwYInW8hwi0XML3kO1M6HH76k4IU0sDg"
+        )
         XCTAssertNotNil(payload.user)
         XCTAssertEqual(payload.user.id, "broken-waterfall-5")
         XCTAssertFalse(payload.user.isBanned)
@@ -33,8 +38,12 @@ final class GuestUserTokenPayload_Tests: XCTestCase {
     
     func test_guestUserNoExtraData_isSerialized() throws {
         let payload = try JSONDecoder.default.decode(GuestUserTokenPayload<NoExtraData>.self, from: guestUserNoExtraDataJSON)
-        
-        XCTAssertEqual(payload.token, "123")
+
+        XCTAssertEqual(
+            payload.token,
+            // swiftlint:disable:next line_length
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.QPeAmdig1KbLwYInW8hwi0XML3kO1M6HH76k4IU0sDg"
+        )
         XCTAssertNotNil(payload.user)
         XCTAssertEqual(payload.user.id, "broken-waterfall-5")
         XCTAssertFalse(payload.user.isBanned)
@@ -51,8 +60,12 @@ final class GuestUserTokenPayload_Tests: XCTestCase {
         }
         
         let payload = try JSONDecoder.default.decode(GuestUserTokenPayload<TestExtraData>.self, from: guestUserCustomExtraDataJSON)
-        
-        XCTAssertEqual(payload.token, "123")
+
+        XCTAssertEqual(
+            payload.token,
+            // swiftlint:disable:next line_length
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.QPeAmdig1KbLwYInW8hwi0XML3kO1M6HH76k4IU0sDg"
+        )
         XCTAssertNotNil(payload.user)
         XCTAssertEqual(payload.user.id, "broken-waterfall-5")
         XCTAssertFalse(payload.user.isBanned)
@@ -61,5 +74,13 @@ final class GuestUserTokenPayload_Tests: XCTestCase {
         XCTAssertEqual(payload.user.extraData.company, "getstream.io")
         XCTAssertEqual(payload.user.role, .guest)
         XCTAssertTrue(payload.user.isOnline)
+    }
+
+    func test_guestUserWithInvalidToken_isFailedToBeSerialized() throws {
+        XCTAssertThrowsError(
+            try JSONDecoder.default.decode(GuestUserTokenPayload<NoExtraData>.self, from: guestUserInvalidTokenJSON)
+        ) { error in
+            XCTAssertTrue(error is ClientError.InvalidToken)
+        }
     }
 }

--- a/Sources_v3/StreamChat/APIClient/Endpoints/WebSocketConnectEndpoint.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/WebSocketConnectEndpoint.swift
@@ -1,29 +1,19 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
 
 extension Endpoint {
-    static func webSocketConnect<UserData: UserExtraData>(
-        userId: UserId,
-        name: String?,
-        imageURL: URL?,
-        role: UserRole = .user,
-        extraData: UserData? = nil
-    ) -> Endpoint<EmptyResponse> {
+    static func webSocketConnect(userId: UserId) -> Endpoint<EmptyResponse> {
         .init(
             path: "connect",
             method: .get,
             queryItems: nil,
             requiresConnectionId: false,
-            body: ["json": WebSocketConnectPayload(
-                userId: userId,
-                name: name,
-                imageURL: imageURL,
-                userRole: role,
-                extraData: extraData
-            )]
+            body: [
+                "json": WebSocketConnectPayload(userId: userId)
+            ]
         )
     }
 }

--- a/Sources_v3/StreamChat/APIClient/Endpoints/WebSocketConnectEndpoint_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/WebSocketConnectEndpoint_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -8,35 +8,17 @@ import XCTest
 final class WebSocketConnectEndpoint_Tests: XCTestCase {
     func test_webSocketConnect_buildsCorrectly() {
         let userId: UserId = .unique
-        let userRole: UserRole = .admin
-        let name = String.unique
-        let imageURL = URL.unique()
-        let extraData = DefaultExtraData.User.defaultValue
         
         let expectedEndpoint = Endpoint<EmptyResponse>(
             path: "connect",
             method: .get,
             queryItems: nil,
             requiresConnectionId: false,
-            body: [
-                "json": WebSocketConnectPayload(
-                    userId: userId,
-                    name: name,
-                    imageURL: imageURL,
-                    userRole: userRole,
-                    extraData: extraData
-                )
-            ]
+            body: ["json": WebSocketConnectPayload(userId: userId)]
         )
         
         // Build endpoint
-        let endpoint: Endpoint<EmptyResponse> = .webSocketConnect(
-            userId: userId,
-            name: name,
-            imageURL: imageURL,
-            role: userRole,
-            extraData: extraData
-        )
+        let endpoint: Endpoint<EmptyResponse> = .webSocketConnect(userId: userId)
         
         // Assert endpoint is built correctly
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))

--- a/Sources_v3/StreamChat/APIClient/HTTPHeader.swift
+++ b/Sources_v3/StreamChat/APIClient/HTTPHeader.swift
@@ -1,0 +1,46 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+struct HTTPHeader {
+    let key: Key
+    let value: String
+}
+
+extension HTTPHeader {
+    enum Key: String {
+        case authorization = "Authorization"
+        case streamAuthType = "Stream-Auth-Type"
+        case contentType = "Content-Type"
+    }
+}
+
+extension HTTPHeader {
+    static var anonymousStreamAuth: Self {
+        .init(key: .streamAuthType, value: "anonymous")
+    }
+
+    static var jwtStreamAuth: Self {
+        .init(key: .streamAuthType, value: "jwt")
+    }
+
+    static func authorization(_ token: String) -> Self {
+        .init(key: .authorization, value: token)
+    }
+}
+
+extension URLRequest {
+    mutating func setHTTPHeaders(_ headers: HTTPHeader...) {
+        headers.forEach {
+            setValue($0.value, forHTTPHeaderField: $0.key.rawValue)
+        }
+    }
+
+    mutating func addHTTPHeaders(_ headers: HTTPHeader...) {
+        headers.forEach {
+            addValue($0.value, forHTTPHeaderField: $0.key.rawValue)
+        }
+    }
+}

--- a/Sources_v3/StreamChat/APIClient/HTTPHeader_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/HTTPHeader_Tests.swift
@@ -1,0 +1,97 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class HTTPHeader_Tests: XCTestCase {
+    func test_anonymousStreamAuth() {
+        // Create the header.
+        let header: HTTPHeader = .anonymousStreamAuth
+
+        // Assert header has correct values.
+        XCTAssertEqual(header.key.rawValue, "Stream-Auth-Type")
+        XCTAssertEqual(header.value, "anonymous")
+    }
+
+    func test_jwtStreamAuth() {
+        // Create the header.
+        let header: HTTPHeader = .jwtStreamAuth
+
+        // Assert header has correct values.
+        XCTAssertEqual(header.key.rawValue, "Stream-Auth-Type")
+        XCTAssertEqual(header.value, "jwt")
+    }
+
+    func test_authorization() {
+        // Create a token.
+        let token: String = .unique
+
+        // Create the header.
+        let header: HTTPHeader = .authorization(token)
+
+        // Assert header has correct values.
+        XCTAssertEqual(header.key.rawValue, "Authorization")
+        XCTAssertEqual(header.value, token)
+    }
+
+    func test_setHTTPHeaders() {
+        // Create a request.
+        var request = URLRequest(url: .unique())
+
+        // Create list of initial headers.
+        let oldHeaders: [HTTPHeader] = [
+            .anonymousStreamAuth,
+            .authorization(.unique)
+        ]
+
+        // Set initial headers.
+        for header in oldHeaders {
+            request.setHTTPHeaders(header)
+        }
+
+        // Create list of new headers.
+        let newHeaders: [HTTPHeader] = [
+            .jwtStreamAuth,
+            .authorization(.unique)
+        ]
+
+        // Set new headers.
+        for header in newHeaders {
+            request.setHTTPHeaders(header)
+        }
+
+        // Assert old headers are replaced with new headers.
+        for header in newHeaders {
+            let value = request.value(forHTTPHeaderField: header.key.rawValue)
+            XCTAssertEqual(value, header.value)
+        }
+    }
+
+    func test_addHTTPHeaders() throws {
+        // Create a request.
+        var request = URLRequest(url: .unique())
+
+        // Create a header key.
+        let headerKey: HTTPHeader.Key = .authorization
+
+        // Create a list of headers with the same key.
+        let headers: [HTTPHeader] = [
+            .init(key: headerKey, value: .unique),
+            .init(key: headerKey, value: .unique)
+        ]
+
+        // Add headers with the same key.
+        for header in headers {
+            request.addHTTPHeaders(header)
+        }
+
+        // Assert the resulting header value contains all
+        let value = try XCTUnwrap(request.value(forHTTPHeaderField: headerKey.rawValue))
+        XCTAssertEqual(
+            Set(value.split(separator: ",").map(String.init)),
+            Set(headers.map(\.value))
+        )
+    }
+}

--- a/Sources_v3/StreamChat/ChatClient.swift
+++ b/Sources_v3/StreamChat/ChatClient.swift
@@ -213,12 +213,20 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
     
     /// The token of the current user. If the current user is anonymous, the token is `nil`.
     @Atomic var currentToken: Token?
+
+    public var tokenProvider: _TokenProvider<ExtraData>
     
     /// Creates a new instance of `ChatClient`.
-    ///
-    /// - Parameter config: The config object for the `Client`. See `ChatClientConfig` for all configuration options.
-    ///
-    public convenience init(config: ChatClientConfig) {
+    /// - Parameters:
+    ///   - config: The config object for the `Client`. See `ChatClientConfig` for all configuration options.
+    ///   - tokenProvider: The `_TokenProvider<ExtraData>` instance that incapsulates the logic of obtaining a JWT
+    ///   token used to communicate with REST-API.
+    ///   - completion: The completion that will be called once the **first** user session for the given token is setup.
+    public convenience init(
+        config: ChatClientConfig,
+        tokenProvider: _TokenProvider<ExtraData>,
+        completion: ((Error?) -> Void)? = nil
+    ) {
         let workerBuilders: [WorkerBuilder]
         let eventWorkerBuilders: [EventWorkerBuilder]
         var environment = Environment()
@@ -246,9 +254,11 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         
         self.init(
             config: config,
+            tokenProvider: tokenProvider,
             workerBuilders: workerBuilders,
             eventWorkerBuilders: eventWorkerBuilders,
-            environment: environment
+            environment: environment,
+            completion: completion
         )
     }
     
@@ -262,11 +272,14 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
     ///
     init(
         config: ChatClientConfig,
+        tokenProvider: _TokenProvider<ExtraData>,
         workerBuilders: [WorkerBuilder],
         eventWorkerBuilders: [EventWorkerBuilder],
-        environment: Environment
+        environment: Environment,
+        completion: ((Error?) -> Void)? = nil
     ) {
         self.config = config
+        self.tokenProvider = tokenProvider
         self.environment = environment
         self.workerBuilders = workerBuilders
         self.eventWorkerBuilders = eventWorkerBuilders

--- a/Sources_v3/StreamChat/ChatClient.swift
+++ b/Sources_v3/StreamChat/ChatClient.swift
@@ -135,6 +135,10 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
             eventNotificationCenter,
             internetConnection
         )
+
+        if let currentUserId = currentUserId {
+            webSocketClient?.connectEndpoint = .webSocketConnect(userId: currentUserId)
+        }
         
         webSocketClient?.connectionStateDelegate = self
         

--- a/Sources_v3/StreamChat/ChatClient.swift
+++ b/Sources_v3/StreamChat/ChatClient.swift
@@ -76,12 +76,8 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
     /// To observe changes in the connection status, create an instance of `CurrentChatUserController`, and use it to receive
     /// callbacks when the connection status changes.
     ///
-    public var connectionStatus: ConnectionStatus {
-        ConnectionStatus(
-            webSocketConnectionState: webSocketClient?.connectionState ?? .disconnected(error: .ClientIsNotInActiveMode())
-        )
-    }
-    
+    public internal(set) var connectionStatus: ConnectionStatus = .initialized
+
     /// The config object of the `ChatClient` instance.
     ///
     /// This value can't be mutated and can only be set when initializing a new `ChatClient` instance.
@@ -397,6 +393,8 @@ extension ClientError {
 /// its `RequestEncoder`.
 extension _ChatClient: ConnectionStateDelegate {
     func webSocketClient(_ client: WebSocketClient, didUpdateConectionState state: WebSocketConnectionState) {
+        connectionStatus = .init(webSocketConnectionState: state)
+
         _connectionId.mutate { mutableConnectionId in
             _connectionIdWaiters.mutate { connectionIdWaiters in
                 

--- a/Sources_v3/StreamChat/ChatClient.swift
+++ b/Sources_v3/StreamChat/ChatClient.swift
@@ -88,7 +88,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
     ///
     /// `ChatClient` initializes a set of background workers that keep observing the current state of the system and perform
     /// work if needed (i.e. when a new message pending sent appears in the database, a worker tries to send it.)
-    private(set) var backgroundWorkers: [Worker]!
+    private(set) var backgroundWorkers: [Worker] = []
     
     /// Builder blocks used for creating `backgroundWorker`s when needed.
     private let workerBuilders: [WorkerBuilder]
@@ -270,9 +270,6 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         self.environment = environment
         self.workerBuilders = workerBuilders
         self.eventWorkerBuilders = eventWorkerBuilders
-        
-        createBackgroundWorkers()
-        createWebSocketClient()
     }
     
     deinit {

--- a/Sources_v3/StreamChat/ChatClient_Mock.swift
+++ b/Sources_v3/StreamChat/ChatClient_Mock.swift
@@ -136,7 +136,8 @@ extension _ChatClient.Environment {
             requestEncoderBuilder: DefaultRequestEncoder.init,
             requestDecoderBuilder: DefaultRequestDecoder.init,
             eventDecoderBuilder: EventDecoder.init,
-            notificationCenterBuilder: EventNotificationCenter.init
+            notificationCenterBuilder: EventNotificationCenter.init,
+            clientUpdaterBuilder: ChatClientUpdaterMock<ExtraData>.init
         )
     }
 }

--- a/Sources_v3/StreamChat/ChatClient_Mock.swift
+++ b/Sources_v3/StreamChat/ChatClient_Mock.swift
@@ -28,8 +28,96 @@ extension ChatClient {
     }
 }
 
-extension _ChatClient.Environment where ExtraData == DefaultExtraData {
-    static var mock: ChatClient.Environment {
+class ChatClientMock<ExtraData: ExtraDataTypes>: _ChatClient<ExtraData> {
+    @Atomic var init_config: ChatClientConfig
+    @Atomic var init_tokenProvider: _TokenProvider<ExtraData>
+    @Atomic var init_workerBuilders: [WorkerBuilder]
+    @Atomic var init_eventWorkerBuilders: [EventWorkerBuilder]
+    @Atomic var init_environment: Environment
+    @Atomic var init_completion: ((Error?) -> Void)?
+
+    @Atomic var fetchCurrentUserIdFromDatabase_called = false
+
+    @Atomic var createBackgroundWorkers_called = false
+
+    @Atomic var completeConnectionIdWaiters_called = false
+    @Atomic var completeConnectionIdWaiters_connectionId: String?
+
+    @Atomic var completeTokenWaiters_called = false
+    @Atomic var completeTokenWaiters_token: Token?
+
+    // MARK: - Overrides
+
+    override init(
+        config: ChatClientConfig,
+        tokenProvider: _TokenProvider<ExtraData>,
+        workerBuilders: [WorkerBuilder] = [],
+        eventWorkerBuilders: [EventWorkerBuilder] = [],
+        environment: Environment = .mock,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        init_config = config
+        init_tokenProvider = tokenProvider
+        init_workerBuilders = workerBuilders
+        init_eventWorkerBuilders = eventWorkerBuilders
+        init_environment = environment
+        init_completion = completion
+
+        super.init(
+            config: config,
+            tokenProvider: tokenProvider,
+            workerBuilders: workerBuilders,
+            eventWorkerBuilders: eventWorkerBuilders,
+            environment: environment,
+            completion: completion
+        )
+    }
+
+    override func fetchCurrentUserIdFromDatabase() -> UserId? {
+        fetchCurrentUserIdFromDatabase_called = true
+        
+        return super.fetchCurrentUserIdFromDatabase()
+    }
+
+    override func createBackgroundWorkers() {
+        createBackgroundWorkers_called = true
+
+        super.createBackgroundWorkers()
+    }
+
+    override func completeConnectionIdWaiters(connectionId: String?) {
+        completeConnectionIdWaiters_called = true
+        completeConnectionIdWaiters_connectionId = connectionId
+
+        super.completeConnectionIdWaiters(connectionId: connectionId)
+    }
+
+    override func completeTokenWaiters(token: Token?) {
+        completeTokenWaiters_called = true
+        completeTokenWaiters_token = token
+
+        super.completeTokenWaiters(token: token)
+    }
+
+    // MARK: - Clean Up
+
+    func cleanUp() {
+        (apiClient as? APIClientMock)?.cleanUp()
+
+        fetchCurrentUserIdFromDatabase_called = false
+
+        createBackgroundWorkers_called = false
+
+        completeConnectionIdWaiters_called = false
+        completeConnectionIdWaiters_connectionId = nil
+
+        completeTokenWaiters_called = false
+        completeTokenWaiters_token = nil
+    }
+}
+
+extension _ChatClient.Environment {
+    static var mock: _ChatClient.Environment {
         .init(
             apiClientBuilder: APIClientMock.init,
             webSocketClientBuilder: {

--- a/Sources_v3/StreamChat/ChatClient_Mock.swift
+++ b/Sources_v3/StreamChat/ChatClient_Mock.swift
@@ -5,10 +5,11 @@
 import Foundation
 @testable import StreamChat
 
-extension ChatClient {
-    static var mock: ChatClient {
-        ChatClient(
+extension _ChatClient {
+    static var mock: _ChatClient {
+        .init(
             config: .init(apiKey: .init(.unique)),
+            tokenProvider: .anonymous,
             workerBuilders: [],
             eventWorkerBuilders: [],
             environment: .mock

--- a/Sources_v3/StreamChat/ChatClient_Tests.swift
+++ b/Sources_v3/StreamChat/ChatClient_Tests.swift
@@ -140,7 +140,7 @@ class ChatClient_Tests: StressTestCase {
     
     // MARK: - WebSocketClient tests
     
-    func test_webSocketClientIsInitialized() throws {
+    func test_webSocketClientConfiguration() throws {
         // Use in-memory store
         // Create a new chat client
         let client = ChatClient(
@@ -149,6 +149,9 @@ class ChatClient_Tests: StressTestCase {
             eventWorkerBuilders: eventWorkerBuilders,
             environment: testEnv.environment
         )
+
+        // Simulate access to `webSocketClient` so it is initialized
+        _ = client.webSocketClient
         
         // Assert the init parameters are correct
         let webSocket = testEnv.webSocketClient
@@ -172,6 +175,9 @@ class ChatClient_Tests: StressTestCase {
             eventWorkerBuilders: [],
             environment: testEnv.environment
         )
+
+        // Simulate access to `webSocketClient` so it is initialized
+        _ = client.webSocketClient
         
         // Assert that mandatory middlewares exists
         let middlewares = try XCTUnwrap(testEnv.webSocketClient?.init_eventNotificationCenter.middlewares)
@@ -265,6 +271,9 @@ class ChatClient_Tests: StressTestCase {
             eventWorkerBuilders: [],
             environment: testEnv.environment
         )
+
+        // Simulate access to `webSocketClient` so it is initialized
+        _ = client.webSocketClient
         
         // Set a connection Id waiter and assert it's `nil`
         var providedConnectionId: ConnectionId?
@@ -308,6 +317,9 @@ class ChatClient_Tests: StressTestCase {
             eventWorkerBuilders: [],
             environment: testEnv.environment
         )
+
+        // Simulate access to `webSocketClient` so it is initialized
+        _ = client.webSocketClient
         
         // Set a connection Id waiter and set `providedConnectionId` to a non-nil value
         var providedConnectionId: ConnectionId? = .unique
@@ -361,7 +373,7 @@ class ChatClient_Tests: StressTestCase {
     
     // MARK: - APIClient tests
     
-    func test_apiClientIsInitialized() throws {
+    func test_apiClientConfiguration() throws {
         // Create a new chat client
         _ = ChatClient(
             config: inMemoryStorageConfig,
@@ -369,6 +381,9 @@ class ChatClient_Tests: StressTestCase {
             eventWorkerBuilders: [],
             environment: testEnv.environment
         )
+
+        // Simulate access to `apiClient` so it is initialized
+        _ = client.apiClient
         
         assertMandatoryHeaderFields(testEnv.apiClient?.init_sessionConfiguration)
         XCTAssert(testEnv.apiClient?.init_requestDecoder is TestRequestDecoder)
@@ -392,7 +407,7 @@ class ChatClient_Tests: StressTestCase {
         XCTAssert(client.backgroundWorkers.contains { $0 is AttachmentUploader<DefaultExtraData> })
     }
     
-    func test_backgroundWorkersAreInitialized() {
+    func test_backgroundWorkersConfiguration() {
         // Set up mocks for APIClient, WSClient and Database
         let config = ChatClientConfig(apiKey: .init(.unique))
         
@@ -403,6 +418,9 @@ class ChatClient_Tests: StressTestCase {
             eventWorkerBuilders: [TestEventWorker.init],
             environment: testEnv.environment
         )
+
+        // Simulate `createBackgroundWorkers` so workers are created.
+        client.createBackgroundWorkers()
         
         let testWorker = client.backgroundWorkers.first as? TestWorker
         XCTAssert(testWorker?.init_database is DatabaseContainerMock)
@@ -470,7 +488,10 @@ class ChatClient_Tests: StressTestCase {
     func test_passiveClient_doesNotHaveWorkers() {
         // Create Client with inactive flag set
         let client = ChatClient(config: inactiveInMemoryStorageConfig)
-        
+
+        // Simulate `createBackgroundWorkers`.
+        client.createBackgroundWorkers()
+
         // Assert that no background worker is initialized
         XCTAssert(client.backgroundWorkers.isEmpty)
     }

--- a/Sources_v3/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources_v3/StreamChat/Config/ChatClientConfig.swift
@@ -45,17 +45,21 @@ public struct ChatClientConfig {
     /// `ChatChannel` specific settings.
 //    public var channel = Channel()
     
-    /// You can optionally provide your custom `TokenProvider` here and it will be called every time a new current user is set.
-    /// If you're using self-expiring tokens, setting the provider is mandatory to ensure the tokens can get automatically
-    /// refreshed.
-    public var tokenProvider: TokenProvider?
-    
     /// Flag for setting a ChatClient instance in connection-less mode.
     /// A connection-less client is not able to connect to websocket and will not
     /// receive websocket events. It can still observe and mutate database.
     /// This flag is automatically set to `false` for app extensions
     /// **Warning**: There should be at max 1 active client at the same time, else it can lead to undefined behavior.
     public var isClientInActiveMode: Bool
+
+    /// If set to `true` the `ChatClient` will automatically establish a web-socket
+    /// connection to listen to the updates when `reloadUserIfNeeded` is called.
+    ///
+    /// If set to `false` the connection won't be established automatically
+    /// but has to be initiated manually by calling `connect`.
+    ///
+    /// Is `true` by default.
+    public var shouldConnectAutomatically = true
     
     /// Creates a new instance of `ChatClientConfig`.
     ///

--- a/Sources_v3/StreamChat/Config/TokenProvider.swift
+++ b/Sources_v3/StreamChat/Config/TokenProvider.swift
@@ -1,0 +1,73 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+public typealias TokenProvider = _TokenProvider<DefaultExtraData>
+
+/// The type designed to provider a `Token` to the `ChatClient` when it asks for it.
+public struct _TokenProvider<ExtraData: ExtraDataTypes> {
+    let getToken: (_ client: _ChatClient<ExtraData>, _ completion: @escaping (Result<Token, Error>) -> Void) -> Void
+}
+
+public extension _TokenProvider {
+    /// The provider that can be used when user is unknown.
+    static var anonymous: Self {
+        .static(.anonymous)
+    }
+
+    /// The provider that can be used during the development. It's handy since doesn't require a token.
+    /// - Parameter userId: The user identifier.
+    /// - Returns: The new `TokenProvider` instance.
+    static func development(userId: UserId) -> Self {
+        .static(.development(userId: userId))
+    }
+
+    /// The provider which can be used to provide a static token known on the client-side which doesn't expire.
+    /// - Parameter token: The token to be returned by the token provider.
+    /// - Returns: The new `TokenProvider` instance.
+    static func `static`(_ token: Token) -> Self {
+        .init {
+            $1(.success(token))
+        }
+    }
+
+    /// The provider which designed to be used for guest users.
+    /// - Parameters:
+    ///   - userId: The identifier a guest user will be created OR updated with if it exists.
+    ///   - name: The name a guest user will be created OR updated with if it exists.
+    ///   - imageURL: The avatar URL a guest user will be created OR updated with if it exists.
+    ///   - extraData: The extra data a guest user will be created OR updated with if it exists.
+    /// - Returns: The new `TokenProvider` instance.
+    static func guest(
+        userId: UserId,
+        name: String? = nil,
+        imageURL: URL? = nil,
+        extraData: ExtraData.User = .defaultValue
+    ) -> Self {
+        .init { client, completion in
+            client.apiClient.request(
+                endpoint: .guestUserToken(userId: userId, name: name, imageURL: imageURL, extraData: extraData)
+            ) {
+                switch $0 {
+                case let .success(payload):
+                    let token = payload.token
+                    completion(.success(token))
+                case let .failure(error):
+                    log.error(error)
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+
+    /// The token provider designed to be used when a token is dynamic (e.g. can change OR expire).
+    /// - Parameter handler: The closure which should get the token and pass it to the `completion`.
+    /// - Returns: The new `TokenProvider` instance.
+    static func closure(
+        _ handler: @escaping (_ client: _ChatClient<ExtraData>, _ completion: @escaping (Result<Token, Error>) -> Void) -> Void
+    ) -> Self {
+        .init(getToken: handler)
+    }
+}

--- a/Sources_v3/StreamChat/Config/TokenProvider_Tests.swift
+++ b/Sources_v3/StreamChat/Config/TokenProvider_Tests.swift
@@ -1,0 +1,168 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class TokenProvider_Tests: StressTestCase {
+    func test_anonymousProvider_propagatesToken() throws {
+        // Get token from `anonymous` provider.
+        let token = try await { TokenProvider.anonymous.getToken(.mock, $0) }.get()
+
+        // Assert token is correct.
+        XCTAssertEqual(token.rawValue, "")
+        XCTAssertTrue(token.userId.isAnonymousUser)
+    }
+
+    func test_developmentProvider_propagatesToken() throws {
+        // Create a user identifier.
+        let userId: UserId = .unique
+
+        // Get a token from `development` token provider.
+        let token = try await {
+            TokenProvider.development(userId: userId).getToken(.mock, $0)
+        }.get()
+
+        // Assert token is correct.
+        XCTAssertEqual(token.rawValue, "development")
+        XCTAssertEqual(token.userId, userId)
+    }
+
+    func test_staticProvider_propagatesToken() throws {
+        // Create a token.
+        let token = Token.unique(userId: .unique)
+
+        // Get a token from `static` token provider.
+        let receivedToken = try await {
+            TokenProvider.static(token).getToken(.mock, $0)
+        }.get()
+
+        // Assert token is propagated.
+        XCTAssertEqual(receivedToken, token)
+    }
+
+    func test_closureProvider_propagatesToken() throws {
+        // Create a token.
+        let token = Token.unique()
+
+        // Get a token from `closure` token provider.
+        let receivedToken = try await {
+            TokenProvider
+                .closure { $1(.success(token)) }
+                .getToken(.mock, $0)
+        }.get()
+
+        // Assert token is propagated.
+        XCTAssertEqual(receivedToken, token)
+    }
+
+    func test_closureProvider_propagatesError() throws {
+        // Create an error.
+        let error = TestError()
+
+        // Get a token from `closure` token provider.
+        let receivedError = try await {
+            TokenProvider
+                .closure { $1(.failure(error)) }
+                .getToken(.mock, $0)
+        }.error
+
+        // Assert error is propagated.
+        XCTAssertEqual(receivedError as! TestError, error)
+    }
+
+    func test_guestProvider_callsAPIClient_and_propagatesToken() throws {
+        // Create guest user data.
+        let userId: UserId = .unique
+        let userName: String = .unique
+        let imageURL: URL = .unique()
+        let extraData: NoExtraData = .defaultValue
+
+        // Create a client.
+        let client = ChatClient.mock
+
+        // Create a `guest` token provider.
+        let tokenProvider = TokenProvider.guest(
+            userId: userId,
+            name: userName,
+            imageURL: imageURL,
+            extraData: extraData
+        )
+
+        // Get token from provider and capture the result.
+        var getTokenResult: Result<Token, Error>?
+        tokenProvider.getToken(client) {
+            getTokenResult = $0
+        }
+
+        // Wait for the API call to guest endpoint.
+        let expectedEndpoint: Endpoint<GuestUserTokenPayload<NoExtraData>> = .guestUserToken(
+            userId: userId,
+            name: userName,
+            imageURL: imageURL,
+            extraData: extraData
+        )
+        AssertAsync.willBeEqual(AnyEndpoint(expectedEndpoint), client.mockAPIClient.request_endpoint)
+
+        // Simulate successful response with a token.
+        let token = Token.unique(userId: userId)
+        let tokenResult: Result<GuestUserTokenPayload<NoExtraData>, Error> = .success(
+            .init(user: .dummy(userId: userId, role: .guest), token: token)
+        )
+        client.mockAPIClient.test_simulateResponse(tokenResult)
+
+        // Wait the result is received.
+        AssertAsync.willBeTrue(getTokenResult != nil)
+
+        // Assert token from the request is propagated.
+        let receivedToken = try XCTUnwrap(try getTokenResult?.get())
+        XCTAssertEqual(receivedToken, token)
+    }
+
+    func test_guestProvider_callsAPIClient_and_propagatesError() throws {
+        // Create guest user data.
+        let userId: UserId = .unique
+        let userName: String = .unique
+        let imageURL: URL = .unique()
+        let extraData: NoExtraData = .defaultValue
+
+        // Create a client.
+        let client = ChatClient.mock
+
+        // Create a `guest` token provider.
+        let tokenProvider = TokenProvider.guest(
+            userId: userId,
+            name: userName,
+            imageURL: imageURL,
+            extraData: extraData
+        )
+
+        // Get token from provider and capture the result.
+        var getTokenResult: Result<Token, Error>?
+        tokenProvider.getToken(client) {
+            getTokenResult = $0
+        }
+
+        // Wait for the API call to guest endpoint.
+        let expectedEndpoint: Endpoint<GuestUserTokenPayload<NoExtraData>> = .guestUserToken(
+            userId: userId,
+            name: userName,
+            imageURL: imageURL,
+            extraData: extraData
+        )
+        AssertAsync.willBeEqual(AnyEndpoint(expectedEndpoint), client.mockAPIClient.request_endpoint)
+
+        // Simulate error.
+        let error = TestError()
+        let tokenResult: Result<GuestUserTokenPayload<NoExtraData>, Error> = .failure(error)
+        client.mockAPIClient.test_simulateResponse(tokenResult)
+
+        // Wait the result is received.
+        AssertAsync.willBeTrue(getTokenResult != nil)
+
+        // Assert error from the request is propagated.
+        let receivedError = try XCTUnwrap(getTokenResult?.error)
+        XCTAssertEqual(receivedError as! TestError, error)
+    }
+}

--- a/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
@@ -187,9 +187,7 @@ class ChannelController_Tests: StressTestCase {
     func test_channelControllerForNewChannel_throwsError_ifCurrentUserDoesNotExist() throws {
         let clientWithoutCurrentUser = ChatClient(
             config: .init(apiKeyString: .unique),
-            tokenProvider: .closure {
-                $1(.failure(TestError()))
-            }
+            tokenProvider: .invalid()
         )
 
         for isCurrentUserMember in [true, false] {
@@ -287,9 +285,7 @@ class ChannelController_Tests: StressTestCase {
     func test_channelControllerForNewDirectMessagesChannel_throwsError_ifCurrentUserDoesNotExist() {
         let client = ChatClient(
             config: .init(apiKeyString: .unique),
-            tokenProvider: .closure {
-                $1(.failure(TestError()))
-            }
+            tokenProvider: .invalid()
         )
 
         for isCurrentUserMember in [true, false] {
@@ -1955,5 +1951,13 @@ private class TestDelegateGeneric: QueueAwareDelegate, _ChatChannelControllerDel
     ) {
         didChangeTypingMembers_typingMembers = typingMembers
         validateQueue()
+    }
+}
+
+extension _TokenProvider {
+    static func invalid(_ error: Error = TestError()) -> Self {
+        .closure {
+            $1(.failure(error))
+        }
     }
 }

--- a/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
@@ -185,10 +185,17 @@ class ChannelController_Tests: StressTestCase {
     }
 
     func test_channelControllerForNewChannel_throwsError_ifCurrentUserDoesNotExist() throws {
+        let clientWithoutCurrentUser = ChatClient(
+            config: .init(apiKeyString: .unique),
+            tokenProvider: .closure {
+                $1(.failure(TestError()))
+            }
+        )
+
         for isCurrentUserMember in [true, false] {
             // Try to create `ChannelController` while current user is missing
             XCTAssertThrowsError(
-                try client.channelController(
+                try clientWithoutCurrentUser.channelController(
                     createChannelWithId: .unique,
                     name: .unique,
                     imageURL: .unique(),
@@ -278,6 +285,13 @@ class ChannelController_Tests: StressTestCase {
     }
 
     func test_channelControllerForNewDirectMessagesChannel_throwsError_ifCurrentUserDoesNotExist() {
+        let client = ChatClient(
+            config: .init(apiKeyString: .unique),
+            tokenProvider: .closure {
+                $1(.failure(TestError()))
+            }
+        )
+
         for isCurrentUserMember in [true, false] {
             // Try to create `ChannelController` with non-empty members while current user is missing
             XCTAssertThrowsError(

--- a/Sources_v3/StreamChat/Controllers/CurrentUserController/CurrentUserController+Combine_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/CurrentUserController/CurrentUserController+Combine_Tests.swift
@@ -89,6 +89,6 @@ class CurrentUserController_Combine_Tests: iOS13TestCase {
         controller?.delegateCallback { $0.currentUserController(controller!, didUpdateConnectionStatus: newStatus) }
         
         // Assert initial value as well as the update are received
-        AssertAsync.willBeEqual(recording.output, [.disconnected(error: nil), newStatus])
+        AssertAsync.willBeEqual(recording.output, [.initialized, newStatus])
     }
 }

--- a/Sources_v3/StreamChat/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -59,7 +59,7 @@ final class CurrentUserController_Tests: StressTestCase {
         XCTAssertEqual(controller.unreadCount, unreadCount)
         
         // Check the initial connection status.
-        XCTAssertEqual(controller.connectionStatus, .disconnected(error: nil))
+        XCTAssertEqual(controller.connectionStatus, .initialized)
     }
     
     func test_initialState_whenLocalDataFetchFailed() throws {

--- a/Sources_v3/StreamChat/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseContainer_Mock.swift
@@ -11,7 +11,8 @@ class DatabaseContainerMock: DatabaseContainer {
     /// If set, the `write` completion block is called with this value.
     @Atomic var write_errorResponse: Error?
     @Atomic var init_kind: DatabaseContainer.Kind
-    @Atomic var flush_called = false
+    @Atomic var removeAllData_called = false
+    @Atomic var removeAllData_errorResponse: Error?
     @Atomic var recreatePersistentStore_called = false
     @Atomic var recreatePersistentStore_errorResponse: Error?
     @Atomic var resetEphemeralValues_called = false
@@ -38,7 +39,12 @@ class DatabaseContainerMock: DatabaseContainer {
     }
     
     override func removeAllData(force: Bool = true) throws {
-        flush_called = true
+        removeAllData_called = true
+
+        if let error = removeAllData_errorResponse {
+            throw error
+        }
+
         try super.removeAllData(force: force)
     }
     

--- a/Sources_v3/StreamChat/WebSocketClient/ConnectionStatus.swift
+++ b/Sources_v3/StreamChat/WebSocketClient/ConnectionStatus.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -8,6 +8,9 @@ import Foundation
 
 /// Describes the possible states of the client connection to the servers.
 public enum ConnectionStatus: Equatable {
+    /// The client is initialized but not connected to the remote server yet.
+    case initialized
+    
     /// The client is disconnected. This is an initial state. Optionally contains an error, if the connection was disconnected
     /// due to an error.
     case disconnected(error: ClientError? = nil)

--- a/Sources_v3/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Sources_v3/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
@@ -37,10 +37,7 @@ class WebSocketClient_Tests: StressTestCase {
         VirtualTimeTimer.time = time
         
         endpoint = .webSocketConnect(
-            userId: .unique,
-            name: nil,
-            imageURL: nil,
-            extraData: nil as DefaultExtraData.User?
+            userId: .unique
         )
         
         decoder = EventDecoderMock()

--- a/Sources_v3/StreamChat/WebSocketClient/WebSocketConnectPayload.swift
+++ b/Sources_v3/StreamChat/WebSocketClient/WebSocketConnectPayload.swift
@@ -1,55 +1,27 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
 
-struct WebSocketConnectPayload<ExtraData: UserExtraData>: Encodable {
+struct WebSocketConnectPayload: Encodable {
     private enum CodingKeys: String, CodingKey {
         case userId = "user_id"
         case userDetails = "user_details"
         case serverDeterminesConnectionId = "server_determines_connection_id"
     }
     
-    let userDetails: UserWebSocketPayload<ExtraData>
     let userId: UserId
-    
-    let serverDeterminesConnectionId = true
-    
-    init(userId: UserId, name: String?, imageURL: URL?, userRole: UserRole? = nil, extraData: ExtraData? = nil) {
-        userDetails = UserWebSocketPayload(id: userId, name: name, imageURL: imageURL, userRole: userRole, extraData: extraData)
+    let userDetails: UserWebSocketPayload
+    let serverDeterminesConnectionId: Bool
+
+    init(userId: UserId) {
         self.userId = userId
+        userDetails = UserWebSocketPayload(id: userId)
+        serverDeterminesConnectionId = true
     }
 }
 
-struct UserWebSocketPayload<ExtraData: UserExtraData>: Encodable {
-    let userRoleRaw: String?
-    let extraData: ExtraData?
+struct UserWebSocketPayload: Encodable {
     let id: String
-    let name: String?
-    let imageURL: URL?
-    
-    init(id: UserId, name: String?, imageURL: URL?, userRole: UserRole? = nil, extraData: ExtraData? = nil) {
-        self.id = id
-        self.name = name
-        self.imageURL = imageURL
-        userRoleRaw = userRole?.rawValue
-        self.extraData = extraData
-    }
-    
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case name
-        case imageURL = "image"
-        case userRoleRaw = "role"
-    }
-    
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(userRoleRaw, forKey: .userRoleRaw)
-        try container.encode(id, forKey: .id)
-        try container.encodeIfPresent(name, forKey: .name)
-        try container.encodeIfPresent(imageURL, forKey: .imageURL)
-        try extraData?.encode(to: encoder)
-    }
 }

--- a/Sources_v3/StreamChat/Workers/ChatClientUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/ChatClientUpdater.swift
@@ -1,0 +1,162 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+class ChatClientUpdater<ExtraData: ExtraDataTypes> {
+    unowned var client: _ChatClient<ExtraData>
+
+    init(client: _ChatClient<ExtraData>) {
+        self.client = client
+    }
+
+    func prepareEnvironment(newToken: Token) throws {
+        // Check token is for different user.
+        guard newToken.userId != client.currentUserId else {
+            // Check the token has changed.
+            guard newToken != client.currentToken else {
+                return
+            }
+
+            // Update the token.
+            client.currentToken = newToken
+
+            // Disconnect from web-socket since the connection was established
+            // with previous token that can be expired.
+            disconnect()
+
+            // Forward the new token to waiting requests.
+            client.completeTokenWaiters(token: newToken)
+
+            // It makes more sense to create background workers here
+            // other than in `init` because workers without currently logged-in
+            // user do nothing.
+            if client.backgroundWorkers.isEmpty {
+                client.createBackgroundWorkers()
+            }
+
+            return
+        }
+
+        // Cancel all API requests since they are related to the previous user.
+        client.completeTokenWaiters(token: nil)
+
+        // Setting a new user is not possible in connectionless mode.
+        guard client.config.isClientInActiveMode else {
+            throw ClientError.ClientIsNotInActiveMode()
+        }
+
+        // Update the current user id to the new one.
+        client.currentUserId = newToken.userId
+
+        // Update the current token with the new one.
+        client.currentToken = newToken
+
+        // Disconnect from web-socket.
+        disconnect()
+
+        // Update web-socket endpoint.
+        client.webSocketClient?.connectEndpoint = .webSocketConnect(userId: newToken.userId)
+
+        // Re-create backgroundWorker's since they are related to the previous user.
+        client.createBackgroundWorkers()
+
+        // Reset all existing local data.
+        try client.databaseContainer.removeAllData(force: true)
+    }
+
+    func reloadUserIfNeeded(completion: ((Error?) -> Void)? = nil) {
+        client.tokenProvider.getToken(client) {
+            switch $0 {
+            case let .success(newToken):
+                do {
+                    try self.prepareEnvironment(newToken: newToken)
+
+                    // We manually change the `connectionStatus` for passive client
+                    // to `disconnected` when environment was prepared correctly
+                    // (e.g. current user session is successfully restored).
+                    if !self.client.config.isClientInActiveMode {
+                        self.client.connectionStatus = .disconnected(error: nil)
+                    }
+
+                    // Establish web-socket connection automatically if it is required
+                    // by the config. If `shouldConnectAutomatically` is set to `false` it means the
+                    // end-user wants to manually control web-socket connection
+                    // by calling `connect/disconnect` when it makes sense.
+                    if self.client.config.shouldConnectAutomatically {
+                        self.connect(completion: completion)
+                    } else {
+                        completion?(nil)
+                    }
+                } catch {
+                    completion?(error)
+                }
+            case let .failure(error):
+                completion?(error)
+            }
+        }
+    }
+
+    /// Connects the chat client the controller represents to the chat servers.
+    ///
+    /// When the connection is established, `ChatClient` starts receiving chat updates, and `currentUser` variable is available.
+    ///
+    /// - Parameter completion: Called when the connection is established. If the connection fails, the completion is
+    /// called with an error.
+    ///
+    func connect(completion: ((Error?) -> Void)? = nil) {
+        // Connecting is not possible in connectionless mode (duh)
+        guard client.config.isClientInActiveMode else {
+            completion?(ClientError.ClientIsNotInActiveMode())
+            return
+        }
+
+        guard client.connectionId == nil else {
+            log.warning("The client is already connected. Skipping the `connect` call.")
+            completion?(nil)
+            return
+        }
+
+        // Set up a waiter for the new connection id to know when the connection process is finished
+        client.provideConnectionId { [weak client] connectionId in
+            if connectionId != nil {
+                completion?(nil)
+            } else {
+                // Try to get a concrete error
+                if case let .disconnected(error) = client?.webSocketClient?.connectionState {
+                    completion?(ClientError.ConnectionNotSuccessfull(with: error))
+                } else {
+                    completion?(ClientError.ConnectionNotSuccessfull())
+                }
+            }
+        }
+
+        client.webSocketClient?.connect()
+    }
+
+    /// Disconnects the chat client the controller represents from the chat servers. No further updates from the servers
+    /// are received.
+    func disconnect() {
+        // Disconnecting is not possible in connectionless mode (duh)
+        guard client.config.isClientInActiveMode else {
+            log.error(ClientError.ClientIsNotInActiveMode().localizedDescription)
+            return
+        }
+
+        guard client.connectionId != nil else {
+            log.warning("The client is already disconnected. Skipping the `disconnect` call.")
+            return
+        }
+
+        // Disconnect the web socket
+        client.webSocketClient?.disconnect(source: .userInitiated)
+
+        // Reset `connectionId`. This would happen asynchronously by the callback from WebSocketClient anyway, but it's
+        // safer to do it here synchronously to immediately stop all API calls.
+        client.connectionId = nil
+
+        // Remove all waiters for connectionId
+        client.completeConnectionIdWaiters(connectionId: nil)
+    }
+}

--- a/Sources_v3/StreamChat/Workers/ChatClientUpdater_Mock.swift
+++ b/Sources_v3/StreamChat/Workers/ChatClientUpdater_Mock.swift
@@ -1,0 +1,59 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+/// Mock implementation of `ChatClientUpdater`
+class ChatClientUpdaterMock<ExtraData: ExtraDataTypes>: ChatClientUpdater<ExtraData> {
+    @Atomic var prepareEnvironment_newToken: Token?
+    var prepareEnvironment_called: Bool { prepareEnvironment_newToken != nil }
+
+    @Atomic var reloadUserIfNeeded_called = false
+    @Atomic var reloadUserIfNeeded_completion: ((Error?) -> Void)?
+    @Atomic var reloadUserIfNeeded_callSuper: (() -> Void)?
+
+    @Atomic var connect_called = false
+    @Atomic var connect_completion: ((Error?) -> Void)?
+
+    @Atomic var disconnect_called = false
+
+    // MARK: - Overrides
+
+    override func prepareEnvironment(newToken: Token) throws {
+        prepareEnvironment_newToken = newToken
+    }
+
+    override func reloadUserIfNeeded(completion: ((Error?) -> Void)?) {
+        reloadUserIfNeeded_called = true
+        reloadUserIfNeeded_completion = completion
+        reloadUserIfNeeded_callSuper = {
+            super.reloadUserIfNeeded(completion: completion)
+        }
+    }
+
+    override func connect(completion: ((Error?) -> Void)? = nil) {
+        connect_called = true
+        connect_completion = completion
+    }
+
+    override func disconnect() {
+        disconnect_called = true
+    }
+
+    // MARK: - Clean Up
+
+    func cleanUp() {
+        prepareEnvironment_newToken = nil
+
+        reloadUserIfNeeded_called = false
+        reloadUserIfNeeded_completion = nil
+        reloadUserIfNeeded_callSuper = nil
+
+        connect_called = false
+        connect_completion = nil
+
+        disconnect_called = false
+    }
+}

--- a/Sources_v3/StreamChat/Workers/ChatClientUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/ChatClientUpdater_Tests.swift
@@ -1,0 +1,552 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class ChatClientUpdater_Tests_Tests: StressTestCase {
+    typealias ExtraData = DefaultExtraData
+
+    // MARK: Disconnect
+
+    func test_disconnect_doesNothing_ifClientIsPassive() {
+        // Create a passive client with user session.
+        let client = mockClientWithUserSession(isActive: false)
+
+        // Create an updater.
+        let updater = ChatClientUpdater<ExtraData>(client: client)
+
+        // Simulate `disconnect` call.
+        updater.disconnect()
+
+        // Assert `disconnect` was not called on `webSocketClient`.
+        XCTAssertEqual(client.mockWebSocketClient.disconnect_calledCounter, 0)
+    }
+
+    func test_disconnect_closesTheConnection_ifClientIsActive() {
+        // Create an active client with user session.
+        let client = mockClientWithUserSession()
+
+        // Create an updater.
+        let updater = ChatClientUpdater<ExtraData>(client: client)
+
+        // Simulate `disconnect` call.
+        updater.disconnect()
+
+        // Assert `webSocketClient` was disconnected.
+        XCTAssertEqual(client.mockWebSocketClient.disconnect_calledCounter, 1)
+        // Assert connection id is `nil`.
+        XCTAssertNil(client.connectionId)
+        // Assert all requests waiting for the connection-id were canceled.
+        XCTAssertTrue(client.completeConnectionIdWaiters_called)
+        XCTAssertNil(client.completeConnectionIdWaiters_connectionId)
+    }
+
+    func test_disconnect_doesNothing_ifThereIsNoConnection() throws {
+        // Create an active client with user session.
+        let client = mockClientWithUserSession()
+
+        // Create an updater.
+        let updater = ChatClientUpdater<ExtraData>(client: client)
+
+        // Simulate `disconnect` call.
+        updater.disconnect()
+
+        // Reset disconnect counter.
+        client.mockWebSocketClient.disconnect_calledCounter = 0
+
+        // Simulate `disconnect` one more time.
+        updater.disconnect()
+
+        // Assert `connect` was not called on `webSocketClient`.
+        XCTAssertEqual(client.mockWebSocketClient.disconnect_calledCounter, 0)
+    }
+
+    // MARK: Connect
+
+    func test_connect_throwsError_ifClientIsPassive() throws {
+        // Create a passive client with user session.
+        let client = mockClientWithUserSession(isActive: false)
+
+        // Create an updater.
+        let updater = ChatClientUpdater<ExtraData>(client: client)
+
+        // Simulate `connect` call.
+        let error = try await(updater.connect)
+
+        // Assert `ClientError.ClientIsNotInActiveMode` is propagated
+        XCTAssertTrue(error is ClientError.ClientIsNotInActiveMode)
+    }
+
+    func test_connect_doesNothing_ifConnectionExist() throws {
+        // Create an active client with user session.
+        let client = mockClientWithUserSession()
+
+        // Create an updater.
+        let updater = ChatClientUpdater<ExtraData>(client: client)
+
+        // Simulate `connect` call.
+        let error = try await(updater.connect)
+
+        // Assert `connect` completion is called without any error.
+        XCTAssertNil(error)
+        // Assert `connect` was not called on `webSocketClient`.
+        XCTAssertEqual(client.mockWebSocketClient.connect_calledCounter, 0)
+        // Assert connection id waiter was not added.
+        XCTAssertEqual(client.connectionIdWaiters.count, 0)
+    }
+
+    func test_connect_callsWebSocketClient_andPropagatesNilError() {
+        // Create an active client with user session.
+        let client = mockClientWithUserSession()
+
+        // Create an updater.
+        let updater = ChatClientUpdater<ExtraData>(client: client)
+
+        // Disconnect client from web-socket.
+        updater.disconnect()
+
+        // Simulate `connect` call and catch the result.
+        var connectCompletionCalled = false
+        var connectCompletionError: Error?
+        updater.connect {
+            connectCompletionCalled = true
+            connectCompletionError = $0
+        }
+
+        // Assert `webSocketClient` is asked to connect.
+        XCTAssertEqual(client.mockWebSocketClient.connect_calledCounter, 1)
+        // Assert new connection id waiter is added.
+        XCTAssertEqual(client.connectionIdWaiters.count, 1)
+
+        // Simulate established connection and provide `connectionId` to waiters.
+        client.completeConnectionIdWaiters(connectionId: .unique)
+
+        AssertAsync {
+            // Wait for completion to be called.
+            Assert.willBeTrue(connectCompletionCalled)
+            // Assert completion is called without any error.
+            Assert.staysTrue(connectCompletionError == nil)
+        }
+    }
+
+    func test_connect_callsWebSocketClient_andPropagatesError() throws {
+        for connectionError in [nil, ClientError.Unexpected()] {
+            // Create an active client with user session.
+            let client = mockClientWithUserSession()
+
+            // Create an updater.
+            let updater = ChatClientUpdater<ExtraData>(client: client)
+
+            // Disconnect client from web-socket.
+            updater.disconnect()
+
+            // Simulate `connect` call and catch the result.
+            var connectCompletionCalled = false
+            var connectCompletionError: Error?
+            updater.connect {
+                connectCompletionCalled = true
+                connectCompletionError = $0
+            }
+
+            // Assert `webSocketClient` is asked to connect.
+            XCTAssertEqual(client.mockWebSocketClient.connect_calledCounter, 1)
+            // Assert new connection id waiter is added.
+            XCTAssertEqual(client.connectionIdWaiters.count, 1)
+
+            if let error = connectionError {
+                // Simulate web socket `disconnected` state with the specific error.
+                client.mockWebSocketClient.simulateConnectionStatus(.disconnected(error: error))
+            }
+
+            // Simulate error while establishing a connection.
+            client.completeConnectionIdWaiters(connectionId: nil)
+
+            // Wait completion is called.
+            AssertAsync.willBeTrue(connectCompletionCalled)
+
+            if connectionError == nil {
+                // Assert `ClientError.ConnectionNotSuccessful` error is propagated.
+                XCTAssertTrue(connectCompletionError is ClientError.ConnectionNotSuccessfull)
+            } else {
+                // Assert `ClientError.ConnectionNotSuccessful` error with underlaying error is propagated.
+                let clientError = connectCompletionError as! ClientError.ConnectionNotSuccessfull
+                XCTAssertTrue(clientError.underlyingError is ClientError.Unexpected)
+            }
+        }
+    }
+
+    func test_connect_callsCompletion_ifUpdaterIsDeallocated() throws {
+        for connectionId in [nil, String.unique] {
+            // Create an active client with user session.
+            let client = mockClientWithUserSession()
+
+            // Create an updater.
+            var updater: ChatClientUpdater<ExtraData>? = .init(client: client)
+
+            // Disconnect client from web-socket.
+            updater?.disconnect()
+
+            // Simulate `connect` call and catch the result.
+            var connectCompletionCalled = false
+            var connectCompletionError: Error?
+            updater?.connect {
+                connectCompletionCalled = true
+                connectCompletionError = $0
+            }
+
+            // Remove strong ref to updater.
+            updater = nil
+
+            // Simulate established connection.
+            client.completeConnectionIdWaiters(connectionId: connectionId)
+
+            // Wait for completion to be called.
+            AssertAsync.willBeTrue(connectCompletionCalled)
+
+            if connectionId == nil {
+                XCTAssertNotNil(connectCompletionError)
+            } else {
+                XCTAssertNil(connectCompletionError)
+            }
+        }
+    }
+
+    // MARK: Reload User
+
+    func test_reloadUserIfNeeded_currentUser_sameToken_happyPath() throws {
+        // Create an active client with user session.
+        let client = mockClientWithUserSession()
+
+        // Create an updater.
+        let updater = ChatClientUpdater<ExtraData>(client: client)
+
+        // Save current background worker ids.
+        let oldWorkderIDs = client.testBackgroundWorkerIDs
+
+        // Call `reloadUserIfNeeded` without changing a token provider
+        // and synchronously get the result since no job should be done.
+        let error = try await(updater.reloadUserIfNeeded)
+
+        // Assert error is nil.
+        XCTAssertNil(error)
+        // Assert `disconnect` was not called.
+        XCTAssertEqual(client.mockWebSocketClient.disconnect_calledCounter, 0)
+        // Assert `completeTokenWaiters` was not called since token is not changed.
+        XCTAssertFalse(client.completeTokenWaiters_called)
+        // Assert background workers stay the same.
+        XCTAssertEqual(client.testBackgroundWorkerIDs, oldWorkderIDs)
+        // Assert database is not flushed.
+        XCTAssertFalse(client.mockDatabaseContainer.removeAllData_called)
+    }
+
+    func test_reloadUserIfNeeded_happyPaths() throws {
+        struct Options {
+            let initialToken: Token
+            let updatedToken: Token
+            let shouldConnectAutomatically: Bool
+        }
+
+        // Create current user id.
+        let currentUserId: UserId = .unique
+        // Create new user id.
+        let newUserId: UserId = .unique
+
+        // Create test cases.
+        let testCases: [Options] = [
+            // Updated token for current user with automatic connect.
+            .init(
+                initialToken: .unique(userId: currentUserId),
+                updatedToken: .unique(userId: currentUserId),
+                shouldConnectAutomatically: true
+            ),
+            // Updated token for current user without automatic connect.
+            .init(
+                initialToken: .unique(userId: currentUserId),
+                updatedToken: .unique(userId: currentUserId),
+                shouldConnectAutomatically: false
+            ),
+            // Token for new user with automatic connect.
+            .init(
+                initialToken: .unique(userId: currentUserId),
+                updatedToken: .unique(userId: newUserId),
+                shouldConnectAutomatically: true
+            ),
+            // Token for new user without automatic connect.
+            .init(
+                initialToken: .unique(userId: currentUserId),
+                updatedToken: .unique(userId: newUserId),
+                shouldConnectAutomatically: false
+            )
+        ]
+
+        for options in testCases {
+            // Create an active client with user session.
+            let client = mockClientWithUserSession(
+                shouldConnectAutomatically: options.shouldConnectAutomatically,
+                token: options.initialToken
+            )
+
+            // Update the token provider to return the updated token.
+            client.tokenProvider = .static(options.updatedToken)
+
+            // Create an updater.
+            let updater = ChatClientUpdater<ExtraData>(client: client)
+
+            // Save current background worker ids.
+            let oldWorkerIDs = client.testBackgroundWorkerIDs
+
+            // Simulate `reloadUserIfNeeded` call.
+            var reloadUserIfNeededCompletionCalled = false
+            var reloadUserIfNeededCompletionError: Error?
+            updater.reloadUserIfNeeded {
+                reloadUserIfNeededCompletionCalled = true
+                reloadUserIfNeededCompletionError = $0
+            }
+
+            // Assert current user id is valid.
+            XCTAssertEqual(client.currentUserId, options.updatedToken.userId)
+            // Assert token is valid.
+            XCTAssertEqual(client.currentToken, options.updatedToken)
+            // Assert web-socket is disconnected.
+            XCTAssertEqual(client.mockWebSocketClient.disconnect_calledCounter, 1)
+            // Assert web-socket endpoint is valid.
+            XCTAssertEqual(
+                client.webSocketClient?.connectEndpoint.map(AnyEndpoint.init),
+                AnyEndpoint(.webSocketConnect(userId: options.updatedToken.userId))
+            )
+            // Assert `completeTokenWaiters` was called.
+            XCTAssertTrue(client.completeTokenWaiters_called)
+
+            // If it's just the updated token for the current user.
+            if options.initialToken.userId == options.updatedToken.userId {
+                // Assert `completeTokenWaiters` was called with updated token.
+                XCTAssertEqual(client.completeTokenWaiters_token, options.updatedToken)
+                // Assert background workers stay the same.
+                XCTAssertEqual(client.testBackgroundWorkerIDs, oldWorkerIDs)
+                // Assert database is not flushed.
+                XCTAssertFalse(client.mockDatabaseContainer.removeAllData_called)
+            } else {
+                // Assert `completeTokenWaiters` was called with `nil` token which means all
+                // pending requests were cancelled.
+                XCTAssertNil(client.completeTokenWaiters_token)
+                // Assert background workers are recreated since the user has changed.
+                XCTAssertNotEqual(client.testBackgroundWorkerIDs, oldWorkerIDs)
+                // Assert database was flushed.
+                XCTAssertTrue(client.mockDatabaseContainer.removeAllData_called)
+            }
+
+            // Assert web-socket `connect` is called if `shouldConnectAutomatically == true`.
+            XCTAssertEqual(
+                client.mockWebSocketClient.connect_calledCounter,
+                options.shouldConnectAutomatically ? 1 : 0
+            )
+
+            if options.shouldConnectAutomatically {
+                // Assert completion hasn't been called yet.
+                XCTAssertFalse(reloadUserIfNeededCompletionCalled)
+
+                // Simulate established connection and provide `connectionId` to waiters.
+                let connectionId: String = .unique
+                client.mockWebSocketClient.simulateConnectionStatus(.connected(connectionId: connectionId))
+
+                AssertAsync {
+                    // Assert completion is called.
+                    Assert.willBeTrue(reloadUserIfNeededCompletionCalled)
+                    // Assert completion is called without any error.
+                    Assert.staysTrue(reloadUserIfNeededCompletionError == nil)
+                    // Assert connection id is set.
+                    Assert.willBeEqual(client.connectionId, connectionId)
+                    // Assert connection status is updated.
+                    Assert.willBeEqual(client.connectionStatus, .connected)
+                }
+            } else {
+                // Assert completion is called.
+                XCTAssertTrue(reloadUserIfNeededCompletionCalled)
+                // Assert completion is called without any error.
+                XCTAssertNil(reloadUserIfNeededCompletionError)
+            }
+        }
+    }
+
+    func test_reloadUserIfNeeded_propagatesTokenProviderError() throws {
+        // Create a token provider returning the error.
+        let tokenProviderError = TestError()
+
+        // Create a client with token provider returning the error.
+        let client = ChatClientMock<ExtraData>(
+            config: .init(apiKeyString: .unique),
+            tokenProvider: .closure {
+                $1(.failure(tokenProviderError))
+            }
+        )
+
+        // Create updater referencing to `active` client.
+        let updater = ChatClientUpdater<ExtraData>(client: client)
+
+        // Simulate `reloadUserIfNeeded` call and catch the result.
+        let error = try await(updater.reloadUserIfNeeded)
+
+        // Assert error from token provider is propagated.
+        XCTAssertEqual(error as? TestError, tokenProviderError)
+    }
+
+    func test_reloadUserIfNeeded_newUser_propagatesClientIsPassiveError() throws {
+        // Create config for `passive` client.
+        var config = ChatClientConfig(apiKeyString: .unique)
+        config.isClientInActiveMode = false
+
+        // Create `passive` client.
+        let client = ChatClientMock<ExtraData>(
+            config: config,
+            tokenProvider: .anonymous
+        )
+
+        // Update token provider to return token for another user.
+        client.tokenProvider = .static(.unique())
+
+        // Create `ChatClientUpdater` instance.
+        let updater = ChatClientUpdater<ExtraData>(client: client)
+
+        // Simulate `reloadUserIfNeeded` call and catch the result.
+        let error = try await(updater.reloadUserIfNeeded)
+
+        // Assert `ClientError.ClientIsNotInActiveMode` is propagated.
+        XCTAssertTrue(error is ClientError.ClientIsNotInActiveMode)
+    }
+
+    func test_reloadUserIfNeeded_newUser_propagatesDatabaseFlushError() throws {
+        // Create `active` client.
+        let client = ChatClientMock<ExtraData>(
+            config: .init(apiKeyString: .unique),
+            tokenProvider: .anonymous
+        )
+
+        // Update token provider to return token for another user.
+        client.tokenProvider = .static(.unique())
+
+        // Create `ChatClientUpdater` instance.
+        let updater = ChatClientUpdater<ExtraData>(client: client)
+
+        // Update database to throw an error when flushed.
+        let databaseFlushError = TestError()
+        client.mockDatabaseContainer.removeAllData_errorResponse = databaseFlushError
+
+        // Simulate `reloadUserIfNeeded` call and catch the result.
+        let error = try await(updater.reloadUserIfNeeded)
+
+        // Assert database error is propagated.
+        XCTAssertEqual(error as? TestError, databaseFlushError)
+    }
+
+    func test_reloadUserIfNeeded_newUser_propagatesWebSocketClientError_whenAutomaticallyConnects() {
+        // Create `active` client.
+        let client = ChatClientMock<ExtraData>(
+            config: .init(apiKeyString: .unique),
+            tokenProvider: .anonymous
+        )
+
+        // Update token provider to return token for another user.
+        client.tokenProvider = .static(.unique())
+
+        // Create `ChatClientUpdater` instance.
+        let updater = ChatClientUpdater<ExtraData>(client: client)
+
+        // Simulate `reloadUserIfNeeded` call.
+        var reloadUserIfNeededCompletionCalled = false
+        var reloadUserIfNeededCompletionError: Error?
+        updater.reloadUserIfNeeded {
+            reloadUserIfNeededCompletionCalled = true
+            reloadUserIfNeededCompletionError = $0
+        }
+
+        // Simulate error while establishing a connection.
+        client.completeConnectionIdWaiters(connectionId: nil)
+
+        // Wait completion is called.
+        AssertAsync.willBeTrue(reloadUserIfNeededCompletionCalled)
+        // Assert `ClientError.ConnectionNotSuccessfull` is propagated.
+        XCTAssertTrue(reloadUserIfNeededCompletionError is ClientError.ConnectionNotSuccessfull)
+    }
+
+    func test_reloadUserIfNeeded_keepsUpdaterAlive() {
+        // Create an active client with user session.
+        let client = mockClientWithUserSession(
+            shouldConnectAutomatically: false
+        )
+
+        // Change the token provider and save the completion.
+        var tokenProviderCompletion: ((Result<Token, Error>) -> Void)?
+        client.tokenProvider = .closure {
+            tokenProviderCompletion = $1
+        }
+
+        // Create an updater.
+        var updater: ChatClientUpdater<ExtraData>? = .init(client: client)
+
+        // Simulate `reloadUserIfNeeded` call.
+        updater?.reloadUserIfNeeded()
+
+        // Create weak ref and drop a strong one.
+        weak var weakUpdater = updater
+        updater = nil
+
+        // Assert `reloadUserIfNeeded` keeps updater alive.
+        AssertAsync.staysTrue(weakUpdater != nil)
+
+        // Call the completion.
+        tokenProviderCompletion!(.success(.anonymous))
+        tokenProviderCompletion = nil
+
+        // Assert updater is deallocated.
+        AssertAsync.willBeNil(weakUpdater)
+    }
+
+    // MARK: - Private
+
+    private func mockClientWithUserSession(
+        isActive: Bool = true,
+        shouldConnectAutomatically: Bool = true,
+        token: Token = .unique(userId: .unique)
+    ) -> ChatClientMock<ExtraData> {
+        // Create a config.
+        var config = ChatClientConfig(apiKeyString: .unique)
+        config.isClientInActiveMode = isActive
+        config.shouldConnectAutomatically = shouldConnectAutomatically
+
+        // Create a client.
+        let client = ChatClientMock<ExtraData>(
+            config: config,
+            tokenProvider: .static(token),
+            workerBuilders: [TestWorker.init],
+            eventWorkerBuilders: [TestEventWorker.init]
+        )
+
+        client.currentUserId = token.userId
+        client.currentToken = token
+
+        client.connectionId = .unique
+        client.connectionStatus = .connected
+        client.webSocketClient?.connectEndpoint = .webSocketConnect(userId: token.userId)
+
+        client.createBackgroundWorkers()
+
+        return client
+    }
+}
+
+// MARK: - Private
+
+private extension _ChatClient {
+    var testBackgroundWorkerIDs: Set<UUID> {
+        .init(
+            backgroundWorkers.compactMap {
+                let testWorker = $0 as? TestWorker
+                let eventTestWorker = $0 as? TestEventWorker
+
+                return testWorker?.id ?? eventTestWorker?.id
+            }
+        )
+    }
+}

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		88381E77258259C70047A6A3 /* FileUploadPayload.json in Resources */ = {isa = PBXBuildFile; fileRef = 88381E76258259C70047A6A3 /* FileUploadPayload.json */; };
 		88381E8725825A240047A6A3 /* AttachmentEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88381E8625825A240047A6A3 /* AttachmentEndpoints_Tests.swift */; };
 		883998212576397900294DB9 /* ChatMessageImageGallery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883998202576397900294DB9 /* ChatMessageImageGallery.swift */; };
+		883EB93925B070AB001858FD /* GuestUser+InvalidToken.json in Resources */ = {isa = PBXBuildFile; fileRef = 883EB93825B070AB001858FD /* GuestUser+InvalidToken.json */; };
 		884C61222594A449008B70DC /* AttachmentActionRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884C61212594A449008B70DC /* AttachmentActionRequestBody.swift */; };
 		884C612A2594A7DB008B70DC /* AttachmentActionRequestBody_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884C61292594A7DB008B70DC /* AttachmentActionRequestBody_Tests.swift */; };
 		8850B92A255C286B003AED69 /* UIConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8850B929255C286B003AED69 /* UIConfig.swift */; };
@@ -1071,6 +1072,7 @@
 		88381E76258259C70047A6A3 /* FileUploadPayload.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = FileUploadPayload.json; sourceTree = "<group>"; };
 		88381E8625825A240047A6A3 /* AttachmentEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentEndpoints_Tests.swift; sourceTree = "<group>"; };
 		883998202576397900294DB9 /* ChatMessageImageGallery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageImageGallery.swift; sourceTree = "<group>"; };
+		883EB93825B070AB001858FD /* GuestUser+InvalidToken.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GuestUser+InvalidToken.json"; sourceTree = "<group>"; };
 		884C61212594A449008B70DC /* AttachmentActionRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentActionRequestBody.swift; sourceTree = "<group>"; };
 		884C61292594A7DB008B70DC /* AttachmentActionRequestBody_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentActionRequestBody_Tests.swift; sourceTree = "<group>"; };
 		8850B929255C286B003AED69 /* UIConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfig.swift; sourceTree = "<group>"; };
@@ -2517,6 +2519,7 @@
 				8A0D649F24E57A260017A3C0 /* GuestUser+DefaultExtraData.json */,
 				8A0D64A024E57A260017A3C0 /* GuestUser+NoExtraData.json */,
 				8A0D64A124E57A260017A3C0 /* GuestUser+CustomExtraData.json */,
+				883EB93825B070AB001858FD /* GuestUser+InvalidToken.json */,
 			);
 			path = GuestUser;
 			sourceTree = "<group>";
@@ -3145,6 +3148,7 @@
 				798779FB2498E47700015F8B /* Member.json in Resources */,
 				8A0CC9F824C608C500705CF9 /* ReactionDeleted.json in Resources */,
 				8AC9CBE124C74DD0006E236C /* NotificationInviteAccepted.json in Resources */,
+				883EB93925B070AB001858FD /* GuestUser+InvalidToken.json in Resources */,
 				8A0C3BCC24C1CA9900CAFD19 /* ChannelUpdated.json in Resources */,
 				798779FD2498E47700015F8B /* OtherUser.json in Resources */,
 				F64F9B6225077CF600834F55 /* MessageNew+MissingFields.json in Resources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -304,6 +304,7 @@
 		8800A278258A17DD006D64C4 /* AttachmentListViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8800A277258A17DD006D64C4 /* AttachmentListViewData.swift */; };
 		8800A28C258A1924006D64C4 /* ChatFileAttachmentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8800A28B258A1924006D64C4 /* ChatFileAttachmentListView.swift */; };
 		8802F9BD25AF1DE200475159 /* WebSocketClient_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8802F9BC25AF1DE200475159 /* WebSocketClient_Mock.swift */; };
+		8802F9EF25AF3D4200475159 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8802F9EE25AF3D4200475159 /* HTTPHeader.swift */; };
 		8806570D259A51C200E31D23 /* ChatMessageInteractiveAttachmentView+ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8806570C259A51C200E31D23 /* ChatMessageInteractiveAttachmentView+ActionButton.swift */; };
 		881506EC258212BF0013935B /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881506EB258212BF0013935B /* MultipartFormData.swift */; };
 		8819DFCF2525F3C600FD1A50 /* UserUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFCE2525F3C600FD1A50 /* UserUpdater.swift */; };
@@ -402,6 +403,7 @@
 		88CABC4625933EE70061BB67 /* ChatMessageReactionsBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88CABC2C25933EB80061BB67 /* ChatMessageReactionsBubbleView.swift */; };
 		88CABC6625934CF60061BB67 /* ChatMessageReactions+Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88CABC6525934CF60061BB67 /* ChatMessageReactions+Types.swift */; };
 		88CABC8E25936E440061BB67 /* ChatMessageReactionsBubbleTail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88CABC8D25936E440061BB67 /* ChatMessageReactionsBubbleTail.swift */; };
+		88CD396625B584E000399F8E /* HTTPHeader_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88CD395E25B5844700399F8E /* HTTPHeader_Tests.swift */; };
 		88D66E762599DF1400CFC102 /* ReactionAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D66E752599DF1400CFC102 /* ReactionAppearance.swift */; };
 		88D85D97252F168000AE1030 /* MemberController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85D96252F168000AE1030 /* MemberController+SwiftUI.swift */; };
 		88D85D9A252F168B00AE1030 /* MemberController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D85D99252F168B00AE1030 /* MemberController+Combine.swift */; };
@@ -1036,6 +1038,7 @@
 		8800A277258A17DD006D64C4 /* AttachmentListViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentListViewData.swift; sourceTree = "<group>"; };
 		8800A28B258A1924006D64C4 /* ChatFileAttachmentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFileAttachmentListView.swift; sourceTree = "<group>"; };
 		8802F9BC25AF1DE200475159 /* WebSocketClient_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient_Mock.swift; sourceTree = "<group>"; };
+		8802F9EE25AF3D4200475159 /* HTTPHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeader.swift; sourceTree = "<group>"; };
 		8806570C259A51C200E31D23 /* ChatMessageInteractiveAttachmentView+ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatMessageInteractiveAttachmentView+ActionButton.swift"; sourceTree = "<group>"; };
 		881506EB258212BF0013935B /* MultipartFormData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		8819DFCE2525F3C600FD1A50 /* UserUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater.swift; sourceTree = "<group>"; };
@@ -1135,6 +1138,7 @@
 		88CABC3425933ECC0061BB67 /* ChatMessageReactionsBubbleView+Default.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatMessageReactionsBubbleView+Default.swift"; sourceTree = "<group>"; };
 		88CABC6525934CF60061BB67 /* ChatMessageReactions+Types.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatMessageReactions+Types.swift"; sourceTree = "<group>"; };
 		88CABC8D25936E440061BB67 /* ChatMessageReactionsBubbleTail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageReactionsBubbleTail.swift; sourceTree = "<group>"; };
+		88CD395E25B5844700399F8E /* HTTPHeader_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeader_Tests.swift; sourceTree = "<group>"; };
 		88D66E752599DF1400CFC102 /* ReactionAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionAppearance.swift; sourceTree = "<group>"; };
 		88D85D96252F168000AE1030 /* MemberController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberController+SwiftUI.swift"; sourceTree = "<group>"; };
 		88D85D99252F168B00AE1030 /* MemberController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemberController+Combine.swift"; sourceTree = "<group>"; };
@@ -2123,6 +2127,8 @@
 				7964F3BD249A5E6E002A09EC /* RequestEncoder_Tests.swift */,
 				79DDF80D249CB920002F4412 /* RequestDecoder.swift */,
 				79DDF80F249CB92E002F4412 /* RequestDecoder_Tests.swift */,
+				8802F9EE25AF3D4200475159 /* HTTPHeader.swift */,
+				88CD395E25B5844700399F8E /* HTTPHeader_Tests.swift */,
 				79877A122498E4EE00015F8B /* Endpoints */,
 			);
 			path = APIClient;
@@ -3587,6 +3593,7 @@
 				DA84070C25250581005A0F62 /* UserListPayload.swift in Sources */,
 				79877A272498E50D00015F8B /* MemberModelDTO.swift in Sources */,
 				7962958C248147430078EB53 /* BaseURL.swift in Sources */,
+				8802F9EF25AF3D4200475159 /* HTTPHeader.swift in Sources */,
 				8A0C3BD424C1DF2100CAFD19 /* MessageEvents.swift in Sources */,
 				795296FC258264A100435B2E /* UserSearchController.swift in Sources */,
 				79CD959224F9380B00E87377 /* MulticastDelegate.swift in Sources */,
@@ -3834,6 +3841,7 @@
 				88EA9B0625472430007EE76B /* MessageReactionPayload_Tests.swift in Sources */,
 				88D85DAE252F468B00AE1030 /* ListDatabaseObserver_Mock.swift in Sources */,
 				79877A292498E51500015F8B /* ChannelDTO_Tests.swift in Sources */,
+				88CD396625B584E000399F8E /* HTTPHeader_Tests.swift in Sources */,
 				DAEAF4B824DC026C0015FB28 /* ChannelEndpoints_Tests.swift in Sources */,
 				792FCB4D24A3D56D000290C7 /* DatabaseSession_Tests.swift in Sources */,
 				F62BE7852506309B00D13B86 /* MissingEventsPayload_Tests.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -342,6 +342,7 @@
 		88381E8725825A240047A6A3 /* AttachmentEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88381E8625825A240047A6A3 /* AttachmentEndpoints_Tests.swift */; };
 		883998212576397900294DB9 /* ChatMessageImageGallery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883998202576397900294DB9 /* ChatMessageImageGallery.swift */; };
 		883EB93925B070AB001858FD /* GuestUser+InvalidToken.json in Resources */ = {isa = PBXBuildFile; fileRef = 883EB93825B070AB001858FD /* GuestUser+InvalidToken.json */; };
+		883EB95325B0A1ED001858FD /* TokenProvider_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883EB95225B0A1ED001858FD /* TokenProvider_Tests.swift */; };
 		884C61222594A449008B70DC /* AttachmentActionRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884C61212594A449008B70DC /* AttachmentActionRequestBody.swift */; };
 		884C612A2594A7DB008B70DC /* AttachmentActionRequestBody_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884C61292594A7DB008B70DC /* AttachmentActionRequestBody_Tests.swift */; };
 		8850B92A255C286B003AED69 /* UIConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8850B929255C286B003AED69 /* UIConfig.swift */; };
@@ -351,6 +352,7 @@
 		8850FE91256558B200C8D534 /* ChatRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8850FE90256558B200C8D534 /* ChatRouter.swift */; };
 		885B3D7725642B3D003E6BDF /* CurrentChatUserAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 885B3D7625642B3D003E6BDF /* CurrentChatUserAvatarView.swift */; };
 		885B3D7D25642B88003E6BDF /* CreateNewChannelButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 885B3D7C25642B88003E6BDF /* CreateNewChannelButton.swift */; };
+		8862922925AC720F00D9AE78 /* TokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8862922825AC720F00D9AE78 /* TokenProvider.swift */; };
 		8875CF9B2587A89F00BBA6AC /* AttachmentId_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8875CF8D2587A7F200BBA6AC /* AttachmentId_Tests.swift */; };
 		888123D2255D430B00070D5A /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888123D1255D430B00070D5A /* UIView+Extensions.swift */; };
 		888123E0255D4D2100070D5A /* UIImageView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888123DF255D4D2100070D5A /* UIImageView+Extensions.swift */; };
@@ -1073,6 +1075,7 @@
 		88381E8625825A240047A6A3 /* AttachmentEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentEndpoints_Tests.swift; sourceTree = "<group>"; };
 		883998202576397900294DB9 /* ChatMessageImageGallery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageImageGallery.swift; sourceTree = "<group>"; };
 		883EB93825B070AB001858FD /* GuestUser+InvalidToken.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "GuestUser+InvalidToken.json"; sourceTree = "<group>"; };
+		883EB95225B0A1ED001858FD /* TokenProvider_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProvider_Tests.swift; sourceTree = "<group>"; };
 		884C61212594A449008B70DC /* AttachmentActionRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentActionRequestBody.swift; sourceTree = "<group>"; };
 		884C61292594A7DB008B70DC /* AttachmentActionRequestBody_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentActionRequestBody_Tests.swift; sourceTree = "<group>"; };
 		8850B929255C286B003AED69 /* UIConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfig.swift; sourceTree = "<group>"; };
@@ -1082,6 +1085,7 @@
 		8850FE90256558B200C8D534 /* ChatRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRouter.swift; sourceTree = "<group>"; };
 		885B3D7625642B3D003E6BDF /* CurrentChatUserAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentChatUserAvatarView.swift; sourceTree = "<group>"; };
 		885B3D7C25642B88003E6BDF /* CreateNewChannelButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNewChannelButton.swift; sourceTree = "<group>"; };
+		8862922825AC720F00D9AE78 /* TokenProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProvider.swift; sourceTree = "<group>"; };
 		8875CF8D2587A7F200BBA6AC /* AttachmentId_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentId_Tests.swift; sourceTree = "<group>"; };
 		888123D1255D430B00070D5A /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		888123DF255D4D2100070D5A /* UIImageView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extensions.swift"; sourceTree = "<group>"; };
@@ -1854,6 +1858,8 @@
 			isa = PBXGroup;
 			children = (
 				79FC85E624ACCBC500A665ED /* Token.swift */,
+				8862922825AC720F00D9AE78 /* TokenProvider.swift */,
+				883EB95225B0A1ED001858FD /* TokenProvider_Tests.swift */,
 				7962958B248147430078EB53 /* BaseURL.swift */,
 				799C9428247D2FB9001F1104 /* ChatClientConfig.swift */,
 			);
@@ -3561,6 +3567,7 @@
 				797A756624814EF8003CF16D /* SystemEnvironment.swift in Sources */,
 				799C9438247D2FB9001F1104 /* ChatClientConfig.swift in Sources */,
 				7964F3B6249A314D002A09EC /* PrefixLogFormatter.swift in Sources */,
+				8862922925AC720F00D9AE78 /* TokenProvider.swift in Sources */,
 				88E26D6E2580F34B00F55AB5 /* AttachmentUploader.swift in Sources */,
 				88A00DD02525F08000259AB4 /* ModerationEndpoints.swift in Sources */,
 				79A0E9B02498C09900E9BD50 /* ConnectionStatus.swift in Sources */,
@@ -3780,6 +3787,7 @@
 				797EEA4A24FFC37600C81203 /* ConnectionStatus_Tests.swift in Sources */,
 				79877A2B2498E51500015F8B /* UserDTO_Tests.swift in Sources */,
 				799F611B2530B62C007F218C /* ChannelListQuery_Tests.swift in Sources */,
+				883EB95325B0A1ED001858FD /* TokenProvider_Tests.swift in Sources */,
 				792921C524C0479700116BBB /* ChannelListUpdater_Tests.swift in Sources */,
 				79177A2D248A6A2600F053A2 /* AssertAsync+Events.swift in Sources */,
 				F6C56D1424F7B89D0012BB1F /* EventMiddleware_Mock.swift in Sources */,

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -313,6 +313,9 @@
 		8819DFE2252628CA00FD1A50 /* UserUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE1252628CA00FD1A50 /* UserUpdater_Tests.swift */; };
 		8819DFE625262B1500FD1A50 /* UserController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE525262B1500FD1A50 /* UserController_Tests.swift */; };
 		8819DFE925262EBA00FD1A50 /* UserUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */; };
+		88206FC425B18C88009D086A /* ChatClientUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88206FC325B18C88009D086A /* ChatClientUpdater.swift */; };
+		88206FD825B1A9B7009D086A /* ChatClientUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88206FD725B1A9B7009D086A /* ChatClientUpdater_Mock.swift */; };
+		88206FE625B1AB34009D086A /* ChatClientUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88206FE525B1AB34009D086A /* ChatClientUpdater_Tests.swift */; };
 		8825333E258CE7AC00B77352 /* ChatMessageActionsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8825333D258CE7AC00B77352 /* ChatMessageActionsVC.swift */; };
 		8825334C258CE82500B77352 /* ChatMessageActionsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8825334B258CE82500B77352 /* ChatMessageActionsRouter.swift */; };
 		882AE057257A176A004095B3 /* ChatChannelRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882AE056257A176A004095B3 /* ChatChannelRouter.swift */; };
@@ -1047,6 +1050,9 @@
 		8819DFE1252628CA00FD1A50 /* UserUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater_Tests.swift; sourceTree = "<group>"; };
 		8819DFE525262B1500FD1A50 /* UserController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserController_Tests.swift; sourceTree = "<group>"; };
 		8819DFE825262EBA00FD1A50 /* UserUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater_Mock.swift; sourceTree = "<group>"; };
+		88206FC325B18C88009D086A /* ChatClientUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatClientUpdater.swift; sourceTree = "<group>"; };
+		88206FD725B1A9B7009D086A /* ChatClientUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatClientUpdater_Mock.swift; sourceTree = "<group>"; };
+		88206FE525B1AB34009D086A /* ChatClientUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatClientUpdater_Tests.swift; sourceTree = "<group>"; };
 		8825333D258CE7AC00B77352 /* ChatMessageActionsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageActionsVC.swift; sourceTree = "<group>"; };
 		8825334B258CE82500B77352 /* ChatMessageActionsRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageActionsRouter.swift; sourceTree = "<group>"; };
 		882AE056257A176A004095B3 /* ChatChannelRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelRouter.swift; sourceTree = "<group>"; };
@@ -2067,6 +2073,9 @@
 				88F6DF90252C8845009A8AF0 /* ChannelMemberUpdater.swift */,
 				88F6DF96252C88BB009A8AF0 /* ChannelMemberUpdater_Mock.swift */,
 				88F6DF93252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift */,
+				88206FC325B18C88009D086A /* ChatClientUpdater.swift */,
+				88206FD725B1A9B7009D086A /* ChatClientUpdater_Mock.swift */,
+				88206FE525B1AB34009D086A /* ChatClientUpdater_Tests.swift */,
 				F63CC36D24E591690052844D /* EventObservers */,
 				79280F4524850ECC00CDEB89 /* Background */,
 			);
@@ -3668,6 +3677,7 @@
 				DAFAD6A124DC476A0043ED06 /* Result+Extensions.swift in Sources */,
 				DAF8359924F8042D00392699 /* TypingEventObserver.swift in Sources */,
 				794927ED249E0BE2009D7EB7 /* ExtraData.swift in Sources */,
+				88206FC425B18C88009D086A /* ChatClientUpdater.swift in Sources */,
 				7991D83B24F5427E00D21BA3 /* EphemeralValuesContainer.swift in Sources */,
 				79682C4B24BF37CB0071578E /* ChannelListPayload.swift in Sources */,
 				DA9985EE24E175AA000E9885 /* ChannelCodingKeys.swift in Sources */,
@@ -3792,6 +3802,7 @@
 				F63CC37524E592DD0052844D /* MemberEventObserver_Tests.swift in Sources */,
 				792FCB4724A33CC2000290C7 /* EventDataProcessorMiddleware_Tests.swift in Sources */,
 				797EEA4A24FFC37600C81203 /* ConnectionStatus_Tests.swift in Sources */,
+				88206FE625B1AB34009D086A /* ChatClientUpdater_Tests.swift in Sources */,
 				79877A2B2498E51500015F8B /* UserDTO_Tests.swift in Sources */,
 				799F611B2530B62C007F218C /* ChannelListQuery_Tests.swift in Sources */,
 				883EB95325B0A1ED001858FD /* TokenProvider_Tests.swift in Sources */,
@@ -3849,6 +3860,7 @@
 				792B805424D95FC700C2963E /* RandomDispatchQueue.swift in Sources */,
 				7952B3B324D4560E00AC53D4 /* ChannelController_Tests.swift in Sources */,
 				7922F30624DACEF100C364BC /* TestDataModel.xcdatamodeld in Sources */,
+				88206FD825B1A9B7009D086A /* ChatClientUpdater_Mock.swift in Sources */,
 				8A0CC9EB24C601F600705CF9 /* MemberEvents_Tests.swift in Sources */,
 				792B805224D95D4300C2963E /* Cached_Tests.swift in Sources */,
 				F62D143E24DD70190081D241 /* ChannelUpdater_Mock.swift in Sources */,

--- a/Tests_v3/Shared/TemporaryData.swift
+++ b/Tests_v3/Shared/TemporaryData.swift
@@ -1,9 +1,9 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
-import StreamChat
+@testable import StreamChat
 
 extension URL {
     /// Returns a unique random URL
@@ -29,6 +29,13 @@ extension URL {
 extension String {
     /// Returns a new unique string
     static var unique: String { UUID().uuidString }
+}
+
+extension Token {
+    /// Returns a new `Token` with the provided `user_id` but not in JWT format.
+    static func unique(userId: UserId = .unique) -> Self {
+        .init(rawValue: .unique, userId: userId)
+    }
 }
 
 extension AttachmentAction {

--- a/Tests_v3/StreamChatTests/MockEnpointResponses/GuestUser/GuestUser+CustomExtraData.json
+++ b/Tests_v3/StreamChatTests/MockEnpointResponses/GuestUser/GuestUser+CustomExtraData.json
@@ -1,5 +1,5 @@
 {
-  "access_token" : "123",
+  "access_token" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.QPeAmdig1KbLwYInW8hwi0XML3kO1M6HH76k4IU0sDg",
   "user" : {
     "id" : "broken-waterfall-5",
     "role" : "guest",

--- a/Tests_v3/StreamChatTests/MockEnpointResponses/GuestUser/GuestUser+DefaultExtraData.json
+++ b/Tests_v3/StreamChatTests/MockEnpointResponses/GuestUser/GuestUser+DefaultExtraData.json
@@ -1,5 +1,5 @@
 {
-  "access_token" : "123",
+  "access_token" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.QPeAmdig1KbLwYInW8hwi0XML3kO1M6HH76k4IU0sDg",
   "user" : {
     "id" : "broken-waterfall-5",
     "role" : "guest",

--- a/Tests_v3/StreamChatTests/MockEnpointResponses/GuestUser/GuestUser+InvalidToken.json
+++ b/Tests_v3/StreamChatTests/MockEnpointResponses/GuestUser/GuestUser+InvalidToken.json
@@ -1,5 +1,5 @@
 {
-  "access_token" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYnJva2VuLXdhdGVyZmFsbC01In0.QPeAmdig1KbLwYInW8hwi0XML3kO1M6HH76k4IU0sDg",
+  "access_token" : "some random value",
   "user" : {
     "id" : "broken-waterfall-5",
     "role" : "guest",


### PR DESCRIPTION
# Introduction

This PR simplifies user-setting API so we have the single flow for all the cases:
- refreshing a token for the current user
- using another token provider for the current user
- setting another user by setting a different token provider

# Making the current user ID optional

Having a non-optional `currentUserId` in **ChatClient**:
- is not consistent with `currentUser: CurrentUser?` in **CurrentUserController** which can be `nil` if there's no current user saved in the database
- is apparently invalid and can be confusing since we have `currentUserID` set even though there's no currently logged in user.

```swift
 public class _ChatClient<ExtraData: ExtraDataTypes> {
     /// The `UserId` of the currently logged in user.
-    @Atomic public var currentUserId: UserId = .anonymous
+    @Atomic public var currentUserId: UserId?
```

Previously the `currentUserId` property was initialized with random `.anonymous` value for the single purpose: make the access simple for end-users, avoiding unwrapping the optional. 

But it turns out if we add additional values to the models (`message.isSentByCurrentUser`, `reation.isCurrentUserReaction`) we can cover most of the cases where `currentUserID` previously had to be accessed and provide a friendly and convenient API for end-users.

_When **ChatClient** is instantiated, the `currentUserId` is taken from the database so it is now consistent with **CurrentUserController**._

# Moving reconnection logic to ChatClient

All stuff from **CurrentUserController** related to setting another user (`setUser/setGuestUser/setAnonymousUser`) is gone and replaces with the single `reconnectIfNeeded` (naming is not final) on a **ChatClient**. 

The decision to move  `reconnectIfNeeded` from **CurrentUserController ->  ChatClient** was made based on the following:
1. `reconnectIfNeeded` is more about establishing a connection other than updating/observing the current user
2. `reconnectIfNeeded` requires whipping the environment including **@Atomic** properties which should be done via acesssing `mutate` on the backing variables which cannot be done from the outside (previously we were doing it in the wrong non-thread-safe way)

# Token waiters

From the inside of **ChatClient.init** background-workers are instantiated. Workers start working immediately and can initiate API calls before the token for the current user is provided. 

_**The use-case:** SDK end-users decide to create a **ChatClient** on app launch but postpone `reconnectIfNeeded` until the chat is opened._

Such cases are handled in the same way we deal with API calls that require `connection-id`: 
- the **Endpoint** type is extended with `requiresToken: Bool`
- the **RequestEncoder** is updated to ask the delegate (the **ChatClient**) for the `token`
- the **ChatClient** is updated to have `tokenWaiters: [(Token?) -> Void]` property storing the closures to be called once the token is provided by the **TokenProvider** 

_If the token has already been provided it is given back to **RequestEncoder** synchronously_