### PR TITLE
V2: Fix table view not at bottom when last message is large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Upcoming
 
 ### 🐞 Fixed
+- Fixed chat table view not starting at the bottom when the last message is long. [#653](https://github.com/GetStream/stream-chat-swift/issues/653)
 - Make an OPTIONS request to `connect` instead of `QueryUsers` request to heat up HTTP connection. [#733](https://github.com/GetStream/stream-chat-swift/issues/733)
 - ComposerView layout overlap when both image and file uploaded [#738](https://github.com/GetStream/stream-chat-swift/issues/738)
 - Message replies (thread) is unreachable when message itself is deleted [#734](https://github.com/GetStream/stream-chat-swift/issues/734)

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -468,7 +468,8 @@ extension ChatViewController {
             tableView.reloadData()
             
             if scrollToRow >= 0 && (isLoading || canScroll) {
-                tableView.scrollToRowIfPossible(at: scrollToRow, animated: false)
+                let isBottom = scrollToRow == items.count - 1
+                tableView.scrollToRowIfPossible(at: scrollToRow, scrollPosition: isBottom ? .bottom : .top, animated: false)
             }
             
             if !items.isEmpty, case .loading = items[0] {

--- a/Sources/UI/Extensions/UIKit/UITableView+Extensions.swift
+++ b/Sources/UI/Extensions/UIKit/UITableView+Extensions.swift
@@ -21,7 +21,7 @@ extension UITableView {
         scrollToRowIfPossible(at: Int.max, animated: animated)
     }
     
-    public func scrollToRowIfPossible(at row: Int, animated: Bool = true) {
+    public func scrollToRowIfPossible(at row: Int, scrollPosition: ScrollPosition = .top, animated: Bool = true) {
         let sectionsCount = numberOfSections
         
         guard sectionsCount > 0 else {
@@ -36,7 +36,7 @@ extension UITableView {
         
         let row: Int = min(row, rowsCount - 1)
         setContentOffset(contentOffset, animated: false)
-        scrollToRow(at: IndexPath(row: row, section: sectionsCount - 1), at: .top, animated: animated)
+        scrollToRow(at: IndexPath(row: row, section: sectionsCount - 1), at: scrollPosition, animated: animated)
     }
     
     func layoutFooterView() {


### PR DESCRIPTION
When scroll to row command is for the last item, it's safer to scroll to the bottom of it (happens after view is loaded). When it's for another item, top is better (happens when loading more messages). 

Closes #653