### PR TITLE
[CIS-733] Load expensive CoreData properties lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix `ChannelDoesNotExist` error is logged by `UserWatchingEventMiddleware` when channels are fetched for the first time [#893](https://github.com/GetStream/stream-chat-swift/issues/893)
+- Improve model loading performance by lazy loading expensive properties [#906](https://github.com/GetStream/stream-chat-swift/issues/906)
 
 # [3.1.3](https://github.com/GetStream/stream-chat-swift/releases/tag/3.1.3)
 _March 12, 2021_

--- a/Sample/Samples/CombineSimpleChat/CombineSimpleChannelsViewController.swift
+++ b/Sample/Samples/CombineSimpleChat/CombineSimpleChannelsViewController.swift
@@ -137,7 +137,7 @@ class CombineSimpleChannelsViewController: UITableViewController {
         let subtitle: String
         if let typingMembersInfo = createTypingMemberString(for: channel) {
             subtitle = typingMembersInfo
-        } else if let latestMessage = channel.latestMessages.first {
+        } else if let latestMessage = channel.lastMessage {
             let author = latestMessage.author.name ?? latestMessage.author.id.description
             subtitle = "\(author): \(latestMessage.text)"
         } else {

--- a/Sample/Samples/SimpleChat/SimpleChannelsViewController.swift
+++ b/Sample/Samples/SimpleChat/SimpleChannelsViewController.swift
@@ -109,7 +109,7 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
         let subtitle: String
         if let typingMembersInfo = createTypingMemberString(for: channel) {
             subtitle = typingMembersInfo
-        } else if let latestMessage = channel.latestMessages.first {
+        } else if let latestMessage = channel.lastMessage {
             let author = latestMessage.author.name ?? latestMessage.author.id.description
             subtitle = "\(author): \(latestMessage.text)"
         } else {

--- a/Sample/Samples/SwiftUISimpleChat/ChannelListView.swift
+++ b/Sample/Samples/SwiftUISimpleChat/ChannelListView.swift
@@ -192,7 +192,7 @@ struct ChannelListView: View {
         
         if let typingMembersInfo = createTypingMemberString(for: channel) {
             return Text(typingMembersInfo)
-        } else if let latestMessage = channel.latestMessages.first {
+        } else if let latestMessage = channel.lastMessage {
             let author = latestMessage.author.name ?? latestMessage.author.id.description
             return Text("\(author): \(latestMessage.text)")
         } else {

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -158,15 +158,15 @@ extension _ChatMessage {
             quotedMessageId: nil,
             isSilent: false,
             reactionScores: ["": 1],
-            author: .init(id: .unique),
-            mentionedUsers: [],
+            author: { .init(id: .unique) },
+            mentionedUsers: { [] },
             threadParticipants: [],
-            attachments: [],
-            latestReplies: [],
+            attachments: { [] },
+            latestReplies: { [] },
             localState: nil,
             isFlaggedByCurrentUser: false,
-            latestReactions: [],
-            currentUserReactions: [],
+            latestReactions: { [] },
+            currentUserReactions: { [] },
             isSentByCurrentUser: false
         )
     }

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -244,11 +244,6 @@ extension _ChatChannel {
         
         let context = dto.managedObjectContext!
         
-        // TODO: make messagesLimit a param
-        let latestMessages: [_ChatMessage<ExtraData>] = MessageDTO
-            .load(for: dto.cid, limit: 25, context: context)
-            .map { $0.asModel() }
-        
         let reads: [_ChatChannelRead<ExtraData>] = dto.reads.map { $0.asModel() }
         
         var unreadCount = ChannelUnreadCount.noUnread
@@ -268,6 +263,12 @@ extension _ChatChannel {
                 messages: currentUserChannelRead.unreadMessagesCount,
                 mentionedMessages: mentionedMessagesCount
             )
+        }
+        
+        let fetchMessages: (Int) -> [_ChatMessage<ExtraData>] = {
+            MessageDTO
+                .load(for: dto.cid, limit: $0, context: context)
+                .map { $0.asModel() }
         }
         
         return _ChatChannel(
@@ -294,7 +295,8 @@ extension _ChatChannel {
             cooldownDuration: Int(dto.cooldownDuration),
             extraData: extraData,
 //            invitedMembers: [],
-            latestMessages: latestMessages
+            latestMessages: { fetchMessages(25) }, // TODO: make messagesLimit a param
+            lastMessage: fetchMessages(1).first
         )
     }
 }

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -95,8 +95,11 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
     /// This field contains only the latest messages of the channel. You can get all existing messages in the channel by creating
     /// and using a `ChatChannelController` for this channel id.
     ///
-    public let latestMessages: [_ChatMessage<ExtraData>]
+    /// - Important: The `latestMessages` property is loaded and evaluated lazily to maintain high performance.
+    public var latestMessages: [_ChatMessage<ExtraData>] { _latestMessages }
+    @Cached private var _latestMessages: [_ChatMessage<ExtraData>]
     
+    /// The newest message of the channel. `nil` if there are no messages in the channel.
     public let lastMessage: _ChatMessage<ExtraData>?
     
     /// Read states of the users for this channel.
@@ -149,7 +152,7 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
         cooldownDuration: Int = 0,
         extraData: ExtraData.Channel,
 //        invitedMembers: Set<_ChatChannelMember<ExtraData.User>> = [],
-        latestMessages: [_ChatMessage<ExtraData>] = []
+        latestMessages: @escaping (() -> [_ChatMessage<ExtraData>]) = { [] },
         lastMessage: _ChatMessage<ExtraData>? = nil
     ) {
         self.cid = cid
@@ -175,8 +178,8 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
         self.cooldownDuration = cooldownDuration
         self.extraData = extraData
 //        self.invitedMembers = invitedMembers
-        self.latestMessages = latestMessages
         self.lastMessage = lastMessage
+        self.$_latestMessages = latestMessages
     }
 }
 

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -97,6 +97,8 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
     ///
     public let latestMessages: [_ChatMessage<ExtraData>]
     
+    public let lastMessage: _ChatMessage<ExtraData>?
+    
     /// Read states of the users for this channel.
     ///
     /// You can use this information to show to your users information about what messages were read by certain users.
@@ -148,6 +150,7 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
         extraData: ExtraData.Channel,
 //        invitedMembers: Set<_ChatChannelMember<ExtraData.User>> = [],
         latestMessages: [_ChatMessage<ExtraData>] = []
+        lastMessage: _ChatMessage<ExtraData>? = nil
     ) {
         self.cid = cid
         self.name = name
@@ -173,6 +176,7 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
         self.extraData = extraData
 //        self.invitedMembers = invitedMembers
         self.latestMessages = latestMessages
+        self.lastMessage = lastMessage
     }
 }
 

--- a/Sources/StreamChat/Models/Message.swift
+++ b/Sources/StreamChat/Models/Message.swift
@@ -84,19 +84,35 @@ public struct _ChatMessage<ExtraData: ExtraDataTypes> {
     public let reactionScores: [MessageReactionType: Int]
     
     /// The user which is the author of the message.
-    public let author: _ChatUser<ExtraData.User>
+    ///
+    /// - Important: The `author` property is loaded and evaluated lazily to maintain high performance.
+    public var author: _ChatUser<ExtraData.User> { _author }
+    
+    @Cached internal var _author: _ChatUser<ExtraData.User>
     
     /// A list of users that are mentioned in this message.
-    public let mentionedUsers: Set<_ChatUser<ExtraData.User>>
+    ///
+    /// - Important: The `mentionedUsers` property is loaded and evaluated lazily to maintain high performance.
+    public var mentionedUsers: Set<_ChatUser<ExtraData.User>> { _mentionedUsers }
+    
+    @Cached internal var _mentionedUsers: Set<_ChatUser<ExtraData.User>>
 
     /// A list of users that participated in this message thread
     public let threadParticipants: Set<UserId>
     
     /// A list of attachments in this message.
-    public let attachments: [ChatMessageAttachment]
+    ///
+    /// - Important: The `attachments` property is loaded and evaluated lazily to maintain high performance.
+    public var attachments: [ChatMessageAttachment] { _attachments }
+    
+    @Cached internal var _attachments: [ChatMessageAttachment]
         
     /// A list of latest 25 replies to this message.
-    public let latestReplies: [_ChatMessage<ExtraData>]
+    ///
+    /// - Important: The `latestReplies` property is loaded and evaluated lazily to maintain high performance.
+    public var latestReplies: [_ChatMessage<ExtraData>] { _latestReplies }
+    
+    @Cached internal var _latestReplies: [_ChatMessage<ExtraData>]
     
     /// A possible additional local state of the message. Applies only for the messages of the current user.
     ///
@@ -114,12 +130,77 @@ public struct _ChatMessage<ExtraData: ExtraDataTypes> {
     /// The latest reactions to the message created by any user.
     ///
     /// - Note: There can be `10` reactions at max.
-    public let latestReactions: Set<_ChatMessageReaction<ExtraData>>
+    /// - Important: The `latestReactions` property is loaded and evaluated lazily to maintain high performance.
+    public var latestReactions: Set<_ChatMessageReaction<ExtraData>> { _latestReactions }
+    
+    @Cached internal var _latestReactions: Set<_ChatMessageReaction<ExtraData>>
     
     /// The entire list of reactions to the message left by the current user.
-    public let currentUserReactions: Set<_ChatMessageReaction<ExtraData>>
+    ///
+    /// - Important: The `currentUserReactions` property is loaded and evaluated lazily to maintain high performance.
+    public var currentUserReactions: Set<_ChatMessageReaction<ExtraData>> { _currentUserReactions }
     
+    @Cached internal var _currentUserReactions: Set<_ChatMessageReaction<ExtraData>>
+    
+    /// `true` if the author of the message is the currently logged-in user.
     public let isSentByCurrentUser: Bool
+    
+    internal init(
+        id: MessageId,
+        text: String,
+        type: MessageType,
+        command: String?,
+        createdAt: Date,
+        locallyCreatedAt: Date?,
+        updatedAt: Date,
+        deletedAt: Date?,
+        arguments: String?,
+        parentMessageId: MessageId?,
+        showReplyInChannel: Bool,
+        replyCount: Int,
+        extraData: ExtraData.Message,
+        quotedMessageId: MessageId?,
+        isSilent: Bool,
+        reactionScores: [MessageReactionType: Int],
+        author: @escaping () -> _ChatUser<ExtraData.User>,
+        mentionedUsers: @escaping () -> Set<_ChatUser<ExtraData.User>>,
+        threadParticipants: Set<UserId>,
+        attachments: @escaping () -> [ChatMessageAttachment],
+        latestReplies: @escaping () -> [_ChatMessage<ExtraData>],
+        localState: LocalMessageState?,
+        isFlaggedByCurrentUser: Bool,
+        latestReactions: @escaping () -> Set<_ChatMessageReaction<ExtraData>>,
+        currentUserReactions: @escaping () -> Set<_ChatMessageReaction<ExtraData>>,
+        isSentByCurrentUser: Bool
+    ) {
+        self.id = id
+        self.text = text
+        self.type = type
+        self.command = command
+        self.createdAt = createdAt
+        self.locallyCreatedAt = locallyCreatedAt
+        self.updatedAt = updatedAt
+        self.deletedAt = deletedAt
+        self.arguments = arguments
+        self.parentMessageId = parentMessageId
+        self.showReplyInChannel = showReplyInChannel
+        self.replyCount = replyCount
+        self.extraData = extraData
+        self.quotedMessageId = quotedMessageId
+        self.isSilent = isSilent
+        self.reactionScores = reactionScores
+        self.threadParticipants = threadParticipants
+        self.localState = localState
+        self.isFlaggedByCurrentUser = isFlaggedByCurrentUser
+        self.isSentByCurrentUser = isSentByCurrentUser
+        
+        self.$_author = author
+        self.$_mentionedUsers = mentionedUsers
+        self.$_attachments = attachments
+        self.$_latestReplies = latestReplies
+        self.$_latestReactions = latestReactions
+        self.$_currentUserReactions = currentUserReactions
+    }
 }
 
 extension _ChatMessage: Hashable {

--- a/Sources/StreamChat/Utils/Cached.swift
+++ b/Sources/StreamChat/Utils/Cached.swift
@@ -32,6 +32,14 @@ class Cached<T> {
         return returnValue
     }
     
+    var projectedValue: (() -> T) {
+        get {
+            log.assert(computeValue != nil, "You must set the `computeValue` closure before accessing it.")
+            return computeValue
+        }
+        set { computeValue = newValue }
+    }
+    
     @Atomic private var _cached: T?
     
     /// Resets the current cached value. When someone access the `wrappedValue`, the `computeValue` closure is used

--- a/Sources/StreamChatTestTools/Models/ChatChannel_Mock.swift
+++ b/Sources/StreamChatTestTools/Models/ChatChannel_Mock.swift
@@ -99,7 +99,8 @@ public extension _ChatChannel {
             memberCount: memberCount,
             reads: reads,
             extraData: extraData,
-            latestMessages: latestMessages
+            latestMessages: { latestMessages },
+            lastMessage: latestMessages.first
         )
     }
     
@@ -143,7 +144,8 @@ public extension _ChatChannel {
             memberCount: memberCount,
             reads: reads,
             extraData: extraData,
-            latestMessages: latestMessages
+            latestMessages: { latestMessages },
+            lastMessage: latestMessages.first
         )
     }
 }

