### PR TITLE
[CIS-603] Fix stability issues when reordering channel list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐞 Fixed
 - Fix development token not working properly [#760](https://github.com/GetStream/stream-chat-swift/pull/760)
+- Fix lists ordering not updating instantly. [#768](https://github.com/GetStream/stream-chat-swift/pull/768/)
+- Fix update changes incorrectly reported when a move change is present for the same index. [#768](https://github.com/GetStream/stream-chat-swift/pull/768/)
 
 
 # [3.0](https://github.com/GetStream/stream-chat-swift/releases/tag/3.0)

--- a/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -292,6 +292,23 @@ class ListChangeAggregator<DTO: NSManagedObject, Item>: NSObject, NSFetchedResul
     }
     
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        // All destination indices of `move` changes
+        let moveToIndexChanges: [IndexPath] = currentChanges.compactMap {
+            if case let .move(_, _, toIndex) = $0 {
+                return toIndex
+            }
+            return nil
+        }
+
+        // Remove `update` operations with the same index path as move's `toIndex`changes.
+        currentChanges = currentChanges.filter {
+            if case let .update(_, index) = $0 {
+                // Include only if the update `index` is not a `move` change destination index.
+                return moveToIndexChanges.contains(index) == false
+            }
+            return true
+        }
+        
         onChange?(currentChanges)
     }
 }

--- a/Sources/StreamChat/Controllers/ListDatabaseObserver_Tests.swift
+++ b/Sources/StreamChat/Controllers/ListDatabaseObserver_Tests.swift
@@ -420,6 +420,58 @@ class ListChangeAggregator_Tests: XCTestCase {
             .update(updatedObject.uniqueValue, index: [2, 0])
         ])
     }
+    
+    func test_controllerWillChangeContent_whenUpdatesAndMovesWithSameIndexPath_removeThoseUpdates() {
+        var result: [ListChange<String>]?
+        aggregator.onChange = { result = $0 }
+        
+        // Simulate FRC starts updating
+        aggregator.controllerWillChangeContent(fakeController)
+        
+        let addedObject = TestManagedObject()
+        let movedObject = TestManagedObject()
+        let updatedObject = TestManagedObject()
+        
+        aggregator.controller(
+            fakeController,
+            didChange: addedObject,
+            at: nil,
+            for: .insert,
+            newIndexPath: [1, 0]
+        )
+        
+        aggregator.controller(
+            fakeController,
+            didChange: updatedObject,
+            at: [2, 0],
+            for: .update,
+            newIndexPath: nil
+        )
+        
+        aggregator.controller(
+            fakeController,
+            didChange: movedObject,
+            at: [4, 0],
+            for: .move,
+            newIndexPath: [2, 0]
+        )
+        
+        aggregator.controller(
+            fakeController,
+            didChange: updatedObject,
+            at: [2, 0],
+            for: .update,
+            newIndexPath: nil
+        )
+        
+        // Simulate FRC finishes updating
+        aggregator.controllerDidChangeContent(fakeController)
+        
+        XCTAssertEqual(result, [
+            .insert(addedObject.uniqueValue, index: [1, 0]),
+            .move(movedObject.uniqueValue, fromIndex: [4, 0], toIndex: [2, 0])
+        ])
+    }
 }
 
 class TestFetchedResultsController: NSFetchedResultsController<TestManagedObject> {

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -234,6 +234,11 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         message.user = currentUserDTO.user
         message.channel = channelDTO
         
+        // We should update the channel dates so the list of channels ordering is updated.
+        // Updating it locally, makes it work also in offline.
+        channelDTO.lastMessageAt = createdDate
+        channelDTO.defaultSortingAt = createdDate
+        
         if let parentMessageId = parentMessageId,
             let parentMessageDTO = MessageDTO.load(id: parentMessageId, context: self) {
             parentMessageDTO.replies.insert(message)

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -118,19 +118,28 @@ extension _ChatChannelListVC: _ChatChannelListControllerDelegate {
         _ controller: _ChatChannelListController<ExtraData>,
         didChangeChannels changes: [ListChange<_ChatChannel<ExtraData>>]
     ) {
-        collectionView.performBatchUpdates({
-            for change in changes {
-                switch change {
-                case let .insert(_, index):
-                    collectionView.insertItems(at: [index])
-                case let .move(_, fromIndex, toIndex):
-                    collectionView.moveItem(at: fromIndex, to: toIndex)
-                case let .remove(_, index):
-                    collectionView.deleteItems(at: [index])
-                case let .update(_, index):
-                    collectionView.reloadItems(at: [index])
+        var movedItems: [IndexPath] = []
+        collectionView.performBatchUpdates(
+            {
+                for change in changes {
+                    switch change {
+                    case let .insert(_, index):
+                        collectionView.insertItems(at: [index])
+                    case let .move(_, fromIndex, toIndex):
+                        collectionView.moveItem(at: fromIndex, to: toIndex)
+                        movedItems.append(toIndex)
+                    case let .remove(_, index):
+                        collectionView.deleteItems(at: [index])
+                    case let .update(_, index):
+                        collectionView.reloadItems(at: [index])
+                    }
                 }
+            },
+            completion: { _ in
+                // Move changes from NSFetchController also can mean an update of the content.
+                // Since a `moveItem` in collections do not update the content of the cell, we need to reload those cells.
+                self.collectionView.reloadItems(at: movedItems)
             }
-        }, completion: nil)
+        )
     }
 }


### PR DESCRIPTION
# In this PR
- Fixes a crash when reordering the channel lists that was caused by moving and updating the same IndexPath in the collection view.
- When creating a new message, the order of the channel list is now updated instantly