### PR TITLE
[CIS-655] Remove collection view hiding hack

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -206,6 +206,8 @@ var streamChatSourcesExcluded: [String] { [
 ] }
 
 var streamChatUIFilesExcluded: [String] { [
+    "ChatMessageList/CollectionViewLayout/ChatMessageListCollectionViewLayout_Tests.swift",
+    "ChatMessageList/CollectionViewLayout/MessageListScrollPreservation_Tests.swift",
     "ChatMessageList/MessageComposer/ChatMessageComposerSuggestionsViewController_Tests.swift",
     "ChatMessageList/MessageComposer/ChatMessageComposerCommandCollectionViewCell_Tests.swift",
     "ChatMessageList/MessageComposer/ChatMessageComposerMentionCellView_Tests.swift",

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.swift
@@ -17,16 +17,8 @@ open class _СhatMessageCollectionViewCell<ExtraData: ExtraDataTypes>: _Collecti
     // MARK: - Subviews
 
     public private(set) lazy var messageView = uiConfig.messageList.messageContentView.init().withoutAutoresizingMaskConstraints
-    private var hasCompletedStreamSetup = false
 
     // MARK: - Lifecycle
-
-    override open func didMoveToSuperview() {
-        super.didMoveToSuperview()
-
-        guard superview != nil, !hasCompletedStreamSetup else { return }
-        hasCompletedStreamSetup = true
-    }
 
     override open func setUpLayout() {
         contentView.addSubview(messageView)
@@ -53,22 +45,18 @@ open class _СhatMessageCollectionViewCell<ExtraData: ExtraDataTypes>: _Collecti
     override open func preferredLayoutAttributesFitting(
         _ layoutAttributes: UICollectionViewLayoutAttributes
     ) -> UICollectionViewLayoutAttributes {
-        guard hasCompletedStreamSetup else {
-            // We cannot calculate size properly right now, because our view hierarchy is not ready yet.
-            // If we just return default size, small text bubbles would not resize itself properly for no reason.
-            let attributes = layoutAttributes.copy() as! UICollectionViewLayoutAttributes
-            attributes.frame.size.height = 300
-            return attributes
-        }
-
         let preferredAttributes = super.preferredLayoutAttributesFitting(layoutAttributes)
 
         let targetSize = CGSize(
             width: layoutAttributes.frame.width,
             height: UIView.layoutFittingCompressedSize.height
         )
-
-        preferredAttributes.frame.size = contentView.systemLayoutSizeFitting(
+        
+        let prototype = prototypes[Self.reuseId] as? Self ?? Self()
+        prototypes[Self.reuseId] = prototype
+        prototype.message = message
+        prototype.streamSetup()
+        preferredAttributes.frame.size = prototype.contentView.systemLayoutSizeFitting(
             targetSize,
             withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
@@ -77,6 +65,8 @@ open class _СhatMessageCollectionViewCell<ExtraData: ExtraDataTypes>: _Collecti
         return preferredAttributes
     }
 }
+
+private var prototypes = [String: UICollectionViewCell]()
 
 class СhatIncomingMessageCollectionViewCell<ExtraData: ExtraDataTypes>: _СhatMessageCollectionViewCell<ExtraData> {
     override func setUpLayout() {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -82,7 +82,6 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: _ViewController,
         collection.keyboardDismissMode = .onDrag
         collection.dataSource = self
         collection.delegate = self
-        collection.isHidden = true
 
         return collection
     }()
@@ -100,16 +99,6 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: _ViewController,
     open var minTimeInvteralBetweenMessagesInGroup: TimeInterval = 10
 
     // MARK: - Life Cycle
-
-    override open func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        if hideInitialLayout {
-            collectionView.reloadData()
-            collectionView.isHidden = false
-            hideInitialLayout = false
-        }
-    }
 
     override open func setUp() {
         super.setUp()

--- a/Sources/StreamChatUI/ChatMessageList/ChatVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatVC.swift
@@ -117,6 +117,10 @@ open class _ChatVC<ExtraData: ExtraDataTypes>: _ViewController,
     override open func setUpLayout() {
         super.setUpLayout()
         
+        // Not a nice solution but as composer changes its intrinsicContentSize several times after getting on screen
+        // it creates ugly jump of message list, this way we can workaround it until this behavior is fixed
+        messageComposerViewController.view.layoutIfNeeded()
+        
         messageList.view.translatesAutoresizingMaskIntoConstraints = false
         messageComposerViewController.view.translatesAutoresizingMaskIntoConstraints = false
         

--- a/Sources/StreamChatUI/ChatMessageList/CollectionViewLayout/ChatMessageListCollectionViewLayout_Tests.swift
+++ b/Sources/StreamChatUI/ChatMessageList/CollectionViewLayout/ChatMessageListCollectionViewLayout_Tests.swift
@@ -1,0 +1,74 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+import XCTest
+
+@testable import StreamChatUI
+
+final class ChatMessageListCollectionViewLayout_Tests: XCTestCase {
+    private var subject: ChatMessageListCollectionViewLayout!
+    private var scrollPreservation: TestScrollPreservation!
+    
+    // MARK: - Setup
+    
+    override func setUp() {
+        super.setUp()
+        
+        scrollPreservation = .init()
+        subject = .init(scrollPreservation: scrollPreservation)
+    }
+    
+    // MARK: - Tests
+    
+    func testPrepareLayoutForCollectionViewUpdatesPreservesScrollOffset() {
+        let prepareExpectation = expectation(description: "Check prepare is called")
+        scrollPreservation.prepareForUpdatesBody = { _ in prepareExpectation.fulfill() }
+        subject.prepare(forCollectionViewUpdates: [])
+        wait(for: [prepareExpectation], timeout: 0.5)
+    }
+    
+    func testFinalizeCollectionViewUpdatesPreservesScrollOffset() {
+        let finalizeExpectation = expectation(description: "Check finalize is called")
+        scrollPreservation.finalizeUpdatesBody = { _, _ in finalizeExpectation.fulfill() }
+        subject.finalizeCollectionViewUpdates()
+        wait(for: [finalizeExpectation], timeout: 0.5)
+    }
+    
+    func testFinalizeCollectionViewAnimatesScrollToMostRecentMessage() {
+        let finalizeExpectation = expectation(description: "Check finalize is called")
+        scrollPreservation.finalizeUpdatesBody = { _, animated in
+            XCTAssertTrue(animated)
+            finalizeExpectation.fulfill()
+        }
+        subject.appearingItems.insert(subject.mostRecentItem)
+        subject.finalizeCollectionViewUpdates()
+        wait(for: [finalizeExpectation], timeout: 0.5)
+    }
+    
+    func testFinalizeCollectionViewDoesntAnimateScrollIfMostRecentMessageHaventChanged() {
+        let finalizeExpectation = expectation(description: "Check finalize is called")
+        scrollPreservation.finalizeUpdatesBody = { _, animated in
+            XCTAssertFalse(animated)
+            finalizeExpectation.fulfill()
+        }
+        subject.appearingItems.insert(IndexPath(item: 1, section: 0))
+        subject.finalizeCollectionViewUpdates()
+        wait(for: [finalizeExpectation], timeout: 0.5)
+    }
+}
+
+private final class TestScrollPreservation: MessageListScrollPreservation {
+    var prepareForUpdatesBody: (ChatMessageListCollectionViewLayout) -> Void = { _ in }
+    
+    func prepareForUpdates(in layout: ChatMessageListCollectionViewLayout) {
+        prepareForUpdatesBody(layout)
+    }
+    
+    var finalizeUpdatesBody: (ChatMessageListCollectionViewLayout, Bool) -> Void = { _, _ in }
+    
+    func finalizeUpdates(in layout: ChatMessageListCollectionViewLayout, animated: Bool) {
+        finalizeUpdatesBody(layout, animated)
+    }
+}

--- a/Sources/StreamChatUI/ChatMessageList/CollectionViewLayout/MessageListScrollPreservation.swift
+++ b/Sources/StreamChatUI/ChatMessageList/CollectionViewLayout/MessageListScrollPreservation.swift
@@ -1,0 +1,34 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+/// Protocol wrapping scroll offset preservation when changes to `ChatMessageListCollectionViewLayout` occur
+public protocol MessageListScrollPreservation {
+    /// Prepare for updates - useful for storing enough information to be able to decide about scroll offset later
+    func prepareForUpdates(in layout: ChatMessageListCollectionViewLayout)
+    /// Here you should perform any updates to scroll offset
+    func finalizeUpdates(in layout: ChatMessageListCollectionViewLayout, animated: Bool)
+}
+
+/// Strategy that scrolls to most recent message after update if most recent message was visible before the update
+open class MessageListMostRecentMessagePreservation: MessageListScrollPreservation {
+    open var mostRecentMessageWasVisible = false
+    
+    public init() {
+        
+    }
+    
+    open func prepareForUpdates(in layout: ChatMessageListCollectionViewLayout) {
+        mostRecentMessageWasVisible = layout.collectionView?.indexPathsForVisibleItems.contains(layout.mostRecentItem) ?? false
+    }
+    
+    open func finalizeUpdates(in layout: ChatMessageListCollectionViewLayout, animated: Bool) {
+        if mostRecentMessageWasVisible {
+            layout.collectionView?.scrollToItem(at: layout.mostRecentItem, at: .bottom, animated: animated)
+        }
+        
+        mostRecentMessageWasVisible = false
+    }
+}

--- a/Sources/StreamChatUI/ChatMessageList/CollectionViewLayout/MessageListScrollPreservation_Tests.swift
+++ b/Sources/StreamChatUI/ChatMessageList/CollectionViewLayout/MessageListScrollPreservation_Tests.swift
@@ -1,0 +1,93 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+import StreamChatUI
+import XCTest
+
+final class MessageListMostRecentMessagePreservation_Tests: XCTestCase {
+    private var subject: MessageListMostRecentMessagePreservation!
+    private var layout: TestLayout!
+    private var collectionView: TestCV!
+    
+    // MARK: - Setup
+    
+    override func setUp() {
+        super.setUp()
+        
+        subject = .init()
+        layout = .init()
+        collectionView = .init(frame: .zero, collectionViewLayout: layout)
+    }
+    
+    // MARK: - Tests
+    
+    func testMostRecentMessageIsVisibleWhenItWasOnScreen() {
+        collectionView._indexPathsForVisibleItems = [layout.mostRecentItem]
+        subject.prepareForUpdates(in: layout)
+        XCTAssertTrue(subject.mostRecentMessageWasVisible)
+    }
+    
+    func testMostRecentMessageIsVisibleWhenItWasntOnScreen() {
+        collectionView._indexPathsForVisibleItems = [IndexPath(item: 1, section: 0)]
+        subject.prepareForUpdates(in: layout)
+        XCTAssertFalse(subject.mostRecentMessageWasVisible)
+    }
+    
+    func testFinalizeWhenMostRecentMessageIsVisible() {
+        let scrollExpectation = expectation(description: "Subject should scroll to most recent indexPath")
+        subject.mostRecentMessageWasVisible = true
+        collectionView.scrollToItemBody = { indexPath, position, _ in
+            XCTAssertEqual(indexPath, IndexPath(item: 0, section: 0))
+            XCTAssertEqual(position, .bottom)
+            scrollExpectation.fulfill()
+        }
+        subject.finalizeUpdates(in: layout, animated: false)
+        wait(for: [scrollExpectation], timeout: 0.5)
+    }
+    
+    func testFinalizeWhenMostRecentMessageIsNotVisible() {
+        let scrollExpectation = expectation(description: "Subject should not scroll at all")
+        scrollExpectation.isInverted = true
+        subject.mostRecentMessageWasVisible = false
+        collectionView.scrollToItemBody = { _, _, _ in
+            scrollExpectation.fulfill()
+        }
+        subject.finalizeUpdates(in: layout, animated: false)
+        wait(for: [scrollExpectation], timeout: 0.5)
+    }
+    
+    func testFinalizePassesAnimatedValue() {
+        let scrollExpectation = expectation(description: "Subject should scroll to most recent indexPath")
+        let willAnimate = [true, false].randomElement()!
+        subject.mostRecentMessageWasVisible = true
+        collectionView.scrollToItemBody = { _, _, animated in
+            XCTAssertEqual(animated, willAnimate)
+            scrollExpectation.fulfill()
+        }
+        subject.finalizeUpdates(in: layout, animated: willAnimate)
+        wait(for: [scrollExpectation], timeout: 0.5)
+    }
+    
+    func testFinalizeResetsMostRecentMessageVisibility() {
+        subject.mostRecentMessageWasVisible = true
+        subject.finalizeUpdates(in: layout, animated: false)
+        XCTAssertFalse(subject.mostRecentMessageWasVisible)
+    }
+}
+
+private final class TestLayout: ChatMessageListCollectionViewLayout {
+}
+
+private final class TestCV: UICollectionView {
+    var _indexPathsForVisibleItems = [IndexPath]()
+    
+    override var indexPathsForVisibleItems: [IndexPath] { _indexPathsForVisibleItems }
+    
+    var scrollToItemBody: (IndexPath, UICollectionView.ScrollPosition, Bool) -> Void = { _, _, _ in }
+    
+    override func scrollToItem(at indexPath: IndexPath, at scrollPosition: UICollectionView.ScrollPosition, animated: Bool) {
+        scrollToItemBody(indexPath, scrollPosition, animated)
+    }
+}

--- a/Sources/StreamChatUI/CommonViews/BaseViews.swift
+++ b/Sources/StreamChatUI/CommonViews/BaseViews.swift
@@ -101,15 +101,8 @@ open class _CollectionViewCell: UICollectionViewCell, AppearanceSetting, Customi
     
     override open func didMoveToSuperview() {
         super.didMoveToSuperview()
-        guard !isInitialized, superview != nil else { return }
-        
-        isInitialized = true
-        
-        setUp()
-        setUpLayout()
-        (self as! Self).applyDefaultAppearance()
-        setUpAppearance()
-        updateContent()
+        guard superview != nil else { return }
+        streamSetup()
     }
     
     public func defaultAppearance() { /* default empty implementation */ }
@@ -134,6 +127,18 @@ open class _CollectionViewCell: UICollectionViewCell, AppearanceSetting, Customi
     override open func layoutSubviews() {
         TraitCollectionReloadStack.executePendingUpdates()
         super.layoutSubviews()
+    }
+    
+    open func streamSetup() {
+        guard !isInitialized else { return }
+        
+        isInitialized = true
+        
+        setUp()
+        setUpLayout()
+        (self as! Self).applyDefaultAppearance()
+        setUpAppearance()
+        updateContent()
     }
 }
 

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -58,6 +58,9 @@
 		22C2359A259CA87B00DC805A /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C23599259CA87B00DC805A /* Animation.swift */; };
 		22CAFA7625CAE278005935D9 /* RawJSON_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */; };
 		22FF4365256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */; };
+		692A563525ECF83A00E887BD /* MessageListScrollPreservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692A563425ECF83A00E887BD /* MessageListScrollPreservation.swift */; };
+		692A567225ED032F00E887BD /* ChatMessageListCollectionViewLayout_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692A564425ED016600E887BD /* ChatMessageListCollectionViewLayout_Tests.swift */; };
+		692A568225ED058700E887BD /* MessageListScrollPreservation_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692A568125ED058700E887BD /* MessageListScrollPreservation_Tests.swift */; };
 		7900452625374CA20096ECA1 /* User+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900452525374CA20096ECA1 /* User+SwiftUI.swift */; };
 		7908820625432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
 		7908821225432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
