### PR TITLE
[CIS-726] Introduce MemberEventMiddleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Upcoming
 
 ### ✅ Added
+- Introduce `MemberEventMiddleware` to observe member events and update database accordingly [#880](https://github.com/GetStream/stream-chat-swift/issues/880)
+
+### 🔄 Changed
+
+# [3.1.2](https://github.com/GetStream/stream-chat-swift/releases/tag/3.1.2)
+_March 09, 2021_
+
+### ✅ Added
 - Add support for slow mode. See more info in the [documentation](https://getstream.io/chat/docs/javascript/slow_mode/?language=swift) [#859](https://github.com/GetStream/stream-chat-swift/issues/859)
 - Add support for channel truncating [#864](https://github.com/GetStream/stream-chat-swift/issues/864)
 

--- a/Package.swift
+++ b/Package.swift
@@ -62,6 +62,7 @@ var streamChatSourcesExcluded: [String] { [
     "Config/TokenProvider_Tests.swift",
     "WebSocketClient/WebSocketClient_Mock.swift",
     "WebSocketClient/EventMiddlewares/ChannelTruncatedEventMiddleware_Tests.swift",
+    "WebSocketClient/EventMiddlewares/MemberEventMiddleware_Tests.swift",
     "WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift",
     "WebSocketClient/EventMiddlewares/MessageReactionsMiddleware_Tests.swift",
     "WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware_Tests.swift",

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MemberPayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MemberPayload.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
@@ -13,6 +13,16 @@ struct MemberContainerPayload<ExtraData: UserExtraData>: Decodable {
         member = try? .init(from: decoder)
         invite = try? .init(from: decoder)
         memberRole = try? .init(from: decoder)
+    }
+    
+    init(
+        member: MemberPayload<ExtraData>?,
+        invite: MemberInivePayload?,
+        memberRole: MemberRolePayload?
+    ) {
+        self.member = member
+        self.invite = invite
+        self.memberRole = memberRole
     }
 }
 

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -92,7 +92,8 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         ChannelReadUpdaterMiddleware<ExtraData>(database: databaseContainer),
         ChannelMemberTypingStateUpdaterMiddleware<ExtraData>(database: databaseContainer),
         MessageReactionsMiddleware<ExtraData>(database: databaseContainer),
-        ChannelTruncatedEventMiddleware<ExtraData>(database: databaseContainer)
+        ChannelTruncatedEventMiddleware<ExtraData>(database: databaseContainer),
+        MemberEventMiddleware<ExtraData>(database: databaseContainer)
     ])
     
     /// The `APIClient` instance `Client` uses to communicate with Stream REST API.

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -224,6 +224,8 @@ class ChatClient_Tests: StressTestCase {
         XCTAssert(middlewares.contains(where: { $0 is MessageReactionsMiddleware<NoExtraData> }))
         // Assert `ChannelTruncatedEventMiddleware` exists
         XCTAssert(middlewares.contains(where: { $0 is ChannelTruncatedEventMiddleware<NoExtraData> }))
+        // Assert `MemberEventMiddleware` exists
+        XCTAssert(middlewares.contains(where: { $0 is MemberEventMiddleware<NoExtraData> }))
     }
     
     func test_connectionStatus_isExposed() {

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import CoreData
@@ -96,6 +96,10 @@ extension NSManagedObjectContext {
         if let query = query {
             let queryDTO = try saveQuery(query)
             queryDTO.members.insert(dto)
+        }
+        
+        if let channelDTO = channel(cid: channelId) {
+            channelDTO.members.insert(dto)
         }
         
         return dto

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -244,10 +244,7 @@ extension DatabaseSession {
             try saveUser(payload: userPayload)
         }
         
-        // Save a member data.
-        if let cid = payload.cid, let memberPayload = payload.memberContainer?.member {
-            try saveMember(payload: memberPayload, channelId: cid)
-        }
+        // Member events are handled in `MemberEventMiddleware`
         
         // Save a channel detail data.
         if let channelDetailPayload = payload.channel {

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware.swift
@@ -1,0 +1,49 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The middleware listens for `MemberEvent`s and updates `ChannelDTO`s accordingly.
+struct MemberEventMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
+    let database: DatabaseContainer
+    
+    func handle(event: Event, completion: @escaping (Event?) -> Void) {
+        guard let memberEvent = event as? MemberEvent else {
+            completion(event)
+            return
+        }
+        
+        database.write { session in
+            switch memberEvent {
+            case is MemberAddedEvent, is MemberUpdatedEvent:
+                guard let eventWithMemberPayload = event as? EventWithMemberPayload,
+                    let eventPayload = eventWithMemberPayload.payload as? EventPayload<ExtraData>,
+                    let memberPayload = eventPayload.memberContainer?.member
+                else {
+                    return
+                }
+                try session.saveMember(payload: memberPayload, channelId: memberEvent.cid)
+            case is MemberRemovedEvent:
+                guard let channel = session.channel(cid: memberEvent.cid) else {
+                    // No need to throw ChannelNotFound error here
+                    return
+                }
+                
+                guard let member = channel.members.first(where: { $0.user.id == memberEvent.userId }) else {
+                    // No need to throw MemberNotFound error here
+                    return
+                }
+                
+                channel.members.remove(member)
+            default:
+                break
+            }
+        } completion: { error in
+            if let error = error {
+                log.error("Failed to update channel members in the database, error: \(error)")
+            }
+            completion(event)
+        }
+    }
+}

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware_Tests.swift
@@ -1,0 +1,231 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class MemberEventMiddleware_Tests: XCTestCase {
+    var database: DatabaseContainerMock!
+    var middleware: MemberEventMiddleware<NoExtraData>!
+    
+    // MARK: - Set up
+    
+    override func setUp() {
+        super.setUp()
+        
+        database = DatabaseContainerMock()
+        middleware = .init(database: database)
+    }
+    
+    override func tearDown() {
+        middleware = nil
+        AssertAsync.canBeReleased(&database)
+        
+        super.tearDown()
+    }
+    
+    // MARK: - Tests
+    
+    func tests_middleware_forwardsNonMemberEvents() throws {
+        let event = TestEvent()
+        
+        // Handle non-member event
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Assert event is forwarded as it is
+        XCTAssertEqual(forwardedEvent as! TestEvent, event)
+    }
+    
+    // MARK: - MemberAddedEvent
+    
+    func tests_middleware_forwardsMemberAddedEvent_ifDatabaseWriteGeneratesError() throws {
+        // Create MemberAddedEvent payload
+        let eventPayload: EventPayload<NoExtraData> = .init(
+            eventType: .memberAdded,
+            cid: .unique,
+            memberContainer: .dummy(userId: .unique)
+        )
+        
+        // Set error to be thrown on write.
+        let error = TestError()
+        database.write_errorResponse = error
+        
+        // Simulate and handle reaction event.
+        let event = try MemberAddedEvent(from: eventPayload)
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Assert `MemberAddedEvent` is forwarded even though database error happened.
+        XCTAssertTrue(forwardedEvent is MemberAddedEvent)
+    }
+    
+    func tests_middleware_handlesMemberAddedEventCorrectly() throws {
+        let cid = ChannelId.unique
+        let memberId = UserId.unique
+        
+        // Create MemberAddedEvent payload
+        let eventPayload: EventPayload<NoExtraData> = .init(
+            eventType: .memberAdded,
+            cid: cid,
+            memberContainer: .dummy(userId: memberId)
+        )
+        
+        // Create event with payload.
+        let event = try MemberAddedEvent(from: eventPayload)
+        
+        // Create channel in the database.
+        try database.createChannel(cid: cid, withMessages: false)
+        
+        // Simulate `MemberAddedEvent` event.
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Load the channel.
+        let channel = try XCTUnwrap(
+            database.viewContext.channel(cid: cid)
+        )
+        
+        // Assert event is forwarded.
+        XCTAssertTrue(forwardedEvent is MemberAddedEvent)
+        // Assert member is linked to the channel.
+        XCTAssert(channel.members.map(\.user.id).contains(memberId))
+    }
+    
+    // MARK: - MemberRemovedEvent
+    
+    func tests_middleware_forwardsMemberRemovedEvent_ifDatabaseWriteGeneratesError() throws {
+        // Create MemberAddedEvent payload
+        let eventPayload: EventPayload<NoExtraData> = .init(
+            eventType: .memberRemoved,
+            cid: .unique,
+            user: .dummy(userId: .unique)
+        )
+        
+        // Set error to be thrown on write.
+        let error = TestError()
+        database.write_errorResponse = error
+        
+        // Simulate and handle reaction event.
+        let event = try MemberRemovedEvent(from: eventPayload)
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Assert `MemberRemovedEvent` is forwarded even though database error happened.
+        XCTAssertTrue(forwardedEvent is MemberRemovedEvent)
+    }
+    
+    func tests_middleware_handlesMemberRemovedEventCorrectly() throws {
+        let cid = ChannelId.unique
+        
+        // Create channel in the database.
+        try database.createChannel(cid: cid, withMessages: false)
+        
+        // Load the channel
+        var channel = try XCTUnwrap(
+            database.viewContext.channel(cid: cid)
+        )
+        
+        // Save channel's member's id so we can remove it
+        let memberId = channel.members.first!.user.id
+        
+        // Create MemberRemovedEvent payload
+        let eventPayload: EventPayload<NoExtraData> = .init(
+            eventType: .memberRemoved,
+            cid: cid,
+            user: .dummy(userId: memberId)
+        )
+        
+        // Create event with payload.
+        let event = try MemberRemovedEvent(from: eventPayload)
+        
+        // Simulate `MemberRemovedEvent` event.
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Load the channel again
+        channel = try XCTUnwrap(
+            database.viewContext.channel(cid: cid)
+        )
+        
+        // Assert event is forwarded.
+        XCTAssertTrue(forwardedEvent is MemberRemovedEvent)
+        // Assert member is not linked to the channel.
+        XCTAssertFalse(channel.members.map(\.user.id).contains(memberId))
+    }
+    
+    // MARK: - MemberUpdatedEvent
+    
+    func tests_middleware_forwardsMemberUpdatedEvent_ifDatabaseWriteGeneratesError() throws {
+        // Create MemberAddedEvent payload
+        let eventPayload: EventPayload<NoExtraData> = .init(
+            eventType: .memberUpdated,
+            cid: .unique,
+            memberContainer: .dummy(userId: .unique)
+        )
+        
+        // Set error to be thrown on write.
+        let error = TestError()
+        database.write_errorResponse = error
+        
+        // Simulate and handle reaction event.
+        let event = try MemberUpdatedEvent(from: eventPayload)
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Assert `MemberUpdatedEvent` is forwarded even though database error happened.
+        XCTAssertTrue(forwardedEvent is MemberUpdatedEvent)
+    }
+    
+    func tests_middleware_handlesMemberUpdatedEventCorrectly() throws {
+        let cid = ChannelId.unique
+        
+        // Create channel in the database.
+        try database.createChannel(cid: cid, withMessages: false)
+        
+        // Load the channel
+        var channel = try XCTUnwrap(
+            database.viewContext.channel(cid: cid)
+        )
+        
+        // Save channel's member's id so we can update it
+        let memberId = channel.members.first!.user.id
+        let memberName = channel.members.first!.user.name
+        
+        // Create MemberUpdatedEvent payload
+        let eventPayload: EventPayload<NoExtraData> = .init(
+            eventType: .memberUpdated,
+            cid: cid,
+            memberContainer: .dummy(userId: memberId)
+        )
+        
+        // Create event with payload.
+        let event = try MemberUpdatedEvent(from: eventPayload)
+        
+        // Simulate `MemberUpdatedEvent` event.
+        let forwardedEvent = try await {
+            self.middleware.handle(event: event, completion: $0)
+        }
+        
+        // Load the channel again
+        channel = try XCTUnwrap(
+            database.viewContext.channel(cid: cid)
+        )
+        
+        // Assert event is forwarded.
+        XCTAssertTrue(forwardedEvent is MemberUpdatedEvent)
+        // Assert member is updated.
+        XCTAssertNotEqual(channel.members.first!.user.name, memberName)
+    }
+}
+
+private struct TestEvent: Event, Equatable {
+    let id = UUID()
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -60,8 +60,8 @@
 		698E2A3525F7C8AF00ED9CCC /* APIPathConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698E2A3425F7C8AF00ED9CCC /* APIPathConvertible.swift */; };
 		69DE605A25F39E6000DC187F /* ChatMessageListCollectionViewLayout_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE605925F39E6000DC187F /* ChatMessageListCollectionViewLayout_Tests.swift */; };
 		7844B10C25EF92B600B87E89 /* ChatChannelListItemView+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7844B10B25EF92B600B87E89 /* ChatChannelListItemView+SwiftUI.swift */; };
-		7849AF6725F243C8007817D4 /* ChatChannelListItemView+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7849AF6625F243C8007817D4 /* ChatChannelListItemView+SwiftUI_Tests.swift */; };
 		7844B16825EFB44600B87E89 /* UIConfig+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7844B16725EFB44600B87E89 /* UIConfig+SwiftUI.swift */; };
