### PR TITLE
 Use temp folder instead of /dev/null for test DB

### DIFF
--- a/Sources/StreamChat/ChatClient_Mock.swift
+++ b/Sources/StreamChat/ChatClient_Mock.swift
@@ -134,7 +134,7 @@ extension _ChatClient.Environment {
             databaseContainerBuilder: {
                 do {
                     return try DatabaseContainerMock(
-                        kind: $0,
+                        kind: .onDisk(databaseFileURL: .newTemporaryFileURL()),
                         shouldFlushOnStart: $1,
                         shouldResetEphemeralValuesOnStart: $2,
                         channelConfig: $3

--- a/Sources/StreamChat/Controllers/EntityDatabaseObserver_Tests.swift
+++ b/Sources/StreamChat/Controllers/EntityDatabaseObserver_Tests.swift
@@ -57,7 +57,7 @@ class EntityDatabaseObserver_Tests: XCTestCase {
         fetchRequest = NSFetchRequest(entityName: "TestManagedObject")
         fetchRequest.sortDescriptors = [.init(keyPath: \TestManagedObject.testId, ascending: true)]
         database = try! DatabaseContainerMock(
-            kind: .inMemory,
+            kind: .onDisk(databaseFileURL: .newTemporaryFileURL()),
             modelName: "TestDataModel",
             bundle: Bundle(for: EntityDatabaseObserver_Tests.self)
         )

--- a/Sources/StreamChat/Controllers/ListDatabaseObserver_Tests.swift
+++ b/Sources/StreamChat/Controllers/ListDatabaseObserver_Tests.swift
@@ -93,7 +93,7 @@ class ListDatabaseObserver_Tests: XCTestCase {
         fetchRequest = NSFetchRequest(entityName: "TestManagedObject")
         fetchRequest.sortDescriptors = [.init(key: "testId", ascending: true)]
         database = try! DatabaseContainerMock(
-            kind: .inMemory,
+            kind: .onDisk(databaseFileURL: .newTemporaryFileURL()),
             modelName: "TestDataModel",
             bundle: Bundle(for: ListDatabaseObserver_Tests.self)
         )

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
@@ -10,7 +10,7 @@ class AttachmentDTO_Tests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        database = try! DatabaseContainer(kind: .inMemory)
+        database = DatabaseContainerMock()
     }
     
     override func tearDown() {

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
@@ -14,7 +14,7 @@ class ChannelDTO_Tests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        database = try! DatabaseContainer(kind: .inMemory)
+        database = DatabaseContainerMock()
     }
     
     override func tearDown() {
@@ -325,7 +325,7 @@ class ChannelDTO_Tests: XCTestCase {
             .map { MemberPayload<NoExtraData>.withLastActivity(at: Date() - TimeInterval($0)) }.shuffled()
         let payload = dummyPayload(with: cid, members: allMembers)
         
-        var database: DatabaseContainerMock! = try DatabaseContainerMock(kind: .inMemory, channelConfig: config)
+        var database: DatabaseContainerMock! = DatabaseContainerMock(channelConfig: config)
         
         try database.writeSynchronously { session in
             try session.saveChannel(payload: payload)
@@ -350,7 +350,7 @@ class ChannelDTO_Tests: XCTestCase {
             .map { UserPayload<NoExtraData>.withLastActivity(at: Date() - TimeInterval($0)) }.shuffled()
         let payload = dummyPayload(with: cid, watchers: allWatchers)
         
-        var database: DatabaseContainerMock! = try DatabaseContainerMock(kind: .inMemory, channelConfig: config)
+        var database: DatabaseContainerMock! = DatabaseContainerMock(channelConfig: config)
         
         try database.writeSynchronously { session in
             try session.saveChannel(payload: payload)

--- a/Sources/StreamChat/Database/DTOs/ChannelMemberListQueryDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelMemberListQueryDTO_Tests.swift
@@ -13,7 +13,7 @@ final class ChannelMemberListQueryDTO_Tests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        database = try! DatabaseContainer(kind: .inMemory)
+        database = DatabaseContainerMock()
     }
     
     override func tearDown() {

--- a/Sources/StreamChat/Database/DTOs/CurrentUserDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/CurrentUserDTO_Tests.swift
@@ -10,7 +10,7 @@ class CurrentUserModelDTO_Tests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        database = try! DatabaseContainer(kind: .inMemory)
+        database = DatabaseContainerMock()
     }
     
     override func tearDown() {

--- a/Sources/StreamChat/Database/DTOs/DeviceDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/DeviceDTO_Tests.swift
@@ -10,7 +10,7 @@ class DeviceDTO_Tests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        database = try! DatabaseContainer(kind: .inMemory)
+        database = DatabaseContainerMock()
     }
     
     override func tearDown() {

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -79,7 +79,7 @@ extension MemberDTO {
     
     static func loadLastActiveMembers(cid: ChannelId, context: NSManagedObjectContext) -> [MemberDTO] {
         let request = NSFetchRequest<MemberDTO>(entityName: MemberDTO.entityName)
-        request.predicate = NSPredicate(format: "ANY channel.cid == %@", cid.rawValue)
+        request.predicate = NSPredicate(format: "channel.cid == %@", cid.rawValue)
         request.sortDescriptors = [ChannelMemberListSortingKey.lastActiveSortDescriptor]
         request.fetchLimit = context.channelConfig?.lastActiveMembersLimit ?? 25
         return try! context.fetch(request)

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO_Tests.swift
@@ -10,7 +10,7 @@ class MemberModelDTO_Tests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        database = try! DatabaseContainer(kind: .inMemory)
+        database = DatabaseContainerMock()
     }
     
     override func tearDown() {

--- a/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
@@ -11,7 +11,7 @@ class MessageDTO_Tests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        database = try! DatabaseContainer(kind: .inMemory)
+        database = DatabaseContainerMock()
     }
     
     override func tearDown() {

--- a/Sources/StreamChat/Database/DTOs/MessageReactionDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageReactionDTO_Tests.swift
@@ -13,7 +13,7 @@ final class MessageReactionDTO_Tests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        database = try! DatabaseContainer(kind: .inMemory)
+        database = DatabaseContainerMock()
     }
     
     override func tearDown() {

--- a/Sources/StreamChat/Database/DTOs/UserDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/UserDTO_Tests.swift
@@ -10,7 +10,7 @@ class UserDTO_Tests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        database = try! DatabaseContainerMock(kind: .inMemory)
+        database = DatabaseContainerMock()
     }
     
     override func tearDown() {

--- a/Sources/StreamChat/Database/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer_Mock.swift
@@ -17,8 +17,8 @@ class DatabaseContainerMock: DatabaseContainer {
     @Atomic var recreatePersistentStore_errorResponse: Error?
     @Atomic var resetEphemeralValues_called = false
     
-    convenience init() {
-        try! self.init(kind: .onDisk(databaseFileURL: .newTemporaryFileURL()))
+    convenience init(channelConfig: ChatClientConfig.Channel? = nil) {
+        try! self.init(kind: .onDisk(databaseFileURL: .newTemporaryFileURL()), channelConfig: channelConfig)
     }
     
     override init(

--- a/Sources/StreamChat/Database/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer_Mock.swift
@@ -18,7 +18,7 @@ class DatabaseContainerMock: DatabaseContainer {
     @Atomic var resetEphemeralValues_called = false
     
     convenience init() {
-        try! self.init(kind: .inMemory)
+        try! self.init(kind: .onDisk(databaseFileURL: .newTemporaryFileURL()))
     }
     
     override init(

--- a/Sources/StreamChat/Database/DatabaseSession_Tests.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Tests.swift
@@ -10,7 +10,7 @@ class DatabaseSession_Tests: StressTestCase {
     
     override func setUp() {
         super.setUp()
-        database = try! DatabaseContainerMock(kind: .inMemory)
+        database = DatabaseContainerMock()
     }
     
     override func tearDown() {

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware_Tests.swift
@@ -14,7 +14,7 @@ final class ChannelMemberTypingStateUpdaterMiddleware_Tests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        database = try! DatabaseContainerMock(kind: .inMemory)
+        database = DatabaseContainerMock()
         middleware = ChannelMemberTypingStateUpdaterMiddleware(database: database)
     }
     

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
@@ -11,7 +11,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        database = try! DatabaseContainerMock(kind: .inMemory)
+        database = DatabaseContainerMock()
         middleware = ChannelReadUpdaterMiddleware(database: database)
     }
     

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
@@ -11,7 +11,7 @@ class EventDataProcessorMiddleware_Tests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        database = try! DatabaseContainerMock(kind: .inMemory)
+        database = DatabaseContainerMock()
         middleware = EventDataProcessorMiddleware(database: database)
     }
     

--- a/Sources/StreamChat/Workers/Background/ChannelWatchStateUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/ChannelWatchStateUpdater_Tests.swift
@@ -17,7 +17,7 @@ class ChannelWatchStateUpdater_Tests: StressTestCase {
     override func setUp() {
         super.setUp()
         
-        database = try! DatabaseContainerMock(kind: .inMemory)
+        database = DatabaseContainerMock()
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
         

--- a/Sources/StreamChat/Workers/Background/MessageEditor_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/MessageEditor_Tests.swift
@@ -20,7 +20,7 @@ final class MessageEditor_Tests: StressTestCase {
         
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
-        database = try! DatabaseContainerMock(kind: .inMemory)
+        database = DatabaseContainerMock()
         editor = MessageEditor(database: database, apiClient: apiClient)
     }
     

--- a/Sources/StreamChat/Workers/Background/MessageSender_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/MessageSender_Tests.swift
@@ -21,7 +21,7 @@ class MessageSender_Tests: StressTestCase {
         
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
-        database = try! DatabaseContainerMock(kind: .inMemory)
+        database = DatabaseContainerMock()
         
         sender = MessageSender(database: database, apiClient: apiClient)
         

--- a/Sources/StreamChat/Workers/Background/MissingEventsPublisher_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/MissingEventsPublisher_Tests.swift
@@ -18,7 +18,7 @@ final class MissingEventsPublisher_Tests: StressTestCase {
     override func setUp() {
         super.setUp()
         
-        database = try! DatabaseContainerMock(kind: .inMemory)
+        database = DatabaseContainerMock()
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
         

--- a/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater_Tests.swift
@@ -20,7 +20,7 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
         super.setUp()
         env = TestEnvironment()
         
-        database = try! DatabaseContainerMock(kind: .inMemory)
+        database = DatabaseContainerMock()
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
         

--- a/Sources/StreamChat/Workers/Background/NewUserQueryUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/NewUserQueryUpdater_Tests.swift
@@ -20,7 +20,7 @@ class NewUserQueryUpdater_Tests: StressTestCase {
         super.setUp()
         env = TestEnvironment()
         
-        database = try! DatabaseContainerMock(kind: .inMemory)
+        database = DatabaseContainerMock()
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
         

--- a/Sources/StreamChat/Workers/ChannelListUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater_Tests.swift
@@ -17,7 +17,7 @@ class ChannelListUpdater_Tests: StressTestCase {
         
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
-        database = try! DatabaseContainer(kind: .inMemory)
+        database = DatabaseContainerMock()
         
         listUpdater = ChannelListUpdater(database: database, apiClient: apiClient)
     }

--- a/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
@@ -19,7 +19,7 @@ class ChannelUpdater_Tests: StressTestCase {
         
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
-        database = try! DatabaseContainerMock(kind: .inMemory)
+        database = DatabaseContainerMock()
         
         channelUpdater = ChannelUpdater(database: database, apiClient: apiClient)
     }

--- a/Sources/StreamChat/Workers/EventSender_Tests.swift
+++ b/Sources/StreamChat/Workers/EventSender_Tests.swift
@@ -19,7 +19,7 @@ class EventSender_Tests: StressTestCase {
         
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
-        database = try! DatabaseContainerMock(kind: .inMemory)
+        database = DatabaseContainerMock()
         
         time = VirtualTime()
         VirtualTimeTimer.time = time

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -21,7 +21,7 @@ final class MessageUpdater_Tests: StressTestCase {
         
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
-        database = try! DatabaseContainerMock(kind: .inMemory)
+        database = DatabaseContainerMock()
         messageUpdater = MessageUpdater(database: database, apiClient: apiClient)
     }
     

--- a/Sources/StreamChat/Workers/UserListUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/UserListUpdater_Tests.swift
@@ -17,7 +17,7 @@ class UserListUpdater_Tests: StressTestCase {
         
         webSocketClient = WebSocketClientMock()
         apiClient = APIClientMock()
-        database = try! DatabaseContainer(kind: .inMemory)
+        database = DatabaseContainerMock()
         
         listUpdater = UserListUpdater(database: database, apiClient: apiClient)
     }

--- a/Tests/Shared/StressTestCase.swift
+++ b/Tests/Shared/StressTestCase.swift
@@ -17,23 +17,22 @@ class StressTestCase: XCTestCase {
     }
     
     override class func tearDown() {
-        // After running test suite cleanup `NSTemporaryDirectory()` and `Documents` directory
-        let fileManager = FileManager.default
-        let tempDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-        let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
-        let tempFileURLs = (try? fileManager.contentsOfDirectory(
-            at: tempDirectoryURL,
-            includingPropertiesForKeys: nil,
-            options: .skipsHiddenFiles
-        )) ?? []
-        let documentsFileURLs = documentsURL.flatMap { try? FileManager.default.contentsOfDirectory(
-            at: $0,
-            includingPropertiesForKeys: nil,
-            options: .skipsHiddenFiles
-        ) } ?? []
-        
-        for fileURL in tempFileURLs + documentsFileURLs {
-            try? fileManager.removeItem(at: fileURL)
+        do {
+            // After running test suite cleanup `NSTemporaryDirectory()` and `Documents` directory
+            let fileManager = FileManager.default
+            let tempDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            
+            let tempFileURLs = try fileManager.contentsOfDirectory(
+                at: tempDirectoryURL,
+                includingPropertiesForKeys: nil,
+                options: .skipsHiddenFiles
+            )
+            
+            try tempFileURLs.forEach {
+                try fileManager.removeItem(at: $0)
+            }
+        } catch {
+            XCTFail("Failed to clean up after tests: \(error)")
         }
         
         super.tearDown()

--- a/Tests/Shared/StressTestCase.swift
+++ b/Tests/Shared/StressTestCase.swift
@@ -7,35 +7,12 @@ import XCTest
 /// Base class for stress tests
 ///
 /// - runs 100 times if `TestRunnerEnvironment.isStressTest`
-/// - removes all files in `NSTemporaryDirectory()` and `Documents` directory when test suite completes
 /// - by default ends test when test failure occurs
 class StressTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
         
         continueAfterFailure = false
-    }
-    
-    override class func tearDown() {
-        do {
-            // After running test suite cleanup `NSTemporaryDirectory()` and `Documents` directory
-            let fileManager = FileManager.default
-            let tempDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-            
-            let tempFileURLs = try fileManager.contentsOfDirectory(
-                at: tempDirectoryURL,
-                includingPropertiesForKeys: nil,
-                options: .skipsHiddenFiles
-            )
-            
-            try tempFileURLs.forEach {
-                try fileManager.removeItem(at: $0)
-            }
-        } catch {
-            XCTFail("Failed to clean up after tests: \(error)")
-        }
-        
-        super.tearDown()
     }
     
     override func invokeTest() {

--- a/Tests/StreamChatTests/TestsEnvironmentSetup.swift
+++ b/Tests/StreamChatTests/TestsEnvironmentSetup.swift
@@ -6,5 +6,28 @@ import Foundation
 
 /// Class encapsulating one-time setup code for all the tests of `StreamChatTests`.
 final class TestsEnvironmentSetup: NSObject {
-    override init() {}
+    override init() {
+        super.init()
+        cleanUpTempFolder()
+    }
+    
+    func cleanUpTempFolder() {
+        do {
+            // Before running the test suite cleanup the `NSTemporaryDirectory()` directory
+            let fileManager = FileManager.default
+            let tempDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            
+            let tempFileURLs = try fileManager.contentsOfDirectory(
+                at: tempDirectoryURL,
+                includingPropertiesForKeys: nil,
+                options: .skipsHiddenFiles
+            )
+            
+            try tempFileURLs.forEach {
+                try fileManager.removeItem(at: $0)
+            }
+        } catch {
+            fatalError("Failed to clean up before tests: \(error)")
+        }
+    }
 }


### PR DESCRIPTION
We see some issues with using `/dev/null` where writes to the test DB are getting locked by another test database. This change makes sure every test has its own _real_ sqlite db file in the temp directory.