### PR TITLE
Fix watcher events received for current user during query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix `ChannelDoesNotExist` error is logged by `UserWatchingEventMiddleware` when channels are fetched for the first time [#893](https://github.com/GetStream/stream-chat-swift/issues/893)
 
 # [3.1.3](https://github.com/GetStream/stream-chat-swift/releases/tag/3.1.3)
 _March 12, 2021_


### PR DESCRIPTION
This happens because when we query channels with watch: true, our current user watches the channels and backend sends the `userStartedWatching` event before we save the channels that we just watched to the DB.
