### PR TITLE
[CIS-655] Remove collection view hiding hack

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -207,6 +207,7 @@ var streamChatSourcesExcluded: [String] { [
 ] }
 
 var streamChatUIFilesExcluded: [String] { [
+    "ChatMessageList/ChatMessageListCollectionViewLayout_Tests.swift",
     "ChatMessageList/MessageComposer/ChatMessageComposerSuggestionsViewController_Tests.swift",
     "ChatMessageList/MessageComposer/ChatMessageComposerCommandCollectionViewCell_Tests.swift",
     "ChatMessageList/MessageComposer/ChatMessageComposerMentionCellView_Tests.swift",

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.swift
@@ -21,13 +21,6 @@ open class _СhatMessageCollectionViewCell<ExtraData: ExtraDataTypes>: _Collecti
 
     // MARK: - Lifecycle
 
-    override open func didMoveToSuperview() {
-        super.didMoveToSuperview()
-
-        guard superview != nil, !hasCompletedStreamSetup else { return }
-        hasCompletedStreamSetup = true
-    }
-
     override open func setUpLayout() {
         contentView.addSubview(messageView)
 
@@ -53,14 +46,6 @@ open class _СhatMessageCollectionViewCell<ExtraData: ExtraDataTypes>: _Collecti
     override open func preferredLayoutAttributesFitting(
         _ layoutAttributes: UICollectionViewLayoutAttributes
     ) -> UICollectionViewLayoutAttributes {
-        guard hasCompletedStreamSetup else {
-            // We cannot calculate size properly right now, because our view hierarchy is not ready yet.
-            // If we just return default size, small text bubbles would not resize itself properly for no reason.
-            let attributes = layoutAttributes.copy() as! UICollectionViewLayoutAttributes
-            attributes.frame.size.height = 300
-            return attributes
-        }
-
         let preferredAttributes = super.preferredLayoutAttributesFitting(layoutAttributes)
 
         let targetSize = CGSize(

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
@@ -27,6 +27,11 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
         public func attribute(for index: Int, width: CGFloat) -> UICollectionViewLayoutAttributes {
             let attribute = UICollectionViewLayoutAttributes(forCellWith: IndexPath(item: index, section: 0))
             attribute.frame = CGRect(x: 0, y: offset, width: width, height: height)
+            // default `zIndex` value is 0, but for some undocumented reason self-sizing
+            // (concretely `contentView.systemLayoutFitting(...)`) doesn't work correctly,
+            // so we need to make sure we do not use it, we need to add 1 so indexPath 0-0 doesn't have
+            // problematic 0 zIndex
+            attribute.zIndex = index + 1
             return attribute
         }
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
@@ -135,6 +135,28 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
 
         return invalidationContext
     }
+    
+    override open func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+        collectionView.map { $0.bounds.size != newBounds.size } ?? true
+    }
+    
+    override open func invalidationContext(forBoundsChange newBounds: CGRect) -> UICollectionViewLayoutInvalidationContext {
+        let context = super.invalidationContext(forBoundsChange: newBounds)
+        
+        guard let collectionView = collectionView else { return context }
+        
+        let delta = newBounds.height - collectionView.bounds.height
+        
+        // If collectionView is shrinking and most recent message is visible, we will make sure it is still fully visible,
+        // but if the conversation is short and not scrollable, this adjustment would be unwanted
+        if delta < 0,
+           collectionView.indexPathsForVisibleItems.contains(IndexPath(item: 0, section: 0)),
+           collectionView.contentOffset.y > -collectionView.contentInset.top {
+            context.contentOffsetAdjustment = CGPoint(x: 0, y: -delta)
+        }
+
+        return context
+    }
 
     // MARK: - Animation updates
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
@@ -94,9 +94,7 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
         forPreferredLayoutAttributes preferredAttributes: UICollectionViewLayoutAttributes,
         withOriginalAttributes originalAttributes: UICollectionViewLayoutAttributes
     ) -> Bool {
-        let idx = originalAttributes.indexPath.item
-        return preferredAttributes.frame.minY != currentItems[idx].offset
-            || preferredAttributes.frame.height != currentItems[idx].height
+        preferredAttributes.size.height != originalAttributes.size.height
     }
 
     override open func invalidationContext(
@@ -113,11 +111,6 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
         currentItems[idx].height = preferredAttributes.frame.height
         // if item have been inserted recently or deleted, we need to update its attributes to prevent weird flickering
         animatingAttributes[preferredAttributes.indexPath]?.frame.size.height = preferredAttributes.frame.height
-
-        // we are bottom-top layout with 0 being most bottom item. So when item X changes its attributes, it affect all
-        // items before it in [0; X] range.
-        let invalidNow = (0...idx).map { IndexPath(item: $0, section: 0) }
-        invalidationContext.invalidateItems(at: invalidNow)
 
         for i in 0..<idx {
             currentItems[i].offset += delta
@@ -200,9 +193,6 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
         disappearingItems.removeAll()
         animatingAttributes.removeAll()
         super.finalizeCollectionViewUpdates()
-        // for some reason when adding / deleting items cv do not reload attributes for rows out of view
-        // this will force reload
-        invalidateLayout()
     }
 
     // MARK: - Main layout access

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
@@ -55,8 +55,18 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
     open var animatingAttributes: [IndexPath: UICollectionViewLayoutAttributes] = [:]
 
     override open var collectionViewContentSize: CGSize {
+        // This is a workaround for `layoutAttributesForElementsInRect:` not getting invoked enough
+        // times if `collectionViewContentSize.width` is not smaller than the width of the collection
+        // view, minus horizontal insets. This results in visual defects when performing batch
+        // updates. To work around this, we subtract 0.0001 from our content size width calculation;
+        // this small decrease in `collectionViewContentSize.width` is enough to work around the
+        // incorrect, internal collection view `CGRect` checks, without introducing any visual
+        // differences for elements in the collection view.
+        // See https://openradar.appspot.com/radar?id=5025850143539200 for more details.
+        //
+        // Credit to https://github.com/airbnb/MagazineLayout/blob/6f88742c282de208e48cb738a7a14b7dc2651701/MagazineLayout/Public/MagazineLayout.swift#L69
         CGSize(
-            width: collectionView!.bounds.width,
+            width: collectionView!.bounds.width - 0.0001,
             height: currentItems.first?.maxY ?? 0
         )
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout_Tests.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout_Tests.swift
@@ -1,0 +1,88 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChatUI
+import XCTest
+
+final class ChatMessageListCollectionViewLayout_Tests: XCTestCase {
+    private final class TestUpdateItem: UICollectionViewUpdateItem {
+        let _indexPathAfterUpdate: IndexPath?
+        override var indexPathAfterUpdate: IndexPath? { _indexPathAfterUpdate }
+        
+        let _indexPathBeforeUpdate: IndexPath?
+        override var indexPathBeforeUpdate: IndexPath? { _indexPathBeforeUpdate }
+        
+        let _updateAction: UICollectionViewUpdateItem.Action
+        override var updateAction: UICollectionViewUpdateItem.Action { _updateAction }
+        
+        init(
+            indexPathBeforeUpdate: IndexPath?,
+            indexPathAfterUpdate: IndexPath?,
+            updateAction: UICollectionViewUpdateItem.Action
+        ) {
+            _indexPathBeforeUpdate = indexPathBeforeUpdate
+            _indexPathAfterUpdate = indexPathAfterUpdate
+            _updateAction = updateAction
+        }
+        
+        convenience init(deleteIndex: Int) {
+            self.init(
+                indexPathBeforeUpdate: IndexPath(item: deleteIndex, section: 0),
+                indexPathAfterUpdate: nil,
+                updateAction: .delete
+            )
+        }
+        
+        convenience init(insertIndex: Int) {
+            self.init(
+                indexPathBeforeUpdate: nil,
+                indexPathAfterUpdate: IndexPath(item: insertIndex, section: 0),
+                updateAction: .insert
+            )
+        }
+    }
+    
+    private typealias LayoutItem = ChatMessageListCollectionViewLayout.LayoutItem
+    
+    private var subject: ChatMessageListCollectionViewLayout!
+    
+    // MARK: - Setup
+    
+    override func setUp() {
+        super.setUp()
+        subject = .init()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+    }
+    
+    // MARK: - Tests
+    
+    func testLayoutDeletions() {
+        let indices = 0..<20
+        
+        subject.currentItems = indices.map { LayoutItem(offset: CGFloat($0 * 200), height: 200) }
+        
+        let updateItems = indices.map(TestUpdateItem.init(deleteIndex:))
+        
+        subject.prepare(forCollectionViewUpdates: updateItems)
+        
+        XCTAssertTrue(subject.currentItems.isEmpty)
+    }
+    
+    func testLayoutInsertions() throws {
+        subject.prepare(forCollectionViewUpdates: [TestUpdateItem(insertIndex: 0)])
+        
+        // As `UUID` in `LayoutItem.id` is "random" adding `Equatable` conformance and direct comparison
+        // wouldn't make sense as we have one "random" property
+        XCTAssertEqual(subject.currentItems.count, 1)
+        
+        let firstItem = try XCTUnwrap(subject.currentItems.first)
+        
+        XCTAssertEqual(firstItem.offset, 0)
+        XCTAssertEqual(firstItem.height, subject.estimatedItemHeight)
+    }
+}

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -82,7 +82,6 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: _ViewController,
         collection.keyboardDismissMode = .onDrag
         collection.dataSource = self
         collection.delegate = self
-        collection.isHidden = true
 
         return collection
     }()
@@ -92,24 +91,9 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: _ViewController,
     /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
     public private(set) var needsToScrollToMostRecentMessageAnimated = false
 
-    /// When controller loaded first time, message layout is in estimated state.
-    /// We force layout reload on first appear, before showing message list.
-    /// This way we able to hide ugly jump
-    public private(set) var hideInitialLayout = true
-
     open var minTimeInvteralBetweenMessagesInGroup: TimeInterval = 10
 
     // MARK: - Life Cycle
-
-    override open func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        if hideInitialLayout {
-            collectionView.reloadData()
-            collectionView.isHidden = false
-            hideInitialLayout = false
-        }
-    }
 
     override open func setUp() {
         super.setUp()

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		22CAFA7625CAE278005935D9 /* RawJSON_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */; };
 		22FF4365256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */; };
 		7844B16825EFB44600B87E89 /* UIConfig+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7844B16725EFB44600B87E89 /* UIConfig+SwiftUI.swift */; };
