### PR TITLE
[CIS-624] Add Hardcoded SDK version generation to project

### DIFF
--- a/Sources/StreamChat/Utils/SystemEnvironment+Version.swift
+++ b/Sources/StreamChat/Utils/SystemEnvironment+Version.swift
@@ -1,0 +1,10 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension SystemEnvironment {
+    /// A Stream Chat version.
+    public static let version: String = "2.2.9"
+}

--- a/Sources/StreamChat/Utils/SystemEnvironment+Version.swift
+++ b/Sources/StreamChat/Utils/SystemEnvironment+Version.swift
@@ -6,5 +6,5 @@ import Foundation
 
 extension SystemEnvironment {
     /// A Stream Chat version.
-    public static let version: String = "2.2.9"
+    public static let version: String = "3.0-beta.4"
 }

--- a/Sources/StreamChat/Utils/SystemEnvironment.swift
+++ b/Sources/StreamChat/Utils/SystemEnvironment.swift
@@ -1,14 +1,10 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import UIKit
 
 public enum SystemEnvironment {
-    /// A Stream Chat version.
-    public static let version: String = Bundle(for: ChatClient.self)
-        .infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
-    
     static let systemName = UIDevice.current.systemName + UIDevice.current.systemVersion
     
     static var deviceModelName: String {

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -652,6 +652,7 @@
 		E79AC10C25831A1500C3CE5D /* ChatMessageComposerSuggestionsCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AC10825831A1500C3CE5D /* ChatMessageComposerSuggestionsCollectionView.swift */; };
 		E79AC10D25831A1500C3CE5D /* ChatMessageComposerSuggestionsCollectionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AC10925831A1500C3CE5D /* ChatMessageComposerSuggestionsCollectionViewLayout.swift */; };
 		E7A37B8425ADA66E0055458F /* ChatMessageComposerSuggestionsCommandsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A37B8325ADA66E0055458F /* ChatMessageComposerSuggestionsCommandsHeaderView.swift */; };
+		E7AD954F25D536AA00076DC3 /* SystemEnvironment+Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AD954E25D536AA00076DC3 /* SystemEnvironment+Version.swift */; };
 		E7C4E74D259D54B5002889AC /* ChatChannelSwipeableListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C4E74C259D54B5002889AC /* ChatChannelSwipeableListItemView.swift */; };
 		E7DF7E2425C2C67E00AE9D21 /* ChatAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7DF7E2325C2C67E00AE9D21 /* ChatAvatarView.swift */; };
 		F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */; };
@@ -1466,6 +1467,7 @@
 		E79AC10825831A1500C3CE5D /* ChatMessageComposerSuggestionsCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageComposerSuggestionsCollectionView.swift; sourceTree = "<group>"; };
 		E79AC10925831A1500C3CE5D /* ChatMessageComposerSuggestionsCollectionViewLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageComposerSuggestionsCollectionViewLayout.swift; sourceTree = "<group>"; };
 		E7A37B8325ADA66E0055458F /* ChatMessageComposerSuggestionsCommandsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageComposerSuggestionsCommandsHeaderView.swift; sourceTree = "<group>"; };
+		E7AD954E25D536AA00076DC3 /* SystemEnvironment+Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemEnvironment+Version.swift"; sourceTree = "<group>"; };
 		E7C4E74C259D54B5002889AC /* ChatChannelSwipeableListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelSwipeableListItemView.swift; sourceTree = "<group>"; };
 		E7DF7E2325C2C67E00AE9D21 /* ChatAvatarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatAvatarView.swift; sourceTree = "<group>"; };
 		F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints_Tests.swift; sourceTree = "<group>"; };
@@ -1885,6 +1887,7 @@
 				DB842E4425C9F94C000AAC46 /* LazyCachedMapCollection_Tests.swift */,
 				792A4F3B247FFBB400EAF71D /* Timers.swift */,
 				797A756524814EF8003CF16D /* SystemEnvironment.swift */,
+				E7AD954E25D536AA00076DC3 /* SystemEnvironment+Version.swift */,
 				797A756724814F0D003CF16D /* Bundle+Extensions.swift */,
 				792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */,
 				792B804F24D95B5D00C2963E /* Cached.swift */,
@@ -3974,6 +3977,7 @@
 				790A4C42252DD377001F4A23 /* DeviceEndpoints.swift in Sources */,
 				797A756424814E7A003CF16D /* WebSocketConnectPayload.swift in Sources */,
 				F6FF1DA624FD17B400151735 /* MessageController.swift in Sources */,
