### PR TITLE
[CIS-256] Lazy model transformation for LLC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
+## StreamChat
+
+### 🔄 Changed
+- Improve serialization performance by exposing items as `LazyCachedMapCollection` instead of `Array` [#776](https://github.com/GetStream/stream-chat-swift/pull/776)
 
 # [3.0.1](https://github.com/GetStream/stream-chat-swift/releases/tag/3.0.1)
 _February 2nd, 2021_

--- a/DemoApp/CreateChatViewController.swift
+++ b/DemoApp/CreateChatViewController.swift
@@ -66,7 +66,7 @@ class CreateChatViewController: UIViewController {
     
     var searchController: ChatUserSearchController!
     
-    var users: [ChatUser] {
+    var users: LazyCachedMapCollection<ChatUser> {
         searchController.users
     }
     

--- a/DemoApp/CreateGroupViewController.swift
+++ b/DemoApp/CreateGroupViewController.swift
@@ -49,7 +49,7 @@ class CreateGroupViewController: UIViewController {
     
     var searchController: ChatUserSearchController!
     
-    var users: [ChatUser] {
+    var users: LazyCachedMapCollection<ChatUser> {
         searchController.users
     }
     

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -19,7 +19,7 @@ extension _ChatChannelController {
         @Published public private(set) var channel: _ChatChannel<ExtraData>?
         
         /// The messages related to the channel.
-        @Published public private(set) var messages: [_ChatMessage<ExtraData>] = []
+        @Published public private(set) var messages: LazyCachedMapCollection<_ChatMessage<ExtraData>> = []
         
         /// The current state of the Controller.
         @Published public private(set) var state: DataController.State

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -55,7 +55,7 @@ class ChannelController_SwiftUI_Tests: iOS13TestCase {
             )
         }
         
-        AssertAsync.willBeEqual(observableObject.messages, [newMessage])
+        AssertAsync.willBeEqual(Array(observableObject.messages), [newMessage])
     }
     
     func test_observableObject_reactsToDelegateStateChangesCallback() {
@@ -117,8 +117,8 @@ class ChannelControllerMock: ChatChannelController {
     }
     
     var messages_simulated: [_ChatMessage<NoExtraData>]?
-    override var messages: [_ChatMessage<NoExtraData>] {
-        messages_simulated ?? super.messages
+    override var messages: LazyCachedMapCollection<_ChatMessage<NoExtraData>> {
+        messages_simulated.map { $0.lazyCachedMap { $0 } } ?? super.messages
     }
 
     var state_simulated: DataController.State?

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -174,7 +174,7 @@ public class _ChatChannelController<ExtraData: ExtraDataTypes>: DataController, 
     /// To observe changes of the messages, set your class as a delegate of this controller or use the provided
     /// `Combine` publishers.
     ///
-    public var messages: [_ChatMessage<ExtraData>] {
+    public var messages: LazyCachedMapCollection<_ChatMessage<ExtraData>> {
         if state == .initialized {
             setLocalStateBasedOnError(startDatabaseObservers())
         }

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController+SwiftUI.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController+SwiftUI.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -16,7 +16,7 @@ extension _ChatChannelListController {
         public let controller: _ChatChannelListController
         
         /// The channels matching the query.
-        @Published public private(set) var channels: [_ChatChannel<ExtraData>] = []
+        @Published public private(set) var channels: LazyCachedMapCollection<_ChatChannel<ExtraData>> = []
         
         /// The current state of the Controller.
         @Published public private(set) var state: DataController.State

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController+SwiftUI_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController+SwiftUI_Tests.swift
@@ -38,7 +38,7 @@ class ChannelListController_SwiftUI_Tests: iOS13TestCase {
             )
         }
         
-        AssertAsync.willBeEqual(observableObject.channels, [newChannel])
+        AssertAsync.willBeEqual(Array(observableObject.channels), [newChannel])
     }
     
     func test_observableObject_reactsToDelegateStateChangesCallback() {
@@ -62,8 +62,8 @@ class ChannelListControllerMock: ChatChannelListController {
     @Atomic var synchronize_called = false
     
     var channels_simulated: [_ChatChannel<NoExtraData>]?
-    override var channels: [_ChatChannel<NoExtraData>] {
-        channels_simulated ?? super.channels
+    override var channels: LazyCachedMapCollection<_ChatChannel<NoExtraData>> {
+        channels_simulated.map { $0.lazyCachedMap { $0 } } ?? super.channels
     }
 
     var state_simulated: DataController.State?

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -50,7 +50,7 @@ public class _ChatChannelListController<ExtraData: ExtraDataTypes>: DataControll
     /// To observe changes of the channels, set your class as a delegate of this controller or use the provided
     /// `Combine` publishers.
     ///
-    public var channels: [_ChatChannel<ExtraData>] { channelListObserver.items }
+    public var channels: LazyCachedMapCollection<_ChatChannel<ExtraData>> { channelListObserver.items }
     
     /// The worker used to fetch the remote data and communicate with servers.
     private lazy var worker: ChannelListUpdater<ExtraData> = self.environment
@@ -189,7 +189,7 @@ extension _ChatChannelListController {
         var createChannelListDabaseObserver: (
             _ context: NSManagedObjectContext,
             _ fetchRequest: NSFetchRequest<ChannelDTO>,
-            _ itemCreator: @escaping (ChannelDTO) -> _ChatChannel<ExtraData>?
+            _ itemCreator: @escaping (ChannelDTO) -> _ChatChannel<ExtraData>
         )
             -> ListDatabaseObserver<_ChatChannel<ExtraData>, ChannelDTO> = {
                 ListDatabaseObserver(context: $0, fetchRequest: $1, itemCreator: $2)

--- a/Sources/StreamChat/Controllers/ListDatabaseObserver_Tests.swift
+++ b/Sources/StreamChat/Controllers/ListDatabaseObserver_Tests.swift
@@ -142,7 +142,7 @@ class ListDatabaseObserver_Tests: XCTestCase {
         ]
         testFRC.test_fetchedObjects = reference1
         
-        XCTAssertEqual(observer.items, reference1.map(\.uniqueValue))
+        XCTAssertEqual(Array(observer.items), reference1.map(\.uniqueValue))
         
         // Update the simulated fetch objects
         let reference2 = [TestManagedObject()]
@@ -150,11 +150,11 @@ class ListDatabaseObserver_Tests: XCTestCase {
         
         // Access items again, the objects should not be updated because the result should be cached until
         // the callback from the change aggregator happens
-        XCTAssertEqual(observer.items, reference1.map(\.uniqueValue))
+        XCTAssertEqual(Array(observer.items), reference1.map(\.uniqueValue))
         
         // Simulate the change aggregator callback and check the items get updated
         observer.changeAggregator.onChange?([])
-        XCTAssertEqual(observer.items, reference2.map(\.uniqueValue))
+        XCTAssertEqual(Array(observer.items), reference2.map(\.uniqueValue))
     }
     
     func test_startObserving_startsFRC() throws {
@@ -212,7 +212,7 @@ class ListDatabaseObserver_Tests: XCTestCase {
             TestManagedObject()
         ]
         testFRC.test_fetchedObjects = objects
-        XCTAssertEqual(observer.items, objects.map(\.uniqueValue))
+        XCTAssertEqual(Array(observer.items), objects.map(\.uniqueValue))
         
         // Listen to callbacks
         var receivedChanges: [ListChange<String>]?

--- a/Sources/StreamChat/Controllers/MemberListController/MemberListController+SwiftUI.swift
+++ b/Sources/StreamChat/Controllers/MemberListController/MemberListController+SwiftUI.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -17,7 +17,7 @@ extension _ChatChannelMemberListController {
         public let controller: _ChatChannelMemberListController
         
         /// The channel members.
-        @Published public private(set) var members: [_ChatChannelMember<ExtraData.User>] = []
+        @Published public private(set) var members: LazyCachedMapCollection<_ChatChannelMember<ExtraData.User>> = []
         
         /// The current state of the controller.
         @Published public private(set) var state: DataController.State

--- a/Sources/StreamChat/Controllers/MemberListController/MemberListController+SwiftUI_Tests.swift
+++ b/Sources/StreamChat/Controllers/MemberListController/MemberListController+SwiftUI_Tests.swift
@@ -56,7 +56,7 @@ final class MemberListController_SwiftUI_Tests: iOS13TestCase {
         }
         
         // Simulate the changes are forwarded to observable object.
-        AssertAsync.willBeEqual(observableObject.members, [newMember])
+        AssertAsync.willBeEqual(Array(observableObject.members), [newMember])
     }
     
     func test_observableObject_reactsToDelegateStateChangesCallback() {

--- a/Sources/StreamChat/Controllers/MemberListController/MemberListController.swift
+++ b/Sources/StreamChat/Controllers/MemberListController/MemberListController.swift
@@ -47,7 +47,7 @@ public class _ChatChannelMemberListController<ExtraData: ExtraDataTypes>: DataCo
     /// The channel members matching the query.
     /// To observe the member list changes, set your class as a delegate of this controller or use the provided
     /// `Combine` publishers.
-    public var members: [_ChatChannelMember<ExtraData.User>] {
+    public var members: LazyCachedMapCollection<_ChatChannelMember<ExtraData.User>> {
         startObservingIfNeeded()
         return memberListObserver.items
     }
@@ -184,7 +184,7 @@ extension _ChatChannelMemberListController {
         var memberListObserverBuilder: (
             _ context: NSManagedObjectContext,
             _ fetchRequest: NSFetchRequest<MemberDTO>,
-            _ itemCreator: @escaping (MemberDTO) -> _ChatChannelMember<ExtraData.User>?,
+            _ itemCreator: @escaping (MemberDTO) -> _ChatChannelMember<ExtraData.User>,
             _ controllerType: NSFetchedResultsController<MemberDTO>.Type
         ) -> ListDatabaseObserver<_ChatChannelMember<ExtraData.User>, MemberDTO> = ListDatabaseObserver.init
     }

--- a/Sources/StreamChat/Controllers/MemberListController/MemberListController_Mock.swift
+++ b/Sources/StreamChat/Controllers/MemberListController/MemberListController_Mock.swift
@@ -8,8 +8,8 @@ import XCTest
 /// A mock for `ChatChannelMemberListController`.
 final class ChatChannelMemberListControllerMock: ChatChannelMemberListController {
     @Atomic var members_simulated: [_ChatChannelMember<NoExtraData>]?
-    override var members: [_ChatChannelMember<NoExtraData>] {
-        members_simulated ?? super.members
+    override var members: LazyCachedMapCollection<_ChatChannelMember<NoExtraData>> {
+        members_simulated.map { $0.lazyCachedMap { $0 } } ?? super.members
     }
     
     @Atomic var state_simulated: DataController.State?

--- a/Sources/StreamChat/Controllers/MemberListController/MemberListController_Tests.swift
+++ b/Sources/StreamChat/Controllers/MemberListController/MemberListController_Tests.swift
@@ -378,7 +378,7 @@ final class MemberListController_Tests: StressTestCase {
                     (delegate.didUpdateMembers_changes ?? []).map { $0.fieldChange(\.id) }
                         .contains(.remove(member2ID, index: [0, 0]))
                 )
-            Assert.willBeEqual(self.controller.members, [])
+            Assert.willBeEqual(Array(self.controller.members), [])
         }
     }
     

--- a/Sources/StreamChat/Controllers/MessageController/MessageController+SwiftUI.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController+SwiftUI.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -19,7 +19,7 @@ extension _ChatMessageController {
         @Published public private(set) var message: _ChatMessage<ExtraData>?
         
         /// The replies to the message controller observes.
-        @Published public private(set) var replies: [_ChatMessage<ExtraData>] = []
+        @Published public private(set) var replies: LazyCachedMapCollection<_ChatMessage<ExtraData>> = []
         
         /// The current state of the Controller.
         @Published public private(set) var state: DataController.State

--- a/Sources/StreamChat/Controllers/MessageController/MessageController+SwiftUI_Tests.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController+SwiftUI_Tests.swift
@@ -55,7 +55,7 @@ class MessageController_SwiftUI_Tests: iOS13TestCase {
             )
         }
         
-        AssertAsync.willBeEqual(observableObject.replies, [newReply])
+        AssertAsync.willBeEqual(Array(observableObject.replies), [newReply])
     }
     
     func test_observableObject_reactsToDelegateStateChangesCallback() {
@@ -83,8 +83,8 @@ class MessageControllerMock: ChatMessageController {
     }
     
     var replies_simulated: [_ChatMessage<NoExtraData>]?
-    override var replies: [_ChatMessage<NoExtraData>] {
-        replies_simulated ?? super.replies
+    override var replies: LazyCachedMapCollection<_ChatMessage<NoExtraData>> {
+        replies_simulated.map { $0.lazyCachedMap { $0 } } ?? super.replies
     }
     
     var state_simulated: DataController.State?

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -58,7 +58,7 @@ public class _ChatMessageController<ExtraData: ExtraDataTypes>: DataController, 
     /// To observe changes of the replies, set your class as a delegate of this controller or use the provided
     /// `Combine` publishers.
     ///
-    public var replies: [_ChatMessage<ExtraData>] {
+    public var replies: LazyCachedMapCollection<_ChatMessage<ExtraData>> {
         if state == .initialized {
             startRepliesObserver { [weak self] error in
                 self?.state = error == nil ? .localDataFetched : .localDataFetchFailed(ClientError(with: error))

--- a/Sources/StreamChat/Controllers/SearchControllers/UserSearchController.swift
+++ b/Sources/StreamChat/Controllers/SearchControllers/UserSearchController.swift
@@ -63,7 +63,7 @@ public class _ChatUserSearchController<ExtraData: ExtraDataTypes>: DataControlle
     /// To observe changes of the users, set your class as a delegate of this controller or use the provided
     /// `Combine` publishers.
     ///
-    public var users: [_ChatUser<ExtraData.User>] { userListObserver.items }
+    public var users: LazyCachedMapCollection<_ChatUser<ExtraData.User>> { userListObserver.items }
     
     lazy var userQueryUpdater = self.environment
         .userQueryUpdaterBuilder(
@@ -212,7 +212,7 @@ extension _ChatUserSearchController {
         var createUserListDatabaseObserver: (
             _ context: NSManagedObjectContext,
             _ fetchRequest: NSFetchRequest<UserDTO>,
-            _ itemCreator: @escaping (UserDTO) -> _ChatUser<ExtraData.User>?
+            _ itemCreator: @escaping (UserDTO) -> _ChatUser<ExtraData.User>
         )
             -> ListDatabaseObserver<_ChatUser<ExtraData.User>, UserDTO> = {
                 ListDatabaseObserver(context: $0, fetchRequest: $1, itemCreator: $2)

--- a/Sources/StreamChat/Controllers/UserListController/UserListController+SwiftUI.swift
+++ b/Sources/StreamChat/Controllers/UserListController/UserListController+SwiftUI.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -16,7 +16,7 @@ extension _ChatUserListController {
         public let controller: _ChatUserListController
         
         /// The users matching the query.
-        @Published public private(set) var users: [_ChatUser<ExtraData.User>] = []
+        @Published public private(set) var users: LazyCachedMapCollection<_ChatUser<ExtraData.User>> = []
         
         /// The current state of the Controller.
         @Published public private(set) var state: DataController.State

--- a/Sources/StreamChat/Controllers/UserListController/UserListController+SwiftUI_Tests.swift
+++ b/Sources/StreamChat/Controllers/UserListController/UserListController+SwiftUI_Tests.swift
@@ -37,7 +37,7 @@ class UserListController_SwiftUI_Tests: iOS13TestCase {
             )
         }
         
-        AssertAsync.willBeEqual(observableObject.users, [newUser])
+        AssertAsync.willBeEqual(Array(observableObject.users), [newUser])
     }
     
     func test_observableObject_reactsToDelegateStateChangesCallback() {
@@ -61,8 +61,8 @@ class UserListControllerMock: ChatUserListController {
     @Atomic var synchronize_called = false
     
     var users_simulated: [_ChatUser<NoExtraData>]?
-    override var users: [_ChatUser<NoExtraData>] {
-        users_simulated ?? super.users
+    override var users: LazyCachedMapCollection<_ChatUser<NoExtraData>> {
+        users_simulated.map { $0.lazyCachedMap { $0 } } ?? super.users
     }
 
     var state_simulated: DataController.State?

--- a/Sources/StreamChat/Controllers/UserListController/UserListController.swift
+++ b/Sources/StreamChat/Controllers/UserListController/UserListController.swift
@@ -50,7 +50,7 @@ public class _ChatUserListController<ExtraData: ExtraDataTypes>: DataController,
     /// To observe changes of the users, set your class as a delegate of this controller or use the provided
     /// `Combine` publishers.
     ///
-    public var users: [_ChatUser<ExtraData.User>] { userListObserver.items }
+    public var users: LazyCachedMapCollection<_ChatUser<ExtraData.User>> { userListObserver.items }
     
     /// The worker used to fetch the remote data and communicate with servers.
     private lazy var worker: UserListUpdater<ExtraData.User> = self.environment
@@ -177,7 +177,7 @@ extension _ChatUserListController {
         var createUserListDabaseObserver: (
             _ context: NSManagedObjectContext,
             _ fetchRequest: NSFetchRequest<UserDTO>,
-            _ itemCreator: @escaping (UserDTO) -> _ChatUser<ExtraData.User>?
+            _ itemCreator: @escaping (UserDTO) -> _ChatUser<ExtraData.User>
         )
             -> ListDatabaseObserver<_ChatUser<ExtraData.User>, UserDTO> = {
                 ListDatabaseObserver(context: $0, fetchRequest: $1, itemCreator: $2)

--- a/Sources/StreamChat/Utils/LazyCachedMapCollection.swift
+++ b/Sources/StreamChat/Utils/LazyCachedMapCollection.swift
@@ -1,0 +1,79 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Read-only collection that applies transformation to element on first access.
+///
+/// Compared to `LazyMapCollection` does not evaluate the whole collection on `count` call.
+public struct LazyCachedMapCollection<Element>: RandomAccessCollection {
+    public typealias Index = Int
+
+    public func index(before i: Index) -> Index {
+        cache.values.index(before: i)
+    }
+
+    public func index(after i: Index) -> Index {
+        cache.values.index(after: i)
+    }
+
+    public var startIndex: Index { cache.values.startIndex }
+
+    public var endIndex: Index { cache.values.endIndex }
+
+    public var count: Index { cache.values.count }
+
+    public init<Collection: RandomAccessCollection, SourceElement>(
+        source: Collection,
+        map: @escaping (SourceElement) -> Element
+    ) where Collection.Element == SourceElement, Collection.Index == Index {
+        generator = { map(source[$0]) }
+        cache = .init(capacity: source.count)
+    }
+
+    private var generator: (Index) -> Element
+    private var cache: Cache<Element>
+
+    public subscript(position: Index) -> Element {
+        if let cached = cache.values[position] {
+            return cached
+        } else {
+            let value = generator(position)
+            defer { cache.values[position] = value }
+            return value
+        }
+    }
+}
+
+extension LazyCachedMapCollection: ExpressibleByArrayLiteral {
+    public typealias ArrayLiteralElement = Element
+
+    public init(arrayLiteral elements: Element...) {
+        generator = { elements[$0] }
+        cache = .init(capacity: elements.count)
+    }
+}
+
+extension LazyCachedMapCollection: Equatable where Element: Equatable {
+    public static func == (lhs: LazyCachedMapCollection<Element>, rhs: LazyCachedMapCollection<Element>) -> Bool {
+        guard lhs.count == rhs.count else { return false }
+        return zip(lhs, rhs).allSatisfy(==)
+    }
+}
+
+extension RandomAccessCollection where Index == Int {
+    /// Lazily apply transformation to sequence
+    public func lazyCachedMap<T>(_ transformation: @escaping (Element) -> T) -> LazyCachedMapCollection<T> {
+        .init(source: self, map: transformation)
+    }
+}
+
+// Must be class so it can be mutable while the collection isn't
+private class Cache<Element> {
+    init(capacity: Int) {
+        values = ContiguousArray(repeating: nil, count: capacity)
+    }
+
+    var values: ContiguousArray<Element?>
+}

--- a/Sources/StreamChat/Utils/LazyCachedMapCollection_Tests.swift
+++ b/Sources/StreamChat/Utils/LazyCachedMapCollection_Tests.swift
@@ -1,0 +1,71 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+class LazyCachedMapCollection_Tests: StressTestCase {
+    func test_mapIsLazy() {
+        // Arrange: Prepare sequence that records transformations
+        var mapped: Set<Int> = []
+        var transformationCount = 0
+        let collection = LazyCachedMapCollection(source: Array(0...10)) { item -> Int in
+            mapped.insert(item)
+            transformationCount += 1
+            return item
+        }
+
+        // Act: Request random elements
+        _ = collection[1]
+        _ = collection[5]
+
+        // Act: Request second time
+        _ = collection[1]
+        _ = collection[5]
+
+        // Assert: Only requested elements where transformed and only once
+        XCTAssertEqual(mapped, [1, 5])
+        XCTAssertEqual(transformationCount, 2)
+    }
+
+    func test_creatingCollection_doesntEvaluateSourceLazyCollection() {
+        // Create source collection that is lazy and record when it's evaluated
+        let source = [0, 1, 2]
+        var lazyMappedEvaluatedValues: [Int] = []
+        let lazyMappedSource = source.lazy.map { number -> String in
+            lazyMappedEvaluatedValues.append(number)
+            return String(number)
+        }
+
+        // So far no values should be evaluated
+        assert(lazyMappedEvaluatedValues.isEmpty)
+
+        // Create a new LazyCachedMapCollection
+        let collection = lazyMappedSource.lazyCachedMap { $0 }
+
+        // Assert the source collection wasn't evaluated yet
+        XCTAssertTrue(lazyMappedEvaluatedValues.isEmpty)
+
+        // Try access a single value and assert only that one is evaluated
+        XCTAssertEqual(collection[0], "0")
+        XCTAssertEqual(lazyMappedEvaluatedValues, [0])
+
+        // Accessing the same value multiple times should not re-evaluate it
+        _ = collection[0]
+        XCTAssertEqual(lazyMappedEvaluatedValues, [0])
+
+        // Access another value and assert only the accessed values are evaluated
+        XCTAssertEqual(collection[2], "2")
+        XCTAssertEqual(lazyMappedEvaluatedValues, [0, 2])
+    }
+
+    func test_equalByTransformedContent() {
+        // Arrange: Prepare two lazy sequences that gives same result but have different sources and transformations
+        let s1 = LazyCachedMapCollection(source: [0, 2, 4], map: { $0 * 3 })
+        let s2 = LazyCachedMapCollection(source: [0, 3, 6], map: { $0 * 2 })
+
+        // Assert: Resulting sequences are equal
+        XCTAssertEqual(s1, s2)
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -591,12 +591,14 @@
 		DB8230F2259B8DBF00E7D7FE /* ChatMessageGiphyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8230F1259B8DBF00E7D7FE /* ChatMessageGiphyView.swift */; };
 		DB823107259C271C00E7D7FE /* SwiftyGif in Frameworks */ = {isa = PBXBuildFile; productRef = DB823106259C271C00E7D7FE /* SwiftyGif */; };
 		DB82310F259C272E00E7D7FE /* SwiftyGif in Frameworks */ = {isa = PBXBuildFile; productRef = DB82310E259C272E00E7D7FE /* SwiftyGif */; };
+		DB842E4525C9F94C000AAC46 /* LazyCachedMapCollection_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB842E4425C9F94C000AAC46 /* LazyCachedMapCollection_Tests.swift */; };
 		DB9A3D562582689A00555D36 /* ChatMessageListRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9A3D552582689A00555D36 /* ChatMessageListRouter.swift */; };
 		DB9A3D662582783F00555D36 /* ChatVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9A3D652582783F00555D36 /* ChatVC.swift */; };
 		DBC8A4BB257E5BFB00B20A82 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DBC8A4BD257E5BFB00B20A82 /* Localizable.stringsdict */; };
 		DBC8A4C6257E696900B20A82 /* ChatMessageThreadInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC8A4C5257E696900B20A82 /* ChatMessageThreadInfoView.swift */; };
 		DBC8A564258113F700B20A82 /* ChatThreadVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC8A563258113F700B20A82 /* ChatThreadVC.swift */; };
 		DBC8A5762581476E00B20A82 /* ChatMessageListVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC8A5752581476E00B20A82 /* ChatMessageListVC.swift */; };
+		DBCAFE2425C44B920015AD58 /* LazyCachedMapCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBCAFE2325C44B920015AD58 /* LazyCachedMapCollection.swift */; };
 		DBF12128258BAFC1001919C6 /* OnlyLinkTappableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF12127258BAFC1001919C6 /* OnlyLinkTappableTextView.swift */; };
 		E701201E2583EBD50036DACD /* CALayer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70120152583EBC90036DACD /* CALayer+Extensions.swift */; };
 		E7166CB225BED22B00B03B07 /* UIConfig+ColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7166CB125BED22B00B03B07 /* UIConfig+ColorPalette.swift */; };
@@ -1351,12 +1353,14 @@
 		DB70CFF325701FE500DDF436 /* ChatChannelNavigationBarListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelNavigationBarListener.swift; sourceTree = "<group>"; };
 		DB70CFFA25702EB900DDF436 /* ChatMessagePopupVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessagePopupVC.swift; sourceTree = "<group>"; };
 		DB8230F1259B8DBF00E7D7FE /* ChatMessageGiphyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageGiphyView.swift; sourceTree = "<group>"; };
+		DB842E4425C9F94C000AAC46 /* LazyCachedMapCollection_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyCachedMapCollection_Tests.swift; sourceTree = "<group>"; };
 		DB9A3D552582689A00555D36 /* ChatMessageListRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListRouter.swift; sourceTree = "<group>"; };
 		DB9A3D652582783F00555D36 /* ChatVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatVC.swift; sourceTree = "<group>"; };
 		DBC8A4BC257E5BFB00B20A82 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DBC8A4C5257E696900B20A82 /* ChatMessageThreadInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageThreadInfoView.swift; sourceTree = "<group>"; };
 		DBC8A563258113F700B20A82 /* ChatThreadVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThreadVC.swift; sourceTree = "<group>"; };
 		DBC8A5752581476E00B20A82 /* ChatMessageListVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListVC.swift; sourceTree = "<group>"; };
+		DBCAFE2325C44B920015AD58 /* LazyCachedMapCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyCachedMapCollection.swift; sourceTree = "<group>"; };
 		DBF12127258BAFC1001919C6 /* OnlyLinkTappableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlyLinkTappableTextView.swift; sourceTree = "<group>"; };
 		E70120152583EBC90036DACD /* CALayer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+Extensions.swift"; sourceTree = "<group>"; };
 		E7166CB125BED22B00B03B07 /* UIConfig+ColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIConfig+ColorPalette.swift"; sourceTree = "<group>"; };
@@ -1756,6 +1760,8 @@
 				79280F702487CD2B00CDEB89 /* Atomic_Tests.swift */,
 				792A4F3D247FFDE700EAF71D /* Codable+Extensions.swift */,
 				792A4F3E247FFDE700EAF71D /* Data+Gzip.swift */,
+				DBCAFE2325C44B920015AD58 /* LazyCachedMapCollection.swift */,
+				DB842E4425C9F94C000AAC46 /* LazyCachedMapCollection_Tests.swift */,
 				792A4F3B247FFBB400EAF71D /* Timers.swift */,
 				797A756524814EF8003CF16D /* SystemEnvironment.swift */,
 				797A756724814F0D003CF16D /* BundleExtensions.swift */,
@@ -3671,6 +3677,7 @@
 				79682C4A24BF37C80071578E /* MessagePayloads.swift in Sources */,
 				8AAB1C6624CB39F2009B783F /* UnreadCount.swift in Sources */,
 				79877A282498E50D00015F8B /* UserDTO.swift in Sources */,
+				DBCAFE2425C44B920015AD58 /* LazyCachedMapCollection.swift in Sources */,
 				79280F47248515FA00CDEB89 /* ChannelEvents.swift in Sources */,
 				DA640FBE2535CF9200D32944 /* UserListSortingKey.swift in Sources */,
 				79877A182498E4EE00015F8B /* ChannelEndpoints.swift in Sources */,
@@ -3760,6 +3767,7 @@
 			files = (
 				DA49714E2549C28000AC68C2 /* AttachmentDTO_Tests.swift in Sources */,
 				88F6DF94252C8866009A8AF0 /* ChannelMemberUpdater_Tests.swift in Sources */,
+				DB842E4525C9F94C000AAC46 /* LazyCachedMapCollection_Tests.swift in Sources */,
 				793C14DC24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift in Sources */,
 				79A0E9AF2498BFD800E9BD50 /* WebSocketClient_Tests.swift in Sources */,
 				DA8407232525E871005A0F62 /* UserListPayload_Tests.swift in Sources */,


### PR DESCRIPTION
Improve performance of CoreData observers by introducing `LazyCachedMapCollection`, data structure that applies transformations to underlying sequence on read access.

Decrease amount of DB queries on DTO -> Model transformation when possible.

Huge FPS drop on channel open happens not because of message list layout or message load (affects it, but not critical).
Apparently when we open channel, channel list observer overload CPU by making useless job.
<img width="618" alt="Screenshot 2021-01-29 at 4 20 39" src="https://user-images.githubusercontent.com/6978940/106227419-70a3f680-61e9-11eb-9866-96e3559b32be.png">