### PR TITLE
Move code from setupAppearance to defaultAppearance

### DIFF
--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -51,12 +51,10 @@ open class _ChatChannelListItemView<ExtraData: ExtraDataTypes>: _ChatChannelSwip
         backgroundColor = uiConfig.colorPalette.generalBackground
         normalBackgroundColor = uiConfig.colorPalette.generalBackground
         highlightedBackgroundColor = uiConfig.colorPalette.channelListHighlightedBackground
-    }
 
-    override open func setUpAppearance() {
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.font = uiConfig.font.bodyBold
-        
+
         subtitleLabel.textColor = uiConfig.colorPalette.subtitleText
         subtitleLabel.adjustsFontForContentSizeCategory = true
         subtitleLabel.font = uiConfig.font.subheadline
@@ -65,7 +63,7 @@ open class _ChatChannelListItemView<ExtraData: ExtraDataTypes>: _ChatChannelSwip
         timestampLabel.adjustsFontForContentSizeCategory = true
         timestampLabel.font = uiConfig.font.subheadline
     }
-    
+
     override open func setUpLayout() {
         super.setUpLayout()
 

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelReadStatusCheckmarkView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelReadStatusCheckmarkView.swift
@@ -31,7 +31,7 @@ open class _ChatChannelReadStatusCheckmarkView<ExtraData: ExtraDataTypes>: View,
         updateContentIfNeeded()
     }
     
-    override open func setUpAppearance() {
+    override public func defaultAppearance() {
         imageView.contentMode = .scaleAspectFit
     }
     

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountView.swift
@@ -62,7 +62,7 @@ open class _ChatChannelUnreadCountView<ExtraData: ExtraDataTypes>: View, UIConfi
     
     // MARK: - Public
     
-    override open func setUpAppearance() {
+    override public func defaultAppearance() {
         layer.masksToBounds = true
         backgroundColor = uiConfig.colorPalette.channelListUnreadCountView
         unreadCountLabel.textColor = uiConfig.colorPalette.channelListUnreadCountLabel

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerSuggestionsViewController.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerSuggestionsViewController.swift
@@ -65,7 +65,7 @@ open class _ChatMessageComposerSuggestionsViewController<ExtraData: ExtraDataTyp
         collectionView.delegate = self
     }
 
-    override open func setUpAppearance() {
+    override public func defaultAppearance() {
         view.backgroundColor = .clear
         view.layer.addShadow(color: uiConfig.colorPalette.shadow)
     }

--- a/Sources/StreamChatUI/Common Views/ChatAvatarView.swift
+++ b/Sources/StreamChatUI/Common Views/ChatAvatarView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import UIKit
@@ -32,13 +32,10 @@ open class ChatAvatarView: View {
 
     override public func defaultAppearance() {
         defaultIntrinsicContentSize = .init(width: 40, height: 40)
-    }
-    
-    override open func setUpAppearance() {
         imageView.contentMode = .scaleAspectFit
         imageView.clipsToBounds = true
     }
-    
+
     override open func setUpLayout() {
         imageView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         imageView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)

--- a/Sources/StreamChatUI/Common Views/CurrentChatUserAvatarView.swift
+++ b/Sources/StreamChatUI/Common Views/CurrentChatUserAvatarView.swift
@@ -51,13 +51,12 @@ open class _CurrentChatUserAvatarView<ExtraData: ExtraDataTypes>: Control, UICon
     }
 
     // MARK: - Content
-    
-    override open func setUpAppearance() {
-        super.setUpAppearance()
 
+    override open func setUp() {
+        super.setUp()
         avatarView.isUserInteractionEnabled = false
     }
-    
+
     override open func setUpLayout() {
         super.setUpLayout()
 


### PR DESCRIPTION
# What this PR do:
- Moves remaining code from `setupAppearance` to `defaultAppearance` inside SDK so the changes happen in correct functions across the SDK