### PR TITLE
[CIS-776] Extract ChatVC logic to separate components

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListKeyboardObserver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListKeyboardObserver.swift
@@ -5,7 +5,7 @@
 import StreamChat
 import UIKit
 
-final class KeyboardFrameObserver {
+final class ChatMessageListKeyboardObserver {
     weak var containerView: UIView!
     weak var scrollView: UIScrollView!
     weak var composerBottomConstraint: NSLayoutConstraint?
@@ -23,6 +23,10 @@ final class KeyboardFrameObserver {
             name: UIResponder.keyboardWillChangeFrameNotification,
             object: nil
         )
+    }
+    
+    public func unregister() {
+        NotificationCenter.default.removeObserver(self)
     }
     
     @objc

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListTitleView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListTitleView.swift
@@ -1,0 +1,48 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+// TODO: Audit
+public class ChatMessageListTitleView<ExtraData: ExtraDataTypes>: UIView, UIConfigProvider {
+    public var title: String? {
+        get { titleLabel.text }
+        set { titleLabel.text = newValue }
+    }
+    
+    public var subtitle: String? {
+        get { subtitleLabel.text }
+        set { subtitleLabel.text = newValue }
+    }
+    
+    private weak var titleLabel: UILabel!
+    private weak var subtitleLabel: UILabel!
+    
+    public init() {
+        super.init(frame: .zero)
+        
+        let titleLabel = UILabel()
+        titleLabel.textAlignment = .center
+        titleLabel.font = uiConfig.font.headlineBold
+        self.titleLabel = titleLabel
+
+        let subtitleLabel = UILabel()
+        subtitleLabel.textAlignment = .center
+        subtitleLabel.font = uiConfig.font.caption1
+        subtitleLabel.textColor = uiConfig.colorPalette.subtitleText
+        self.subtitleLabel = subtitleLabel
+
+        let titleView = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+        titleView.axis = .vertical
+        addSubview(titleView)
+        titleView.translatesAutoresizingMaskIntoConstraints = false
+        titleView.pin(to: self)
+    }
+    
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Sources/StreamChatUI/Utils/KeyboardFrameObserver.swift
+++ b/Sources/StreamChatUI/Utils/KeyboardFrameObserver.swift
@@ -1,0 +1,87 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+final class KeyboardFrameObserver {
+    weak var containerView: UIView!
+    weak var scrollView: UIScrollView!
+    weak var composerBottomConstraint: NSLayoutConstraint?
+    
+    init(containerView: UIView, scrollView: UIScrollView, composerBottomConstraint: NSLayoutConstraint?) {
+        self.containerView = containerView
+        self.scrollView = scrollView
+        self.composerBottomConstraint = composerBottomConstraint
+    }
+    
+    public func register() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillChangeFrame),
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil
+        )
+    }
+    
+    @objc
+    private func keyboardWillChangeFrame(_ notification: Notification) {
+        guard
+            let frame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
+            let oldFrame = (notification.userInfo?[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue,
+            let duration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
+            let curve = notification.userInfo?[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt
+        else { return }
+
+        let localFrame = containerView.convert(frame, from: nil)
+        let localOldFrame = containerView.convert(oldFrame, from: nil)
+
+        // message composer follows keyboard
+        composerBottomConstraint?.constant = -(containerView.bounds.height - localFrame.minY)
+
+        // calculate new contentOffset for message list, so bottom message still visible when keyboard appears
+        var keyboardTop = localFrame.minY
+        if keyboardTop == containerView.bounds.height {
+            keyboardTop -= containerView.safeAreaInsets.bottom
+        }
+
+        var oldKeyboardTop = localOldFrame.minY
+        if oldKeyboardTop == containerView.bounds.height {
+            oldKeyboardTop -= containerView.safeAreaInsets.bottom
+        }
+
+        let keyboardDelta = oldKeyboardTop - keyboardTop
+        // need to calculate delta in content when `contentSize` is smaller than `frame.size`
+        let contentDelta = max(
+            // 8 is just some padding constant to make it look better
+            scrollView.frame.height - scrollView.contentSize.height + scrollView.contentOffset.y - 8,
+            // 0 is for the case when `contentSize` if larger than `frame.size`
+            0
+        )
+        
+        let newContentOffset = CGPoint(
+            x: 0,
+            y: max(
+                scrollView.contentOffset.y + keyboardDelta - contentDelta,
+                // case when keyboard is activated but not shown, probably only on simulator
+                -scrollView.contentInset.top
+            )
+        )
+        
+        // changing contentOffset will cancel any scrolling in collectionView, bad UX
+        let needUpdateContentOffset = !scrollView.isDecelerating && !scrollView.isDragging
+        
+        UIView.animate(
+            withDuration: duration,
+            delay: 0.0,
+            options: UIView.AnimationOptions(rawValue: curve),
+            animations: { [weak self] in
+                self?.containerView.layoutIfNeeded()
+                if needUpdateContentOffset {
+                    self?.scrollView.contentOffset = newContentOffset
+                }
+            }
+        )
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -675,6 +675,8 @@
 		8AE335A924FCF999002B6677 /* InternetConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE335A624FCF999002B6677 /* InternetConnection.swift */; };
 		8AE335AA24FCF99E002B6677 /* InternetConnection_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE335A424FCF999002B6677 /* InternetConnection_Tests.swift */; };
 		8AE8950D24D8660800E852EC /* PingPongEmojiFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */; };
+		A35757C72613081B00DC914C /* KeyboardFrameObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35757C62613081B00DC914C /* KeyboardFrameObserver.swift */; };
+		A35757D12613082B00DC914C /* ChatMessageListTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35757D02613082B00DC914C /* ChatMessageListTitleView.swift */; };
 		AD0169CB25CAEDC0009EBAD2 /* yoda.jpg in Resources */ = {isa = PBXBuildFile; fileRef = AD0169CA25CAEDC0009EBAD2 /* yoda.jpg */; };
 		AD0169E625CAF235009EBAD2 /* CurrentChatUserController_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0169D825CAF212009EBAD2 /* CurrentChatUserController_Mock.swift */; };
 		AD0169F425CAF689009EBAD2 /* vader.jpg in Resources */ = {isa = PBXBuildFile; fileRef = AD0169F325CAF689009EBAD2 /* vader.jpg */; };
