### PR TITLE
[CIS-699] Make separators supplementary views

### DIFF
--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -43,20 +43,28 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
         .currentUserViewAvatarView.init()
         .withoutAutoresizingMaskConstraints
     
+    /// Reuse identifier of separator
+    open var separatorReuseIdentifier: String { "CellSeparatorIdentifier" }
+    
+    /// Reuse identiifer of `collectionViewCell`
+    open var collectionViewCellReuseIdentifier: String { "Cell" }
+    
     override open func setUp() {
         super.setUp()
         
         controller.setDelegate(self)
         controller.synchronize()
         
-        collectionView.register(uiConfig.channelList.collectionViewCell.self, forCellWithReuseIdentifier: "Cell")
-
-        if let cellSeparatorIdentifier = (collectionViewLayout as? ListCollectionViewLayout)?.separatorIdentifier {
-            collectionViewLayout.register(
-                uiConfig.channelList.cellSeparatorReusableView,
-                forDecorationViewOfKind: cellSeparatorIdentifier
-            )
-        }
+        collectionView.register(
+            uiConfig.channelList.collectionViewCell.self,
+            forCellWithReuseIdentifier: collectionViewCellReuseIdentifier
+        )
+        
+        collectionView.register(
+            uiConfig.channelList.cellSeparatorReusableView,
+            forSupplementaryViewOfKind: ListCollectionViewLayout.separatorKind,
+            withReuseIdentifier: separatorReuseIdentifier
+        )
 
         collectionView.dataSource = self
         collectionView.delegate = self
@@ -100,7 +108,7 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
         cellForItemAt indexPath: IndexPath
     ) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: "Cell",
+            withReuseIdentifier: collectionViewCellReuseIdentifier,
             for: indexPath
         ) as! _ChatChannelListCollectionViewCell<ExtraData>
     
@@ -108,6 +116,18 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
         cell.itemView.content = (controller.channels[indexPath.row], controller.client.currentUserId)
         
         return cell
+    }
+    
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        viewForSupplementaryElementOfKind kind: String,
+        at indexPath: IndexPath
+    ) -> UICollectionReusableView {
+        collectionView.dequeueReusableSupplementaryView(
+            ofKind: ListCollectionViewLayout.separatorKind,
+            withReuseIdentifier: separatorReuseIdentifier,
+            for: indexPath
+        )
     }
         
     open func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC_Tests.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC_Tests.swift
@@ -149,7 +149,6 @@ class ChatChannelListVC_Tests: XCTestCase {
 
             if let listLayout = $0.collectionViewLayout as? ListCollectionViewLayout {
                 listLayout.separatorHeight = 4
-                listLayout.register(TestSeparatorView.self, forDecorationViewOfKind: listLayout.separatorIdentifier)
             }
 
             TestSeparatorView.defaultAppearance {
@@ -159,6 +158,10 @@ class ChatChannelListVC_Tests: XCTestCase {
 
         let vc = TestView()
         vc.controller = mockedChannelListController
+        
+        var config = UIConfig()
+        config.channelList.cellSeparatorReusableView = TestSeparatorView.self
+        vc.uiConfig = config
 
         mockedChannelListController.simulateInitial(
             channels: channels,
@@ -181,13 +184,16 @@ class ChatChannelListVC_Tests: XCTestCase {
                 createNewChannelButton.tintColor = UIColor.orange
                 if let listLayout = collectionViewLayout as? ListCollectionViewLayout {
                     listLayout.separatorHeight = 4
-                    listLayout.register(TestSeparatorView.self, forDecorationViewOfKind: listLayout.separatorIdentifier)
                 }
             }
         }
 
         let vc = TestView()
         vc.controller = mockedChannelListController
+        
+        var config = UIConfig()
+        config.channelList.cellSeparatorReusableView = TestSeparatorView.self
+        vc.uiConfig = config
 
         mockedChannelListController.simulate(
             channels: channels,

--- a/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/ListCollectionViewLayout.swift
+++ b/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/ListCollectionViewLayout.swift
@@ -16,10 +16,12 @@ public protocol ListCollectionViewLayoutDelegate: class, UICollectionViewDelegat
 }
 
 /// An `UICollectionViewFlowLayout` implementation to make the collection view behave as a `UITableView`.
-open class ListCollectionViewLayout: UICollectionViewFlowLayout{
+open class ListCollectionViewLayout: UICollectionViewFlowLayout {
 
-    /// The reuse identifier of the cell separator view.
-    open var separatorIdentifier: String = "CellSeparatorIdentifier"
+    /// The kind identifier of the cell separator view.
+    open class var separatorKind: String {
+        "CellSeparator"
+    }
 
     /// The height of the cell separator view. This changes the `minimumLineSpacing` to properly display the separator height.
     /// By default it is the hair height, one physical pixel (1 / displayScale). If a value is set, it will change the default.
@@ -37,6 +39,17 @@ open class ListCollectionViewLayout: UICollectionViewFlowLayout{
             width: collectionView?.bounds.width ?? 0,
             height: estimatedItemSize.height
         )
+    }
+    
+    /// Partly taken from: https://github.com/Instagram/IGListKit/issues/571#issuecomment-386960195
+    override open func invalidateLayout(with context: UICollectionViewLayoutInvalidationContext) {
+        if let indexPaths = context.invalidatedItemIndexPaths {
+            context.invalidateSupplementaryElements(
+                ofKind: Self.separatorKind,
+                at: indexPaths
+            )
+        }
+        super.invalidateLayout(with: context)
     }
 
     override open func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
@@ -60,7 +73,7 @@ open class ListCollectionViewLayout: UICollectionViewFlowLayout{
             ) ?? true else { return nil }
 
             let separatorAttribute = UICollectionViewLayoutAttributes(
-                forDecorationViewOfKind: separatorIdentifier,
+                forSupplementaryViewOfKind: Self.separatorKind,
                 with: cellAttribute.indexPath
             )
 


### PR DESCRIPTION
## Description of the pull request

- fixed a bug where separators would disappear when the height of the cell would be different from estimated size
- make separators supplementary views instead of decorators

Possible Qs:
- I was not completely sure how to handle the kind and reuse identifier. As reuse identifier is quite contained, I had hard coded it in `ChatChannelListVC`. The kind identifier is then reused via a property defined in `ListCollectionViewLayout`. LMK if you'd have done it differently