### PR TITLE
[CIS-581] Introduce StreamTextStyles, fix minor UI issues in ChannelList

### DIFF
--- a/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageAttachmentInfoView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageAttachmentInfoView.swift
@@ -14,14 +14,14 @@ open class ChatMessageAttachmentInfoView<ExtraData: ExtraDataTypes>: View, UICon
 
     public private(set) lazy var fileNameLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .body).bold
+        label.font = uiConfig.font.bodyBold
         label.adjustsFontForContentSizeCategory = true
         return label.withoutAutoresizingMaskConstraints
     }()
 
     public private(set) lazy var fileSizeLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .footnote)
+        label.font = uiConfig.font.footnoteBold
         label.adjustsFontForContentSizeCategory = true
         return label.withoutAutoresizingMaskConstraints
     }()

--- a/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageGiphyView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageGiphyView.swift
@@ -93,7 +93,7 @@ extension ChatMessageGiphyView {
             let label = UILabel().withoutAutoresizingMaskConstraints
             label.text = "GIPHY"
             label.textColor = uiConfig.colorPalette.giphyBadgeText
-            label.font = UIFont.preferredFont(forTextStyle: .caption1).bold
+            label.font = uiConfig.font.bodyBold
             return label
         }()
 

--- a/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageImageGallery.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageImageGallery.swift
@@ -21,7 +21,7 @@ open class ChatMessageImageGallery<ExtraData: ExtraDataTypes>: View, UIConfigPro
 
     public private(set) lazy var moreImagesOverlay: UILabel = {
         let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .largeTitle).bold
+        label.font = uiConfig.font.title
         label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         return label.withoutAutoresizingMaskConstraints

--- a/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageInteractiveAttachmentView+ActionButton.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageInteractiveAttachmentView+ActionButton.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -19,7 +19,7 @@ extension ChatMessageInteractiveAttachmentView {
         }
 
         override public func defaultAppearance() {
-            titleLabel?.font = UIFont.preferredFont(forTextStyle: .body).bold
+            titleLabel?.font = uiConfig.font.body
         }
 
         override open func setUp() {

--- a/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageInteractiveAttachmentView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageInteractiveAttachmentView.swift
@@ -22,7 +22,7 @@ open class ChatMessageInteractiveAttachmentView<ExtraData: ExtraDataTypes>: View
 
     public private(set) lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .headline).italic
+        label.font = uiConfig.font.bodyItalic
         label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         return label.withoutAutoresizingMaskConstraints

--- a/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageLinkPreviewView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/Attachments/ChatMessageLinkPreviewView.swift
@@ -25,14 +25,14 @@ open class ChatMessageLinkPreviewView<ExtraData: ExtraDataTypes>: Control, UICon
 
     public private(set) lazy var authorLabel: UILabel = {
         let label = UILabel().withoutAutoresizingMaskConstraints
-        label.font = .preferredFont(forTextStyle: .title3)
+        label.font = uiConfig.font.bodyBold
         label.adjustsFontForContentSizeCategory = true
         return label
     }()
 
     public private(set) lazy var headlineLabel: UILabel = {
         let label = UILabel().withoutAutoresizingMaskConstraints
-        label.font = UIFont.preferredFont(forTextStyle: .subheadline).bold
+        label.font = uiConfig.font.footnoteBold
         label.adjustsFontForContentSizeCategory = true
         return label
     }()
@@ -42,7 +42,7 @@ open class ChatMessageLinkPreviewView<ExtraData: ExtraDataTypes>: Control, UICon
         textView.isEditable = false
         textView.isScrollEnabled = false
         textView.backgroundColor = .clear
-        textView.font = .preferredFont(forTextStyle: .footnote)
+        textView.font = uiConfig.font.footnote
         textView.adjustsFontForContentSizeCategory = true
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessage/ChatMessageBubbleView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessage/ChatMessageBubbleView.swift
@@ -30,7 +30,7 @@ open class ChatMessageBubbleView<ExtraData: ExtraDataTypes>: View, UIConfigProvi
         textView.dataDetectorTypes = .link
         textView.isScrollEnabled = false
         textView.backgroundColor = .clear
-        textView.font = .preferredFont(forTextStyle: .body)
+        textView.font = uiConfig.font.body
         textView.adjustsFontForContentSizeCategory = true
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
@@ -220,7 +220,7 @@ open class ChatMessageBubbleView<ExtraData: ExtraDataTypes>: View, UIConfigProvi
         repliedMessageView?.message = message?.parentMessage
         repliedMessageView?.isVisible = layoutOptions.contains(.inlineReply)
         
