### PR TITLE
[CIS-629] Fix mint failing run phase if swiftlint is not installed

### DIFF
--- a/Sources/StreamChatUI/Utils/Bundle+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/Bundle+Extensions.swift
@@ -8,14 +8,14 @@ private class BundleIdentifyingClass {}
 
 extension Bundle {
     static var streamChatUI: Bundle {
-        /// We're using `resource_bundles` to export our resources in the podspec file
-        /// (See https://guides.cocoapods.org/syntax/podspec.html#resource_bundles)
-        /// since we need to support building pod as a static library.
-        /// This attribute causes cocoapods to build a resource bundle and put all our resources inside, during `pod install`
-        /// But this bundle exists only for cocoapods builds, and for other methods (Carthage, git submodule) we directly export
-        /// assets.
-        /// So we need this compiler check to decide which bundle to use.
-        /// See https://github.com/GetStream/stream-chat-swift/issues/774
+        // We're using `resource_bundles` to export our resources in the podspec file
+        // (See https://guides.cocoapods.org/syntax/podspec.html#resource_bundles)
+        // since we need to support building pod as a static library.
+        // This attribute causes cocoapods to build a resource bundle and put all our resources inside, during `pod install`
+        // But this bundle exists only for cocoapods builds, and for other methods (Carthage, git submodule) we directly export
+        // assets.
+        // So we need this compiler check to decide which bundle to use.
+        // See https://github.com/GetStream/stream-chat-swift/issues/774
         #if COCOAPODS
         return Bundle(for: BundleIdentifyingClass.self)
             .url(forResource: "StreamChatUI", withExtension: "bundle")

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -3262,7 +3262,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mint run swiftlint lint ./Sources/StreamChatUI ./Tests/StreamChatUI --config .swiftlint.yml \n\n";
+			shellScript = "if which mint >/dev/null && mint which swiftlint; then\n  xcrun --sdk macosx mint run swiftlint lint ./Sources/StreamChatUI ./Tests/StreamChatUI --config .swiftlint.yml\nelse\n  echo \"Warning: Bootstrap not run, please run ./bootstrap.sh\"\nfi\n";
 		};
 		792DDA73256FB723001DB91B /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3280,7 +3280,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mint run swiftlint lint ./DemoApp --config .swiftlint.yml\n";
+			shellScript = "if which mint >/dev/null && mint which swiftlint; then\n  xcrun --sdk macosx mint run swiftlint lint ./DemoApp --config .swiftlint.yml\nelse\n  echo \"Warning: Bootstrap not run, please run ./bootstrap.sh\"\nfi\n";
 		};
 		7990A5DD256BE4CC00389DF7 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3298,7 +3298,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mint run swiftlint lint ./Sample --config .swiftlint.yml\n";
+			shellScript = "if which mint >/dev/null && mint which swiftlint; then\n  xcrun --sdk macosx mint run swiftlint lint ./Sample --config .swiftlint.yml\nelse\n  echo \"Warning: Bootstrap not run, please run ./bootstrap.sh\"\nfi\n\n";
 		};
 		88F0D6EB257E40B300F4B050 /* SwiftGen */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3335,7 +3335,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mint run swiftlint lint ./Sources/StreamChat ./Tests/StreamChat --config .swiftlint.yml \n";
+			shellScript = "if which mint >/dev/null && mint which swiftlint; then\n  xcrun --sdk macosx mint run swiftlint lint ./Sources/StreamChat ./Tests/StreamChat --config .swiftlint.yml\nelse\n  echo \"Warning: Bootstrap not run, please run ./bootstrap.sh\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Fixes #783
Cause: https://github.com/yonaskolb/Mint/issues/179

Since `mint run` always installs a package, and installing `swiftlint` takes around 3-4 minutes (on my computer), I've decided it's best that developers don't have to install swiftlint to run the project.

#skip_changelog