### PR TITLE
Fix constraints on ChatMessageComposerVC

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -126,6 +126,7 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: _ViewController,
 
     override open func setUpLayout() {
         super.setUpLayout()
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
 
         view.addSubview(collectionView)
         collectionView.pin(to: view.safeAreaLayoutGuide)

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerDocumentAttachmentsView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerDocumentAttachmentsView.swift
@@ -65,6 +65,7 @@ open class _ChatMessageComposerDocumentAttachmentsView<ExtraData: ExtraDataTypes
     }
     
     override open func setUpLayout() {
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
         embed(collectionView)
         
         flowLayout.itemHeight = documentPreviewItemHeight

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerImageAttachmentsView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerImageAttachmentsView.swift
@@ -61,6 +61,7 @@ open class _ChatMessageComposerImageAttachmentsView<ExtraData: ExtraDataTypes>: 
     }
     
     override open func setUpLayout() {
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
         embed(collectionView)
         
         flowLayout.itemSize = imagePreviewItemSize

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.swift
@@ -65,6 +65,7 @@ open class _ChatMessagePopupVC<ExtraData: ExtraDataTypes>: _ViewController, UICo
         addChildViewController(actionsController, targetView: contentView)
 
         contentView.addSubview(messageContentView)
+        messageContentView.setupMessageBubbleView()
         scrollContentView.addSubview(contentView)
         scrollView.embed(scrollContentView)
         view.embed(blurView)


### PR DESCRIPTION
Fixes issues with composer view having bad size because TAMIC was set to true in underlying components, causing it not to expand properly.
