### PR TITLE
Replace passing of userSearchController in ChatVC

### DIFF
--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListRouter.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListRouter.swift
@@ -15,7 +15,6 @@ open class _ChatChannelListRouter<ExtraData: ExtraDataTypes>: ChatRouter<_ChatCh
     open func openChat(for channel: _ChatChannel<ExtraData>) {
         let vc = _ChatChannelVC<ExtraData>()
         vc.channelController = rootViewController.controller.client.channelController(for: channel.cid)
-        vc.userSuggestionSearchController = rootViewController.controller.client.userSearchController()
         
         guard let navController = navigationController else {
             log.error("Can't push chat detail, no navigation controller available")

--- a/Sources/StreamChatUI/ChatMessageList/ChatChannelRouter.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatChannelRouter.swift
@@ -11,9 +11,7 @@ open class _ChatChannelRouter<ExtraData: ExtraDataTypes>: ChatRouter<_ChatChanne
     open func showThreadDetail(for message: _ChatMessage<ExtraData>, within channel: _ChatChannelController<ExtraData>) {
         let controller = _ChatThreadVC<ExtraData>()
         controller.channelController = channel
-        controller.userSuggestionSearchController = rootViewController.channelController.client.userSearchController()
         controller.controller = channel.client.messageController(cid: channel.cid!, messageId: message.id)
-        controller.userSuggestionSearchController = channel.client.userSearchController()
         navigationController?.show(controller, sender: self)
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatVC.swift
@@ -16,7 +16,9 @@ open class _ChatVC<ExtraData: ExtraDataTypes>: ViewController,
     // MARK: - Properties
 
     public var channelController: _ChatChannelController<ExtraData>!
-    public var userSuggestionSearchController: _ChatUserSearchController<ExtraData>!
+    public lazy var userSuggestionSearchController: _ChatUserSearchController<ExtraData> = {
+        channelController.client.userSearchController()
+    }()
 
     public private(set) lazy var messageComposerViewController = uiConfig
         .messageComposer


### PR DESCRIPTION
# What this PR do:
- UserSearchController is now created from `channelController` in `ChatVC`