+				E7AD954F25D536AA00076DC3 /* SystemEnvironment+Version.swift in Sources */,
 				797E10A824EAF6DE00353791 /* UniqueId.swift in Sources */,
 				DA4EE5B8252B69E300CB26D4 /* UserListController+Combine.swift in Sources */,
 				F6ED5F7425023EB4005D7327 /* MissingEventsPublisher.swift in Sources */,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,6 +11,70 @@ before_all do
     setup_ci()
   end
 end
+desc "Release a new version"
+lane :release do |options|
+  UI.user_error!("Please use type parameter with one of the options: type:patch, type:minor, type:major") unless ["patch", "minor", "major"].include?(options[:type])
+  
+  ensure_git_branch(branch: 'main') # We can only release on default branch
+  ensure_git_status_clean unless options[:no_ensure_clean]
+  
+  version_number = increment_version_number_in_plist(bump_type: options[:type], xcodeproj: "StreamChat.xcodeproj", target: "StreamChat")
+
+  set_SDK_version(version: version_number)
+
+  increment_version_number_in_plist(version_number: version_number, xcodeproj: "StreamChat.xcodeproj", target: "StreamChatUI")
+
+  if git_tag_exists(tag: version_number)
+    UI.user_error!("Tag for version #{version_number} already exists!")
+  end
+  
+  changes = touch_changelog(release_version: version_number)
+
+  version_bump_podspec(path: "StreamChat.podspec", version_number: version_number)
+  version_bump_podspec(path: "StreamChatUI.podspec", version_number: version_number)
+
+  sh("git add -A")
+  sh("git commit -m 'Bump #{version_number}'")
+  sh("git tag #{version_number}")
+                   
+  push_to_git_remote(tags: true)
+  
+  github_release = set_github_release(
+                     repository_name: "GetStream/stream-chat-swift",
+                     api_token: ENV["GITHUB_TOKEN"],
+                     name: version_number,
+                     tag_name: version_number,
+                     description: changes
+                   )
+  
+  # First pod release will not have any problems
+  pod_push(path: "StreamChat.podspec", allow_warnings: true)
+  
+  def release_ui
+    begin
+      pod_push(path: "StreamChatUI.podspec", allow_warnings: true)
+    rescue
+      puts "pod_push failed. Waiting a minute until retry for trunk to get updated..."
+      sleep(60) # sleep for a minute, wait until trunk gets updates
+      release_ui
+    end
+  end
+  
+  puts "Sleeping for 2 minutes for trunk to get updated..."
+  sleep(60 * 2)
+  release_ui
+  
+  slack(
+    message: "#{version_number} successfully released!",
+    payload: {
+      "Changelog" => changes,
+    },
+    default_payloads: [:git_author],
+  )
+  
+  UI.success("Successfully released #{version_number}")
+  UI.success("Github release was created as draft, please visit #{github_release["url"]} to publish it")
+end
 
 lane :set_SDK_version do |options|
   pathToVersionFile = "../Sources/StreamChat/Utils/SystemEnvironment+Version.swift"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -12,6 +12,24 @@ before_all do
   end
 end
 
+lane :set_SDK_version do |options|
+  pathToVersionFile = "../Sources/StreamChat/Utils/SystemEnvironment+Version.swift"
+  versionGeneratedFile = "
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+// ⚠️  Generated file, please use `fastlane :bump_SDK_version or fastlane release major|minor|patch` lanes 
+
+import Foundation
+
+extension SystemEnvironment {
+  /// A Stream Chat version.
+  public static let version: String = \"#{options[:version]}\"
+}
+"
+  File.write(pathToVersionFile, versionGeneratedFile)
+end 
+
 desc "If `readonly: true` (by default), installs all Certs and Profiles necessary for development and ad-hoc.\nIf `readonly: false`, recreates all Profiles necessary for development and ad-hoc, updates them locally and remotely."
 lane :match_me do |options|
   # Get `:readonly` value, fallback to `true` if it's missing.


### PR DESCRIPTION
# What this PR do:
- Adds generation of hardcoded `StreamChat` SDK to project, done via 2 additional lanes, one for setting the version to the project file, second for releasing the project and bumping it easily, mostly taken from v2 Fastfile but a bit modified.
# How to test it
- For testing setting the version, you can run `fastlane set_SDK_version version: x.y.z` and you should see change in `SystemEnvironment+Version.swift`. I wouldn't test the release lane, it can help @b-onc once we are ready for next versions.
# Where you can start
-  Probably just `Fastfile`