### PR TITLE
[CIS-431] Use Int~32~64 for database

### DIFF
--- a/Sources_v3/StreamChat/Controllers/CurrentUserController/CurrentUserController+Combine_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/CurrentUserController/CurrentUserController+Combine_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Combine
@@ -68,7 +68,7 @@ class CurrentUserController_Combine_Tests: iOS13TestCase {
             $0.currentUserController(controller!, didChangeCurrentUserUnreadCount: newUnreadCount)
         }
         
-        XCTAssertEqual(recording.output, [.noUnread, .dummy])
+        XCTAssertEqual(recording.output, [.noUnread, newUnreadCount])
     }
     
     func test_connectionStatusPublisher() throws {

--- a/Sources_v3/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -20,8 +20,8 @@ class ChannelDTO: NSManagedObject {
     @NSManaged var updatedAt: Date
     @NSManaged var lastMessageAt: Date?
     
-    @NSManaged var watcherCount: Int16
-    @NSManaged var memberCount: Int16
+    @NSManaged var watcherCount: Int64
+    @NSManaged var memberCount: Int64
     
     @NSManaged var isFrozen: Bool
     
@@ -91,7 +91,7 @@ extension NSManagedObjectContext {
         dto.updatedAt = payload.updatedAt
         dto.defaultSortingAt = payload.lastMessageAt ?? payload.createdAt
         dto.lastMessageAt = payload.lastMessageAt
-        dto.memberCount = Int16(payload.memberCount)
+        dto.memberCount = Int64(clamping: payload.memberCount)
         
         dto.isFrozen = payload.isFrozen
         
@@ -131,7 +131,7 @@ extension NSManagedObjectContext {
             dto.members.insert(member)
         }
         
-        dto.watcherCount = Int16(payload.watcherCount ?? 0)
+        dto.watcherCount = Int64(clamping: payload.watcherCount ?? 0)
         
         return dto
     }

--- a/Sources_v3/StreamChat/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/CurrentUserDTO.swift
@@ -7,8 +7,8 @@ import Foundation
 
 @objc(CurrentUserDTO)
 class CurrentUserDTO: NSManagedObject {
-    @NSManaged var unreadChannelsCount: Int16
-    @NSManaged var unreadMessagesCount: Int16
+    @NSManaged var unreadChannelsCount: Int64
+    @NSManaged var unreadMessagesCount: Int64
     
     /// Into this field the creation date of last locally received event is saved.
     /// The date later serves as reference date for `/sync` endpoint
@@ -81,10 +81,9 @@ extension NSManagedObjectContext: CurrentUserDatabaseSession {
         guard let dto = currentUser() else {
             throw ClientError.CurrentUserDoesNotExist()
         }
-        
-        // TODO: Fix this properly in CIS-431
-        dto.unreadChannelsCount = Int16(clamping: count.channels)
-        dto.unreadMessagesCount = Int16(clamping: count.messages)
+                
+        dto.unreadChannelsCount = Int64(clamping: count.channels)
+        dto.unreadMessagesCount = Int64(clamping: count.messages)
     }
     
     func saveCurrentUserDevices(_ devices: [DevicePayload], clearExisting: Bool) throws {

--- a/Sources_v3/StreamChat/Database/DTOs/CurrentUserDTO_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/CurrentUserDTO_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -49,8 +49,8 @@ class CurrentUserModelDTO_Tests: XCTestCase {
             Assert.willBeEqual(payload.createdAt, loadedCurrentUser?.user.userCreatedAt)
             Assert.willBeEqual(payload.updatedAt, loadedCurrentUser?.user.userUpdatedAt)
             Assert.willBeEqual(payload.lastActiveAt, loadedCurrentUser?.user.lastActivityAt)
-            Assert.willBeEqual(Int16(payload.unreadCount!.messages), loadedCurrentUser?.unreadMessagesCount)
-            Assert.willBeEqual(Int16(payload.unreadCount!.channels), loadedCurrentUser?.unreadChannelsCount)
+            Assert.willBeEqual(Int64(payload.unreadCount!.messages), loadedCurrentUser?.unreadMessagesCount)
+            Assert.willBeEqual(Int64(payload.unreadCount!.channels), loadedCurrentUser?.unreadChannelsCount)
             Assert.willBeEqual(payload.extraData, loadedCurrentUser.map {
                 try? JSONDecoder.default.decode(DefaultExtraData.User.self, from: $0.user.extraData)
             })

--- a/Sources_v3/StreamChat/Database/DTOs/MessageReactionDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/MessageReactionDTO.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -104,7 +104,7 @@ extension NSManagedObjectContext {
         )
         
         dto.type = payload.type.rawValue
-        dto.score = Int64(payload.score)
+        dto.score = Int64(clamping: payload.score)
         dto.createdAt = payload.createdAt
         dto.updatedAt = payload.updatedAt
         dto.extraData = try JSONEncoder.default.encode(payload.extraData)

--- a/Sources_v3/StreamChat/Database/DTOs/MessageReactionDTO_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/MessageReactionDTO_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData

--- a/Sources_v3/StreamChat/Database/DatabaseSession_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseSession_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -173,8 +173,8 @@ class DatabaseSession_Tests: StressTestCase {
         let currentUser = database.viewContext.currentUser()
         
         // Assert unread count is taken from event payload
-        XCTAssertEqual(Int16(eventPayload.unreadCount!.messages), currentUser?.unreadMessagesCount)
-        XCTAssertEqual(Int16(eventPayload.unreadCount!.channels), currentUser?.unreadChannelsCount)
+        XCTAssertEqual(Int64(eventPayload.unreadCount!.messages), currentUser?.unreadMessagesCount)
+        XCTAssertEqual(Int64(eventPayload.unreadCount!.channels), currentUser?.unreadChannelsCount)
     }
     
     func test_saveCurrentUserUnreadCount_failsIfThereIsNoCurrentUser() throws {

--- a/Sources_v3/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources_v3/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -99,8 +99,8 @@
     <entity name="CurrentUserDTO" representedClassName="CurrentUserDTO" syncable="YES">
         <attribute name="lastReceivedEventDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="uniquenessKey" attributeType="String" defaultValueString="this is an immmutable arbitrary key which makes sure we have only once instance of CurrentUserDTO in the db"/>
-        <attribute name="unreadChannelsCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="unreadMessagesCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="unreadChannelsCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="unreadMessagesCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="devices" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DeviceDTO" inverseName="user" inverseEntity="DeviceDTO"/>
         <relationship name="flaggedMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="flaggedBy" inverseEntity="MessageDTO"/>
         <relationship name="flaggedUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="flaggedBy" inverseEntity="UserDTO"/>

--- a/Sources_v3/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources_v3/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -33,11 +33,11 @@
         <attribute name="imageURL" optional="YES" attributeType="URI"/>
         <attribute name="isFrozen" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="lastMessageAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="memberCount" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="memberCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="typeRawValue" optional="YES" attributeType="String"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="watcherCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="watcherCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="attachments" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AttachmentDTO" inverseName="channel" inverseEntity="AttachmentDTO"/>
         <relationship name="createdBy" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="createdChannels" inverseEntity="UserDTO"/>
         <relationship name="currentlyTypingMembers" toMany="YES" deletionRule="Nullify" destinationEntity="MemberDTO" inverseName="typingIn" inverseEntity="MemberDTO"/>

--- a/Tests_v3/StreamChatTests/Dummy data/UnreadCount.swift
+++ b/Tests_v3/StreamChatTests/Dummy data/UnreadCount.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -7,6 +7,6 @@ import Foundation
 
 extension UnreadCount {
     static var dummy: Self {
-        .init(channels: 10, messages: 323)
+        .init(channels: Int.random(in: 0...Int.max), messages: Int.random(in: 0...Int.max))
     }
 }


### PR DESCRIPTION
We used all variants of ints for storing numbers in the DB. To avoid overthinking in what kind of `IntXX` to use, let's use ~`Int32`~ `Int64` everywhere ( `Int16` can sometimes not be enough for certain cases - like our demo app).

We also convert any incoming number to ~`Int32`~ `Int64` safely using ~`Int32(clamping:)`~`Int34(clamping:)`. So even when the number (due to a bug on the backend for example) exceeds ~`Int32.max`~ `Int64.max`, we will just clamp it,

