### PR TITLE
[CIS-546] Fix Suggestion presenting and colors

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerCommandCollectionViewCell.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerCommandCollectionViewCell.swift
@@ -8,6 +8,8 @@ import UIKit
 open class MessageComposerCommandCellView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
     // MARK: Properties
 
+    open var commandImageHeight: CGFloat = 24
+
     open var command: Command? {
         didSet {
             updateContentIfNeeded()
@@ -22,7 +24,7 @@ open class MessageComposerCommandCellView<ExtraData: ExtraDataTypes>: View, UICo
     // MARK: - Appearance
 
     override public func defaultAppearance() {
-        backgroundColor = uiConfig.colorPalette.generalBackground
+        backgroundColor = .clear
 
         commandNameLabel.font = UIFont.preferredFont(forTextStyle: .footnote).bold
 

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerMentionCollectionViewCell.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerMentionCollectionViewCell.swift
@@ -28,7 +28,7 @@ open class MessageComposerMentionCellView<ExtraData: ExtraDataTypes>: View, UICo
     // MARK: - Appearance
 
     override public func defaultAppearance() {
-        backgroundColor = uiConfig.colorPalette.generalBackground
+        backgroundColor = .clear
         usernameLabel.font = UIFont.preferredFont(forTextStyle: .footnote).bold
 
         usernameTagLabel.font = .preferredFont(forTextStyle: .caption1)

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerSuggestionsCollectionView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerSuggestionsCollectionView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -33,7 +33,7 @@ open class MessageComposerSuggestionsCollectionView<ExtraData: ExtraDataTypes>: 
     // MARK: - Appearance
 
     public func defaultAppearance() {
-        backgroundColor = uiConfig.colorPalette.generalBackground
+        backgroundColor = uiConfig.colorPalette.popupBackground
         showsVerticalScrollIndicator = false
         showsHorizontalScrollIndicator = false
         bounces = true

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerSuggestionsCommandsHeaderView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerSuggestionsCommandsHeaderView.swift
@@ -1,0 +1,50 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+open class MessageComposerSuggestionsCommandsReusableView<ExtraData: ExtraDataTypes>: UICollectionReusableView, UIConfigProvider {
+    class var reuseId: String { String(describing: self) }
+
+    public lazy var suggestionsHeader: MessageComposerSuggestionsCommandsHeaderView<ExtraData> = {
+        let header = uiConfig.messageComposer.suggestionsHeaderView.init().withoutAutoresizingMaskConstraints
+        embed(header)
+        return header
+    }()
+}
+
+open class MessageComposerSuggestionsCommandsHeaderView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+    lazy var commandImageView: UIImageView = UIImageView().withoutAutoresizingMaskConstraints
+    lazy var headerLabel: UILabel = UILabel().withoutAutoresizingMaskConstraints
+
+    override public func defaultAppearance() {
+        backgroundColor = uiConfig.colorPalette.popupBackground
+
+        headerLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
+        headerLabel.textColor = uiConfig.colorPalette.subtitleText
+        commandImageView.contentMode = .scaleAspectFit
+    }
+
+    override open func setUpLayout() {
+        let view = UIView().withoutAutoresizingMaskConstraints
+        embed(view, insets: directionalLayoutMargins)
+
+        view.addSubview(commandImageView)
+        view.addSubview(headerLabel)
+        commandImageView.pin(anchors: [.leading], to: view)
+        commandImageView.pin(anchors: [.centerY], to: view)
+
+        NSLayoutConstraint.activate(
+            [
+                commandImageView.centerYAnchor.pin(equalTo: headerLabel.centerYAnchor),
+                headerLabel.centerYAnchor.pin(equalTo: commandImageView.centerYAnchor),
+                headerLabel.leadingAnchor.pin(
+                    equalToSystemSpacingAfter: commandImageView.trailingAnchor,
+                    multiplier: 2
+                )
+            ]
+        )
+    }
+}

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerSuggestionsViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerSuggestionsViewController.swift
@@ -135,21 +135,29 @@ open class MessageComposerSuggestionsViewController<ExtraData: ExtraDataTypes>: 
     }
 }
 
-class SuggestionsCommandDataSource<ExtraData: ExtraDataTypes>: NSObject, UICollectionViewDataSource {
-    var collectionView: MessageComposerSuggestionsCollectionView<ExtraData>
-    var commands: [Command]
+open class SuggestionsCommandDataSource<ExtraData: ExtraDataTypes>: NSObject, UICollectionViewDataSource {
+    open var collectionView: MessageComposerSuggestionsCollectionView<ExtraData>
+    open var commands: [Command]
 
-    var uiConfig: UIConfig<ExtraData> {
+    open var uiConfig: UIConfig<ExtraData> {
         collectionView.uiConfig()
     }
 
-    init(with commands: [Command], collectionView: MessageComposerSuggestionsCollectionView<ExtraData>) {
+    public init(with commands: [Command], collectionView: MessageComposerSuggestionsCollectionView<ExtraData>) {
         self.commands = commands
         self.collectionView = collectionView
 
         super.init()
 
         registerCollectionViewCell()
+
+        collectionView.register(
+            MessageComposerSuggestionsCommandsReusableView<ExtraData>.self,
+            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: "CommandsHeader"
+        )
+        (collectionView.collectionViewLayout as? UICollectionViewFlowLayout)?
+            .headerReferenceSize = CGSize(width: self.collectionView.frame.size.width, height: 40)
     }
 
     private func registerCollectionViewCell() {
@@ -159,11 +167,32 @@ class SuggestionsCommandDataSource<ExtraData: ExtraDataTypes>: NSObject, UIColle
         )
     }
 
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        viewForSupplementaryElementOfKind kind: String,
+        at indexPath: IndexPath
+    ) -> UICollectionReusableView {
+        let headerView = collectionView.dequeueReusableSupplementaryView(
+            ofKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: "CommandsHeader",
+            for: indexPath
+        ) as! MessageComposerSuggestionsCommandsReusableView<ExtraData>
+
+        headerView.suggestionsHeader.headerLabel.text = L10n.Composer.Suggestions.Commands.header
+        headerView.suggestionsHeader.commandImageView.image = UIImage(
+            named: "bolt",
+            in: .streamChatUI
+        )?
+            .tinted(with: headerView.tintColor)
+
+        return headerView
+    }
+
+    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         commands.count
     }
 
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(
             withReuseIdentifier: MessageComposerCommandCollectionViewCell<ExtraData>.reuseId,
             for: indexPath
@@ -176,7 +205,7 @@ class SuggestionsCommandDataSource<ExtraData: ExtraDataTypes>: NSObject, UIColle
     }
 }
 
-class SuggestionsMentionDataSource<ExtraData: ExtraDataTypes>: NSObject,
+open class SuggestionsMentionDataSource<ExtraData: ExtraDataTypes>: NSObject,
     UICollectionViewDataSource,
     _ChatUserSearchControllerDelegate {
     var collectionView: MessageComposerSuggestionsCollectionView<ExtraData>
@@ -194,6 +223,8 @@ class SuggestionsMentionDataSource<ExtraData: ExtraDataTypes>: NSObject,
         self.searchController = searchController
         super.init()
         registerCollectionViewCell()
+        (collectionView.collectionViewLayout as? UICollectionViewFlowLayout)?
+            .headerReferenceSize = CGSize(width: self.collectionView.frame.size.width, height: 0)
         searchController.setDelegate(self)
     }
 
@@ -206,11 +237,19 @@ class SuggestionsMentionDataSource<ExtraData: ExtraDataTypes>: NSObject,
 
     // MARK: - CollectionViewDataSource
 
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        viewForSupplementaryElementOfKind kind: String,
+        at indexPath: IndexPath
+    ) -> UICollectionReusableView {
+        UICollectionReusableView()
+    }
+
+    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         searchController.users.count
     }
 
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(
             withReuseIdentifier: MessageComposerMentionCollectionViewCell<ExtraData>.reuseId,
             for: indexPath
@@ -224,7 +263,7 @@ class SuggestionsMentionDataSource<ExtraData: ExtraDataTypes>: NSObject,
 
     // MARK: - ChatUserSearchControllerDelegate
 
-    func controller(
+    public func controller(
         _ controller: _ChatUserSearchController<ExtraData>,
         didChangeUsers changes: [ListChange<_ChatUser<ExtraData.User>>]
     ) {

--- a/Sources_v3/StreamChatUI/Generated/L10n.swift
+++ b/Sources_v3/StreamChatUI/Generated/L10n.swift
@@ -1,3 +1,7 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
 // swiftlint:disable all
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
@@ -10,125 +14,139 @@ import Foundation
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
+    internal enum Alert {
+        internal enum Actions {
+            /// Cancel
+            internal static let cancel = L10n.tr("Localizable", "alert.actions.cancel")
+            /// Delete
+            internal static let delete = L10n.tr("Localizable", "alert.actions.delete")
+        }
+    }
 
-  internal enum Alert {
-    internal enum Actions {
-      /// Cancel
-      internal static let cancel = L10n.tr("Localizable", "alert.actions.cancel")
-      /// Delete
-      internal static let delete = L10n.tr("Localizable", "alert.actions.delete")
+    internal enum Channel {
+        internal enum Name {
+            /// and
+            internal static let and = L10n.tr("Localizable", "channel.name.and")
+            /// NoChannel
+            internal static let missing = L10n.tr("Localizable", "channel.name.missing")
+            /// more
+            internal static let more = L10n.tr("Localizable", "channel.name.more")
+        }
     }
-  }
 
-  internal enum Channel {
-    internal enum Name {
-      /// and
-      internal static let and = L10n.tr("Localizable", "channel.name.and")
-      /// NoChannel
-      internal static let missing = L10n.tr("Localizable", "channel.name.missing")
-      /// more
-      internal static let more = L10n.tr("Localizable", "channel.name.more")
-    }
-  }
+    internal enum Composer {
+        internal enum Checkmark {
+            /// Also send in channel
+            internal static let channelReply = L10n.tr("Localizable", "composer.checkmark.channel-reply")
+            /// Also send as direct message
+            internal static let directMessageReply = L10n.tr("Localizable", "composer.checkmark.direct-message-reply")
+        }
 
-  internal enum Composer {
-    internal enum Checkmark {
-      /// Also send in channel
-      internal static let channelReply = L10n.tr("Localizable", "composer.checkmark.channel-reply")
-      /// Also send as direct message
-      internal static let directMessageReply = L10n.tr("Localizable", "composer.checkmark.direct-message-reply")
-    }
-    internal enum Picker {
-      /// Cancel
-      internal static let cancel = L10n.tr("Localizable", "composer.picker.cancel")
-      /// File
-      internal static let file = L10n.tr("Localizable", "composer.picker.file")
-      /// Photo
-      internal static let image = L10n.tr("Localizable", "composer.picker.image")
-      /// Choose attachment type: 
-      internal static let title = L10n.tr("Localizable", "composer.picker.title")
-    }
-    internal enum Placeholder {
-      /// Search GIFs
-      internal static let giphy = L10n.tr("Localizable", "composer.placeholder.giphy")
-      /// Send a message
-      internal static let message = L10n.tr("Localizable", "composer.placeholder.message")
-    }
-    internal enum Title {
-      /// Edit Message
-      internal static let edit = L10n.tr("Localizable", "composer.title.edit")
-      /// Reply to Message
-      internal static let reply = L10n.tr("Localizable", "composer.title.reply")
-    }
-  }
+        internal enum Picker {
+            /// Cancel
+            internal static let cancel = L10n.tr("Localizable", "composer.picker.cancel")
+            /// File
+            internal static let file = L10n.tr("Localizable", "composer.picker.file")
+            /// Photo
+            internal static let image = L10n.tr("Localizable", "composer.picker.image")
+            /// Choose attachment type:
+            internal static let title = L10n.tr("Localizable", "composer.picker.title")
+        }
 
-  internal enum Message {
-    /// Message deleted
-    internal static let deletedMessagePlaceholder = L10n.tr("Localizable", "message.deleted-message-placeholder")
-    /// Only visible to you
-    internal static let onlyVisibleToYou = L10n.tr("Localizable", "message.only-visible-to-you")
-    internal enum Actions {
-      /// Copy Message
-      internal static let copy = L10n.tr("Localizable", "message.actions.copy")
-      /// Delete Message
-      internal static let delete = L10n.tr("Localizable", "message.actions.delete")
-      /// Edit Message
-      internal static let edit = L10n.tr("Localizable", "message.actions.edit")
-      /// Reply
-      internal static let inlineReply = L10n.tr("Localizable", "message.actions.inline-reply")
-      /// Resend
-      internal static let resend = L10n.tr("Localizable", "message.actions.resend")
-      /// Thread Reply
-      internal static let threadReply = L10n.tr("Localizable", "message.actions.thread-reply")
-      /// Block User
-      internal static let userBlock = L10n.tr("Localizable", "message.actions.user-block")
-      /// Mute User
-      internal static let userMute = L10n.tr("Localizable", "message.actions.user-mute")
-      /// Unblock User
-      internal static let userUnblock = L10n.tr("Localizable", "message.actions.user-unblock")
-      /// Unmute User
-      internal static let userUnmute = L10n.tr("Localizable", "message.actions.user-unmute")
-      internal enum Delete {
-        /// Are you sure you want to permanently delete this message?
-        internal static let confirmationMessage = L10n.tr("Localizable", "message.actions.delete.confirmation-message")
-        /// Delete Message
-        internal static let confirmationTitle = L10n.tr("Localizable", "message.actions.delete.confirmation-title")
-      }
+        internal enum Placeholder {
+            /// Search GIFs
+            internal static let giphy = L10n.tr("Localizable", "composer.placeholder.giphy")
+            /// Send a message
+            internal static let message = L10n.tr("Localizable", "composer.placeholder.message")
+        }
+
+        internal enum Suggestions {
+            internal enum Commands {
+                /// Instant Commands
+                internal static let header = L10n.tr("Localizable", "composer.suggestions.commands.header")
+            }
+        }
+
+        internal enum Title {
+            /// Edit Message
+            internal static let edit = L10n.tr("Localizable", "composer.title.edit")
+            /// Reply to Message
+            internal static let reply = L10n.tr("Localizable", "composer.title.reply")
+        }
     }
-    internal enum Sending {
-      /// UPLOADING FAILED
-      internal static let attachmentUploadingFailed = L10n.tr("Localizable", "message.sending.attachment-uploading-failed")
+
+    internal enum Message {
+        /// Message deleted
+        internal static let deletedMessagePlaceholder = L10n.tr("Localizable", "message.deleted-message-placeholder")
+        /// Only visible to you
+        internal static let onlyVisibleToYou = L10n.tr("Localizable", "message.only-visible-to-you")
+        internal enum Actions {
+            /// Copy Message
+            internal static let copy = L10n.tr("Localizable", "message.actions.copy")
+            /// Delete Message
+            internal static let delete = L10n.tr("Localizable", "message.actions.delete")
+            /// Edit Message
+            internal static let edit = L10n.tr("Localizable", "message.actions.edit")
+            /// Reply
+            internal static let inlineReply = L10n.tr("Localizable", "message.actions.inline-reply")
+            /// Resend
+            internal static let resend = L10n.tr("Localizable", "message.actions.resend")
+            /// Thread Reply
+            internal static let threadReply = L10n.tr("Localizable", "message.actions.thread-reply")
+            /// Block User
+            internal static let userBlock = L10n.tr("Localizable", "message.actions.user-block")
+            /// Mute User
+            internal static let userMute = L10n.tr("Localizable", "message.actions.user-mute")
+            /// Unblock User
+            internal static let userUnblock = L10n.tr("Localizable", "message.actions.user-unblock")
+            /// Unmute User
+            internal static let userUnmute = L10n.tr("Localizable", "message.actions.user-unmute")
+            internal enum Delete {
+                /// Are you sure you want to permanently delete this message?
+                internal static let confirmationMessage = L10n.tr("Localizable", "message.actions.delete.confirmation-message")
+                /// Delete Message
+                internal static let confirmationTitle = L10n.tr("Localizable", "message.actions.delete.confirmation-title")
+            }
+        }
+
+        internal enum Sending {
+            /// UPLOADING FAILED
+            internal static let attachmentUploadingFailed = L10n.tr("Localizable", "message.sending.attachment-uploading-failed")
+        }
+
+        internal enum Threads {
+            /// Plural format key: "%#@replies@"
+            internal static func count(_ p1: Int) -> String {
+                L10n.tr("Localizable", "message.threads.count", p1)
+            }
+
+            /// Thread Reply
+            internal static let reply = L10n.tr("Localizable", "message.threads.reply")
+        }
     }
-    internal enum Threads {
-      /// Plural format key: "%#@replies@"
-      internal static func count(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "message.threads.count", p1)
-      }
-      /// Thread Reply
-      internal static let reply = L10n.tr("Localizable", "message.threads.reply")
-    }
-  }
 }
+
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
 
 // MARK: - Implementation Details
 
 extension L10n {
-  private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
-    let format = BundleToken.bundle.localizedString(forKey: key, value: nil, table: table)
-    return String(format: format, locale: Locale.current, arguments: args)
-  }
+    private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
+        let format = BundleToken.bundle.localizedString(forKey: key, value: nil, table: table)
+        return String(format: format, locale: Locale.current, arguments: args)
+    }
 }
 
 // swiftlint:disable convenience_type
 private final class BundleToken {
-  static let bundle: Bundle = {
-    #if SWIFT_PACKAGE
-    return Bundle.module
-    #else
-    return Bundle(for: BundleToken.self)
-    #endif
-  }()
+    static let bundle: Bundle = {
+        #if SWIFT_PACKAGE
+        return Bundle.module
+        #else
+        return Bundle(for: BundleToken.self)
+        #endif
+    }()
 }
+
 // swiftlint:enable convenience_type

--- a/Sources_v3/StreamChatUI/Resources/en.lproj/Localizable.strings
+++ b/Sources_v3/StreamChatUI/Resources/en.lproj/Localizable.strings
@@ -38,4 +38,5 @@
 "composer.picker.image" = "Photo";
 "composer.picker.cancel" = "Cancel";
 
+"composer.suggestions.commands.header" = "Instant Commands";
 "message.sending.attachment-uploading-failed" = "UPLOADING FAILED";

--- a/Sources_v3/StreamChatUI/UIConfig.swift
+++ b/Sources_v3/StreamChatUI/UIConfig.swift
@@ -49,7 +49,8 @@ public extension UIConfig {
         public var subtitleText: UIColor = .streamGray
         public var text: UIColor = .streamBlack
         public var generalBackground: UIColor = .streamWhiteSnow
-        public var shadow: UIColor = .streamGray
+        public var popupBackground: UIColor = .streamWhite
+        public var shadow: UIColor = .streamModalShadow
 
         // MARK: - Channel List
 
@@ -308,6 +309,10 @@ public extension UIConfig {
             MessageComposerCommandCellView<ExtraData>.self
         public var suggestionsCollectionViewLayout: MessageComposerSuggestionsCollectionViewLayout.Type =
             MessageComposerSuggestionsCollectionViewLayout.self
+        public var suggestionsHeaderReusableView: MessageComposerSuggestionsCommandsReusableView<ExtraData>.Type =
+            MessageComposerSuggestionsCommandsReusableView.self
+        public var suggestionsHeaderView: MessageComposerSuggestionsCommandsHeaderView<ExtraData>.Type =
+            MessageComposerSuggestionsCommandsHeaderView.self
         public var mentionAvatarView: ChatChannelAvatarView<ExtraData>.Type = ChatChannelAvatarView<ExtraData>.self
         public var commandIcons: [String: UIImage] = [
             "ban": UIImage(named: "command_ban", in: .streamChatUI)!,
@@ -360,6 +365,7 @@ private extension UIColor {
     static let streamAccentBlue = mode(0x005fff, 0x005fff)
     static let streamAccentRed = mode(0xff3742, 0xff3742)
     static let streamAccentGreen = mode(0x20e070, 0x20e070)
+    static let streamModalShadow = mode(0, lightAlpha: 0.15, 0, darkAlpha: 1)
 
     static let streamBGGradientFrom = mode(0xf7f7f7, 0x101214)
     static let streamBGGradientTo = mode(0xfcfcfc, 0x070a0d)

--- a/StreamChat_v3.xcodeproj/project.pbxproj
+++ b/StreamChat_v3.xcodeproj/project.pbxproj
@@ -592,6 +592,7 @@
 		E79AC10B25831A1500C3CE5D /* MessageComposerCommandCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AC10725831A1500C3CE5D /* MessageComposerCommandCollectionViewCell.swift */; };
 		E79AC10C25831A1500C3CE5D /* MessageComposerSuggestionsCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AC10825831A1500C3CE5D /* MessageComposerSuggestionsCollectionView.swift */; };
 		E79AC10D25831A1500C3CE5D /* MessageComposerSuggestionsCollectionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AC10925831A1500C3CE5D /* MessageComposerSuggestionsCollectionViewLayout.swift */; };
+		E7A37B8425ADA66E0055458F /* MessageComposerSuggestionsCommandsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A37B8325ADA66E0055458F /* MessageComposerSuggestionsCommandsHeaderView.swift */; };
 		E7C4E74D259D54B5002889AC /* ChatSwipeableListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C4E74C259D54B5002889AC /* ChatSwipeableListItemView.swift */; };
 		F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */; };
 		F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */; };
