### PR TITLE
LLC public API polishing

### DIFF
--- a/Sample_v3/LoginViewController.swift
+++ b/Sample_v3/LoginViewController.swift
@@ -53,7 +53,7 @@ extension LoginViewController {
         let chatClient = logIn()
         
         let channelListController = chatClient.channelListController(
-            query: ChannelListQuery(
+            query: _ChannelListQuery(
                 filter: .containMembers(userIds: [chatClient.currentUserId!]),
                 pageSize: 25
             )

--- a/Sources_v3/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
@@ -16,7 +16,7 @@ extension Endpoint {
         )
     }
     
-    static func channel<ExtraData: ExtraDataTypes>(query: ChannelQuery<ExtraData>) -> Endpoint<ChannelPayload<ExtraData>> {
+    static func channel<ExtraData: ExtraDataTypes>(query: _ChannelQuery<ExtraData>) -> Endpoint<ChannelPayload<ExtraData>> {
         .init(
             path: "channels/\(query.pathParameters)/query",
             method: .post,

--- a/Sources_v3/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
@@ -1,11 +1,11 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
 
 extension Endpoint {
-    static func channels<ExtraData: ExtraDataTypes>(query: ChannelListQuery<ExtraData.Channel>)
+    static func channels<ExtraData: ExtraDataTypes>(query: _ChannelListQuery<ExtraData.Channel>)
         -> Endpoint<ChannelListPayload<ExtraData>> {
         .init(
             path: "channels",

--- a/Sources_v3/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class ChannelEndpoints_Tests: XCTestCase {
     func test_channels_buildsCorrectly() {
-        let filter: Filter<ChannelListFilterScope<NoExtraData>> = .containMembers(userIds: [.unique])
+        let filter: Filter<ChannelListFilterScope> = .containMembers(userIds: [.unique])
         
         func channelListQuery(options: QueryOptions) -> ChannelListQuery {
             var query: ChannelListQuery = .init(filter: filter)

--- a/Sources_v3/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -43,13 +43,13 @@ final class ChannelEndpoints_Tests: XCTestCase {
     func test_channel_buildsCorrectly() {
         let cid = ChannelId(type: .livestream, id: "qwerty")
         
-        func channelQuery(options: QueryOptions) -> ChannelQuery<NoExtraData> {
-            var query: ChannelQuery<NoExtraData> = .init(cid: cid)
+        func channelQuery(options: QueryOptions) -> ChannelQuery {
+            var query: ChannelQuery = .init(cid: cid)
             query.options = options
             return query
         }
         
-        let testCases: [(ChannelQuery<NoExtraData>, Bool)] = [
+        let testCases: [(ChannelQuery, Bool)] = [
             (channelQuery(options: .state), true),
             (channelQuery(options: .presence), true),
             (channelQuery(options: .watch), true),

--- a/Sources_v3/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -9,13 +9,13 @@ final class ChannelEndpoints_Tests: XCTestCase {
     func test_channels_buildsCorrectly() {
         let filter: Filter<ChannelListFilterScope<NoExtraData>> = .containMembers(userIds: [.unique])
         
-        func channelListQuery(options: QueryOptions) -> ChannelListQuery<NoExtraData> {
-            var query: ChannelListQuery<NoExtraData> = .init(filter: filter)
+        func channelListQuery(options: QueryOptions) -> ChannelListQuery {
+            var query: ChannelListQuery = .init(filter: filter)
             query.options = options
             return query
         }
         
-        let testCases: [(ChannelListQuery<NoExtraData>, Bool)] = [
+        let testCases: [(ChannelListQuery, Bool)] = [
             (channelListQuery(options: .state), true),
             (channelListQuery(options: .presence), true),
             (channelListQuery(options: .watch), true),

--- a/Sources_v3/StreamChat/APIClient/Endpoints/MemberEndpoints.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/MemberEndpoints.swift
@@ -6,7 +6,7 @@ import Foundation
 
 extension Endpoint {
     static func channelMembers<ExtraData: UserExtraData>(
-        query: ChannelMemberListQuery<ExtraData>
+        query: _ChannelMemberListQuery<ExtraData>
     ) -> Endpoint<ChannelMemberListPayload<ExtraData>> {
         .init(
             path: "members",

--- a/Sources_v3/StreamChat/APIClient/Endpoints/MemberEndpoints_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/MemberEndpoints_Tests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class MemberEndpoints_Tests: XCTestCase {
     func test_channelMembers_buildsCorrectly() {
-        let query = ChannelMemberListQuery<NoExtraData>(
+        let query = ChannelMemberListQuery(
             cid: .unique,
             filter: .equal(.id, to: "Luke"),
             sort: [.init(key: .createdAt)]

--- a/Sources_v3/StreamChat/APIClient/Endpoints/UserEndpoints.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/UserEndpoints.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 extension Endpoint {
-    static func users<ExtraData: UserExtraData>(query: UserListQuery<ExtraData>)
+    static func users<ExtraData: UserExtraData>(query: _UserListQuery<ExtraData>)
         -> Endpoint<UserListPayload<ExtraData>> {
         .init(
             path: "users",

--- a/Sources_v3/StreamChat/APIClient/Endpoints/UserEndpoints_Tests.swift
+++ b/Sources_v3/StreamChat/APIClient/Endpoints/UserEndpoints_Tests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 final class UserEndpoints_Tests: XCTestCase {
     func test_users_buildsCorrectly() {
-        let query: UserListQuery<NoExtraData> = .init(
+        let query: UserListQuery = .init(
             filter: .equal(.id, to: .unique),
             sort: [.init(key: .lastActivityAt)]
         )

--- a/Sources_v3/StreamChat/ChatClient.swift
+++ b/Sources_v3/StreamChat/ChatClient.swift
@@ -54,7 +54,7 @@ public typealias ChatClient = _ChatClient<NoExtraData>
 /// case requires it (i.e. more than one window with different workspaces in a Slack-like app).
 ///
 /// - Note: `_ChatClient` type is not meant to be used directly. If you don't use custom extra data types, use `ChatClient`
-/// typealis instead. When using custom extra data types, you should create your own `ChatClient` typealias for `_ChatClient`.
+/// typealias instead. When using custom extra data types, you should create your own `ChatClient` typealias for `_ChatClient`.
 /// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
 ///
 public class _ChatClient<ExtraData: ExtraDataTypes> {

--- a/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -23,7 +23,7 @@ public extension _ChatClient {
     ///
     /// - Returns: A new instance of `ChatChannelController`.
     ///
-    func channelController(for channelQuery: ChannelQuery<ExtraData>) -> _ChatChannelController<ExtraData> {
+    func channelController(for channelQuery: _ChannelQuery<ExtraData>) -> _ChatChannelController<ExtraData> {
         .init(channelQuery: channelQuery, client: self)
     }
     
@@ -136,7 +136,7 @@ public typealias ChatChannelController = _ChatChannelController<NoExtraData>
 ///
 public class _ChatChannelController<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
     /// The ChannelQuery this controller observes.
-    @Atomic public private(set) var channelQuery: ChannelQuery<ExtraData>
+    @Atomic public private(set) var channelQuery: _ChannelQuery<ExtraData>
     
     /// Flag indicating whether channel is created on backend. We need this flag to restrict channel modification requests
     /// before channel is created on backend.
@@ -261,7 +261,7 @@ public class _ChatChannelController<ExtraData: ExtraDataTypes>: DataController, 
     ///   - environment: Environment for this controller.
     ///   - isChannelAlreadyCreated: Flag indicating whether channel is created on backend.
     init(
-        channelQuery: ChannelQuery<ExtraData>,
+        channelQuery: _ChannelQuery<ExtraData>,
         client: _ChatClient<ExtraData>,
         environment: Environment = .init(),
         isChannelAlreadyCreated: Bool = true
@@ -345,7 +345,7 @@ public class _ChatChannelController<ExtraData: ExtraDataTypes>: DataController, 
     /// - Returns: Error if it occurs while setting up database observers.
     private func set(cid: ChannelId) -> Error? {
         if channelQuery.cid != cid {
-            channelQuery = ChannelQuery(cid: cid, channelQuery: channelQuery)
+            channelQuery = _ChannelQuery(cid: cid, channelQuery: channelQuery)
         }
         setupEventObservers(for: cid)
         return startDatabaseObservers()

--- a/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
@@ -548,7 +548,7 @@ class ChannelController_Tests: StressTestCase {
     func test_delegateContinueToReceiveEvents_afterObserversReset() throws {
         // Assign `ChannelController` that creates new channel
         controller = ChatChannelController(
-            channelQuery: ChannelQuery(cid: channelId),
+            channelQuery: _ChannelQuery(cid: channelId),
             client: client,
             environment: env.environment,
             isChannelAlreadyCreated: false
@@ -750,7 +750,7 @@ class ChannelController_Tests: StressTestCase {
     
     // MARK: - Channel actions propagation tests
 
-    func setupControllerForNewChannel(query: ChannelQuery<NoExtraData>) {
+    func setupControllerForNewChannel(query: ChannelQuery) {
         controller = ChatChannelController(
             channelQuery: query,
             client: client,
@@ -765,7 +765,7 @@ class ChannelController_Tests: StressTestCase {
     
     func test_updateChannel_failsForNewChannels() throws {
         //  Create `ChannelController` for new channel
-        let query = ChannelQuery(channelPayload: .unique)
+        let query = _ChannelQuery(channelPayload: .unique)
         setupControllerForNewChannel(query: query)
 
         // Simulate `updateChannel` call and assert the error is returned
@@ -841,7 +841,7 @@ class ChannelController_Tests: StressTestCase {
     
     func test_muteChannel_failsForNewChannels() throws {
         //  Create `ChannelController` for new channel
-        let query = ChannelQuery(channelPayload: .unique)
+        let query = _ChannelQuery(channelPayload: .unique)
         setupControllerForNewChannel(query: query)
 
         // Simulate `muteChannel` call and assert error is returned
@@ -920,7 +920,7 @@ class ChannelController_Tests: StressTestCase {
     
     func test_unmuteChannel_failsForNewChannels() throws {
         //  Create `ChannelController` for new channel
-        let query = ChannelQuery(channelPayload: .unique)
+        let query = _ChannelQuery(channelPayload: .unique)
         setupControllerForNewChannel(query: query)
 
         // Simulate `unmuteChannel` call and assert error is returned
@@ -999,7 +999,7 @@ class ChannelController_Tests: StressTestCase {
     
     func test_deleteChannel_failsForNewChannels() throws {
         //  Create `ChannelController` for new channel
-        let query = ChannelQuery(channelPayload: .unique)
+        let query = _ChannelQuery(channelPayload: .unique)
         setupControllerForNewChannel(query: query)
 
         // Simulate `deleteChannel` call and assert error is returned
@@ -1077,7 +1077,7 @@ class ChannelController_Tests: StressTestCase {
 
     func test_hideChannel_failsForNewChannels() throws {
         //  Create `ChannelController` for new channel
-        let query = ChannelQuery(channelPayload: .unique)
+        let query = _ChannelQuery(channelPayload: .unique)
         setupControllerForNewChannel(query: query)
 
         // Simulate `hideChannel` call and assert error is returned
@@ -1156,7 +1156,7 @@ class ChannelController_Tests: StressTestCase {
 
     func test_showChannel_failsForNewChannels() throws {
         //  Create `ChannelController` for new channel
-        let query = ChannelQuery(channelPayload: .unique)
+        let query = _ChannelQuery(channelPayload: .unique)
         setupControllerForNewChannel(query: query)
 
         // Simulate `showChannel` call and assert error is returned
@@ -1582,7 +1582,7 @@ class ChannelController_Tests: StressTestCase {
     
     func test_createNewMessage_failsForNewChannels() throws {
         //  Create `ChannelController` for new channel
-        let query = ChannelQuery(channelPayload: .unique)
+        let query = _ChannelQuery(channelPayload: .unique)
         setupControllerForNewChannel(query: query)
         
         // Simulate `createNewMessage` call and assert error is returned
@@ -1609,7 +1609,7 @@ class ChannelController_Tests: StressTestCase {
     
     func test_addMembers_failsForNewChannels() throws {
         //  Create `ChannelController` for new channel
-        let query = ChannelQuery(channelPayload: .unique)
+        let query = _ChannelQuery(channelPayload: .unique)
         setupControllerForNewChannel(query: query)
         let members: Set<UserId> = [.unique]
 
@@ -1693,7 +1693,7 @@ class ChannelController_Tests: StressTestCase {
     
     func test_removeMembers_failsForNewChannels() throws {
         //  Create `ChannelController` for new channel
-        let query = ChannelQuery(channelPayload: .unique)
+        let query = _ChannelQuery(channelPayload: .unique)
         setupControllerForNewChannel(query: query)
         let members: Set<UserId> = [.unique]
 
@@ -1777,7 +1777,7 @@ class ChannelController_Tests: StressTestCase {
     
     func test_markRead_failsForNewChannels() throws {
         //  Create `ChannelController` for new channel
-        let query = ChannelQuery(channelPayload: .unique)
+        let query = _ChannelQuery(channelPayload: .unique)
         setupControllerForNewChannel(query: query)
         
         // Simulate `markRead` call and assert error is returned

--- a/Sources_v3/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources_v3/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -12,7 +12,7 @@ extension _ChatClient {
     ///
     /// - Returns: A new instance of `ChannelController`.
     ///
-    public func channelListController(query: ChannelListQuery<ExtraData.Channel>) -> _ChatChannelListController<ExtraData> {
+    public func channelListController(query: _ChannelListQuery<ExtraData.Channel>) -> _ChatChannelListController<ExtraData> {
         .init(query: query, client: self)
     }
 }
@@ -40,7 +40,7 @@ public typealias ChatChannelListController = _ChatChannelListController<NoExtraD
 ///
 public class _ChatChannelListController<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
     /// The query specifying and filtering the list of channels.
-    public let query: ChannelListQuery<ExtraData.Channel>
+    public let query: _ChannelListQuery<ExtraData.Channel>
     
     /// The `ChatClient` instance this controller belongs to.
     public let client: _ChatClient<ExtraData>
@@ -110,7 +110,7 @@ public class _ChatChannelListController<ExtraData: ExtraDataTypes>: DataControll
     /// - Parameters:
     ///   - query: The query used for filtering the channels.
     ///   - client: The `Client` instance this controller belongs to.
-    init(query: ChannelListQuery<ExtraData.Channel>, client: _ChatClient<ExtraData>, environment: Environment = .init()) {
+    init(query: _ChannelListQuery<ExtraData.Channel>, client: _ChatClient<ExtraData>, environment: Environment = .init()) {
         self.client = client
         self.query = query
         self.environment = environment

--- a/Sources_v3/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -11,7 +11,7 @@ class ChannelListController_Tests: StressTestCase {
     
     var client: ChatClient!
     
-    var query: ChannelListQuery<NoExtraData>!
+    var query: ChannelListQuery!
     
     var controller: ChatChannelListController!
     var controllerCallbackQueueID: UUID!

--- a/Sources_v3/StreamChat/Controllers/MemberListController/MemberListController+SwiftUI_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/MemberListController/MemberListController+SwiftUI_Tests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 @available(iOS 13, *)
 final class MemberListController_SwiftUI_Tests: iOS13TestCase {
-    var query: ChannelMemberListQuery<NoExtraData>!
+    var query: ChannelMemberListQuery!
     var memberListController: ChatChannelMemberListControllerMock!
     
     // MARK: - Setup

--- a/Sources_v3/StreamChat/Controllers/MemberListController/MemberListController.swift
+++ b/Sources_v3/StreamChat/Controllers/MemberListController/MemberListController.swift
@@ -10,7 +10,7 @@ extension _ChatClient {
     /// - Parameter query: The query specify the filter and sorting options for members the controller should fetch.
     /// - Returns: A new instance of `_ChatChannelMemberListController`.
     public func memberListController(
-        query: ChannelMemberListQuery<ExtraData.User>
+        query: _ChannelMemberListQuery<ExtraData.User>
     ) -> _ChatChannelMemberListController<ExtraData> {
         .init(query: query, client: self)
     }
@@ -39,7 +39,7 @@ public typealias ChatChannelMemberListController = _ChatChannelMemberListControl
 /// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
 public class _ChatChannelMemberListController<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
     /// The query specifying sorting and filtering for the list of channel members.
-    @Atomic public private(set) var query: ChannelMemberListQuery<ExtraData.User>
+    @Atomic public private(set) var query: _ChannelMemberListQuery<ExtraData.User>
     
     /// The `ChatClient` instance this controller belongs to.
     public let client: _ChatClient<ExtraData>
@@ -80,7 +80,7 @@ public class _ChatChannelMemberListController<ExtraData: ExtraDataTypes>: DataCo
     ///   - query: The query used for filtering and sorting the channel members.
     ///   - client: The `Client` this controller belongs to.
     ///   - environment: Environment for this controller.
-    init(query: ChannelMemberListQuery<ExtraData.User>, client: _ChatClient<ExtraData>, environment: Environment = .init()) {
+    init(query: _ChannelMemberListQuery<ExtraData.User>, client: _ChatClient<ExtraData>, environment: Environment = .init()) {
         self.client = client
         self.query = query
         self.environment = environment

--- a/Sources_v3/StreamChat/Controllers/MemberListController/MemberListController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/MemberListController/MemberListController_Tests.swift
@@ -9,7 +9,7 @@ import XCTest
 final class MemberListController_Tests: StressTestCase {
     private var env: TestEnvironment!
     
-    var query: ChannelMemberListQuery<NoExtraData>!
+    var query: ChannelMemberListQuery!
     var client: ChatClient!
     var controller: ChatChannelMemberListController!
     var controllerCallbackQueueID: UUID!

--- a/Sources_v3/StreamChat/Controllers/MessageController/MessageController+Combine.swift
+++ b/Sources_v3/StreamChat/Controllers/MessageController/MessageController+Combine.swift
@@ -42,13 +42,13 @@ extension _ChatMessageController {
             self.controller = controller
             state = .init(controller.state)
             
-            controller.multicastDelegate.additionalDelegates.append(AnyMessageControllerDelegate(self))
+            controller.multicastDelegate.additionalDelegates.append(AnyChatMessageControllerDelegate(self))
         }
     }
 }
 
 @available(iOS 13, *)
-extension _ChatMessageController.BasePublishers: _MessageControllerDelegate {
+extension _ChatMessageController.BasePublishers: _ChatMessageControllerDelegate {
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
         self.state.send(state)
     }

--- a/Sources_v3/StreamChat/Controllers/MessageController/MessageController+SwiftUI.swift
+++ b/Sources_v3/StreamChat/Controllers/MessageController/MessageController+SwiftUI.swift
@@ -29,7 +29,7 @@ extension _ChatMessageController {
             self.controller = controller
             state = controller.state
             
-            controller.multicastDelegate.additionalDelegates.append(AnyMessageControllerDelegate(self))
+            controller.multicastDelegate.additionalDelegates.append(AnyChatMessageControllerDelegate(self))
             
             message = controller.message
             replies = controller.replies
@@ -38,7 +38,7 @@ extension _ChatMessageController {
 }
 
 @available(iOS 13, *)
-extension _ChatMessageController.ObservableObject: _MessageControllerDelegate {
+extension _ChatMessageController.ObservableObject: _ChatMessageControllerDelegate {
     public func messageController(
         _ controller: _ChatMessageController<ExtraData>,
         didChangeMessage change: EntityChange<_ChatMessage<ExtraData>>

--- a/Sources_v3/StreamChat/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/MessageController/MessageController_Tests.swift
@@ -1130,7 +1130,7 @@ private class TestDelegate: QueueAwareDelegate, ChatMessageControllerDelegate {
     }
 }
 
-private class TestDelegateGeneric: QueueAwareDelegate, _MessageControllerDelegate {
+private class TestDelegateGeneric: QueueAwareDelegate, _ChatMessageControllerDelegate {
     @Atomic var state: DataController.State?
     @Atomic var didChangeMessage_change: EntityChange<ChatMessage>?
    

--- a/Sources_v3/StreamChat/Controllers/SearchControllers/UserSearchController.swift
+++ b/Sources_v3/StreamChat/Controllers/SearchControllers/UserSearchController.swift
@@ -17,17 +17,25 @@ extension _ChatClient {
     }
 }
 
-/// `_ChatUserSearchController` is a controller class which allows observing a list of chat users based on the provided query.
+/// `ChatUserSearchController` is a controller class which allows observing a list of chat users based on the provided query.
 ///
-/// Learn more about `_ChatUserSearchController` and its usage in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#user-list).
-///
-/// - Note: `ChatUserSearchController` is a typealias of `_ChatUserSearchController` with default extra data. If you're using
-/// custom extra data, create your own typealias of `_ChatUserSearchController`.
+/// - Note: `ChatUserSearchController` is a typealias of `_ChatUserSearchController` with the default extra data types.
+/// If you want to use your custom extra data types, you should create your own `ChatUserSearchController`
+/// typealias for `_ChatUserSearchController`.
 ///
 /// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
 ///
 public typealias ChatUserSearchController = _ChatUserSearchController<NoExtraData>
 
+/// `_ChatUserSearchController` is a controller class which allows observing a list of chat users based on the provided query.
+///
+/// - Note: `_ChatUserSearchController` type is not meant to be used directly.
+/// If you don't use custom extra data types, use `ChatUserSearchController` typealias instead.
+/// When using custom extra data types, you should create your own `ChatUserSearchController` typealias
+/// for `_ChatUserSearchController`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
 public class _ChatUserSearchController<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
     /// The `ChatClient` instance this controller belongs to.
     public let client: _ChatClient<ExtraData>

--- a/Sources_v3/StreamChat/Controllers/SearchControllers/UserSearchController.swift
+++ b/Sources_v3/StreamChat/Controllers/SearchControllers/UserSearchController.swift
@@ -35,9 +35,9 @@ public class _ChatUserSearchController<ExtraData: ExtraDataTypes>: DataControlle
     /// Filter hash this controller observes.
     let explicitFilterHash = UUID().uuidString
     
-    lazy var query: UserListQuery<ExtraData.User> = {
+    lazy var query: _UserListQuery<ExtraData.User> = {
         // Filter is just a mock, explicit hash will override it
-        var query = UserListQuery<ExtraData.User>(filter: .exists(.id), sort: [.init(key: .name, isAscending: true)])
+        var query = _UserListQuery<ExtraData.User>(filter: .exists(.id), sort: [.init(key: .name, isAscending: true)])
         // Setting `shouldBeObserved` to false prevents NewUserQueryUpdater to pick this query up
         query.shouldBeUpdatedInBackground = false
         // The initial DB fetch will return 0 users and this is expected
@@ -48,7 +48,7 @@ public class _ChatUserSearchController<ExtraData: ExtraDataTypes>: DataControlle
     }()
     
     /// Copy of last search query made, used for getting next page.
-    var lastQuery: UserListQuery<ExtraData.User>?
+    var lastQuery: _UserListQuery<ExtraData.User>?
     
     /// The users matching the query of this controller.
     ///
@@ -148,7 +148,7 @@ public class _ChatUserSearchController<ExtraData: ExtraDataTypes>: DataControlle
     ///   - completion: Called when the controller has finished fetching remote data.
     ///   If the data fetching fails, the error variable contains more details about the problem.
     public func search(term: String?, completion: ((_ error: Error?) -> Void)? = nil) {
-        var query = UserListQuery<ExtraData.User>(sort: [.init(key: .name, isAscending: true)])
+        var query = _UserListQuery<ExtraData.User>(sort: [.init(key: .name, isAscending: true)])
         if let term = term, !term.isEmpty {
             query.filter = .or([
                 .autocomplete(.name, text: term),

--- a/Sources_v3/StreamChat/Controllers/UserListController/UserListController.swift
+++ b/Sources_v3/StreamChat/Controllers/UserListController/UserListController.swift
@@ -12,7 +12,7 @@ extension _ChatClient {
     ///
     /// - Returns: A new instance of `_ChatUserListController`.
     ///
-    public func userListController(query: UserListQuery<ExtraData.User> = .init()) -> _ChatUserListController<ExtraData> {
+    public func userListController(query: _UserListQuery<ExtraData.User> = .init()) -> _ChatUserListController<ExtraData> {
         .init(query: query, client: self)
     }
 }
@@ -40,7 +40,7 @@ public typealias ChatUserListController = _ChatUserListController<NoExtraData>
 ///
 public class _ChatUserListController<ExtraData: ExtraDataTypes>: DataController, DelegateCallable, DataStoreProvider {
     /// The query specifying and filtering the list of users.
-    public let query: UserListQuery<ExtraData.User>
+    public let query: _UserListQuery<ExtraData.User>
     
     /// The `ChatClient` instance this controller belongs to.
     public let client: _ChatClient<ExtraData>
@@ -110,7 +110,7 @@ public class _ChatUserListController<ExtraData: ExtraDataTypes>: DataController,
     /// - Parameters:
     ///   - query: The query used for filtering the users.
     ///   - client: The `Client` instance this controller belongs to.
-    init(query: UserListQuery<ExtraData.User>, client: _ChatClient<ExtraData>, environment: Environment = .init()) {
+    init(query: _UserListQuery<ExtraData.User>, client: _ChatClient<ExtraData>, environment: Environment = .init()) {
         self.client = client
         self.query = query
         self.environment = environment

--- a/Sources_v3/StreamChat/Controllers/UserListController/UserListController_Tests.swift
+++ b/Sources_v3/StreamChat/Controllers/UserListController/UserListController_Tests.swift
@@ -11,7 +11,7 @@ class UserListController_Tests: StressTestCase {
     
     var client: ChatClient!
     
-    var query: UserListQuery<NoExtraData>!
+    var query: UserListQuery!
     
     var controller: ChatUserListController!
     var controllerCallbackQueueID: UUID!

--- a/Sources_v3/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -78,7 +78,7 @@ extension ChannelDTO: EphemeralValuesContainer {
 extension NSManagedObjectContext {
     func saveChannel<ExtraData: ExtraDataTypes>(
         payload: ChannelDetailPayload<ExtraData>,
-        query: ChannelListQuery<ExtraData.Channel>?
+        query: _ChannelListQuery<ExtraData.Channel>?
     ) throws -> ChannelDTO {
         let dto = ChannelDTO.loadOrCreate(cid: payload.cid, context: self)
         dto.name = payload.name
@@ -117,7 +117,7 @@ extension NSManagedObjectContext {
     
     func saveChannel<ExtraData: ExtraDataTypes>(
         payload: ChannelPayload<ExtraData>,
-        query: ChannelListQuery<ExtraData.Channel>?
+        query: _ChannelListQuery<ExtraData.Channel>?
     ) throws -> ChannelDTO {
         let dto = try saveChannel(payload: payload.channel, query: query)
         
@@ -145,7 +145,7 @@ extension NSManagedObjectContext {
 
 extension ChannelDTO {
     static func channelListFetchRequest<ExtraData: ChannelExtraData>(
-        query: ChannelListQuery<ExtraData>
+        query: _ChannelListQuery<ExtraData>
     ) -> NSFetchRequest<ChannelDTO> {
         let request = NSFetchRequest<ChannelDTO>(entityName: ChannelDTO.entityName)
         

--- a/Sources_v3/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
@@ -171,7 +171,7 @@ class ChannelDTO_Tests: XCTestCase {
     
     func test_channelListQuery_withSorting() {
         // Create two channels queries with different sortings.
-        let filter: Filter<ChannelListFilterScope<NoExtraData>> = .in(.members, values: [.unique])
+        let filter: Filter<ChannelListFilterScope> = .in(.members, values: [.unique])
         let queryWithDefaultSorting = _ChannelListQuery(filter: filter)
         let queryWithUpdatedAtSorting = _ChannelListQuery(filter: filter, sort: [.init(key: .updatedAt, isAscending: false)])
 

--- a/Sources_v3/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
@@ -143,7 +143,7 @@ class ChannelDTO_Tests: XCTestCase {
     }
     
     func test_channelWithChannelListQuery_isSavedAndLoaded() {
-        let query = ChannelListQuery<NoExtraData>(
+        let query = ChannelListQuery(
             filter: .and([.less(.createdAt, than: .unique), .exists(.deletedAt, exists: false)])
         )
         
@@ -172,8 +172,8 @@ class ChannelDTO_Tests: XCTestCase {
     func test_channelListQuery_withSorting() {
         // Create two channels queries with different sortings.
         let filter: Filter<ChannelListFilterScope<NoExtraData>> = .in(.members, values: [.unique])
-        let queryWithDefaultSorting = ChannelListQuery(filter: filter)
-        let queryWithUpdatedAtSorting = ChannelListQuery(filter: filter, sort: [.init(key: .updatedAt, isAscending: false)])
+        let queryWithDefaultSorting = _ChannelListQuery(filter: filter)
+        let queryWithUpdatedAtSorting = _ChannelListQuery(filter: filter, sort: [.init(key: .updatedAt, isAscending: false)])
 
         // Create dummy channels payloads with ids: a, b, c, d.
         let payload1 = dummyPayload(with: try! .init(cid: "a:a"))

--- a/Sources_v3/StreamChat/Database/DTOs/ChannelListQueryDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/ChannelListQueryDTO.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -28,7 +28,7 @@ extension NSManagedObjectContext {
         ChannelListQueryDTO.load(filterHash: filterHash, context: self)
     }
     
-    func saveQuery<ExtraData: ChannelExtraData>(query: ChannelListQuery<ExtraData>) -> ChannelListQueryDTO {
+    func saveQuery<ExtraData: ChannelExtraData>(query: _ChannelListQuery<ExtraData>) -> ChannelListQueryDTO {
         if let existingDTO = ChannelListQueryDTO.load(filterHash: query.filter.filterHash, context: self) {
             return existingDTO
         }

--- a/Sources_v3/StreamChat/Database/DTOs/ChannelMemberListQueryDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/ChannelMemberListQueryDTO.swift
@@ -40,7 +40,7 @@ extension NSManagedObjectContext: MemberListQueryDatabaseSession {
         ChannelMemberListQueryDTO.load(queryHash: queryHash, context: self)
     }
     
-    func saveQuery<ExtraData: UserExtraData>(_ query: ChannelMemberListQuery<ExtraData>) throws -> ChannelMemberListQueryDTO {
+    func saveQuery<ExtraData: UserExtraData>(_ query: _ChannelMemberListQuery<ExtraData>) throws -> ChannelMemberListQueryDTO {
         guard let channelDTO = channel(cid: query.cid) else {
             throw ClientError.ChannelDoesNotExist(cid: query.cid)
         }

--- a/Sources_v3/StreamChat/Database/DTOs/ChannelMemberListQueryDTO_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/ChannelMemberListQueryDTO_Tests.swift
@@ -25,7 +25,7 @@ final class ChannelMemberListQueryDTO_Tests: XCTestCase {
     
     func test_channelMemberListQuery_loadsCorrectQuery() throws {
         // Create the query.
-        let query = ChannelMemberListQuery<NoExtraData>(cid: .unique, filter: .query(.id, text: .unique))
+        let query = ChannelMemberListQuery(cid: .unique, filter: .query(.id, text: .unique))
         
         // Save the query to the database.
         try database.writeSynchronously {
@@ -41,7 +41,7 @@ final class ChannelMemberListQueryDTO_Tests: XCTestCase {
     
     func test_saveQuery_savesQueryCorrectly_ifChannelExists() throws {
         // Create the query.
-        let query = ChannelMemberListQuery<NoExtraData>(cid: .unique, filter: .query(.id, text: .unique))
+        let query = ChannelMemberListQuery(cid: .unique, filter: .query(.id, text: .unique))
         
         // Save channel to the database.
         try database.createChannel(cid: query.cid)
@@ -56,7 +56,7 @@ final class ChannelMemberListQueryDTO_Tests: XCTestCase {
     
     func test_saveQuery_throwsError_ifChannelDoesNotExist() throws {
         // Create the query.
-        let query = ChannelMemberListQuery<NoExtraData>(cid: .unique, filter: .query(.id, text: .unique))
+        let query = ChannelMemberListQuery(cid: .unique, filter: .query(.id, text: .unique))
         
         // Try to save query to the database.
         XCTAssertThrowsError(try database.createMemberListQuery(query: query)) { error in
@@ -67,7 +67,7 @@ final class ChannelMemberListQueryDTO_Tests: XCTestCase {
     
     // MARK: - Tests
 
-    private func assert(_ dto: ChannelMemberListQueryDTO, match query: ChannelMemberListQuery<NoExtraData>) {
+    private func assert(_ dto: ChannelMemberListQueryDTO, match query: ChannelMemberListQuery) {
         XCTAssertEqual(dto.queryHash, query.queryHash)
         
         if let filterJSONData = dto.filterJSONData {

--- a/Sources_v3/StreamChat/Database/DTOs/ChannelMemberListQueryDTO_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/ChannelMemberListQueryDTO_Tests.swift
@@ -72,7 +72,7 @@ final class ChannelMemberListQueryDTO_Tests: XCTestCase {
         
         if let filterJSONData = dto.filterJSONData {
             let filter = try? JSONDecoder.default.decode(
-                Filter<MemberListFilterScope<NoExtraData>>.self,
+                Filter<MemberListFilterScope>.self,
                 from: filterJSONData
             )
             XCTAssertEqual(filter?.filterHash, query.filter?.filterHash)

--- a/Sources_v3/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -40,7 +40,7 @@ extension MemberDTO {
     }
     
     /// Returns a fetch request for the DTOs matching the provided `query`.
-    static func members<ExtraData: UserExtraData>(matching query: ChannelMemberListQuery<ExtraData>) -> NSFetchRequest<MemberDTO> {
+    static func members<ExtraData: UserExtraData>(matching query: _ChannelMemberListQuery<ExtraData>) -> NSFetchRequest<MemberDTO> {
         let request = NSFetchRequest<MemberDTO>(entityName: MemberDTO.entityName)
         request.predicate = NSPredicate(format: "ANY queries.queryHash == %@", query.queryHash)
         request.sortDescriptors = query.sortDescriptors
@@ -78,7 +78,7 @@ extension NSManagedObjectContext {
     func saveMember<ExtraData: UserExtraData>(
         payload: MemberPayload<ExtraData>,
         channelId: ChannelId,
-        query: ChannelMemberListQuery<ExtraData>?
+        query: _ChannelMemberListQuery<ExtraData>?
     ) throws -> MemberDTO {
         let dto = MemberDTO.loadOrCreate(id: payload.user.id, channelId: channelId, context: self)
         
@@ -146,7 +146,7 @@ extension _ChatChannelMember {
     }
 }
 
-private extension ChannelMemberListQuery {
+private extension _ChannelMemberListQuery {
     var sortDescriptors: [NSSortDescriptor] {
         let sortDescriptors = sort.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
         return sortDescriptors.isEmpty ? [ChannelMemberListSortingKey.defaultSortDescriptor] : sortDescriptors

--- a/Sources_v3/StreamChat/Database/DTOs/MemberModelDTO_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/MemberModelDTO_Tests.swift
@@ -105,7 +105,7 @@ class MemberModelDTO_Tests: XCTestCase {
 
         // Create member and query.
         let member: MemberPayload<NoExtraData> = .dummy(userId: userId)
-        let query = ChannelMemberListQuery<NoExtraData>(cid: cid, filter: .equal("id", to: userId))
+        let query = ChannelMemberListQuery(cid: cid, filter: .equal("id", to: userId))
 
         // Save channel, then member, and pass the query in.
         try database.writeSynchronously { session in

--- a/Sources_v3/StreamChat/Database/DTOs/UserDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/UserDTO.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -74,7 +74,7 @@ extension NSManagedObjectContext: UserDatabaseSession {
     
     func saveUser<ExtraData: UserExtraData>(
         payload: UserPayload<ExtraData>,
-        query: UserListQuery<ExtraData>?
+        query: _UserListQuery<ExtraData>?
     ) throws -> UserDTO {
         let dto = UserDTO.loadOrCreate(id: payload.id, context: self)
         
@@ -120,7 +120,7 @@ extension UserDTO {
 }
 
 extension UserDTO {
-    static func userListFetchRequest<ExtraData: UserExtraData>(query: UserListQuery<ExtraData>) -> NSFetchRequest<UserDTO> {
+    static func userListFetchRequest<ExtraData: UserExtraData>(query: _UserListQuery<ExtraData>) -> NSFetchRequest<UserDTO> {
         let request = NSFetchRequest<UserDTO>(entityName: UserDTO.entityName)
         
         // Fetch results controller requires at least one sorting descriptor.

--- a/Sources_v3/StreamChat/Database/DTOs/UserDTO_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/UserDTO_Tests.swift
@@ -142,7 +142,7 @@ class UserDTO_Tests: XCTestCase {
     }
     
     func test_userWithUserListQuery_isSavedAndLoaded() {
-        let query = UserListQuery<NoExtraData>(filter: .query(.name, text: "a"))
+        let query = UserListQuery(filter: .query(.name, text: "a"))
         
         // Create user
         let payload1 = dummyUser
@@ -166,7 +166,7 @@ class UserDTO_Tests: XCTestCase {
     }
 
     func test_userListQueryWithoutFilter_matchesAllUsers() throws {
-        let query = UserListQuery<NoExtraData>()
+        let query = UserListQuery()
         
         // Save 4 users to the DB
         try database.writeSynchronously { session in
@@ -187,8 +187,8 @@ class UserDTO_Tests: XCTestCase {
     func test_userListQuery_withSorting() {
         // Create two user queries with different sortings.
         let filter = Filter<UserListFilterScope<NoExtraData>>.query(.name, text: "a")
-        let queryWithLastActiveAtSorting = UserListQuery(filter: filter, sort: [.init(key: .lastActivityAt, isAscending: false)])
-        let queryWithIdSorting = UserListQuery(filter: filter, sort: [.init(key: .id, isAscending: false)])
+        let queryWithLastActiveAtSorting = _UserListQuery(filter: filter, sort: [.init(key: .lastActivityAt, isAscending: false)])
+        let queryWithIdSorting = _UserListQuery(filter: filter, sort: [.init(key: .id, isAscending: false)])
 
         // Create dummy users payloads.
         let payload1 = dummyUser

--- a/Sources_v3/StreamChat/Database/DTOs/UserDTO_Tests.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/UserDTO_Tests.swift
@@ -186,7 +186,7 @@ class UserDTO_Tests: XCTestCase {
 
     func test_userListQuery_withSorting() {
         // Create two user queries with different sortings.
-        let filter = Filter<UserListFilterScope<NoExtraData>>.query(.name, text: "a")
+        let filter = Filter<UserListFilterScope>.query(.name, text: "a")
         let queryWithLastActiveAtSorting = _UserListQuery(filter: filter, sort: [.init(key: .lastActivityAt, isAscending: false)])
         let queryWithIdSorting = _UserListQuery(filter: filter, sort: [.init(key: .id, isAscending: false)])
 

--- a/Sources_v3/StreamChat/Database/DTOs/UserListQueryDTO.swift
+++ b/Sources_v3/StreamChat/Database/DTOs/UserListQueryDTO.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -38,7 +38,7 @@ extension NSManagedObjectContext {
         UserListQueryDTO.load(filterHash: filterHash, context: self)
     }
     
-    func saveQuery<ExtraData: UserExtraData>(query: UserListQuery<ExtraData>) throws -> UserListQueryDTO? {
+    func saveQuery<ExtraData: UserExtraData>(query: _UserListQuery<ExtraData>) throws -> UserListQueryDTO? {
         guard let filterHash = query.filter?.filterHash else {
             // A query without a filter doesn't have to be saved to the DB because it matches all users by default.
             return nil
@@ -62,7 +62,7 @@ extension NSManagedObjectContext {
         return newDTO
     }
     
-    func deleteQuery<ExtraData: UserExtraData>(_ query: UserListQuery<ExtraData>) {
+    func deleteQuery<ExtraData: UserExtraData>(_ query: _UserListQuery<ExtraData>) {
         guard let filterHash = query.filter?.filterHash else {
             // A query without a filter is not saved in DB.
             return

--- a/Sources_v3/StreamChat/Database/DataStore.swift
+++ b/Sources_v3/StreamChat/Database/DataStore.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -31,6 +31,8 @@ public struct DataStore<ExtraData: ExtraDataTypes> {
     /// - Returns: If there's a user object in the locally cached data matching the provided `id`, returns the matching
     /// model object. If a user object doesn't exist locally, returns `nil`.
     ///
+    /// **Warning**: Should be called on the `main` thread only.
+    ///
     /// - Parameter id: An id of a user.
     public func user(id: UserId) -> _ChatUser<ExtraData.User>? {
         database.viewContext.user(id: id)?.asModel()
@@ -39,6 +41,8 @@ public struct DataStore<ExtraData: ExtraDataTypes> {
     /// Loads a current user model with a matching `id` from the **local data store**.
     ///
     /// If the data doesn't exist locally, it's recommended to use controllers to fetch data from remote servers.
+    ///
+    /// **Warning**: Should be called on the `main` thread only.
     ///
     /// - Returns: If there's a current user object in the locally cached data, returns the matching
     /// model object. If a user object doesn't exist locally, returns `nil`.
@@ -49,6 +53,8 @@ public struct DataStore<ExtraData: ExtraDataTypes> {
     /// Loads a channel model with a matching `cid` from the **local data store**.
     ///
     /// If the data doesn't exist locally, it's recommended to use controllers to fetch data from remote servers.
+    ///
+    /// **Warning**: Should be called on the `main` thread only.
     ///
     /// - Returns: If there's a channel object in the locally cached data matching the provided `cid`, returns the matching
     /// model object. If a channel object doesn't exist locally, returns `nil`.
@@ -61,6 +67,8 @@ public struct DataStore<ExtraData: ExtraDataTypes> {
     /// Loads a message model with a matching `id` from the **local data store**.
     ///
     /// If the data doesn't exist locally, it's recommended to use controllers to fetch data from remote servers.
+    ///
+    /// **Warning**: Should be called on the `main` thread only.
     ///
     /// - Returns: If there's a message object in the locally cached data matching the provided `id`, returns the matching
     /// model object. If a user object doesn't exist locally, returns `nil`.

--- a/Sources_v3/StreamChat/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseContainer_Mock.swift
@@ -116,7 +116,7 @@ extension DatabaseContainer {
     }
     
     func createChannelListQuery(
-        filter: Filter<ChannelListFilterScope<NoExtraData>> = .query(.cid, text: .unique)
+        filter: Filter<ChannelListFilterScope> = .query(.cid, text: .unique)
     ) throws {
         try writeSynchronously { session in
             let dto = NSEntityDescription

--- a/Sources_v3/StreamChat/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseContainer_Mock.swift
@@ -129,7 +129,7 @@ extension DatabaseContainer {
         }
     }
     
-    func createUserListQuery(filter: Filter<UserListFilterScope<NoExtraData>> = .query(.id, text: .unique)) throws {
+    func createUserListQuery(filter: Filter<UserListFilterScope> = .query(.id, text: .unique)) throws {
         try writeSynchronously { session in
             let dto = NSEntityDescription
                 .insertNewObject(

--- a/Sources_v3/StreamChat/Database/DatabaseContainer_Mock.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseContainer_Mock.swift
@@ -141,7 +141,7 @@ extension DatabaseContainer {
         }
     }
     
-    func createMemberListQuery<ExtraData: UserExtraData>(query: ChannelMemberListQuery<ExtraData>) throws {
+    func createMemberListQuery<ExtraData: UserExtraData>(query: _ChannelMemberListQuery<ExtraData>) throws {
         try writeSynchronously { session in
             try session.saveQuery(query)
         }
@@ -177,7 +177,7 @@ extension DatabaseContainer {
         userId: UserId = .unique,
         role: MemberRole = .member,
         cid: ChannelId,
-        query: ChannelMemberListQuery<NoExtraData>? = nil
+        query: ChannelMemberListQuery? = nil
     ) throws {
         try writeSynchronously { session in
             try session.saveMember(

--- a/Sources_v3/StreamChat/Database/DatabaseSession.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseSession.swift
@@ -126,14 +126,14 @@ protocol ChannelDatabaseSession {
     @discardableResult
     func saveChannel<ExtraData: ExtraDataTypes>(
         payload: ChannelPayload<ExtraData>,
-        query: ChannelListQuery<ExtraData.Channel>?
+        query: _ChannelListQuery<ExtraData.Channel>?
     ) throws -> ChannelDTO
     
     /// Creates a new `ChannelDTO` object in the database with the given `payload` and `query`.
     @discardableResult
     func saveChannel<ExtraData: ExtraDataTypes>(
         payload: ChannelDetailPayload<ExtraData>,
-        query: ChannelListQuery<ExtraData.Channel>?
+        query: _ChannelListQuery<ExtraData.Channel>?
     ) throws -> ChannelDTO
     
     /// Fetches `ChannelDTO` with the given `cid` from the database.

--- a/Sources_v3/StreamChat/Database/DatabaseSession.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseSession.swift
@@ -10,18 +10,18 @@ protocol UserDatabaseSession {
     /// Saves the provided payload to the DB. Return's the matching `UserDTO` if the save was successful. Throws an error
     /// if the save fails.
     @discardableResult
-    func saveUser<ExtraData: UserExtraData>(payload: UserPayload<ExtraData>, query: UserListQuery<ExtraData>?) throws -> UserDTO
+    func saveUser<ExtraData: UserExtraData>(payload: UserPayload<ExtraData>, query: _UserListQuery<ExtraData>?) throws -> UserDTO
     
     /// Saves the provided query to the DB. Return's the matching `UserListQueryDTO` if the save was successful. Throws an error
     /// if the save fails.
     @discardableResult
-    func saveQuery<ExtraData: UserExtraData>(query: UserListQuery<ExtraData>) throws -> UserListQueryDTO?
+    func saveQuery<ExtraData: UserExtraData>(query: _UserListQuery<ExtraData>) throws -> UserListQueryDTO?
     
     /// Fetches `UserDTO` with the given `id` from the DB. Returns `nil` if no `UserDTO` matching the `id` exists.
     func user(id: UserId) -> UserDTO?
     
     /// Removes the specified query from DB.
-    func deleteQuery<ExtraData: UserExtraData>(_ query: UserListQuery<ExtraData>)
+    func deleteQuery<ExtraData: UserExtraData>(_ query: _UserListQuery<ExtraData>)
 }
 
 protocol CurrentUserDatabaseSession {

--- a/Sources_v3/StreamChat/Database/DatabaseSession.swift
+++ b/Sources_v3/StreamChat/Database/DatabaseSession.swift
@@ -162,7 +162,7 @@ protocol MemberDatabaseSession {
     func saveMember<ExtraData: UserExtraData>(
         payload: MemberPayload<ExtraData>,
         channelId: ChannelId,
-        query: ChannelMemberListQuery<ExtraData>?
+        query: _ChannelMemberListQuery<ExtraData>?
     ) throws -> MemberDTO
     
     /// Fetches `MemberDTO`entity for the given `userId` and `cid`.
@@ -175,7 +175,7 @@ protocol MemberListQueryDatabaseSession {
     
     /// Creates a new `MemberListQueryDatabaseSession` object in the database based in the given `ChannelMemberListQuery`.
     @discardableResult
-    func saveQuery<ExtraData: UserExtraData>(_ query: ChannelMemberListQuery<ExtraData>) throws -> ChannelMemberListQueryDTO
+    func saveQuery<ExtraData: UserExtraData>(_ query: _ChannelMemberListQuery<ExtraData>) throws -> ChannelMemberListQueryDTO
 }
 
 protocol AttachmentDatabaseSession {

--- a/Sources_v3/StreamChat/Models/Attachment.swift
+++ b/Sources_v3/StreamChat/Models/Attachment.swift
@@ -38,14 +38,23 @@ extension _ChatMessageAttachment {
             )
         }
 
+        /// Creates a new `_ChatMessageAttachment<ExtraData>.Seed` instance
+        /// - Parameters:
+        ///   - localURL: The local file URL the attachment will be uploaded from.
+        ///   - fileName: The filename. Once attachment is uploaded this value will
+        ///   be available under `_ChatMessageAttachment.title` field. If `nil` is provided the `localURL.lastPathComponent`
+        ///   will be used.
+        ///   - type: The attachment type. Attachment rendering will be chosen based on it type.
+        ///   - extraData: The extra data which can be used to include additional information about the attachment
+        /// used in client application.
         public init(
             localURL: URL,
-            fileName: String,
+            fileName: String? = nil,
             type: AttachmentType,
-            extraData: ExtraData.Attachment
+            extraData: ExtraData.Attachment = .defaultValue
         ) {
             self.localURL = localURL
-            self.fileName = fileName
+            self.fileName = fileName ?? localURL.lastPathComponent
             self.type = type
             self.extraData = extraData
         }

--- a/Sources_v3/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources_v3/StreamChat/Query/ChannelListQuery.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -63,7 +63,25 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
 
 /// A query is used for querying specific channels from backend.
 /// You can specify filter, sorting, pagination, limit for fetched messages in channel and other options.
-public struct ChannelListQuery<ExtraData: ChannelExtraData>: Encodable {
+///
+/// - Note: `ChannelListQuery` is a typealias of `_ChannelListQuery` with the default extra data types.
+/// If you want to use your custom extra data types, you should create your own `ChannelListQuery` typealias
+/// for `_ChannelListQuery`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public typealias ChannelListQuery = _ChannelListQuery<NoExtraData>
+
+/// A query is used for querying specific channels from backend.
+/// You can specify filter, sorting, pagination, limit for fetched messages in channel and other options.
+///
+/// - Note: `_ChannelListQuery` type is not meant to be used directly.
+/// If you don't use custom extra data types, use `ChannelListQuery` typealias instead.
+/// When using custom extra data types, you should create your own `ChannelListQuery` typealias for `_ChannelListQuery`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public struct _ChannelListQuery<ExtraData: ChannelExtraData>: Encodable {
     private enum CodingKeys: String, CodingKey {
         case filter = "filter_conditions"
         case sort

--- a/Sources_v3/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources_v3/StreamChat/Query/ChannelListQuery.swift
@@ -8,7 +8,24 @@ import Foundation
 public protocol AnyChannelListFilterScope {}
 
 /// An extra-data-specific namespace for the `FilterKey`s suitable to be used for `ChannelListQuery`.
-public struct ChannelListFilterScope<ExtraData: ChannelExtraData>: FilterScope, AnyChannelListFilterScope {}
+///
+/// - Note: `ChannelListFilterScope` is a typealias of `_ChannelListFilterScope` with the default extra data types.
+/// If you want to use your custom extra data types, you should create your own `ChannelListFilterScope`
+/// typealias for `_ChannelListFilterScope`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public typealias ChannelListFilterScope = _ChannelListFilterScope<NoExtraData>
+
+/// An extra-data-specific namespace for the `FilterKey`s suitable to be used for `_ChannelListQuery`.
+///
+/// - Note: `_ChannelListFilterScope` type is not meant to be used directly.
+/// If you don't use custom extra data types, use `ChannelListFilterScope` typealias instead.
+/// When using custom extra data types, you should create your own `ChannelListFilterScope` typealias for `_ChannelListFilterScope`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public struct _ChannelListFilterScope<ExtraData: ChannelExtraData>: FilterScope, AnyChannelListFilterScope {}
 
 public extension Filter where Scope: AnyChannelListFilterScope {
     /// Filter to match channels containing members with specified user ids.
@@ -94,7 +111,7 @@ public struct _ChannelListQuery<ExtraData: ChannelExtraData>: Encodable {
     }
     
     /// A filter for the query (see `Filter`).
-    public let filter: Filter<ChannelListFilterScope<ExtraData>>
+    public let filter: Filter<_ChannelListFilterScope<ExtraData>>
     /// A sorting for the query (see `Sorting`).
     public let sort: [Sorting<ChannelListSortingKey>]
     /// A pagination.
@@ -111,7 +128,7 @@ public struct _ChannelListQuery<ExtraData: ChannelExtraData>: Encodable {
     ///   - pageSize: a page size for pagination.
     ///   - messagesLimit: a number of messages for the channel to be retrieved.
     public init(
-        filter: Filter<ChannelListFilterScope<ExtraData>>,
+        filter: Filter<_ChannelListFilterScope<ExtraData>>,
         sort: [Sorting<ChannelListSortingKey>] = [],
         pageSize: Int = .channelsPageSize,
         messagesLimit: Int = .messagesPageSize

--- a/Sources_v3/StreamChat/Query/ChannelListQuery_Tests.swift
+++ b/Sources_v3/StreamChat/Query/ChannelListQuery_Tests.swift
@@ -40,7 +40,7 @@ final class ChannelListFilterScope_Tests: XCTestCase {
         
         // Create queries with sortings
         let queries = sortings.map {
-            ChannelListQuery<NoExtraData>(filter: .containMembers(userIds: [.unique]), sort: $0)
+            ChannelListQuery(filter: .containMembers(userIds: [.unique]), sort: $0)
         }
         
         // Assert safe sorting option is added

--- a/Sources_v3/StreamChat/Query/ChannelListQuery_Tests.swift
+++ b/Sources_v3/StreamChat/Query/ChannelListQuery_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 final class ChannelListFilterScope_Tests: XCTestCase {
-    typealias Key<T: FilterValue> = FilterKey<ChannelListFilterScope<NoExtraData>, T>
+    typealias Key<T: FilterValue> = FilterKey<ChannelListFilterScope, T>
     
     func test_filterKeys_matchChannelCodingKeys() {
         XCTAssertEqual(Key<ChannelId>.cid.rawValue, ChannelCodingKeys.cid.rawValue)
@@ -26,8 +26,8 @@ final class ChannelListFilterScope_Tests: XCTestCase {
         // Check the `containMembers` helper translates to `members $in [ids]`
         let ids: [UserId] = [.unique, .unique]
         XCTAssertEqual(
-            Filter<ChannelListFilterScope<NoExtraData>>.containMembers(userIds: ids),
-            Filter<ChannelListFilterScope<NoExtraData>>.in(.members, values: ids)
+            Filter<ChannelListFilterScope>.containMembers(userIds: ids),
+            Filter<ChannelListFilterScope>.in(.members, values: ids)
         )
     }
     

--- a/Sources_v3/StreamChat/Query/ChannelMemberListQuery.swift
+++ b/Sources_v3/StreamChat/Query/ChannelMemberListQuery.swift
@@ -9,7 +9,24 @@ import Foundation
 public protocol AnyMemberListFilterScope: AnyUserListFilterScope {}
 
 /// An extra-data-specific namespace for the `FilterKey`s suitable to be used for `ChannelMemberListQuery`.
-public class MemberListFilterScope<ExtraData: UserExtraData>: _UserListFilterScope<ExtraData>, AnyMemberListFilterScope {}
+///
+/// - Note: `MemberListFilterScope` is a typealias of `_MemberListFilterScope` with the default extra data types.
+/// If you want to use your custom extra data types, you should create your own `MemberListFilterScope`
+/// typealias for `_MemberListFilterScope`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public typealias MemberListFilterScope = _MemberListFilterScope<NoExtraData>
+
+/// An extra-data-specific namespace for the `FilterKey`s suitable to be used for `_ChannelMemberListQuery`.
+///
+/// - Note: `_MemberListFilterScope` type is not meant to be used directly.
+/// If you don't use custom extra data types, use `MemberListFilterScope` typealias instead.
+/// When using custom extra data types, you should create your own `MemberListFilterScope` typealias for `_MemberListFilterScope`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public class _MemberListFilterScope<ExtraData: UserExtraData>: _UserListFilterScope<ExtraData>, AnyMemberListFilterScope {}
 
 /// Non extra-data-specific filer keys for member list.
 public extension FilterKey where Scope: AnyMemberListFilterScope {
@@ -46,7 +63,7 @@ public struct _ChannelMemberListQuery<ExtraData: UserExtraData>: Encodable {
     /// A channel identifier the members should be fetched for.
     public let cid: ChannelId
     /// A filter for the query (see `Filter`).
-    public let filter: Filter<MemberListFilterScope<ExtraData>>?
+    public let filter: Filter<_MemberListFilterScope<ExtraData>>?
     /// A sorting for the query (see `Sorting`).
     public let sort: [Sorting<ChannelMemberListSortingKey>]
     /// A pagination.
@@ -60,7 +77,7 @@ public struct _ChannelMemberListQuery<ExtraData: UserExtraData>: Encodable {
     ///   - pageSize: The page size for pagination.
     public init(
         cid: ChannelId,
-        filter: Filter<MemberListFilterScope<ExtraData>>? = nil,
+        filter: Filter<_MemberListFilterScope<ExtraData>>? = nil,
         sort: [Sorting<ChannelMemberListSortingKey>] = [],
         pageSize: Int = .channelMembersPageSize
     ) {

--- a/Sources_v3/StreamChat/Query/ChannelMemberListQuery.swift
+++ b/Sources_v3/StreamChat/Query/ChannelMemberListQuery.swift
@@ -18,7 +18,24 @@ public extension FilterKey where Scope: AnyMemberListFilterScope {
 }
 
 /// A query type used for fetching channel members from the backend.
-public struct ChannelMemberListQuery<ExtraData: UserExtraData>: Encodable {
+///
+/// - Note: `ChannelMemberListQuery` is a typealias of `_ChannelMemberListQuery` with the default extra data types.
+/// If you want to use your custom extra data types, you should create your own `ChannelMemberListQuery`
+/// typealias for `_ChannelMemberListQuery`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public typealias ChannelMemberListQuery = _ChannelMemberListQuery<NoExtraData>
+
+/// A query type used for fetching channel members from the backend.
+///
+/// - Note: `_ChannelMemberListQuery` type is not meant to be used directly.
+/// If you don't use custom extra data types, use `ChannelMemberListQuery` typealias instead.
+/// When using custom extra data types, you should create your own `ChannelMemberListQuery` typealias for `_ChannelMemberListQuery`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public struct _ChannelMemberListQuery<ExtraData: UserExtraData>: Encodable {
     private enum CodingKeys: String, CodingKey {
         case filter = "filter_conditions"
         case sort
@@ -70,7 +87,7 @@ public struct ChannelMemberListQuery<ExtraData: UserExtraData>: Encodable {
     }
 }
 
-extension ChannelMemberListQuery {
+extension _ChannelMemberListQuery {
     var queryHash: String {
         [
             cid.rawValue,
@@ -80,7 +97,7 @@ extension ChannelMemberListQuery {
     }
 }
 
-extension ChannelMemberListQuery {
+extension _ChannelMemberListQuery {
     /// Builds `ChannelMemberListQuery` for a single member in a specific channel
     /// - Parameters:
     ///   - userId: The user identifier.

--- a/Sources_v3/StreamChat/Query/ChannelMemberListQuery.swift
+++ b/Sources_v3/StreamChat/Query/ChannelMemberListQuery.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -9,7 +9,7 @@ import Foundation
 public protocol AnyMemberListFilterScope: AnyUserListFilterScope {}
 
 /// An extra-data-specific namespace for the `FilterKey`s suitable to be used for `ChannelMemberListQuery`.
-public class MemberListFilterScope<ExtraData: UserExtraData>: UserListFilterScope<ExtraData>, AnyMemberListFilterScope {}
+public class MemberListFilterScope<ExtraData: UserExtraData>: _UserListFilterScope<ExtraData>, AnyMemberListFilterScope {}
 
 /// Non extra-data-specific filer keys for member list.
 public extension FilterKey where Scope: AnyMemberListFilterScope {

--- a/Sources_v3/StreamChat/Query/ChannelMemberListQuery_Tests.swift
+++ b/Sources_v3/StreamChat/Query/ChannelMemberListQuery_Tests.swift
@@ -32,7 +32,7 @@ final class MemberListFilterScope_Tests: XCTestCase {
 final class ChannelMemberListQuery_Tests: XCTestCase {
     func test_query_isEncodedCorrectly() throws {
         // Create the query.
-        let query = ChannelMemberListQuery<NoExtraData>(
+        let query = ChannelMemberListQuery(
             cid: .unique,
             filter: .equal(.id, to: "luke"),
             sort: [.init(key: .createdAt, isAscending: true)]
@@ -53,7 +53,7 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
     
     func test_hash_isCalculatedCorrectly() {
         // Create the query.
-        let query = ChannelMemberListQuery<NoExtraData>(
+        let query = ChannelMemberListQuery(
             cid: .unique,
             filter: .equal(.id, to: "luke"),
             sort: [.init(key: .createdAt, isAscending: true)]
@@ -71,7 +71,7 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
     
     func test_emptySorting_isNotEncoded() throws {
         // Create the query without any sort options.
-        let query = ChannelMemberListQuery<NoExtraData>(
+        let query = ChannelMemberListQuery(
             cid: .unique,
             filter: .equal(.id, to: "luke")
         )
@@ -90,7 +90,7 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
     
     func test_defaultPageSizeIsUsed_ifNotSpecified() throws {
         // Create the query with default params.
-        let query = ChannelMemberListQuery<NoExtraData>(
+        let query = ChannelMemberListQuery(
             cid: .unique,
             filter: .equal(.id, to: "luke")
         )
@@ -111,10 +111,10 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
         let userId: UserId = .unique
         let cid: ChannelId = .unique
 
-        let actual = ChannelMemberListQuery<NoExtraData>.channelMember(userId: userId, cid: cid)
+        let actual = ChannelMemberListQuery.channelMember(userId: userId, cid: cid)
         let actualJSON = try JSONEncoder.default.encode(actual)
 
-        let expected = ChannelMemberListQuery<NoExtraData>(cid: cid, filter: .equal("id", to: userId))
+        let expected = ChannelMemberListQuery(cid: cid, filter: .equal("id", to: userId))
         let expectedJSON = try JSONEncoder.default.encode(expected)
     
         // Assert queries match

--- a/Sources_v3/StreamChat/Query/ChannelMemberListQuery_Tests.swift
+++ b/Sources_v3/StreamChat/Query/ChannelMemberListQuery_Tests.swift
@@ -1,12 +1,12 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
 import XCTest
 
 final class MemberListFilterScope_Tests: XCTestCase {
-    typealias Key<T: FilterValue> = FilterKey<MemberListFilterScope<NoExtraData>, T>
+    typealias Key<T: FilterValue> = FilterKey<MemberListFilterScope, T>
     
     func test_filterKeys_matchChannelCodingKeys() {
         // Member specific coding keys

--- a/Sources_v3/StreamChat/Query/ChannelQuery.swift
+++ b/Sources_v3/StreamChat/Query/ChannelQuery.swift
@@ -1,11 +1,28 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
 
 /// A channel query.
-public struct ChannelQuery<ExtraData: ExtraDataTypes>: Encodable {
+///
+/// - Note: `ChannelQuery` is a typealias of `_ChannelQuery` with the default extra data types.
+/// If you want to use your custom extra data types, you should create your own `ChannelQuery`
+/// typealias for `_ChannelQuery`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public typealias ChannelQuery = _ChannelQuery<NoExtraData>
+
+/// A channel query.
+///
+/// - Note: `_ChannelQuery` type is not meant to be used directly.
+/// If you don't use custom extra data types, use `ChannelQuery` typealias instead.
+/// When using custom extra data types, you should create your own `ChannelQuery` typealias for `_ChannelQuery`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public struct _ChannelQuery<ExtraData: ExtraDataTypes>: Encodable {
     private enum CodingKeys: String, CodingKey {
         case data
         case messages

--- a/Sources_v3/StreamChat/Query/ChannelQuery_Tests.swift
+++ b/Sources_v3/StreamChat/Query/ChannelQuery_Tests.swift
@@ -14,7 +14,7 @@ class ChannelQuery_Tests: XCTestCase {
         let watchersLimit = 10
 
         // Create ChannelQuery
-        let query = ChannelQuery<NoExtraData>(
+        let query = ChannelQuery(
             cid: cid,
             paginationParameter: paginationParameter,
             membersLimit: membersLimit,
@@ -39,7 +39,7 @@ class ChannelQuery_Tests: XCTestCase {
     
     func test_pathParameters() {
         // Create query without id specified
-        let query1: ChannelQuery<NoExtraData> = .init(channelPayload: .init(
+        let query1: ChannelQuery = .init(channelPayload: .init(
             type: .messaging,
             name: .unique,
             imageURL: .unique(),
@@ -54,7 +54,7 @@ class ChannelQuery_Tests: XCTestCase {
         
         // Create query with id and type specified
         let cid: ChannelId = .unique
-        let query2: ChannelQuery<NoExtraData> = .init(cid: cid)
+        let query2: ChannelQuery = .init(cid: cid)
         
         // Assert type and id are part of path
         XCTAssertEqual(query2.pathParameters, "\(query2.type)/\(query2.id!)")

--- a/Sources_v3/StreamChat/Query/UserListQuery.swift
+++ b/Sources_v3/StreamChat/Query/UserListQuery.swift
@@ -7,8 +7,25 @@ import Foundation
 /// A namespace for the `FilterKey`s suitable to be used for `UserListQuery`. This scope is not aware of any extra data types.
 public protocol AnyUserListFilterScope {}
 
-/// An extra-data-specific namespace for the `FilterKey`s suitable to be used for `UserListQuery`.
-public class UserListFilterScope<ExtraData: UserExtraData>: FilterScope, AnyUserListFilterScope {}
+/// An extra-data-specific namespace for the `FilterKey`s suitable to be used for `_UserListQuery`.
+///
+/// - Note: `UserListFilterScope` is a typealias of `_UserListFilterScope` with the default extra data types.
+/// If you want to use your custom extra data types, you should create your own `UserListFilterScope`
+/// typealias for `_UserListFilterScope`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public typealias UserListFilterScope = _UserListFilterScope<NoExtraData>
+
+/// An extra-data-specific namespace for the `FilterKey`s suitable to be used for `_UserListQuery`.
+///
+/// - Note: `_UserListFilterScope` type is not meant to be used directly.
+/// If you don't use custom extra data types, use `UserListFilterScope` typealias instead.
+/// When using custom extra data types, you should create your own `UserListFilterScope` typealias for `_UserListFilterScope`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public class _UserListFilterScope<ExtraData: UserExtraData>: FilterScope, AnyUserListFilterScope {}
 
 /// Non extra-data-specific filer keys for channel list.
 public extension FilterKey where Scope: AnyUserListFilterScope {
@@ -81,7 +98,7 @@ public struct _UserListQuery<ExtraData: UserExtraData>: Encodable {
     }
     
     /// A filter for the query (see `Filter`).
-    public var filter: Filter<UserListFilterScope<ExtraData>>?
+    public var filter: Filter<_UserListFilterScope<ExtraData>>?
     
     /// A sorting for the query (see `Sorting`).
     public let sort: [Sorting<UserListSortingKey>]
@@ -102,7 +119,7 @@ public struct _UserListQuery<ExtraData: UserExtraData>: Encodable {
     ///   - sort: a sorting list for users.
     ///   - pageSize: a page size for pagination.
     public init(
-        filter: Filter<UserListFilterScope<ExtraData>>? = nil,
+        filter: Filter<_UserListFilterScope<ExtraData>>? = nil,
         sort: [Sorting<UserListSortingKey>] = [],
         pageSize: Int = .usersPageSize
     ) {

--- a/Sources_v3/StreamChat/Query/UserListQuery.swift
+++ b/Sources_v3/StreamChat/Query/UserListQuery.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -56,7 +56,24 @@ public extension FilterKey where Scope: AnyUserListFilterScope {
 
 /// A query is used for querying specific users from backend.
 /// You can specify filter, sorting and pagination.
-public struct UserListQuery<ExtraData: UserExtraData>: Encodable {
+///
+/// - Note: `UserListQuery` is a typealias of `_UserListQuery` with the default extra data types.
+/// If you want to use your custom extra data types, you should create your own `UserListQuery` typealias for `_UserListQuery`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+typealias UserListQuery = _UserListQuery<NoExtraData>
+
+/// A query is used for querying specific users from backend.
+/// You can specify filter, sorting and pagination.
+///
+/// - Note: `_UserListQuery` type is not meant to be used directly.
+/// If you don't use custom extra data types, use `UserListQuery` typealias instead.
+/// When using custom extra data types, you should create your own `UserListQuery` typealias for `_UserListQuery`.
+///
+/// Learn more about using custom extra data in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#working-with-extra-data).
+///
+public struct _UserListQuery<ExtraData: UserExtraData>: Encodable {
     private enum CodingKeys: String, CodingKey {
         case filter = "filter_conditions"
         case sort
@@ -112,7 +129,7 @@ public struct UserListQuery<ExtraData: UserExtraData>: Encodable {
     }
 }
 
-extension UserListQuery {
+extension _UserListQuery {
     /// Builds `UserListQuery` for a user with the provided `userId`
     /// - Parameter userId: The user identifier
     /// - Returns: `UserListQuery` for a specific user

--- a/Sources_v3/StreamChat/Query/UserListQuery_Tests.swift
+++ b/Sources_v3/StreamChat/Query/UserListQuery_Tests.swift
@@ -32,7 +32,7 @@ class UserListQuery_Tests: XCTestCase {
         let sort: [Sorting<UserListSortingKey>] = [.init(key: .lastActivityAt)]
 
         // Create UserListQuery
-        let query = UserListQuery(
+        let query = _UserListQuery(
             filter: filter,
             sort: sort,
             pageSize: 23
@@ -55,10 +55,10 @@ class UserListQuery_Tests: XCTestCase {
     func test_singleUserQuery_worksCorrectly() throws {
         let userId: UserId = .unique
         
-        let actual = UserListQuery<NoExtraData>.user(withID: userId)
+        let actual = UserListQuery.user(withID: userId)
         let actualJSON = try JSONEncoder.default.encode(actual)
 
-        let expected = UserListQuery<NoExtraData>(filter: .equal("id", to: userId))
+        let expected = UserListQuery(filter: .equal("id", to: userId))
         let expectedJSON = try JSONEncoder.default.encode(expected)
     
         // Assert queries match
@@ -73,7 +73,7 @@ class UserListQuery_Tests: XCTestCase {
         ]
         
         // Create queries with sortings
-        let queries = sortings.map { UserListQuery<NoExtraData>(sort: $0) }
+        let queries = sortings.map { UserListQuery(sort: $0) }
         
         // Assert safe sorting option is added
         queries.forEach {

--- a/Sources_v3/StreamChat/Query/UserListQuery_Tests.swift
+++ b/Sources_v3/StreamChat/Query/UserListQuery_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 final class UserListFilterScope_Tests: XCTestCase {
-    typealias Key<T: FilterValue> = FilterKey<UserListFilterScope<NoExtraData>, T>
+    typealias Key<T: FilterValue> = FilterKey<UserListFilterScope, T>
     
     func test_filterKeys_matchChannelCodingKeys() {
         XCTAssertEqual(Key<UserId>.id.rawValue, UserPayloadsCodingKeys.id.rawValue)
@@ -28,7 +28,7 @@ final class UserListFilterScope_Tests: XCTestCase {
 class UserListQuery_Tests: XCTestCase {
     // Test UserListQuery encoded correctly
     func test_UserListQuery_encodedCorrectly() throws {
-        let filter: Filter<UserListFilterScope<NoExtraData>> = .equal(.id, to: "luke")
+        let filter: Filter<UserListFilterScope> = .equal(.id, to: "luke")
         let sort: [Sorting<UserListSortingKey>] = [.init(key: .lastActivityAt)]
 
         // Create UserListQuery

--- a/Sources_v3/StreamChat/Utils/Codable+Extensions.swift
+++ b/Sources_v3/StreamChat/Utils/Codable+Extensions.swift
@@ -8,10 +8,10 @@ import Foundation
 
 extension JSONDecoder {
     /// A default `JSONDecoder`.
-    public static var `default`: JSONDecoder = stream
+    static var `default`: JSONDecoder = stream
     
     /// A Stream Chat JSON decoder.
-    public static let stream: JSONDecoder = {
+    static let stream: JSONDecoder = {
         let decoder = JSONDecoder()
         
         /// A custom decoding for a date.

--- a/Sources_v3/StreamChat/Utils/Codable+Extensions.swift
+++ b/Sources_v3/StreamChat/Utils/Codable+Extensions.swift
@@ -44,19 +44,19 @@ extension JSONDecoder {
 
 extension JSONEncoder {
     /// A default `JSONEncoder`.
-    public static var `default`: JSONEncoder = stream
+    static var `default`: JSONEncoder = stream
     /// A default gzip `JSONEncoder`.
-    public static var defaultGzip: JSONEncoder = streamGzip
+    static var defaultGzip: JSONEncoder = streamGzip
     
     /// A Stream Chat JSON encoder.
-    public static let stream: JSONEncoder = {
+    static let stream: JSONEncoder = {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .stream
         return encoder
     }()
     
     /// A Stream Chat JSON encoder with a gzipped content.
-    public static let streamGzip: JSONEncoder = {
+    static let streamGzip: JSONEncoder = {
         let encoder = JSONEncoder()
         encoder.dataEncodingStrategy = .gzip
         encoder.dateEncodingStrategy = .stream

--- a/Sources_v3/StreamChat/Utils/Codable+Extensions.swift
+++ b/Sources_v3/StreamChat/Utils/Codable+Extensions.swift
@@ -89,12 +89,12 @@ extension JSONEncoder.DateEncodingStrategy {
 
 extension DateFormatter {
     /// A Stream Chat date formatters.
-    public enum Stream {
+    enum Stream {
         /// Creates and returns a date object from the specified ISO 8601 formatted string representation.
         ///
         /// - Parameter string: The ISO 8601 formatted string representation of a date.
         /// - Returns: A date object, or nil if no valid date was found.
-        public static func iso8601Date(from string: String) -> Date? {
+        static func iso8601Date(from string: String) -> Date? {
             if #available(iOS 11.2, macOS 10.13, *) {
                 return Stream.iso8601DateFormatter.date(from: string)
             }
@@ -106,7 +106,7 @@ extension DateFormatter {
         ///
         /// - Parameter date: The date to be represented.
         /// - Returns: A user-readable string representing the date.
-        public static func iso8601DateString(from date: Date) -> String? {
+        static func iso8601DateString(from date: Date) -> String? {
             if #available(iOS 11.2, macOS 10.13, *) {
                 return Stream.iso8601DateFormatter.string(from: date)
             }

--- a/Sources_v3/StreamChat/Utils/Data+Gzip.swift
+++ b/Sources_v3/StreamChat/Utils/Data+Gzip.swift
@@ -35,7 +35,7 @@ extension Data {
     ///
     /// - Returns: Gzip-compressed `Data` instance.
     /// - Throws: `GzipError`
-    public func gzipped() throws -> Data {
+    func gzipped() throws -> Data {
         guard !isEmpty else {
             return Data()
         }
@@ -106,10 +106,10 @@ extension Data {
 }
 
 /// Errors on gzipping/gunzipping based on the zlib error codes.
-public struct GzipError: Swift.Error {
+struct GzipError: Swift.Error {
     // cf. http://www.zlib.net/manual.html
     
-    public enum Kind: Equatable {
+    enum Kind: Equatable {
         /// The stream structure was inconsistent.
         ///
         /// - underlying zlib error: `Z_STREAM_ERROR` (-2)
@@ -143,12 +143,12 @@ public struct GzipError: Swift.Error {
     }
     
     /// Error kind.
-    public let kind: Kind
+    let kind: Kind
     
     /// Returned message by zlib.
-    public let message: String
+    let message: String
     
-    internal init(code: Int32, msg: UnsafePointer<CChar>?) {
+    init(code: Int32, msg: UnsafePointer<CChar>?) {
         message = {
             guard let msg = msg, let message = String(validatingUTF8: msg) else {
                 return "Unknown gzip error"
@@ -174,7 +174,7 @@ public struct GzipError: Swift.Error {
         }()
     }
     
-    public var localizedDescription: String {
+    var localizedDescription: String {
         message
     }
 }

--- a/Sources_v3/StreamChat/Workers/Background/ChannelWatchStateUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/Background/ChannelWatchStateUpdater.swift
@@ -57,7 +57,7 @@ final class ChannelWatchStateUpdater<ExtraData: ExtraDataTypes>: EventWorker {
             
             guard !channelIds.isEmpty else { return }
             
-            let channelListQuery = ChannelListQuery<ExtraData.Channel>(
+            let channelListQuery = _ChannelListQuery<ExtraData.Channel>(
                 filter: .in(.cid, values: channelIds),
                 pageSize: 1
             )

--- a/Sources_v3/StreamChat/Workers/Background/ChannelWatchStateUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/Background/ChannelWatchStateUpdater_Tests.swift
@@ -74,7 +74,7 @@ class ChannelWatchStateUpdater_Tests: StressTestCase {
         // Simulate WebSocket successfully connected
         webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
         
-        let query: ChannelListQuery<NoExtraData> = .init(
+        let query: ChannelListQuery = .init(
             filter: .in(.cid, values: [cid]),
             pageSize: 1
         )

--- a/Sources_v3/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
@@ -118,13 +118,13 @@ extension NewChannelQueryUpdater {
 
 private extension ChannelListQueryDTO {
     func asChannelListQueryWithUpdatedFilter<ExtraData: ChannelExtraData>(
-        filterToAdd filter: Filter<ChannelListFilterScope<ExtraData>>
+        filterToAdd filter: Filter<_ChannelListFilterScope<ExtraData>>
     ) throws -> _ChannelListQuery<ExtraData> {
         let encodedFilter = try JSONDecoder.default
-            .decode(Filter<ChannelListFilterScope<ExtraData>>.self, from: filterJSONData)
+            .decode(Filter<_ChannelListFilterScope<ExtraData>>.self, from: filterJSONData)
         
         // We need to pass original `filterHash` so channel will be linked to original query, not the modified one
-        var updatedFilter: Filter<ChannelListFilterScope> = .and([encodedFilter, filter])
+        var updatedFilter: Filter<_ChannelListFilterScope> = .and([encodedFilter, filter])
         updatedFilter.explicitHash = filterHash
         
         return _ChannelListQuery(filter: updatedFilter)

--- a/Sources_v3/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
@@ -82,7 +82,7 @@ final class NewChannelQueryUpdater<ExtraData: ExtraDataTypes>: Worker {
         database.backgroundReadOnlyContext.perform { [weak self] in
             guard let queries = self?.queries else { return }
             
-            var updatedQueries: [ChannelListQuery<ExtraData.Channel>] = []
+            var updatedQueries: [_ChannelListQuery<ExtraData.Channel>] = []
             
             do {
                 updatedQueries = try queries.map {
@@ -119,7 +119,7 @@ extension NewChannelQueryUpdater {
 private extension ChannelListQueryDTO {
     func asChannelListQueryWithUpdatedFilter<ExtraData: ChannelExtraData>(
         filterToAdd filter: Filter<ChannelListFilterScope<ExtraData>>
-    ) throws -> ChannelListQuery<ExtraData> {
+    ) throws -> _ChannelListQuery<ExtraData> {
         let encodedFilter = try JSONDecoder.default
             .decode(Filter<ChannelListFilterScope<ExtraData>>.self, from: filterJSONData)
         
@@ -127,6 +127,6 @@ private extension ChannelListQueryDTO {
         var updatedFilter: Filter<ChannelListFilterScope> = .and([encodedFilter, filter])
         updatedFilter.explicitHash = filterHash
         
-        return ChannelListQuery(filter: updatedFilter)
+        return _ChannelListQuery(filter: updatedFilter)
     }
 }

--- a/Sources_v3/StreamChat/Workers/Background/NewChannelQueryUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/Background/NewChannelQueryUpdater_Tests.swift
@@ -46,8 +46,8 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
     }
     
     func test_update_called_forEachQuery() throws {
-        let filter1: Filter<ChannelListFilterScope<NoExtraData>> = .equal(.frozen, to: true)
-        let filter2: Filter<ChannelListFilterScope<NoExtraData>> = .equal(.cid, to: .unique)
+        let filter1: Filter<ChannelListFilterScope> = .equal(.frozen, to: true)
+        let filter2: Filter<ChannelListFilterScope> = .equal(.cid, to: .unique)
         
         try database.createChannelListQuery(filter: filter1)
         try database.createChannelListQuery(filter: filter2)
@@ -65,7 +65,7 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
         // Deinitialize newChannelQueryUpdater
         newChannelQueryUpdater = nil
         
-        let filter: Filter<ChannelListFilterScope<NoExtraData>> = .equal(.cid, to: .unique)
+        let filter: Filter<ChannelListFilterScope> = .equal(.cid, to: .unique)
         try database.createChannelListQuery(filter: filter)
         try database.createChannel(cid: .unique)
         
@@ -85,7 +85,7 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
     
     func test_filter_isModified() throws {
         let cid: ChannelId = .unique
-        let filter: Filter<ChannelListFilterScope<NoExtraData>> = .equal(.cid, to: .unique)
+        let filter: Filter<ChannelListFilterScope> = .equal(.cid, to: .unique)
         
         try database.createChannelListQuery(filter: filter)
         try database.createChannel(cid: cid)
@@ -100,7 +100,7 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
     }
     
     func test_newChannelQueryUpdater_doesNotRetainItself() throws {
-        let filter: Filter<ChannelListFilterScope<NoExtraData>> = .equal(.cid, to: .unique)
+        let filter: Filter<ChannelListFilterScope> = .equal(.cid, to: .unique)
         try database.createChannelListQuery(filter: filter)
         try database.createChannel()
         

--- a/Sources_v3/StreamChat/Workers/Background/NewUserQueryUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/Background/NewUserQueryUpdater.swift
@@ -119,12 +119,12 @@ extension NewUserQueryUpdater {
 
 private extension UserListQueryDTO {
     func asUserListQueryWithUpdatedFilter<ExtraData: UserExtraData>(
-        filterToAdd filter: Filter<UserListFilterScope<ExtraData>>
+        filterToAdd filter: Filter<_UserListFilterScope<ExtraData>>
     ) throws -> _UserListQuery<ExtraData> {
-        let encodedFilter = try JSONDecoder.default.decode(Filter<UserListFilterScope<ExtraData>>.self, from: filterJSONData)
+        let encodedFilter = try JSONDecoder.default.decode(Filter<_UserListFilterScope<ExtraData>>.self, from: filterJSONData)
         
         // We need to pass original `filterHash` so user will be linked to original query, not the modified one
-        var updatedFilter: Filter<UserListFilterScope<ExtraData>> = .and([encodedFilter, filter])
+        var updatedFilter: Filter<_UserListFilterScope<ExtraData>> = .and([encodedFilter, filter])
         updatedFilter.explicitHash = filterHash
         
         return _UserListQuery(filter: updatedFilter)

--- a/Sources_v3/StreamChat/Workers/Background/NewUserQueryUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/Background/NewUserQueryUpdater.swift
@@ -83,7 +83,7 @@ final class NewUserQueryUpdater<ExtraData: UserExtraData>: Worker {
             guard let queries = self?.queries else { return }
 
             // Existing queries with modified filter parameter
-            var updatedQueries: [UserListQuery<ExtraData>] = []
+            var updatedQueries: [_UserListQuery<ExtraData>] = []
             
             do {
                 updatedQueries = try queries.map {
@@ -120,13 +120,13 @@ extension NewUserQueryUpdater {
 private extension UserListQueryDTO {
     func asUserListQueryWithUpdatedFilter<ExtraData: UserExtraData>(
         filterToAdd filter: Filter<UserListFilterScope<ExtraData>>
-    ) throws -> UserListQuery<ExtraData> {
+    ) throws -> _UserListQuery<ExtraData> {
         let encodedFilter = try JSONDecoder.default.decode(Filter<UserListFilterScope<ExtraData>>.self, from: filterJSONData)
         
         // We need to pass original `filterHash` so user will be linked to original query, not the modified one
         var updatedFilter: Filter<UserListFilterScope<ExtraData>> = .and([encodedFilter, filter])
         updatedFilter.explicitHash = filterHash
         
-        return UserListQuery(filter: updatedFilter)
+        return _UserListQuery(filter: updatedFilter)
     }
 }

--- a/Sources_v3/StreamChat/Workers/Background/NewUserQueryUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/Background/NewUserQueryUpdater_Tests.swift
@@ -46,8 +46,8 @@ class NewUserQueryUpdater_Tests: StressTestCase {
     }
     
     func test_update_called_forEachQuery() throws {
-        let filter1: Filter<UserListFilterScope<NoExtraData>> = .equal(.id, to: .unique)
-        let filter2: Filter<UserListFilterScope<NoExtraData>> = .notEqual(.id, to: .unique)
+        let filter1: Filter<UserListFilterScope> = .equal(.id, to: .unique)
+        let filter2: Filter<UserListFilterScope> = .notEqual(.id, to: .unique)
         
         try database.createUserListQuery(filter: filter1)
         try database.createUserListQuery(filter: filter2)
@@ -65,7 +65,7 @@ class NewUserQueryUpdater_Tests: StressTestCase {
         // Deinitialize newUserQueryUpdater
         newUserQueryUpdater = nil
         
-        let filter: Filter<UserListFilterScope<NoExtraData>> = .notEqual(.id, to: .unique)
+        let filter: Filter<UserListFilterScope> = .notEqual(.id, to: .unique)
         try database.createUserListQuery(filter: filter)
         try database.createUser(id: .unique)
         
@@ -85,7 +85,7 @@ class NewUserQueryUpdater_Tests: StressTestCase {
     
     func test_filter_isModified() throws {
         let id: UserId = .unique
-        let filter: Filter<UserListFilterScope<NoExtraData>> = .notEqual(.id, to: .unique)
+        let filter: Filter<UserListFilterScope> = .notEqual(.id, to: .unique)
         
         try database.createUserListQuery(filter: filter)
         try database.createUser(id: id)
@@ -100,7 +100,7 @@ class NewUserQueryUpdater_Tests: StressTestCase {
     }
     
     func test_newUserQueryUpdater_doesNotRetainItself() throws {
-        let filter: Filter<UserListFilterScope<NoExtraData>> = .notEqual(.id, to: .unique)
+        let filter: Filter<UserListFilterScope> = .notEqual(.id, to: .unique)
         try database.createUserListQuery(filter: filter)
         try database.createUser()
         
@@ -112,7 +112,7 @@ class NewUserQueryUpdater_Tests: StressTestCase {
     }
     
     func test_updater_ignoresNonObservedQueries() throws {
-        let filter1: Filter<UserListFilterScope<NoExtraData>> = .equal(.id, to: .unique)
+        let filter1: Filter<UserListFilterScope> = .equal(.id, to: .unique)
         
         try database.createUserListQuery(filter: filter1)
         

--- a/Sources_v3/StreamChat/Workers/Background/NewUserQueryUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/Background/NewUserQueryUpdater_Tests.swift
@@ -116,7 +116,7 @@ class NewUserQueryUpdater_Tests: StressTestCase {
         
         try database.createUserListQuery(filter: filter1)
         
-        var nonObservedQuery = UserListQuery<NoExtraData>(filter: .equal(.name, to: .unique))
+        var nonObservedQuery = UserListQuery(filter: .equal(.name, to: .unique))
         nonObservedQuery.shouldBeUpdatedInBackground = false
         
         try database.writeSynchronously { session in

--- a/Sources_v3/StreamChat/Workers/ChannelListUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelListUpdater.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -12,7 +12,7 @@ class ChannelListUpdater<ExtraData: ExtraDataTypes>: Worker {
     ///   - channelListQuery: The channels query used in the request
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     ///
-    func update(channelListQuery: ChannelListQuery<ExtraData.Channel>, completion: ((Error?) -> Void)? = nil) {
+    func update(channelListQuery: _ChannelListQuery<ExtraData.Channel>, completion: ((Error?) -> Void)? = nil) {
         apiClient
             .request(endpoint: .channels(query: channelListQuery)) { (result: Result<ChannelListPayload<ExtraData>, Error>) in
                 switch result {

--- a/Sources_v3/StreamChat/Workers/ChannelListUpdater_Mock.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelListUpdater_Mock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -7,7 +7,7 @@ import XCTest
 
 /// Mock implementation of ChannelListUpdater
 class ChannelListUpdaterMock<ExtraData: ExtraDataTypes>: ChannelListUpdater<ExtraData> {
-    @Atomic var update_queries: [ChannelListQuery<ExtraData.Channel>] = []
+    @Atomic var update_queries: [_ChannelListQuery<ExtraData.Channel>] = []
     @Atomic var update_completion: ((Error?) -> Void)?
     
     @Atomic var markAllRead_completion: ((Error?) -> Void)?
@@ -19,7 +19,7 @@ class ChannelListUpdaterMock<ExtraData: ExtraDataTypes>: ChannelListUpdater<Extr
         markAllRead_completion = nil
     }
     
-    override func update(channelListQuery: ChannelListQuery<ExtraData.Channel>, completion: ((Error?) -> Void)? = nil) {
+    override func update(channelListQuery: _ChannelListQuery<ExtraData.Channel>, completion: ((Error?) -> Void)? = nil) {
         _update_queries.mutate { $0.append(channelListQuery) }
         update_completion = completion
     }

--- a/Sources_v3/StreamChat/Workers/ChannelListUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelListUpdater_Tests.swift
@@ -34,7 +34,7 @@ class ChannelListUpdater_Tests: StressTestCase {
     
     func test_update_makesCorrectAPICall() {
         // Simulate `update` call
-        let query = ChannelListQuery<NoExtraData>(filter: .in(.members, values: [.unique]))
+        let query = ChannelListQuery(filter: .in(.members, values: [.unique]))
         listUpdater.update(channelListQuery: query)
         
         let referenceEndpoint: Endpoint<ChannelListPayload<NoExtraData>> = .channels(query: query)
@@ -43,7 +43,7 @@ class ChannelListUpdater_Tests: StressTestCase {
     
     func test_update_successfulResponseData_areSavedToDB() {
         // Simulate `update` call
-        let query = ChannelListQuery<NoExtraData>(filter: .in(.members, values: [.unique]))
+        let query = ChannelListQuery(filter: .in(.members, values: [.unique]))
         var completionCalled = false
         listUpdater.update(channelListQuery: query, completion: { error in
             XCTAssertNil(error)
@@ -67,7 +67,7 @@ class ChannelListUpdater_Tests: StressTestCase {
     
     func test_update_errorResponse_isPropagatedToCompletion() {
         // Simulate `update` call
-        let query = ChannelListQuery<NoExtraData>(filter: .in(.members, values: [.unique]))
+        let query = ChannelListQuery(filter: .in(.members, values: [.unique]))
         var completionCalledError: Error?
         listUpdater.update(channelListQuery: query, completion: { completionCalledError = $0 })
         

--- a/Sources_v3/StreamChat/Workers/ChannelMemberListUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelMemberListUpdater.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -53,7 +53,7 @@ private extension ChannelMemberListUpdater {
     }
     
     func fetchAndSaveChannel(with cid: ChannelId, completion: @escaping (Error?) -> Void) {
-        let query = ChannelQuery<ExtraData>(cid: cid)
+        let query = _ChannelQuery<ExtraData>(cid: cid)
         apiClient.request(endpoint: .channel(query: query)) {
             switch $0 {
             case let .success(payload):

--- a/Sources_v3/StreamChat/Workers/ChannelMemberListUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelMemberListUpdater.swift
@@ -10,7 +10,7 @@ class ChannelMemberListUpdater<ExtraData: ExtraDataTypes>: Worker {
     /// - Parameters:
     ///   - query: The query used in the request.
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
-    func load(_ query: ChannelMemberListQuery<ExtraData.User>, completion: ((Error?) -> Void)? = nil) {
+    func load(_ query: _ChannelMemberListQuery<ExtraData.User>, completion: ((Error?) -> Void)? = nil) {
         fetchAndSaveChannelIfNeeded(query.cid) { error in
             guard error == nil else {
                 completion?(error)

--- a/Sources_v3/StreamChat/Workers/ChannelMemberListUpdater_Mock.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelMemberListUpdater_Mock.swift
@@ -7,7 +7,7 @@ import XCTest
 
 /// Mock implementation of `ChannelMemberListUpdater`
 final class ChannelMemberListUpdaterMock<ExtraData: ExtraDataTypes>: ChannelMemberListUpdater<ExtraData> {
-    @Atomic var load_query: ChannelMemberListQuery<ExtraData.User>?
+    @Atomic var load_query: _ChannelMemberListQuery<ExtraData.User>?
     @Atomic var load_completion: ((Error?) -> Void)?
     
     func cleanUp() {
@@ -15,7 +15,7 @@ final class ChannelMemberListUpdaterMock<ExtraData: ExtraDataTypes>: ChannelMemb
         load_completion = nil
     }
 
-    override func load(_ query: ChannelMemberListQuery<ExtraData.User>, completion: ((Error?) -> Void)? = nil) {
+    override func load(_ query: _ChannelMemberListQuery<ExtraData.User>, completion: ((Error?) -> Void)? = nil) {
         load_query = query
         load_completion = completion
     }

--- a/Sources_v3/StreamChat/Workers/ChannelMemberListUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelMemberListUpdater_Tests.swift
@@ -9,7 +9,7 @@ final class ChannelMemberListUpdater_Tests: StressTestCase {
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!
     var database: DatabaseContainerMock!
-    var query: ChannelMemberListQuery<NoExtraData>!
+    var query: ChannelMemberListQuery!
 
     var listUpdater: ChannelMemberListUpdater<NoExtraData>!
     
@@ -19,7 +19,7 @@ final class ChannelMemberListUpdater_Tests: StressTestCase {
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
         database = DatabaseContainerMock()
-        query = ChannelMemberListQuery(cid: .unique, filter: .query(.id, text: "Luke"))
+        query = .init(cid: .unique, filter: .query(.id, text: "Luke"))
 
         listUpdater = .init(database: database, apiClient: apiClient)
     }

--- a/Sources_v3/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelUpdater.swift
@@ -15,7 +15,7 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     ///
     func update(
-        channelQuery: ChannelQuery<ExtraData>,
+        channelQuery: _ChannelQuery<ExtraData>,
         channelCreatedCallback: ((ChannelId) -> Void)? = nil,
         completion: ((Error?) -> Void)? = nil
     ) {

--- a/Sources_v3/StreamChat/Workers/ChannelUpdater_Mock.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelUpdater_Mock.swift
@@ -7,7 +7,7 @@ import XCTest
 
 /// Mock implementation of ChannelUpdater
 class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
-    @Atomic var update_channelQuery: ChannelQuery<ExtraData>?
+    @Atomic var update_channelQuery: _ChannelQuery<ExtraData>?
     @Atomic var update_channelCreatedCallback: ((ChannelId) -> Void)?
     @Atomic var update_completion: ((Error?) -> Void)?
 
@@ -92,7 +92,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
     }
     
     override func update(
-        channelQuery: ChannelQuery<ExtraData>,
+        channelQuery: _ChannelQuery<ExtraData>,
         channelCreatedCallback: ((ChannelId) -> Void)?,
         completion: ((Error?) -> Void)?
     ) {

--- a/Sources_v3/StreamChat/Workers/ChannelUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/ChannelUpdater_Tests.swift
@@ -34,7 +34,7 @@ class ChannelUpdater_Tests: StressTestCase {
     
     func test_updateChannelQuery_makesCorrectAPICall() {
         // Simulate `update(channelQuery:)` call
-        let query = ChannelQuery<ExtraData>(cid: .unique)
+        let query = _ChannelQuery<ExtraData>(cid: .unique)
         channelUpdater.update(channelQuery: query)
         
         let referenceEndpoint: Endpoint<ChannelPayload<ExtraData>> = .channel(query: query)
@@ -43,7 +43,7 @@ class ChannelUpdater_Tests: StressTestCase {
     
     func test_updateChannelQuery_successfulResponseData_areSavedToDB() {
         // Simulate `update(channelQuery:)` call
-        let query = ChannelQuery<ExtraData>(cid: .unique)
+        let query = _ChannelQuery<ExtraData>(cid: .unique)
         var completionCalled = false
         channelUpdater.update(channelQuery: query, completion: { error in
             XCTAssertNil(error)
@@ -67,7 +67,7 @@ class ChannelUpdater_Tests: StressTestCase {
     
     func test_updateChannelQuery_errorResponse_isPropagatedToCompletion() {
         // Simulate `update(channelQuery:)` call
-        let query = ChannelQuery<ExtraData>(cid: .unique)
+        let query = _ChannelQuery<ExtraData>(cid: .unique)
         var completionCalledError: Error?
         channelUpdater.update(channelQuery: query, completion: { completionCalledError = $0 })
         
@@ -81,7 +81,7 @@ class ChannelUpdater_Tests: StressTestCase {
 
     func test_updateChannelQuery_completionForCreatedChannelCalled() {
         // Simulate `update(channelQuery:)` call
-        let query = ChannelQuery(channelPayload: .unique)
+        let query = _ChannelQuery(channelPayload: .unique)
         var cid: ChannelId = .unique
 
         var channel: ChatChannel? {

--- a/Sources_v3/StreamChat/Workers/UserListUpdater.swift
+++ b/Sources_v3/StreamChat/Workers/UserListUpdater.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -21,7 +21,7 @@ class UserListUpdater<ExtraData: UserExtraData>: Worker {
     ///   - policy: The update policy for the resulting user set. See `UpdatePolicy`
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     ///
-    func update(userListQuery: UserListQuery<ExtraData>, policy: UpdatePolicy = .merge, completion: ((Error?) -> Void)? = nil) {
+    func update(userListQuery: _UserListQuery<ExtraData>, policy: UpdatePolicy = .merge, completion: ((Error?) -> Void)? = nil) {
         apiClient
             .request(endpoint: .users(query: userListQuery)) { (result: Result<UserListPayload<ExtraData>, Error>) in
                 switch result {

--- a/Sources_v3/StreamChat/Workers/UserListUpdater_Mock.swift
+++ b/Sources_v3/StreamChat/Workers/UserListUpdater_Mock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -7,7 +7,7 @@ import XCTest
 
 /// Mock implementation of UserListUpdater
 class UserListUpdaterMock<ExtraData: UserExtraData>: UserListUpdater<ExtraData> {
-    @Atomic var update_queries: [UserListQuery<ExtraData>] = []
+    @Atomic var update_queries: [_UserListQuery<ExtraData>] = []
     @Atomic var update_policy: UpdatePolicy?
     @Atomic var update_completion: ((Error?) -> Void)?
     
@@ -18,7 +18,7 @@ class UserListUpdaterMock<ExtraData: UserExtraData>: UserListUpdater<ExtraData> 
     }
         
     override func update(
-        userListQuery: UserListQuery<ExtraData>,
+        userListQuery: _UserListQuery<ExtraData>,
         policy: UpdatePolicy = .merge,
         completion: ((Error?) -> Void)? = nil
     ) {

--- a/Sources_v3/StreamChat/Workers/UserListUpdater_Tests.swift
+++ b/Sources_v3/StreamChat/Workers/UserListUpdater_Tests.swift
@@ -34,7 +34,7 @@ class UserListUpdater_Tests: StressTestCase {
     
     func test_update_makesCorrectAPICall() {
         // Simulate `update` call
-        let query = UserListQuery<NoExtraData>(filter: .equal(.id, to: "Luke"))
+        let query = UserListQuery(filter: .equal(.id, to: "Luke"))
         listUpdater.update(userListQuery: query)
         
         let referenceEndpoint: Endpoint<UserListPayload<NoExtraData>> = .users(query: query)
@@ -43,7 +43,7 @@ class UserListUpdater_Tests: StressTestCase {
     
     func test_update_successfullReponseData_areSavedToDB() {
         // Simulate `update` call
-        let query = UserListQuery<NoExtraData>(filter: .equal(.id, to: "Luke"))
+        let query = UserListQuery(filter: .equal(.id, to: "Luke"))
         var completionCalled = false
         listUpdater.update(userListQuery: query, completion: { error in
             XCTAssertNil(error)
@@ -69,7 +69,7 @@ class UserListUpdater_Tests: StressTestCase {
     
     func test_update_errorResponse_isPropagatedToCompletion() {
         // Simulate `update` call
-        let query = UserListQuery<NoExtraData>(filter: .equal(.id, to: "Luke"))
+        let query = UserListQuery(filter: .equal(.id, to: "Luke"))
         var completionCalledError: Error?
         listUpdater.update(userListQuery: query, completion: { completionCalledError = $0 })
         
@@ -83,7 +83,7 @@ class UserListUpdater_Tests: StressTestCase {
     
     func test_mergePolicy_takesAffect() throws {
         // Simulate `update` call
-        let query = UserListQuery<NoExtraData>(filter: .equal(.id, to: "Luke"))
+        let query = UserListQuery(filter: .equal(.id, to: "Luke"))
         listUpdater.update(userListQuery: query)
         
         // Simulate API response with user data
@@ -134,7 +134,7 @@ class UserListUpdater_Tests: StressTestCase {
     func test_removePolicy_takesAffect() throws {
         // Create query
         let filterHash = String.unique
-        var query = UserListQuery<NoExtraData>(filter: .equal(.id, to: "Luke"))
+        var query = UserListQuery(filter: .equal(.id, to: "Luke"))
         query.filter?.explicitHash = filterHash
         // Simulate `update` call
         // This call doesn't need `policy` argument specified since
@@ -185,7 +185,7 @@ class UserListUpdater_Tests: StressTestCase {
         let dummyUserId = UserId.unique
         
         // Simulate `update` call
-        let query = UserListQuery<NoExtraData>(filter: .equal(.id, to: "Luke"))
+        let query = UserListQuery(filter: .equal(.id, to: "Luke"))
         var completionCalled = false
         listUpdater.update(userListQuery: query, completion: { _ in
             // At this point, DB write should have completed

--- a/Sources_v3/StreamChatUI/ChatChannel/ChatThreadVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/ChatThreadVC.swift
@@ -71,7 +71,7 @@ open class ChatThreadVC<ExtraData: ExtraDataTypes>: ChatVC<ExtraData> {
 
 // MARK: - _ChatChannelControllerDelegate
 
-extension ChatThreadVC: _MessageControllerDelegate {
+extension ChatThreadVC: _ChatMessageControllerDelegate {
     public func messageController(
         _ controller: _ChatMessageController<ExtraData>,
         didChangeReplies changes: [ListChange<_ChatMessage<ExtraData>>]

--- a/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerViewController.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/MessageComposer/MessageComposerViewController.swift
@@ -378,18 +378,14 @@ open class MessageComposerViewController<ExtraData: ExtraDataTypes>: ViewControl
             return imageAttachments.map {
                 .init(
                     localURL: $0.localURL,
-                    fileName: $0.localURL.lastPathComponent,
-                    type: .image,
-                    extraData: .defaultValue
+                    type: .image
                 )
             }
         case .documents:
             return documentAttachments.map {
                 .init(
                     localURL: $0.localURL,
-                    fileName: $0.localURL.lastPathComponent,
-                    type: .file,
-                    extraData: .defaultValue
+                    type: .file
                 )
             }
         case .none:

--- a/Sources_v3/StreamChatUI/ChatChannel/Reactions/ChatMessageReactionVC.swift
+++ b/Sources_v3/StreamChatUI/ChatChannel/Reactions/ChatMessageReactionVC.swift
@@ -61,7 +61,7 @@ open class ChatMessageReactionVC<ExtraData: ExtraDataTypes>: ViewController, UIC
 
 // MARK: - _MessageControllerDelegate
 
-extension ChatMessageReactionVC: _MessageControllerDelegate {
+extension ChatMessageReactionVC: _ChatMessageControllerDelegate {
     public func messageController(
         _ controller: _ChatMessageController<ExtraData>,
         didChangeMessage change: EntityChange<_ChatMessage<ExtraData>>


### PR DESCRIPTION
**This PR**:
- updates `UserListQuery` to follow the naming convention (+ filter scope)
- updates `ChannelListQuery` to follow the naming convention (+ filter scope)
- updates `ChannelMemberListQuery` to follow the naming convention (+ filter scope)
- updates `ChannelQuery` to follow the naming convention
- fixes visability scope for `JSONEncoder/JSONDecoder/Data` extensions