+		7849AF6725F243C8007817D4 /* ChatChannelListItemView+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7849AF6625F243C8007817D4 /* ChatChannelListItemView+SwiftUI_Tests.swift */; };
 		7900452625374CA20096ECA1 /* User+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7900452525374CA20096ECA1 /* User+SwiftUI.swift */; };
 		7908820625432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
 		7908821225432B7200896F03 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
@@ -294,6 +294,8 @@
 		79CD959424F9381700E87377 /* MulticastDelegate_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CD959324F9381700E87377 /* MulticastDelegate_Tests.swift */; };
 		79CD959624F9414700E87377 /* ChannelListController+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CD959524F9414700E87377 /* ChannelListController+SwiftUI_Tests.swift */; };
 		79CDE1DD24B321FE0003BD1D /* CurrentUserDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CDE1DC24B321FE0003BD1D /* CurrentUserDTO.swift */; };
+		79D6CF1825FA671C00BE2EEC /* MemberEventMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D6CF1725FA671C00BE2EEC /* MemberEventMiddleware.swift */; };
+		79D6CF2125FA6ACF00BE2EEC /* MemberEventMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D6CF2025FA6ACF00BE2EEC /* MemberEventMiddleware_Tests.swift */; };
 		79D7A1CE2593A40900D3C2BF /* ChannelPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D7A1CD2593A40900D3C2BF /* ChannelPayload.swift */; };
 		79D86E832562BAB900DCD1D2 /* AppearanceSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D86E822562BAB900DCD1D2 /* AppearanceSetting.swift */; };
 		79DDF80E249CB920002F4412 /* RequestDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDF80D249CB920002F4412 /* RequestDecoder.swift */; };