-        let font = UIFont.preferredFont(forTextStyle: .body)
+        let font: UIFont = uiConfig.font.body
         textView.attributedText = .init(string: message?.textContent ?? "", attributes: [
             .foregroundColor: message?.deletedAt == nil ? uiConfig.colorPalette.text : uiConfig.colorPalette.messageTimestampText,
             .font: message?.deletedAt == nil ? font : font.italic

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessage/ChatMessageMetadataView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessage/ChatMessageMetadataView.swift
@@ -52,7 +52,7 @@ open class ChatMessageMetadataView<ExtraData: ExtraDataTypes>: View, UIConfigPro
     }
 }
 
-open class ChatMessageOnlyVisibleForCurrentUserIndicator: View {
+open class ChatMessageOnlyVisibleForCurrentUserIndicator<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
     // MARK: - Subviews
 
     public private(set) lazy var stack: UIStackView = {

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessage/ChatMessageMetadataView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessage/ChatMessageMetadataView.swift
@@ -35,7 +35,7 @@ open class ChatMessageMetadataView<ExtraData: ExtraDataTypes>: View, UIConfigPro
         currentUserVisabilityIndicator.textLabel.textColor = color
         currentUserVisabilityIndicator.imageView.tintColor = color
         
-        timestampLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
+        timestampLabel.font = uiConfig.font.footnote
         timestampLabel.adjustsFontForContentSizeCategory = true
         timestampLabel.textColor = color
     }
@@ -70,7 +70,7 @@ open class ChatMessageOnlyVisibleForCurrentUserIndicator: View {
 
     public private(set) lazy var textLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .callout).bold
+        label.font = uiConfig.font.footnote
         label.adjustsFontForContentSizeCategory = true
         return label.withoutAutoresizingMaskConstraints
     }()

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatMessage/ChatMessageThreadInfoView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatMessage/ChatMessageThreadInfoView.swift
@@ -66,7 +66,7 @@ open class ChatMessageThreadInfoView<ExtraData: ExtraDataTypes>: Control, UIConf
     public private(set) lazy var avatarView = AvatarView().withoutAutoresizingMaskConstraints
     public private(set) lazy var replyCountLabel: UILabel = {
         let label = UILabel().withoutAutoresizingMaskConstraints
-        label.font = .preferredFont(forTextStyle: .footnote)
+        label.font = uiConfig.font.footnoteBold
         label.adjustsFontForContentSizeCategory = true
         label.text = L10n.Message.Threads.reply
         label.textColor = tintColor

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatReplyBubbleView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatReplyBubbleView.swift
@@ -53,7 +53,7 @@ open class ChatReplyBubbleView<ExtraData: ExtraDataTypes>: View, UIConfigProvide
         textView.textContainer.lineFragmentPadding = .zero
         
         textView.backgroundColor = .clear
-        textView.font = .preferredFont(forTextStyle: .footnote)
+        textView.font = uiConfig.font.footnote
         textView.textContainerInset = .zero
         textView.textColor = uiConfig.colorPalette.text
 

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatVC.swift
@@ -151,6 +151,8 @@ open class ChatVC<ExtraData: ExtraDataTypes>: ViewController,
 
         let titleView = UIStackView(arrangedSubviews: [title, subtitle])
         titleView.axis = .vertical
+        titleView.spacing = 2
+
         navigationItem.titleView = titleView
 
         navbarListener = makeNavbarListener { data in

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatVC.swift
@@ -142,11 +142,11 @@ open class ChatVC<ExtraData: ExtraDataTypes>: ViewController,
 
         let title = UILabel()
         title.textAlignment = .center
-        title.font = .preferredFont(forTextStyle: .headline)
+        title.font = uiConfig.font.headline
 
         let subtitle = UILabel()
         subtitle.textAlignment = .center
-        subtitle.font = .preferredFont(forTextStyle: .subheadline)
+        subtitle.font = uiConfig.font.footnote
         subtitle.textColor = uiConfig.colorPalette.subtitleText
 
         let titleView = UIStackView(arrangedSubviews: [title, subtitle])

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerCheckmarkControl.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerCheckmarkControl.swift
@@ -38,7 +38,7 @@ open class MessageComposerCheckmarkControl<ExtraData: ExtraDataTypes>: Control, 
     }
     
     override public func defaultAppearance() {
-        label.font = .preferredFont(forTextStyle: .footnote)
+        label.font = uiConfig.font.footnote
         label.textColor = uiConfig.colorPalette.messageComposerCheckmarkLabel
         
         checkmark.layer.cornerRadius = 4

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerCommandCollectionViewCell.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerCommandCollectionViewCell.swift
@@ -26,9 +26,9 @@ open class MessageComposerCommandCellView<ExtraData: ExtraDataTypes>: View, UICo
     override public func defaultAppearance() {
         backgroundColor = .clear
 
-        commandNameLabel.font = UIFont.preferredFont(forTextStyle: .footnote).bold
+        commandNameLabel.font = uiConfig.font.bodyBold
 
-        commandNameSubtitleLabel.font = .preferredFont(forTextStyle: .caption1)
+        commandNameSubtitleLabel.font = uiConfig.font.body
         commandNameSubtitleLabel.textColor = uiConfig.colorPalette.subtitleText
 
         commandNameLabel.textColor = uiConfig.colorPalette.text

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerInputSlashCommandView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerInputSlashCommandView.swift
@@ -44,7 +44,7 @@ open class MessageInputSlashCommandView<ExtraData: ExtraDataTypes>: View, UIConf
         backgroundColor = uiConfig.colorPalette.slashCommandViewBackground
         
         commandLabel.textColor = uiConfig.colorPalette.slashCommandViewText
-        commandLabel.font = UIFont.preferredFont(forTextStyle: .caption1).bold
+        commandLabel.font = uiConfig.font.footnoteBold
         commandLabel.adjustsFontForContentSizeCategory = true
         commandLabel.textAlignment = .center
         

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerInputTextView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerInputTextView.swift
@@ -46,7 +46,7 @@ open class MessageComposerInputTextView<ExtraData: ExtraDataTypes>: UITextView,
     // MARK: Public
     
     open func defaultAppearance() {
-        font = .preferredFont(forTextStyle: .callout)
+        font = uiConfig.font.body
         textContainer.lineFragmentPadding = 10
         textColor = uiConfig.colorPalette.text
         

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerMentionCollectionViewCell.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerMentionCollectionViewCell.swift
@@ -29,9 +29,9 @@ open class MessageComposerMentionCellView<ExtraData: ExtraDataTypes>: View, UICo
 
     override public func defaultAppearance() {
         backgroundColor = .clear
-        usernameLabel.font = UIFont.preferredFont(forTextStyle: .footnote).bold
+        usernameLabel.font = uiConfig.font.headlineBold
 
-        usernameTagLabel.font = .preferredFont(forTextStyle: .caption1)
+        usernameTagLabel.font = uiConfig.font.footnoteBold
         usernameTagLabel.textColor = uiConfig.colorPalette.subtitleText
 
         usernameLabel.textColor = uiConfig.colorPalette.text

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerSuggestionsCommandsHeaderView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerSuggestionsCommandsHeaderView.swift
@@ -22,7 +22,7 @@ open class MessageComposerSuggestionsCommandsHeaderView<ExtraData: ExtraDataType
     override public func defaultAppearance() {
         backgroundColor = uiConfig.colorPalette.popupBackground
 
-        headerLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
+        headerLabel.font = uiConfig.font.body
         headerLabel.textColor = uiConfig.colorPalette.subtitleText
         commandImageView.contentMode = .scaleAspectFit
     }

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerView.swift
@@ -131,7 +131,7 @@ open class MessageComposerView<ExtraData: ExtraDataTypes>: View,
         
         titleLabel.textAlignment = .center
         titleLabel.textColor = uiConfig.colorPalette.text
-        titleLabel.font = .preferredFont(forTextStyle: .headline)
+        titleLabel.font = uiConfig.font.bodyBold
         titleLabel.adjustsFontForContentSizeCategory = true
     }
     

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -83,7 +83,6 @@ open class ChatChannelListItemView<ExtraData: ExtraDataTypes>: ChatSwipeableList
         let containerCenterView = UIView()
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.spacing = UIStackView.spacingUseSystem
         
         containerCenterView.addSubview(stackView)
         stackView.topAnchor.pin(greaterThanOrEqualTo: containerCenterView.topAnchor, constant: 0).isActive = true

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -47,15 +47,15 @@ open class ChatChannelListItemView<ExtraData: ExtraDataTypes>: ChatSwipeableList
 
     override open func setUpAppearance() {
         titleLabel.adjustsFontForContentSizeCategory = true
-        titleLabel.font = .preferredFont(forTextStyle: .headline)
+        titleLabel.font = uiConfig.font.bodyBold
         
         subtitleLabel.textColor = uiConfig.colorPalette.subtitleText
         subtitleLabel.adjustsFontForContentSizeCategory = true
-        subtitleLabel.font = .preferredFont(forTextStyle: .subheadline)
+        subtitleLabel.font = uiConfig.font.footnote
         
         timestampLabel.textColor = uiConfig.colorPalette.subtitleText
         timestampLabel.adjustsFontForContentSizeCategory = true
-        timestampLabel.font = .preferredFont(forTextStyle: .subheadline)
+        timestampLabel.font = uiConfig.font.footnote
     }
     
     override open func setUpLayout() {

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatUnreadCountView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatUnreadCountView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -64,11 +64,11 @@ open class ChatUnreadCountView: View {
         layer.masksToBounds = true
         backgroundColor = .systemRed
         unreadCountLabel.textColor = .white
-        unreadCountLabel.font = UIFont.preferredFont(forTextStyle: .caption1).bold
+        unreadCountLabel.font = uiConfig.font.captionBold
         unreadCountLabel.adjustsFontForContentSizeCategory = true
         unreadCountLabel.textAlignment = .center
     }
-    
+
     override open func setUpLayout() {
         embed(unreadCountLabel, insets: .init(top: inset, leading: inset, bottom: inset, trailing: inset))
         setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)

--- a/Sources_v3/StreamChatUI/ChatChannelList/ChatUnreadCountView.swift
+++ b/Sources_v3/StreamChatUI/ChatChannelList/ChatUnreadCountView.swift
@@ -5,7 +5,7 @@
 import StreamChat
 import UIKit
 
-open class ChatUnreadCountView: View {
+open class ChatUnreadCountView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
     // MARK: - Properties
     
     public var inset: CGFloat = 3
@@ -62,8 +62,8 @@ open class ChatUnreadCountView: View {
     
     override open func setUpAppearance() {
         layer.masksToBounds = true
-        backgroundColor = .systemRed
-        unreadCountLabel.textColor = .white
+        backgroundColor = uiConfig.colorPalette.channelListUnreadCountView
+        unreadCountLabel.textColor = uiConfig.colorPalette.channelListUnreadCountLabel
         unreadCountLabel.font = uiConfig.font.captionBold
         unreadCountLabel.adjustsFontForContentSizeCategory = true
         unreadCountLabel.textAlignment = .center
@@ -71,7 +71,8 @@ open class ChatUnreadCountView: View {
 
     override open func setUpLayout() {
         embed(unreadCountLabel, insets: .init(top: inset, leading: inset, bottom: inset, trailing: inset))
-        setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        setContentCompressionResistancePriority(.streamRequire, for: .horizontal)
+        widthAnchor.pin(greaterThanOrEqualTo: heightAnchor, multiplier: 1).isActive = true
     }
     
     override open func updateContent() {

--- a/Sources_v3/StreamChatUI/MessageActionsPopup/MessageActionsView+ActionButton.swift
+++ b/Sources_v3/StreamChatUI/MessageActionsPopup/MessageActionsView+ActionButton.swift
@@ -14,7 +14,7 @@ extension MessageActionsView {
 
         override public func defaultAppearance() {
             backgroundColor = uiConfig.colorPalette.generalBackground
-            titleLabel?.font = UIFont.preferredFont(forTextStyle: .headline).bold
+            titleLabel?.font = uiConfig.font.body
             contentEdgeInsets = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
             titleEdgeInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
             contentHorizontalAlignment = .left

--- a/Sources_v3/StreamChatUI/UIConfig.swift
+++ b/Sources_v3/StreamChatUI/UIConfig.swift
@@ -59,6 +59,8 @@ public extension UIConfig {
         public var channelListIndicatorBorderColor: UIColor = .streamWhiteSnow
         public var channelListActionDeleteChannel: UIColor = .streamAccentRed
         public var channelListAvatarOnlineIndicator: UIColor = .streamAccentGreen
+        public var channelListUnreadCountView: UIColor = .streamAccentRed
+        public var channelListUnreadCountLabel: UIColor = .streamWhite
 
         // MARK: - Text interactions
 
@@ -151,7 +153,7 @@ public extension UIConfig {
     
     struct ChannelListItemSubviews {
         public var avatarView: ChatChannelAvatarView<ExtraData>.Type = ChatChannelAvatarView.self
-        public var unreadCountView: ChatUnreadCountView.Type = ChatUnreadCountView.self
+        public var unreadCountView: ChatUnreadCountView<ExtraData>.Type = ChatUnreadCountView<ExtraData>.self
         public var readStatusView: ChatReadStatusCheckmarkView<ExtraData>.Type = ChatReadStatusCheckmarkView<ExtraData>.self
     }
 }
@@ -237,8 +239,8 @@ public extension UIConfig {
         public var repliedMessageContentView: ChatRepliedMessageContentView<ExtraData>.Type =
             ChatRepliedMessageContentView<ExtraData>.self
         public var attachmentSubviews = MessageAttachmentViewSubviews()
-        public var onlyVisibleForCurrentUserIndicator: ChatMessageOnlyVisibleForCurrentUserIndicator.Type =
-            ChatMessageOnlyVisibleForCurrentUserIndicator.self
+        public var onlyVisibleForCurrentUserIndicator: ChatMessageOnlyVisibleForCurrentUserIndicator<ExtraData>.Type =
+            ChatMessageOnlyVisibleForCurrentUserIndicator<ExtraData>.self
         public var threadArrowView: ChatMessageThreadArrowView<ExtraData>.Type = ChatMessageThreadArrowView<ExtraData>.self
         public var threadInfoView: ChatMessageThreadInfoView<ExtraData>.Type = ChatMessageThreadInfoView<ExtraData>.self
         public var errorIndicator: ChatMessageErrorIndicator<ExtraData>.Type = ChatMessageErrorIndicator<ExtraData>.self

--- a/Sources_v3/StreamChatUI/UIConfig.swift
+++ b/Sources_v3/StreamChatUI/UIConfig.swift
@@ -12,6 +12,7 @@ public struct UIConfig<ExtraData: ExtraDataTypes> {
     public var currentUser = CurrentUserUI()
     public var navigation = Navigation()
     public var colorPalette = ColorPalette()
+    public var font = Font()
     public var loadingIndicator = LoadingIndicatorUI()
 
     public init() {}
@@ -103,6 +104,20 @@ public extension UIConfig {
         public var messageActionDefaultText: UIColor = .streamBlack
         public var messageActionErrorTint: UIColor = .streamAccentRed
         public var messageInteractiveAttachmentActionsBorder: UIColor = .streamGrayGainsboro
+    }
+}
+
+public extension UIConfig {
+    struct Font {
+        public var captionBold: UIFont = .streamCaptionBold
+        public var footnote: UIFont = .streamFootnote
+        public var footnoteBold: UIFont = .streamFootnoteBold
+        public var body: UIFont = .streamBody
+        public var bodyBold: UIFont = .streamBodyBold
+        public var bodyItalic: UIFont = .streamBodyItalic
+        public var headline: UIFont = .streamHeadline
+        public var headlineBold: UIFont = .streamHeadlineBold
+        public var title: UIFont = .streamTitle
     }
 }
 
@@ -383,4 +398,18 @@ private extension UIColor {
             return UIColor(rgb: light).withAlphaComponent(lightAlpha)
         }
     }
+}
+
+// Typography defined in Figma design.
+// Because our design guidelines don't really fit the `prefferedFont`, we need to redaclare this.
+private extension UIFont {
+    static let streamCaptionBold = UIFontMetrics(forTextStyle: .caption1).scaledFont(for: boldSystemFont(ofSize: 10))
+    static let streamFootnote = UIFontMetrics(forTextStyle: .footnote).scaledFont(for: UIFont.systemFont(ofSize: 12))
+    static let streamFootnoteBold = UIFontMetrics(forTextStyle: .footnote).scaledFont(for: boldSystemFont(ofSize: 12))
+    static let streamBody = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.systemFont(ofSize: 14))
+    static let streamBodyBold = UIFontMetrics(forTextStyle: .body).scaledFont(for: boldSystemFont(ofSize: 14))
+    static let streamBodyItalic = UIFontMetrics(forTextStyle: .body).scaledFont(for: italicSystemFont(ofSize: 14))
+    static let streamHeadline = UIFontMetrics(forTextStyle: .headline).scaledFont(for: UIFont.systemFont(ofSize: 16))
+    static let streamHeadlineBold = UIFontMetrics(forTextStyle: .headline).scaledFont(for: boldSystemFont(ofSize: 16))
+    static let streamTitle = UIFontMetrics(forTextStyle: .title1).scaledFont(for: boldSystemFont(ofSize: 22))
 }


### PR DESCRIPTION
# What this PR does:
- Introduces correct TextStyles according to design team, also fixes some minor UI issues in ChannelList
# How to test it
- Launch the application, play with the fontSize in Accessibility settings in iOS settings, probably wait for Design to finish their QA cycle :) 
# Where you can start
- `UIConfig.swift`, then all the files. 

NOTE: Maybe check `ChatMessageInteractiveAttachmentView` and tell me if the italic headline feels wrong, we probably need to introduce new font to our line-up. 