@@ -1788,6 +1790,8 @@
 		8AE335A524FCF999002B6677 /* Reachability_Vendor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability_Vendor.swift; sourceTree = "<group>"; };
 		8AE335A624FCF999002B6677 /* InternetConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternetConnection.swift; sourceTree = "<group>"; };
 		8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingPongEmojiFormatter.swift; sourceTree = "<group>"; };
+		A35757C62613081B00DC914C /* KeyboardFrameObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserver.swift; sourceTree = "<group>"; };
+		A35757D02613082B00DC914C /* ChatMessageListTitleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageListTitleView.swift; sourceTree = "<group>"; };
 		AD0169CA25CAEDC0009EBAD2 /* yoda.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = yoda.jpg; sourceTree = "<group>"; };
 		AD0169D825CAF212009EBAD2 /* CurrentChatUserController_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentChatUserController_Mock.swift; sourceTree = "<group>"; };
 		AD0169F325CAF689009EBAD2 /* vader.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = vader.jpg; sourceTree = "<group>"; };
@@ -2274,6 +2278,7 @@
 				79088331254876C100896F03 /* ChatMessageListCollectionView.swift */,
 				79088330254876C100896F03 /* ChatMessageListCollectionViewLayout.swift */,
 				F8933D9025FFC0050054BBFF /* ChatMessageListCollectionViewLayout_Tests.swift */,
+				A35757D02613082B00DC914C /* ChatMessageListTitleView.swift */,
 				DB9A3D652582783F00555D36 /* ChatVC.swift */,
 				7908832D254876C100896F03 /* ChatChannelVC.swift */,
 				882AE056257A176A004095B3 /* ChatChannelRouter.swift */,
@@ -3529,6 +3534,7 @@
 				E73262D725ED6432008CB152 /* ChatChannelNamer_Tests.swift */,
 				796CBD1B25FF9552003299B0 /* UIStackView+Extensions.swift */,
 				79F691B12604C10A000AE89B /* SystemEnvironment.swift */,
+				A35757C62613081B00DC914C /* KeyboardFrameObserver.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -4790,6 +4796,7 @@
 				88F836612578D1A80039AEC8 /* ChatMessageActionItem.swift in Sources */,
 				228DC80E25704B410080A49F /* ChatMessageComposerImageAttachmentCollectionViewCell.swift in Sources */,
 				F87A4866260B3516001653A8 /* SwiftUIViewRepresentable.swift in Sources */,
+				A35757D12613082B00DC914C /* ChatMessageListTitleView.swift in Sources */,
 				E7166CC225BED44A00B03B07 /* UIConfig+MessageList.swift in Sources */,
 				790882DF25486B6800896F03 /* ChatChannelListVC.swift in Sources */,
 				DBC8A564258113F700B20A82 /* ChatThreadVC.swift in Sources */,
@@ -4819,6 +4826,7 @@
 				ADB22F7D25F1626200853C92 /* ChatPresenceAvatarView.swift in Sources */,
 				2245B2B625602465006A612D /* ChatChannelAvatarView.swift in Sources */,
 				88EF29FF2571288600B06EF1 /* Array+Extensions.swift in Sources */,
