### PR TITLE
[CIS-638] Decrease channel launch times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔄 Changed
 - Improve serialization performance by exposing items as `LazyCachedMapCollection` instead of `Array` [#776](https://github.com/GetStream/stream-chat-swift/pull/776)
+- Reduce amount of fake updates by erasing touched objects [#802](https://github.com/GetStream/stream-chat-swift/pull/802)
+- Trigger members and current user updates on UserDTO changes [#802](https://github.com/GetStream/stream-chat-swift/pull/802)
 
 ### 🐞 Fixed
 - Fix race conditions in database observers [#796](https://github.com/GetStream/stream-chat-swift/pull/796)
@@ -26,7 +28,7 @@ _February 2nd, 2021_
 ## StreamChat
 
 ### ✅ Added
-- Add support for `enforce_unique` parameter on sending reactions 
+- Add support for `enforce_unique` parameter on sending reactions
     [#770](https://github.com/GetStream/stream-chat-swift/pull/770)
 ### 🔄 Changed
 
@@ -34,14 +36,14 @@ _February 2nd, 2021_
 - Fix development token not working properly [#760](https://github.com/GetStream/stream-chat-swift/pull/760)
 - Fix lists ordering not updating instantly. [#768](https://github.com/GetStream/stream-chat-swift/pull/768/)
 - Fix update changes incorrectly reported when a move change is present for the same index. [#768](https://github.com/GetStream/stream-chat-swift/pull/768/)
-- Fix issue with decoding `member_count` for `ChannelDetailPayload` 
+- Fix issue with decoding `member_count` for `ChannelDetailPayload`
     [#782](https://github.com/GetStream/stream-chat-swift/pull/782)
 - Fix wrong extra data cheat sheet documentation link [#786](https://github.com/GetStream/stream-chat-swift/pull/786)
 
 # [3.0](https://github.com/GetStream/stream-chat-swift/releases/tag/3.0)
 _January 22nd, 2021_
 
-## StreamChat SDK reaches another milestone with version 3.0 🎉  
+## StreamChat SDK reaches another milestone with version 3.0 🎉
 
 ### New features:
 
@@ -57,7 +59,7 @@ pod 'StreamChat', '~> 3.0'
 
 ### ⚠️ Breaking Changes ⚠️
 
-In order to provide new features like offline support and `SwiftUI` wrappers, we had to make notable breaking changes to the public API of the SDKs. 
+In order to provide new features like offline support and `SwiftUI` wrappers, we had to make notable breaking changes to the public API of the SDKs.
 
 **Please don't upgrade to version `3.0` before you get familiar with the changes and their impact on your codebase.**
 

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -41,6 +41,16 @@ class AttachmentDTO: NSManagedObject {
     
     @NSManaged var message: MessageDTO
     @NSManaged var channel: ChannelDTO
+
+    override func willSave() {
+        super.willSave()
+
+        // When attachment changed, we need to propagate this change up to holding message
+        if hasPersistentChangedValues, !message.hasChanges {
+            // this will not change object, but mark it as dirty, triggering updates
+            message.id = message.id
+        }
+    }
     
     static func load(id: AttachmentId, context: NSManagedObjectContext) -> AttachmentDTO? {
         let request = NSFetchRequest<AttachmentDTO>(entityName: AttachmentDTO.entityName)

--- a/Sources/StreamChat/Database/DTOs/UserDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/UserDTO_Tests.swift
@@ -373,4 +373,82 @@ class UserDTO_Tests: XCTestCase {
             NSSortDescriptor(key: "userRoleRaw", ascending: true)
         )
     }
+
+    func test_userChange_triggerMembersUpdate() throws {
+        // Arrange: Store member and user in database
+        let userId: UserId = .unique
+        let channelId: ChannelId = .unique
+
+        let userPayload: UserPayload<NoExtraData> = .dummy(userId: userId)
+
+        let payload: MemberPayload<NoExtraData> = .init(
+            user: userPayload,
+            role: .moderator,
+            createdAt: .init(timeIntervalSince1970: 4000),
+            updatedAt: .init(timeIntervalSince1970: 5000)
+        )
+
+        try database.writeSynchronously { session in
+            try session.saveMember(payload: payload, channelId: channelId)
+        }
+
+        // Arrange: Observe changes on members
+        let observer = EntityDatabaseObserver<MemberDTO, MemberDTO>(
+            context: database.viewContext,
+            fetchRequest: MemberDTO.member(userId, in: channelId),
+            itemCreator: { $0 }
+        )
+        try observer.startObserving()
+
+        var receivedChange: EntityChange<MemberDTO>?
+        observer.onChange { receivedChange = $0 }
+
+        // Act: Update user
+        try database.writeSynchronously { session in
+            let loadedUser: UserDTO = try XCTUnwrap(session.user(id: userId))
+            loadedUser.name = "Jo Jo"
+        }
+
+        // Assert: Members should be updated
+        XCTAssertNotNil(receivedChange)
+    }
+
+    func test_userChange_triggerCurrentUserUpdate() throws {
+        // Arrange: Store current user in database
+        let userId: UserId = .unique
+
+        let payload: CurrentUserPayload<NoExtraData> = .dummy(
+            userId: userId,
+            role: .admin,
+            extraData: .defaultValue,
+            devices: [DevicePayload.dummy],
+            mutedUsers: [
+                .dummy(userId: .unique)
+            ]
+        )
+
+        try database.writeSynchronously { session in
+            try session.saveCurrentUser(payload: payload)
+        }
+
+        // Arrange: Observe changes on current user
+        let observer = EntityDatabaseObserver<CurrentUserDTO, CurrentUserDTO>(
+            context: database.viewContext,
+            fetchRequest: CurrentUserDTO.defaultFetchRequest,
+            itemCreator: { $0 }
+        )
+        try observer.startObserving()
+
+        var receivedChange: EntityChange<CurrentUserDTO>?
+        observer.onChange { receivedChange = $0 }
+
+        // Act: Update user
+        try database.writeSynchronously { session in
+            let loadedUser: UserDTO = try XCTUnwrap(session.user(id: userId))
+            loadedUser.name = "Jo Jo"
+        }
+
+        // Assert: Members should be updated
+        XCTAssertNotNil(receivedChange)
+    }
 }

--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -152,6 +152,14 @@ class DatabaseContainer: NSPersistentContainer {
             log.debug("Starting a database session.")
             do {
                 try actions(self.writableContext)
+                // If you touch ManagedObject and update one of it properties to same value
+                // Object will be marked as `updated` even it hasn't changed.
+                // By reseting such objects we remove updates that are not updates.
+                for object in self.writableContext.updatedObjects {
+                    if object.changedValues().isEmpty {
+                        self.writableContext.refresh(object, mergeChanges: false)
+                    }
+                }
                 
                 if self.writableContext.hasChanges {
                     log.debug("Context has changes. Saving.")

--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -160,7 +160,7 @@ class DatabaseContainer: NSPersistentContainer {
                         self.writableContext.refresh(object, mergeChanges: false)
                     }
                 }
-                
+
                 if self.writableContext.hasChanges {
                     log.debug("Context has changes. Saving.")
                     try self.writableContext.save()

--- a/Sources/StreamChat/Workers/Background/AttachmentUploader.swift
+++ b/Sources/StreamChat/Workers/Background/AttachmentUploader.swift
@@ -180,9 +180,6 @@ class AttachmentUploader: Worker {
 
             // Apply further attachment updates.
             try attachmentUpdates(attachmentDTO)
-
-            // Re-assign message id to trigger entity update.
-            messageDTO.id = id.messageId
         }, completion: {
             if let error = $0 {
                 log.error("Error changing localState for attachment with id \(id) to `\(newState)`: \(error)")

--- a/Sources/StreamChat/Workers/Background/MessageSender_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/MessageSender_Tests.swift
@@ -125,7 +125,6 @@ class MessageSender_Tests: StressTestCase {
         try database.writeSynchronously { session in
             let message2 = try XCTUnwrap(session.message(id: message2Id))
             message2.attachments.forEach { $0.localState = .uploaded }
-            message2.id = message2Id
         }
 
         // Check message2 was sent.
@@ -187,7 +186,6 @@ class MessageSender_Tests: StressTestCase {
         try database.writeSynchronously { session in
             let message = try XCTUnwrap(session.message(id: messageId))
             message.attachments.forEach { $0.localState = .uploaded }
-            message.id = messageId
         }
         
         AssertAsync {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
@@ -222,7 +222,7 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
         }
 
         // scroll to make first item visible
-        cv.contentOffset.y = currentItems[0].maxY - cv.bounds.height
+        cv.contentOffset.y = currentItems[0].maxY - cv.bounds.height + cv.contentInset.bottom
     }
 
     override open func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {


### PR DESCRIPTION
Average channel open time (duration from tap to idle state) is 1.3s.
A lot of time takes data base updates and table reloads.
But in most cases such reloads are redundant because object haven;t been changed, only touched and marked as dirty.

By reseting dirty, but not changed, objects I was able to reduce open time from 1.3s to 0.6s.

Rest of time is initial layout setup (VC and message list).  It doesn't make much sense to invest time in this, since layout policy is about to change.