@@ -966,6 +969,9 @@
 		22C23599259CA87B00DC805A /* Animation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
 		22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawJSON_Tests.swift; sourceTree = "<group>"; };
 		22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageComposerSuggestionsViewController.swift; sourceTree = "<group>"; };
+		692A563425ECF83A00E887BD /* MessageListScrollPreservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListScrollPreservation.swift; sourceTree = "<group>"; };
+		692A564425ED016600E887BD /* ChatMessageListCollectionViewLayout_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListCollectionViewLayout_Tests.swift; sourceTree = "<group>"; };
+		692A568125ED058700E887BD /* MessageListScrollPreservation_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListScrollPreservation_Tests.swift; sourceTree = "<group>"; };
 		7900452525374CA20096ECA1 /* User+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+SwiftUI.swift"; sourceTree = "<group>"; };
 		790881FD25432B7200896F03 /* StreamChatUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7908820525432B7200896F03 /* StreamChatUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1821,6 +1827,17 @@
 			path = Attachments;
 			sourceTree = "<group>";
 		};
+		692A562C25ECF7F700E887BD /* CollectionViewLayout */ = {
+			isa = PBXGroup;
+			children = (
+				79088330254876C100896F03 /* ChatMessageListCollectionViewLayout.swift */,
+				692A564425ED016600E887BD /* ChatMessageListCollectionViewLayout_Tests.swift */,
+				692A563425ECF83A00E887BD /* MessageListScrollPreservation.swift */,
+				692A568125ED058700E887BD /* MessageListScrollPreservation_Tests.swift */,
+			);
+			path = CollectionViewLayout;
+			sourceTree = "<group>";
+		};
 		790881AB254327C800896F03 /* StreamChat */ = {
 			isa = PBXGroup;
 			children = (
@@ -1931,7 +1948,7 @@
 				DBC8A5752581476E00B20A82 /* ChatMessageListVC.swift */,
 				DB9A3D552582689A00555D36 /* ChatMessageListRouter.swift */,
 				79088331254876C100896F03 /* ChatMessageListCollectionView.swift */,
-				79088330254876C100896F03 /* ChatMessageListCollectionViewLayout.swift */,
+				692A562C25ECF7F700E887BD /* CollectionViewLayout */,
 				DB9A3D652582783F00555D36 /* ChatVC.swift */,
 				7908832D254876C100896F03 /* ChatChannelVC.swift */,
 				882AE056257A176A004095B3 /* ChatChannelRouter.swift */,
@@ -4183,6 +4200,7 @@
 				8825334C258CE82500B77352 /* ChatMessageActionsRouter.swift in Sources */,
 				DB9A3D662582783F00555D36 /* ChatVC.swift in Sources */,
 				88BA7F87258B97C9006CE0C5 /* ChatMessageImageGallery+UploadingOverlay.swift in Sources */,
+				692A563525ECF83A00E887BD /* MessageListScrollPreservation.swift in Sources */,
 				88A8CF26256E7C31004EA4C7 /* ChatMessageMetadataView.swift in Sources */,
 				8806570D259A51C200E31D23 /* ChatMessageInteractiveAttachmentView+ActionButton.swift in Sources */,
 				E79AC10C25831A1500C3CE5D /* ChatMessageComposerSuggestionsCollectionView.swift in Sources */,
@@ -4271,6 +4289,7 @@
 				AD154C6D25DC3BA000850925 /* ChatMessageComposerCommandCollectionViewCell_Tests.swift in Sources */,
 				ADFCCD7625C9D4D10024505D /* SnapshotVariant.swift in Sources */,
 				2208246A25DFD0060033544B /* ChatChannelListRouter_Mock.swift in Sources */,
+				692A568225ED058700E887BD /* MessageListScrollPreservation_Tests.swift in Sources */,
 				ADAA377125E43C3700C31528 /* ChatMessageComposerSuggestionsViewController_Tests.swift in Sources */,
 				E7AD958925D7510900076DC3 /* ChatMessageComposerMentionCellView_Tests.swift in Sources */,
 				E791E4D625D3E2DA00B0E076 /* ChatChannelAvatarView_Tests.swift in Sources */,
@@ -4280,6 +4299,7 @@
 				227299BC25DBFE0C005EAFCF /* ChatChannelSwipeableListItemView_Tests.swift in Sources */,
 				ADFCCD7525C9D4D10024505D /* AssertSnapshot.swift in Sources */,
 				79B4F14A25D3F1120063FFB5 /* TemporaryData.swift in Sources */,
+				692A567225ED032F00E887BD /* ChatMessageListCollectionViewLayout_Tests.swift in Sources */,
 				AD16174125D6A7ED007E9FA8 /* ChatChannelCreateNewButton_Tests.swift in Sources */,
 				795296C12582494000435B2E /* UIConfigProvider_Tests.swift in Sources */,
 				225503B825DC59FD00A5A65A /* Helpers.swift in Sources */,


### PR DESCRIPTION
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

- removes hidden `collectionView` hack from `ChatMessageListVC`
- uses prototype cells for self-sizing of cells as this approach seems to be more reliable
- initial jump caused by loading older messages is solved by preserving scroll offset when `performBatchUpdates` occurs on `ChatMessageListCollectionViewLayout`
    - currently I went for a simple solution - if most recent message was visible before update, I make sure most recent message is visible after update
    - this preservation is responsibility of newly created object `MessageListMostRecentMessagePreservation` so it can be easily tested and extended when implementing [other message list updates](https://www.notion.so/Updates-in-Message-list-6596b29411d94d4283dfaca17ad5eaa1)
    - scrolling needs to be done in layout (even though I'd rather seen it elsewhere) as this seems to be the only option how user will not notice it
- currently I commented out the `initialAttributesForAppearingItem` and `finalLayoutAttributesForDisappearingItem` as they caused newly added elements to appear briefly on initial message list load - adding it back will be my next quest.
