### PR TITLE
Introduce custom layout for message list

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.swift
@@ -53,6 +53,14 @@ open class _СhatMessageCollectionViewCell<ExtraData: ExtraDataTypes>: Collectio
     override open func preferredLayoutAttributesFitting(
         _ layoutAttributes: UICollectionViewLayoutAttributes
     ) -> UICollectionViewLayoutAttributes {
+        guard hasCompletedStreamSetup else {
+            // We cannot calculate size properly right now, because our view hierarchy is not ready yet.
+            // If we just return default size, small text bubbles would not resize itself properly for no reason.
+            let attributes = layoutAttributes.copy() as! UICollectionViewLayoutAttributes
+            attributes.frame.size = .zero
+            return attributes
+        }
+
         let preferredAttributes = super.preferredLayoutAttributesFitting(layoutAttributes)
 
         let targetSize = CGSize(

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.swift
@@ -13,12 +13,20 @@ open class _СhatMessageCollectionViewCell<ExtraData: ExtraDataTypes>: Collectio
     public var message: _ChatMessageGroupPart<ExtraData>? {
         didSet { updateContentIfNeeded() }
     }
-    
+
     // MARK: - Subviews
 
     public private(set) lazy var messageView = uiConfig.messageList.messageContentView.init().withoutAutoresizingMaskConstraints
-    
+    private var hasCompletedStreamSetup = false
+
     // MARK: - Lifecycle
+
+    override open func didMoveToSuperview() {
+        super.didMoveToSuperview()
+
+        guard superview != nil, !hasCompletedStreamSetup else { return }
+        hasCompletedStreamSetup = true
+    }
 
     override open func setUpLayout() {
         contentView.addSubview(messageView)
@@ -41,23 +49,23 @@ open class _СhatMessageCollectionViewCell<ExtraData: ExtraDataTypes>: Collectio
 
         message = nil
     }
-    
+
     override open func preferredLayoutAttributesFitting(
         _ layoutAttributes: UICollectionViewLayoutAttributes
     ) -> UICollectionViewLayoutAttributes {
         let preferredAttributes = super.preferredLayoutAttributesFitting(layoutAttributes)
-        
+
         let targetSize = CGSize(
             width: layoutAttributes.frame.width,
             height: UIView.layoutFittingCompressedSize.height
         )
-        
+
         preferredAttributes.frame.size = contentView.systemLayoutSizeFitting(
             targetSize,
             withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )
-        
+
         return preferredAttributes
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
@@ -2,146 +2,308 @@
 // Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
-/// This layout flips items such that item at indexPath 0-0 appears at the bottom of collectionView,
-/// while last item appears first.
+/// Custom Table View like layout that position item at index path 0-0 on bottom of the list.
 ///
-/// Such approach comes with self-sizing cell issue: when you scroll to "estimated" cell bottom anchor, cell size calculated
-/// and you may jump right into middle of cell, because `collectionViewContentSize` have been changed,
-/// while `contentOffset` stay same.
-/// To fight it we lock `collectionViewContentSize`, now newly calculated cell "expands" up into invisible yet area, removing jumps.
-open class ChatMessageListCollectionViewLayout: UICollectionViewFlowLayout {
-    // MARK: - Init & Deinit
-    
-    override public required init() {
-        super.init()
-        commonInit()
-    }
-    
-    public required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        commonInit()
-    }
-    
-    private func commonInit() {
-        minimumInteritemSpacing = 0
-        minimumLineSpacing = 4
-    }
+/// Unlike `UICollectionViewFlowLayout` we ignore some invalidation calls and persist items attributes between updates.
+/// This resolves problem when on item reload layout would change content offset and user ends up on completely different item.
+/// Layout intended for batch updates and right now I have no idea how it will react to `collectionView.reloadData()`.
+open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
+    public struct LayoutItem {
+        let id = UUID()
+        public var offset: CGFloat
+        public var height: CGFloat
 
-    var bottomContentOffsetBeforeInvalidation: CGFloat?
-    /// Use this flag to signal that all cells layout have been calculated and it's safe to remove "infinite scroll" hack.
-    /// e.g. set to `true` when showing top most cell, set to `false` when new cell appears
-    var layoutCached: Bool = false {
-        willSet {
-            guard newValue != layoutCached else { return }
-            let offsetY = collectionView?.contentOffset.y ?? 0
-            bottomContentOffsetBeforeInvalidation = collectionViewContentSize.height - offsetY
+        public var maxY: CGFloat {
+            offset + height
         }
-        didSet {
-            guard oldValue != layoutCached else { return }
-            let context = UICollectionViewFlowLayoutInvalidationContext()
-            context.invalidateFlowLayoutAttributes = true
-            invalidateLayout(with: context)
+
+        public init(offset: CGFloat, height: CGFloat) {
+            self.offset = offset
+            self.height = height
+        }
+
+        public func attribute(for index: Int, width: CGFloat) -> UICollectionViewLayoutAttributes {
+            let attribute = UICollectionViewLayoutAttributes(forCellWith: IndexPath(item: index, section: 0))
+            attribute.frame = CGRect(x: 0, y: offset, width: width, height: height)
+            return attribute
         }
     }
 
-    open var zeroOffset: CGPoint {
-        CGPoint(
-            x: 0,
-            y: collectionViewContentSize.height - realContentSize.height
-        )
-    }
+    /// Layout items before currently running batch update
+    open var previousItems: [LayoutItem] = []
+    /// Actual layout
+    open var currentItems: [LayoutItem] = []
 
-    open var realContentSize: CGSize {
-        super.collectionViewContentSize
-    }
-    
-    // MARK: - Overrides
+    /// With better approximation you are getting better performance
+    open var estimatedItemHeight: CGFloat = 200
+    /// Vertical spacing between items
+    open var spacing: CGFloat = 4
+
+    /// Items that have been added to collectionview during currently running batch updates
+    open var appearingItems: Set<IndexPath> = []
+    /// Items that have been removed from collectionview during currently running batch updates
+    open var disappearingItems: Set<IndexPath> = []
+    /// We need to cache attributes used for initial/final state of added/removed items to update them after AutoLayout pass.
+    /// This will prevent items to appear with `estimatedItemHeight` and animating to real size
+    open var animatingAttributes: [IndexPath: UICollectionViewLayoutAttributes] = [:]
 
     override open var collectionViewContentSize: CGSize {
-        let size = super.collectionViewContentSize
-        if layoutCached {
-            return size
-        }
-        return CGSize(width: size.width, height: 100_000)
+        CGSize(
+            width: collectionView!.bounds.width,
+            height: currentItems.first?.maxY ?? 0
+        )
     }
-    
+
+    open var currentCollectionViewWidth: CGFloat = 0
+
+    /// Used to prevent layout issues during batch updates.
+    ///
+    /// Before batch updates collection view says to invalidate layout with `invalidateDataSourceCounts`.
+    /// Next it ask us for attributes for new items before says which items are new. So we have no way to properly calculate it.
+    /// `UICollectionViewFlowLayout` uses private API to get this info. We are don not have such privilege.
+    /// If we return wrong attributes user will see artifacts and broken layout during batch update animation.
+    /// By not returning any attributes during batch updates we are able to prevent such artifacts.
+    open var preBatchUpdatesCall = false
+
+    // MARK: - Initialization
+
+    override public required init() {
+        super.init()
+    }
+
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    // MARK: - Layout invalidation
+
+    override open func invalidateLayout(with context: UICollectionViewLayoutInvalidationContext) {
+        preBatchUpdatesCall = context.invalidateDataSourceCounts &&
+            !context.invalidateEverything
+        super.invalidateLayout(with: context)
+    }
+
+    override open func shouldInvalidateLayout(
+        forPreferredLayoutAttributes preferredAttributes: UICollectionViewLayoutAttributes,
+        withOriginalAttributes originalAttributes: UICollectionViewLayoutAttributes
+    ) -> Bool {
+        let idx = originalAttributes.indexPath.item
+        return preferredAttributes.frame.minY != currentItems[idx].offset
+            || preferredAttributes.frame.height != currentItems[idx].height
+    }
+
+    override open func invalidationContext(
+        forPreferredLayoutAttributes preferredAttributes: UICollectionViewLayoutAttributes,
+        withOriginalAttributes originalAttributes: UICollectionViewLayoutAttributes
+    ) -> UICollectionViewLayoutInvalidationContext {
+        let invalidationContext = super.invalidationContext(
+            forPreferredLayoutAttributes: preferredAttributes,
+            withOriginalAttributes: originalAttributes
+        )
+        let idx = originalAttributes.indexPath.item
+
+        let delta = preferredAttributes.frame.height - currentItems[idx].height
+        currentItems[idx].height = preferredAttributes.frame.height
+        // if item have been inserted recently or deleted, we need to update its attributes to prevent weird flickering
+        animatingAttributes[preferredAttributes.indexPath]?.frame.size.height = preferredAttributes.frame.height
+
+        // we are bottom-top layout with 0 being most bottom item. So when item X changes its attributes, it affect all
+        // items before it in [0; X] range.
+        let invalidNow = (0...idx).map { IndexPath(item: $0, section: 0) }
+        invalidationContext.invalidateItems(at: invalidNow)
+
+        for i in 0..<idx {
+            currentItems[i].offset += delta
+        }
+        invalidationContext.contentSizeAdjustment = CGSize(width: 0, height: delta)
+
+        // when we scrolling up and item above screens top edge changes its attributes it will push all items below it to bottom
+        // making unpleasant jump. To prevent it we need to adjust current content offset by item delta
+        let isSizingElementAboveTopEdge = originalAttributes.frame.minY < (collectionView?.contentOffset.y ?? 0)
+        // when collection view is idle and one of items change its attributes we adjust content offset to stick with bottom item
+        let isScrolling: Bool = {
+            guard let cv = collectionView else { return false }
+            return cv.isDragging || cv.isDecelerating
+        }()
+        if isSizingElementAboveTopEdge || !isScrolling {
+            invalidationContext.contentOffsetAdjustment = CGPoint(x: 0, y: delta)
+        }
+
+        return invalidationContext
+    }
+
+    // MARK: - Animation updates
+
+    override open func prepare(forCollectionViewUpdates updateItems: [UICollectionViewUpdateItem]) {
+        previousItems = currentItems
+        let delete: (UICollectionViewUpdateItem) -> Void = { update in
+            guard let ip = update.indexPathBeforeUpdate else { return }
+            let idx = ip.item
+            self.disappearingItems.insert(ip)
+            var delta = self.currentItems[idx].height
+            if idx > 0 {
+                delta += self.spacing
+            }
+            for i in 0..<idx {
+                self.currentItems[i].offset -= delta
+            }
+            self.currentItems.remove(at: idx)
+        }
+
+        let insert: (UICollectionViewUpdateItem) -> Void = { update in
+            guard let ip = update.indexPathAfterUpdate else { return }
+            self.appearingItems.insert(ip)
+            let idx = ip.item
+            let item: LayoutItem
+            if idx == self.currentItems.count {
+                item = LayoutItem(offset: 0, height: 60)
+            } else {
+                item = LayoutItem(
+                    offset: self.currentItems[idx].maxY + self.spacing,
+                    height: self.currentItems[idx].height
+                )
+            }
+            let delta = item.height + self.spacing
+            for i in 0..<idx {
+                self.currentItems[i].offset += delta
+            }
+            self.currentItems.insert(item, at: idx)
+        }
+
+        for update in updateItems {
+            switch update.updateAction {
+            case .delete:
+                delete(update)
+            case .insert:
+                insert(update)
+            case .move:
+                delete(update)
+                insert(update)
+            case .reload, .none: break
+            @unknown default: break
+            }
+        }
+
+        preBatchUpdatesCall = false
+        super.prepare(forCollectionViewUpdates: updateItems)
+    }
+
+    override open func finalizeCollectionViewUpdates() {
+        appearingItems.removeAll()
+        disappearingItems.removeAll()
+        animatingAttributes.removeAll()
+        super.finalizeCollectionViewUpdates()
+        // for some reason when adding / deleting items cv do not reload attributes for rows out of view
+        // this will force reload
+        invalidateLayout()
+    }
+
+    // MARK: - Main layout access
+
     override open func prepare() {
         super.prepare()
-        
-        estimatedItemSize = .init(
-            width: collectionView?.bounds.width ?? 0,
-            height: 60
-        )
 
-        if let offset = bottomContentOffsetBeforeInvalidation {
-            collectionView?.contentOffset = CGPoint(
-                x: 0,
-                y: collectionViewContentSize.height - offset
-            )
-            bottomContentOffsetBeforeInvalidation = nil
+        guard currentItems.isEmpty else { return }
+        guard let cv = collectionView else { return }
+        currentCollectionViewWidth = cv.bounds.width
+
+        let count = cv.numberOfItems(inSection: 0)
+        guard count > 0 else { return } // swiftlint:disable:this empty_count
+
+        let height = estimatedItemHeight * CGFloat(count) + spacing * CGFloat(count - 1)
+        var offset: CGFloat = height
+        for _ in 0..<count {
+            offset -= estimatedItemHeight
+            let item = LayoutItem(offset: offset, height: estimatedItemHeight)
+            currentItems.append(item)
+            offset -= spacing
         }
+
+        // scroll to make first item visible
+        cv.contentOffset.y = currentItems[0].maxY - cv.bounds.height
     }
 
     override open func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
-        let contentSize = collectionViewContentSize
-        let portalRect = CGRect(
-            x: rect.origin.x,
-            y: contentSize.height - rect.origin.y - rect.height,
-            width: rect.width,
-            height: rect.height
-        )
-        return super.layoutAttributesForElements(in: portalRect)?
-            .map(flip(_:))
+        guard !preBatchUpdatesCall else { return nil }
+
+        return currentItems
+            .enumerated()
+            .filter { _, item in
+                let isBeforeRect = item.offset < rect.minY && item.maxY < rect.minY
+                let isAfterRect = rect.minY < item.offset && rect.maxY < item.offset
+                return !(isBeforeRect || isAfterRect)
+            }
+            .map {
+                $1.attribute(for: $0, width: currentCollectionViewWidth)
+            }
     }
+
+    // MARK: - Layout for collection view items
 
     override open func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
-        super.layoutAttributesForItem(at: indexPath).map(flip(_:))
+        guard !preBatchUpdatesCall else { return nil }
+
+        guard indexPath.item < currentItems.count else { return nil }
+        let idx = indexPath.item
+        return currentItems[idx].attribute(for: idx, width: currentCollectionViewWidth)
     }
 
-    override open func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint) -> CGPoint {
-        if layoutCached {
-            return super.targetContentOffset(forProposedContentOffset: proposedContentOffset)
+    override open func initialLayoutAttributesForAppearingItem(at itemIndexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        let idx = itemIndexPath.item
+        if appearingItems.contains(itemIndexPath) {
+            // this is item that have been inserted into collection view in current batch update
+            let attribute = currentItems[idx].attribute(for: idx, width: currentCollectionViewWidth)
+            animatingAttributes[itemIndexPath] = attribute
+            return attribute
+        } else {
+            // this is item that already presented in collection view, but collection view decided to reload it
+            // by removing and inserting it back (4head)
+            // to properly animate possible change of such item, we need to return its attributes BEFORE batch update
+            let id = idForItem(at: idx)
+            return oldIdxForItem(with: id).map { oldIdx in
+                previousItems[oldIdx].attribute(for: oldIdx, width: currentCollectionViewWidth)
+            }
         }
-        // Content offset may be zero only when view just loaded for first time and needs to be scrolled to bottom
-        if proposedContentOffset == .zero {
-            let insets = collectionView?.contentInset ?? .zero
-            return CGPoint(
-                x: 0,
-                y: collectionViewContentSize.height - (collectionView?.bounds.height ?? 0) + insets.top + insets.bottom
-            )
-        }
-        if proposedContentOffset.y < zeroOffset.y {
-            return zeroOffset
-        }
-        return super.targetContentOffset(forProposedContentOffset: proposedContentOffset)
     }
 
-    override open func targetContentOffset(
-        forProposedContentOffset proposedContentOffset: CGPoint,
-        withScrollingVelocity velocity: CGPoint
-    ) -> CGPoint {
-        if layoutCached {
-            return super.targetContentOffset(forProposedContentOffset: proposedContentOffset, withScrollingVelocity: velocity)
+    override open func finalLayoutAttributesForDisappearingItem(at itemIndexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        let idx = itemIndexPath.item
+        let id = oldIdForItem(at: idx)
+        if disappearingItems.contains(itemIndexPath) {
+            // item gets removed from collection view, we don't do any special delete animations for now, so just return
+            // item attributes BEFORE batch update and let it fade away
+            let attribute = previousItems[idx].attribute(for: idx, width: currentCollectionViewWidth)
+            attribute.alpha = 0
+            return attribute
+        } else if let newIdx = idxForItem(with: id) {
+            // this is item that will stay in collection view, but collection view decided to reload it
+            // by removing and inserting it back (4head)
+            // to properly animate possible change of such item, we need to return its attributes AFTER batch update
+            let attribute = currentItems[newIdx].attribute(for: newIdx, width: currentCollectionViewWidth)
+            animatingAttributes[attribute.indexPath] = attribute
+            return attribute
         }
-        if proposedContentOffset.y < zeroOffset.y {
-            return zeroOffset
-        }
-        return super.targetContentOffset(forProposedContentOffset: proposedContentOffset, withScrollingVelocity: velocity)
+
+        return super.finalLayoutAttributesForDisappearingItem(at: itemIndexPath)
     }
 
-    // MARK: - Dark Magic
+    // MARK: - Access Layout Item
 
-    private func flip(_ attribute: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
-        let contentSize = collectionViewContentSize
-        attribute.frame = CGRect(
-            x: attribute.frame.origin.x,
-            y: contentSize.height - attribute.frame.origin.y - attribute.frame.height,
-            width: attribute.frame.width,
-            height: attribute.frame.height
-        )
-        return attribute
+    open func idForItem(at idx: Int) -> UUID {
+        currentItems[idx].id
+    }
+
+    open func idxForItem(with id: UUID) -> Int? {
+        currentItems.firstIndex { $0.id == id }
+    }
+
+    open func oldIdForItem(at idx: Int) -> UUID {
+        previousItems[idx].id
+    }
+
+    open func oldIdxForItem(with id: UUID) -> Int? {
+        previousItems.firstIndex { $0.id == id }
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -69,6 +69,7 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: ViewController,
         let outgoingCell = uiConfig.messageList.outgoingMessageCell
         collection.register(incomingCell, forCellWithReuseIdentifier: incomingCell.reuseId)
         collection.register(outgoingCell, forCellWithReuseIdentifier: outgoingCell.reuseId)
+        collection.isPrefetchingEnabled = false
         collection.showsHorizontalScrollIndicator = false
         collection.alwaysBounceVertical = true
         collection.keyboardDismissMode = .onDrag
@@ -82,11 +83,6 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: ViewController,
     public private(set) var needsToScrollToMostRecentMessage = true
     /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
     public private(set) var needsToScrollToMostRecentMessageAnimated = false
-
-    /// Consider to call `setLayoutCached(_ value:)` instead
-    public private(set) var needsLayoutSwitch = false
-    /// Consider to call `setLayoutCached(_ value:)` instead
-    public private(set) var newLayoutCachedValue = false
 
     // MARK: - Life Cycle
 
@@ -136,20 +132,6 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: ViewController,
     }
 
     public func updateMessages(with changes: [ListChange<_ChatMessage<ExtraData>>], completion: ((Bool) -> Void)? = nil) {
-        if let max = collectionView.indexPathsForVisibleItems.map(\.item).max() {
-            let hasChangesOnTop = changes.contains { change in
-                if case let .insert(_, index) = change, index.item > max {
-                    return true
-                }
-                return false
-            }
-            if hasChangesOnTop {
-                setLayoutCached(false)
-            }
-        } else {
-            setLayoutCached(false)
-        }
-
         collectionView.performBatchUpdates {
             for change in changes {
                 switch change {
@@ -179,28 +161,6 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: ViewController,
         guard let cell = collectionView.cellForItem(at: ip) as? _СhatMessageCollectionViewCell<ExtraData> else { return }
 
         didSelectMessageCell(cell)
-    }
-
-    // MARK: - Layout optimizations
-
-    public func setLayoutCached(_ value: Bool) {
-        needsLayoutSwitch = true
-        newLayoutCachedValue = value
-        // invalidating layout while collection view is not in idle state, leads to crash
-        if collectionView.isDecelerating || collectionView.isDragging {
-            return
-        }
-        // I have no idea why it crashing without dispatch
-        DispatchQueue.main.async {
-            self.switchLayoutIfNeeded()
-        }
-    }
-
-    public func switchLayoutIfNeeded() {
-        if needsLayoutSwitch {
-            collectionViewLayout.layoutCached = newLayoutCachedValue
-        }
-        needsLayoutSwitch = false
     }
 
     // MARK: - UICollectionViewDataSource
@@ -259,12 +219,7 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: ViewController,
     ) {
         if indexPath.row + 1 >= collectionView.numberOfItems(inSection: 0) {
             dataSource.loadMoreMessages(self)
-            setLayoutCached(true)
         }
-    }
-
-    public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        switchLayoutIfNeeded()
     }
 
     // MARK: - ChatMessageActionsVCDelegate

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -75,6 +75,7 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: ViewController,
         collection.keyboardDismissMode = .onDrag
         collection.dataSource = self
         collection.delegate = self
+        collection.isHidden = true
 
         return collection
     }()
@@ -84,7 +85,22 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: ViewController,
     /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
     public private(set) var needsToScrollToMostRecentMessageAnimated = false
 
+    /// When controller loaded first time, message layout is in estimated state.
+    /// We force layout reload on first appear, before showing message list.
+    /// This way we able to hide ugly jump
+    public private(set) var hideInitialLayout = true
+
     // MARK: - Life Cycle
+
+    override open func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if hideInitialLayout {
+            collectionView.reloadData()
+            collectionView.isHidden = false
+            hideInitialLayout = false
+        }
+    }
 
     override open func setUp() {
         super.setUp()


### PR DESCRIPTION
Custom Table View like layout that position item at index path 0-0 on bottom of the list. 
Unlike `UICollectionViewFlowLayout` we ignore some invalidation calls and persist items attributes between updates.
This resolves problem when on item reload layout would change content offset and user ends up on completely different item.
Layout intended for batch updates and right now I have no idea how it will react to `collectionView.reloadData()` (so far fine).

During testing on iPhone SE (1st gen) iOS 14.2 I was able to achieve hitch ratio:
- initial scroll from bottom to top: 49 ms/s
- scroll from top to bottom on already layouted list: 46 ms/s

So whole collection view layout related logic bring almost no overhead. (This are still awful numbers, Apple do not recommend ratio over 10 ms/s)

Known issues:
> when message list first time appears on screen, all items are in estimated height state (system just doesn't call autolayout updates until later)

Worked around by hiding message list till first layout reload

> messages that contains just small text return wrong size in `preferredLayoutAttributesFitting` initially and proper one after sometime. This cause unpleasant jump when cell in the middle of screen resize.

Solved by returning zero size for cells that haven't been injected to tree yet.

---
Hitch - any time a frame appears on screen later than expected
Hitch duration - time past deadline for frame preparation (in ms)
Hitch ratio = combined duration of all hitches / total test duration (in ms/s)
https://developer.apple.com/videos/play/tech-talks/10855