### PR TITLE
[CIS-692] Implement Channel Truncating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Upcoming
 
 ### ✅ Added
-- Add support for slow mode. Documentation [here](https://getstream.io/chat/docs/javascript/slow_mode/?language=swift) [#859](https://github.com/GetStream/stream-chat-swift/issues/859)
+- Add support for slow mode. See more info in the [documentation](https://getstream.io/chat/docs/javascript/slow_mode/?language=swift) [#859](https://github.com/GetStream/stream-chat-swift/issues/859)
+- Add support for channel truncating [#864](https://github.com/GetStream/stream-chat-swift/issues/864)
 
 ### 🔄 Changed
 - `ChatChannelNamer` is now closure instead of class so it allows better customization of channel naming in `ChatChannelListItemView`.

--- a/Package.swift
+++ b/Package.swift
@@ -61,6 +61,7 @@ var streamChatSourcesExcluded: [String] { [
     "Database/DatabaseContainer_Tests.swift",
     "Config/TokenProvider_Tests.swift",
     "WebSocketClient/WebSocketClient_Mock.swift",
+    "WebSocketClient/EventMiddlewares/ChannelTruncatedUpdaterMiddleware_Tests.swift",
     "WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift",
     "WebSocketClient/EventMiddlewares/MessageReactionsMiddleware_Tests.swift",
     "WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware_Tests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -61,6 +61,7 @@ var streamChatSourcesExcluded: [String] { [
     "Database/DatabaseContainer_Tests.swift",
     "Config/TokenProvider_Tests.swift",
     "WebSocketClient/WebSocketClient_Mock.swift",
+    "WebSocketClient/EventMiddlewares/ChannelTruncatedEventMiddleware_Tests.swift",
     "WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift",
     "WebSocketClient/EventMiddlewares/MessageReactionsMiddleware_Tests.swift",
     "WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware_Tests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -61,7 +61,6 @@ var streamChatSourcesExcluded: [String] { [
     "Database/DatabaseContainer_Tests.swift",
     "Config/TokenProvider_Tests.swift",
     "WebSocketClient/WebSocketClient_Mock.swift",
-    "WebSocketClient/EventMiddlewares/ChannelTruncatedUpdaterMiddleware_Tests.swift",
     "WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift",
     "WebSocketClient/EventMiddlewares/MessageReactionsMiddleware_Tests.swift",
     "WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware_Tests.swift",

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
@@ -56,7 +56,17 @@ extension Endpoint {
             body: nil
         )
     }
-    
+
+    static func truncateChannel(cid: ChannelId) -> Endpoint<EmptyResponse> {
+        .init(
+            path: "channels/\(cid.type)/\(cid.id)/truncate",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: nil
+        )
+    }
+
     static func hideChannel(cid: ChannelId, clearHistory: Bool) -> Endpoint<EmptyResponse> {
         .init(
             path: "channels/\(cid.type)/\(cid.id)/hide",

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -110,7 +110,25 @@ final class ChannelEndpoints_Tests: XCTestCase {
         // Assert endpoint is built correctly
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
     }
-    
+
+    func test_truncateChannel_buildsCorrectly() {
+        let cid = ChannelId.unique
+
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: "channels/\(cid.type)/\(cid.id)/truncate",
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: nil
+        )
+
+        // Build endpoint
+        let endpoint: Endpoint<EmptyResponse> = .truncateChannel(cid: cid)
+
+        // Assert endpoint is built correctly
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
+
     func test_hideChannel_buildsCorrectly() {
         let testCases = [true, false]
         

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -91,7 +91,8 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         ),
         ChannelReadUpdaterMiddleware<ExtraData>(database: databaseContainer),
         ChannelMemberTypingStateUpdaterMiddleware<ExtraData>(database: databaseContainer),
-        MessageReactionsMiddleware<ExtraData>(database: databaseContainer)
+        MessageReactionsMiddleware<ExtraData>(database: databaseContainer),
+        ChannelTruncatedEventMiddleware<ExtraData>(database: databaseContainer)
     ])
     
     /// The `APIClient` instance `Client` uses to communicate with Stream REST API.

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -222,6 +222,9 @@ class ChatClient_Tests: StressTestCase {
         XCTAssertTrue(typingStateUpdaterMiddlewareIndex! > typingStartCleanupMiddlewareIndex!)
         // Assert `MessageReactionsMiddleware` exists
         XCTAssert(middlewares.contains(where: { $0 is MessageReactionsMiddleware<NoExtraData> }))
+        // Assert `ChannelTruncatedEventMiddleware` exists
+        XCTAssert(middlewares.contains(where: { $0 is ChannelTruncatedEventMiddleware<NoExtraData> }))
+
     }
     
     func test_connectionStatus_isExposed() {

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -509,6 +509,27 @@ public extension _ChatChannelController {
             }
         }
     }
+
+    /// Truncates the channel this controller manages.
+    ///
+    /// Removes all of the messages of the channel but doesn't affect the channel data or members.
+    ///
+    /// - Parameter completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
+    /// If request fails, the completion will be called with an error.
+    ///
+    func truncateChannel(completion: ((Error?) -> Void)? = nil) {
+        /// Perform action only if channel is already created on backend side and have a valid `cid`.
+        guard let cid = cid, isChannelAlreadyCreated else {
+            channelModificationFailed(completion)
+            return
+        }
+
+        updater.truncateChannel(cid: cid) { error in
+            self.callback {
+                completion?(error)
+            }
+        }
+    }
     
     /// Hide the channel this controller manages from queryChannels for the user until a message is added.
     ///

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -41,7 +41,23 @@ class ChannelDTO: NSManagedObject {
     @NSManaged var messages: Set<MessageDTO>
     @NSManaged var reads: Set<ChannelReadDTO>
     @NSManaged var attachments: Set<AttachmentDTO>
-    
+
+    override func willSave() {
+        super.willSave()
+
+        // Change to the `trunctedAt` value have effect on messages, we need to mark them dirty manually
+        // to triggers related FRC updates
+        if changedValues().keys.contains("truncatedAt") {
+            messages
+                .filter { !$0.hasChanges }
+                .forEach {
+                    // Simulate an update
+                    $0.willChangeValue(for: \.id)
+                    $0.didChangeValue(for: \.id)
+                }
+        }
+    }
+
     /// The fetch request that returns all existed channels from the database
     static var allChannelsFetchRequest: NSFetchRequest<ChannelDTO> {
         let request = NSFetchRequest<ChannelDTO>(entityName: ChannelDTO.entityName)

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -19,6 +19,12 @@ class ChannelDTO: NSManagedObject {
     @NSManaged var defaultSortingAt: Date
     @NSManaged var updatedAt: Date
     @NSManaged var lastMessageAt: Date?
+
+    // This field lives only locally and is not populated from the payload. The main purpose of having this is to
+    // visually truncate the channel that exists and have messages locally already. It should be safe to have this
+    // only locally because once the DB is flushed and the channels are fetched fresh, the messages before the
+    // `truncatedAt` date are not returned from the backend.
+    @NSManaged var truncatedAt: Date?
     
     @NSManaged var watcherCount: Int64
     @NSManaged var memberCount: Int64

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
@@ -374,7 +374,7 @@ extension XCTestCase {
             id: .unique,
             type: .regular,
             user: dummyUser,
-            createdAt: Date(timeIntervalSince1970: 2), // See dummyChannelRead.lastReadAt below for reason
+            createdAt: .unique,
             updatedAt: .unique,
             deletedAt: nil,
             text: .unique,

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
@@ -395,7 +395,7 @@ extension XCTestCase {
         ChannelReadPayload(user: dummyCurrentUser, lastReadAt: Date(timeIntervalSince1970: 1), unreadMessagesCount: 10)
     }
     
-    func dummyPayload(with channelId: ChannelId) -> ChannelPayload<NoExtraData> {
+    func dummyPayload(with channelId: ChannelId, numberOfMessages: Int = 1) -> ChannelPayload<NoExtraData> {
         let member: MemberPayload<NoExtraData> =
             .init(
                 user: .init(
@@ -419,7 +419,12 @@ extension XCTestCase {
         
         let channelCreatedDate = Date.unique
         let lastMessageAt: Date? = Bool.random() ? channelCreatedDate.addingTimeInterval(.random(in: 100_000...900_000)) : nil
-        
+
+        var messages: [MessagePayload<NoExtraData>] = []
+        for _ in 0..<numberOfMessages {
+            messages += [dummyMessage]
+        }
+
         let payload: ChannelPayload<NoExtraData> =
             .init(
                 channel: .init(
@@ -464,7 +469,7 @@ extension XCTestCase {
                 ),
                 watcherCount: 10,
                 members: [member],
-                messages: [dummyMessage],
+                messages: messages,
                 channelReads: [dummyChannelRead]
             )
         

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -107,10 +107,16 @@ class MessageDTO: NSManagedObject {
             ])
         ])
 
+        let nonTruncatedMessagePredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [
+            .init(format: "channel.truncatedAt == nil"),
+            .init(format: "createdAt > channel.truncatedAt")
+        ])
+
         return .init(andPredicateWithSubpredicates: [
             channelMessage,
             messageTypePredicate,
-            deletedMessagePredicate
+            deletedMessagePredicate,
+            nonTruncatedMessagePredicate
         ])
     }
     

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -29,6 +29,7 @@
         <attribute name="lastMessageAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="memberCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="truncatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="typeRawValue" optional="YES" attributeType="String"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="watcherCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Sources/StreamChat/Utils/Logger/Logger.swift
+++ b/Sources/StreamChat/Utils/Logger/Logger.swift
@@ -260,3 +260,16 @@ private extension Logger {
         }
     }
 }
+
+extension Data {
+    /// Converts the data into a pretty-printed JSON string. Use only for debug purposes since this operation can be expensive.
+    var debugPrettyPrintedJSON: String {
+        do {
+            let jsonObject = try JSONSerialization.jsonObject(with: self, options: [.allowFragments])
+            let prettyPrintedData = try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted])
+            return String(data: prettyPrintedData, encoding: .utf8) ?? "Error: Data to String decoding failed."
+        } catch {
+            return "JSON decoding failed with error: \(error)"
+        }
+    }
+}

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelTruncatedEventMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelTruncatedEventMiddleware.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// The middleware listens for `ChannelTruncatedEventMiddleware` events and updates `ChannelDTO` accordingly.
+struct ChannelTruncatedEventMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
+    let database: DatabaseContainer
+
+    func handle(event: Event, completion: @escaping (Event?) -> Void) {
+        guard
+            let truncatedEvent = event as? ChannelTruncatedEvent,
+            let payload = truncatedEvent.payload as? EventPayload<ExtraData>
+        else {
+            completion(event)
+            return
+        }
+
+        database.write { session in
+            if let channelDTO = session.channel(cid: truncatedEvent.cid) {
+                channelDTO.truncatedAt = payload.createdAt
+            } else {
+                throw ClientError.ChannelDoesNotExist(cid: truncatedEvent.cid)
+            }
+        } completion: { error in
+            if let error = error {
+                log.error("Failed to update message reaction in the database, error: \(error)")
+            }
+            completion(event)
+        }
+    }
+}

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelTruncatedEventMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelTruncatedEventMiddleware.swift
@@ -21,7 +21,7 @@ struct ChannelTruncatedEventMiddleware<ExtraData: ExtraDataTypes>: EventMiddlewa
             }
         } completion: { error in
             if let error = error {
-                log.error("Failed to update message reaction in the database, error: \(error)")
+                log.error("Failed to write the `truncatedAt` field update in the database, error: \(error)")
             }
             completion(event)
         }

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelTruncatedEventMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelTruncatedEventMiddleware_Tests.swift
@@ -1,0 +1,92 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class ChannelTruncatedEventMiddleware_Tests: XCTestCase {
+    var database: DatabaseContainerMock!
+    var middleware: ChannelTruncatedEventMiddleware<NoExtraData>!
+
+    // MARK: - Set up
+
+    override func setUp() {
+        super.setUp()
+
+        database = DatabaseContainerMock()
+        middleware = .init(database: database)
+    }
+
+    override func tearDown() {
+        middleware = nil
+        AssertAsync.canBeReleased(&database)
+
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func tests_middleware_forwardsOtherEvents() throws {
+        let event = TestEvent()
+
+        // Handle non-reaction event
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+
+        // Assert event is forwarded as it is
+        XCTAssertEqual(forwardedEvent as! TestEvent, event)
+    }
+
+    func tests_middleware_forwardsTheEvent_ifDatabaseWriteGeneratesError() throws {
+        let eventPayload: EventPayload<NoExtraData> = .init(
+            eventType: .channelTruncated,
+            cid: .unique,
+            user: .dummy(userId: .unique)
+        )
+
+        // Set error to be thrown on write.
+        let error = TestError()
+        database.write_errorResponse = error
+
+        // Simulate and handle channel truncated event.
+        let event = try ChannelTruncatedEvent(from: eventPayload)
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+
+        // Assert `ChannelTruncatedEvent` is forwarded even though database error happened.
+        XCTAssertTrue(forwardedEvent is ChannelTruncatedEvent)
+    }
+
+    func tests_middleware_handlesCuannelTruncatedEventCorrectly() throws {
+        let cid: ChannelId = .unique
+        // Create channel truncate event
+        let eventPayload: EventPayload<NoExtraData> = .init(
+            eventType: .channelTruncated,
+            cid: cid,
+            user: .dummy(userId: .unique),
+            createdAt: .unique
+        )
+        let event = try ChannelTruncatedEvent(from: eventPayload)
+
+        try database.createChannel(cid: cid, withMessages: true)
+
+        // Assert `truncatedAt` is `nil` by default
+        assert(database.viewContext.channel(cid: cid)?.truncatedAt == nil)
+
+        // Simulate incoming event
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+
+        // Assert the `truncatedAt` value is updated
+        XCTAssertEqual(database.viewContext.channel(cid: cid)?.truncatedAt, eventPayload.createdAt)
+        XCTAssert(forwardedEvent is ChannelTruncatedEvent)
+    }
+}
+
+private struct TestEvent: Event, Equatable {
+    let id = UUID()
+}

--- a/Sources/StreamChat/WebSocketClient/Events/ChannelEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/ChannelEvents.swift
@@ -64,6 +64,18 @@ public struct ChannelHiddenEvent<ExtraData: ExtraDataTypes>: EventWithUserPayloa
     }
 }
 
