### PR TITLE
Update certificates repo url to SSH

### DIFF
--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,4 +1,4 @@
-git_url("https://github.com/GetStream/ios-certificates")
+git_url("git@github.com:GetStream/ios-certificates.git")
 
 storage_mode("git")
 


### PR DESCRIPTION
# In this PR
Updates the url of the certificates repo in Matchfile to SSH.