### PR TITLE
[CIS-396] Improve ChannelId path encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🔄 Changed
 - `ChatChannelNamer` is now closure instead of class so it allows better customization of channel naming in `ChatChannelListItemView`.
 
+### 🐞 Fixed
+- Fix encoding of channels with custom type [#872](https://github.com/GetStream/stream-chat-swift/pull/872)
+
 # [3.1.1](https://github.com/GetStream/stream-chat-swift/releases/tag/3.1.1)
 _February 26, 2021_
 

--- a/Sources/StreamChat/APIClient/APIPathConvertible.swift
+++ b/Sources/StreamChat/APIClient/APIPathConvertible.swift
@@ -1,0 +1,11 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Object representing path on API
+protocol APIPathConvertible {
+    /// Build APi path representing `self`
+    var apiPath: String { get }
+}

--- a/Sources/StreamChat/APIClient/Endpoints/AttachmentEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/AttachmentEndpoints.swift
@@ -7,7 +7,7 @@ import Foundation
 extension Endpoint {
     static func uploadAttachment(with id: AttachmentId, type: AttachmentType) -> Endpoint<FileUploadPayload> {
         .init(
-            path: "channels/\(id.cid.type)/\(id.cid.id)/\(type == .image ? "image" : "file")",
+            path: "channels/" + id.cid.apiPath + "/\(type == .image ? "image" : "file")",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,

--- a/Sources/StreamChat/APIClient/Endpoints/AttachmentEndpoints_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/AttachmentEndpoints_Tests.swift
@@ -21,7 +21,7 @@ final class AttachmentEndpoints_Tests: XCTestCase {
 
         for (type, pathComponent) in testCases {
             let expectedEndpoint: Endpoint<FileUploadPayload> = .init(
-                path: "channels/\(id.cid.type)/\(id.cid.id)/\(pathComponent)",
+                path: "channels/\(id.cid.type.rawValue)/\(id.cid.id)/\(pathComponent)",
                 method: .post,
                 queryItems: nil,
                 requiresConnectionId: false,

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
@@ -18,7 +18,7 @@ extension Endpoint {
     
     static func channel<ExtraData: ExtraDataTypes>(query: _ChannelQuery<ExtraData>) -> Endpoint<ChannelPayload<ExtraData>> {
         .init(
-            path: "channels/\(query.pathParameters)/query",
+            path: "channels/" + query.apiPath + "/query",
             method: .post,
             queryItems: nil,
             requiresConnectionId: query.options.contains(oneOf: [.presence, .state, .watch]),
@@ -29,7 +29,7 @@ extension Endpoint {
     static func updateChannel<ExtraData: ExtraDataTypes>(channelPayload: ChannelEditDetailPayload<ExtraData>)
         -> Endpoint<EmptyResponse> {
         .init(
-            path: "channels/\(channelPayload.pathParameters)",
+            path: "channels/" + channelPayload.apiPath,
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -49,7 +49,7 @@ extension Endpoint {
     
     static func deleteChannel(cid: ChannelId) -> Endpoint<EmptyResponse> {
         .init(
-            path: "channels/\(cid.type)/\(cid.id)",
+            path: "channels/" + cid.apiPath,
             method: .delete,
             queryItems: nil,
             requiresConnectionId: false,
@@ -59,7 +59,7 @@ extension Endpoint {
 
     static func truncateChannel(cid: ChannelId) -> Endpoint<EmptyResponse> {
         .init(
-            path: "channels/\(cid.type)/\(cid.id)/truncate",
+            path: "channels/" + cid.apiPath + "/truncate",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -69,7 +69,7 @@ extension Endpoint {
 
     static func hideChannel(cid: ChannelId, clearHistory: Bool) -> Endpoint<EmptyResponse> {
         .init(
-            path: "channels/\(cid.type)/\(cid.id)/hide",
+            path: "channels/" + cid.apiPath + "/hide",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -79,7 +79,7 @@ extension Endpoint {
     
     static func showChannel(cid: ChannelId) -> Endpoint<EmptyResponse> {
         .init(
-            path: "channels/\(cid.type)/\(cid.id)/show",
+            path: "channels/" + cid.apiPath + "/show",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -90,7 +90,7 @@ extension Endpoint {
     static func sendMessage<ExtraData: ExtraDataTypes>(cid: ChannelId, messagePayload: MessageRequestBody<ExtraData>)
         -> Endpoint<MessagePayload<ExtraData>.Boxed> {
         .init(
-            path: "channels/\(cid.type)/\(cid.id)/message",
+            path: "channels/" + cid.apiPath + "/message",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -100,7 +100,7 @@ extension Endpoint {
     
     static func addMembers(cid: ChannelId, userIds: Set<UserId>) -> Endpoint<EmptyResponse> {
         .init(
-            path: "channels/\(cid.type)/\(cid.id)",
+            path: "channels/" + cid.apiPath,
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -110,7 +110,7 @@ extension Endpoint {
     
     static func removeMembers(cid: ChannelId, userIds: Set<UserId>) -> Endpoint<EmptyResponse> {
         .init(
-            path: "channels/\(cid.type)/\(cid.id)",
+            path: "channels/" + cid.apiPath,
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -120,7 +120,7 @@ extension Endpoint {
     
     static func markRead(cid: ChannelId) -> Endpoint<EmptyResponse> {
         .init(
-            path: "channels/\(cid.type)/\(cid.id)/read",
+            path: "channels/" + cid.apiPath + "/read",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -140,7 +140,7 @@ extension Endpoint {
     
     static func sendEvent(cid: ChannelId, eventType: EventType) -> Endpoint<EmptyResponse> {
         .init(
-            path: "channels/\(cid.type)/\(cid.id)/event",
+            path: "channels/" + cid.apiPath + "/event",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -150,7 +150,7 @@ extension Endpoint {
     
     static func enableSlowMode(cid: ChannelId, cooldownDuration: Int) -> Endpoint<EmptyResponse> {
         .init(
-            path: "channels/\(cid.type)/\(cid.id)",
+            path: "channels/" + cid.apiPath,
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -60,7 +60,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
         for (query, requiresConnectionId) in testCases {
             let expectedEndpoint =
                 Endpoint<ChannelPayload<NoExtraData>>(
-                    path: "channels/\(query.pathParameters)/query",
+                    path: "channels/\(query.apiPath)/query",
                     method: .post,
                     queryItems: nil,
                     requiresConnectionId: requiresConnectionId,
@@ -79,7 +79,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
         let channelPayload: ChannelEditDetailPayload<NoExtraData> = .unique
         
         let expectedEndpoint = Endpoint<EmptyResponse>(
-            path: "channels/\(channelPayload.pathParameters)",
+            path: "channels/\(channelPayload.apiPath)",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -97,7 +97,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
         let cid = ChannelId.unique
         
         let expectedEndpoint = Endpoint<EmptyResponse>(
-            path: "channels/\(cid.type)/\(cid.id)",
+            path: "channels/\(cid.type.rawValue)/\(cid.id)",
             method: .delete,
             queryItems: nil,
             requiresConnectionId: false,
@@ -115,7 +115,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
         let cid = ChannelId.unique
 
         let expectedEndpoint = Endpoint<EmptyResponse>(
-            path: "channels/\(cid.type)/\(cid.id)/truncate",
+            path: "channels/\(cid.type.rawValue)/\(cid.id)/truncate",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -136,7 +136,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
             let cid = ChannelId.unique
 
             let expectedEndpoint = Endpoint<EmptyResponse>(
-                path: "channels/\(cid.type)/\(cid.id)/hide",
+                path: "channels/\(cid.type.rawValue)/\(cid.id)/hide",
                 method: .post,
                 queryItems: nil,
                 requiresConnectionId: false,
@@ -180,7 +180,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
         let cid = ChannelId.unique
 
         let expectedEndpoint = Endpoint<EmptyResponse>(
-            path: "channels/\(cid.type)/\(cid.id)/show",
+            path: "channels/\(cid.type.rawValue)/\(cid.id)/show",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -209,7 +209,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
         )
         
         let expectedEndpoint = Endpoint<MessagePayload<NoExtraData>.Boxed>(
-            path: "channels/\(cid.type)/\(cid.id)/message",
+            path: "channels/\(cid.type.rawValue)/\(cid.id)/message",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -228,7 +228,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
         let userIds: Set<UserId> = Set([UserId.unique])
 
         let expectedEndpoint = Endpoint<EmptyResponse>(
-            path: "channels/\(cid.type)/\(cid.id)",
+            path: "channels/\(cid.type.rawValue)/\(cid.id)",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -247,7 +247,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
         let userIds: Set<UserId> = Set([UserId.unique])
 
         let expectedEndpoint = Endpoint<EmptyResponse>(
-            path: "channels/\(cid.type)/\(cid.id)",
+            path: "channels/\(cid.type.rawValue)/\(cid.id)",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -265,7 +265,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
         let cid = ChannelId.unique
         
         let expectedEndpoint = Endpoint<EmptyResponse>(
-            path: "channels/\(cid.type)/\(cid.id)/read",
+            path: "channels/\(cid.type.rawValue)/\(cid.id)/read",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -296,7 +296,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
         let eventType = EventType.userStartTyping
         
         let expectedEndpoint = Endpoint<EmptyResponse>(
-            path: "channels/\(cid.type)/\(cid.id)/event",
+            path: "channels/\(cid.type.rawValue)/\(cid.id)/event",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
@@ -313,7 +313,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
         let cooldownDuration = Int.random(in: 0...120)
         
         let expectedEndpoint = Endpoint<EmptyResponse>(
-            path: "channels/\(cid.type)/\(cid.id)",
+            path: "channels/\(cid.type.rawValue)/\(cid.id)",
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/ChannelEditDetailPayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/ChannelEditDetailPayload.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -73,11 +73,13 @@ struct ChannelEditDetailPayload<ExtraData: ExtraDataTypes>: Encodable {
 
         try extraData.encode(to: encoder)
     }
-    
-    var pathParameters: String {
+}
+
+extension ChannelEditDetailPayload: APIPathConvertible {
+    var apiPath: String {
         guard let id = id else {
-            return "\(type)"
+            return type.rawValue
         }
-        return "\(type)/\(id)"
+        return type.rawValue + "/" + id
     }
 }

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/ChannelEditDetailPayload_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/ChannelEditDetailPayload_Tests.swift
@@ -41,7 +41,7 @@ class ChannelEditDetailPayload_Tests: XCTestCase {
         AssertJSONEqual(encodedJSON, expectedJSON)
     }
     
-    func test_pathParameters() {
+    func test_apiPath() {
         // Create payload without id specified
         let payload1: ChannelEditDetailPayload<NoExtraData> = .init(
             type: .messaging,
@@ -54,7 +54,7 @@ class ChannelEditDetailPayload_Tests: XCTestCase {
         )
         
         // Assert only type is part of path
-        XCTAssertEqual(payload1.pathParameters, "\(payload1.type)")
+        XCTAssertEqual(payload1.apiPath, "\(payload1.type)")
         
         // Create payload with id and type specified
         let cid: ChannelId = .unique
@@ -69,6 +69,6 @@ class ChannelEditDetailPayload_Tests: XCTestCase {
         )
         
         // Assert type and id are part of path
-        XCTAssertEqual(payload2.pathParameters, "\(payload2.type)/\(payload2.id!)")
+        XCTAssertEqual(payload2.apiPath, "\(payload2.type.rawValue)/\(payload2.id!)")
     }
 }

--- a/Sources/StreamChat/Models/ChannelId.swift
+++ b/Sources/StreamChat/Models/ChannelId.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -69,4 +69,8 @@ extension ChannelId: Codable {
 
 extension ClientError {
     public class InvalidChannelId: ClientError {}
+}
+
+extension ChannelId: APIPathConvertible {
+    var apiPath: String { type.rawValue + "/" + id }
 }

--- a/Sources/StreamChat/Models/ChannelId_Tests.swift
+++ b/Sources/StreamChat/Models/ChannelId_Tests.swift
@@ -43,6 +43,11 @@ class ChannelId_Tests: XCTestCase {
         XCTAssertEqual(decode(value: "asd:123"), ChannelId(type: .custom("asd"), id: "123"))
     }
     
+    func test_apiPath() {
+        let channelId = ChannelId.unique
+        XCTAssertEqual(channelId.apiPath, channelId.type.rawValue + "/" + channelId.id)
+    }
+    
     @available(iOS, deprecated: 12.0, message: "Remove this workaround when dropping iOS 12 support.")
     private func decode(value: String) -> ChannelId? {
         // We must decode it as a part of JSON because older iOS version don't support JSON fragments

--- a/Sources/StreamChat/Query/ChannelQuery.swift
+++ b/Sources/StreamChat/Query/ChannelQuery.swift
@@ -50,12 +50,6 @@ public struct _ChannelQuery<ExtraData: ExtraDataTypes>: Encodable {
     public var cid: ChannelId? {
         id.map { ChannelId(type: type, id: $0) }
     }
-    
-    /// Path parameters that are used in endpoints.
-    var pathParameters: String {
-        guard let id = id else { return type.rawValue }
-        return type.rawValue + "/" + id
-    }
 
     /// Init a channel query.
     /// - Parameters:
@@ -118,6 +112,10 @@ public struct _ChannelQuery<ExtraData: ExtraDataTypes>: Encodable {
         try membersLimit.map { try container.encode(Pagination(pageSize: $0), forKey: .members) }
         try watchersLimit.map { try container.encode(Pagination(pageSize: $0), forKey: .watchers) }
     }
+}
+
+extension _ChannelQuery: APIPathConvertible {
+    var apiPath: String { cid?.apiPath ?? type.rawValue }
 }
 
 ///// An answer for an invite to a channel.

--- a/Sources/StreamChat/Query/ChannelQuery_Tests.swift
+++ b/Sources/StreamChat/Query/ChannelQuery_Tests.swift
@@ -37,7 +37,7 @@ class ChannelQuery_Tests: XCTestCase {
         AssertJSONEqual(expectedJSON, encodedJSON)
     }
     
-    func test_pathParameters() {
+    func test_apiPath() {
         // Create query without id specified
         let query1: ChannelQuery = .init(channelPayload: .init(
             type: .messaging,
@@ -50,17 +50,17 @@ class ChannelQuery_Tests: XCTestCase {
         ))
         
         // Assert only type is part of path
-        XCTAssertEqual(query1.pathParameters, "\(query1.type)")
+        XCTAssertEqual(query1.apiPath, "\(query1.type)")
         
         // Create query with id and type specified
         let cid: ChannelId = .unique
         let query2: ChannelQuery = .init(cid: cid)
         
         // Assert type and id are part of path
-        XCTAssertEqual(query2.pathParameters, "\(query2.type.rawValue)/\(query2.id!)")
+        XCTAssertEqual(query2.apiPath, "\(query2.type.rawValue)/\(query2.id!)")
     }
     
-    func test_pathParameters_customType() {
+    func test_apiPath_customType() {
         let query: ChannelQuery = .init(channelPayload: .init(
             type: .custom("custom_type"),
             name: .unique,
@@ -70,10 +70,10 @@ class ChannelQuery_Tests: XCTestCase {
             invites: [],
             extraData: .defaultValue
         ))
-        XCTAssertEqual(query.pathParameters, "custom_type")
+        XCTAssertEqual(query.apiPath, "custom_type")
     }
     
-    func test_pathParameters_customTypeAndId() {
+    func test_apiPath_customTypeAndId() {
         let query: ChannelQuery = .init(channelPayload: .init(
             cid: .init(type: .custom("custom_type"), id: "id"),
             name: .unique,
@@ -83,6 +83,6 @@ class ChannelQuery_Tests: XCTestCase {
             invites: [],
             extraData: .defaultValue
         ))
-        XCTAssertEqual(query.pathParameters, "custom_type/id")
+        XCTAssertEqual(query.apiPath, "custom_type/id")
     }
 }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -57,10 +57,11 @@
 		22C2359A259CA87B00DC805A /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C23599259CA87B00DC805A /* Animation.swift */; };
 		22CAFA7625CAE278005935D9 /* RawJSON_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */; };
 		22FF4365256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */; };
-		7844B16825EFB44600B87E89 /* UIConfig+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7844B16725EFB44600B87E89 /* UIConfig+SwiftUI.swift */; };
+		698E2A3525F7C8AF00ED9CCC /* APIPathConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698E2A3425F7C8AF00ED9CCC /* APIPathConvertible.swift */; };
 		69DE605A25F39E6000DC187F /* ChatMessageListCollectionViewLayout_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE605925F39E6000DC187F /* ChatMessageListCollectionViewLayout_Tests.swift */; };
 		7844B10C25EF92B600B87E89 /* ChatChannelListItemView+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7844B10B25EF92B600B87E89 /* ChatChannelListItemView+SwiftUI.swift */; };
 		7849AF6725F243C8007817D4 /* ChatChannelListItemView+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7849AF6625F243C8007817D4 /* ChatChannelListItemView+SwiftUI_Tests.swift */; };
+		7844B16825EFB44600B87E89 /* UIConfig+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7844B16725EFB44600B87E89 /* UIConfig+SwiftUI.swift */; };
 		7900452625374CA20096ECA1 /* User+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900452525374CA20096ECA1 /* User+SwiftUI.swift */; };
 		7908820625432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
 		7908821225432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
@@ -982,10 +983,11 @@
 		22C23599259CA87B00DC805A /* Animation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
 		22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawJSON_Tests.swift; sourceTree = "<group>"; };
 		22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageComposerSuggestionsViewController.swift; sourceTree = "<group>"; };
-		7844B16725EFB44600B87E89 /* UIConfig+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIConfig+SwiftUI.swift"; sourceTree = "<group>"; };
+		698E2A3425F7C8AF00ED9CCC /* APIPathConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPathConvertible.swift; sourceTree = "<group>"; };
 		69DE605925F39E6000DC187F /* ChatMessageListCollectionViewLayout_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListCollectionViewLayout_Tests.swift; sourceTree = "<group>"; };
 		7844B10B25EF92B600B87E89 /* ChatChannelListItemView+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatChannelListItemView+SwiftUI.swift"; sourceTree = "<group>"; };
 		7849AF6625F243C8007817D4 /* ChatChannelListItemView+SwiftUI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatChannelListItemView+SwiftUI_Tests.swift"; sourceTree = "<group>"; };
+		7844B16725EFB44600B87E89 /* UIConfig+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIConfig+SwiftUI.swift"; sourceTree = "<group>"; };
 		7900452525374CA20096ECA1 /* User+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+SwiftUI.swift"; sourceTree = "<group>"; };
 		790881FD25432B7200896F03 /* StreamChatUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7908820525432B7200896F03 /* StreamChatUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2549,6 +2551,7 @@
 				799C9442247D3DA7001F1104 /* APIClient.swift */,
 				79DDF811249CD5AC002F4412 /* APIClient_Tests.swift */,
 				792921C624C047DD00116BBB /* APIClient_Mock.swift */,
+				698E2A3425F7C8AF00ED9CCC /* APIPathConvertible.swift */,
 				7964F3BB249A5E60002A09EC /* RequestEncoder.swift */,
 				7964F3BD249A5E6E002A09EC /* RequestEncoder_Tests.swift */,
 				79DDF80D249CB920002F4412 /* RequestDecoder.swift */,
@@ -4358,7 +4361,6 @@
 				79158D4425F15BE600186102 /* UIConfig+SwiftUI_Tests.swift in Sources */,
 				E7AD958925D7510900076DC3 /* ChatMessageComposerMentionCellView_Tests.swift in Sources */,
 				79158D5B25F15CF900186102 /* AssertAsync.swift in Sources */,
-				E791E4D625D3E2DA00B0E076 /* ChatChannelAvatarView_Tests.swift in Sources */,
 				225504C725DEA03700A5A65A /* ChatChannelListItemView_Tests.swift in Sources */,
 				79B4F0E625D305D40063FFB5 /* CurrentChatUserAvatarView_Tests.swift in Sources */,
 				AD016A1425CAFAF2009EBAD2 /* ChatChannelListVC_Tests.swift in Sources */,
@@ -4504,6 +4506,7 @@
 				881506EC258212BF0013935B /* MultipartFormData.swift in Sources */,
 				792A4F472480107A00EAF71D /* Filter.swift in Sources */,
 				22692C8F25D18097007C41D0 /* ChatMessageGiphyAttachment.swift in Sources */,
+				698E2A3525F7C8AF00ED9CCC /* APIPathConvertible.swift in Sources */,
 				792A4F4B248010A600EAF71D /* QueryOptions.swift in Sources */,
 				792FCB4B24A3D52A000290C7 /* DatabaseSession.swift in Sources */,
 				792A4F1D247FEA2200EAF71D /* ChannelListController.swift in Sources */,


### PR DESCRIPTION
- introduce `APIPathConvertible` protocol to unify access to paths using `ChannelId` and its properties
- all SDK calls should now on use this API - I already updated the ones I could find (I searched for `type)` in the whole project so we might be quite safe)
- I kept original approach in tests, just added `rawValue`s (at least for now) to make sure no regressions are created