### PR TITLE
[CIS-632] Fix race conditions on database observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🔄 Changed
 - Improve serialization performance by exposing items as `LazyCachedMapCollection` instead of `Array` [#776](https://github.com/GetStream/stream-chat-swift/pull/776)
 
+### 🐞 Fixed
+- Fix race conditions in database observers [#796](https://github.com/GetStream/stream-chat-swift/pull/796)
+
 # [3.0.1](https://github.com/GetStream/stream-chat-swift/releases/tag/3.0.1)
 _February 2nd, 2021_
 


### PR DESCRIPTION
We already have a fix like this at other places in the observers. I just extended it to cover the other exposed cases, too.

---

Fixed exactly as @cardoso suggested :trollface: 

![Screen Shot 2021-02-03 at 14 40 02](https://user-images.githubusercontent.com/6388510/106754806-b4559080-662d-11eb-9454-44f0acb977c0.png)
