### PR TITLE
Fix Channels not showing up when Message attachment has malformed data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐞 Fixed
 - Fix user devices not being removed locally when removed on the backend [#882](https://github.com/GetStream/stream-chat-swift/pull/822)
+- Fix issue with bad parsing of malformed attachment data causing channelList not showing channels [#834](https://github.com/GetStream/stream-chat-swift/pull/834/)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/AttachmentPayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/AttachmentPayload.swift
@@ -27,7 +27,7 @@ struct AttachmentPayload: Decodable {
         if itWasLinkOriginally {
             type = .link(try? container.decode(String.self, forKey: .type))
         } else {
-            type = AttachmentType(rawValue: try? container.decode(String.self, forKey: .type))
+            type = AttachmentType(rawValue: try container.decode(String.self, forKey: .type))
         }
         self.type = type
         

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
@@ -7,6 +7,7 @@ import XCTest
 
 class MessagePayload_Tests: XCTestCase {
     let messageJSON = XCTestCase.mockData(fromFile: "Message")
+    let messageJSONWithCorruptedAttachments = XCTestCase.mockData(fromFile: "MessageWithBrokenAttachments")
     
     func test_messagePayload_isSerialized_withDefaultExtraData() throws {
         let box = try JSONDecoder.default.decode(MessagePayload<NoExtraData>.Boxed.self, from: messageJSON)
@@ -33,6 +34,34 @@ class MessagePayload_Tests: XCTestCase {
         XCTAssertEqual(payload.isSilent, true)
         XCTAssertEqual(payload.channel?.cid.rawValue, "messaging:channel-ex7-63")
         XCTAssertEqual(payload.quotedMessage?.id, "4C0CC2DA-8AB5-421F-808E-50DC7E40653D")
+    }
+
+    func test_messagePayload_isSerialized_withDefaultExtraData_withBrokenAttachmentPayload() throws {
+        let box = try JSONDecoder.default.decode(MessagePayload<NoExtraData>.Boxed.self, from: messageJSONWithCorruptedAttachments)
+        let payload = box.message
+
+        XCTAssertEqual(payload.id, "7baa1533-3294-4c0c-9a62-c9d0928bf733")
+        XCTAssertEqual(payload.type.rawValue, "regular")
+        XCTAssertEqual(payload.user.id, "broken-waterfall-5")
+        XCTAssertEqual(payload.createdAt, "2020-07-16T15:39:03.010717Z".toDate())
+        XCTAssertEqual(payload.updatedAt, "2020-08-17T13:15:39.895109Z".toDate())
+        XCTAssertEqual(payload.deletedAt, "2020-07-16T15:55:03.010717Z".toDate())
+        XCTAssertEqual(payload.text, "No, I am your father!")
+        XCTAssertEqual(payload.command, nil)
+        XCTAssertEqual(payload.args, nil)
+        XCTAssertEqual(payload.parentId, "3294-4c0c-9a62-c9d0928bf733")
+        XCTAssertEqual(payload.showReplyInChannel, true)
+        XCTAssertEqual(payload.mentionedUsers.map(\.id), [])
+        XCTAssertEqual(payload.threadParticipants.map(\.id), ["josh"])
+        XCTAssertEqual(payload.replyCount, 0)
+        XCTAssertEqual(payload.extraData, .defaultValue)
+        XCTAssertEqual(payload.latestReactions.count, 1)
+        XCTAssertEqual(payload.ownReactions.count, 1)
+        XCTAssertEqual(payload.reactionScores, ["love": 1])
+        XCTAssertEqual(payload.isSilent, true)
+        XCTAssertEqual(payload.channel?.cid.rawValue, "messaging:channel-ex7-63")
+        XCTAssertEqual(payload.quotedMessage?.id, "4C0CC2DA-8AB5-421F-808E-50DC7E40653D")
+        XCTAssertEqual(payload.attachments.count, 1)
     }
     
     func test_messagePayload_isSerialized_withCustomExtraData() throws {

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -90,14 +90,10 @@ extension NSManagedObjectContext: AttachmentDatabaseSession {
         guard let channelDTO = channel(cid: id.cid) else {
             throw ClientError.ChannelDoesNotExist(cid: id.cid)
         }
-        
-        guard let type = payload.type.rawValue else {
-            throw ClientError.MissingAttachmentType(id: id)
-        }
-        
+
         let dto = AttachmentDTO.loadOrCreate(id: id, context: self)
         
-        dto.type = type
+        dto.type = payload.type.rawValue
         dto.data = try JSONEncoder.default.encode(payload.payload)
         dto.channel = channelDTO
         dto.message = messageDTO
@@ -119,15 +115,11 @@ extension NSManagedObjectContext: AttachmentDatabaseSession {
         guard let channelDTO = channel(cid: id.cid) else {
             throw ClientError.ChannelDoesNotExist(cid: id.cid)
         }
-        
-        guard let type = seed.type.rawValue else {
-            throw ClientError.MissingAttachmentType(id: id)
-        }
 
         let dto = AttachmentDTO.loadOrCreate(id: id, context: self)
         dto.localURL = seed.localURL
         dto.localState = .pendingUpload
-        dto.type = type
+        dto.type = seed.type.rawValue
         dto.title = seed.fileName
         
         if isAttachmentModelSeparationChangesApplied {
@@ -146,7 +138,7 @@ extension NSManagedObjectContext: AttachmentDatabaseSession {
         } else {
             let attachment = ChatMessageDefaultAttachment(
                 id: id,
-                type: AttachmentType(rawValue: type),
+                type: seed.type,
                 localURL: seed.localURL,
                 localState: dto.localState,
                 title: seed.fileName,
@@ -173,14 +165,10 @@ extension NSManagedObjectContext: AttachmentDatabaseSession {
         guard let channelDTO = channel(cid: id.cid) else {
             throw ClientError.ChannelDoesNotExist(cid: id.cid)
         }
-        
-        guard let type = attachment.type.rawValue else {
-            throw ClientError.MissingAttachmentType(id: id)
-        }
 
         let dto = AttachmentDTO.loadOrCreate(id: id, context: self)
         
-        dto.type = type
+        dto.type = attachment.type.rawValue
         dto.localState = .uploaded
         dto.data = try JSONEncoder.stream.encode(AnyEncodable(attachment))
 

--- a/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
+++ b/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
@@ -112,9 +112,9 @@ public enum AttachmentType: RawRepresentable, Codable, Hashable, ExpressibleBySt
     /// Could be `audio`, `video`, `image`.
     case link(String?)
     /// `.custom` type is used for any unrecognised type.
-    case custom(String?)
+    case custom(String)
     
-    public var rawValue: String? {
+    public var rawValue: String {
         switch self {
         case let .custom(raw):
             return raw
@@ -133,9 +133,8 @@ public enum AttachmentType: RawRepresentable, Codable, Hashable, ExpressibleBySt
         }
     }
         
-    public init(rawValue: String?) {
-        if let rawValue = rawValue,
-            rawValue.prefix(4) == "link" {
+    public init(rawValue: String) {
+        if rawValue.prefix(4) == "link" {
             self = .link(rawValue.replacingOccurrences(of: "link-", with: ""))
             return
         }

--- a/Sources/StreamChat/Models/Attachments/ChatMessageDefaultAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageDefaultAttachment.swift
@@ -93,7 +93,7 @@ public struct ChatMessageDefaultAttachment: ChatMessageAttachment, AttachmentEnv
         if itWasLinkOriginally {
             type = .link(try? container.decode(String.self, forKey: .type))
         } else {
-            type = AttachmentType(rawValue: try? container.decode(String.self, forKey: .type))
+            type = AttachmentType(rawValue: try container.decode(String.self, forKey: .type))
         }
         // compiler is confused by expression unless we use helper variable for type
         self.type = type

--- a/Sources/StreamChat/Utils/OptionalDecodable.swift
+++ b/Sources/StreamChat/Utils/OptionalDecodable.swift
@@ -1,0 +1,27 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// This structure is a wrapper for all decodable object
+/// What it does is that it stores the optional Decodable object into
+/// itself. When the object is malformed, it assignes the object to base as `nil` value
+/// When the value is not corrupted somehow, it stores into base and we can use it.
+///
+/// Use this when you are decoding objects in array and there is possibility
+/// that some of the objects can be malformed in JSON. Then you should `compactMap` the array
+/// For example usage, see `MessagePayload.swift` `init(from decoder:)`
+struct OptionalDecodable<Base: Decodable>: Decodable {
+    let base: Base?
+    public init(from decoder: Decoder) throws {
+        let base: Base?
+        do {
+            base = try Base(from: decoder)
+        } catch {
+            log.error("Failed to decode \(Base.self): \(error)")
+            base = nil
+        }
+        self.base = base
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -666,6 +666,8 @@
 		E7AD954F25D536AA00076DC3 /* SystemEnvironment+Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AD954E25D536AA00076DC3 /* SystemEnvironment+Version.swift */; };
 		E7AD958925D7510900076DC3 /* ChatMessageComposerMentionCellView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AD958825D7510900076DC3 /* ChatMessageComposerMentionCellView_Tests.swift */; };
 		E7C4E74D259D54B5002889AC /* ChatChannelSwipeableListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C4E74C259D54B5002889AC /* ChatChannelSwipeableListItemView.swift */; };
+		E7DD8EA825E3F7F50059A322 /* MessageWithBrokenAttachments.json in Resources */ = {isa = PBXBuildFile; fileRef = E7DD8EA725E3F7F50059A322 /* MessageWithBrokenAttachments.json */; };
+		E7DD8EC125E4083B0059A322 /* OptionalDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7DD8EC025E4083B0059A322 /* OptionalDecodable.swift */; };
 		E7DF7E2425C2C67E00AE9D21 /* ChatAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7DF7E2325C2C67E00AE9D21 /* ChatAvatarView.swift */; };
 		F61D7C3124FF9D1F00188A0E /* MessageEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */; };
 		F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */; };
@@ -1490,6 +1492,8 @@
 		E7AD954E25D536AA00076DC3 /* SystemEnvironment+Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemEnvironment+Version.swift"; sourceTree = "<group>"; };
 		E7AD958825D7510900076DC3 /* ChatMessageComposerMentionCellView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageComposerMentionCellView_Tests.swift; sourceTree = "<group>"; };
 		E7C4E74C259D54B5002889AC /* ChatChannelSwipeableListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelSwipeableListItemView.swift; sourceTree = "<group>"; };
+		E7DD8EA725E3F7F50059A322 /* MessageWithBrokenAttachments.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MessageWithBrokenAttachments.json; sourceTree = "<group>"; };
+		E7DD8EC025E4083B0059A322 /* OptionalDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalDecodable.swift; sourceTree = "<group>"; };
 		E7DF7E2325C2C67E00AE9D21 /* ChatAvatarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatAvatarView.swift; sourceTree = "<group>"; };
 		F61D7C3024FF9D1F00188A0E /* MessageEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEndpoints_Tests.swift; sourceTree = "<group>"; };
 		F61D7C3224FFA60600188A0E /* MessageUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageUpdater_Mock.swift; sourceTree = "<group>"; };
@@ -1905,6 +1909,7 @@
 				8AE335A324FCF95D002B6677 /* InternetConnection */,
 				79BF83EA248F8EC0007611A1 /* Logger */,
 				79280F6F2487CD2B00CDEB89 /* Atomic.swift */,
+				E7DD8EC025E4083B0059A322 /* OptionalDecodable.swift */,
 				79280F702487CD2B00CDEB89 /* Atomic_Tests.swift */,
 				792A4F3D247FFDE700EAF71D /* Codable+Extensions.swift */,
 				792A4F3E247FFDE700EAF71D /* Data+Gzip.swift */,
@@ -2154,6 +2159,7 @@
 				798779F72498E47700015F8B /* Channel.json */,
 				798779F92498E47700015F8B /* CurrentUser.json */,
 				224116B1258BACF90034184D /* Message.json */,
+				E7DD8EA725E3F7F50059A322 /* MessageWithBrokenAttachments.json */,
 				DA653BB9253F47EB00B448A0 /* Messages.json */,
 				798779F82498E47700015F8B /* OtherUser.json */,
 				798779FA2498E47700015F8B /* ChannelsQuery.json */,
@@ -3483,6 +3489,7 @@
 				2289852A25CC0332007F2C26 /* AttachmentPayloadImage.json in Resources */,
 				8A62706224BE35E40040BFD6 /* UserStartTyping.json in Resources */,
 				88EA9B102547271B007EE76B /* MessageReactionPayload+CustomExtraData.json in Resources */,
+				E7DD8EA825E3F7F50059A322 /* MessageWithBrokenAttachments.json in Resources */,
 				7908824B25432CC600896F03 /* StreamChatTestPlan.xctestplan in Resources */,
 				2289852925CC0332007F2C26 /* AttachmentPayloadCustom.json in Resources */,
 				88381E77258259C70047A6A3 /* FileUploadPayload.json in Resources */,
@@ -4047,6 +4054,7 @@
 				8899BC53254318CC003CB98B /* MessageReaction.swift in Sources */,
 				DA99D0D024ED63C600AD5354 /* NewChannelQueryUpdater.swift in Sources */,
 				8A0175F02501174000570345 /* EventSender.swift in Sources */,
+				E7DD8EC125E4083B0059A322 /* OptionalDecodable.swift in Sources */,
 				F6FF1DAA24FD23D300151735 /* MessageEndpoints.swift in Sources */,
 				DA8407002524F778005A0F62 /* UserListController.swift in Sources */,
 				799C943E247D2FB9001F1104 /* Message.swift in Sources */,

--- a/Tests/StreamChatTests/DummyData/AttachmentPayload.swift
+++ b/Tests/StreamChatTests/DummyData/AttachmentPayload.swift
@@ -16,7 +16,7 @@ extension AttachmentPayload {
     ) -> AttachmentPayload {
         let data: Data = """
         {
-            "type": "\(type.rawValue!)",
+            "type": "\(type.rawValue)",
             "image_url" : "\(imageURL.absoluteString)",
             "title" : "\(title)",
             "thumb_url" : "\(imagePreviewURL.absoluteString)",

--- a/Tests/StreamChatTests/MockEnpointResponses/MessageWithBrokenAttachments.json
+++ b/Tests/StreamChatTests/MockEnpointResponses/MessageWithBrokenAttachments.json
@@ -1,0 +1,239 @@
+{
+    "message" : {
+        "id" : "7baa1533-3294-4c0c-9a62-c9d0928bf733",
+        "reaction_counts" : {
+            "love" : 1
+        },
+        "silent" : true,
+        "created_at" : "2020-07-16T15:39:03.010717Z",
+        "deleted_at" : "2020-07-16T15:55:03.010717Z",
+        "reaction_scores" : {
+            "love" : 1
+        },
+        "type" : "regular",
+        "latest_reactions" : [
+            {
+                "score" : 1,
+                "message_id" : "7baa1533-3294-4c0c-9a62-c9d0928bf733",
+                "created_at" : "2020-08-17T13:15:39.892884Z",
+                "user_id" : "broken-waterfall-5",
+                "type" : "love",
+                "updated_at" : "2020-08-17T13:15:39.892884Z",
+                "user" : {
+                    "id" : "broken-waterfall-5",
+                    "banned" : false,
+                    "unread_channels" : 0,
+                    "totalUnreadCount" : 0,
+                    "extraData" : {
+                        "name" : "Tester"
+                    },
+                    "last_active" : "2020-08-17T13:00:51.509134Z",
+                    "created_at" : "2019-12-12T15:33:46.488935Z",
+                    "invisible" : false,
+                    "unreadChannels" : 0,
+                    "unread_count" : 0,
+                    "image" : "https:\/\/s3.amazonaws.com\/eventmobi-test-assets\/eventsbyids\/8024\/people\/100no-pic.png",
+                    "updated_at" : "2020-08-17T13:15:27.5564Z",
+                    "role" : "user",
+                    "total_unread_count" : 0,
+                    "online" : true,
+                    "name" : "John Doe"
+                }
+            }
+        ],
+        "text" : "No, I am your father!",
+        "show_in_channel": true,
+        "parent_id": "3294-4c0c-9a62-c9d0928bf733",
+        "channel" : {
+            "id" : "channel-ex7-63",
+            "created_at" : "2019-12-17T17:11:26.131888Z",
+            "created_by" : null,
+            "type" : "messaging",
+            "cid" : "messaging:channel-ex7-63",
+            "frozen" : false,
+            "member_count" : 5,
+            "updated_at" : "2019-12-17T17:11:26.131888Z",
+            "config" : {
+                "typing_events" : true,
+                "connect_events" : true,
+                "reactions" : true,
+                "replies" : true,
+                "uploads" : true,
+                "commands" : [
+                    {
+                        "set" : "fun_set",
+                        "args" : "[text]",
+                        "name" : "giphy",
+                        "description" : "Post a random gif to the channel"
+                    },
+                    {
+                        "set" : "moderation_set",
+                        "args" : "[@username] [text]",
+                        "name" : "ban",
+                        "description" : "Ban a user"
+                    },
+                    {
+                        "set" : "moderation_set",
+                        "args" : "[@username]",
+                        "name" : "mute",
+                        "description" : "Mute a user"
+                    },
+                    {
+                        "set" : "moderation_set",
+                        "args" : "[@username]",
+                        "name" : "unmute",
+                        "description" : "Unmute a user"
+                    }
+                ],
+                "updated_at" : "2020-12-15T21:28:45.83429Z",
+                "automod_behavior" : "flag",
+                "url_enrichment" : true,
+                "mutes" : true,
+                "custom_events" : false,
+                "message_retention" : "infinite",
+                "name" : "messaging",
+                "automod" : "disabled",
+                "automod_thresholds" : {
+                    
+                },
+                "created_at" : "2020-03-16T19:59:52.3886Z",
+                "max_message_length" : 5000,
+                "blocklist_behavior" : "flag",
+                "read_events" : true,
+                "search" : true
+            },
+            "image" : "https:\/\/picsum.photos\/seed\/63\/100\/100",
+            "example" : 7,
+            "name" : "Giant Disk",
+            "last_message_at" : "2020-12-23T08:26:45.307447Z"
+        },
+        "secret_note": "Anakin is Vader!",
+        "attachments" : [
+            {
+                "type" : "image",
+                "fallback" : "IMG_0007.JPG",
+                "image_url" : "https:\/\/stream-cloud-uploads-dev.imgix.net\/images\/47574\/8493ab56-a02e-49fb-becf-1a6bbed2ac62.IMG_0007.JPG?ro=0&s=09ace099e749ea6f8902aa4b9a6957eb"
+            },
+            {
+
+            }
+        ],
+        "own_reactions" : [
+            {
+                "score" : 1,
+                "message_id" : "7baa1533-3294-4c0c-9a62-c9d0928bf733",
+                "created_at" : "2020-08-17T13:15:39.892884Z",
+                "user_id" : "broken-waterfall-5",
+                "type" : "love",
+                "updated_at" : "2020-08-17T13:15:39.892884Z",
+                "user" : {
+                    "id" : "broken-waterfall-5",
+                    "banned" : false,
+                    "unread_channels" : 0,
+                    "totalUnreadCount" : 0,
+                    "extraData" : {
+                        "name" : "Tester"
+                    },
+                    "last_active" : "2020-08-17T13:00:51.509134Z",
+                    "created_at" : "2019-12-12T15:33:46.488935Z",
+                    "invisible" : false,
+                    "unreadChannels" : 0,
+                    "unread_count" : 0,
+                    "image" : "https:\/\/s3.amazonaws.com\/eventmobi-test-assets\/eventsbyids\/8024\/people\/100no-pic.png",
+                    "updated_at" : "2020-08-17T13:15:27.5564Z",
+                    "role" : "user",
+                    "total_unread_count" : 0,
+                    "online" : true,
+                    "name" : "John Doe"
+                }
+            }
+        ],
+        "updated_at" : "2020-08-17T13:15:39.895109Z",
+        "reply_count" : 0,
+        "user" : {
+            "id" : "broken-waterfall-5",
+            "banned" : false,
+            "extraData" : {
+                "name" : "Tester"
+            },
+            "totalUnreadCount" : 0,
+            "unread_channels" : 0,
+            "last_active" : "2020-08-17T13:00:51.509134Z",
+            "created_at" : "2019-12-12T15:33:46.488935Z",
+            "invisible" : false,
+            "unreadChannels" : 0,
+            "unread_count" : 0,
+            "image" : "https:\/\/s3.amazonaws.com\/eventmobi-test-assets\/eventsbyids\/8024\/people\/100no-pic.png",
+            "updated_at" : "2020-08-17T13:15:27.5564Z",
+            "role" : "user",
+            "total_unread_count" : 0,
+            "online" : true,
+            "name" : "John Doe"
+        },
+        "mentioned_users" : [
+            
+        ],
+        "quoted_message" : {
+            "secret_note": "",
+            "updated_at" : "2021-01-02T07:23:41.411638Z",
+            "reply_count" : 0,
+            "html" : "<p>@thierry @1ae405d6-c279-3a8e-a27f-b91ec604de07 Hey!<\/p>\n",
+            "type" : "regular",
+            "own_reactions" : [
+                
+            ],
+            "pinned_at" : null,
+            "id" : "4C0CC2DA-8AB5-421F-808E-50DC7E40653D",
+            "user" : {
+                "banned" : false,
+                "online" : true,
+                "id" : "cilvia",
+                "role" : "user",
+                "created_at" : "2019-10-24T08:34:11.155375Z",
+                "image" : "https:\/\/ca.slack-edge.com\/T02RM6X6B-U01173D1D5J-0dead6eea6ea-512",
+                "value" : "cilvia",
+                "updated_at" : "2021-01-12T16:43:25.726221Z",
+                "last_active" : "2021-01-12T16:38:26.444716Z",
+                "name" : "Neil Hannah"
+            },
+            "shadowed" : false,
+            "pin_expires" : null,
+            "attachments" : [
+                
+            ],
+            "reaction_counts" : {
+                
+            },
+            "reaction_scores" : {
+                
+            },
+            "silent" : false,
+            "text" : "@thierry @1ae405d6-c279-3a8e-a27f-b91ec604de07 Hey!",
+            "pinned_by" : null,
+            "created_at" : "2021-01-02T07:23:41.411638Z",
+            "mentioned_users" : [
+                
+            ],
+            "pinned" : false,
+            "latest_reactions" : [
+                
+            ]
+        },
+        "quoted_message_id" : "4C0CC2DA-8AB5-421F-808E-50DC7E40653D",
+        "thread_participants" : [
+            {
+                "id" : "josh",
+                "role" : "user",
+                "created_at" : "2020-04-15T06:43:08.776911Z",
+                "updated_at" : "2020-12-08T16:23:50.80847Z",
+                "last_active" : "2020-12-08T10:23:12.28392Z",
+                "banned" : false,
+                "online" : false,
+                "name" : "Joshua",
+                "value" : "josh",
+                "image" : "https:\/\/ca.slack-edge.com\/T02RM6X6B-U0JNN4BFE-52b2c5f7e1f6-512"
+            }
+        ],
+        "html" : "<p>Hi<\/p>\n"
+    }
+}


### PR DESCRIPTION
# What this PR do:
- Fixes issue where malformed attachment data could cause Channel not to appear
# How to test it
1. Open 2 simulator device at same time and on each run the same instance of Demo App
1. Select any user 
1. Exit one of the simulators (A)
1. From the other one (B) send some messages for the selected user account
1. Start A again with the app and log in to the same user
1. Observe that all channels are displayed for the same user on both devices
