### PR TITLE
[CIS-603] Fix crash when reording channel list

### DIFF
--- a/Sources/StreamChatUI/ChatChannel/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatMessageListVC.swift
@@ -153,7 +153,8 @@ open class ChatMessageListVC<ExtraData: ExtraDataTypes>: ViewController,
                 case let .insert(_, index):
                     collectionView.insertItems(at: [index])
                 case let .move(_, fromIndex, toIndex):
-                    collectionView.moveItem(at: fromIndex, to: toIndex)
+                    collectionView.deleteItems(at: [fromIndex])
+                    collectionView.insertItems(at: [toIndex])
                 case let .remove(_, index):
                     collectionView.deleteItems(at: [index])
                 case let .update(_, index):

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import StreamChat
@@ -120,7 +120,8 @@ extension ChatChannelListVC: _ChatChannelListControllerDelegate {
                 case let .insert(_, index):
                     collectionView.insertItems(at: [index])
                 case let .move(_, fromIndex, toIndex):
-                    collectionView.moveItem(at: fromIndex, to: toIndex)
+                    collectionView.deleteItems(at: [fromIndex])
+                    collectionView.insertItems(at: [toIndex])
                 case let .remove(_, index):
                     collectionView.deleteItems(at: [index])
                 case let .update(_, index):


### PR DESCRIPTION
# In this PR
Doing multiple operations in `performBatchUpdates()` has some problems. When there are an update and a move at the same time, it can cause a crash. There are multiple ways to fix this: 
- Moving the `reloadItems()` from outside of `performBatchUpdates()`.
- Update the cell directly by getting the instance of it with `collectionView.cellForItem()`
- Change the `moveItem()` to a `delete()` and `insert()`.

I opted for the last option, since it the cleanest one, and requires least changes. But feel free to give feedback.

**Maybe adding a rule to SwiftLint to avoid using `moveItem` could be a good idea? Thoughts?** 

# Upcoming

### ✅ Added

### 🐞 Fixed
Fixes crash when performing a move and an update at the same time in Channel's List

### 🔄 Changed