### PR TITLE
[CIS-729] Remove setting of TAMIC inside pin methods

### DIFF
--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView+SwiftUI_Tests.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView+SwiftUI_Tests.swift
@@ -52,8 +52,6 @@ class ChatChannelListItemView_SwiftUI_Tests: XCTestCase {
 
 private extension UIView {
     func addWidthConstraint() {
-        translatesAutoresizingMaskIntoConstraints = false
-
         NSLayoutConstraint.activate([
             widthAnchor.constraint(equalToConstant: 350)
         ])

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -31,6 +31,7 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
     open private(set) lazy var collectionView: UICollectionView = uiConfig
         .channelList
         .collectionView.init(frame: .zero, collectionViewLayout: collectionViewLayout)
+        .withoutAutoresizingMaskConstraints
     
     /// The `UIButton` instance used for navigating to new channel screen creation,
     open private(set) lazy var createNewChannelButton: UIButton = uiConfig

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountView+SwiftUI_Tests.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountView+SwiftUI_Tests.swift
@@ -32,8 +32,6 @@ class ChatChannelUnreadCountView_SwiftUI_Tests: XCTestCase {
 
         let view = ChatChannelUnreadCountView.SwiftUIWrapper<CustomUnreadCountView>()
         view.content = .mock(messages: 20)
-        view.translatesAutoresizingMaskIntoConstraints = false
-
         AssertSnapshot(view)
     }
 }

--- a/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView+SwiftUI_Tests.swift
+++ b/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView+SwiftUI_Tests.swift
@@ -43,8 +43,6 @@ class ChatChannelAvatarView_SwiftUI_Tests: XCTestCase {
 
 private extension UIView {
     func addSizeConstraints() {
-        translatesAutoresizingMaskIntoConstraints = false
-
         NSLayoutConstraint.activate([
             heightAnchor.constraint(equalToConstant: 50),
             widthAnchor.constraint(equalToConstant: 50)

--- a/Sources/StreamChatUI/Utils/UIView+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/UIView+Extensions.swift
@@ -6,10 +6,10 @@ import UIKit
 
 extension UIView {
     // MARK: - `embed` family of helpers
-    
+
     func embed(_ subview: UIView, insets: NSDirectionalEdgeInsets = .zero) {
         addSubview(subview)
-        subview.translatesAutoresizingMaskIntoConstraints = false
+
         NSLayoutConstraint.activate([
             subview.leadingAnchor.pin(equalTo: leadingAnchor, constant: insets.leading),
             subview.trailingAnchor.pin(equalTo: trailingAnchor, constant: -insets.trailing),
@@ -18,25 +18,19 @@ extension UIView {
         ])
     }
     
-    // MARK: - `pin` family of helpers
-    
     func pin(anchors: [LayoutAnchorName] = [.top, .left, .bottom, .right], to view: UIView) {
-        translatesAutoresizingMaskIntoConstraints = false
-        view.translatesAutoresizingMaskIntoConstraints = false
         anchors
             .map { $0.makeConstraint(fromView: self, toView: view) }
             .forEach { $0.isActive = true }
     }
     
     func pin(anchors: [LayoutAnchorName] = [.top, .left, .bottom, .right], to layoutGuide: UILayoutGuide) {
-        translatesAutoresizingMaskIntoConstraints = false
         anchors
             .compactMap { $0.makeConstraint(fromView: self, toLayoutGuide: layoutGuide) }
             .forEach { $0.isActive = true }
     }
     
     func pin(anchors: [LayoutAnchorName] = [.width, .height], to constant: CGFloat) {
-        translatesAutoresizingMaskIntoConstraints = false
         anchors
             .compactMap { $0.makeConstraint(fromView: self, constant: constant) }
             .forEach { $0.isActive = true }


### PR DESCRIPTION
# What this PR do:
- Removes TAMIC from pin view extensions and replaces the 
# How to test it
- Probably CI can take care of UI Tests, if they pass, we are fine :) 
# Where you can start
- `UIView+Extensions.swift`
