### PR TITLE
[CIS-637] Sending attachments without uploading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ✅ Added
 - Add support for custom attachment types with unknown structure
     [#795](https://github.com/GetStream/stream-chat-swift/pull/795)
+- Add possibility to send attachments that don't need prior uploading
+    [#799](https://github.com/GetStream/stream-chat-swift/pull/799)
 
 ### 🔄 Changed
 - Improve serialization performance by exposing items as `LazyCachedMapCollection` instead of `Array` [#776](https://github.com/GetStream/stream-chat-swift/pull/776)

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -671,7 +671,8 @@ public extension _ChatChannelController {
     /// - Parameters:
     ///   - text: Text of the message.
     ///   - extraData: Additional extra data of the message object.
-    ///   - attachments: An array of the attachments for the message.
+    ///   - attachments: An array of the attachments for the message that already uploaded or doesn't need uploading.
+    ///   - attachmentSeeds: An array of the attachments that needs to be uploaded before sending.
     ///   - quotedMessageId: An id of the message new message quotes. (inline reply)
     ///   - completion: Called when saving the message to the local DB finishes.
     ///
@@ -679,7 +680,8 @@ public extension _ChatChannelController {
         text: String,
 //        command: String? = nil,
 //        arguments: String? = nil,
-        attachments: [ChatMessageAttachmentSeed] = [],
+        attachments: [AttachmentEnvelope] = [],
+        attachmentSeeds: [ChatMessageAttachmentSeed] = [],
         quotedMessageId: MessageId? = nil,
         extraData: ExtraData.Message = .defaultValue,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
@@ -701,6 +703,7 @@ public extension _ChatChannelController {
             command: nil,
             arguments: nil,
             attachments: attachments,
+            attachmentSeeds: attachmentSeeds,
             quotedMessageId: quotedMessageId,
             extraData: extraData
         ) { result in

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
@@ -1241,7 +1241,7 @@ class ChannelController_Tests: StressTestCase {
             in: channelId,
             text: "Message",
             quotedMessageId: nil,
-            attachments: [
+            attachmentSeeds: [
                 ChatMessageAttachmentSeed.dummy(),
                 ChatMessageAttachmentSeed.dummy(),
                 ChatMessageAttachmentSeed.dummy()
@@ -1530,7 +1530,8 @@ class ChannelController_Tests: StressTestCase {
 //        let command: String = .unique
 //        let arguments: String = .unique
         let extraData: NoExtraData = .defaultValue
-        let attachments: [ChatMessageAttachmentSeed] = [
+        let attachments: [TestAttachmentEnvelope] = [.init(), .init(), .init()]
+        let attachmentSeeds: [ChatMessageAttachmentSeed] = [
             .dummy(),
             .dummy(),
             .dummy()
@@ -1544,6 +1545,7 @@ class ChannelController_Tests: StressTestCase {
 //            command: command,
 //            arguments: arguments,
             attachments: attachments,
+            attachmentSeeds: attachmentSeeds,
             quotedMessageId: quotedMessageId,
             extraData: extraData
         ) { [callbackQueueID] result in
@@ -1566,7 +1568,11 @@ class ChannelController_Tests: StressTestCase {
         //        XCTAssertEqual(env.channelUpdater?.createNewMessage_command, command)
         //        XCTAssertEqual(env.channelUpdater?.createNewMessage_arguments, arguments)
         XCTAssertEqual(env.channelUpdater?.createNewMessage_extraData, extraData)
-        XCTAssertEqual(env.channelUpdater?.createNewMessage_attachments, attachments)
+        XCTAssertEqual(
+            env.channelUpdater?.createNewMessage_attachments?.compactMap { $0 as? TestAttachmentEnvelope },
+            attachments
+        )
+        XCTAssertEqual(env.channelUpdater?.createNewMessage_attachmentSeeds, attachmentSeeds)
         XCTAssertEqual(env.channelUpdater?.createNewMessage_quotedMessageId, quotedMessageId)
         
         // Simulate successful update

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -193,7 +193,8 @@ public extension _ChatMessageController {
     ///
     /// - Parameters:
     ///   - text: Text of the message.
-    ///   - attachments: An array of the attachments for the message.
+    ///   - attachments: An array of the attachments for the message that already uploaded or doesn't need uploading.
+    ///   - attachmentSeeds: An array of the attachments that needs to be uploaded before sending.
     ///   - showReplyInChannel: Set this flag to `true` if you want the message to be also visible in the channel, not only
     ///   in the response thread.
     ///   - quotedMessageId: An id of the message new message quotes. (inline reply)
@@ -204,7 +205,8 @@ public extension _ChatMessageController {
         text: String,
 //        command: String? = nil,
 //        arguments: String? = nil,
-        attachments: [ChatMessageAttachmentSeed] = [],
+        attachments: [AttachmentEnvelope] = [],
+        attachmentSeeds: [ChatMessageAttachmentSeed] = [],
         showReplyInChannel: Bool = false,
         quotedMessageId: MessageId? = nil,
         extraData: ExtraData.Message = .defaultValue,
@@ -217,6 +219,7 @@ public extension _ChatMessageController {
             arguments: nil,
             parentMessageId: messageId,
             attachments: attachments,
+            attachmentSeeds: attachmentSeeds,
             showReplyInChannel: showReplyInChannel,
             quotedMessageId: quotedMessageId,
             extraData: extraData

--- a/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
@@ -610,7 +610,7 @@ final class MessageController_Tests: StressTestCase {
     
     // MARK: - Create new reply
     
-    func test_createNewReply_callsChannelUpdater() {
+    func test_createNewReply_callsMessageUpdater() {
         let newMessageId: MessageId = .unique
         
         // New message values
@@ -620,7 +620,8 @@ final class MessageController_Tests: StressTestCase {
         let showReplyInChannel = true
         let quotedMessageId: MessageId = .unique
         let extraData: NoExtraData = .defaultValue
-        let attachments: [ChatMessageAttachmentSeed] = [
+        let attachments: [TestAttachmentEnvelope] = [.init(), .init(), .init()]
+        let attachmentSeeds: [ChatMessageAttachmentSeed] = [
             .dummy(),
             .dummy(),
             .dummy()
@@ -633,6 +634,7 @@ final class MessageController_Tests: StressTestCase {
 //            command: command,
 //            arguments: arguments,
             attachments: attachments,
+            attachmentSeeds: attachmentSeeds,
             showReplyInChannel: showReplyInChannel,
             quotedMessageId: quotedMessageId,
             extraData: extraData
@@ -658,7 +660,11 @@ final class MessageController_Tests: StressTestCase {
         XCTAssertEqual(env.messageUpdater.createNewReply_parentMessageId, messageId)
         XCTAssertEqual(env.messageUpdater.createNewReply_showReplyInChannel, showReplyInChannel)
         XCTAssertEqual(env.messageUpdater.createNewReply_extraData, extraData)
-        XCTAssertEqual(env.messageUpdater.createNewReply_attachments, attachments)
+        XCTAssertEqual(
+            env.messageUpdater.createNewReply_attachments?.compactMap { $0 as? TestAttachmentEnvelope },
+            attachments
+        )
+        XCTAssertEqual(env.messageUpdater.createNewReply_attachmentSeeds, attachmentSeeds)
         XCTAssertEqual(env.messageUpdater.createNewReply_quotedMessageId, quotedMessageId)
         
         // Simulate successful update

--- a/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
@@ -351,6 +351,7 @@ class MessageDTO_Tests: XCTestCase {
         let messageText: String = .unique
         let messageCommand: String = .unique
         let messageArguments: String = .unique
+        let messageAttachments: [TestAttachmentEnvelope] = [.init(), .init()]
         let messageAttachmentSeeds: [ChatMessageAttachmentSeed] = [.dummy(), .dummy(), .dummy()]
         let messageShowReplyInChannel = true
         let messageExtraData: NoExtraData = .defaultValue
@@ -363,7 +364,8 @@ class MessageDTO_Tests: XCTestCase {
                 command: messageCommand,
                 arguments: messageArguments,
                 parentMessageId: parentMessageId,
-                attachments: messageAttachmentSeeds,
+                attachments: messageAttachments,
+                attachmentSeeds: messageAttachmentSeeds,
                 showReplyInChannel: true,
                 quotedMessageId: nil,
                 extraData: messageExtraData
@@ -467,7 +469,8 @@ class MessageDTO_Tests: XCTestCase {
                     command: nil,
                     arguments: nil,
                     parentMessageId: nil,
-                    attachments: [ChatMessageAttachmentSeed](),
+                    attachments: [TestAttachmentEnvelope](),
+                    attachmentSeeds: [ChatMessageAttachmentSeed](),
                     showReplyInChannel: false,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
@@ -482,7 +485,8 @@ class MessageDTO_Tests: XCTestCase {
                     command: nil,
                     arguments: nil,
                     parentMessageId: nil,
-                    attachments: [ChatMessageAttachmentSeed](),
+                    attachments: [TestAttachmentEnvelope](),
+                    attachmentSeeds: [ChatMessageAttachmentSeed](),
                     showReplyInChannel: false,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
@@ -677,6 +681,7 @@ class MessageDTO_Tests: XCTestCase {
         let newMessageCommand: String = .unique
         let newMessageArguments: String = .unique
         let newMessageParentMessageId: String = .unique
+        let newMessageAttachments: [TestAttachmentEnvelope] = [.init(), .init()]
         let newMessageAttachmentSeeds: [ChatMessageAttachmentSeed] = [
             .dummy(),
             .dummy()
@@ -690,7 +695,8 @@ class MessageDTO_Tests: XCTestCase {
                     command: newMessageCommand,
                     arguments: newMessageArguments,
                     parentMessageId: newMessageParentMessageId,
-                    attachments: newMessageAttachmentSeeds,
+                    attachments: newMessageAttachments,
+                    attachmentSeeds: newMessageAttachmentSeeds,
                     showReplyInChannel: true,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
@@ -714,8 +720,12 @@ class MessageDTO_Tests: XCTestCase {
         XCTAssertEqual(loadedMessage.createdAt, loadedMessage.locallyCreatedAt)
         XCTAssertEqual(loadedMessage.createdAt, loadedMessage.updatedAt)
         XCTAssertEqual(
-            loadedMessage.attachments.map { ($0 as? ChatMessageDefaultAttachment)?.title },
+            loadedMessage.attachments.compactMap { ($0 as? ChatMessageDefaultAttachment)?.title },
             newMessageAttachmentSeeds.map(\.fileName)
+        )
+        XCTAssertEqual(
+            loadedMessage.attachments.compactMap { ($0 as? ChatMessageRawAttachment)?.data },
+            newMessageAttachments.map { try? JSONEncoder.stream.encode($0) }
         )
     }
     
@@ -728,7 +738,8 @@ class MessageDTO_Tests: XCTestCase {
                     command: .unique,
                     arguments: .unique,
                     parentMessageId: .unique,
-                    attachments: [ChatMessageAttachmentSeed](),
+                    attachments: [TestAttachmentEnvelope](),
+                    attachmentSeeds: [ChatMessageAttachmentSeed](),
                     showReplyInChannel: true,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
@@ -760,7 +771,8 @@ class MessageDTO_Tests: XCTestCase {
                     command: .unique,
                     arguments: .unique,
                     parentMessageId: .unique,
-                    attachments: [ChatMessageAttachmentSeed](),
+                    attachments: [TestAttachmentEnvelope](),
+                    attachmentSeeds: [ChatMessageAttachmentSeed](),
                     showReplyInChannel: true,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
@@ -796,7 +808,7 @@ class MessageDTO_Tests: XCTestCase {
                 in: cid,
                 text: newMessageText,
                 quotedMessageId: nil,
-                attachments: newMessageAttachmentSeeds,
+                attachmentSeeds: newMessageAttachmentSeeds,
                 extraData: NoExtraData.defaultValue
             )
             newMessageId = messageDTO.id
@@ -831,7 +843,8 @@ class MessageDTO_Tests: XCTestCase {
                 command: nil,
                 arguments: nil,
                 parentMessageId: messageId,
-                attachments: [ChatMessageAttachmentSeed](),
+                attachments: [TestAttachmentEnvelope](),
+                attachmentSeeds: [ChatMessageAttachmentSeed](),
                 showReplyInChannel: false,
                 quotedMessageId: nil,
                 extraData: NoExtraData.defaultValue

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -60,7 +60,8 @@ protocol MessageDatabaseSession {
         command: String?,
         arguments: String?,
         parentMessageId: MessageId?,
-        attachments: [ChatMessageAttachmentSeed],
+        attachments: [AttachmentEnvelope],
+        attachmentSeeds: [ChatMessageAttachmentSeed],
         showReplyInChannel: Bool,
         quotedMessageId: MessageId?,
         extraData: ExtraData
@@ -104,7 +105,8 @@ extension MessageDatabaseSession {
         in cid: ChannelId,
         text: String,
         quotedMessageId: MessageId?,
-        attachments: [ChatMessageAttachmentSeed] = [],
+        attachments: [AttachmentEnvelope] = [],
+        attachmentSeeds: [ChatMessageAttachmentSeed] = [],
         extraData: ExtraData = .defaultValue
     ) throws -> MessageDTO {
         try createNewMessage(
@@ -114,6 +116,7 @@ extension MessageDatabaseSession {
             arguments: nil,
             parentMessageId: nil,
             attachments: attachments,
+            attachmentSeeds: attachmentSeeds,
             showReplyInChannel: false,
             quotedMessageId: quotedMessageId,
             extraData: extraData
@@ -195,6 +198,14 @@ protocol AttachmentDatabaseSession {
     @discardableResult
     func createNewAttachment(
         seed: ChatMessageAttachmentSeed,
+        id: AttachmentId
+    ) throws -> AttachmentDTO
+    
+    /// Creates a new `AttachmentDTO` object in the database from the given model for the message
+    /// with the given `messageId` in the channel with the given `cid`.
+    @discardableResult
+    func createNewAttachment(
+        attachment: AttachmentEnvelope,
         id: AttachmentId
     ) throws -> AttachmentDTO
 }

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -91,7 +91,8 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
     /// - Parameters:
     ///   - cid: The cid of the channel the message is create in.
     ///   - text: Text of the message.
-    ///   - attachments: Attachments for the message.
+    ///   - attachments: An array of the attachments for the message that already uploaded or doesn't need uploading.
+    ///   - attachmentSeeds: An array of the attachments that needs to be uploaded before sending.
     ///   - quotedMessageId: An id of the message new message quotes. (inline reply)
     ///   - extraData: Additional extra data of the message object.
     ///   - completion: Called when saving the message to the local DB finishes.
@@ -101,7 +102,8 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
         text: String,
         command: String?,
         arguments: String?,
-        attachments: [ChatMessageAttachmentSeed] = [],
+        attachments: [AttachmentEnvelope] = [],
+        attachmentSeeds: [ChatMessageAttachmentSeed] = [],
         quotedMessageId: MessageId?,
         extraData: ExtraData.Message,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
@@ -115,6 +117,7 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
                 arguments: arguments,
                 parentMessageId: nil,
                 attachments: attachments,
+                attachmentSeeds: attachmentSeeds,
                 showReplyInChannel: false,
                 quotedMessageId: quotedMessageId,
                 extraData: extraData

--- a/Sources/StreamChat/Workers/ChannelUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Mock.swift
@@ -40,7 +40,8 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
     @Atomic var createNewMessage_text: String?
     @Atomic var createNewMessage_command: String?
     @Atomic var createNewMessage_arguments: String?
-    @Atomic var createNewMessage_attachments: [ChatMessageAttachmentSeed]?
+    @Atomic var createNewMessage_attachments: [AttachmentEnvelope]?
+    @Atomic var createNewMessage_attachmentSeeds: [ChatMessageAttachmentSeed]?
     @Atomic var createNewMessage_quotedMessageId: MessageId?
     @Atomic var createNewMessage_extraData: ExtraData.Message?
     @Atomic var createNewMessage_completion: ((Result<MessageId, Error>) -> Void)?
@@ -84,6 +85,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         createNewMessage_command = nil
         createNewMessage_arguments = nil
         createNewMessage_attachments = nil
+        createNewMessage_attachmentSeeds = nil
         createNewMessage_extraData = nil
         createNewMessage_completion = nil
         
@@ -133,7 +135,8 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         text: String,
         command: String?,
         arguments: String?,
-        attachments: [ChatMessageAttachmentSeed],
+        attachments: [AttachmentEnvelope],
+        attachmentSeeds: [ChatMessageAttachmentSeed],
         quotedMessageId: MessageId?,
         extraData: ExtraData.Message,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
@@ -143,6 +146,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         createNewMessage_command = command
         createNewMessage_arguments = arguments
         createNewMessage_attachments = attachments
+        createNewMessage_attachmentSeeds = attachmentSeeds
         createNewMessage_quotedMessageId = quotedMessageId
         createNewMessage_extraData = extraData
         createNewMessage_completion = completion

--- a/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
@@ -131,7 +131,8 @@ class ChannelUpdater_Tests: StressTestCase {
         let text: String = .unique
         let command: String = .unique
         let arguments: String = .unique
-        let attachments: [ChatMessageAttachmentSeed] = [.dummy(), .dummy(), .dummy()]
+        let attachments: [TestAttachmentEnvelope] = [.init(), .init(), .init()]
+        let attachmentSeeds: [ChatMessageAttachmentSeed] = [.dummy(), .dummy(), .dummy()]
         let extraData: NoExtraData = .defaultValue
         
         // Create new message
@@ -142,6 +143,7 @@ class ChannelUpdater_Tests: StressTestCase {
                 command: command,
                 arguments: arguments,
                 attachments: attachments,
+                attachmentSeeds: attachmentSeeds,
                 quotedMessageId: nil,
                 extraData: extraData
             ) { result in
@@ -163,7 +165,11 @@ class ChannelUpdater_Tests: StressTestCase {
             Assert.willBeEqual(message?.arguments, arguments)
             Assert.willBeEqual(
                 message?.attachments.compactMap { ($0 as? ChatMessageDefaultAttachment)?.title },
-                attachments.map(\.fileName)
+                attachmentSeeds.map(\.fileName)
+            )
+            Assert.willBeEqual(
+                message?.attachments.compactMap { ($0 as? ChatMessageRawAttachment)?.data },
+                attachments.map { try? JSONEncoder.stream.encode($0) }
             )
             Assert.willBeEqual(message?.extraData, extraData)
             Assert.willBeEqual(message?.localState, .pendingSend)

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -122,7 +122,8 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
     ///   - cid: The cid of the channel the message is create in.
     ///   - text: Text of the message.
     ///   - parentMessageId: The `MessageId` of the message this message replies to.
-    ///   - attachments: An array of the attachments for the message.
+    ///   - attachments: An array of the attachments for the message that already uploaded or doesn't need uploading.
+    ///   - attachmentSeeds: An array of the attachments that needs to be uploaded before sending.
     ///   - showReplyInChannel: Set this flag to `true` if you want the message to be also visible in the channel, not only
     ///   in the response thread.
     ///   - quotedMessageId: An id of the message new message quotes. (inline reply)
@@ -135,7 +136,8 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
         command: String?,
         arguments: String?,
         parentMessageId: MessageId,
-        attachments: [ChatMessageAttachmentSeed],
+        attachments: [AttachmentEnvelope],
+        attachmentSeeds: [ChatMessageAttachmentSeed],
         showReplyInChannel: Bool,
         quotedMessageId: MessageId?,
         extraData: ExtraData.Message,
@@ -150,6 +152,7 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
                 arguments: arguments,
                 parentMessageId: parentMessageId,
                 attachments: attachments,
+                attachmentSeeds: attachmentSeeds,
                 showReplyInChannel: showReplyInChannel,
                 quotedMessageId: quotedMessageId,
                 extraData: extraData

--- a/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -23,7 +23,8 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
     @Atomic var createNewReply_command: String?
     @Atomic var createNewReply_arguments: String?
     @Atomic var createNewReply_parentMessageId: MessageId?
-    @Atomic var createNewReply_attachments: [ChatMessageAttachmentSeed]?
+    @Atomic var createNewReply_attachments: [AttachmentEnvelope]?
+    @Atomic var createNewReply_attachmentSeeds: [ChatMessageAttachmentSeed]?
     @Atomic var createNewReply_showReplyInChannel: Bool?
     @Atomic var createNewReply_quotedMessageId: MessageId?
     @Atomic var createNewReply_extraData: ExtraData.Message?
@@ -144,7 +145,8 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         command: String?,
         arguments: String?,
         parentMessageId: MessageId?,
-        attachments: [ChatMessageAttachmentSeed],
+        attachments: [AttachmentEnvelope],
+        attachmentSeeds: [ChatMessageAttachmentSeed],
         showReplyInChannel: Bool,
         quotedMessageId: MessageId?,
         extraData: ExtraData.Message,
@@ -156,6 +158,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         createNewReply_arguments = arguments
         createNewReply_parentMessageId = parentMessageId
         createNewReply_attachments = attachments
+        createNewReply_attachmentSeeds = attachmentSeeds
         createNewReply_showReplyInChannel = showReplyInChannel
         createNewReply_quotedMessageId = quotedMessageId
         createNewReply_extraData = extraData

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -434,6 +434,7 @@ final class MessageUpdater_Tests: StressTestCase {
         let showReplyInChannel = true
         let command: String = .unique
         let arguments: String = .unique
+        let attachments: [TestAttachmentEnvelope] = [.init(), .init(), .init()]
         let attachmentSeeds: [ChatMessageAttachmentSeed] = [
             .dummy(),
             .dummy(),
@@ -449,7 +450,8 @@ final class MessageUpdater_Tests: StressTestCase {
                 command: command,
                 arguments: arguments,
                 parentMessageId: parentMessageId,
-                attachments: attachmentSeeds,
+                attachments: attachments,
+                attachmentSeeds: attachmentSeeds,
                 showReplyInChannel: showReplyInChannel,
                 quotedMessageId: nil,
                 extraData: extraData
@@ -476,6 +478,10 @@ final class MessageUpdater_Tests: StressTestCase {
                 message?.attachments.compactMap { ($0 as? ChatMessageDefaultAttachment)?.title },
                 attachmentSeeds.map(\.fileName)
             )
+            Assert.willBeEqual(
+                message?.attachments.compactMap { ($0 as? ChatMessageRawAttachment)?.data },
+                attachments.map { try? JSONEncoder.stream.encode($0) }
+            )
             Assert.willBeEqual(message?.extraData, extraData)
             Assert.willBeEqual(message?.localState, .pendingSend)
         }
@@ -501,6 +507,7 @@ final class MessageUpdater_Tests: StressTestCase {
                 arguments: .unique,
                 parentMessageId: .unique,
                 attachments: [],
+                attachmentSeeds: [],
                 showReplyInChannel: false,
                 quotedMessageId: nil,
                 extraData: .defaultValue

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
@@ -237,12 +237,12 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: ViewController,
             
             messageController?.createNewReply(
                 text: text,
-                attachments: attachmentSeeds,
+                attachmentSeeds: attachmentSeeds,
                 showReplyInChannel: composerView.checkmarkControl.isSelected,
                 quotedMessageId: quotedMessageId
             )
         } else {
-            controller?.createNewMessage(text: text, attachments: attachmentSeeds, quotedMessageId: quotedMessageId)
+            controller?.createNewMessage(text: text, attachmentSeeds: attachmentSeeds, quotedMessageId: quotedMessageId)
         }
     }
     

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		2229C6D9256562AC00C56B63 /* ChatMessageAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2229C6D8256562AC00C56B63 /* ChatMessageAttachment.swift */; };
 		2229C6DF256562DB00C56B63 /* AttachmentPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2229C6DE256562DB00C56B63 /* AttachmentPayload.swift */; };
 		222E54A025B106D20032C459 /* ChatMessageQuoteBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222E549F25B106D20032C459 /* ChatMessageQuoteBubbleView.swift */; };
+		2236D97B25CC68E400C47F30 /* TestAttachmentEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2236D97A25CC68E400C47F30 /* TestAttachmentEnvelope.swift */; };
 		22411680258A91280034184D /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2241167F258A91280034184D /* String+Extensions.swift */; };
 		224116B2258BACF90034184D /* Message.json in Resources */ = {isa = PBXBuildFile; fileRef = 224116B1258BACF90034184D /* Message.json */; };
 		224165A825910A2C00ED7F78 /* ChatMessageComposerCheckmarkControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224165A725910A2C00ED7F78 /* ChatMessageComposerCheckmarkControl.swift */; };
@@ -762,6 +763,7 @@
 		2229C6D8256562AC00C56B63 /* ChatMessageAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageAttachment.swift; sourceTree = "<group>"; };
 		2229C6DE256562DB00C56B63 /* AttachmentPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentPayload.swift; sourceTree = "<group>"; };
 		222E549F25B106D20032C459 /* ChatMessageQuoteBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageQuoteBubbleView.swift; sourceTree = "<group>"; };
+		2236D97A25CC68E400C47F30 /* TestAttachmentEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAttachmentEnvelope.swift; sourceTree = "<group>"; };
 		2241167F258A91280034184D /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		224116B1258BACF90034184D /* Message.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Message.json; sourceTree = "<group>"; };
 		224165A725910A2C00ED7F78 /* ChatMessageComposerCheckmarkControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageComposerCheckmarkControl.swift; sourceTree = "<group>"; };
@@ -1620,6 +1622,7 @@
 				88AA92872547332000BFA0C3 /* MessageReactionPayload.swift */,
 				2229C6D8256562AC00C56B63 /* ChatMessageAttachment.swift */,
 				2229C6DE256562DB00C56B63 /* AttachmentPayload.swift */,
+				2236D97A25CC68E400C47F30 /* TestAttachmentEnvelope.swift */,
 				792A71E22578EF650082498D /* ChannelId.swift */,
 				79D7A1CD2593A40900D3C2BF /* ChannelPayload.swift */,
 			);
@@ -3900,6 +3903,7 @@
 				F62BE7922506692700D13B86 /* MissingEventsPublisher_Tests.swift in Sources */,
 				79200D42250118A1002F4EB1 /* iOS13TestCase.swift in Sources */,
 				88EA9B0625472430007EE76B /* MessageReactionPayload_Tests.swift in Sources */,
+				2236D97B25CC68E400C47F30 /* TestAttachmentEnvelope.swift in Sources */,
 				88D85DAE252F468B00AE1030 /* ListDatabaseObserver_Mock.swift in Sources */,
 				79877A292498E51500015F8B /* ChannelDTO_Tests.swift in Sources */,
 				88CD396625B584E000399F8E /* HTTPHeader_Tests.swift in Sources */,

--- a/Tests/StreamChatTests/Dummy data/TestAttachmentEnvelope.swift
+++ b/Tests/StreamChatTests/Dummy data/TestAttachmentEnvelope.swift
@@ -1,0 +1,16 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+
+struct TestAttachmentEnvelope: AttachmentEnvelope, Equatable, Decodable {
+    var type: AttachmentType = .custom(.unique)
+    let name: String
+    let number: Int
+    
+    init(name: String = .unique, number: Int = .random(in: 1...100)) {
+        self.name = name
+        self.number = number
+    }
+}


### PR DESCRIPTION
**In this PR:** 

- Make it possible to save `AttachmentEnvelope` to DB
- Make it possible to create `MessageDTO` with `[AttachmentEnvelope]`
- Add possibility to send message with `[AttachmentEnvelope]` to `ChannelUpdater`
- Add possibility to send message with `[AttachmentEnvelope]` to `MessageUpdater`
- Expose possibility to send message with `[AttachmentEnvelope]` in `ChannelController`
- Expose possibility to send message with `[AttachmentEnvelope]` in `MessageController`
- Fix and update `MessageSender_Tests`
- Fix `Demo` app after API changes
