### PR TITLE
[CIS-727] `ChatChannel` limits refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Expose `pinDetails` on `ChatMessage` which contains the pinning information, like the expiration date [#896](https://github.com/GetStream/stream-chat-swift/pull/896) 
 - Add support for pinning and unpinning messages through `pin()` and `unpin()` methods in `MessageController` [#896](https://github.com/GetStream/stream-chat-swift/pull/896)
 - Add new optional `pinning: Pinning` parameter when creating a new message in `ChannelController` to create a new message and pin it instantly [#896](https://github.com/GetStream/stream-chat-swift/pull/896)
-- Add `lastActiveMembers` and `lastActiveWatchers` to `Channel`. The max number of entities these fields expose if configurable via `ChatConfig` [#911](https://github.com/GetStream/stream-chat-swift/pull/911)
+- Add `lastActiveMembers` and `lastActiveWatchers` to `ChatChannel`. The max number of entities these fields expose is configurable via `ChatClientConfig.localCaching.chatChannel` [#911](https://github.com/GetStream/stream-chat-swift/pull/911)
+
+### 🔄 Changed
+- `ChatChannel.latestMessages` now by default contains max 5 messages. You can change this setting in `ChatClientConfig.localCaching.chatChannel.latestMessagesLimit` [#923](https://github.com/GetStream/stream-chat-swift/pull/923)
 
 ### ⛔️ Deprecated
 - `ChatChannel`'s properties `cachedMembers` and `watchers` were deprecated. Use `lastActiveMembers` and `lastActiveWatchers` instead [#911](https://github.com/GetStream/stream-chat-swift/pull/911)

--- a/Sample/Samples/CombineSimpleChat/CombineSimpleChannelsViewController.swift
+++ b/Sample/Samples/CombineSimpleChat/CombineSimpleChannelsViewController.swift
@@ -137,7 +137,7 @@ class CombineSimpleChannelsViewController: UITableViewController {
         let subtitle: String
         if let typingMembersInfo = createTypingMemberString(for: channel) {
             subtitle = typingMembersInfo
-        } else if let latestMessage = channel.lastMessage {
+        } else if let latestMessage = channel.latestMessages.first {
             let author = latestMessage.author.name ?? latestMessage.author.id.description
             subtitle = "\(author): \(latestMessage.text)"
         } else {

--- a/Sample/Samples/SimpleChat/SimpleChannelsViewController.swift
+++ b/Sample/Samples/SimpleChat/SimpleChannelsViewController.swift
@@ -109,7 +109,7 @@ class SimpleChannelsViewController: UITableViewController, ChatChannelListContro
         let subtitle: String
         if let typingMembersInfo = createTypingMemberString(for: channel) {
             subtitle = typingMembersInfo
-        } else if let latestMessage = channel.lastMessage {
+        } else if let latestMessage = channel.latestMessages.first {
             let author = latestMessage.author.name ?? latestMessage.author.id.description
             subtitle = "\(author): \(latestMessage.text)"
         } else {

--- a/Sample/Samples/SwiftUISimpleChat/ChannelListView.swift
+++ b/Sample/Samples/SwiftUISimpleChat/ChannelListView.swift
@@ -192,7 +192,7 @@ struct ChannelListView: View {
         
         if let typingMembersInfo = createTypingMemberString(for: channel) {
             return Text(typingMembersInfo)
-        } else if let latestMessage = channel.lastMessage {
+        } else if let latestMessage = channel.latestMessages.first {
             let author = latestMessage.author.name ?? latestMessage.author.id.description
             return Text("\(author): \(latestMessage.text)")
         } else {

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -152,7 +152,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
                     .onDisk(databaseFileURL: dbFileURL),
                     config.shouldFlushLocalStorageOnStart,
                     config.isClientInActiveMode, // Only reset Ephemeral values in active mode
-                    config.channel
+                    config.localCaching
                 )
             }
             
@@ -168,7 +168,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
                 .inMemory,
                 config.shouldFlushLocalStorageOnStart,
                 config.isClientInActiveMode, // Only reset Ephemeral values in active mode
-                config.channel
+                config.localCaching
             )
         } catch {
             fatalError("Failed to initialize the in-memory storage with error: \(error). This is a non-recoverable error.")
@@ -354,9 +354,9 @@ extension _ChatClient {
             _ kind: DatabaseContainer.Kind,
             _ shouldFlushOnStart: Bool,
             _ shouldResetEphemeralValuesOnStart: Bool,
-            _ channelConfig: ChatClientConfig.Channel?
+            _ localCachingSettings: ChatClientConfig.LocalCaching?
         ) throws -> DatabaseContainer = {
-            try DatabaseContainer(kind: $0, shouldFlushOnStart: $1, shouldResetEphemeralValuesOnStart: $2, channelConfig: $3)
+            try DatabaseContainer(kind: $0, shouldFlushOnStart: $1, shouldResetEphemeralValuesOnStart: $2, localCachingSettings: $3)
         }
         
         var requestEncoderBuilder: (_ baseURL: URL, _ apiKey: APIKey) -> RequestEncoder = DefaultRequestEncoder.init

--- a/Sources/StreamChat/ChatClient_Mock.swift
+++ b/Sources/StreamChat/ChatClient_Mock.swift
@@ -137,7 +137,7 @@ extension _ChatClient.Environment {
                         kind: .onDisk(databaseFileURL: .newTemporaryFileURL()),
                         shouldFlushOnStart: $1,
                         shouldResetEphemeralValuesOnStart: $2,
-                        channelConfig: $3
+                        localCachingSettings: $3
                     )
                 } catch {
                     XCTFail("Unable to initialize DatabaseContainerMock \(error)")

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -58,22 +58,22 @@ class ChatClient_Tests: StressTestCase {
         config.shouldFlushLocalStorageOnStart = true
         config.localStorageFolderURL = storeFolderURL
         
-        config.channel.lastActiveMembersLimit = .unique
-        config.channel.lastActiveWatchersLimit = .unique
+        config.localCaching.chatChannel.lastActiveMembersLimit = .unique
+        config.localCaching.chatChannel.lastActiveWatchersLimit = .unique
         
         var usedDatabaseKind: DatabaseContainer.Kind?
         var shouldFlushDBOnStart: Bool?
         var shouldResetEphemeralValues: Bool?
-        var channelConfig: ChatClientConfig.Channel?
+        var localCachingSettings: ChatClientConfig.LocalCaching?
         
         // Create env object with custom database builder
         var env = ChatClient.Environment()
         env.clientUpdaterBuilder = ChatClientUpdaterMock.init
-        env.databaseContainerBuilder = { kind, shouldFlushOnStart, shouldResetEphemeralValuesOnStart, receivedChannelConfig in
+        env.databaseContainerBuilder = { kind, shouldFlushOnStart, shouldResetEphemeralValuesOnStart, cachingSettings in
             usedDatabaseKind = kind
             shouldFlushDBOnStart = shouldFlushOnStart
             shouldResetEphemeralValues = shouldResetEphemeralValuesOnStart
-            channelConfig = receivedChannelConfig
+            localCachingSettings = cachingSettings
             return DatabaseContainerMock()
         }
         
@@ -92,7 +92,7 @@ class ChatClient_Tests: StressTestCase {
         )
         XCTAssertEqual(shouldFlushDBOnStart, config.shouldFlushLocalStorageOnStart)
         XCTAssertEqual(shouldResetEphemeralValues, config.isClientInActiveMode)
-        XCTAssertEqual(channelConfig, config.channel)
+        XCTAssertEqual(localCachingSettings, config.localCaching)
     }
     
     func test_clientDatabaseStackInitialization_whenLocalStorageDisabled() {
@@ -645,7 +645,7 @@ private class TestEnvironment<ExtraData: ExtraDataTypes> {
                     kind: $0,
                     shouldFlushOnStart: $1,
                     shouldResetEphemeralValuesOnStart: $2,
-                    channelConfig: $3
+                    localCachingSettings: $3
                 )
                 return self.databaseContainer!
             },

--- a/Sources/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources/StreamChat/Config/ChatClientConfig.swift
@@ -42,8 +42,8 @@ public struct ChatClientConfig {
     ///
     public var shouldFlushLocalStorageOnStart: Bool = false
     
-    /// `ChatChannel` specific settings.
-    public var channel = Channel()
+    /// Advanced settings for the local caching and model serialization.
+    public var localCaching = LocalCaching()
     
     /// Flag for setting a ChatClient instance in connection-less mode.
     /// A connection-less client is not able to connect to websocket and will not
@@ -84,17 +84,19 @@ extension ChatClientConfig {
 }
 
 extension ChatClientConfig {
-    /// `ChatChannel` specific settings.
-    public struct Channel: Equatable {
-        /// Limit how many watchers are returned in `_ChatChannel.lastActiveWatchers`
-        public var lastActiveWatchersLimit = 25
-        /// Limit how many members are returned in `_ChatChannel.lastActiveMembers`
-        public var lastActiveMembersLimit = 25
+    /// Advanced settings for the local caching and model serialization.
+    public struct LocalCaching: Equatable {
+        /// `ChatChannel` specific local caching and model serialization settings.
+        public var chatChannel = ChatChannel()
     }
-
-//    public struct Message {
-//        // something
-//    }
+    
+    /// `ChatChannel` specific local caching and model serialization settings.
+    public struct ChatChannel: Equatable {
+        /// Limit the max number of watchers included in `ChatChannel.lastActiveWatchers`.
+        public var lastActiveWatchersLimit = 5
+        /// Limit the max number of members included in `ChatChannel.lastActiveMembers`.
+        public var lastActiveMembersLimit = 5
+    }
 }
 
 /// A struct representing an API key of the chat app.

--- a/Sources/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources/StreamChat/Config/ChatClientConfig.swift
@@ -96,6 +96,8 @@ extension ChatClientConfig {
         public var lastActiveWatchersLimit = 5
         /// Limit the max number of members included in `ChatChannel.lastActiveMembers`.
         public var lastActiveMembersLimit = 5
+        /// Limit the max number of messages included in `ChatChannel.latestMessages`.
+        public var latestMessagesLimit = 5
     }
 }
 

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -276,9 +276,13 @@ extension _ChatChannel {
             )
         }
         
-        let fetchMessages: (Int) -> [_ChatMessage<ExtraData>] = {
+        let fetchMessages: () -> [_ChatMessage<ExtraData>] = {
             MessageDTO
-                .load(for: dto.cid, limit: $0, context: context)
+                .load(
+                    for: dto.cid,
+                    limit: dto.managedObjectContext?.localCachingSettings?.chatChannel.latestMessagesLimit ?? 25,
+                    context: context
+                )
                 .map { $0.asModel() }
         }
         
@@ -318,8 +322,7 @@ extension _ChatChannel {
             cooldownDuration: Int(dto.cooldownDuration),
             extraData: extraData,
 //            invitedMembers: [],
-            latestMessages: { fetchMessages(25) }, // TODO: make messagesLimit a param
-            lastMessage: fetchMessages(1).first,
+            latestMessages: { fetchMessages() },
             pinnedMessages: { dto.pinnedMessages.map { $0.asModel() } }
         )
     }

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
@@ -319,6 +319,9 @@ class ChannelDTO_Tests: XCTestCase {
     }
     
     func test_channelPayload_localCachingDefaults() throws {
+        // This is just a temp fix. The CI fail if there are multiple Database instance alive at the same time,=
+        AssertAsync.canBeReleased(&self.database)
+        
         let memberLimit = Int.random(in: 1..<50)
         let watcherLimit = Int.random(in: 1..<50)
         let messagesLimit = Int.random(in: 1..<50)

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -81,7 +81,7 @@ extension MemberDTO {
         let request = NSFetchRequest<MemberDTO>(entityName: MemberDTO.entityName)
         request.predicate = NSPredicate(format: "channel.cid == %@", cid.rawValue)
         request.sortDescriptors = [ChannelMemberListSortingKey.lastActiveSortDescriptor]
-        request.fetchLimit = context.channelConfig?.lastActiveMembersLimit ?? 25
+        request.fetchLimit = context.localCachingSettings?.chatChannel.lastActiveMembersLimit ?? 5
         return try! context.fetch(request)
     }
 }

--- a/Sources/StreamChat/Database/DTOs/UserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/UserDTO.swift
@@ -93,7 +93,7 @@ extension UserDTO {
         let request = NSFetchRequest<UserDTO>(entityName: UserDTO.entityName)
         request.sortDescriptors = [UserListSortingKey.lastActiveSortDescriptor]
         request.predicate = NSPredicate(format: "ANY watchedChannels.cid == %@", cid.rawValue)
-        request.fetchLimit = context.channelConfig?.lastActiveWatchersLimit ?? 25
+        request.fetchLimit = context.localCachingSettings?.chatChannel.lastActiveWatchersLimit ?? 5
         return try! context.fetch(request)
     }
 }

--- a/Sources/StreamChat/Database/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer_Mock.swift
@@ -31,7 +31,7 @@ class DatabaseContainerMock: DatabaseContainer {
         shouldResetEphemeralValuesOnStart: Bool = true,
         modelName: String = "StreamChatModel",
         bundle: Bundle? = nil,
-        channelConfig: ChatClientConfig.Channel? = nil
+        localCachingSettings: ChatClientConfig.LocalCaching? = nil
     ) throws {
         init_kind = kind
         try super.init(
@@ -40,7 +40,7 @@ class DatabaseContainerMock: DatabaseContainer {
             shouldResetEphemeralValuesOnStart: shouldResetEphemeralValuesOnStart,
             modelName: modelName,
             bundle: bundle,
-            channelConfig: channelConfig
+            localCachingSettings: localCachingSettings
         )
     }
     

--- a/Sources/StreamChat/Database/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer_Mock.swift
@@ -20,8 +20,8 @@ class DatabaseContainerMock: DatabaseContainer {
     /// If set to `true` and the mock will remove its database files once deinited.
     private var shouldCleanUpTempDBFiles = false
     
-    convenience init(channelConfig: ChatClientConfig.Channel? = nil) {
-        try! self.init(kind: .onDisk(databaseFileURL: .newTemporaryFileURL()), channelConfig: channelConfig)
+    convenience init(localCachingSettings: ChatClientConfig.LocalCaching? = nil) {
+        try! self.init(kind: .onDisk(databaseFileURL: .newTemporaryFileURL()), localCachingSettings: localCachingSettings)
         shouldCleanUpTempDBFiles = true
     }
     

--- a/Sources/StreamChat/Database/DatabaseContainer_Tests.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer_Tests.swift
@@ -208,15 +208,15 @@ class DatabaseContainer_Tests: StressTestCase {
     }
     
     func test_channelConfig_isStoredInAllContexts() throws {
-        var channelConfig = ChatClientConfig.Channel()
-        channelConfig.lastActiveMembersLimit = .unique
-        channelConfig.lastActiveWatchersLimit = .unique
+        var cachingSettings = ChatClientConfig.LocalCaching()
+        cachingSettings.chatChannel.lastActiveMembersLimit = .unique
+        cachingSettings.chatChannel.lastActiveWatchersLimit = .unique
         
-        let database = try DatabaseContainerMock(kind: .inMemory, channelConfig: channelConfig)
+        let database = try DatabaseContainerMock(kind: .inMemory, localCachingSettings: cachingSettings)
         
-        XCTAssertEqual(database.viewContext.channelConfig, channelConfig)
-        XCTAssertEqual(database.writableContext.channelConfig, channelConfig)
-        XCTAssertEqual(database.backgroundReadOnlyContext.channelConfig, channelConfig)
+        XCTAssertEqual(database.viewContext.localCachingSettings, cachingSettings)
+        XCTAssertEqual(database.writableContext.localCachingSettings, cachingSettings)
+        XCTAssertEqual(database.backgroundReadOnlyContext.localCachingSettings, cachingSettings)
     }
 }
 

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -113,9 +113,6 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
     public var latestMessages: [_ChatMessage<ExtraData>] { _latestMessages }
     @Cached private var _latestMessages: [_ChatMessage<ExtraData>]
     
-    /// The newest message of the channel. `nil` if there are no messages in the channel.
-    public let lastMessage: _ChatMessage<ExtraData>?
-
     /// Pinned messages present on the channel.
     ///
     /// This field contains only the pinned messages of the channel. You can get all existing messages in the channel by creating
@@ -176,7 +173,6 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
         extraData: ExtraData.Channel,
 //        invitedMembers: Set<_ChatChannelMember<ExtraData.User>> = [],
         latestMessages: @escaping (() -> [_ChatMessage<ExtraData>]) = { [] },
-        lastMessage: _ChatMessage<ExtraData>? = nil,
         pinnedMessages: @escaping (() -> [_ChatMessage<ExtraData>]) = { [] }
     ) {
         self.cid = cid
@@ -200,7 +196,6 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
         self.cooldownDuration = cooldownDuration
         self.extraData = extraData
 //        self.invitedMembers = invitedMembers
-        self.lastMessage = lastMessage
         
         $_latestMessages = latestMessages
         $_lastActiveMembers = lastActiveMembers

--- a/Sources/StreamChat/Utils/Database/NSManagedObjectContext+Extensions.swift
+++ b/Sources/StreamChat/Utils/Database/NSManagedObjectContext+Extensions.swift
@@ -5,10 +5,11 @@
 import CoreData
 
 extension NSManagedObjectContext {
-    private static let channelConfigKey = "io.getStream.chat.core.channel_config_key"
+    private static let localCachingKey = "io.getStream.StreamChat.local_caching_key"
     
-    var channelConfig: ChatClientConfig.Channel? {
-        get { userInfo[Self.channelConfigKey] as? ChatClientConfig.Channel }
-        set { userInfo[Self.channelConfigKey] = newValue }
+    /// Provides the defaults for local caching and model serialization for this context.
+    var localCachingSettings: ChatClientConfig.LocalCaching? {
+        get { userInfo[Self.localCachingKey] as? ChatClientConfig.LocalCaching }
+        set { userInfo[Self.localCachingKey] = newValue }
     }
 }

--- a/Sources/StreamChatTestTools/Models/ChatChannel_Mock.swift
+++ b/Sources/StreamChatTestTools/Models/ChatChannel_Mock.swift
@@ -99,8 +99,7 @@ public extension _ChatChannel {
             memberCount: memberCount,
             reads: reads,
             extraData: extraData,
-            latestMessages: { latestMessages },
-            lastMessage: latestMessages.first
+            latestMessages: { latestMessages }
         )
     }
     
@@ -144,8 +143,7 @@ public extension _ChatChannel {
             memberCount: memberCount,
             reads: reads,
             extraData: extraData,
-            latestMessages: { latestMessages },
-            lastMessage: latestMessages.first
+            latestMessages: { latestMessages }
         )
     }
 }

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -91,7 +91,7 @@ open class _ChatChannelListItemView<ExtraData: ExtraDataTypes>: _View, UIConfigP
         guard let channel = content.channel else { return nil }
         if let typingMembersInfo = typingMemberString {
             return typingMembersInfo
-        } else if let latestMessage = channel.lastMessage {
+        } else if let latestMessage = channel.latestMessages.first {
             return "\(latestMessage.author.name ?? latestMessage.author.id): \(latestMessage.text)"
         } else {
             return L10n.Channel.Item.emptyMessages


### PR DESCRIPTION
This is a follow-up PR on #911 . It improves the naming and adds a limit for `ChatChannel.latestMesages`.