### PR TITLE
Improve base view naming + fix CIS-509

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -2,8 +2,6 @@
 --header "\nCopyright © {year} Stream.io Inc. All rights reserved.\n"
 --swiftversion 5.2
 
---exclude **/*_Vendor.swift
-
 --ifdef no-indent
 
 # Rules inferred from Swift Standard Library:

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListCollectionViewCell.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListCollectionViewCell.swift
@@ -8,7 +8,7 @@ import UIKit
 
 public typealias ChatChannelListCollectionViewCell = _ChatChannelListCollectionViewCell<NoExtraData>
 
-open class _ChatChannelListCollectionViewCell<ExtraData: ExtraDataTypes>: CollectionViewCell, UIConfigProvider {
+open class _ChatChannelListCollectionViewCell<ExtraData: ExtraDataTypes>: _CollectionViewCell, UIConfigProvider {
     // MARK: - Properties
 
     public private(set) lazy var channelView: _ChatChannelListItemView<ExtraData> = uiConfig.channelList.channelListItemView.init()

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatChannelListVC = _ChatChannelListVC<NoExtraData>
 
-open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: ViewController,
+open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
     UICollectionViewDataSource,
     UICollectionViewDelegate,
     UIConfigProvider {

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelReadStatusCheckmarkView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelReadStatusCheckmarkView.swift
@@ -9,7 +9,7 @@ import UIKit
 public typealias ChatChannelReadStatusCheckmarkView = _ChatChannelReadStatusCheckmarkView<NoExtraData>
 
 /// A view that shows a read/unread status of the last message in channel.
-open class _ChatChannelReadStatusCheckmarkView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatChannelReadStatusCheckmarkView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     /// An underlying type for status in the view.
     /// Right now corresponding functionality in LLC is missing and it will likely be replaced with the type from LLC.
     public enum Status {

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelSwipeableListItemView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelSwipeableListItemView.swift
@@ -9,7 +9,7 @@ import UIKit
 public typealias ChatChannelSwipeableListItemView = _ChatChannelSwipeableListItemView<NoExtraData>
 
 /// A view with swipe functionality that is used as base view for channel list item view.
-open class _ChatChannelSwipeableListItemView<ExtraData: ExtraDataTypes>: View, UIConfigProvider, UIGestureRecognizerDelegate {
+open class _ChatChannelSwipeableListItemView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider, UIGestureRecognizerDelegate {
     /// Constraint constant should be reset when view is being reused inside `UICollectionViewCell`.
     public var trailingConstraint: NSLayoutConstraint?
     

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountView.swift
@@ -8,7 +8,7 @@ import UIKit
 /// A view that shows a number of unread messages in channel.
 public typealias ChatChannelUnreadCountView = _ChatChannelUnreadCountView<NoExtraData>
 /// A view that shows a number of unread messages in channel.
-open class _ChatChannelUnreadCountView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatChannelUnreadCountView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     /// The `UILabel` instance that holds number of unread messages.
     open private(set) lazy var unreadCountLabel = UILabel().withoutAutoresizingMaskConstraints
     

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageAttachmentInfoView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageAttachmentInfoView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageAttachmentInfoView = _ChatMessageAttachmentInfoView<NoExtraData>
 
-open class _ChatMessageAttachmentInfoView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageAttachmentInfoView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     public var content: _ChatMessageAttachmentListViewData<ExtraData>.ItemData? {
         didSet { updateContentIfNeeded() }
     }

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageAttachmentPreviewVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageAttachmentPreviewVC.swift
@@ -6,7 +6,7 @@ import StreamChat
 import UIKit
 import WebKit
 
-open class ChatMessageAttachmentPreviewVC<ExtraData: ExtraDataTypes>: ViewController, WKNavigationDelegate, UIConfigProvider {
+open class ChatMessageAttachmentPreviewVC<ExtraData: ExtraDataTypes>: _ViewController, WKNavigationDelegate, UIConfigProvider {
     public var content: URL? {
         didSet { updateContentIfNeeded() }
     }

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageAttachmentsView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageAttachmentsView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageAttachmentsView = _ChatMessageAttachmentsView<NoExtraData>
 
-open class _ChatMessageAttachmentsView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageAttachmentsView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     /// All attachments with `type == .image` will be shown in a gallery
     /// All the other ones will be treated as files.
     public var content: _ChatMessageAttachmentListViewData<ExtraData>? {

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageFileAttachmentListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageFileAttachmentListView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageFileAttachmentListView = _ChatMessageFileAttachmentListView<NoExtraData>
 
-open class _ChatMessageFileAttachmentListView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageFileAttachmentListView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     public var content: _ChatMessageAttachmentListViewData<ExtraData>? {
         didSet { updateContentIfNeeded() }
     }

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageGiphyView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageGiphyView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 public typealias ChatMessageGiphyView = _ChatMessageGiphyView<NoExtraData>
 
-open class _ChatMessageGiphyView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageGiphyView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     public var content: ChatMessageDefaultAttachment? {
         didSet {
             let isDifferentImage = oldValue?.imageURL != content?.imageURL
@@ -91,7 +91,7 @@ open class _ChatMessageGiphyView<ExtraData: ExtraDataTypes>: View, UIConfigProvi
 }
 
 extension _ChatMessageGiphyView {
-    open class GiphyBadge: View, UIConfigProvider {
+    open class GiphyBadge: _View, UIConfigProvider {
         public private(set) lazy var title: UILabel = {
             let label = UILabel().withoutAutoresizingMaskConstraints
             label.text = "GIPHY"

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery+ImagePreview.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery+ImagePreview.swift
@@ -7,7 +7,7 @@ import StreamChat
 import UIKit
 
 extension _ChatMessageImageGallery {
-    open class ImagePreview: View, UIConfigProvider {
+    open class ImagePreview: _View, UIConfigProvider {
         public var content: _ChatMessageAttachmentListViewData<ExtraData>.ItemData? {
             didSet { updateContentIfNeeded() }
         }

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageImageGallery = _ChatMessageImageGallery<NoExtraData>
 
-open class _ChatMessageImageGallery<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageImageGallery<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     open var interItemSpacing: CGFloat = 2
 
     public var content: _ChatMessageAttachmentListViewData<ExtraData>? {

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView+ActionButton.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView+ActionButton.swift
@@ -6,7 +6,7 @@ import StreamChat
 import UIKit
 
 extension _ChatMessageInteractiveAttachmentView {
-    open class ActionButton: Button, UIConfigProvider {
+    open class ActionButton: _Button, UIConfigProvider {
         public var content: Content? {
             didSet { updateContentIfNeeded() }
         }

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageInteractiveAttachmentView = _ChatMessageInteractiveAttachmentView<NoExtraData>
 
-open class _ChatMessageInteractiveAttachmentView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageInteractiveAttachmentView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     public var content: _ChatMessageAttachmentListViewData<ExtraData>.ItemData? {
         didSet { updateContentIfNeeded() }
     }

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageLinkPreviewView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageLinkPreviewView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageLinkPreviewView = _ChatMessageLinkPreviewView<NoExtraData>
 
-open class _ChatMessageLinkPreviewView<ExtraData: ExtraDataTypes>: Control, UIConfigProvider {
+open class _ChatMessageLinkPreviewView<ExtraData: ExtraDataTypes>: _Control, UIConfigProvider {
     public var content: ChatMessageDefaultAttachment? { didSet { updateContentIfNeeded() } }
 
     public private(set) lazy var imagePreview = uiConfig

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageBubbleView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageBubbleView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageBubbleView = _ChatMessageBubbleView<NoExtraData>
 
-open class _ChatMessageBubbleView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageBubbleView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     public var message: _ChatMessageGroupPart<ExtraData>? {
         didSet { updateContentIfNeeded() }
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias СhatMessageCollectionViewCell = _СhatMessageCollectionViewCell<NoExtraData>
 
-open class _СhatMessageCollectionViewCell<ExtraData: ExtraDataTypes>: CollectionViewCell, UIConfigProvider {
+open class _СhatMessageCollectionViewCell<ExtraData: ExtraDataTypes>: _CollectionViewCell, UIConfigProvider {
     class var reuseId: String { String(describing: self) }
 
     public var message: _ChatMessageGroupPart<ExtraData>? {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageContentView = _ChatMessageContentView<NoExtraData>
 
-open class _ChatMessageContentView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageContentView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     public var message: _ChatMessageGroupPart<ExtraData>? {
         didSet { updateContentIfNeeded() }
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageErrorIndicator.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageErrorIndicator.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageErrorIndicator = _ChatMessageErrorIndicator<NoExtraData>
 
-open class _ChatMessageErrorIndicator<ExtraData: ExtraDataTypes>: Button, UIConfigProvider {
+open class _ChatMessageErrorIndicator<ExtraData: ExtraDataTypes>: _Button, UIConfigProvider {
     override public func defaultAppearance() {
         super.defaultAppearance()
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageMetadataView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageMetadataView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageMetadataView = _ChatMessageMetadataView<NoExtraData>
 
-open class _ChatMessageMetadataView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageMetadataView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     public var message: _ChatMessageGroupPart<ExtraData>? {
         didSet { updateContentIfNeeded() }
     }
@@ -54,7 +54,7 @@ open class _ChatMessageMetadataView<ExtraData: ExtraDataTypes>: View, UIConfigPr
     }
 }
 
-open class ChatMessageOnlyVisibleForCurrentUserIndicator<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class ChatMessageOnlyVisibleForCurrentUserIndicator<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     // MARK: - Subviews
 
     public private(set) lazy var stack: UIStackView = {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageThreadInfoView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageThreadInfoView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageThreadArrowView = _ChatMessageThreadArrowView<NoExtraData>
 
-open class _ChatMessageThreadArrowView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageThreadArrowView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     public enum Direction {
         case toTrailing
         case toLeading
@@ -62,7 +62,7 @@ open class _ChatMessageThreadArrowView<ExtraData: ExtraDataTypes>: View, UIConfi
 
 public typealias ChatMessageThreadInfoView = _ChatMessageThreadInfoView<NoExtraData>
 
-open class _ChatMessageThreadInfoView<ExtraData: ExtraDataTypes>: Control, UIConfigProvider {
+open class _ChatMessageThreadInfoView<ExtraData: ExtraDataTypes>: _Control, UIConfigProvider {
     public var message: _ChatMessageGroupPart<ExtraData>? {
         didSet { updateContentIfNeeded() }
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -33,7 +33,7 @@ public protocol _ChatMessageListVCDelegate: AnyObject {
 
 public typealias ChatMessageListVC = _ChatMessageListVC<NoExtraData>
 
-open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: ViewController,
+open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: _ViewController,
     UICollectionViewDataSource,
     UICollectionViewDelegate,
     UIConfigProvider,

--- a/Sources/StreamChatUI/ChatMessageList/ChatVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatVC.swift
@@ -8,7 +8,7 @@ import UIKit
 /// Abstract controller representing list of messages with message composer.
 /// You should never instantiate this class. Instead stick to one of subclasses.
 /// When subclassing you must override without calling super all methods of `ChatMessageListVCDataSource`
-open class _ChatVC<ExtraData: ExtraDataTypes>: ViewController,
+open class _ChatVC<ExtraData: ExtraDataTypes>: _ViewController,
     UIConfigProvider,
     _ChatMessageListVCDataSource,
     _ChatMessageListVCDelegate,

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerCheckmarkControl.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerCheckmarkControl.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageComposerCheckmarkControl = _ChatMessageComposerCheckmarkControl<NoExtraData>
 
-open class _ChatMessageComposerCheckmarkControl<ExtraData: ExtraDataTypes>: Control, UIConfigProvider {
+open class _ChatMessageComposerCheckmarkControl<ExtraData: ExtraDataTypes>: _Control, UIConfigProvider {
     // MARK: - Properties
     
     public var checkmarkHeight: CGFloat = 16

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerCommandCollectionViewCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerCommandCollectionViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 public typealias ChatMessageComposerCommandCellView = _ChatMessageComposerCommandCellView<NoExtraData>
 
 /// A view that displays the command name, image and arguments.
-open class _ChatMessageComposerCommandCellView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageComposerCommandCellView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     /// The command that the view will display.
     open var content: Command? {
         didSet {
@@ -90,7 +90,7 @@ open class _ChatMessageComposerCommandCellView<ExtraData: ExtraDataTypes>: View,
 
 public typealias ChatMessageComposerCommandCollectionViewCell = _ChatMessageComposerCommandCollectionViewCell<NoExtraData>
 
-open class _ChatMessageComposerCommandCollectionViewCell<ExtraData: ExtraDataTypes>: CollectionViewCell, UIConfigProvider {
+open class _ChatMessageComposerCommandCollectionViewCell<ExtraData: ExtraDataTypes>: _CollectionViewCell, UIConfigProvider {
     open class var reuseId: String { String(describing: self) }
 
     public private(set) lazy var commandView = uiConfig

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerDocumentAttachmentCollectionViewCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerDocumentAttachmentCollectionViewCell.swift
@@ -8,7 +8,7 @@ import UIKit
 public typealias ChatMessageComposerDocumentAttachmentCollectionViewCell =
     _ChatMessageComposerDocumentAttachmentCollectionViewCell<NoExtraData>
 
-open class _ChatMessageComposerDocumentAttachmentCollectionViewCell<ExtraData: ExtraDataTypes>: CollectionViewCell,
+open class _ChatMessageComposerDocumentAttachmentCollectionViewCell<ExtraData: ExtraDataTypes>: _CollectionViewCell,
     UIConfigProvider {
     // MARK: - Properties
     

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerDocumentAttachmentsView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerDocumentAttachmentsView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageComposerDocumentAttachmentsView = _ChatMessageComposerDocumentAttachmentsView<NoExtraData>
 
-open class _ChatMessageComposerDocumentAttachmentsView<ExtraData: ExtraDataTypes>: View,
+open class _ChatMessageComposerDocumentAttachmentsView<ExtraData: ExtraDataTypes>: _View,
     UIConfigProvider,
     UICollectionViewDelegate,
     UICollectionViewDataSource {

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerImageAttachmentCollectionViewCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerImageAttachmentCollectionViewCell.swift
@@ -8,7 +8,7 @@ import UIKit
 public typealias ChatMessageComposerImageAttachmentCollectionViewCell =
     _ChatMessageComposerImageAttachmentCollectionViewCell<NoExtraData>
 
-open class _ChatMessageComposerImageAttachmentCollectionViewCell<ExtraData: ExtraDataTypes>: CollectionViewCell,
+open class _ChatMessageComposerImageAttachmentCollectionViewCell<ExtraData: ExtraDataTypes>: _CollectionViewCell,
     UIConfigProvider {
     // MARK: - Properties
     

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerImageAttachmentsView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerImageAttachmentsView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageComposerImageAttachmentsView = _ChatMessageComposerImageAttachmentsView<NoExtraData>
 
-open class _ChatMessageComposerImageAttachmentsView<ExtraData: ExtraDataTypes>: View,
+open class _ChatMessageComposerImageAttachmentsView<ExtraData: ExtraDataTypes>: _View,
     UIConfigProvider,
     UICollectionViewDelegate,
     UICollectionViewDataSource {

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerInputContainerView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerInputContainerView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageComposerInputContainerView = _ChatMessageComposerInputContainerView<NoExtraData>
 
-open class _ChatMessageComposerInputContainerView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageComposerInputContainerView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     // MARK: - Properties
     
     open var rightAccessoryButtonHeight: CGFloat = 30

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerMentionCollectionViewCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerMentionCollectionViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 public typealias ChatMessageComposerMentionCellView = _ChatMessageComposerMentionCellView<NoExtraData>
 
 /// A View that is embed inside `UICollectionViewCell`  which shows information about user which we want to tag in suggestions
-open class _ChatMessageComposerMentionCellView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageComposerMentionCellView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     /// Content of the cell - `ChatUser` instance from which we take all information.
     open var content: _ChatUser<ExtraData.User>? {
         didSet {
@@ -117,7 +117,7 @@ open class _ChatMessageComposerMentionCellView<ExtraData: ExtraDataTypes>: View,
 public typealias ChatMessageComposerMentionCollectionViewCell = _ChatMessageComposerMentionCollectionViewCell<NoExtraData>
 
 /// `UICollectionView` subclass which embeds inside `ChatMessageComposerMentionCellView`
-open class _ChatMessageComposerMentionCollectionViewCell<ExtraData: ExtraDataTypes>: CollectionViewCell, UIConfigProvider {
+open class _ChatMessageComposerMentionCollectionViewCell<ExtraData: ExtraDataTypes>: _CollectionViewCell, UIConfigProvider {
     /// Reuse identifier for the cell used in `collectionView(cellForItem:)`
     open class var reuseId: String { String(describing: self) }
 

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerQuoteBubbleView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerQuoteBubbleView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageComposerQuoteBubbleView = _ChatMessageComposerQuoteBubbleView<NoExtraData>
 
-open class _ChatMessageComposerQuoteBubbleView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageComposerQuoteBubbleView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     // MARK: - Properties
     
     public var avatarViewSize: CGSize = .init(width: 24, height: 24)

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerSuggestionsCommandsHeaderView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerSuggestionsCommandsHeaderView.swift
@@ -21,7 +21,7 @@ open class _ChatMessageComposerSuggestionsCommandsReusableView<ExtraData: ExtraD
 
 public typealias ChatMessageComposerSuggestionsCommandsHeaderView = _ChatMessageComposerSuggestionsCommandsHeaderView<NoExtraData>
 
-open class _ChatMessageComposerSuggestionsCommandsHeaderView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageComposerSuggestionsCommandsHeaderView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     public private(set) lazy var commandImageView = UIImageView()
         .withoutAutoresizingMaskConstraints
 

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerSuggestionsViewController.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerSuggestionsViewController.swift
@@ -12,7 +12,7 @@ public enum SuggestionKind {
 
 public typealias ChatMessageComposerSuggestionsViewController = _ChatMessageComposerSuggestionsViewController<NoExtraData>
 
-open class _ChatMessageComposerSuggestionsViewController<ExtraData: ExtraDataTypes>: ViewController,
+open class _ChatMessageComposerSuggestionsViewController<ExtraData: ExtraDataTypes>: _ViewController,
     UIConfigProvider,
     UICollectionViewDelegate {
     // MARK: - Property

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
@@ -13,7 +13,7 @@ public protocol _ChatMessageComposerViewControllerDelegate: AnyObject {
 
 public typealias ChatMessageComposerVC = _ChatMessageComposerVC<NoExtraData>
 
-open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: ViewController,
+open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
     UIConfigProvider,
     UITextViewDelegate,
     UIImagePickerControllerDelegate,

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageComposerView = _ChatMessageComposerView<NoExtraData>
 
-open class _ChatMessageComposerView<ExtraData: ExtraDataTypes>: View,
+open class _ChatMessageComposerView<ExtraData: ExtraDataTypes>: _View,
     UIConfigProvider {
     // MARK: - Properties
     

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageInputSlashCommandView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageInputSlashCommandView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageInputSlashCommandView = _ChatMessageInputSlashCommandView<NoExtraData>
 
-open class _ChatMessageInputSlashCommandView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageInputSlashCommandView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     // MARK: - Properties
     
     public var commandName: String? {

--- a/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsBubbleView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsBubbleView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageReactionsBubbleView = _ChatMessageReactionsBubbleView<NoExtraData>
 
-open class _ChatMessageReactionsBubbleView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageReactionsBubbleView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     public var content: Content? {
         didSet { updateContentIfNeeded() }
     }

--- a/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsVC.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageReactionsVC = _ChatMessageReactionsVC<NoExtraData>
 
-open class _ChatMessageReactionsVC<ExtraData: ExtraDataTypes>: ViewController, UIConfigProvider {
+open class _ChatMessageReactionsVC<ExtraData: ExtraDataTypes>: _ViewController, UIConfigProvider {
     public var messageController: _ChatMessageController<ExtraData>!
 
     // MARK: - Subviews

--- a/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView+ItemView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView+ItemView.swift
@@ -6,7 +6,7 @@ import StreamChat
 import UIKit
 
 extension _ChatMessageReactionsView {
-    open class ItemView: Button, UIConfigProvider {
+    open class ItemView: _Button, UIConfigProvider {
         public var content: Content? {
             didSet { updateContentIfNeeded() }
         }

--- a/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageReactionsView = _ChatMessageReactionsView<NoExtraData>
 
-open class _ChatMessageReactionsView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageReactionsView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     public var content: Content? {
         didSet { updateContentIfNeeded() }
     }

--- a/Sources/StreamChatUI/CommonViews/BaseViews.swift
+++ b/Sources/StreamChatUI/CommonViews/BaseViews.swift
@@ -51,7 +51,7 @@ public extension Customizable where Self: UIViewController {
 
 /// Base class for overridable views StreamChatUI provides.
 /// All conformers will have StreamChatUI appearance settings by default.
-open class View: UIView, AppearanceSetting, Customizable {
+open class _View: UIView, AppearanceSetting, Customizable {
     // Flag for preventing multiple lifecycle methods calls.
     private var isInitialized: Bool = false
     
@@ -95,7 +95,7 @@ open class View: UIView, AppearanceSetting, Customizable {
 
 /// Base class for overridable views StreamChatUI provides.
 /// All conformers will have StreamChatUI appearance settings by default.
-open class CollectionViewCell: UICollectionViewCell, AppearanceSetting, Customizable {
+open class _CollectionViewCell: UICollectionViewCell, AppearanceSetting, Customizable {
     // Flag for preventing multiple lifecycle methods calls.
     private var isInitialized: Bool = false
     
@@ -139,7 +139,7 @@ open class CollectionViewCell: UICollectionViewCell, AppearanceSetting, Customiz
 
 /// Base class for overridable views StreamChatUI provides.
 /// All conformers will have StreamChatUI appearance settings by default.
-open class Control: UIControl, AppearanceSetting, Customizable {
+open class _Control: UIControl, AppearanceSetting, Customizable {
     // Flag for preventing multiple lifecycle methods calls.
     private var isInitialized: Bool = false
     
@@ -183,7 +183,7 @@ open class Control: UIControl, AppearanceSetting, Customizable {
 
 /// Base class for overridable views StreamChatUI provides.
 /// All conformers will have StreamChatUI appearance settings by default.
-open class Button: UIButton, AppearanceSetting, Customizable {
+open class _Button: UIButton, AppearanceSetting, Customizable {
     // Flag for preventing multiple lifecycle methods calls.
     private var isInitialized: Bool = false
     
@@ -227,7 +227,7 @@ open class Button: UIButton, AppearanceSetting, Customizable {
 
 /// Base class for overridable views StreamChatUI provides.
 /// All conformers will have StreamChatUI appearance settings by default.
-open class NavigationBar: UINavigationBar, AppearanceSetting, Customizable {
+open class _NavigationBar: UINavigationBar, AppearanceSetting, Customizable {
     // Flag for preventing multiple lifecycle methods calls.
     private var isInitialized: Bool = false
     
@@ -269,7 +269,7 @@ open class NavigationBar: UINavigationBar, AppearanceSetting, Customizable {
     }
 }
 
-open class ViewController: UIViewController, AppearanceSetting, Customizable {
+open class _ViewController: UIViewController, AppearanceSetting, Customizable {
     override open func viewDidLoad() {
         super.viewDidLoad()
         

--- a/Sources/StreamChatUI/CommonViews/ChatAvatarView.swift
+++ b/Sources/StreamChatUI/CommonViews/ChatAvatarView.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 /// A simple container view that holds `UIImageView` instance and applies some basic appearance styling.
-open class ChatAvatarView: View {
+open class ChatAvatarView: _View {
     /// The `UIImageView` instance that shows the avatar image.
     open private(set) var imageView: UIImageView = UIImageView().withoutAutoresizingMaskConstraints
     

--- a/Sources/StreamChatUI/CommonViews/ChatChannelCreateNewButton.swift
+++ b/Sources/StreamChatUI/CommonViews/ChatChannelCreateNewButton.swift
@@ -9,7 +9,7 @@ import UIKit
 public typealias ChatChannelCreateNewButton = _ChatChannelCreateNewButton<NoExtraData>
 
 /// A Button subclass that should be used for creating new channels.
-open class _ChatChannelCreateNewButton<ExtraData: ExtraDataTypes>: Button, UIConfigProvider {
+open class _ChatChannelCreateNewButton<ExtraData: ExtraDataTypes>: _Button, UIConfigProvider {
     override public func defaultAppearance() {
         super.defaultAppearance()
         setImage(uiConfig.images.newChat, for: .normal)

--- a/Sources/StreamChatUI/CommonViews/ChatLoadingIndicator.swift
+++ b/Sources/StreamChatUI/CommonViews/ChatLoadingIndicator.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatLoadingIndicator = _ChatLoadingIndicator<NoExtraData>
 
-open class _ChatLoadingIndicator<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatLoadingIndicator<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     override open var isHidden: Bool {
         didSet { updateContentIfNeeded() }
     }

--- a/Sources/StreamChatUI/CommonViews/ChatNavigationBar.swift
+++ b/Sources/StreamChatUI/CommonViews/ChatNavigationBar.swift
@@ -5,7 +5,7 @@
 import StreamChat
 import UIKit
 
-open class ChatNavigationBar<ExtraData: ExtraDataTypes>: NavigationBar, UIConfigProvider {
+open class ChatNavigationBar<ExtraData: ExtraDataTypes>: _NavigationBar, UIConfigProvider {
     override public func defaultAppearance() {
         let backIcon = uiConfig.images.back
         backIndicatorTransitionMaskImage = backIcon

--- a/Sources/StreamChatUI/CommonViews/ChatOnlineIndicatorView.swift
+++ b/Sources/StreamChatUI/CommonViews/ChatOnlineIndicatorView.swift
@@ -9,7 +9,7 @@ import UIKit
 public typealias ChatOnlineIndicatorView = _ChatOnlineIndicatorView<NoExtraData>
 
 /// A view used to indicate the presence of a user.
-open class _ChatOnlineIndicatorView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatOnlineIndicatorView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     override public func defaultAppearance() {
         super.defaultAppearance()
 

--- a/Sources/StreamChatUI/CommonViews/ChatSquareButton.swift
+++ b/Sources/StreamChatUI/CommonViews/ChatSquareButton.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatSquareButton = _ChatSquareButton<NoExtraData>
 
-open class _ChatSquareButton<ExtraData: ExtraDataTypes>: Button, UIConfigProvider {
+open class _ChatSquareButton<ExtraData: ExtraDataTypes>: _Button, UIConfigProvider {
     // MARK: - Properties
     
     public var defaultIntrinsicContentSize: CGSize?

--- a/Sources/StreamChatUI/CommonViews/CurrentChatUserAvatarView.swift
+++ b/Sources/StreamChatUI/CommonViews/CurrentChatUserAvatarView.swift
@@ -17,7 +17,7 @@ public typealias CurrentChatUserAvatarView = _CurrentChatUserAvatarView<NoExtraD
 /// It uses `CurrentChatUserController` for its input data and is able to update the avatar automatically based
 /// on the currently logged-in user.
 ///
-open class _CurrentChatUserAvatarView<ExtraData: ExtraDataTypes>: Control, UIConfigProvider {
+open class _CurrentChatUserAvatarView<ExtraData: ExtraDataTypes>: _Control, UIConfigProvider {
     /// `StreamChat`'s controller that observe the currently logged-in user.
     open var controller: _CurrentChatUserController<ExtraData>? {
         didSet {

--- a/Sources/StreamChatUI/Generated/L10n.swift
+++ b/Sources/StreamChatUI/Generated/L10n.swift
@@ -1,7 +1,3 @@
-//
-// Copyright © 2021 Stream.io Inc. All rights reserved.
-//
-
 // swiftlint:disable all
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
@@ -14,139 +10,131 @@ import Foundation
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
-    internal enum Alert {
-        internal enum Actions {
-            /// Cancel
-            internal static let cancel = L10n.tr("Localizable", "alert.actions.cancel")
-            /// Delete
-            internal static let delete = L10n.tr("Localizable", "alert.actions.delete")
-        }
+
+  internal enum Alert {
+    internal enum Actions {
+      /// Cancel
+      internal static let cancel = L10n.tr("Localizable", "alert.actions.cancel")
+      /// Delete
+      internal static let delete = L10n.tr("Localizable", "alert.actions.delete")
     }
+  }
 
-    internal enum Channel {
-        internal enum Name {
-            /// and
-            internal static let and = L10n.tr("Localizable", "channel.name.and")
-            /// NoChannel
-            internal static let missing = L10n.tr("Localizable", "channel.name.missing")
-            /// more
-            internal static let more = L10n.tr("Localizable", "channel.name.more")
-        }
+  internal enum Channel {
+    internal enum Name {
+      /// and
+      internal static let and = L10n.tr("Localizable", "channel.name.and")
+      /// NoChannel
+      internal static let missing = L10n.tr("Localizable", "channel.name.missing")
+      /// more
+      internal static let more = L10n.tr("Localizable", "channel.name.more")
     }
+  }
 
-    internal enum Composer {
-        internal enum Checkmark {
-            /// Also send in channel
-            internal static let channelReply = L10n.tr("Localizable", "composer.checkmark.channel-reply")
-            /// Also send as direct message
-            internal static let directMessageReply = L10n.tr("Localizable", "composer.checkmark.direct-message-reply")
-        }
-
-        internal enum Picker {
-            /// Cancel
-            internal static let cancel = L10n.tr("Localizable", "composer.picker.cancel")
-            /// File
-            internal static let file = L10n.tr("Localizable", "composer.picker.file")
-            /// Photo
-            internal static let image = L10n.tr("Localizable", "composer.picker.image")
-            /// Choose attachment type:
-            internal static let title = L10n.tr("Localizable", "composer.picker.title")
-        }
-
-        internal enum Placeholder {
-            /// Search GIFs
-            internal static let giphy = L10n.tr("Localizable", "composer.placeholder.giphy")
-            /// Send a message
-            internal static let message = L10n.tr("Localizable", "composer.placeholder.message")
-        }
-
-        internal enum Suggestions {
-            internal enum Commands {
-                /// Instant Commands
-                internal static let header = L10n.tr("Localizable", "composer.suggestions.commands.header")
-            }
-        }
-
-        internal enum Title {
-            /// Edit Message
-            internal static let edit = L10n.tr("Localizable", "composer.title.edit")
-            /// Reply to Message
-            internal static let reply = L10n.tr("Localizable", "composer.title.reply")
-        }
+  internal enum Composer {
+    internal enum Checkmark {
+      /// Also send in channel
+      internal static let channelReply = L10n.tr("Localizable", "composer.checkmark.channel-reply")
+      /// Also send as direct message
+      internal static let directMessageReply = L10n.tr("Localizable", "composer.checkmark.direct-message-reply")
     }
-
-    internal enum Message {
-        /// Message deleted
-        internal static let deletedMessagePlaceholder = L10n.tr("Localizable", "message.deleted-message-placeholder")
-        /// Only visible to you
-        internal static let onlyVisibleToYou = L10n.tr("Localizable", "message.only-visible-to-you")
-        internal enum Actions {
-            /// Copy Message
-            internal static let copy = L10n.tr("Localizable", "message.actions.copy")
-            /// Delete Message
-            internal static let delete = L10n.tr("Localizable", "message.actions.delete")
-            /// Edit Message
-            internal static let edit = L10n.tr("Localizable", "message.actions.edit")
-            /// Reply
-            internal static let inlineReply = L10n.tr("Localizable", "message.actions.inline-reply")
-            /// Resend
-            internal static let resend = L10n.tr("Localizable", "message.actions.resend")
-            /// Thread Reply
-            internal static let threadReply = L10n.tr("Localizable", "message.actions.thread-reply")
-            /// Block User
-            internal static let userBlock = L10n.tr("Localizable", "message.actions.user-block")
-            /// Mute User
-            internal static let userMute = L10n.tr("Localizable", "message.actions.user-mute")
-            /// Unblock User
-            internal static let userUnblock = L10n.tr("Localizable", "message.actions.user-unblock")
-            /// Unmute User
-            internal static let userUnmute = L10n.tr("Localizable", "message.actions.user-unmute")
-            internal enum Delete {
-                /// Are you sure you want to permanently delete this message?
-                internal static let confirmationMessage = L10n.tr("Localizable", "message.actions.delete.confirmation-message")
-                /// Delete Message
-                internal static let confirmationTitle = L10n.tr("Localizable", "message.actions.delete.confirmation-title")
-            }
-        }
-
-        internal enum Sending {
-            /// UPLOADING FAILED
-            internal static let attachmentUploadingFailed = L10n.tr("Localizable", "message.sending.attachment-uploading-failed")
-        }
-
-        internal enum Threads {
-            /// Plural format key: "%#@replies@"
-            internal static func count(_ p1: Int) -> String {
-                L10n.tr("Localizable", "message.threads.count", p1)
-            }
-
-            /// Thread Reply
-            internal static let reply = L10n.tr("Localizable", "message.threads.reply")
-        }
+    internal enum Picker {
+      /// Cancel
+      internal static let cancel = L10n.tr("Localizable", "composer.picker.cancel")
+      /// File
+      internal static let file = L10n.tr("Localizable", "composer.picker.file")
+      /// Photo
+      internal static let image = L10n.tr("Localizable", "composer.picker.image")
+      /// Choose attachment type: 
+      internal static let title = L10n.tr("Localizable", "composer.picker.title")
     }
+    internal enum Placeholder {
+      /// Search GIFs
+      internal static let giphy = L10n.tr("Localizable", "composer.placeholder.giphy")
+      /// Send a message
+      internal static let message = L10n.tr("Localizable", "composer.placeholder.message")
+    }
+    internal enum Suggestions {
+      internal enum Commands {
+        /// Instant Commands
+        internal static let header = L10n.tr("Localizable", "composer.suggestions.commands.header")
+      }
+    }
+    internal enum Title {
+      /// Edit Message
+      internal static let edit = L10n.tr("Localizable", "composer.title.edit")
+      /// Reply to Message
+      internal static let reply = L10n.tr("Localizable", "composer.title.reply")
+    }
+  }
+
+  internal enum Message {
+    /// Message deleted
+    internal static let deletedMessagePlaceholder = L10n.tr("Localizable", "message.deleted-message-placeholder")
+    /// Only visible to you
+    internal static let onlyVisibleToYou = L10n.tr("Localizable", "message.only-visible-to-you")
+    internal enum Actions {
+      /// Copy Message
+      internal static let copy = L10n.tr("Localizable", "message.actions.copy")
+      /// Delete Message
+      internal static let delete = L10n.tr("Localizable", "message.actions.delete")
+      /// Edit Message
+      internal static let edit = L10n.tr("Localizable", "message.actions.edit")
+      /// Reply
+      internal static let inlineReply = L10n.tr("Localizable", "message.actions.inline-reply")
+      /// Resend
+      internal static let resend = L10n.tr("Localizable", "message.actions.resend")
+      /// Thread Reply
+      internal static let threadReply = L10n.tr("Localizable", "message.actions.thread-reply")
+      /// Block User
+      internal static let userBlock = L10n.tr("Localizable", "message.actions.user-block")
+      /// Mute User
+      internal static let userMute = L10n.tr("Localizable", "message.actions.user-mute")
+      /// Unblock User
+      internal static let userUnblock = L10n.tr("Localizable", "message.actions.user-unblock")
+      /// Unmute User
+      internal static let userUnmute = L10n.tr("Localizable", "message.actions.user-unmute")
+      internal enum Delete {
+        /// Are you sure you want to permanently delete this message?
+        internal static let confirmationMessage = L10n.tr("Localizable", "message.actions.delete.confirmation-message")
+        /// Delete Message
+        internal static let confirmationTitle = L10n.tr("Localizable", "message.actions.delete.confirmation-title")
+      }
+    }
+    internal enum Sending {
+      /// UPLOADING FAILED
+      internal static let attachmentUploadingFailed = L10n.tr("Localizable", "message.sending.attachment-uploading-failed")
+    }
+    internal enum Threads {
+      /// Plural format key: "%#@replies@"
+      internal static func count(_ p1: Int) -> String {
+        return L10n.tr("Localizable", "message.threads.count", p1)
+      }
+      /// Thread Reply
+      internal static let reply = L10n.tr("Localizable", "message.threads.reply")
+    }
+  }
 }
-
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
 
 // MARK: - Implementation Details
 
 extension L10n {
-    private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
-        let format = BundleToken.bundle.localizedString(forKey: key, value: nil, table: table)
-        return String(format: format, locale: Locale.current, arguments: args)
-    }
+  private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
+    let format = BundleToken.bundle.localizedString(forKey: key, value: nil, table: table)
+    return String(format: format, locale: Locale.current, arguments: args)
+  }
 }
 
 // swiftlint:disable convenience_type
 private final class BundleToken {
-    static let bundle: Bundle = {
-        #if SWIFT_PACKAGE
-        return Bundle.module
-        #else
-        return Bundle(for: BundleToken.self)
-        #endif
-    }()
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
 }
-
 // swiftlint:enable convenience_type

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
@@ -16,7 +16,7 @@ public protocol _ChatMessageActionsVCDelegate: AnyObject {
 
 public typealias ChatMessageActionsVC = _ChatMessageActionsVC<NoExtraData>
 
-open class _ChatMessageActionsVC<ExtraData: ExtraDataTypes>: ViewController, UIConfigProvider {
+open class _ChatMessageActionsVC<ExtraData: ExtraDataTypes>: _ViewController, UIConfigProvider {
     public var messageController: _ChatMessageController<ExtraData>!
     public var delegate: Delegate? // swiftlint:disable:this weak_delegate
     public lazy var router = uiConfig.navigation.messageActionsRouter.init(rootViewController: self)

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsView+ActionButton.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsView+ActionButton.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 extension _ChatMessageActionsView {
-    open class ActionButton: Button, UIConfigProvider {
+    open class ActionButton: _Button, UIConfigProvider {
         public var actionItem: ChatMessageActionItem<ExtraData>? {
             didSet { updateContentIfNeeded() }
         }

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsView.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessageActionsView = _ChatMessageActionsView<NoExtraData>
 
-open class _ChatMessageActionsView<ExtraData: ExtraDataTypes>: View, UIConfigProvider {
+open class _ChatMessageActionsView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     public var actionItems: [ChatMessageActionItem<ExtraData>] = [] {
         didSet { updateContentIfNeeded() }
     }

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.swift
@@ -7,7 +7,7 @@ import UIKit
 
 public typealias ChatMessagePopupVC = _ChatMessagePopupVC<NoExtraData>
 
-open class _ChatMessagePopupVC<ExtraData: ExtraDataTypes>: ViewController, UIConfigProvider {
+open class _ChatMessagePopupVC<ExtraData: ExtraDataTypes>: _ViewController, UIConfigProvider {
     public private(set) lazy var scrollView = UIScrollView()
         .withoutAutoresizingMaskConstraints
     public private(set) lazy var scrollContentView = UIView()

--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'Sources/*.swift'
+./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'Sources/*.swift | grep -v "Generated'
 ./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'Tests/*.swift'
 ./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'Sample/*.swift'
 ./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'DemoApp/*.swift'


### PR DESCRIPTION
We have a collision between `StreamChatUI.View` and `SwiftUI.View`. We don't want to break the existing SwiftUI code just by importing `StreamChatUI`.  This PR adds `_` prefix to all base views we use.

Adding `_` works nicely with the existing `_XXX` types because the same "don't use directly" rule applies to the base types, too.

---

I also fixed CIS-509 (formatting of generated files), since it took me just a minute and it was extremely annoying :) 