@@ -1330,6 +1331,7 @@
 		E79AC10725831A1500C3CE5D /* MessageComposerCommandCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageComposerCommandCollectionViewCell.swift; sourceTree = "<group>"; };
 		E79AC10825831A1500C3CE5D /* MessageComposerSuggestionsCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageComposerSuggestionsCollectionView.swift; sourceTree = "<group>"; };
 		E79AC10925831A1500C3CE5D /* MessageComposerSuggestionsCollectionViewLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageComposerSuggestionsCollectionViewLayout.swift; sourceTree = "<group>"; };
+		E7A37B8325ADA66E0055458F /* MessageComposerSuggestionsCommandsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposerSuggestionsCommandsHeaderView.swift; sourceTree = "<group>"; };
 		E7C4E74C259D54B5002889AC /* ChatSwipeableListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSwipeableListItemView.swift; sourceTree = "<group>"; };
 		F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints_Tests.swift; sourceTree = "<group>"; };
 		F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Mock.swift; sourceTree = "<group>"; };
@@ -2309,7 +2311,6 @@
 				228C7EE42583AF4800AAE9E3 /* UITextView+Extensions.swift */,
 				2241167F258A91280034184D /* String+Extensions.swift */,
 				88A11B092590AFBB0000AC24 /* ChatMessage+Extensions.swift */,
