### PR TITLE
[CIS-610] Message list UI polishing

### DIFF
--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -58,6 +58,8 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: ViewController,
         
         controller.setDelegate(self)
         controller.synchronize()
+        
+        navigationItem.backButtonTitle = ""
     }
     
     // MARK: - UICollectionViewDataSource

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageQuoteBubbleView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageQuoteBubbleView.swift
@@ -17,8 +17,9 @@ open class _ChatMessageQuoteBubbleView<ExtraData: ExtraDataTypes>: _ChatMessageC
     override open func setUpLayout() {
         super.setUpLayout()
         
-        container.preservesSuperviewLayoutMargins = false
-        container.isLayoutMarginsRelativeArrangement = false
+        containerConstraints.forEach {
+            $0.constant = 0
+        }
     }
     
     override open func updateContent() {
@@ -27,21 +28,18 @@ open class _ChatMessageQuoteBubbleView<ExtraData: ExtraDataTypes>: _ChatMessageC
         guard let isParentMessageSentByCurrentUser = isParentMessageSentByCurrentUser else { return }
         authorAvatarView.removeFromSuperview()
         
-        container.leftStackView.isHidden = !isParentMessageSentByCurrentUser
-        container.rightStackView.isHidden = isParentMessageSentByCurrentUser
-        
-        container.centerStackView.layer.maskedCorners = [
+        contentView.layer.maskedCorners = [
             .layerMinXMinYCorner,
             .layerMaxXMinYCorner,
             isParentMessageSentByCurrentUser ? .layerMaxXMaxYCorner : .layerMinXMaxYCorner
         ]
     
         if isParentMessageSentByCurrentUser {
-            container.centerStackView.backgroundColor = uiConfig.colorPalette.incomingMessageBubbleBackground
-            container.leftStackView.addArrangedSubview(authorAvatarView)
+            contentView.backgroundColor = uiConfig.colorPalette.incomingMessageBubbleBackground
+            container.insertArrangedSubview(authorAvatarView, at: 0)
         } else {
-            container.centerStackView.backgroundColor = uiConfig.colorPalette.outgoingMessageBubbleBackground
-            container.rightStackView.addArrangedSubview(authorAvatarView)
+            contentView.backgroundColor = uiConfig.colorPalette.outgoingMessageBubbleBackground
+            container.addArrangedSubview(authorAvatarView)
         }
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatVC.swift
@@ -146,12 +146,11 @@ open class _ChatVC<ExtraData: ExtraDataTypes>: ViewController,
 
         let subtitle = UILabel()
         subtitle.textAlignment = .center
-        subtitle.font = uiConfig.font.subheadline
+        subtitle.font = uiConfig.font.caption1
         subtitle.textColor = uiConfig.colorPalette.subtitleText
 
         let titleView = UIStackView(arrangedSubviews: [title, subtitle])
         titleView.axis = .vertical
-        titleView.spacing = 2
 
         navigationItem.titleView = titleView
 

--- a/Sources/StreamChatUI/UIConfig.swift
+++ b/Sources/StreamChatUI/UIConfig.swift
@@ -116,6 +116,7 @@ public extension _UIConfig {
 
 public extension _UIConfig {
     struct Font {
+        public var caption1 = UIFont.preferredFont(forTextStyle: .caption1)
         public var footnoteBold = UIFont.preferredFont(forTextStyle: .footnote).bold
         public var subheadline = UIFont.preferredFont(forTextStyle: .subheadline)
         public var subheadlineBold = UIFont.preferredFont(forTextStyle: .subheadline).bold


### PR DESCRIPTION
**In this PR:** 

- Adjust navigation bar layout on `ChatVC`

Before / After
<img width="300" alt="Screenshot 2021-01-28 at 13 43 43" src="https://user-images.githubusercontent.com/10098359/106140391-00588f00-616f-11eb-9c2e-b46d12cbe035.png">  <img width="300" alt="Screenshot 2021-01-28 at 14 32 13" src="https://user-images.githubusercontent.com/10098359/106145622-0e5dde00-6176-11eb-80c1-8ccf01861d82.png">


- Change the layout of the `ChatMessageComposerQuoteBubbleView`

Before / After

<img width="300" alt="Screenshot 2021-01-28 at 13 45 43" src="https://user-images.githubusercontent.com/10098359/106140648-5299b000-616f-11eb-9599-84d5401ffc55.png">     <img width="300" alt="Screenshot 2021-01-28 at 13 36 21" src="https://user-images.githubusercontent.com/10098359/106140654-54637380-616f-11eb-9f31-bd6027fb9826.png">

Before / After

<img width="180" alt="Screenshot 2021-01-28 at 13 44 10" src="https://user-images.githubusercontent.com/10098359/106140683-5fb69f00-616f-11eb-93ce-1eb42b3c8a5f.png"> <img width="180" alt="Screenshot 2021-01-28 at 13 36 05" src="https://user-images.githubusercontent.com/10098359/106140692-6218f900-616f-11eb-93c1-9cbc031a5e47.png">


