### PR TITLE
Add team filter keys

### DIFF
--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -75,7 +75,8 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
     /// A filter key for matching the `memberCount` value.
     static var memberCount: FilterKey<Scope, Int> { "member_count" }
     
-    //    static var team: FilterKey<Scope, > { "team" }
+    /// A filter key for matching the `team` value.
+    static var team: FilterKey<Scope, TeamId> { "team" }
 }
 
 /// A query is used for querying specific channels from backend.

--- a/Sources/StreamChat/Query/ChannelListQuery_Tests.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery_Tests.swift
@@ -20,6 +20,7 @@ final class ChannelListFilterScope_Tests: XCTestCase {
         XCTAssertEqual(Key<Date>.deletedAt.rawValue, ChannelCodingKeys.deletedAt.rawValue)
         XCTAssertEqual(Key<Bool>.frozen.rawValue, ChannelCodingKeys.frozen.rawValue)
         XCTAssertEqual(Key<Int>.memberCount.rawValue, ChannelCodingKeys.memberCount.rawValue)
+        XCTAssertEqual(Key<TeamId>.team.rawValue, ChannelCodingKeys.team.rawValue)
     }
 
     func test_containMembersHelper() {

--- a/Sources/StreamChat/Query/UserListQuery.swift
+++ b/Sources/StreamChat/Query/UserListQuery.swift
@@ -68,7 +68,8 @@ public extension FilterKey where Scope: AnyUserListFilterScope {
     /// A filter key for matching the `isAnonymous` value.
     static var isAnonymous: FilterKey<Scope, Bool> { "anon" }
     
-    //    static var team: FilterKey<Scope, > { "team" }
+    /// A filter key for matching the `teams` value.
+    static var teams: FilterKey<Scope, TeamId> { "teams" }
 }
 
 /// A query is used for querying specific users from backend.

--- a/Sources/StreamChat/Query/UserListQuery_Tests.swift
+++ b/Sources/StreamChat/Query/UserListQuery_Tests.swift
@@ -22,6 +22,7 @@ final class UserListFilterScope_Tests: XCTestCase {
         XCTAssertEqual(Key<Int>.unreadChannelsCount.rawValue, UserPayloadsCodingKeys.unreadChannelsCount.rawValue)
         XCTAssertEqual(Key<Int>.unreadMessagesCount.rawValue, UserPayloadsCodingKeys.unreadMessagesCount.rawValue)
         XCTAssertEqual(Key<Bool>.isAnonymous.rawValue, UserPayloadsCodingKeys.isAnonymous.rawValue)
+        XCTAssertEqual(Key<TeamId>.teams.rawValue, UserPayloadsCodingKeys.teams.rawValue)
     }
 }
 


### PR DESCRIPTION
Just something we forgot to add in #905. This PR adds the possibility to filter users and channels using the `team(s)` keys.