+				A35757C72613081B00DC914C /* KeyboardFrameObserver.swift in Sources */,
 				8800A278258A17DD006D64C4 /* ChatMessageAttachmentListViewData.swift in Sources */,
 				E7166CBA25BED29200B03B07 /* UIConfig+Fonts.swift in Sources */,
 				E7073A6325DD67B3003896B9 /* UILabel+Extensions.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -675,7 +675,7 @@
 		8AE335A924FCF999002B6677 /* InternetConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE335A624FCF999002B6677 /* InternetConnection.swift */; };
 		8AE335AA24FCF99E002B6677 /* InternetConnection_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE335A424FCF999002B6677 /* InternetConnection_Tests.swift */; };
 		8AE8950D24D8660800E852EC /* PingPongEmojiFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */; };
-		A35757C72613081B00DC914C /* KeyboardFrameObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35757C62613081B00DC914C /* KeyboardFrameObserver.swift */; };
+		A35757C72613081B00DC914C /* ChatMessageListKeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35757C62613081B00DC914C /* ChatMessageListKeyboardObserver.swift */; };
 		A35757D12613082B00DC914C /* ChatMessageListTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35757D02613082B00DC914C /* ChatMessageListTitleView.swift */; };
 		AD0169CB25CAEDC0009EBAD2 /* yoda.jpg in Resources */ = {isa = PBXBuildFile; fileRef = AD0169CA25CAEDC0009EBAD2 /* yoda.jpg */; };
 		AD0169E625CAF235009EBAD2 /* CurrentChatUserController_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0169D825CAF212009EBAD2 /* CurrentChatUserController_Mock.swift */; };
@@ -1790,7 +1790,7 @@
 		8AE335A524FCF999002B6677 /* Reachability_Vendor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability_Vendor.swift; sourceTree = "<group>"; };
 		8AE335A624FCF999002B6677 /* InternetConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternetConnection.swift; sourceTree = "<group>"; };
 		8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingPongEmojiFormatter.swift; sourceTree = "<group>"; };
-		A35757C62613081B00DC914C /* KeyboardFrameObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserver.swift; sourceTree = "<group>"; };
+		A35757C62613081B00DC914C /* ChatMessageListKeyboardObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageListKeyboardObserver.swift; sourceTree = "<group>"; };
 		A35757D02613082B00DC914C /* ChatMessageListTitleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageListTitleView.swift; sourceTree = "<group>"; };
 		AD0169CA25CAEDC0009EBAD2 /* yoda.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = yoda.jpg; sourceTree = "<group>"; };
 		AD0169D825CAF212009EBAD2 /* CurrentChatUserController_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentChatUserController_Mock.swift; sourceTree = "<group>"; };
@@ -2279,6 +2279,7 @@
 				79088330254876C100896F03 /* ChatMessageListCollectionViewLayout.swift */,
 				F8933D9025FFC0050054BBFF /* ChatMessageListCollectionViewLayout_Tests.swift */,
 				A35757D02613082B00DC914C /* ChatMessageListTitleView.swift */,
+				A35757C62613081B00DC914C /* ChatMessageListKeyboardObserver.swift */,
 				DB9A3D652582783F00555D36 /* ChatVC.swift */,
 				7908832D254876C100896F03 /* ChatChannelVC.swift */,
 				882AE056257A176A004095B3 /* ChatChannelRouter.swift */,
@@ -3534,7 +3535,6 @@
 				E73262D725ED6432008CB152 /* ChatChannelNamer_Tests.swift */,
 				796CBD1B25FF9552003299B0 /* UIStackView+Extensions.swift */,
 				79F691B12604C10A000AE89B /* SystemEnvironment.swift */,
-				A35757C62613081B00DC914C /* KeyboardFrameObserver.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -4826,7 +4826,7 @@
 				ADB22F7D25F1626200853C92 /* ChatPresenceAvatarView.swift in Sources */,
 				2245B2B625602465006A612D /* ChatChannelAvatarView.swift in Sources */,
 				88EF29FF2571288600B06EF1 /* Array+Extensions.swift in Sources */,
-				A35757C72613081B00DC914C /* KeyboardFrameObserver.swift in Sources */,
+				A35757C72613081B00DC914C /* ChatMessageListKeyboardObserver.swift in Sources */,
 				8800A278258A17DD006D64C4 /* ChatMessageAttachmentListViewData.swift in Sources */,
 				E7166CBA25BED29200B03B07 /* UIConfig+Fonts.swift in Sources */,
 				E7073A6325DD67B3003896B9 /* UILabel+Extensions.swift in Sources */,


### PR DESCRIPTION
# Description of the pull request

Extracted common logic for `ChatVC`'s children to separate components:

* `ChatMessageListTitleView` (audit will be in future PR)
* `KeyboardFrameObserver`
