### PR TITLE
[CIS-779] Fix hardcoded channel type for DM channels

### DIFF
--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -26,7 +26,10 @@ public extension _ChatClient {
         .init(channelQuery: channelQuery, client: self)
     }
     
-    /// Creates a new `ChatChannelController` that will create a new channel.
+    /// Creates a `ChatChannelController` that will create a new channel, if the channel doesn't exist already.
+    ///
+    /// It's safe to call this method for already existing channels. However, if you queried the channel before and you're sure it exists locally,
+    /// it can be faster and more convenient to use `channelController(for cid: ChannelId)` to create a controller for it.
     ///
     /// - Parameters:
     ///   - cid: The `ChannelId` for the new channel.
@@ -41,13 +44,13 @@ public extension _ChatClient {
     /// - Returns: A new instance of `ChatChannelController`.
     func channelController(
         createChannelWithId cid: ChannelId,
-        name: String?,
-        imageURL: URL?,
+        name: String? = nil,
+        imageURL: URL? = nil,
         team: String? = nil,
         members: Set<UserId> = [],
         isCurrentUserMember: Bool = true,
         invites: Set<UserId> = [],
-        extraData: ExtraData.Channel
+        extraData: ExtraData.Channel = .defaultValue
     ) throws -> _ChatChannelController<ExtraData> {
         guard let currentUserId = currentUserId else {
             throw ClientError.CurrentUserDoesNotExist()
@@ -66,10 +69,12 @@ public extension _ChatClient {
         return .init(channelQuery: .init(channelPayload: payload), client: self, isChannelAlreadyCreated: false)
     }
 
-    /// Creates a new `ChatChannelController` that will create new a channel with provided members without having to specify
-    /// the channel id explicitly.
+    /// Creates a `ChatChannelController` that will create a new channel with the provided members without having to specify
+    /// the channel id explicitly. This is great for direct message channels because the channel should be uniquely identified by
+    /// its members. If the channel for these members already exist, it will be reused.
     ///
-    /// This is great for direct message channels because the channel should be uniquely identified by its members.
+    /// It's safe to call this method for already existing channels. However, if you queried the channel before and you're sure it exists locally,
+    /// it can be faster and more convenient to use `channelController(for cid: ChannelId)` to create a controller for it.
     ///
     /// - Parameters:
     ///   - members: Members for the new channel. Must not be empty.
@@ -85,10 +90,10 @@ public extension _ChatClient {
     func channelController(
         createDirectMessageChannelWith members: Set<UserId>,
         isCurrentUserMember: Bool = true,
-        name: String?,
-        imageURL: URL?,
+        name: String? = nil,
+        imageURL: URL? = nil,
         team: String? = nil,
-        extraData: ExtraData.Channel
+        extraData: ExtraData.Channel = .defaultValue
     ) throws -> _ChatChannelController<ExtraData> {
         guard let currentUserId = currentUserId else { throw ClientError.CurrentUserDoesNotExist() }
         guard !members.isEmpty else { throw ClientError.ChannelEmptyMembers() }

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -78,6 +78,7 @@ public extension _ChatClient {
     ///
     /// - Parameters:
     ///   - members: Members for the new channel. Must not be empty.
+    ///   - type: The type of the channel.
     ///   - isCurrentUserMember: If set to `true` the current user will be included into the channel. Is `true` by default.
     ///   - name: The new channel name.
     ///   - imageURL: The new channel avatar URL.
@@ -89,6 +90,7 @@ public extension _ChatClient {
     /// - Returns: A new instance of `ChatChannelController`.
     func channelController(
         createDirectMessageChannelWith members: Set<UserId>,
+        type: ChannelType = .messaging,
         isCurrentUserMember: Bool = true,
         name: String? = nil,
         imageURL: URL? = nil,
@@ -99,7 +101,7 @@ public extension _ChatClient {
         guard !members.isEmpty else { throw ClientError.ChannelEmptyMembers() }
 
         let payload = ChannelEditDetailPayload<ExtraData>(
-            type: .messaging,
+            type: type,
             name: name,
             imageURL: imageURL,
             team: team,

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
@@ -246,10 +246,12 @@ class ChannelController_Tests: StressTestCase {
             let team: String = .unique
             let members: Set<UserId> = [.unique]
             let extraData: NoExtraData = .defaultValue
+            let channelType: ChannelType = .custom(.unique)
 
             // Create a new `ChannelController`
             let controller = try client.channelController(
                 createDirectMessageChannelWith: members,
+                type: channelType,
                 isCurrentUserMember: isCurrentUserMember,
                 name: .unique,
                 imageURL: .unique(),
@@ -259,6 +261,7 @@ class ChannelController_Tests: StressTestCase {
 
             // Assert `ChannelQuery` created correctly
             XCTAssertEqual(team, controller.channelQuery.channelPayload?.team)
+            XCTAssertEqual(controller.channelQuery.type, channelType)
             XCTAssertEqual(
                 members.union(isCurrentUserMember ? [currentUserId] : []),
                 controller.channelQuery.channelPayload?.members

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
@@ -260,13 +260,13 @@ class ChannelController_Tests: StressTestCase {
             )
 
             // Assert `ChannelQuery` created correctly
-            XCTAssertEqual(team, controller.channelQuery.channelPayload?.team)
+            XCTAssertEqual(controller.channelQuery.channelPayload?.team, team)
             XCTAssertEqual(controller.channelQuery.type, channelType)
             XCTAssertEqual(
                 members.union(isCurrentUserMember ? [currentUserId] : []),
                 controller.channelQuery.channelPayload?.members
             )
-            XCTAssertEqual(extraData, controller.channelQuery.channelPayload?.extraData)
+            XCTAssertEqual(controller.channelQuery.channelPayload?.extraData, extraData)
         }
     }
 


### PR DESCRIPTION
- The documentation for the factory methods for `ChannelController` is improved + I added missing default parameters for convenience reasons.
- It's now possible to specify channel type when creating a controller for a DM channel