### PR TITLE
[CIS-719] Fix app getting terminated in bg due to unfinished task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
+### 🐞 Fixed
+- Fix app getting terminated in background during an unfinished background task [#877](https://github.com/GetStream/stream-chat-swift/issues/877)
+
 ### ✅ Added
 - Add support for slow mode. See more info in the [documentation](https://getstream.io/chat/docs/javascript/slow_mode/?language=swift) [#859](https://github.com/GetStream/stream-chat-swift/issues/859)
 - Add support for channel truncating [#864](https://github.com/GetStream/stream-chat-swift/issues/864)

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -187,6 +187,8 @@ class WebSocketClient {
         
         let backgroundTask = backgroundTaskScheduler?.beginBackgroundTask { [weak self] in
             self?.disconnect(source: .systemInitiated)
+            // We need to call `endBackgroundTask` else our app will be killed
+            self?.cancelBackgroundTaskIfNeeded()
         }
         
         if backgroundTask != .invalid {

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
@@ -590,6 +590,27 @@ class WebSocketClient_Tests: StressTestCase {
         // Check the background task is terminated
         AssertAsync.willBeEqual(backgroundTaskScheduler.endBackgroundTask_called, task)
     }
+    
+    func test_backgroundTaskIsCancelled_whenExpirationHandlerIsCalled() {
+        // Simulate connection and start a background task
+        test_connectionFlow()
+        let task = UIBackgroundTaskIdentifier(rawValue: .random(in: 1...100))
+        backgroundTaskScheduler.beginBackgroundTask = task
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+        
+        // Wait for `beginBackgroundTask` being called since it can be done asynchronously
+        AssertAsync.willBeTrue(backgroundTaskScheduler.beginBackgroundTask_called)
+        assert(backgroundTaskScheduler.endBackgroundTask_called == nil)
+        
+        // We don't simulate explicit cancelation here
+        // since we expect expiration handler to call disconnect
+        
+        // Call expiration handler
+        backgroundTaskScheduler.beginBackgroundTask_expirationHandler!()
+        
+        // Check the background task is terminated
+        AssertAsync.willBeEqual(backgroundTaskScheduler.endBackgroundTask_called, task)
+    }
 }
 
 final class HealthCheckMiddleware_Tests: XCTestCase {


### PR DESCRIPTION
From UIBackgroundTask documentation:
> ... If you do not call endBackgroundTask(_:) for each task before time expires, the system kills the app. If you provide a block object in the handler parameter, the system calls your handler before time expires to give you a chance to end the task.

In v2, `endBackgroundTask` was being called after `disconnect` implicitly, so no crashes were observed. We oversaw this in v3. If you keep the app open long enough in background, console logs:

```
2021-03-11 14:19:30.793611+0100 ChatSample[13949:4184668] [BackgroundTask] Background task still not ended after expiration handlers were called: <_UIBackgroundTaskInfo: 0x282149cc0>: taskID = 109, taskName = Called by StreamChat, from $sSo13UIApplicationC19beginBackgroundTask17expirationHandlerSo012UIBackgroundD10IdentifierayycSg_tFTO, creationTime = 399290 (elapsed = 27). This app will likely be terminated by the system. Call UIApplication.endBackgroundTask(_:) to avoid this.
...
2021-03-11 14:21:22.170894+0100 ChatSample[13949:4184668] [BackgroundTask] Background Task 109 ("Called by StreamChat, from $sSo13UIApplicationC19beginBackgroundTask17expirationHandlerSo012UIBackgroundD10IdentifierayycSg_tFTO"), was created over 30 seconds ago. In applications running in the background, this creates a risk of termination. Remember to call UIApplication.endBackgroundTask(_:) for your task in a timely manner to avoid this.
```