### PR TITLE
V2: Add channel property to message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
+### ✅ Added
+- `Message.channel` to access the channel from a message. [#650](https://github.com/GetStream/stream-chat-swift/issues/650)
+
 ### 🐞 Fixed
 - Make an OPTIONS request to `connect` instead of `QueryUsers` request to heat up HTTP connection. [#733](https://github.com/GetStream/stream-chat-swift/issues/733)
 - ComposerView layout overlap when both image and file uploaded [#738](https://github.com/GetStream/stream-chat-swift/issues/738)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Upcoming
 
 ### ✅ Added
-- `Message.channel` to access the channel from a message. [#650](https://github.com/GetStream/stream-chat-swift/issues/650)
+- `Message.channel` to access the channel from a message. PS: Due to a temporary backend issue, it's possible that `Message.channel.config` will not be accurate when using the `search` functionality. This should be fixed soon. [#650](https://github.com/GetStream/stream-chat-swift/issues/650)
 
 ### 🐞 Fixed
 - Make an OPTIONS request to `connect` instead of `QueryUsers` request to heat up HTTP connection. [#733](https://github.com/GetStream/stream-chat-swift/issues/733)

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -197,6 +197,7 @@ public final class Channel: Codable {
         let members = try container.decodeIfPresent([Member].self, forKey: .members) ?? []
         self.members = Set<Member>(members)
         invitedMembers = Set<Member>()
+        // Fallback because config doesn't come in message search and to avoid breaking API by making it optional
         let config = (try? container.decode(Config.self, forKey: .config)) ?? Config()
         self.config = config
         created = try container.decodeIfPresent(Date.self, forKey: .created) ?? config.created

--- a/Sources/Client/Model/Channel/Channel.swift
+++ b/Sources/Client/Model/Channel/Channel.swift
@@ -197,7 +197,7 @@ public final class Channel: Codable {
         let members = try container.decodeIfPresent([Member].self, forKey: .members) ?? []
         self.members = Set<Member>(members)
         invitedMembers = Set<Member>()
-        let config = try container.decode(Config.self, forKey: .config)
+        let config = (try? container.decode(Config.self, forKey: .config)) ?? Config()
         self.config = config
         created = try container.decodeIfPresent(Date.self, forKey: .created) ?? config.created
         deleted = try container.decodeIfPresent(Date.self, forKey: .deleted)

--- a/Sources/Client/Model/Message/Message.swift
+++ b/Sources/Client/Model/Message/Message.swift
@@ -14,6 +14,7 @@ public struct Message: Codable {
         case id
         case type
         case user
+        case channel
         case created = "created_at"
         case updated = "updated_at"
         case deleted = "deleted_at"
@@ -44,6 +45,8 @@ public struct Message: Codable {
     public var type: MessageType
     /// A user (see `User`).
     public var user: User
+    /// A channel (see `Channel`).
+    public var channel: Channel?
     /// A created date.
     public var created: Date
     /// A updated date.
@@ -143,6 +146,7 @@ public struct Message: Codable {
                 text: String,
                 silent: Bool = false,
                 user: User = User.current,
+                channel: Channel? = nil,
                 command: String? = nil,
                 args: String? = nil,
                 attachments: [Attachment] = [],
@@ -162,6 +166,7 @@ public struct Message: Codable {
         self.text = text
         self.isSilent = silent
         self.user = user
+        self.channel = channel
         self.command = command
         self.args = args
         self.attachments = attachments
@@ -199,6 +204,7 @@ public struct Message: Codable {
         id = try container.decode(String.self, forKey: .id)
         type = try container.decode(MessageType.self, forKey: .type)
         user = try container.decode(User.self, forKey: .user)
+        channel = try container.decode(Channel.self, forKey: .channel)
         created = try container.decode(Date.self, forKey: .created)
         updated = try container.decode(Date.self, forKey: .updated)
         deleted = try container.decodeIfPresent(Date.self, forKey: .deleted)

--- a/Sources/Client/Model/Message/Message.swift
+++ b/Sources/Client/Model/Message/Message.swift
@@ -204,7 +204,7 @@ public struct Message: Codable {
         id = try container.decode(String.self, forKey: .id)
         type = try container.decode(MessageType.self, forKey: .type)
         user = try container.decode(User.self, forKey: .user)
-        channel = try container.decode(Channel.self, forKey: .channel)
+        channel = try container.decodeIfPresent(Channel.self, forKey: .channel)
         created = try container.decode(Date.self, forKey: .created)
         updated = try container.decode(Date.self, forKey: .updated)
         deleted = try container.decodeIfPresent(Date.self, forKey: .deleted)


### PR DESCRIPTION
Had to add a fallback for `Config` because it doesn't come in result of message search and I didn't want to break API by making it optional.

Closes #650 