### PR TITLE
Fix CI not running tests below iOS 14

### DIFF
--- a/.github/actions/prepare-ios-simulator/action.yml
+++ b/.github/actions/prepare-ios-simulator/action.yml
@@ -6,16 +6,27 @@ inputs:
   ios:
     description: 'The iOS version'
     required: true
+  xcode:
+    description: 'The Xcode version. The ios simulators supported for each xcode version: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#installed-simulators'
+    required: true
 runs:
   using: "composite"
   steps:
-    - run: 
+    - run: |
+        xcode_version=${{ inputs.xcode }}
+        ios_version=${{ inputs.ios }}
+        ios_version_dash=${ios_version//./-} # ex: 12.4 -> 12-4
+
         sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
-        sudo ln -s /Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ ${{ inputs.ios }}.simruntime
+
+        if [[ "$xcode_version" == "10.3" ]]; then
+          sudo ln -s /Applications/Xcode_$xcode_version.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ $ios_version.simruntime
+        else
+          sudo ln -s /Applications/Xcode_$xcode_version.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ $ios_version.simruntime
+        fi
+
         xcrun simctl list runtimes
-        ios=${{ inputs.ios }}
-        ios_runtime=${ios//./-}
-        xcrun simctl create custom-test-device "${{ inputs.device }}" "com.apple.CoreSimulator.SimRuntime.iOS-$ios_runtime"
-        xcrun simctl list devices ${{ inputs.ios }}
+        xcrun simctl create custom-test-device "${{ inputs.device }}" "com.apple.CoreSimulator.SimRuntime.iOS-$ios_version_dash"
+        xcrun simctl list devices $ios_version
       shell: bash
   

--- a/.github/workflows/full-checks.yml
+++ b/.github/workflows/full-checks.yml
@@ -92,9 +92,10 @@ jobs:
     - uses: ./.github/actions/prepare-ios-simulator
       with:
         device: "iPhone 11"
-        ios: "13.4"
+        ios: "13.5"
+        xcode: "11.5"
     - name: Run Stress Tests - iOS 13.4 (Release)
-      run: bundle exec fastlane stress_test_release device:"iPhone 11 (13.4)"
+      run: bundle exec fastlane stress_test_release device:"iPhone 11 (13.5)"
 
   stress-tests-ios12:
     name: Stress Test LLC - iOS 12.4 (Release)
@@ -121,6 +122,7 @@ jobs:
       with:
         device: "iPhone 11"
         ios: "12.4"
+        xcode: "10.3"
     - name: Run Stress Tests
       run: bundle exec fastlane stress_test_release device:"iPhone 11 (12.4)"
 
@@ -147,12 +149,13 @@ jobs:
     - uses: ./.github/actions/bootstrap
     - uses: ./.github/actions/prepare-ios-simulator
       with:
-        device: "iPhone 7"
-        ios: "13.4"
+        device: "iPhone 11"
+        ios: "13.5"
+        xcode: "11.5"
     - name: Build Sample App - iOS 13.4
-      run: bundle exec fastlane build_sample device:"iPhone 7 (13.4)"
+      run: bundle exec fastlane build_sample device:"iPhone 11 (13.5)"
     - name: Build Demo App - iOS 13.4
-      run: bundle exec fastlane build_demo device:"iPhone 7 (13.4)"
+      run: bundle exec fastlane build_demo device:"iPhone 11 (13.5)"
     - uses: 8398a7/action-slack@v3
       with:
         status: ${{ job.status }}
@@ -188,6 +191,7 @@ jobs:
       with:
         device: "iPhone 7"
         ios: "12.4"
+        xcode: "10.3"
     - name: Build Sample App - iOS 12.4
       run: bundle exec fastlane build_sample device:"iPhone 7 (12.4)"
     - name: Build Demo App - iOS 12.4

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -78,6 +78,7 @@ jobs:
       with:
         device: "iPhone 7"
         ios: "12.4"
+        xcode: "10.3"
     - name: Run LLC Tests (Debug - iOS < 13)
       run: bundle exec fastlane test device:"iPhone 7 (12.4)"
     - uses: codecov/codecov-action@v1

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -249,6 +249,7 @@ lane :test_release do
     testplan: "StreamChatTestPlan",
     configuration: "ReleaseTests",
     clean: true,
+    devices: options[:device]
   )
 end
 
@@ -258,7 +259,8 @@ lane :stress_test do
     project: "StreamChat.xcodeproj",
     scheme: "StreamChat",
     clean: true,
-    build_for_testing: true
+    build_for_testing: true,
+    devices: options[:device]
   )
 
   setCIEnvironmentVariable("../Tests/StreamChatTests/StreamChatStressTestPlan.xctestplan")
@@ -269,6 +271,7 @@ lane :stress_test do
       scheme: "StreamChat",
       test_without_building: true,
       testplan: "StreamChatStressTestPlan",
+      devices: options[:device],
       xcpretty_args: "--test" # simplify logs
     )
   }
@@ -281,7 +284,8 @@ lane :stress_test_release do
     scheme: "StreamChat",
     configuration: "ReleaseTests",
     clean: true,
-    build_for_testing: true
+    build_for_testing: true,
+    devices: options[:device]
   )
 
   setCIEnvironmentVariable("../Tests/StreamChatTests/StreamChatStressTestPlan.xctestplan")
@@ -293,6 +297,7 @@ lane :stress_test_release do
       configuration: "ReleaseTests",
       test_without_building: true,
       testplan: "StreamChatStressTestPlan",
+      devices: options[:device],
       xcpretty_args: "--test" # simplify logs
     )
   }
@@ -340,6 +345,7 @@ lane :build_docs_snippets do |options|
     scheme: "DocsSnippets",
     clean: true,
     build_for_testing: true,
+    devices: options[:device]
   )
 end
 


### PR DESCRIPTION
# In This PR

The tests were not running below < iOS 14. It would fall back to the default device 🤦‍♂️

Issues found:
- The Xcode version was hardcoded, and it can't be because each Xcode includes different default ios simulator runtimes.
- There was missing a pipe "|" for the action to actually work -.-
- The stress tests were not even running on the specified versions because it was missing the `options[:device]` parameter on the lanes. Even if the prepare-simulator-action was working, the stress tests were always running on the default device.

The script needs to have a condition because of how the Xcode path is different on 10.3 vs >10.3
More details here: https://github.com/actions/virtual-environments/issues/551#issuecomment-637344435

Now I finally got why the iOS 12 coverage was the same as the iOS 14 😄 

It probably would be a good idea to open source this action actually 🤔 It took a lot of time to make it work properly for every case.