### PR TITLE
[CIS-681] Log error when UIConfig is assigned after the view is initialized

### DIFF
--- a/Sources/StreamChatUI/CommonViews/BaseViews.swift
+++ b/Sources/StreamChatUI/CommonViews/BaseViews.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import StreamChat
 import UIKit
 
 // Just a protocol to formalize the methods required
@@ -49,11 +50,23 @@ public extension Customizable where Self: UIViewController {
     }
 }
 
+extension UIConfigProvider where Self: _View {
+    public func uiConfigDidRegister() {
+        if isInitialized {
+            log.assertionFailure(
+                "`UIConfig` was assigned after the view has been already initialized. This is most likely caused by assigning " +
+                    "the custom `UIConfig` instance after the view has been added to the view hierarchy, or after the view's subviews " +
+                    "have been initialized already. This is undefined behavior and should be avoided."
+            )
+        }
+    }
+}
+
 /// Base class for overridable views StreamChatUI provides.
 /// All conformers will have StreamChatUI appearance settings by default.
 open class _View: UIView, AppearanceSetting, Customizable {
     // Flag for preventing multiple lifecycle methods calls.
-    private var isInitialized: Bool = false
+    fileprivate var isInitialized: Bool = false
     
     override open func didMoveToSuperview() {
         super.didMoveToSuperview()

--- a/Sources/StreamChatUI/Utils/UIConfigProvider.swift
+++ b/Sources/StreamChatUI/Utils/UIConfigProvider.swift
@@ -21,6 +21,7 @@ private extension UIResponder {
 public protocol GenericUIConfigProvider: AnyObject {
     func register<T: ExtraDataTypes>(config: _UIConfig<T>)
     func uiConfig<T: ExtraDataTypes>(_ type: T.Type) -> _UIConfig<T>
+    func uiConfigDidRegister()
 }
 
 public protocol UIConfigProvider: GenericUIConfigProvider {
@@ -31,8 +32,11 @@ public protocol UIConfigProvider: GenericUIConfigProvider {
 // MARK: - Protocol extensions for UIView
 
 public extension GenericUIConfigProvider where Self: UIResponder {
+    func uiConfigDidRegister() {}
+    
     func register<T: ExtraDataTypes>(config: _UIConfig<T>) {
         anyUIConfig = config
+        uiConfigDidRegister()
     }
     
     func uiConfig<T: ExtraDataTypes>(_ type: T.Type = T.self) -> _UIConfig<T> {


### PR DESCRIPTION
## Description of the pull request

Assigning `UIConfig` instance explicitly is possible only before view's subviews are instantiated. When someone assigns `UIConfig` after the view has been initialized, we should log an error. You can use the base views' `isInitialized` for this.