+		69DE605A25F39E6000DC187F /* ChatMessageListCollectionViewLayout_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE605925F39E6000DC187F /* ChatMessageListCollectionViewLayout_Tests.swift */; };
 		7900452625374CA20096ECA1 /* User+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900452525374CA20096ECA1 /* User+SwiftUI.swift */; };
 		7908820625432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
 		7908821225432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
@@ -759,9 +760,7 @@
 		E7166CE225BEE20600B03B07 /* UIConfig+Images.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7166CE125BEE20600B03B07 /* UIConfig+Images.swift */; };
 		E73262E025ED64AB008CB152 /* ChatChannelNamer_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73262D725ED6432008CB152 /* ChatChannelNamer_Tests.swift */; };
 		E73A8B2B2578EB2B00FBDC56 /* ChatMessageComposerVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73A8B2A2578EB2B00FBDC56 /* ChatMessageComposerVC.swift */; };
-		E759AC4D256E694F00341865 /* ChatOnlineIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E759AC4C256E694F00341865 /* ChatOnlineIndicatorView.swift */; };
 		E76B2F0425F23EE200E57112 /* CustomUIViewSubclasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70A09E925F230EE00C55BBE /* CustomUIViewSubclasses.swift */; };
-		E791E4D625D3E2DA00B0E076 /* ChatChannelAvatarView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E791E4D525D3E2DA00B0E076 /* ChatChannelAvatarView_Tests.swift */; };
 		E79AC10A25831A1500C3CE5D /* ChatMessageComposerMentionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AC10625831A1100C3CE5D /* ChatMessageComposerMentionCollectionViewCell.swift */; };
 		E79AC10B25831A1500C3CE5D /* ChatMessageComposerCommandCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AC10725831A1500C3CE5D /* ChatMessageComposerCommandCollectionViewCell.swift */; };
 		E79AC10C25831A1500C3CE5D /* ChatMessageComposerSuggestionsCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79AC10825831A1500C3CE5D /* ChatMessageComposerSuggestionsCollectionView.swift */; };
