### PR TITLE
[CIS-599] Introduce `register_new_device` lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -12,27 +12,22 @@ before_all do
   end
 end
 
-desc "Installs all Certs and Profiles necessary for development and ad-hoc"
-lane :match_me do
-  match(
-    type: "development",
-    app_identifier: [
-      "io.getstream.StreamChat",
-      "io.getstream.iOS.ChatDemoApp",
-    ],
-    readonly: true,
-    force_for_new_devices: !is_ci
-  )
-  
-  match(
-    type: "adhoc",
-    app_identifier: [
-      "io.getstream.StreamChat",
-      "io.getstream.iOS.ChatDemoApp",
-    ],
-    readonly: true,
-    force_for_new_devices: !is_ci
-  )
+desc "If `readonly: true` (by default), installs all Certs and Profiles necessary for development and ad-hoc.\nIf `readonly: false`, recreates all Profiles necessary for development and ad-hoc, updates them locally and remotely."
+lane :match_me do |options|
+  # Get `:readonly` value, fallback to `true` if it's missing.
+  readonly = options.fetch(:readonly) { true }
+
+  ["development", "adhoc"].each do |type|
+    match(
+      type: type,
+      app_identifier: [
+        "io.getstream.StreamChat",
+        "io.getstream.iOS.ChatDemoApp",
+      ],
+      readonly: readonly,
+      force_for_new_devices: !is_ci
+    )
+  end
 end
 
 desc "Builds the latest version of Demo app and uploads it to Firebase"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,6 +30,19 @@ lane :match_me do |options|
   end
 end
 
+desc "Register new device, regenerates profiles, updates them remotely and locally"
+lane :register_new_device_and_recreate_profiles do
+  device_name = prompt(text: "Enter the device name: ")
+  device_udid = prompt(text: "Enter the device UDID: ")
+
+  register_device(
+    name: device_name,
+    udid: device_udid
+  )
+
+  match_me(readonly: false)
+end
+
 desc "Builds the latest version of Demo app and uploads it to Firebase"
 lane :distribute_demo_app do
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -21,6 +21,11 @@ fastlane match_me
 ```
 If `readonly: true` (by default), installs all Certs and Profiles necessary for development and ad-hoc.
 If `readonly: false`, recreates all Profiles necessary for development and ad-hoc, updates them locally and remotely.
+### register_new_device_and_recreate_profiles
+```
+fastlane register_new_device_and_recreate_profiles
+```
+Register new device, regenerates profiles, updates them remotely and locally
 ### distribute_demo_app
 ```
 fastlane distribute_demo_app

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -19,7 +19,8 @@ or alternatively using `brew install fastlane`
 ```
 fastlane match_me
 ```
-Installs all Certs and Profiles necessary for development and ad-hoc
+If `readonly: true` (by default), installs all Certs and Profiles necessary for development and ad-hoc.
+If `readonly: false`, recreates all Profiles necessary for development and ad-hoc, updates them locally and remotely.
 ### distribute_demo_app
 ```
 fastlane distribute_demo_app


### PR DESCRIPTION
**This PR**:
- introduces `register_new_device_and_recreate_profiles` lane
- adds `readonly` option to`match_me` lane

#no_changelog