### PR TITLE
[CIS-674] Fix channel list inconsistency

### DIFF
--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -16,6 +16,9 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
     SwipeableViewDelegate {
     /// The `ChatChannelListController` instance that provides channels data.
     public var controller: _ChatChannelListController<ExtraData>!
+    
+    /// To prevent inconsistencies during `collectionView.performBatchUpdates` we need to update are dataSource count in updates block
+    private var channelsCount = 0
 
     open private(set) lazy var loadingIndicator: UIActivityIndicatorView = {
         if #available(iOS 13.0, *) {
@@ -62,6 +65,7 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
     override open func setUp() {
         super.setUp()
 
+        channelsCount = controller.channels.count
         controller.setDelegate(self)
         controller.synchronize()
         
@@ -111,7 +115,7 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
     }
 
     open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        controller.channels.count
+        channelsCount
     }
     
     open func collectionView(
@@ -236,11 +240,13 @@ extension _ChatChannelListVC: _ChatChannelListControllerDelegate {
                     switch change {
                     case let .insert(_, index):
                         collectionView.insertItems(at: [index])
+                        channelsCount += 1
                     case let .move(_, fromIndex, toIndex):
                         collectionView.moveItem(at: fromIndex, to: toIndex)
                         movedItems.append(toIndex)
                     case let .remove(_, index):
                         collectionView.deleteItems(at: [index])
+                        channelsCount -= 1
                     case let .update(_, index):
                         collectionView.reloadItems(at: [index])
                     }


### PR DESCRIPTION
Well the inconsistency error we are getting is actually [docummented](https://developer.apple.com/documentation/uikit/uicollectionview/1618045-performbatchupdates#discussion).

> If the collection view's layout is not up to date before you call this method, a reload may occur. To avoid problems, you should update your data model inside the updates block or ensure the layout is updated before you call performBatchUpdates(_:completion:).

This is actually what is happening in test I added (will be removed as it only logs the error but it is not thrown 🤷)

<img width="1635" alt="Screen Shot 2021-03-25 at 23 07 39" src="https://user-images.githubusercontent.com/3148214/112550384-93085980-8dbf-11eb-9060-0adf59d579bb.png">

So we need to make sure to update channel (especially its count) inside `performBatchUpdates`. Currently I thought about mirroring `controller.channels` to local property in `ChatChannelListVC`, the implementation is definitely to be discussed as there are other options, this is the most straight-forward solution I could think of.

I can imagine that we will just copy `controller.channels.count` property and update only that in `performBatchUpdates`, we could improve this mirroring solution and we might force the `collectionView` to lay out, but that is definitely not my favorite.

Got any more ideas?