+public struct ChannelTruncatedEvent: EventWithUserPayload, EventWithChannelId {
+    public let userId: UserId
+    public let cid: ChannelId
+    let payload: Any
+
+    init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
+        userId = try response.value(at: \.user?.id)
+        cid = try response.value(at: \.cid)
+        payload = response
+    }
+}
+
 // MARK: - Invite Answer
 
 /// An answer for an invite to join a channel.

--- a/Sources/StreamChat/WebSocketClient/Events/ChannelEvents_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/ChannelEvents_Tests.swift
@@ -40,4 +40,15 @@ class ChannelEvents_Tests: XCTestCase {
         XCTAssertEqual(event?.hiddenAt.description, "2020-07-17 12:11:46 +0000")
         XCTAssertTrue(event?.isHistoryCleared ?? false)
     }
+
+    func test_channelTruncatedEvent() throws {
+        let mockData = XCTestCase.mockData(fromFile: "ChannelTruncated")
+
+        let event = try eventDecoder.decode(from: mockData) as? ChannelTruncatedEvent
+        XCTAssertEqual(event?.userId, "broken-waterfall-5")
+        XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_7011"))
+
+        let rawPayload = try JSONDecoder.stream.decode(EventPayload<NoExtraData>.self, from: mockData)
+        XCTAssertEqual((event?.payload as? EventPayload<NoExtraData>)?.createdAt, rawPayload.createdAt)
+    }
 }