@@ -986,8 +988,8 @@
 		698E2A3425F7C8AF00ED9CCC /* APIPathConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPathConvertible.swift; sourceTree = "<group>"; };
 		69DE605925F39E6000DC187F /* ChatMessageListCollectionViewLayout_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListCollectionViewLayout_Tests.swift; sourceTree = "<group>"; };
 		7844B10B25EF92B600B87E89 /* ChatChannelListItemView+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatChannelListItemView+SwiftUI.swift"; sourceTree = "<group>"; };
-		7849AF6625F243C8007817D4 /* ChatChannelListItemView+SwiftUI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatChannelListItemView+SwiftUI_Tests.swift"; sourceTree = "<group>"; };
 		7844B16725EFB44600B87E89 /* UIConfig+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIConfig+SwiftUI.swift"; sourceTree = "<group>"; };
+		7849AF6625F243C8007817D4 /* ChatChannelListItemView+SwiftUI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatChannelListItemView+SwiftUI_Tests.swift"; sourceTree = "<group>"; };
 		7900452525374CA20096ECA1 /* User+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+SwiftUI.swift"; sourceTree = "<group>"; };
 		790881FD25432B7200896F03 /* StreamChatUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StreamChatUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7908820525432B7200896F03 /* StreamChatUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1220,6 +1222,8 @@
 		79CD959324F9381700E87377 /* MulticastDelegate_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MulticastDelegate_Tests.swift; sourceTree = "<group>"; };
 		79CD959524F9414700E87377 /* ChannelListController+SwiftUI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelListController+SwiftUI_Tests.swift"; sourceTree = "<group>"; };
 		79CDE1DC24B321FE0003BD1D /* CurrentUserDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserDTO.swift; sourceTree = "<group>"; };
+		79D6CF1725FA671C00BE2EEC /* MemberEventMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventMiddleware.swift; sourceTree = "<group>"; };
+		79D6CF2025FA6ACF00BE2EEC /* MemberEventMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEventMiddleware_Tests.swift; sourceTree = "<group>"; };
 		79D7A1CD2593A40900D3C2BF /* ChannelPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelPayload.swift; sourceTree = "<group>"; };
 		79D86E822562BAB900DCD1D2 /* AppearanceSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSetting.swift; sourceTree = "<group>"; };
 		79DDF80D249CB920002F4412 /* RequestDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestDecoder.swift; sourceTree = "<group>"; };
@@ -2327,6 +2331,8 @@
 				79158CEA25F0EADF00186102 /* ChannelTruncatedEventMiddleware_Tests.swift */,
 				8899BC56254337C7003CB98B /* MessageReactionsMiddleware.swift */,
 				889062422548387D00E1898E /* MessageReactionsMiddleware_Tests.swift */,
