### PR TITLE
Fix messages content offset when few messages displayed

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatVC.swift
@@ -91,13 +91,26 @@ open class _ChatVC<ExtraData: ExtraDataTypes>: _ViewController,
         if oldKeyboardTop == view.bounds.height {
             oldKeyboardTop -= view.safeAreaInsets.bottom
         }
-
+        
         let keyboardDelta = oldKeyboardTop - keyboardTop
+        let collectionView = messageList.collectionView
+        // need to calculate delta in content when `contentSize` is smaller than `frame.size`
+        let contentDelta = max(
+            // 8 is just some padding constant to make it look better
+            collectionView.frame.height - collectionView.contentSize.height + collectionView.contentOffset.y - 8,
+            // 0 is for the case when `contentSize` if larger than `frame.size`
+            0
+        )
+        
         let newContentOffset = CGPoint(
             x: 0,
-            y: messageList.collectionView.contentOffset.y + keyboardDelta
+            y: max(
+                collectionView.contentOffset.y + keyboardDelta - contentDelta,
+                // case when keyboard is activated but not shown, probably only on simulator
+                -collectionView.contentInset.top
+            )
         )
-
+        
         // changing contentOffset will cancel any scrolling in collectionView, bad UX
         let needUpdateContentOffset = !messageList.collectionView.isDecelerating && !messageList.collectionView.isDragging
         


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

When few messages are displayed in messages list (`contentSize.height` is smaller than `frame.height`) the general keyboard avoiding behavior is not great. Each time the `scrollView.contentOffset` is shifted by the height of the keyboard.

In this PR I addressed this issue. The final code is documented and tested on iPhone with notch, iPhone without notch and on iPad. Both orientations – portrait and landscape – were tested as well.

You can see the result on the screenshots below.

Before             |  After
--- | ---
![before-2](https://user-images.githubusercontent.com/2185200/112442634-59e2d180-8d4c-11eb-84b0-77732759be2e.gif) | ![ater-2](https://user-images.githubusercontent.com/2185200/112442647-5e0eef00-8d4c-11eb-8759-08489fbebe95.gif)
![before](https://user-images.githubusercontent.com/2185200/112442665-6404d000-8d4c-11eb-951b-6d2a4e4c9ad7.gif) | ![after](https://user-images.githubusercontent.com/2185200/112442679-6830ed80-8d4c-11eb-9bbe-8fec6a7ae366.gif)