--- a/Sources/StreamChat/WebSocketClient/Events/EventType.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/EventType.swift
@@ -36,7 +36,9 @@ enum EventType: String, Codable {
     case channelDeleted = "channel.deleted"
     /// When a channel was hidden.
     case channelHidden = "channel.hidden"
-    
+    /// When a channel was truncated.
+    case channelTruncated = "channel.truncated"
+
     /// When a new message was added on a channel.
     case messageNew = "message.new"
     /// When a message was updated.
@@ -94,6 +96,7 @@ enum EventType: String, Codable {
         case .channelUpdated: return try ChannelUpdatedEvent(from: response)
         case .channelDeleted: return try ChannelDeletedEvent(from: response)
         case .channelHidden: return try ChannelHiddenEvent(from: response)
+        case .channelTruncated: return try ChannelTruncatedEvent(from: response)
             
         case .messageNew: return try MessageNewEvent(from: response)
         case .messageUpdated: return try MessageUpdatedEvent(from: response)

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -259,6 +259,8 @@ extension WebSocketClient: WebSocketEngineDelegate {
     func webSocketDidReceiveMessage(_ message: String) {
         do {
             let messageData = Data(message.utf8)
+            log.debug("Event received:\n\(messageData.debugPrettyPrintedJSON)")
+
             let event = try eventDecoder.decode(from: messageData)
             eventNotificationCenter.process(event)
         } catch is ClientError.UnsupportedEventType {

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -64,7 +64,17 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
             completion?($0.error)
         }
     }
-    
+
+    /// Truncates the specific channel.
+    /// - Parameters:
+    ///   - cid: The channel identifier.
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
+    func truncateChannel(cid: ChannelId, completion: ((Error?) -> Void)? = nil) {
+        apiClient.request(endpoint: .truncateChannel(cid: cid)) {
+            completion?($0.error)
+        }
+    }
+
     /// Hides the channel from queryChannels for the user until a message is added.
     /// - Parameters:
     ///   - cid: The channel identifier.

--- a/Sources/StreamChat/Workers/ChannelUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Mock.swift
@@ -21,6 +21,9 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
     @Atomic var deleteChannel_cid: ChannelId?
     @Atomic var deleteChannel_completion: ((Error?) -> Void)?
 
+    @Atomic var truncateChannel_cid: ChannelId?
+    @Atomic var truncateChannel_completion: ((Error?) -> Void)?
+
     @Atomic var hideChannel_cid: ChannelId?
     @Atomic var hideChannel_clearHistory: Bool?
     @Atomic var hideChannel_completion: ((Error?) -> Void)?
@@ -68,6 +71,9 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         
         deleteChannel_cid = nil
         deleteChannel_completion = nil
+
+        truncateChannel_cid = nil
+        truncateChannel_completion = nil
         
         hideChannel_cid = nil
         hideChannel_clearHistory = nil
@@ -125,6 +131,11 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
     override func deleteChannel(cid: ChannelId, completion: ((Error?) -> Void)? = nil) {
         deleteChannel_cid = cid
         deleteChannel_completion = completion
+    }
+
+    override func truncateChannel(cid: ChannelId, completion: ((Error?) -> Void)? = nil) {
+        truncateChannel_cid = cid
+        truncateChannel_completion = completion
     }
 
     override func hideChannel(cid: ChannelId, clearHistory: Bool, completion: ((Error?) -> Void)? = nil) {

--- a/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
@@ -346,6 +346,50 @@ class ChannelUpdater_Tests: StressTestCase {
         AssertAsync.willBeEqual(completionCalledError as? TestError, error)
     }
 
+    // MARK: - Truncate channel
+
+    func test_truncateChannel_makesCorrectAPICall() {
+        let channelID = ChannelId.unique
+
+        // Simulate `truncateChannel(cid:, completion:)` call
+        channelUpdater.truncateChannel(cid: channelID)
+
+        // Assert correct endpoint is called
+        let referenceEndpoint: Endpoint<EmptyResponse> = .truncateChannel(cid: channelID)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
+    }
+
+    func test_truncateChannel_successfulResponse_isPropagatedToCompletion() {
+        // Simulate `truncateChannel(cid:, completion:)` call
+        var completionCalled = false
+        channelUpdater.truncateChannel(cid: .unique) { error in
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+
+        // Assert completion is not called yet
+        XCTAssertFalse(completionCalled)
+
+        // Simulate API response with success
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.success(.init()))
+
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+    }
+
+    func test_truncateChannel_errorResponse_isPropagatedToCompletion() {
+        // Simulate `truncateChannel(cid:, completion:)` call
+        var completionCalledError: Error?
+        channelUpdater.truncateChannel(cid: .unique) { completionCalledError = $0 }
+
+        // Simulate API response with failure
+        let error = TestError()
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(error))
+
+        // Assert the completion is called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, error)
+    }
+
     // MARK: - Hide channel
 
     func test_hideChannel_makesCorrectAPICall() {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
@@ -138,53 +138,53 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
 
     override open func prepare(forCollectionViewUpdates updateItems: [UICollectionViewUpdateItem]) {
         previousItems = currentItems
-        let delete: (UICollectionViewUpdateItem) -> Void = { update in
-            guard let ip = update.indexPathBeforeUpdate else { return }
-            let idx = ip.item
-            self.disappearingItems.insert(ip)
-            var delta = self.currentItems[idx].height
-            if idx > 0 {
-                delta += self.spacing
-            }
-            for i in 0..<idx {
-                self.currentItems[i].offset -= delta
-            }
-            self.currentItems.remove(at: idx)
-        }
-
-        let insert: (UICollectionViewUpdateItem) -> Void = { update in
-            guard let ip = update.indexPathAfterUpdate else { return }
-            self.appearingItems.insert(ip)
-            let idx = ip.item
-            let item: LayoutItem
-            if idx == self.currentItems.count {
-                item = LayoutItem(offset: 0, height: self.estimatedItemHeight)
-            } else {
-                item = LayoutItem(
-                    offset: self.currentItems[idx].maxY + self.spacing,
-                    height: self.currentItems[idx].height
-                )
-            }
-            let delta = item.height + self.spacing
-            for i in 0..<idx {
-                self.currentItems[i].offset += delta
-            }
-            self.currentItems.insert(item, at: idx)
-        }
-
-        for update in updateItems {
-            switch update.updateAction {
-            case .delete:
-                delete(update)
-            case .insert:
-                insert(update)
-            case .move:
-                delete(update)
-                insert(update)
-            case .reload, .none: break
-            @unknown default: break
-            }
-        }
+//        let delete: (UICollectionViewUpdateItem) -> Void = { update in
+//            guard let ip = update.indexPathBeforeUpdate else { return }
+//            let idx = ip.item
+//            self.disappearingItems.insert(ip)
+//            var delta = self.currentItems[idx].height
+//            if idx > 0 {
+//                delta += self.spacing
+//            }
+//            for i in 0..<idx {
+//                self.currentItems[i].offset -= delta
+//            }
+//            self.currentItems.remove(at: idx)
+//        }
+//
+//        let insert: (UICollectionViewUpdateItem) -> Void = { update in
+//            guard let ip = update.indexPathAfterUpdate else { return }
+//            self.appearingItems.insert(ip)
+//            let idx = ip.item
+//            let item: LayoutItem
+//            if idx == self.currentItems.count {
+//                item = LayoutItem(offset: 0, height: self.estimatedItemHeight)
+//            } else {
+//                item = LayoutItem(
+//                    offset: self.currentItems[idx].maxY + self.spacing,
+//                    height: self.currentItems[idx].height
+//                )
+//            }
+//            let delta = item.height + self.spacing
+//            for i in 0..<idx {
+//                self.currentItems[i].offset += delta
+//            }
+//            self.currentItems.insert(item, at: idx)
+//        }
+//
+//        for update in updateItems {
+//            switch update.updateAction {
+//            case .delete:
+//                delete(update)
+//            case .insert:
+//                insert(update)
+//            case .move:
+//                delete(update)
+//                insert(update)
+//            case .reload, .none: break
+//            @unknown default: break
+//            }
+//        }
 
         preBatchUpdatesCall = false
         super.prepare(forCollectionViewUpdates: updateItems)

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		790A4C58252F2AF2001F4A23 /* DeviceDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790A4C57252F2AF2001F4A23 /* DeviceDTO_Tests.swift */; };
 		790B9E3024DC21D7005455AA /* MessagePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790B9E2F24DC21D7005455AA /* MessagePayload.swift */; };
 		790B9E3224DC221A005455AA /* UserPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790B9E3124DC221A005455AA /* UserPayload.swift */; };
+		79158CE225F0E9DF00186102 /* ChannelTruncated.json in Resources */ = {isa = PBXBuildFile; fileRef = 79158CE125F0E9DF00186102 /* ChannelTruncated.json */; };
 		79177A2D248A6A2600F053A2 /* AssertAsync+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79177A2C248A6A2600F053A2 /* AssertAsync+Events.swift */; };
 		791C0B6324EEBDF40013CA2F /* MessageSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */; };
 		791C0B6524EFBD260013CA2F /* UnwrapAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */; };
