### PR TITLE
[CIS-718] Fix message actions not visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐞 Fixed
 - Fix encoding of channels with custom type [#872](https://github.com/GetStream/stream-chat-swift/pull/872)
+- Fix `CurreUserController.currentUser` returning nil before `synchronize()` is called [#875](https://github.com/GetStream/stream-chat-swift/pull/875)
 
 # [3.1.1](https://github.com/GetStream/stream-chat-swift/releases/tag/3.1.1)
 _February 26, 2021_

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -70,7 +70,8 @@ public class _CurrentChatUserController<ExtraData: ExtraDataTypes>: DataControll
     /// The currently logged-in user. `nil` if the connection hasn't been fully established yet, or the connection
     /// wasn't successful.
     public var currentUser: _CurrentChatUser<ExtraData.User>? {
-        currentUserObserver.item
+        startObservingIfNeeded()
+        return currentUserObserver.item
     }
 
     /// The unread messages and channels count for the current user.

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -41,6 +41,18 @@ final class CurrentUserController_Tests: StressTestCase {
     }
     
     // MARK: Controller
+
+    // MARK: - currentUser tests
+
+    func test_currentUser_startsObserving_returnsCurrentUserObserverItem() {
+        let expectedId = UserId.unique
+        let expectedUnreadCount = UnreadCount(channels: .unique, messages: .unique)
+
+        env.currentUserObserverItem = .init(id: expectedId, unreadCount: expectedUnreadCount)
+
+        XCTAssertEqual(controller.currentUser?.id, expectedId)
+        XCTAssertTrue(env.currentUserObserver.startObservingCalled)
+    }
     
     // MARK: - Synchronize tests
     

--- a/Sources/StreamChat/Controllers/EntityDatabaseObserver_Mock.swift
+++ b/Sources/StreamChat/Controllers/EntityDatabaseObserver_Mock.swift
@@ -8,11 +8,13 @@ import XCTest
 
 class EntityDatabaseObserverMock<Item, DTO: NSManagedObject>: EntityDatabaseObserver<Item, DTO> {
     var synchronizeError: Error?
+    var startObservingCalled: Bool = false
     
     override func startObserving() throws {
         if let error = synchronizeError {
             throw error
         } else {
+            startObservingCalled = true
             try super.startObserving()
         }
     }


### PR DESCRIPTION
# In this PR

Fixes hidden message actions. When getting the `currentUser` from `CurrentUserController`, it was missing the start observing. So the `currentUser` would only be retrieved if `synchronize` was called.