### PR TITLE
[CIS-713] Prefix SDK Version in Client Header with 'v'

### DIFF
--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -187,7 +187,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
     
     /// Stream-specific request headers.
     private let sessionHeaders: [String: String] = [
-        "X-Stream-Client": "stream-chat-swift-client-\(SystemEnvironment.version)"
+        "X-Stream-Client": "stream-chat-swift-client-v\(SystemEnvironment.version)"
     ]
     
     /// The current connection id

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -224,7 +224,6 @@ class ChatClient_Tests: StressTestCase {
         XCTAssert(middlewares.contains(where: { $0 is MessageReactionsMiddleware<NoExtraData> }))
         // Assert `ChannelTruncatedEventMiddleware` exists
         XCTAssert(middlewares.contains(where: { $0 is ChannelTruncatedEventMiddleware<NoExtraData> }))
-
     }
     
     func test_connectionStatus_isExposed() {
@@ -679,7 +678,7 @@ extension ChatClient_Tests {
         let headers = config.httpAdditionalHeaders as? [String: String] ?? [:]
         XCTAssertEqual(
             headers["X-Stream-Client"],
-            "stream-chat-swift-client-\(SystemEnvironment.version)"
+            "stream-chat-swift-client-v\(SystemEnvironment.version)"
         )
     }
 }


### PR DESCRIPTION
# In this PR

Send the client header version prefixed with ´v´ so we can identify the new SDK versions in the Dashboard.