@@ -995,6 +996,7 @@
 		790A4C57252F2AF2001F4A23 /* DeviceDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceDTO_Tests.swift; sourceTree = "<group>"; };
 		790B9E2F24DC21D7005455AA /* MessagePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagePayload.swift; sourceTree = "<group>"; };
 		790B9E3124DC221A005455AA /* UserPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPayload.swift; sourceTree = "<group>"; };
+		79158CE125F0E9DF00186102 /* ChannelTruncated.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ChannelTruncated.json; sourceTree = "<group>"; };
 		79177A2C248A6A2600F053A2 /* AssertAsync+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AssertAsync+Events.swift"; sourceTree = "<group>"; };
 		791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSender_Tests.swift; sourceTree = "<group>"; };
 		791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnwrapAsync.swift; sourceTree = "<group>"; };
@@ -3249,6 +3251,7 @@
 				8A0C3BCD24C1CAF000CAFD19 /* ChannelDeleted.json */,
 				8A0C3BCF24C1CCD800CAFD19 /* ChannelHidden.json */,
 				8A0C3BD024C1CCEB00CAFD19 /* ChannelHiddenCleared.json */,
+				79158CE125F0E9DF00186102 /* ChannelTruncated.json */,
 			);
 			path = Channel;
 			sourceTree = "<group>";
