### PR TITLE
[CIS-689] Refactor ChatChannelNamer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Upcoming
 
 ### 🔄 Changed
+- `ChatChannelNamer` is now closure instead of class so it allows better customization of channel naming in `ChatChannelListItemView`.
 
 # [3.1.1](https://github.com/GetStream/stream-chat-swift/releases/tag/3.1.1)
 _February 26, 2021_

--- a/Package.swift
+++ b/Package.swift
@@ -299,6 +299,7 @@ var streamChatUIFilesExcluded: [String] { [
     "CommonViews/__Snapshots__/CurrentChatUserAvatarView_Tests/test_customizationUsingSubclassingHook.default-dark.png",
     "CommonViews/__Snapshots__/CurrentChatUserAvatarView_Tests/test_customizationUsingAppearanceHook.default-dark.png",
     "Utils/UIConfigProvider_Tests.swift",
+    "Utils/ChatChannelNamer_Tests.swift",
     "ChatChannelList/ChatChannelListCollectionViewCell_Tests.swift",
     "ChatChannelList/ChatChannelSwipeableListItemView_Tests.swift",
     "ChatChannelList/ChatChannelUnreadCountView_Tests.swift",

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -189,8 +189,7 @@ open class _ChatChannelListItemView<ExtraData: ExtraDataTypes>: _ChatChannelSwip
     
     override open func updateContent() {
         if let channel = content.channel {
-            let namer = uiConfig.channelList.channelNamer.init()
-            titleLabel.text = namer.name(for: channel, as: content.currentUserId)
+            titleLabel.text = uiConfig.channelList.channelNamer(channel, content.currentUserId)
         } else {
             titleLabel.text = nil
         }

--- a/Sources/StreamChatUI/ChatMessageList/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatChannelVC.swift
@@ -25,8 +25,11 @@ open class _ChatChannelVC<ExtraData: ExtraDataTypes>: _ChatVC<ExtraData> {
         _ handler: @escaping (ChatChannelNavigationBarListener<ExtraData>.NavbarData) -> Void
     ) -> ChatChannelNavigationBarListener<ExtraData>? {
         guard let channel = channelController.channel else { return nil }
-        let namer = uiConfig.messageList.channelNamer.init()
-        let navbarListener = ChatChannelNavigationBarListener.make(for: channel.cid, in: channelController.client, using: namer)
+        let navbarListener = ChatChannelNavigationBarListener.make(
+            for: channel.cid,
+            in: channelController.client,
+            using: uiConfig.channelList.channelNamer
+        )
         navbarListener.onDataChange = handler
         return navbarListener
     }

--- a/Sources/StreamChatUI/Generated/L10n.swift
+++ b/Sources/StreamChatUI/Generated/L10n.swift
@@ -24,10 +24,12 @@ internal enum L10n {
     internal enum Name {
       /// and
       internal static let and = L10n.tr("Localizable", "channel.name.and")
+      /// and %@ more
+      internal static func andXMore(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "channel.name.andXMore", String(describing: p1))
+      }
       /// NoChannel
       internal static let missing = L10n.tr("Localizable", "channel.name.missing")
-      /// more
-      internal static let more = L10n.tr("Localizable", "channel.name.more")
     }
   }
 

--- a/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
@@ -3,7 +3,7 @@
 //
 
 "channel.name.and" = "and";
-"channel.name.more" = "more";
+"channel.name.andXMore" = "and %@ more";
 "channel.name.missing" = "NoChannel";
 
 "message.actions.inline-reply" = "Reply";

--- a/Sources/StreamChatUI/UIConfig+ChannelList.swift
+++ b/Sources/StreamChatUI/UIConfig+ChannelList.swift
@@ -28,11 +28,8 @@ public extension _UIConfig {
 
         /// A button used for creating new channels.
         public var newChannelButton: UIButton.Type = _ChatChannelCreateNewButton<ExtraData>.self
-
         /// The logic to generate a name for the given channel.
-        public var channelNamer: ChatChannelNamer.Type = ChatChannelNamer.self
-
-        /// The subviews that make the list item view.
+        public var channelNamer: ChatChannelNamer<ExtraData> = DefaultChatChannelNamer()
         public var channelListItemSubviews = ChannelListItemSubviews()
     }
     

--- a/Sources/StreamChatUI/UIConfig+MessageList.swift
+++ b/Sources/StreamChatUI/UIConfig+MessageList.swift
@@ -20,7 +20,7 @@ public extension _UIConfig {
 
         public var collectionView: ChatMessageListCollectionView.Type = ChatMessageListCollectionView.self
         public var collectionLayout: ChatMessageListCollectionViewLayout.Type = ChatMessageListCollectionViewLayout.self
-        public var channelNamer: ChatChannelNamer.Type = ChatChannelNamer.self
+        public var channelNamer: ChatChannelNamer<ExtraData> = DefaultChatChannelNamer()
         public var messageContentView: _ChatMessageContentView<ExtraData>.Type = _ChatMessageContentView<ExtraData>.self
         public var messageAttachmentContentView: _ChatMessageAttachmentContentView<ExtraData>
             .Type = _ChatMessageAttachmentContentView<ExtraData>.self

--- a/Sources/StreamChatUI/Utils/ChatChannelNamer.swift
+++ b/Sources/StreamChatUI/Utils/ChatChannelNamer.swift
@@ -5,24 +5,45 @@
 import Foundation
 import StreamChat
 
-open class ChatChannelNamer {
-    open var maxMemberNames: Int { 2 }
-    open var separator: String { "," }
-    
-    public required init() {}
-    
-    /// Generates a name for the given channel, given the current user's id.
-    ///
-    /// The priority order is:
-    /// - Assigned name of the channel, if not empty
-    /// - If the channel is direct message (implicit cid):
-    ///   - Name generated from cached members of the channel
-    /// - Channel's id
-    /// - Parameters:
-    ///   - channel: Channel to generate name for.
-    ///   - currentUserId: Logged-in user. This parameter is used when deciding which member's names are going to be displayed.
-    /// - Returns: A valid Channel name.
-    open func name<ExtraData: ExtraDataTypes>(for channel: _ChatChannel<ExtraData>, as currentUserId: UserId?) -> String {
+/// Typealias for closure taking `_ChatChannel<ExtraData>` and `UserId` which returns
+/// the current name of the channel. Use this type when you create closure for naming a channel.
+/// For example usage, see `DefaultChatChannelNamer`
+public typealias ChatChannelNamer = _ChatChannelNamer
+
+/// Typealias for closure taking `_ChatChannel<ExtraData>` and `UserId` which returns
+/// the current name of the channel. Use this type when you create closure for naming a channel.
+/// For example usage, see `DefaultChatChannelNamer`
+public typealias _ChatChannelNamer<ExtraData: ExtraDataTypes> =
+    (_ channel: _ChatChannel<ExtraData>, _ currentUserId: UserId?) -> String?
+
+/// Generates a name for the given channel, given the current user's id.
+///
+/// The priority order is:
+/// - Assigned name of the channel, if not empty
+/// - If the channel is direct message (implicit cid):
+///   - Name generated from cached members of the channel
+/// - Channel's id
+///
+/// Examples:
+/// - If channel has some name, ie. `Channel 1`, this returns `Channel 1`
+/// - If channel has no name and is not direct message, this returns channel ID of the channel
+/// - If channel is direct message, has no name and has members where there just 2,
+/// returns name of the members in alphabetic order: `Leia, Luke`
+/// - If channel is direct message, has no name and has members where there are more than 2,
+/// returns name of the members in alphabetic order with how many members left: `Leia, Luke and 5 others`
+///  - If channel is direct message, has no name and no members, this returns `nil`
+///  - If channel is direct message, has no name and only one member, shows the one member name
+///
+/// - Parameters:
+///   - maxMemberNames: Maximum number of visible members in Channel defaults to `2`
+///   - separator: Separator of the members, defaults to `y`
+/// - Returns: A closure with 2 parameters carrying `channel` used for name generation and `currentUserId` to decide
+/// which members' names are going to be displayed
+public func DefaultChatChannelNamer<ExtraData: ExtraDataTypes>(
+    maxMemberNames: Int = 2,
+    separator: String = ","
+) -> _ChatChannelNamer<ExtraData> {
+    return { channel, currentUserId in
         if let channelName = channel.name, !channelName.isEmpty {
             // If there's an assigned name and it's not empty, we use it
             return channelName
@@ -37,40 +58,45 @@ open class ChatChannelNamer {
                 if let currentUser = channel.cachedMembers.first(where: { $0.id == currentUserId }) {
                     channelName = nameOrId(currentUser.name, currentUser.id)
                 } else {
-                    channelName = currentUserId ?? channel.cid.id
+                    return nil
                 }
             } else {
-                // This channel has more than 2 members
-                // Name it as "Luke, Leia, .. and <n> more"
-                channelName = prefixedMemberNames
-                    .joined(separator: "\(separator) ")
-                    + (
-                        memberNames.count > maxMemberNames
-                            ? " \(L10n.Channel.Name.and) \(memberNames.count - maxMemberNames) \(L10n.Channel.Name.more)"
-                            : ""
-                    )
+                // This channel has exactly 2 members
+                // Name it as "Darth Maul and Darth Vader
+                if memberNames.count == 2 {
+                    channelName = "\(prefixedMemberNames.first!) \(L10n.Channel.Name.and) \(prefixedMemberNames.last!)"
+                    // This channel has more than 2 members
+                    // Name it as "Darth Maul, Darth Vader and <n> more"
+                } else {
+                    channelName = prefixedMemberNames
+                        .joined(separator: "\(separator) ")
+                        + (
+                            memberNames.count > maxMemberNames
+                                ? " \(L10n.Channel.Name.andXMore(memberNames.count - maxMemberNames))"
+                                : ""
+                        )
+                }
             }
-            
             return channelName
         } else {
             // We don't have a valid name assigned, and this is not a DM channel
-            // makes sense to use channel's id (so for messaging:general we'll have general)
-            return channel.cid.id
+            // makes sense to return `nil` because `channelId` could be confusing for our users.
+            return nil
         }
     }
-    
-    /// Entities such as `User`, `Member` and `Channel` have both `name` and `id`, and `name` is preferred for display.
-    /// However, `name` and exists but can be empty, in that case we display `id`.
-    /// This helper encapsulates choosing logic between `name` and `id`
-    /// - Parameters:
-    ///   - name: name of the entity.
-    ///   - id: id of the entity
-    /// - Returns: `name` if it exists and not empty, otherwise `id`
-    private func nameOrId(_ name: String?, _ id: String) -> String {
-        if let name = name, !name.isEmpty {
-            return name
-        } else {
-            return id
-        }
+}
+
+/// Entities such as `User`, `Member` and `Channel` have both `name` and `id`, and `name` is preferred for display.
+/// However, `name` and exists but can be empty, in that case we display `id`.
+/// This helper encapsulates choosing logic between `name` and `id`
+/// - Parameters:
+///   - name: name of the entity.
+///   - id: id of the entity
+/// - Returns: `name` if it exists and not empty, otherwise `id`
+private func nameOrId(_ name: String?, _ id: String) -> String {
+    if let name = name, !name.isEmpty {
+        return name
+    } else {
+        return id
     }
 }

--- a/Sources/StreamChatUI/Utils/ChatChannelNamer_Tests.swift
+++ b/Sources/StreamChatUI/Utils/ChatChannelNamer_Tests.swift
@@ -1,0 +1,207 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import StreamChatTestTools
+@testable import StreamChatUI
+import XCTest
+
+class ChatChannelNamer_Tests: XCTestCase {
+
+    var defaultMembers: Set<ChatChannelMember>!
+
+    override func setUp() {
+        super.setUp()
+        
+        defaultMembers = [
+            .mock(
+                id: .unique,
+                name: "Darth Vader",
+                imageURL: nil,
+                isOnline: true
+            ),
+            .mock(
+                id: .unique,
+                name: "Darth Maul",
+                imageURL: nil,
+                isOnline: true
+            ),
+            .mock(
+                id: .unique,
+                name: "Kylo Ren",
+                imageURL: nil,
+                isOnline: true
+            )
+        ]
+    }
+
+    func test_defaultChannelNamer_whenChannelHasName_showsChannelName() {
+        // Create channel and currentUserId
+        let channel = ChatChannel.mock(
+            cid: .unique,
+            name: "Darth Channel",
+            imageURL: TestImages.vader.url,
+            members: defaultMembers
+        )
+
+        let currentUserId: String = .unique
+        let namer: ChatChannelNamer<NoExtraData> = DefaultChatChannelNamer()
+        let nameForChannel = namer(channel, currentUserId)
+
+        XCTAssertEqual(nameForChannel, "Darth Channel")
+    }
+
+    func test_defaultChannelNamer_directChannel_whenChannelHasNoName_andExactly2Members_showsCurrentMembers() {
+        // Create channel and currentUserId
+
+        defaultMembers = [
+            .mock(
+                id: .unique,
+                name: "Darth Vader",
+                imageURL: nil,
+                isOnline: true
+            ),
+            .mock(
+                id: .unique,
+                name: "Darth Maul",
+                imageURL: nil,
+                isOnline: true
+            )
+        ]
+
+        let channel = ChatChannel.mockDMChannel(
+            name: nil,
+            members: defaultMembers
+        )
+
+        let currentUserId: String = .unique
+
+        let namer: ChatChannelNamer<NoExtraData> = DefaultChatChannelNamer()
+        let nameForChannel = namer(channel, currentUserId)
+
+        XCTAssertEqual(nameForChannel, "Darth Maul and Darth Vader")
+    }
+
+    func test_defaultChannelNamer_directChannel_whenChannelHasNoName_whenChannelHasNoMembers_showsCurrentUserId() {
+        // Create channel and currentUserId
+        let channel = ChatChannel.mockDMChannel(
+            name: nil
+        )
+
+        let currentUserId: String = .unique
+
+        let namer: ChatChannelNamer<NoExtraData> = DefaultChatChannelNamer()
+        let nameForChannel = namer(channel, currentUserId)
+
+        XCTAssertEqual(nameForChannel, nil)
+    }
+
+    func test_defaultChannelNamer_directChannel_whenChannelHasNoName_whenChannelHasOnlyCurrentMember_showsCurrentMemberName() {
+        // Create channel and currentUserId
+        let currentUser: _ChatChannelMember<NoExtraData> = .mock(id: .unique, name: "Luke Skywalker")
+
+        let channel = ChatChannel.mockDMChannel(
+            name: nil,
+            members: [currentUser]
+        )
+
+        let currentUserId: String = currentUser.id
+
+        let namer: ChatChannelNamer<NoExtraData> = DefaultChatChannelNamer()
+        let nameForChannel = namer(channel, currentUserId)
+
+        XCTAssertEqual(nameForChannel, currentUser.name)
+    }
+
+    func test_defaultChannelNamer_directChannel_whenChannelHasNoName_andMoreThan2Members_showsMembersAndNMore() {
+        // Create channel and currentUserId
+        let channel = ChatChannel.mockDMChannel(
+            name: nil,
+            members: defaultMembers
+        )
+
+        let currentUserId: String = .unique
+
+        let namer: ChatChannelNamer<NoExtraData> = DefaultChatChannelNamer()
+        let nameForChannel = namer(channel, currentUserId)
+
+        XCTAssertEqual(nameForChannel, "Darth Maul, Darth Vader and 1 more")
+    }
+    
+    func test_defaultChannelNamer_whenChannelHasNoName_AndNotDM_returnsNil() {
+        // Create channel ID, channel and currentUserId
+        let channelID: String = .unique
+
+        let channel = ChatChannel.mock(
+            cid: ChannelId(type: .gaming, id: channelID),
+            name: nil
+        )
+
+        let currentUserId: String = .unique
+
+        let namer: ChatChannelNamer<NoExtraData> = DefaultChatChannelNamer()
+        let nameForChannel = namer(channel, currentUserId)
+
+        XCTAssertEqual(nameForChannel, nil)
+    }
+
+    func test_defaultChannelNamer_withModifiedParameters_customSeparator() {
+
+        // Create channel ID, channel and currentUserId
+
+        let channel = ChatChannel.mockDMChannel(
+            name: nil,
+            members: defaultMembers
+        )
+
+        let currentUserId: String = .unique
+
+        let namer: ChatChannelNamer<NoExtraData> = DefaultChatChannelNamer(separator: " |")
+        let nameForChannel = namer(channel, currentUserId)
+
+        XCTAssertEqual(nameForChannel, "Darth Maul | Darth Vader and 1 more")
+    }
+
+    func test_defaultChannelNamer_withModifiedParameters_numberOfMaximumMembers() {
+        defaultMembers = [
+            .mock(
+                id: .unique,
+                name: "Darth Vader",
+                imageURL: nil,
+                isOnline: true
+            ),
+            .mock(
+                id: .unique,
+                name: "Darth Maul",
+                imageURL: nil,
+                isOnline: true
+            ),
+            .mock(
+                id: .unique,
+                name: "Kylo Ren",
+                imageURL: nil,
+                isOnline: true
+            ),
+            .mock(
+                id: .unique,
+                name: "Darth Bane",
+                imageURL: nil,
+                isOnline: true
+            )
+        ]
+        // Create channel ID, channel and currentUserId
+        let channel = ChatChannel.mockDMChannel(
+            name: nil,
+            members: defaultMembers
+        )
+
+        let currentUserId: String = .unique
+
+        let namer: ChatChannelNamer<NoExtraData> = DefaultChatChannelNamer(maxMemberNames: 4, separator: " |")
+        let nameForChannel = namer(channel, currentUserId)
+
+        XCTAssertEqual(nameForChannel, "Darth Bane | Darth Maul | Darth Vader | Kylo Ren")
+    }
+
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -744,6 +744,7 @@
 		E7166CD225BED4BD00B03B07 /* UIConfig+ChannelList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7166CD125BED4BD00B03B07 /* UIConfig+ChannelList.swift */; };
 		E7166CDA25BED62D00B03B07 /* UIConfig+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7166CD925BED62D00B03B07 /* UIConfig+Navigation.swift */; };
 		E7166CE225BEE20600B03B07 /* UIConfig+Images.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7166CE125BEE20600B03B07 /* UIConfig+Images.swift */; };
+		E73262E025ED64AB008CB152 /* ChatChannelNamer_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73262D725ED6432008CB152 /* ChatChannelNamer_Tests.swift */; };
 		E73A8B2B2578EB2B00FBDC56 /* ChatMessageComposerVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73A8B2A2578EB2B00FBDC56 /* ChatMessageComposerVC.swift */; };
 		E759AC4D256E694F00341865 /* ChatOnlineIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E759AC4C256E694F00341865 /* ChatOnlineIndicatorView.swift */; };
 		E791E4D625D3E2DA00B0E076 /* ChatChannelAvatarView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E791E4D525D3E2DA00B0E076 /* ChatChannelAvatarView_Tests.swift */; };
