### PR TITLE
[CIS-702] Add custom view modifier for SwiftUI usage of UIConfig

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -273,6 +273,7 @@ var streamChatUIFilesExcluded: [String] { [
     "ChatMessageList/MessageComposer/__Snapshots__/ChatMessageComposerSuggestionsViewController_Tests/test_mentions_emptyAppearance.default-light.png",
     "ChatMessageList/MessageComposer/__Snapshots__/ChatMessageComposerSuggestionsViewController_Tests/test_mentions_emptyAppearance.default-dark.png",
     "ChatMessageList/MessageComposer/__Snapshots__/ChatMessageComposerSuggestionsViewController_Tests/test_commands_appearanceCustomization_usingUIConfig.default-dark.png",
+    "UIConfig+SwiftUI_Tests.swift",
     "CommonViews/CurrentChatUserAvatarView_Tests.swift",
     "CommonViews/AvatarView/ChatChannelAvatarView_Tests.swift",
     "CommonViews/AvatarView/ChatUserAvatarView_Tests.swift",

--- a/Sources/StreamChatUI/UIConfig+SwiftUI.swift
+++ b/Sources/StreamChatUI/UIConfig+SwiftUI.swift
@@ -1,0 +1,57 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import SwiftUI
+
+@available(iOS 13.0, *)
+extension _UIConfig {
+
+    /// Used to initialize `_UIConfig` as `ObservableObject`.
+    public var asObservableObject: ObservableObject { .init(self) }
+
+    @dynamicMemberLookup
+    /// `_UIConfig` represented as `ObservableObject` class for SwiftUI requirements.
+    public class ObservableObject: SwiftUI.ObservableObject {
+
+        private let wrappedConfig: _UIConfig<ExtraData>
+
+        public subscript<T>(dynamicMember keyPath: KeyPath<_UIConfig<ExtraData>, T>) -> T {
+            wrappedConfig[keyPath: keyPath]
+        }
+
+        fileprivate init(_ wrappedConfig: _UIConfig<ExtraData>) {
+            self.wrappedConfig = wrappedConfig
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+/// Modifier for setting `UIConfig` environment object.
+private struct SwiftUIEnvironment<ExtraData: ExtraDataTypes>: ViewModifier {
+    /// Custom `ObservableObject` of `UIConfig`
+    private let config: _UIConfig<ExtraData>
+
+    public init(_ config: _UIConfig<ExtraData>) {
+        self.config = config
+    }
+
+    public func body(content: Content) -> some View {
+        content.environmentObject(config.asObservableObject)
+    }
+}
+
+@available(iOS 13.0, *)
+public extension View {
+    /// Sets up custom `UIConfig`.
+    func setUpStreamChatUIConfig<ExtraData: ExtraDataTypes>(
+        _ config: _UIConfig<ExtraData> = .default
+    ) -> some View {
+        self.modifier(SwiftUIEnvironment<ExtraData>(config))
+    }
+
+    func setUpStreamChatUIConfig() -> some View {
+        self.modifier(SwiftUIEnvironment<NoExtraData>(.default))
+    }
+}

--- a/Sources/StreamChatUI/UIConfig+SwiftUI_Tests.swift
+++ b/Sources/StreamChatUI/UIConfig+SwiftUI_Tests.swift
@@ -1,0 +1,49 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatUI
+import XCTest
+import SwiftUI
+
+@available(iOS 13, *)
+class UIConfig_SwiftUI_Tests: iOS13TestCase {
+
+    func test_correctInstanceIsUsed() {
+        class TestView: UIView {}
+
+        var referenceConfig = UIConfig()
+        referenceConfig.onlineIndicatorView = TestView.self
+
+        var usedConfig: UIConfig.ObservableObject?
+
+        struct UIConfigSpyView: View {
+            @EnvironmentObject var uiConfig: UIConfig.ObservableObject
+            let uiConfigCallback: (UIConfig.ObservableObject) -> Void
+            var body: some View {
+                uiConfigCallback(uiConfig)
+                return Text("I am your father!")
+            }
+        }
+
+        // Simulate the view is used
+        let view = UIConfigSpyView { usedConfig = $0 }
+            .setUpStreamChatUIConfig(referenceConfig)
+        view.simulateViewAddedToHierarchy()
+
+        // Assert the correct UIConfig is used
+        AssertAsync.willBeTrue(usedConfig?.onlineIndicatorView is TestView.Type)
+    }
+}
+
+@available(iOS 13.0, *)
+extension View {
+    /// Simulates the View was added to the view hierarchy and shown on the screen
+    func simulateViewAddedToHierarchy() {
+        let hostingVC = UIHostingController(rootView: self)
+        let window = UIWindow()
+        window.rootViewController = hostingVC
+        window.layoutIfNeeded()
+        window.isHidden = false
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		22C2359A259CA87B00DC805A /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C23599259CA87B00DC805A /* Animation.swift */; };
 		22CAFA7625CAE278005935D9 /* RawJSON_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */; };
 		22FF4365256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */; };
+		7844B16825EFB44600B87E89 /* UIConfig+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7844B16725EFB44600B87E89 /* UIConfig+SwiftUI.swift */; };
 		7900452625374CA20096ECA1 /* User+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900452525374CA20096ECA1 /* User+SwiftUI.swift */; };
 		7908820625432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
 		7908821225432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
@@ -976,6 +977,7 @@
 		22C23599259CA87B00DC805A /* Animation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
 		22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawJSON_Tests.swift; sourceTree = "<group>"; };
 		22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageComposerSuggestionsViewController.swift; sourceTree = "<group>"; };
+		7844B16725EFB44600B87E89 /* UIConfig+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIConfig+SwiftUI.swift"; sourceTree = "<group>"; };
 		7900452525374CA20096ECA1 /* User+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+SwiftUI.swift"; sourceTree = "<group>"; };
 		790881FD25432B7200896F03 /* StreamChatUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7908820525432B7200896F03 /* StreamChatUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1875,6 +1877,7 @@
 				E7166CD125BED4BD00B03B07 /* UIConfig+ChannelList.swift */,
 				E7166CD925BED62D00B03B07 /* UIConfig+Navigation.swift */,
 				AD9A0FA325EE9FD800883C57 /* UIConfig+CurrentUser.swift */,
+				7844B16725EFB44600B87E89 /* UIConfig+SwiftUI.swift */,
 				888123D0255D42F000070D5A /* Utils */,
 				888123E5255D51BD00070D5A /* CommonViews */,
 				7908830C2548707B00896F03 /* ChatMessageList */,
@@ -4295,6 +4298,7 @@
 				228C7F022584132F00AAE9E3 /* ChatMessageComposerQuoteBubbleView.swift in Sources */,
 				885B3D7725642B3D003E6BDF /* CurrentChatUserAvatarView.swift in Sources */,
 				DBC8A4C6257E696900B20A82 /* ChatMessageThreadInfoView.swift in Sources */,
+				7844B16825EFB44600B87E89 /* UIConfig+SwiftUI.swift in Sources */,
 				224FF6912562F58F00725DD1 /* UIColor+Extensions.swift in Sources */,
 				22C2359A259CA87B00DC805A /* Animation.swift in Sources */,
 				79088339254876F200896F03 /* ChatMessageListCollectionView.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -86,6 +86,9 @@
 		79158CE225F0E9DF00186102 /* ChannelTruncated.json in Resources */ = {isa = PBXBuildFile; fileRef = 79158CE125F0E9DF00186102 /* ChannelTruncated.json */; };
 		79158CF425F133FB00186102 /* ChannelTruncatedEventMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79158CF325F133FB00186102 /* ChannelTruncatedEventMiddleware.swift */; };
 		79158CFC25F1341300186102 /* ChannelTruncatedEventMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79158CEA25F0EADF00186102 /* ChannelTruncatedEventMiddleware_Tests.swift */; };