@@ -4016,6 +4019,7 @@
 				88F896F92541AC0900DE517D /* FlagMessagePayload+NoExtraData.json in Resources */,
 				8A0CC9ED24C602B600705CF9 /* MemberRemoved.json in Resources */,
 				8A0C3BC724C0AEDB00CAFD19 /* UserBanned.json in Resources */,
+				79158CE225F0E9DF00186102 /* ChannelTruncated.json in Resources */,
 				88EA9B112547271B007EE76B /* MessageReactionPayload+DefaultExtraData.json in Resources */,
 				8A0D64A424E57A260017A3C0 /* GuestUser+CustomExtraData.json in Resources */,
 				224116B2258BACF90034184D /* Message.json in Resources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		790B9E3024DC21D7005455AA /* MessagePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790B9E2F24DC21D7005455AA /* MessagePayload.swift */; };
 		790B9E3224DC221A005455AA /* UserPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790B9E3124DC221A005455AA /* UserPayload.swift */; };
 		79158CE225F0E9DF00186102 /* ChannelTruncated.json in Resources */ = {isa = PBXBuildFile; fileRef = 79158CE125F0E9DF00186102 /* ChannelTruncated.json */; };
+		79158CF425F133FB00186102 /* ChannelTruncatedEventMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79158CF325F133FB00186102 /* ChannelTruncatedEventMiddleware.swift */; };
+		79158CFC25F1341300186102 /* ChannelTruncatedEventMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79158CEA25F0EADF00186102 /* ChannelTruncatedEventMiddleware_Tests.swift */; };
 		79177A2D248A6A2600F053A2 /* AssertAsync+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79177A2C248A6A2600F053A2 /* AssertAsync+Events.swift */; };
 		791C0B6324EEBDF40013CA2F /* MessageSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */; };
 		791C0B6524EFBD260013CA2F /* UnwrapAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */; };