@@ -1666,6 +1667,7 @@
 		E7166CD125BED4BD00B03B07 /* UIConfig+ChannelList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIConfig+ChannelList.swift"; sourceTree = "<group>"; };
 		E7166CD925BED62D00B03B07 /* UIConfig+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIConfig+Navigation.swift"; sourceTree = "<group>"; };
 		E7166CE125BEE20600B03B07 /* UIConfig+Images.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIConfig+Images.swift"; sourceTree = "<group>"; };
+		E73262D725ED6432008CB152 /* ChatChannelNamer_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelNamer_Tests.swift; sourceTree = "<group>"; };
 		E73A8B2A2578EB2B00FBDC56 /* ChatMessageComposerVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageComposerVC.swift; sourceTree = "<group>"; };
 		E759AC4C256E694F00341865 /* ChatOnlineIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatOnlineIndicatorView.swift; sourceTree = "<group>"; };
 		E791E4D525D3E2DA00B0E076 /* ChatChannelAvatarView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelAvatarView_Tests.swift; sourceTree = "<group>"; };
@@ -3105,6 +3107,7 @@
 				88A11B092590AFBB0000AC24 /* ChatMessage+Extensions.swift */,
 				22C23599259CA87B00DC805A /* Animation.swift */,
 				79CCB66D259CBC4F0082F172 /* ChatChannelNamer.swift */,
