### PR TITLE
Fix QueryUsers is used for TCP heatup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Make an OPTIONS request to `connect` instead of `QueryUsers` request to heat up HTTP connection. [#733](https://github.com/GetStream/stream-chat-swift/issues/733)
 
 # [2.6.2](https://github.com/GetStream/stream-chat-swift/releases/tag/2.6.2)
 _December 31, 2020_

--- a/Sources/Client/Client/Client.swift
+++ b/Sources/Client/Client/Client.swift
@@ -257,7 +257,7 @@ public final class Client: Uploader {
             webSocket.connect()
             
             // The improve latency, call the preheat endpoint to set up TCP connection which can be reused.
-            self.request(endpoint: .users(.init(filter: .none))) { (_: Result<EmptyData, ClientError>) in
+            self.request(endpoint: .heatUpTCPConnection) { (_: Result<EmptyData, ClientError>) in
                 self.logger?.log("♨️ TCP connection heated up.")
             }
             


### PR DESCRIPTION
In #401, heatUpTCPConnection was introduced to improve latency, but for unknown reasons the endpoint used was changed to queryUsers in #442. This fixes that and resolves #729