+				79D6CF1725FA671C00BE2EEC /* MemberEventMiddleware.swift */,
+				79D6CF2025FA6ACF00BE2EEC /* MemberEventMiddleware_Tests.swift */,
 			);
 			path = EventMiddlewares;
 			sourceTree = "<group>";
@@ -4665,6 +4671,7 @@
 				22692C8725D176F4007C41D0 /* ChatMessageLinkAttachment.swift in Sources */,
 				79877A092498E4BC00015F8B /* User.swift in Sources */,
 				79B5517324E593C200CE9FEC /* UserPayloads.swift in Sources */,
+				79D6CF1825FA671C00BE2EEC /* MemberEventMiddleware.swift in Sources */,
 				8899BC53254318CC003CB98B /* MessageReaction.swift in Sources */,
 				DA99D0D024ED63C600AD5354 /* NewChannelQueryUpdater.swift in Sources */,
 				8A0175F02501174000570345 /* EventSender.swift in Sources */,
@@ -4697,6 +4704,7 @@
 				F67415C024F0129800C3222F /* UnreadCount.swift in Sources */,
 				8A0175F425013B6400570345 /* EventSender_Tests.swift in Sources */,
 				8875CF9B2587A89F00BBA6AC /* AttachmentId_Tests.swift in Sources */,
+				79D6CF2125FA6ACF00BE2EEC /* MemberEventMiddleware_Tests.swift in Sources */,
 				79DDF819249CE38B002F4412 /* MockNetworkURLProtocol.swift in Sources */,
 				F61D7C3724FFE17200188A0E /* MessageEditor_Tests.swift in Sources */,
 				8AE335AA24FCF99E002B6677 /* InternetConnection_Tests.swift in Sources */,

--- a/Tests/StreamChatTests/DummyData/MemberPayload.swift
+++ b/Tests/StreamChatTests/DummyData/MemberPayload.swift
@@ -21,3 +21,9 @@ extension MemberPayload where ExtraData == NoExtraData {
         )
     }
 }
+
+extension MemberContainerPayload where ExtraData == NoExtraData {
+    static func dummy(userId: UserId = .unique) -> MemberContainerPayload {
+        .init(member: .dummy(userId: userId), invite: nil, memberRole: nil)
+    }
+}


### PR DESCRIPTION
I was surprised to see `saveMember` doesn't actually link the member to the Channel! Is that intentional? Introducing this logic didn't break any test.