### PR TITLE
[CIS-511] Update `addReaction` API with `enforce_unique` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## StreamChat
 
 ### ✅ Added
-
+- Add support for `enforce_unique` parameter on sending reactions 
+    [#770](https://github.com/GetStream/stream-chat-swift/pull/770)
 ### 🔄 Changed
 
 ### 🐞 Fixed

--- a/Sources/StreamChat/APIClient/Endpoints/MessageEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/MessageEndpoints.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -50,6 +50,7 @@ extension Endpoint {
     static func addReaction<ExtraData: MessageReactionExtraData>(
         _ type: MessageReactionType,
         score: Int,
+        enforceUnique: Bool,
         extraData: ExtraData,
         messageId: MessageId
     ) -> Endpoint<EmptyResponse> {
@@ -62,6 +63,7 @@ extension Endpoint {
                 "reaction": MessageReactionRequestPayload(
                     type: type,
                     score: score,
+                    enforceUnique: enforceUnique,
                     extraData: extraData
                 )
             ]

--- a/Sources/StreamChat/APIClient/Endpoints/MessageEndpoints_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/MessageEndpoints_Tests.swift
@@ -99,6 +99,7 @@ final class MessageEndpoints_Tests: XCTestCase {
                 "reaction": MessageReactionRequestPayload(
                     type: reaction,
                     score: score,
+                    enforceUnique: false,
                     extraData: extraData
                 )
             ]
@@ -108,6 +109,7 @@ final class MessageEndpoints_Tests: XCTestCase {
         let endpoint: Endpoint<EmptyResponse> = .addReaction(
             reaction,
             score: score,
+            enforceUnique: false,
             extraData: extraData,
             messageId: messageId
         )

--- a/Sources/StreamChat/APIClient/Endpoints/Requests/MessageReactionRequestPayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Requests/MessageReactionRequestPayload.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -9,16 +9,19 @@ struct MessageReactionRequestPayload<ExtraData: MessageReactionExtraData>: Encod
     private enum CodingKeys: String, CodingKey {
         case type
         case score
+        case enforceUnique = "enforce_unique"
     }
     
     let type: MessageReactionType
     let score: Int
+    let enforceUnique: Bool
     let extraData: ExtraData
     
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(type, forKey: .type)
         try container.encode(score, forKey: .score)
+        try container.encode(enforceUnique, forKey: .enforceUnique)
         try extraData.encode(to: encoder)
     }
 }

--- a/Sources/StreamChat/APIClient/Endpoints/Requests/MessageReactionRequestPayload_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Requests/MessageReactionRequestPayload_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat
@@ -11,6 +11,7 @@ final class MessageReactionRequestPayload_Tests: XCTestCase {
         let payload = MessageReactionRequestPayload(
             type: "like",
             score: 10,
+            enforceUnique: false,
             extraData: Mood(mood: "good one")
         )
         
@@ -21,6 +22,7 @@ final class MessageReactionRequestPayload_Tests: XCTestCase {
         AssertJSONEqual(json, [
             "type": payload.type.rawValue,
             "score": payload.score,
+            "enforce_unique": payload.enforceUnique,
             "mood": payload.extraData.mood
         ])
     }

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -308,15 +308,23 @@ public extension _ChatMessageController {
     /// - Parameters:
     ///   - type: The reaction type.
     ///   - score: The reaction score.
+    ///   - enforceUnique: If set to `true`, new reaction will replace all reactions the user has (if any) on this message.
     ///   - extraData: The reaction extra data.
     ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
     func addReaction(
         _ type: MessageReactionType,
         score: Int = 1,
+        enforceUnique: Bool = false,
         extraData: ExtraData.MessageReaction = .defaultValue,
         completion: ((Error?) -> Void)? = nil
     ) {
-        messageUpdater.addReaction(type, score: score, extraData: extraData, messageId: messageId) { error in
+        messageUpdater.addReaction(
+            type,
+            score: score,
+            enforceUnique: enforceUnique,
+            extraData: extraData,
+            messageId: messageId
+        ) { error in
             self.callback {
                 completion?(error)
             }

--- a/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
@@ -843,15 +843,18 @@ final class MessageController_Tests: StressTestCase {
     func test_addReaction_callsUpdater_withCorrectValues() {
         let type: MessageReactionType = "like"
         let score = 5
+        let enforceUnique = true
         let extraData: NoExtraData = .defaultValue
         
         // Simulate `addReaction` call.
-        controller.addReaction(type, score: score, extraData: extraData)
+        controller.addReaction(type, score: score, enforceUnique: true, extraData: extraData)
         
         // Assert updater is called with correct `type`.
         XCTAssertEqual(env.messageUpdater.addReaction_type, type)
         // Assert updater is called with correct `score`.
         XCTAssertEqual(env.messageUpdater.addReaction_score, score)
+        // Assert updater is called with correct `enforceUnique`.
+        XCTAssertEqual(env.messageUpdater.addReaction_enforceUnique, enforceUnique)
         // Assert updater is called with correct `extraData`.
         XCTAssertEqual(env.messageUpdater.addReaction_extraData, extraData)
         // Assert updater is called with correct `messageId`.

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -239,12 +239,14 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
     /// - Parameters:
     ///   - type: The reaction type.
     ///   - score: The reaction score.
+    ///   - enforceUnique: If set to `true`, new reaction will replace all reactions the user has (if any) on this message.
     ///   - extraData: The extra data attached to the reaction.
     ///   - messageId: The message identifier the reaction will be added to.
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     func addReaction(
         _ type: MessageReactionType,
         score: Int,
+        enforceUnique: Bool,
         extraData: ExtraData.MessageReaction,
         messageId: MessageId,
         completion: ((Error?) -> Void)? = nil
@@ -252,6 +254,7 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
         let endpoint: Endpoint<EmptyResponse> = .addReaction(
             type,
             score: score,
+            enforceUnique: enforceUnique,
             extraData: extraData,
             messageId: messageId
         )

--- a/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -41,6 +41,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
     
     @Atomic var addReaction_type: MessageReactionType?
     @Atomic var addReaction_score: Int?
+    @Atomic var addReaction_enforceUnique: Bool?
     @Atomic var addReaction_extraData: ExtraData.MessageReaction?
     @Atomic var addReaction_messageId: MessageId?
     @Atomic var addReaction_completion: ((Error?) -> Void)?
@@ -183,6 +184,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
     override func addReaction(
         _ type: MessageReactionType,
         score: Int,
+        enforceUnique: Bool = false,
         extraData: ExtraData.MessageReaction,
         messageId: MessageId,
         completion: ((Error?) -> Void)? = nil
@@ -191,6 +193,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         addReaction_score = score
         addReaction_extraData = extraData
         addReaction_messageId = messageId
+        addReaction_enforceUnique = enforceUnique
         addReaction_completion = completion
     }
     

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -829,6 +829,7 @@ final class MessageUpdater_Tests: StressTestCase {
         messageUpdater.addReaction(
             reactionType,
             score: reactionScore,
+            enforceUnique: false,
             extraData: reactionExtraData,
             messageId: messageId
         )
@@ -836,7 +837,13 @@ final class MessageUpdater_Tests: StressTestCase {
         // Assert correct endpoint is called.
         XCTAssertEqual(
             apiClient.request_endpoint,
-            AnyEndpoint(.addReaction(reactionType, score: reactionScore, extraData: reactionExtraData, messageId: messageId))
+            AnyEndpoint(.addReaction(
+                reactionType,
+                score: reactionScore,
+                enforceUnique: false,
+                extraData: reactionExtraData,
+                messageId: messageId
+            ))
         )
     }
 
@@ -846,6 +853,7 @@ final class MessageUpdater_Tests: StressTestCase {
         messageUpdater.addReaction(
             .init(rawValue: .unique),
             score: 1,
+            enforceUnique: false,
             extraData: .defaultValue,
             messageId: .unique
         ) { error in
@@ -869,6 +877,7 @@ final class MessageUpdater_Tests: StressTestCase {
         messageUpdater.addReaction(
             .init(rawValue: .unique),
             score: 1,
+            enforceUnique: false,
             extraData: .defaultValue,
             messageId: .unique
         ) {


### PR DESCRIPTION
In this PR:

- Update `addReaction` API with `enforce_unique` parameter