### PR TITLE
[CIS-744] Fix observer starting logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix `ChannelDoesNotExist` error is logged by `UserWatchingEventMiddleware` when channels are fetched for the first time [#893](https://github.com/GetStream/stream-chat-swift/issues/893)
 - Improve model loading performance by lazy loading expensive properties [#906](https://github.com/GetStream/stream-chat-swift/issues/906)
+- Fix possible loops when accessing controllers' data from within delegate callbacks [#915](https://github.com/GetStream/stream-chat-swift/issues/915)
 
 ### ✅ Added
 - Introduce support for [multitenancy](https://getstream.io/chat/docs/react/multi_tenant_chat/?language=swift) - `teams` for `User` and `team` for `Channel` are now exposed. [#905](https://github.com/GetStream/stream-chat-swift/pull/905)

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -50,7 +50,10 @@ public class _ChatChannelListController<ExtraData: ExtraDataTypes>: DataControll
     /// To observe changes of the channels, set your class as a delegate of this controller or use the provided
     /// `Combine` publishers.
     ///
-    public var channels: LazyCachedMapCollection<_ChatChannel<ExtraData>> { channelListObserver.items }
+    public var channels: LazyCachedMapCollection<_ChatChannel<ExtraData>> {
+        startChannelListObserverIfNeeded()
+        return channelListObserver.items
+    }
     
     /// The worker used to fetch the remote data and communicate with servers.
     private lazy var worker: ChannelListUpdater<ExtraData> = self.environment
@@ -66,7 +69,7 @@ public class _ChatChannelListController<ExtraData: ExtraDataTypes>: DataControll
             stateMulticastDelegate.additionalDelegates = multicastDelegate.additionalDelegates
             
             // After setting delegate local changes will be fetched and observed.
-            startChannelListObserver()
+            startChannelListObserverIfNeeded()
         }
     }
     
@@ -84,14 +87,6 @@ public class _ChatChannelListController<ExtraData: ExtraDataTypes>: DataControll
             self.delegateCallback {
                 $0.controller(self, didChangeChannels: changes)
             }
-        }
-        
-        do {
-            try observer.startObserving()
-            state = .localDataFetched
-        } catch {
-            state = .localDataFetchFailed(ClientError(with: error))
-            log.error("Failed to perform fetch request with error: \(error). This is an internal error.")
         }
         
         return observer
@@ -123,11 +118,21 @@ public class _ChatChannelListController<ExtraData: ExtraDataTypes>: DataControll
         }
     }
     
-    /// Initializing of `channelListObserver` will start local data observing.
-    /// In most cases it will be done by accessing `channels` but it's possible that only
-    /// changes will be observed.
-    private func startChannelListObserver() {
-        _ = channelListObserver
+    /// If the `state` of the controller is `initialized`, this method calls `startObserving` on the
+    /// `channelListObserver` to fetch the local data and start observing the changes. It also changes
+    /// `state` based on the result.
+    ///
+    /// It's safe to call this method repeatedly.
+    ///
+    private func startChannelListObserverIfNeeded() {
+        guard state == .initialized else { return }
+        do {
+            try channelListObserver.startObserving()
+            state = .localDataFetched
+        } catch {
+            state = .localDataFetchFailed(ClientError(with: error))
+            log.error("Failed to perform fetch request with error: \(error). This is an internal error.")
+        }
     }
     
     /// Sets the provided object as a delegate of this controller.

--- a/Sources/StreamChat/Controllers/UserListController/UserListController.swift
+++ b/Sources/StreamChat/Controllers/UserListController/UserListController.swift
@@ -50,7 +50,10 @@ public class _ChatUserListController<ExtraData: ExtraDataTypes>: DataController,
     /// To observe changes of the users, set your class as a delegate of this controller or use the provided
     /// `Combine` publishers.
     ///
-    public var users: LazyCachedMapCollection<_ChatUser<ExtraData.User>> { userListObserver.items }
+    public var users: LazyCachedMapCollection<_ChatUser<ExtraData.User>> {
+        startUserListObserverIfNeeded()
+        return userListObserver.items
+    }
     
     /// The worker used to fetch the remote data and communicate with servers.
     private lazy var worker: UserListUpdater<ExtraData.User> = self.environment
@@ -66,7 +69,7 @@ public class _ChatUserListController<ExtraData: ExtraDataTypes>: DataController,
             stateMulticastDelegate.additionalDelegates = multicastDelegate.additionalDelegates
             
             // After setting delegate local changes will be fetched and observed.
-            startUserListObserver()
+            startUserListObserverIfNeeded()
         }
     }
     
@@ -84,14 +87,6 @@ public class _ChatUserListController<ExtraData: ExtraDataTypes>: DataController,
             self.delegateCallback {
                 $0.controller(self, didChangeUsers: changes)
             }
-        }
-        
-        do {
-            try observer.startObserving()
-            state = .localDataFetched
-        } catch {
-            state = .localDataFetchFailed(ClientError(with: error))
-            log.error("Failed to perform fetch request with error: \(error). This is an internal error.")
         }
         
         return observer
@@ -123,11 +118,21 @@ public class _ChatUserListController<ExtraData: ExtraDataTypes>: DataController,
         }
     }
     
-    /// Initializing of `userListObserver` will start local data observing.
-    /// In most cases it will be done by accessing `users` but it's possible that only
-    /// changes will be observed.
-    private func startUserListObserver() {
-        _ = userListObserver
+    /// If the `state` of the controller is `initialized`, this method calls `startObserving` on the
+    /// `userListObserver` to fetch the local data and start observing the changes. It also changes
+    /// `state` based on the result.
+    ///
+    /// It's safe to call this method repeatedly.
+    ///
+    private func startUserListObserverIfNeeded() {
+        guard state == .initialized else { return }
+        do {
+            try userListObserver.startObserving()
+            state = .localDataFetched
+        } catch {
+            state = .localDataFetchFailed(ClientError(with: error))
+            log.error("Failed to perform fetch request with error: \(error). This is an internal error.")
+        }
     }
     
     /// Sets the provided object as a delegate of this controller.

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -2865,8 +2865,8 @@
 		79C5CBF925F671AE00D98001 /* ChannelWatcherListController */ = {
 			isa = PBXGroup;
 			children = (
-				79D6CE6125F7D6C700BE2EEC /* ChatChannelWatcherListController_Mock.swift */,
 				79C5CBE725F66DBD00D98001 /* ChatChannelWatcherListController.swift */,
+				79D6CE6125F7D6C700BE2EEC /* ChatChannelWatcherListController_Mock.swift */,
 				79D6CE2625F7C83C00BE2EEC /* ChatChannelWatcherListController+Combine.swift */,
 				79D6CE5825F7D6B300BE2EEC /* ChatChannelWatcherListController_Tests.swift */,
 				79D6CE3625F7C84500BE2EEC /* ChatChannelWatcherListController+SwiftUI.swift */,


### PR DESCRIPTION
In most of our controllers, this was correct. However, some controllers have this done incorrectly which leads to loops when accessing controllers' variables from within delegate callbacks.