### PR TITLE
Fix ChatViewController title and avatar is not shown correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- `ChatViewController` title and avatar is wrong when it's pushed with an unsynced `ChannelPresenter` [#828](https://github.com/GetStream/stream-chat-swift/issues/828)
 
 # [2.6.3](https://github.com/GetStream/stream-chat-swift/releases/tag/2.6.3)
 _January 15, 2021_

--- a/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
+++ b/Sources/UI/Chat/Chat View Controller/ChatViewController.swift
@@ -161,8 +161,6 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
         super.viewDidLoad()
         view.backgroundColor = style.incomingMessage.chatBackgroundColor
         
-        updateTitle()
-        
         guard let presenter = presenter else {
             return
         }
@@ -170,9 +168,13 @@ open class ChatViewController: ViewController, UITableViewDataSource, UITableVie
         if !presenter.channel.didLoad {
             presenter.rx.channelDidUpdate.asObservable()
                 .takeWhile { !$0.didLoad }
-                .subscribe(onCompleted: { [weak self] in self?.setupComposerView() })
+                .subscribe(onCompleted: { [weak self] in
+                    self?.updateTitle()
+                    self?.setupComposerView()
+                })
                 .disposed(by: disposeBag)
         } else {
+            updateTitle()
             setupComposerView()
         }
         


### PR DESCRIPTION
...on cold launches

### Issue Description

When this happens:
```swift
let channel = Client.shared.channel(type: .messaging, id: channelId)
let channelPresenter = ChannelPresenter(channel: channel)
let controller = createChatViewController(with: channelPresenter)
setupChatViewController(controller, with: channelPresenter)
navigationController?.pushViewController(controller, animated: false)
```

`ChatViewController` needs to `query` the channel so it can get more info (at this point it only has `cid`). The VC setup the title and avatar before it had all the channel info.