### PR TITLE
Fix Swift file formatter pre-commit hook

### DIFF
--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'Sources/*.swift | grep -v "Generated'
+
+./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'Sources/*.swift' '!*Generated*'
 ./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'Tests/*.swift'
 ./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'Sample/*.swift'
 ./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'DemoApp/*.swift'


### PR DESCRIPTION
# What this PR do:
- Fixes issue with pre-commit hook that header formatter was not ran due to not being compatible with bash commands in path arguments. Uses native `git-format-staged` exclusion instead 😅 

⚠️ 
**Don't forget to re-link your pre-commit hooks via `bootstrap.sh` after this is merged **