@@ -997,6 +999,8 @@
 		790B9E2F24DC21D7005455AA /* MessagePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagePayload.swift; sourceTree = "<group>"; };
 		790B9E3124DC221A005455AA /* UserPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPayload.swift; sourceTree = "<group>"; };
 		79158CE125F0E9DF00186102 /* ChannelTruncated.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ChannelTruncated.json; sourceTree = "<group>"; };
+		79158CEA25F0EADF00186102 /* ChannelTruncatedEventMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTruncatedEventMiddleware_Tests.swift; sourceTree = "<group>"; };
+		79158CF325F133FB00186102 /* ChannelTruncatedEventMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTruncatedEventMiddleware.swift; sourceTree = "<group>"; };
 		79177A2C248A6A2600F053A2 /* AssertAsync+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AssertAsync+Events.swift"; sourceTree = "<group>"; };
 		791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSender_Tests.swift; sourceTree = "<group>"; };
 		791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnwrapAsync.swift; sourceTree = "<group>"; };
@@ -2295,6 +2299,8 @@
 				79896D65250A6D1500BA8F1C /* ChannelReadUpdaterMiddleware_Tests.swift */,
 				F6CCA24C251235F7004C1859 /* ChannelMemberTypingStateUpdaterMiddleware.swift */,
 				F6CCA24E2512491B004C1859 /* ChannelMemberTypingStateUpdaterMiddleware_Tests.swift */,
