### PR TITLE
[CIS-675] Fix caret position overlapping placeholder in ChatMessageComposerInputTextView

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerInputTextView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerInputTextView.swift
@@ -71,12 +71,15 @@ open class _ChatMessageComposerInputTextView<ExtraData: ExtraDataTypes>: UITextV
     open func setUpAppearance() {}
     
     open func setUpLayout() {
-        embed(placeholderLabel, insets: .init(
-            top: .zero,
-            leading: textContainer.lineFragmentPadding,
-            bottom: .zero,
-            trailing: .zero
-        ))
+        embed(
+            placeholderLabel,
+            insets: .init(
+                top: .zero,
+                leading: directionalLayoutMargins.leading,
+                bottom: .zero,
+                trailing: .zero
+            )
+        )
         placeholderLabel.pin(anchors: [.centerY], to: self)
         
         isScrollEnabled = false


### PR DESCRIPTION
Before: 
<img width="378" alt="Snímek obrazovky 2021-02-19 v 10 44 50" src="https://user-images.githubusercontent.com/17381941/108487396-844df480-729f-11eb-99fd-4ca8e3af7462.png">

After:
<img width="380" alt="Snímek obrazovky 2021-02-19 v 10 44 06" src="https://user-images.githubusercontent.com/17381941/108487414-87e17b80-729f-11eb-9b32-f74ec880653b.png">


# What this PR do:
- Fixes issue where caret was overlapping placeholder position in `ChatMessageComposerInputTextView`
# How to test it
- You can run the app and check composer textview on different devices and see if the insets are same, they should be same, tested on iPhone SE (2nd Gen), iPhone 12 Pro and iPhone 12 Simulator)
# Where you can start
- `ChatMessageComposerInputTextView`