### PR TITLE
[CIS-633] Fix beta lane

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -14,6 +14,10 @@ jobs:
     name: Distribute Demo App
     runs-on: macos-latest
     steps:
+    - name: Install Bot SSH Key
+      uses: webfactory/ssh-agent@v0.4.1
+      with:
+        ssh-private-key: ${{ secrets.BOT_SSH_PRIVATE_KEY }}
     - uses: actions/checkout@v1
     - name: Cache RubyGems
       uses: actions/cache@v2


### PR DESCRIPTION
Installs @Stream-iOS-Bot 's SSH key to the device when running `beta` lane such that it has access to our certs repo.