### PR TITLE
[CIS-710] Fix flaky LLC tests

### DIFF
--- a/Sources/StreamChat/Controllers/ListDatabaseObserver_Tests.swift
+++ b/Sources/StreamChat/Controllers/ListDatabaseObserver_Tests.swift
@@ -107,7 +107,10 @@ class ListDatabaseObserver_Tests: XCTestCase {
     }
     
     override func tearDown() {
-        AssertAsync.canBeReleased(&observer)
+        AssertAsync {
+            Assert.canBeReleased(&observer)
+            Assert.canBeReleased(&database)
+        }
         super.tearDown()
     }
     

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
@@ -12,6 +12,11 @@ class AttachmentDTO_Tests: XCTestCase {
         super.setUp()
         database = try! DatabaseContainer(kind: .inMemory)
     }
+    
+    override func tearDown() {
+        AssertAsync.canBeReleased(&database)
+        super.tearDown()
+    }
 
     func test_attachmentSeed_isStoredAndLoadedFromDB() throws {
         let cid: ChannelId = .unique

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
@@ -13,6 +13,11 @@ class ChannelDTO_Tests: XCTestCase {
         database = try! DatabaseContainer(kind: .inMemory)
     }
     
+    override func tearDown() {
+        AssertAsync.canBeReleased(&database)
+        super.tearDown()
+    }
+    
     func test_channelPayload_isStoredAndLoadedFromDB() {
         let channelId: ChannelId = .unique
         

--- a/Sources/StreamChat/Database/DTOs/ChannelMemberListQueryDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelMemberListQueryDTO_Tests.swift
@@ -17,7 +17,7 @@ final class ChannelMemberListQueryDTO_Tests: XCTestCase {
     }
     
     override func tearDown() {
-        database = nil
+        AssertAsync.canBeReleased(&database)
         super.tearDown()
     }
     

--- a/Sources/StreamChat/Database/DTOs/CurrentUserDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/CurrentUserDTO_Tests.swift
@@ -13,6 +13,11 @@ class CurrentUserModelDTO_Tests: XCTestCase {
         database = try! DatabaseContainer(kind: .inMemory)
     }
     
+    override func tearDown() {
+        AssertAsync.canBeReleased(&database)
+        super.tearDown()
+    }
+    
     func test_currentUserPayload_isStoredAndLoadedFromDB() {
         let userId = UUID().uuidString
         let extraData = NoExtraData.defaultValue

--- a/Sources/StreamChat/Database/DTOs/DeviceDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/DeviceDTO_Tests.swift
@@ -13,6 +13,11 @@ class DeviceDTO_Tests: XCTestCase {
         database = try! DatabaseContainer(kind: .inMemory)
     }
     
+    override func tearDown() {
+        AssertAsync.canBeReleased(&database)
+        super.tearDown()
+    }
+    
     func test_deviceListPayload_isStoredAndLoadedFromDB() throws {
         let dummyDevices = DeviceListPayload.dummy
         

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO_Tests.swift
@@ -13,6 +13,11 @@ class MemberModelDTO_Tests: XCTestCase {
         database = try! DatabaseContainer(kind: .inMemory)
     }
     
+    override func tearDown() {
+        AssertAsync.canBeReleased(&database)
+        super.tearDown()
+    }
+    
     func test_memberPayload_isStoredAndLoadedFromDB() throws {
         let userId = UUID().uuidString
         let channelId = ChannelId(type: .init(rawValue: "messsaging"), id: UUID().uuidString)

--- a/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
@@ -14,6 +14,11 @@ class MessageDTO_Tests: XCTestCase {
         database = try! DatabaseContainer(kind: .inMemory)
     }
     
+    override func tearDown() {
+        AssertAsync.canBeReleased(&database)
+        super.tearDown()
+    }
+    
     func test_messagePayload_isStoredAndLoadedFromDB() {
         let userId: UserId = .unique
         let messageId: MessageId = .unique

--- a/Sources/StreamChat/Database/DTOs/MessageReactionDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageReactionDTO_Tests.swift
@@ -17,7 +17,7 @@ final class MessageReactionDTO_Tests: XCTestCase {
     }
     
     override func tearDown() {
-        database = nil
+        AssertAsync.canBeReleased(&database)
         super.tearDown()
     }
     

--- a/Sources/StreamChat/Database/DTOs/UserDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/UserDTO_Tests.swift
@@ -13,6 +13,11 @@ class UserDTO_Tests: XCTestCase {
         database = try! DatabaseContainerMock(kind: .inMemory)
     }
     
+    override func tearDown() {
+        AssertAsync.canBeReleased(&database)
+        super.tearDown()
+    }
+    
     func test_userPayload_isStoredAndLoadedFromDB() {
         let userId = UUID().uuidString
         

--- a/Sources/StreamChat/Database/DatabaseSession_Tests.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Tests.swift
@@ -13,6 +13,11 @@ class DatabaseSession_Tests: StressTestCase {
         database = try! DatabaseContainerMock(kind: .inMemory)
     }
     
+    override func tearDown() {
+        AssertAsync.canBeReleased(&database)
+        super.tearDown()
+    }
+    
     func test_eventPayloadChannelData_isSavedToDatabase() {
         // Prepare an Event payload with a channel data
         let channelId: ChannelId = .unique

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
@@ -15,6 +15,12 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         middleware = ChannelReadUpdaterMiddleware(database: database)
     }
     
+    override func tearDown() {
+        middleware = nil
+        AssertAsync.canBeReleased(&database)
+        super.tearDown()
+    }
+
     func test_messageReadEvent_handledCorrectly() throws {
         // Save a channel with a channel read
         let channelId = ChannelId.unique

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
@@ -15,6 +15,12 @@ class EventDataProcessorMiddleware_Tests: XCTestCase {
         middleware = EventDataProcessorMiddleware(database: database)
     }
     
+    override func tearDown() {
+        middleware = nil
+        AssertAsync.canBeReleased(&database)
+        super.tearDown()
+    }
+    
     func test_eventWithPayload_isSavedToDB() throws {
         // Prepare an Event with a payload with channel data
         struct TestEvent: Event, EventWithPayload {

--- a/Sources/StreamChat/Workers/ChannelListUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater_Tests.swift
@@ -25,7 +25,10 @@ class ChannelListUpdater_Tests: StressTestCase {
     override func tearDown() {
         apiClient.cleanUp()
         
-        AssertAsync.canBeReleased(&listUpdater)
+        AssertAsync {
+            Assert.canBeReleased(&listUpdater)
+            Assert.canBeReleased(&database)
+        }
         
         super.tearDown()
     }

--- a/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
@@ -26,6 +26,7 @@ class ChannelUpdater_Tests: StressTestCase {
     
     override func tearDown() {
         apiClient.cleanUp()
+        AssertAsync.canBeReleased(&database)
         
         super.tearDown()
     }

--- a/Sources/StreamChat/Workers/EventSender_Tests.swift
+++ b/Sources/StreamChat/Workers/EventSender_Tests.swift
@@ -30,6 +30,7 @@ class EventSender_Tests: StressTestCase {
     
     override func tearDown() {
         apiClient.cleanUp()
+        AssertAsync.canBeReleased(&database)
         super.tearDown()
     }
     

--- a/Sources/StreamChat/Workers/UserListUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/UserListUpdater_Tests.swift
@@ -25,7 +25,10 @@ class UserListUpdater_Tests: StressTestCase {
     override func tearDown() {
         apiClient.cleanUp()
         
-        AssertAsync.canBeReleased(&listUpdater)
+        AssertAsync {
+            Assert.canBeReleased(&listUpdater)
+            Assert.canBeReleased(&database)
+        }
         
         super.tearDown()
     }

--- a/Tests/Shared/StressTestCase.swift
+++ b/Tests/Shared/StressTestCase.swift
@@ -40,15 +40,10 @@ class StressTestCase: XCTestCase {
     }
     
     override func invokeTest() {
-        if TestRunnerEnvironment.isStressTest {
-            // Invoke the test 100 times
-            for _ in 0...100 {
-                autoreleasepool {
-                    super.invokeTest()
-                }
+        for _ in 0..<TestRunnerEnvironment.testInvocations {
+            autoreleasepool {
+                super.invokeTest()
             }
-        } else {
-            super.invokeTest()
         }
     }
 }

--- a/Tests/Shared/TestRunnerEnvironment.swift
+++ b/Tests/Shared/TestRunnerEnvironment.swift
@@ -4,16 +4,18 @@
 
 import Foundation
 
-struct TestRunnerEnvironment {
+enum TestRunnerEnvironment {
     /// `true` if the tests are currently running on the CI. We get this information by checking for the custom `CI` environment
     /// variable passed in to the process.
     static var isCI: Bool {
         ProcessInfo.processInfo.environment["CI"] == "TRUE"
     }
     
-    /// `true` if the current tests are stress test. We get this information by checking for the custom `STRESS_TESTS` environment
-    /// variable passed in to the process.
-    static var isStressTest: Bool {
-        ProcessInfo.processInfo.environment["STRESS_TESTS"] == "TRUE"
+    /// Number of stress test invocations
+    static var testInvocations: Int {
+        ProcessInfo.processInfo.environment["TEST_INVOCATIONS"].flatMap(Int.init) ?? 1
     }
+    
+    /// `true` if we invoke stress tests more than a single time
+    static var isStressTest: Bool { testInvocations > 1 }
 }

--- a/Tests/StreamChatTests/StreamChatStressTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatStressTestPlan.xctestplan
@@ -12,10 +12,11 @@
     "codeCoverage" : false,
     "environmentVariableEntries" : [
       {
-        "key" : "STRESS_TESTS",
-        "value" : "TRUE"
+        "key" : "TEST_INVOCATIONS",
+        "value" : "10"
       }
-    ]
+    ],
+    "testExecutionOrdering" : "random"
   },
   "testTargets" : [
     {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,7 +4,7 @@ default_platform :ios
 require 'json'
 
 # The number of times the stress test suite is ran
-stress_tests_cycles = 10
+stress_tests_cycles = 50
 
 before_all do
   if is_ci


### PR DESCRIPTION
Wait for release of database so CoreData tests do no affect each other. I also reduced stress tests cycles to 5 for now so we pass the 6h job limit on CI.

Seems to work well as tonight stress tests [passed](https://github.com/GetStream/stream-chat-swift/actions/runs/659391394) 🎉