+		79158D4425F15BE600186102 /* UIConfig+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79158D4325F15BE600186102 /* UIConfig+SwiftUI_Tests.swift */; };
+		79158D5325F15BF900186102 /* iOS13TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79200D41250118A1002F4EB1 /* iOS13TestCase.swift */; };
+		79158D5B25F15CF900186102 /* AssertAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C9466247D7919001F1104 /* AssertAsync.swift */; };
 		79177A2D248A6A2600F053A2 /* AssertAsync+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79177A2C248A6A2600F053A2 /* AssertAsync+Events.swift */; };
 		791C0B6324EEBDF40013CA2F /* MessageSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */; };
 		791C0B6524EFBD260013CA2F /* UnwrapAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */; };
@@ -193,6 +196,7 @@
 		79682C4624BC9DAF0071578E /* ChannelUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79682C4524BC9DAF0071578E /* ChannelUpdater.swift */; };
 		79682C4A24BF37C80071578E /* MessagePayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79682C4824BF37650071578E /* MessagePayloads.swift */; };
 		79682C4B24BF37CB0071578E /* ChannelListPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79682C4924BF37970071578E /* ChannelListPayload.swift */; };
+		7969D20225F15E3D00C66F87 /* TestRunnerEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7988F6B024D010890004219B /* TestRunnerEnvironment.swift */; };
 		797A756424814E7A003CF16D /* WebSocketConnectPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797A756324814E7A003CF16D /* WebSocketConnectPayload.swift */; };
 		797A756624814EF8003CF16D /* SystemEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797A756524814EF8003CF16D /* SystemEnvironment.swift */; };
 		797A756824814F0D003CF16D /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797A756724814F0D003CF16D /* Bundle+Extensions.swift */; };
