### PR TITLE
Fix message replies are unreachable when message is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Message replies (thread) is unreachable when message itself is deleted [#734](https://github.com/GetStream/stream-chat-swift/issues/734)
 
 # [2.6.2](https://github.com/GetStream/stream-chat-swift/releases/tag/2.6.2)
 _December 31, 2020_

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController+Cells.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController+Cells.swift
@@ -25,12 +25,14 @@ extension ChatViewController {
         let messageStyle = message.isOwn ? style.outgoingMessage : style.incomingMessage
         let cell = tableView.dequeueMessageCell(for: indexPath, style: messageStyle)
         
-        if message.isDeleted {
-            cell.update(info: "This message was deleted.", date: message.deleted)
-        } else if message.isEphemeral {
+        if message.isEphemeral {
             cell.update(text: message.args ?? "")
         } else {
-            cell.update(text: message.textOrArgs)
+            if message.isDeleted {
+                cell.update(info: "This message was deleted.", date: message.deleted)
+            } else {
+                cell.update(text: message.textOrArgs)
+            }
             
             if message.isOwn {
                 cell.readUsersView?.update(readUsers: readUsers)


### PR DESCRIPTION
The new behavior, where thread is still reachable, was requested and is more like indistury (Slack)
Fixes #660