### PR TITLE
Fix photo library permission asked unnecessarily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Photo library permission was asked unnecessarily. 
+  StreamChat v2.x uses `UIImagePickerController` which handles the photo library access internally, so the SDK doesn't ever need full photo library access. 
+  This was introduced with [#199](https://github.com/GetStream/stream-chat-swift/issues/199) incorrectly. 
+  Further reading can be found [here](https://stackoverflow.com/questions/46404628/ios11-photo-library-access-is-possible-even-if-settings-are-set-to-never) [#735](https://github.com/GetStream/stream-chat-swift/issues/735)
 
 # [2.6.2](https://github.com/GetStream/stream-chat-swift/releases/tag/2.6.2)
 _December 31, 2020_

--- a/Sources/UI/Extensions/UIKit/ViewController+ImagePicker.swift
+++ b/Sources/UI/Extensions/UIKit/ViewController+ImagePicker.swift
@@ -24,27 +24,7 @@ extension ViewController {
             return
         }
         
-        let status = PHPhotoLibrary.authorizationStatus()
-        
-        switch status {
-        case .notDetermined:
-            PHPhotoLibrary.requestAuthorization { [weak self] status in
-                DispatchQueue.main.async {
-                    if status == .authorized {
-                        self?.showAuthorizedImagePicker(sourceType: sourceType, completion)
-                    } else {
-                        completion(.failure(.invalidStatus(status)))
-                    }
-                }
-            }
-        case .restricted, .denied:
-            completion(.failure(.invalidStatus(status)))
-        case .authorized:
-            showAuthorizedImagePicker(sourceType: sourceType, completion)
-        @unknown default:
-            print(#file, #function, #line, "Unknown authorization status: \(status.rawValue)")
-            return
-        }
+        showAuthorizedImagePicker(sourceType: sourceType, completion)
     }
     
     private func showAuthorizedImagePicker(sourceType: UIImagePickerController.SourceType,


### PR DESCRIPTION
Closes #657

Tested and works. SDK can access assets selected by user, and camera asks for permission automatically.

This makes me wonder why so many apps require full access while they could get by with this approach... (Nearly all messaging apps, marketplace apps, etc...)