-				880656F8259A2C0800E31D23 /* ChatMessageAttachment+Extensions.swift */,
 				22C23599259CA87B00DC805A /* Animation.swift */,
 				79CCB66D259CBC4F0082F172 /* ChannelNamer.swift */,
 			);
@@ -2703,6 +2704,7 @@
 				22086B47259509AC0007F8C0 /* MessageComposerDocumentAttachmentsCollectionViewLayout.swift */,
 				2210525E256FE16600A5F0DB /* MessageComposerInputSlashCommandView.swift */,
 				22FF4364256E943F00133910 /* MessageComposerSuggestionsViewController.swift */,
+				E7A37B8325ADA66E0055458F /* MessageComposerSuggestionsCommandsHeaderView.swift */,
 				E73A8B2A2578EB2B00FBDC56 /* MessageComposerViewController.swift */,
 				E79AC10725831A1500C3CE5D /* MessageComposerCommandCollectionViewCell.swift */,
 				E79AC10625831A1100C3CE5D /* MessageComposerMentionCollectionViewCell.swift */,
@@ -3275,6 +3277,7 @@
 				8825333E258CE7AC00B77352 /* ChatMessageActionsVC.swift in Sources */,
 				224FF6872562F55F00725DD1 /* Date+Extensions.swift in Sources */,
 				22ADD682256C40410098EFEB /* MessageComposerView.swift in Sources */,
+				E7A37B8425ADA66E0055458F /* MessageComposerSuggestionsCommandsHeaderView.swift in Sources */,
 				8850FE91256558B200C8D534 /* ChatRouter.swift in Sources */,
 				22C2350E259A25A300DC805A /* MessageComposerImageAttachmentsView.swift in Sources */,
 				E701201E2583EBD50036DACD /* CALayer+Extensions.swift in Sources */,


### PR DESCRIPTION
# What this PR do:
 Fixes issues with SuggestionsViewController:
- [X] If Suggestions are already presented, just update the UI while typing some command/mention
- [X] Fix silent failure on unwrapping parentVC for suggestions 
- [X] Make updating content internally in SuggestionsViewController instead of calling `updateContentIfNeeded` somewhere else
- [X] Calculate contentSize for suggestions according to visible cells
- [X] Add CollectionView header to mentions
- [X] Add constant for avatarView height(and width)
- [X] Add constraint for commandImage height 
- [X] Set correct colors for suggestions background and shadow

# How to test this
- Go to ChatVC and try suggestions, you should see header for commands right now, if you change the commands to suggestions and tagging, you should not see any header. Also check the code for the related issues :) 