@@ -1007,6 +1011,7 @@
 		79158CE125F0E9DF00186102 /* ChannelTruncated.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ChannelTruncated.json; sourceTree = "<group>"; };
 		79158CEA25F0EADF00186102 /* ChannelTruncatedEventMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTruncatedEventMiddleware_Tests.swift; sourceTree = "<group>"; };
 		79158CF325F133FB00186102 /* ChannelTruncatedEventMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTruncatedEventMiddleware.swift; sourceTree = "<group>"; };
+		79158D4325F15BE600186102 /* UIConfig+SwiftUI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIConfig+SwiftUI_Tests.swift"; sourceTree = "<group>"; };
 		79177A2C248A6A2600F053A2 /* AssertAsync+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AssertAsync+Events.swift"; sourceTree = "<group>"; };
 		791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSender_Tests.swift; sourceTree = "<group>"; };
 		791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnwrapAsync.swift; sourceTree = "<group>"; };
@@ -1878,6 +1883,7 @@
 				E7166CD925BED62D00B03B07 /* UIConfig+Navigation.swift */,
 				AD9A0FA325EE9FD800883C57 /* UIConfig+CurrentUser.swift */,
 				7844B16725EFB44600B87E89 /* UIConfig+SwiftUI.swift */,
+				79158D4325F15BE600186102 /* UIConfig+SwiftUI_Tests.swift */,
 				888123D0255D42F000070D5A /* Utils */,
 				888123E5255D51BD00070D5A /* CommonViews */,
 				7908830C2548707B00896F03 /* ChatMessageList */,
@@ -4331,12 +4337,18 @@
 				227299AA25DAA505005EAFCF /* ChatChannelReadStatusCheckmarkView_Tests.swift in Sources */,
 				227299B325DBF52D005EAFCF /* ChatChannelUnreadCountView_Tests.swift in Sources */,
 				AD71131225F138D500932AEE /* ChatUserAvatarView_Tests.swift in Sources */,
+				7969D20225F15E3D00C66F87 /* TestRunnerEnvironment.swift in Sources */,
+				79158D5325F15BF900186102 /* iOS13TestCase.swift in Sources */,
 				AD154C6D25DC3BA000850925 /* ChatMessageComposerCommandCollectionViewCell_Tests.swift in Sources */,
 				ADFCCD7625C9D4D10024505D /* SnapshotVariant.swift in Sources */,
 				2208246A25DFD0060033544B /* ChatChannelListRouter_Mock.swift in Sources */,
 				ADAA377125E43C3700C31528 /* ChatMessageComposerSuggestionsViewController_Tests.swift in Sources */,
 				E73262E025ED64AB008CB152 /* ChatChannelNamer_Tests.swift in Sources */,
 				E7AD958925D7510900076DC3 /* ChatMessageComposerMentionCellView_Tests.swift in Sources */,
+				79158D4425F15BE600186102 /* UIConfig+SwiftUI_Tests.swift in Sources */,
+				E7AD958925D7510900076DC3 /* ChatMessageComposerMentionCellView_Tests.swift in Sources */,
+				79158D5B25F15CF900186102 /* AssertAsync.swift in Sources */,
+				E791E4D625D3E2DA00B0E076 /* ChatChannelAvatarView_Tests.swift in Sources */,
 				225504C725DEA03700A5A65A /* ChatChannelListItemView_Tests.swift in Sources */,
 				79B4F0E625D305D40063FFB5 /* CurrentChatUserAvatarView_Tests.swift in Sources */,
 				AD016A1425CAFAF2009EBAD2 /* ChatChannelListVC_Tests.swift in Sources */,


### PR DESCRIPTION
## Description of the pull request

This PR adds custom view modifier `setUpStreamChatUIEnvironment()` which is to be called when user desires to setup `UIConfig` environment object for usage in `SwiftUI` app.
