### PR TITLE
Allow message edit/delete from all users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduce amount of fake updates by erasing touched objects [#802](https://github.com/GetStream/stream-chat-swift/pull/802)
 - Trigger members and current user updates on UserDTO changes [#802](https://github.com/GetStream/stream-chat-swift/pull/802)
 - Extracts the connection handling responsibility of `CurrentUserController` to a new `ChatConnectionController`. [#804](https://github.com/GetStream/stream-chat-swift/pull/804)
+- Allow delete/edit message for all users [#809](https://github.com/GetStream/stream-chat-swift/issues/809)
+  By default, only admin/moderators can edit/delete other's messages, but this configurable on backend and it's not known by the client, so we allow all actions and invalid actions will cause backend to return error.
 
 ### 🐞 Fixed
 - Fix race conditions in database observers [#796](https://github.com/GetStream/stream-chat-swift/pull/796)

--- a/Sources/StreamChat/Workers/Background/AttachmentUploader.swift
+++ b/Sources/StreamChat/Workers/Background/AttachmentUploader.swift
@@ -158,8 +158,7 @@ class AttachmentUploader: Worker {
     ) {
         database.write({ [minSignificantUploadingProgressChange] session in
             guard
-                let attachmentDTO = session.attachment(id: id),
-                let messageDTO = session.message(id: id.messageId)
+                let attachmentDTO = session.attachment(id: id)
             else { return }
 
             var stateHasChanged: Bool {

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -44,19 +44,11 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
         var shouldDeleteOnBackend = true
         
         database.write({ session in
-            guard let currentUserDTO = session.currentUser() else {
-                throw ClientError.CurrentUserDoesNotExist()
-            }
-            
             guard let messageDTO = session.message(id: messageId) else {
                 // Even though the message does not exist locally
                 // we don't throw any error because we still want
                 // to try to delete the message on the backend.
                 return
-            }
-            
-            guard messageDTO.user.id == currentUserDTO.user.id else {
-                throw ClientError.MessageCannotBeUpdatedByCurrentUser(messageId: messageId)
             }
             
             if messageDTO.existsOnlyLocally {
@@ -405,12 +397,6 @@ extension ClientError {
         }
     }
     
-    class MessageCannotBeUpdatedByCurrentUser: ClientError {
-        init(messageId: MessageId) {
-            super.init("Current user can not perform actions on the message with id: \(messageId)")
-        }
-    }
-    
     class MessageEditing: ClientError {
         init(messageId: String, reason: String) {
             super.init("Message with id: \(messageId) can't be edited (\(reason)")
@@ -430,19 +416,15 @@ private extension DatabaseSession {
     /// If any of the requirements is not met the error will be thrown.
     ///
     /// - Parameter messageId: The message identifier.
-    /// - Throws: Either `CurrentUserDoesNotExist`/`MessageDoesNotExist`/`MessageCannotBeUpdatedByCurrentUser`
+    /// - Throws: Either `CurrentUserDoesNotExist`/`MessageDoesNotExist`/
     /// - Returns: The message entity.
     func messageEditableByCurrentUser(_ messageId: MessageId) throws -> MessageDTO {
-        guard let currentUserDTO = currentUser() else {
+        guard currentUser() != nil else {
             throw ClientError.CurrentUserDoesNotExist()
         }
 
         guard let messageDTO = message(id: messageId) else {
             throw ClientError.MessageDoesNotExist(messageId: messageId)
-        }
-
-        guard messageDTO.user.id == currentUserDTO.user.id else {
-            throw ClientError.MessageCannotBeUpdatedByCurrentUser(messageId: messageId)
         }
 
         return messageDTO

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -62,25 +62,6 @@ final class MessageUpdater_Tests: StressTestCase {
         // Assert `MessageDoesNotExist` is received
         XCTAssertTrue(completionError is ClientError.MessageDoesNotExist)
     }
-    
-    func test_editMessage_propogates_MessageCanNotBeUpdatedByCurrentUser_Error() throws {
-        let anotherUserId: UserId = .unique
-        let anotherUserMessageId: MessageId = .unique
-
-        // Create current user is the database
-        try database.createCurrentUser()
-    
-        // Create message authored by another user in the database
-        try database.createMessage(id: anotherUserMessageId, authorId: anotherUserId)
-
-        // Try to edit another user's message
-        let completionError = try await {
-            messageUpdater.editMessage(messageId: anotherUserMessageId, text: .unique, completion: $0)
-        }
-        
-        // Assert `MessageCannotBeUpdatedByCurrentUser` is received
-        XCTAssertTrue(completionError is ClientError.MessageCannotBeUpdatedByCurrentUser)
-    }
 
     func test_editMessage_updatesLocalMessageCorrectly() throws {
         let pairs: [(LocalMessageState?, LocalMessageState?)] = [
@@ -160,35 +141,6 @@ final class MessageUpdater_Tests: StressTestCase {
     }
     
     // MARK: Delete message
-    
-    func test_deleteMessage_propogates_CurrentUserDoesNotExist_Error() throws {
-        // Simulate `deleteMessage(messageId:)` call
-        let completionError = try await {
-            messageUpdater.deleteMessage(messageId: .unique, completion: $0)
-        }
-        
-        // Assert `CurrentUserDoesNotExist` is received
-        XCTAssertTrue(completionError is ClientError.CurrentUserDoesNotExist)
-    }
-    
-    func test_deleteMessage_propogates_MessageCanNotBeUpdatedByCurrentUser_Error() throws {
-        let anotherUserId: UserId = .unique
-        let anotherUserMessageId: MessageId = .unique
-        
-        // Create current user is the database
-        try database.createCurrentUser()
-        
-        // Create message authored by another user in the database
-        try database.createMessage(id: anotherUserMessageId, authorId: anotherUserId)
-        
-        // Simulate `deleteMessage(messageId:)` call
-        let completionError = try await {
-            messageUpdater.deleteMessage(messageId: anotherUserMessageId, completion: $0)
-        }
-        
-        // Assert `MessageCannotBeUpdatedByCurrentUser` is received
-        XCTAssertTrue(completionError is ClientError.MessageCannotBeUpdatedByCurrentUser)
-    }
     
     func test_deleteMessage_sendsCorrectAPICall_ifMessageDoesNotExistLocally() throws {
         let messageId: MessageId = .unique
@@ -1078,25 +1030,6 @@ final class MessageUpdater_Tests: StressTestCase {
         XCTAssertTrue(completionError is ClientError.MessageDoesNotExist)
     }
 
-    func test_resendMessage_propagatesMessageCanNotBeUpdatedByCurrentUser_Error() throws {
-        let anotherUserId: UserId = .unique
-        let anotherUserMessageId: MessageId = .unique
-
-        // Create current user is the database
-        try database.createCurrentUser()
-
-        // Create message authored by another user in the database
-        try database.createMessage(id: anotherUserMessageId, authorId: anotherUserId)
-
-        // Try to resend another user's message
-        let completionError = try await {
-            messageUpdater.resendMessage(with: anotherUserMessageId, completion: $0)
-        }
-
-        // Assert `MessageCannotBeUpdatedByCurrentUser` is received
-        XCTAssertTrue(completionError is ClientError.MessageCannotBeUpdatedByCurrentUser)
-    }
-
     func test_resendMessage_propagatesMessageEditingError() throws {
         let currentUserId: UserId = .unique
         
@@ -1366,34 +1299,6 @@ final class MessageUpdater_Tests: StressTestCase {
 
         // Assert `MessageDoesNotExist` is received
         XCTAssertTrue(completionError is ClientError.MessageDoesNotExist)
-    }
-
-    func test_dispatchEphemeralMessageAction_propagatesMessageCanNotBeUpdatedByCurrentUser_Error() throws {
-        let cid: ChannelId = .unique
-        let anotherUserId: UserId = .unique
-        let anotherUserMessageId: MessageId = .unique
-
-        // Create current user is the database
-        try database.createCurrentUser()
-
-        // Create channel is the database
-        try database.createChannel(cid: cid, withMessages: false)
-
-        // Create message authored by another user in the database
-        try database.createMessage(id: anotherUserMessageId, authorId: anotherUserId, cid: cid)
-
-        // Simulate `dispatchEphemeralMessageAction` call
-        let completionError = try await {
-            messageUpdater.dispatchEphemeralMessageAction(
-                cid: cid,
-                messageId: anotherUserMessageId,
-                action: .unique,
-                completion: $0
-            )
-        }
-
-        // Assert `MessageCannotBeUpdatedByCurrentUser` is received
-        XCTAssertTrue(completionError is ClientError.MessageCannotBeUpdatedByCurrentUser)
     }
 
     func test_dispatchEphemeralMessageAction_propagatesMessageEditingError_forNonEphemeralMessage() throws {


### PR DESCRIPTION
Message edit/delete is a user permission so some users are able to edit/delete other's messages. Backend controls this, so we should let backend return an error. By default, admin/moderators have this permission, but this configurable and it's not sent by backend, so safest to let users control this logic on their end.