+				79158CF325F133FB00186102 /* ChannelTruncatedEventMiddleware.swift */,
+				79158CEA25F0EADF00186102 /* ChannelTruncatedEventMiddleware_Tests.swift */,
 				8899BC56254337C7003CB98B /* MessageReactionsMiddleware.swift */,
 				889062422548387D00E1898E /* MessageReactionsMiddleware_Tests.swift */,
 			);
@@ -4529,6 +4535,7 @@
 				DABC6ABC2546FD0100A8FC78 /* AttachmentPayload.swift in Sources */,
 				88D85DA7252F3C1D00AE1030 /* MemberListController.swift in Sources */,
 				79280F4B248523C000CDEB89 /* ConnectionEvents.swift in Sources */,
+				79158CF425F133FB00186102 /* ChannelTruncatedEventMiddleware.swift in Sources */,
 				882C574A252C767E00E60C44 /* ChannelMemberListPayload.swift in Sources */,
 				DAFAD6A324DD8E1A0043ED06 /* ChannelEditDetailPayload.swift in Sources */,
 				88BEBCD62536FDBF00D9E8B7 /* MemberListController+SwiftUI.swift in Sources */,
@@ -4712,6 +4719,7 @@
 				DAF8359C24F8059900392699 /* TypingEventObserver_Tests.swift in Sources */,
 				799C9468247D791A001F1104 /* AssertJSONEqual.swift in Sources */,
 				DA84072A2525EB2F005A0F62 /* UserListQuery_Tests.swift in Sources */,
+				79158CFC25F1341300186102 /* ChannelTruncatedEventMiddleware_Tests.swift in Sources */,
 				799C9460247D77D6001F1104 /* DatabaseContainer_Tests.swift in Sources */,
 				8A5D3EF924AF749200E2FE35 /* ChannelId_Tests.swift in Sources */,
 				799C945C247D59D8001F1104 /* ChatClient_Tests.swift in Sources */,

