### PR TITLE
Add cleanup to stress tests

### DIFF
--- a/Sources/StreamChat/ChatClient_Mock.swift
+++ b/Sources/StreamChat/ChatClient_Mock.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 @testable import StreamChat
+import XCTest
 
 extension _ChatClient {
     static var mock: _ChatClient {
@@ -131,7 +132,12 @@ extension _ChatClient.Environment {
                 )
             },
             databaseContainerBuilder: {
-                try! DatabaseContainerMock(kind: $0, shouldFlushOnStart: $1, shouldResetEphemeralValuesOnStart: $2)
+                do {
+                    return try DatabaseContainerMock(kind: $0, shouldFlushOnStart: $1, shouldResetEphemeralValuesOnStart: $2)
+                } catch {
+                    XCTFail("Unable to initialize DatabaseContainerMock \(error)")
+                    fatalError("Unable to initialize DatabaseContainerMock \(error)")
+                }
             },
             requestEncoderBuilder: DefaultRequestEncoder.init,
             requestDecoderBuilder: DefaultRequestDecoder.init,

--- a/Tests/Shared/StressTestCase.swift
+++ b/Tests/Shared/StressTestCase.swift
@@ -5,6 +5,12 @@
 import XCTest
 
 class StressTestCase: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        
+        continueAfterFailure = false
+    }
+    
     override func invokeTest() {
         if TestRunnerEnvironment.isStressTest {
             // Invoke the test 100 times

--- a/Tests/Shared/StressTestCase.swift
+++ b/Tests/Shared/StressTestCase.swift
@@ -4,11 +4,39 @@
 
 import XCTest
 
+/// Base class for stress tests
+///
+/// - runs 100 times if `TestRunnerEnvironment.isStressTest`
+/// - removes all files in `NSTemporaryDirectory()` and `Documents` directory when test suite completes
+/// - by default ends test when test failure occurs
 class StressTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
         
         continueAfterFailure = false
+    }
+    
+    override class func tearDown() {
+        // After running test suite cleanup `NSTemporaryDirectory()` and `Documents` directory
+        let fileManager = FileManager.default
+        let tempDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
+        let tempFileURLs = (try? fileManager.contentsOfDirectory(
+            at: tempDirectoryURL,
+            includingPropertiesForKeys: nil,
+            options: .skipsHiddenFiles
+        )) ?? []
+        let documentsFileURLs = documentsURL.flatMap { try? FileManager.default.contentsOfDirectory(
+            at: $0,
+            includingPropertiesForKeys: nil,
+            options: .skipsHiddenFiles
+        ) } ?? []
+        
+        for fileURL in tempFileURLs + documentsFileURLs {
+            try? fileManager.removeItem(at: fileURL)
+        }
+        
+        super.tearDown()
     }
     
     override func invokeTest() {


### PR DESCRIPTION
- adds cleanup after each test suite so disk space issue should be resolved
- prefers test failure to crash if `DatabaseContainer_Mock` in `ChatClient_Mock` cannot be instantiated