### PR TITLE
[CIS-623] Add text truncating in Suggestion cell

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerMentionCollectionViewCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerMentionCollectionViewCell.swift
@@ -79,10 +79,14 @@ open class _ChatMessageComposerMentionCellView<ExtraData: ExtraDataTypes>: View,
 
         textStackView.addArrangedSubview(usernameLabel)
         textStackView.addArrangedSubview(usernameTagLabel)
-        textStackView.centerYAnchor.pin(equalTo: centerYAnchor).isActive = true
+        textStackView.centerYAnchor.pin(equalTo: avatarView.centerYAnchor).isActive = true
         textStackView.leadingAnchor.pin(
             equalToSystemSpacingAfter: avatarView.trailingAnchor,
             multiplier: 1
+        ).isActive = true
+
+        textStackView.trailingAnchor.pin(
+            equalTo: suggestionTypeImageView.leadingAnchor
         ).isActive = true
     }
 
@@ -106,10 +110,29 @@ open class _ChatMessageComposerMentionCollectionViewCell<ExtraData: ExtraDataTyp
 
     override open func setUpLayout() {
         super.setUpLayout()
-
+        
         contentView.embed(
             mentionView,
             insets: contentView.directionalLayoutMargins
         )
+    }
+
+    override open func preferredLayoutAttributesFitting(
+        _ layoutAttributes: UICollectionViewLayoutAttributes
+    ) -> UICollectionViewLayoutAttributes {
+        let preferredAttributes = super.preferredLayoutAttributesFitting(layoutAttributes)
+
+        let targetSize = CGSize(
+            width: layoutAttributes.frame.width,
+            height: UIView.layoutFittingCompressedSize.height
+        )
+
+        preferredAttributes.frame.size = contentView.systemLayoutSizeFitting(
+            targetSize,
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+
+        return preferredAttributes
     }
 }


### PR DESCRIPTION
# What this PR do:
- Fixes text overlapping the mention image and continuing beyond screen in suggestion cells (see screenshots)
# How to test it
- Run suggestions in any chat screen
# The issue

The problem in this case is that the collectionView cells ignored the `estimatedRowSize` width and rather use the maximum width based on cell content. because we missed the method `preferredLayoutAttributesFitting` where we set the width to be required.

So before introducing this method and changing the text stackView trailing to the image on the right,  it was actually a go for cell autoresizing width. Also without us knowing, the cell was much wider because of the long id text (had no trailing and stack view caused to expand wider).

Basically this issue could have been solved with using explicit `itemSize` with some magic height constraint instead of `estimatedSize` in `CollectionViewFlowLayout` and implementing `preferredLayoutAttributesFitting`.

I was also trying to somehow make work `itemSize` and `estimatedItemSize` together so I would set `itemSize.width` to collectionView width and height to approx 60 but this caused UI loop... So this is probably best available solution I could came up 


Before: 
<img width="441" alt="Snímek obrazovky 2021-02-01 v 13 07 11" src="https://user-images.githubusercontent.com/17381941/106459218-d4504d00-6491-11eb-93a5-7670cae10313.png">


After: 
<img width="441" alt="Snímek obrazovky 2021-02-01 v 13 31 32" src="https://user-images.githubusercontent.com/17381941/106459251-ddd9b500-6491-11eb-95ce-30ae7ac60d25.png">