+				E73262D725ED6432008CB152 /* ChatChannelNamer_Tests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -4284,6 +4287,7 @@
 				ADFCCD7625C9D4D10024505D /* SnapshotVariant.swift in Sources */,
 				2208246A25DFD0060033544B /* ChatChannelListRouter_Mock.swift in Sources */,
 				ADAA377125E43C3700C31528 /* ChatMessageComposerSuggestionsViewController_Tests.swift in Sources */,
+				E73262E025ED64AB008CB152 /* ChatChannelNamer_Tests.swift in Sources */,
 				E7AD958925D7510900076DC3 /* ChatMessageComposerMentionCellView_Tests.swift in Sources */,
 				E791E4D625D3E2DA00B0E076 /* ChatChannelAvatarView_Tests.swift in Sources */,
 				225504C725DEA03700A5A65A /* ChatChannelListItemView_Tests.swift in Sources */,

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,6 +27,7 @@ echo
 echo -e "👉 Create symlink for pre-commit hooks"
 # Symlink needs to be ../../hooks and not ./hooks because git evaluates them in .git/hooks
 ln -sf ../../hooks/pre-commit.sh .git/hooks/pre-commit
+ln -sf ../../hooks/pre-commit.sh .git/hooks/post-rewrite
 chmod +x .git/hooks/pre-commit
 chmod +x ./hooks/git-format-staged
 


### PR DESCRIPTION
# What this PR do:
- Makes `ChatChannelNamer` more customizable by changing the class into one global function with same purpose as suggested by @VojtaStavik in our slack Channel
# How to test it
- The tests should cover all cases, you can run the demo application and check if the channel names are the same. 
# Where you can start
- `ChatChannelNamer.swift`

Note: Maybe we could create some different `ChannelNamer` closure to show how the customization is done? 