### PR TITLE
[CIS-753] First message in group

### DIFF
--- a/SlackClone/SlackChatChannelListViewController.swift
+++ b/SlackClone/SlackChatChannelListViewController.swift
@@ -32,6 +32,12 @@ final class SlackChatChannelListViewController: ChatChannelListVC {
         createNewChannelButton.addTarget(self, action: #selector(didTapCreateNewChannel), for: .touchUpInside)
     }
     
+    override func setUpAppearance() {
+        super.setUpAppearance()
+        
+        navigationItem.rightBarButtonItem = nil
+    }
+    
     override func setUpLayout() {
         let titleView = UIView()
         titleView.backgroundColor = Colors.primary

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageGroupPart.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageGroupPart.swift
@@ -10,6 +10,9 @@ public typealias ChatMessageGroupPart = _ChatMessageGroupPart<NoExtraData>
 public struct _ChatMessageGroupPart<ExtraData: ExtraDataTypes> {
     public let message: _ChatMessage<ExtraData>
     public let quotedMessage: _ChatMessage<ExtraData>?
+    /// `true` if `message` is the first one in a group
+    public let isFirstInGroup: Bool
+    /// `true` if `message` is the last one in a group
     public let isLastInGroup: Bool
     public let didTapOnAttachment: ((ChatMessageDefaultAttachment) -> Void)?
     public let didTapOnAttachmentAction: ((ChatMessageDefaultAttachment, AttachmentAction) -> Void)?

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -299,10 +299,19 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: _ViewController,
             let delay = nextMessage.createdAt.timeIntervalSince(message.createdAt)
             return delay > minTimeInvteralBetweenMessagesInGroup
         }
+        
+        var isFirstInGroup: Bool {
+            guard indexPath.row < dataSource.numberOfMessages(self) - 1 else { return true }
+            let previousMessage = dataSource.messageAtIndex(self, indexPath.row + 1)
+            guard previousMessage.author == message.author else { return true }
+            let delay = previousMessage.createdAt.timeIntervalSince(message.createdAt)
+            return delay > minTimeInvteralBetweenMessagesInGroup
+        }
 
         return .init(
             message: message,
             quotedMessage: dataSource.replyMessageForMessageAtIndex(self, message, indexPath.row),
+            isFirstInGroup: isFirstInGroup,
             isLastInGroup: isLastInGroup,
             didTapOnAttachment: { [weak self] attachment in
                 self?.didTapOnAttachment(attachment, in: message)


### PR DESCRIPTION
## Description of the pull request

Added property to `ChatMessageGroupPart` for `isFirstInGroup` - similar to `isLastInGroup`.

I have two following questions:
- any recommendations for making tests for this?
- I was asked to look at how to refactor `ChatMessageGroupPart` - and honestly, I am not really sure how. I was thinking of adding a delegate but views should only be configurable via `content` property, so that did not seem like a good path to take. Possible refactor would probably be better to do in a different PR anyways, in order for this to be purely additional