### PR TITLE
Increase fake size for non-sized cells

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.swift
@@ -57,7 +57,7 @@ open class _СhatMessageCollectionViewCell<ExtraData: ExtraDataTypes>: Collectio
             // We cannot calculate size properly right now, because our view hierarchy is not ready yet.
             // If we just return default size, small text bubbles would not resize itself properly for no reason.
             let attributes = layoutAttributes.copy() as! UICollectionViewLayoutAttributes
-            attributes.frame.size = .zero
+            attributes.frame.size.height = 300
             return attributes
         }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
@@ -158,7 +158,7 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
             let idx = ip.item
             let item: LayoutItem
             if idx == self.currentItems.count {
-                item = LayoutItem(offset: 0, height: 60)
+                item = LayoutItem(offset: 0, height: self.estimatedItemHeight)
             } else {
                 item = LayoutItem(
                     offset: self.currentItems[idx].maxY + self.spacing,


### PR DESCRIPTION
Follow up for #737 

While using zero size for non-sizided cells, we forced layout to iterate over ALL cells (who would expect from zero height cells :D ).
After quick test, this magic size worked well, and I haven't noticed any weird text cell flicks.