### PR TITLE
[CIS-636] Validate database flushing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve serialization performance by exposing items as `LazyCachedMapCollection` instead of `Array` [#776](https://github.com/GetStream/stream-chat-swift/pull/776)
 - Reduce amount of fake updates by erasing touched objects [#802](https://github.com/GetStream/stream-chat-swift/pull/802)
 - Trigger members and current user updates on UserDTO changes [#802](https://github.com/GetStream/stream-chat-swift/pull/802)
+- Extracts the connection handling responsibility of `CurrentUserController` to a new `ChatConnectionController`. [#804](https://github.com/GetStream/stream-chat-swift/pull/804)
 
 ### 🐞 Fixed
 - Fix race conditions in database observers [#796](https://github.com/GetStream/stream-chat-swift/pull/796)

--- a/Sources/StreamChat/Database/DatabaseContainer_Tests.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer_Tests.swift
@@ -175,6 +175,26 @@ class DatabaseContainer_Tests: StressTestCase {
         XCTAssertNil(testObject)
     }
     
+    func test_databaseContainer_createsNewDatabase_whenPersistentStoreFailsToLoad() throws {
+        // Create a new on-disc database with the test data model
+        let dbURL = URL.newTemporaryFileURL()
+        _ = try DatabaseContainerMock(
+            kind: .onDisk(databaseFileURL: dbURL),
+            modelName: "TestDataModel",
+            bundle: Bundle(for: DatabaseContainer_Tests.self)
+        )
+                
+        // Create a new database with the same url but totally different models
+        // Should re-create the database
+        XCTAssertNoThrow(
+            try DatabaseContainerMock(
+                kind: .onDisk(databaseFileURL: dbURL),
+                modelName: "TestDataModel2",
+                bundle: Bundle(for: DatabaseContainer_Tests.self)
+            )
+        )
+    }
+    
     func test_databaseContainer_hasDefinedBehaviorForInMemoryStore_whenShouldFlushOnStartIsTrue() throws {
         // Create a new in-memory database that should flush on start and assert no error is thrown
         XCTAssertNoThrow(

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -525,6 +525,7 @@
 		AD45333A25D153CF00CD9D47 /* ConnectionController+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD45333925D153CF00CD9D47 /* ConnectionController+SwiftUI_Tests.swift */; };
 		AD45334E25D153E500CD9D47 /* ConnectionController+Combine_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD45334D25D153E500CD9D47 /* ConnectionController+Combine_Tests.swift */; };
 		AD7D633325AF577E0051219B /* UserUpdateResponse+MissingUser.json in Resources */ = {isa = PBXBuildFile; fileRef = AD7D633225AF577E0051219B /* UserUpdateResponse+MissingUser.json */; };
+		AD7DFBEC25D2AE7400DD9DA3 /* TestDataModel2.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = AD7DFBEA25D2AE7400DD9DA3 /* TestDataModel2.xcdatamodeld */; };
 		ADCDDCC525AE1293004E15FB /* UserUpdateResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = ADCDDCC425AE1293004E15FB /* UserUpdateResponse.json */; };
 		ADCDDD0025AE2784004E15FB /* UserUpdateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCDDCEC25AE2214004E15FB /* UserUpdateViewController.swift */; };
 		ADCDDD0825AE2F4A004E15FB /* InputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCDDD0725AE2F4A004E15FB /* InputViewController.swift */; };
@@ -1307,6 +1308,7 @@
 		AD45333925D153CF00CD9D47 /* ConnectionController+SwiftUI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionController+SwiftUI_Tests.swift"; sourceTree = "<group>"; };
 		AD45334D25D153E500CD9D47 /* ConnectionController+Combine_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionController+Combine_Tests.swift"; sourceTree = "<group>"; };
 		AD7D633225AF577E0051219B /* UserUpdateResponse+MissingUser.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "UserUpdateResponse+MissingUser.json"; sourceTree = "<group>"; };
+		AD7DFBEB25D2AE7400DD9DA3 /* TestDataModel2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TestDataModel2.xcdatamodel; sourceTree = "<group>"; };
 		AD9F7B7C25C8215400DF8CD2 /* SnapshotVariant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotVariant.swift; sourceTree = "<group>"; };
 		AD9F7B8525C821C300DF8CD2 /* AssertSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertSnapshot.swift; sourceTree = "<group>"; };
 		ADCDDCC425AE1293004E15FB /* UserUpdateResponse.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = UserUpdateResponse.json; sourceTree = "<group>"; };
@@ -1858,6 +1860,7 @@
 				8A62706924BF02D80040BFD6 /* XCTAssertEqual+Difference.swift */,
 				7988F6B024D010890004219B /* TestRunnerEnvironment.swift */,
 				7922F30424DACEF100C364BC /* TestDataModel.xcdatamodeld */,
+				AD7DFBEA25D2AE7400DD9DA3 /* TestDataModel2.xcdatamodeld */,
 				7922F30724DACF1F00C364BC /* TestManagedObject.swift */,
 				792B805324D95FC700C2963E /* RandomDispatchQueue.swift */,
 				79200D41250118A1002F4EB1 /* iOS13TestCase.swift */,
@@ -4001,6 +4004,7 @@
 				88EA9AFC25472269007EE76B /* MessageReactionType_Tests.swift in Sources */,
 				79A0E9BC2498C31A00E9BD50 /* TypingStartCleanupMiddleware_Tests.swift in Sources */,
 				796610BB248E687000761629 /* EventMiddleware_Tests.swift in Sources */,
+				AD7DFBEC25D2AE7400DD9DA3 /* TestDataModel2.xcdatamodeld in Sources */,
 				DA15A20424DF257500BE2423 /* ChannelQuery_Tests.swift in Sources */,
 				DA6AC7F62538725B009C1B39 /* Pagination_Tests.swift in Sources */,
 				79CD959624F9414700E87377 /* ChannelListController+SwiftUI_Tests.swift in Sources */,
@@ -5131,6 +5135,16 @@
 			);
 			currentVersion = 799C9478247E3DEA001F1104 /* StreamChatModel.xcdatamodel */;
 			path = StreamChatModel.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+		AD7DFBEA25D2AE7400DD9DA3 /* TestDataModel2.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				AD7DFBEB25D2AE7400DD9DA3 /* TestDataModel2.xcdatamodel */,
+			);
+			currentVersion = AD7DFBEB25D2AE7400DD9DA3 /* TestDataModel2.xcdatamodel */;
+			path = TestDataModel2.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};

--- a/Tests/Shared/TestDataModel2.xcdatamodeld/TestDataModel2.xcdatamodel/contents
+++ b/Tests/Shared/TestDataModel2.xcdatamodeld/TestDataModel2.xcdatamodel/contents
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="20C69" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="TestManagedObject" representedClassName="TestManagedObject" syncable="YES">
-        <attribute name="resetEphemeralValuesCalled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+    <entity name="TestEntityManagedObject" representedClassName="TestEntityManagedObject" syncable="YES">
         <attribute name="testId" optional="YES" attributeType="String"/>
         <attribute name="testValue" optional="YES" attributeType="String"/>
     </entity>
     <elements>
-        <element name="TestManagedObject" positionX="-63" positionY="-18" width="128" height="88"/>
+        <element name="TestEntityManagedObject" positionX="-54" positionY="-9" width="128" height="59"/>
     </elements>
 </model>


### PR DESCRIPTION
# In this PR
Adds test coverage to validate that the Database is flushed when it fails to load the persistent store (For example, when there are significant DB changes that would require a migration).
