### PR TITLE
Fix ChannelUpdatedEvent failing to parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `ChannelDoesNotExist` error is logged by `UserWatchingEventMiddleware` when channels are fetched for the first time [#893](https://github.com/GetStream/stream-chat-swift/issues/893)
 - Improve model loading performance by lazy loading expensive properties [#906](https://github.com/GetStream/stream-chat-swift/issues/906)
 - Fix possible loops when accessing controllers' data from within delegate callbacks [#915](https://github.com/GetStream/stream-chat-swift/issues/915)
+- Fix `channel.updated` events failing to parse due to missing `user` field [#922](https://github.com/GetStream/stream-chat-swift/issues/922)
+  This was due to backend not sending `user` field when the update was done by server-side auth.
 
 ### ✅ Added
 - Introduce support for [multitenancy](https://getstream.io/chat/docs/react/multi_tenant_chat/?language=swift) - `teams` for `User` and `team` for `Channel` are now exposed. [#905](https://github.com/GetStream/stream-chat-swift/pull/905)

--- a/Sources/StreamChat/WebSocketClient/Events/ChannelEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/ChannelEvents.swift
@@ -4,18 +4,20 @@
 
 import Foundation
 
-public struct ChannelUpdatedEvent<ExtraData: ExtraDataTypes>: EventWithUserPayload, EventWithChannelId {
-    public let userId: UserId
+public struct ChannelUpdatedEvent: EventWithChannelId {
     public let cid: ChannelId
+    public let userId: UserId?
     public let messageId: MessageId?
     public let inviteAnswer: InviteAnswer?
     public let updatedAt: Date
     
     let payload: Any
     
-    init(from response: EventPayload<ExtraData>) throws {
-        userId = try response.value(at: \.user?.id)
+    init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
         cid = try response.value(at: \.channel?.cid)
+        // The `user` is only present in the event if the update is done by client-side auth
+        // so it'll not be present if update was done by server-side or CLI (which is also server-side auth)
+        userId = response.user?.id
         messageId = response.message?.id
         updatedAt = try response.value(at: \.createdAt)
         payload = response

--- a/Sources/StreamChat/WebSocketClient/Events/ChannelEvents_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/ChannelEvents_Tests.swift
@@ -10,9 +10,16 @@ class ChannelEvents_Tests: XCTestCase {
     
     func test_updated() throws {
         let json = XCTestCase.mockData(fromFile: "ChannelUpdated")
-        let event = try eventDecoder.decode(from: json) as? ChannelUpdatedEvent<NoExtraData>
+        let event = try eventDecoder.decode(from: json) as? ChannelUpdatedEvent
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_7070"))
         XCTAssertEqual(event?.userId, "broken-waterfall-5")
+    }
+    
+    func test_updated_usingServerSideAuth() throws {
+        let json = XCTestCase.mockData(fromFile: "ChannelUpdated_ServerSide")
+        let event = try eventDecoder.decode(from: json) as? ChannelUpdatedEvent
+        XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_7070"))
+        XCTAssertNil(event?.userId)
     }
     
     func test_deleted() throws {

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		7937282A2498FFD300E13FE5 /* MemberPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793728292498FFD300E13FE5 /* MemberPayload.swift */; };
 		7937282C249900CB00E13FE5 /* MemberPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7937282B249900CB00E13FE5 /* MemberPayload_Tests.swift */; };
 		793C14DC24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793C14DB24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift */; };
+		7943379A260E04B60094471F /* ChannelUpdated_ServerSide.json in Resources */ = {isa = PBXBuildFile; fileRef = 79433799260E04AF0094471F /* ChannelUpdated_ServerSide.json */; };
 		794927ED249E0BE2009D7EB7 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794927EC249E0BE2009D7EB7 /* ExtraData.swift */; };
 		794927F3249E3F77009D7EB7 /* NotificationAddedToChannel.json in Resources */ = {isa = PBXBuildFile; fileRef = 794927EE249E3D37009D7EB7 /* NotificationAddedToChannel.json */; };
 		794E20F52577DF4D00790DAB /* NameGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794E20F42577DF4D00790DAB /* NameGroupViewController.swift */; };
@@ -1291,6 +1292,7 @@
 		793728292498FFD300E13FE5 /* MemberPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberPayload.swift; sourceTree = "<group>"; };
 		7937282B249900CB00E13FE5 /* MemberPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberPayload_Tests.swift; sourceTree = "<group>"; };
 		793C14DB24BF2A0800B8BFB7 /* ListDatabaseObserver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListDatabaseObserver_Tests.swift; sourceTree = "<group>"; };
+		79433799260E04AF0094471F /* ChannelUpdated_ServerSide.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ChannelUpdated_ServerSide.json; sourceTree = "<group>"; };
 		794927EC249E0BE2009D7EB7 /* ExtraData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraData.swift; sourceTree = "<group>"; };
 		794927EE249E3D37009D7EB7 /* NotificationAddedToChannel.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = NotificationAddedToChannel.json; sourceTree = "<group>"; };
 		794927F0249E3DE6009D7EB7 /* EventPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventPayload_Tests.swift; sourceTree = "<group>"; };
@@ -3662,6 +3664,7 @@
 			isa = PBXGroup;
 			children = (
 				8A0C3BCB24C1C6AB00CAFD19 /* ChannelUpdated.json */,
+				79433799260E04AF0094471F /* ChannelUpdated_ServerSide.json */,
 				8A0C3BCD24C1CAF000CAFD19 /* ChannelDeleted.json */,
 				8A0C3BCF24C1CCD800CAFD19 /* ChannelHidden.json */,
 				8A0C3BD024C1CCEB00CAFD19 /* ChannelHiddenCleared.json */,
@@ -4626,6 +4629,7 @@
 				8AC9CBE624C7500E006E236C /* NotificationMarkAllRead.json in Resources */,
 				88F896F92541AC0900DE517D /* FlagMessagePayload+NoExtraData.json in Resources */,
 				8A0CC9ED24C602B600705CF9 /* MemberRemoved.json in Resources */,
+				7943379A260E04B60094471F /* ChannelUpdated_ServerSide.json in Resources */,
 				8A0C3BC724C0AEDB00CAFD19 /* UserBanned.json in Resources */,
 				79158CE225F0E9DF00186102 /* ChannelTruncated.json in Resources */,
 				88EA9B112547271B007EE76B /* MessageReactionPayload+DefaultExtraData.json in Resources */,
@@ -4871,7 +4875,6 @@
 				78C8474125FA0F2900A5D1D0 /* ChatChannelUnreadCountView+SwiftUI_Tests.swift in Sources */,
 				AD71131225F138D500932AEE /* ChatUserAvatarView_Tests.swift in Sources */,
 				780057FF25F6353600D21095 /* ChatChannel.swift in Sources */,
-				7849AE8B25F2306C007817D4 /* iOS13TestCase.swift in Sources */,
 				7969D20225F15E3D00C66F87 /* TestRunnerEnvironment.swift in Sources */,
 				79158D5325F15BF900186102 /* iOS13TestCase.swift in Sources */,
 				780057FF25F6353600D21095 /* ChatChannel.swift in Sources */,

--- a/Tests/StreamChatTests/MockEnpointResponses/Events/Channel/ChannelUpdated_ServerSide.json
+++ b/Tests/StreamChatTests/MockEnpointResponses/Events/Channel/ChannelUpdated_ServerSide.json
@@ -1,0 +1,113 @@
+{
+    "channel" : {
+        "id" : "new_channel_7070",
+        "members" : [
+            {
+                "created_at" : "2020-07-16T12:50:34.79057Z",
+                "user_id" : "broken-waterfall-5",
+                "updated_at" : "2020-07-16T12:50:34.79057Z",
+                "user" : {
+                    "id" : "broken-waterfall-5",
+                    "banned" : false,
+                    "extraData" : {
+                        "name" : "Tester"
+                    },
+                    "totalUnreadCount" : 0,
+                    "unread_channels" : 0,
+                    "last_active" : "2020-07-17T11:37:46.056937Z",
+                    "created_at" : "2019-12-12T15:33:46.488935Z",
+                    "invisible" : false,
+                    "unreadChannels" : 0,
+                    "unread_count" : 0,
+                    "image" : "https:\/\/getstream.io\/random_svg\/?id=broken-waterfall-5&amp;name=Broken+waterfall",
+                    "updated_at" : "2020-07-17T11:43:46.310104Z",
+                    "role" : "user",
+                    "total_unread_count" : 0,
+                    "online" : true,
+                    "name" : "Broken waterfall"
+                }
+            },
+            {
+                "created_at" : "2020-07-16T15:38:56.905657Z",
+                "user_id" : "steep-moon-9",
+                "updated_at" : "2020-07-16T15:38:56.905657Z",
+                "user" : {
+                    "id" : "steep-moon-9",
+                    "banned" : false,
+                    "unread_channels" : 3,
+                    "totalUnreadCount" : 0,
+                    "last_active" : "2020-07-17T11:34:03.009496Z",
+                    "created_at" : "2019-12-12T15:34:00.762372Z",
+                    "invisible" : false,
+                    "unreadChannels" : 0,
+                    "unread_count" : 21,
+                    "image" : "https:\/\/api.adorable.io\/avatars\/285\/steep-moon-9.png",
+                    "updated_at" : "2020-07-17T11:34:03.009496Z",
+                    "role" : "user",
+                    "total_unread_count" : 21,
+                    "online" : true,
+                    "name" : "steep-moon-9"
+                }
+            }
+        ],
+        "created_at" : "2020-07-16T12:50:34.786899Z",
+        "created_by" : {
+            "id" : "broken-waterfall-5",
+            "banned" : false,
+            "extraData" : {
+                "name" : "Tester"
+            },
+            "totalUnreadCount" : 0,
+            "unread_channels" : 0,
+            "last_active" : "2020-07-17T11:37:46.056937Z",
+            "created_at" : "2019-12-12T15:33:46.488935Z",
+            "invisible" : false,
+            "unreadChannels" : 0,
+            "unread_count" : 0,
+            "image" : "https:\/\/getstream.io\/random_svg\/?id=broken-waterfall-5&amp;name=Broken+waterfall",
+            "updated_at" : "2020-07-17T11:43:46.310104Z",
+            "role" : "user",
+            "total_unread_count" : 0,
+            "online" : true,
+            "name" : "Broken waterfall"
+        },
+        "type" : "messaging",
+        "cid" : "messaging:new_channel_7070",
+        "frozen" : false,
+        "member_count" : 2,
+        "updated_at" : "2020-07-17T11:44:16.63728Z",
+        "config" : {
+            "automod_behavior" : "flag",
+            "reactions" : true,
+            "typing_events" : true,
+            "mutes" : true,
+            "max_message_length" : 5000,
+            "created_at" : "2019-03-21T15:49:15.40182Z",
+            "automod" : "AI",
+            "read_events" : true,
+            "commands" : [
+                {
+                    "set" : "fun_set",
+                    "args" : "[text]",
+                    "name" : "giphy",
+                    "description" : "Post a random gif to the channel"
+                }
+            ],
+            "connect_events" : true,
+            "replies" : true,
+            "updated_at" : "2020-03-17T18:54:09.460881Z",
+            "url_enrichment" : true,
+            "search" : false,
+            "message_retention" : "infinite",
+            "uploads" : true,
+            "name" : "messaging"
+        },
+        "name" : "7070",
+        "last_message_at" : "2020-07-16T15:39:03.010717Z"
+    },
+    "channel_type" : "messaging",
+    "channel_id" : "new_channel_7070",
+    "created_at" : "2020-07-17T11:44:16.644995177Z",
+    "type" : "channel.updated",
+    "cid" : "messaging:new_channel_7070"
+}


### PR DESCRIPTION
This was due to missing `user` field. Backend doesn't send `user` field (it's optional in v2) for every event. ChannelUpdated event hasn't received much love yet
