### PR TITLE
Fix command button in composer

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerInputContainerView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerInputContainerView.swift
@@ -47,10 +47,10 @@ open class _ChatMessageComposerInputContainerView<ExtraData: ExtraDataTypes>: Vi
         container.alignment = .center
 
         container.addArrangedSubview(slashCommandView)
-//        slashCommandView.setContentHuggingPriority(.required, for: .horizontal)
+        slashCommandView.setContentHuggingPriority(.required, for: .horizontal)
 
         container.addArrangedSubview(textView)
-//        textView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        textView.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         container.addArrangedSubview(rightAccessoryButton)
 

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageInputSlashCommandView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageInputSlashCommandView.swift
@@ -40,10 +40,10 @@ open class _ChatMessageInputSlashCommandView<ExtraData: ExtraDataTypes>: View, U
     }
     
     // MARK: - Public
-    
+
     override public func defaultAppearance() {
         layer.masksToBounds = true
-        backgroundColor = uiConfig.colorPalette.highlightedBackground
+        backgroundColor = uiConfig.colorPalette.highlightedAccentBackground
 
         commandLabel.textColor = uiConfig.colorPalette.staticColorText
         commandLabel.font = uiConfig.font.subheadlineBold


### PR DESCRIPTION
# What this PR do:
- Fixes issue with forgotten and commented out code while merging UIConfig...
# How to test it
- Go to some conversation, open composer, add some slash command and expect the badge to look according to designs.

Before:
<img width="372" alt="Snímek obrazovky 2021-01-29 v 10 42 43" src="https://user-images.githubusercontent.com/17381941/106272450-60176e80-6231-11eb-88ec-bc8c496ea3d6.png">

After:
<img width="375" alt="Snímek obrazovky 2021-01-29 v 12 56 51" src="https://user-images.githubusercontent.com/17381941/106272533-7c1b1000-6231-11eb-9a43-cb9fe196529d.png">