--- a/Sources/StreamChatTestTools/Models/ChatMessage_Mock.swift
+++ b/Sources/StreamChatTestTools/Models/ChatMessage_Mock.swift
@@ -52,15 +52,15 @@ public extension _ChatMessage {
             quotedMessageId: quotedMessageId,
             isSilent: isSilent,
             reactionScores: reactionScores,
-            author: author,
-            mentionedUsers: mentionedUsers,
+            author: { author },
+            mentionedUsers: { mentionedUsers },
             threadParticipants: threadParticipants,
-            attachments: attachments,
-            latestReplies: latestReplies,
+            attachments: { attachments },
+            latestReplies: { latestReplies },
             localState: localState,
             isFlaggedByCurrentUser: isFlaggedByCurrentUser,
-            latestReactions: latestReactions,
-            currentUserReactions: currentUserReactions,
+            latestReactions: { latestReactions },
+            currentUserReactions: { currentUserReactions },
             isSentByCurrentUser: isSentByCurrentUser
         )
     }

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -91,7 +91,7 @@ open class _ChatChannelListItemView<ExtraData: ExtraDataTypes>: _View, UIConfigP
         guard let channel = content.channel else { return nil }
         if let typingMembersInfo = typingMemberString {
             return typingMembersInfo
-        } else if let latestMessage = channel.latestMessages.first {
+        } else if let latestMessage = channel.lastMessage {
             return "\(latestMessage.author.name ?? latestMessage.author.id): \(latestMessage.text)"
         } else {
             return L10n.Channel.Item.emptyMessages


### PR DESCRIPTION
Improve some `asModel` function performance by loading expensive top level properties lazily. This means that affected model structs are now thread-confined which should be addressed later as it does not make much sense for value types.

Some other changes were necessary:
- `@Cached` wrapper now has `computeValue` closure as `projectedValue` as otherwise it cannot be set from outside as `_cachedWrapper` property is private ➡️ this will not be possible as `__mentionedUsers` is inaccessible because it is private automatically
```
__mentionedUsers.computeValue = { Set(dto.mentionedUsers.map { $0.asModel() }) }
```
- some model inits needed to be reorder to make compiler happy

I consider the semantic change of `_ChatChannel` and `_ChatMessage` to be breaking so it is marked this way in changelog, even though the API remains unchanged.