--- a/Tests/StreamChatTests/MockEnpointResponses/Events/Channel/ChannelTruncated.json
+++ b/Tests/StreamChatTests/MockEnpointResponses/Events/Channel/ChannelTruncated.json
@@ -1,0 +1,128 @@
+{
+    "user" : {
+        "banned" : false,
+        "online" : true,
+        "id" : "broken-waterfall-5",
+        "role" : "user",
+        "created_at" : "2019-10-24T08:34:11.155375Z",
+        "image" : "https:\/\/ca.slack-edge.com\/T02RM6X6B-U01173D1D5J-0dead6eea6ea-512",
+        "value" : "cilvia",
+        "updated_at" : "2021-03-04T10:09:51.834025Z",
+        "last_active" : "2021-03-04T10:02:01.668566Z",
+        "name" : "Neil Hannah"
+    },
+    "channel" : {
+        "created_by" : null,
+        "frozen" : false,
+        "config" : {
+            "typing_events" : true,
+            "connect_events" : true,
+            "reactions" : true,
+            "replies" : true,
+            "uploads" : true,
+            "commands" : [
+                {
+                    "set" : "fun_set",
+                    "args" : "[text]",
+                    "name" : "giphy",
+                    "description" : "Post a random gif to the channel"
+                },
+                {
+                    "set" : "moderation_set",
+                    "args" : "[@username] [text]",
+                    "name" : "ban",
+                    "description" : "Ban a user"
+                },
+                {
+                    "set" : "moderation_set",
+                    "args" : "[@username]",
+                    "name" : "mute",
+                    "description" : "Mute a user"
+                },
+                {
+                    "set" : "moderation_set",
+                    "args" : "[@username]",
+                    "name" : "unmute",
+                    "description" : "Unmute a user"
+                }
+            ],
+            "updated_at" : "2021-03-01T19:27:53.045745Z",
+            "automod_behavior" : "flag",
+            "url_enrichment" : true,
+            "mutes" : true,
+            "custom_events" : false,
+            "message_retention" : "infinite",
+            "name" : "messaging",
+            "automod" : "AI",
+            "automod_thresholds" : {
+                "spam" : {
+                    "flag" : 0.84999999999999998,
+                    "block" : 0.90000000000000002
+                },
+                "toxic" : {
+                    "flag" : 0.84999999999999998,
+                    "block" : 0.90000000000000002
+                },
+                "explicit" : {
+                    "flag" : 0.84999999999999998,
+                    "block" : 0.90000000000000002
+                }
+            },
+            "created_at" : "2020-03-16T19:59:52.3886Z",
+            "max_message_length" : 5000,
+            "blocklist_behavior" : "flag",
+            "read_events" : true,
+            "search" : true
+        },
+        "id" : "new_channel_7011",
+        "created_at" : "2020-11-13T08:55:55.464959Z",
+        "members" : [
+            {
+                "created_at" : "2020-11-13T08:55:55.473851Z",
+                "banned" : false,
+                "shadow_banned" : false,
+                "user_id" : "broken-waterfall-5",
+                "updated_at" : "2020-11-13T08:55:55.473851Z",
+                "user" : {
+                    "banned" : false,
+                    "online" : true,
+                    "id" : "cilvia",
+                    "role" : "user",
+                    "created_at" : "2019-10-24T08:34:11.155375Z",
+                    "image" : "https:\/\/ca.slack-edge.com\/T02RM6X6B-U01173D1D5J-0dead6eea6ea-512",
+                    "value" : "cilvia",
+                    "updated_at" : "2021-03-04T10:09:51.834025Z",
+                    "last_active" : "2021-03-04T10:02:01.668566Z",
+                    "name" : "Neil Hannah"
+                }
+            },
+            {
+                "created_at" : "2020-11-13T08:55:55.473852Z",
+                "banned" : false,
+                "shadow_banned" : false,
+                "user_id" : "148ff9e8-46c8-314f-89b2-9fabb685ee9f",
+                "updated_at" : "2020-11-13T08:55:55.473852Z",
+                "user" : {
+                    "banned" : false,
+                    "online" : false,
+                    "id" : "148ff9e8-46c8-314f-89b2-9fabb685ee9f",
+                    "role" : "user",
+                    "created_at" : "2020-06-17T09:23:42.875544Z",
+                    "image" : "https:\/\/picsum.photos\/seed\/630\/100\/100",
+                    "updated_at" : "2021-01-27T13:24:09.490174Z",
+                    "name" : "Abbie O'Reilly"
+                }
+            }
+        ],
+        "member_count" : 2,
+        "type" : "messaging",
+        "updated_at" : "2020-11-13T08:55:55.464959Z",
+        "name" : "",
+        "cid" : "messaging:new_channel_7011"
+    },
+    "channel_type" : "messaging",
+    "channel_id" : "!members-XFUSh76wb261G6dAQOibpTNpD2YFy6tVTcCIUqLVdng",
+    "created_at" : "2021-03-04T10:09:59.888290075Z",
+    "type" : "channel.truncated",
+    "cid" : "messaging:new_channel_7011"
+}


### PR DESCRIPTION
When the channel is truncated, it means all messages sent before the truncation disappear. When you query the channel, it has no messages and even the `last_message_at` value is reset.

### Possible ways to implement this locally

a) Delete all messages from the DB -> hard deleting entities from CoreData is not trivial because of our complex data model scheme. This would be the most complicated way to implement this feature. 🔴 

b) Soft-delete messages by `message.type = .deleted`-> this is less complex but not ideal. Deleted messages have different semantics from the truncated messages, especially when it's the messages sent by the current user. Almost there... 🔴 

c) Do it the same way the backed does it -> I added `truncatedAt` field to `ChannelDTO` and adjusted the message predicates to ignore the message created before this date. This solution is the most simple one and works nicely  ✅ 

### Issues

- We will have to introduce some kind of DB cleanup worker that will take care of "physically" removing the truncated messages from the DB. This worker can run only when there are no observers attached to the DB in order to prevent invalid updates. However, the clean-up worker is needed anyway otherwise the DB size would just grow and grow with more incoming messages and new channels.

- Our current custom layout crashes when all messages are removed. I found the issue but the fix was not obvious. I didn't want to spend more time on it since @olejnjak is working on fixing the layout anyway.