@@ -982,6 +981,7 @@
 		22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawJSON_Tests.swift; sourceTree = "<group>"; };
 		22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageComposerSuggestionsViewController.swift; sourceTree = "<group>"; };
 		7844B16725EFB44600B87E89 /* UIConfig+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIConfig+SwiftUI.swift"; sourceTree = "<group>"; };
+		69DE605925F39E6000DC187F /* ChatMessageListCollectionViewLayout_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListCollectionViewLayout_Tests.swift; sourceTree = "<group>"; };
 		7900452525374CA20096ECA1 /* User+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+SwiftUI.swift"; sourceTree = "<group>"; };
 		790881FD25432B7200896F03 /* StreamChatUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7908820525432B7200896F03 /* StreamChatUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1964,6 +1964,7 @@
 				882AE056257A176A004095B3 /* ChatChannelRouter.swift */,
 				DB70CFF325701FE500DDF436 /* ChatChannelNavigationBarListener.swift */,
 				DBC8A563258113F700B20A82 /* ChatThreadVC.swift */,
+				69DE605925F39E6000DC187F /* ChatMessageListCollectionViewLayout_Tests.swift */,
 			);
 			path = ChatMessageList;
 			sourceTree = "<group>";
@@ -4332,6 +4333,7 @@
 			files = (
 				2208241625DEE8070033544B /* ChatChannelListCollectionViewCell_Tests.swift in Sources */,
 				79B4F14325D3F0F70063FFB5 /* ChannelId.swift in Sources */,
+				69DE605A25F39E6000DC187F /* ChatMessageListCollectionViewLayout_Tests.swift in Sources */,
 				AD71130225F138BA00932AEE /* ChatChannelAvatarView_Tests.swift in Sources */,
 				ADEB2F8025CC0B8A00EAAEB6 /* XCTestCase+TestImages.swift in Sources */,
 				227299AA25DAA505005EAFCF /* ChatChannelReadStatusCheckmarkView_Tests.swift in Sources */,


### PR DESCRIPTION
- remove initial layout hack on `ChatMessageListVC` (main issue was missing `zIndex` on layout attributes returned from layout)
- thanks to fix above there is no more need to check for Stream setup in `ChatMessageCollectionViewCell`
- implement batch update changes correctly for deletions
- add basic unit tests for layout deletions and insertions

- fix initial message list jumping by restoring `contentOffset` after batch updates
  - the only reliable way I was able to find is by either updating `targetContentOffset(forProposedContentOffset:)` in layout or to scroll in `finalizeCollectionViewUpdates()` if we rely on invalidation contexts from self-sizing the changes are always visible
  - this sort of mimics the behavior of `_ChatMessageListVC.scrollToMostRecentMessageIfNeeded()` so maybe it would be useful to move this logic from controller to layout, what do you think about it?