### PR TITLE
[CIS-780] Update channel's lastMessageAt when saving Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix `ChannelController`s created with `createChannelWithId` and `createChannelWithMembers` functions not reporting their initial values [#945](https://github.com/GetStream/stream-chat-swift/pull/945)
+- Fix issue where channel `lastMessageDate` was not updated when new message arrived [#949](https://github.com/GetStream/stream-chat-swift/pull/949)
 
 ### 🔄 Changed
 - `Logger.assertationFailure` was renamed to `Logger.assertionFailure` [#935](https://github.com/GetStream/stream-chat-swift/pull/935)

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -66,6 +66,13 @@ class ChannelDTO: NSManagedObject {
                     $0.didChangeValue(for: \.id)
                 }
         }
+        
+        // Update the date for sorting every time new message in this channel arrive.
+        // This will ensure that the channel list is updated/sorted when new message arrives.
+        let lastDate = lastMessageAt ?? createdAt
+        if lastDate != defaultSortingAt {
+            defaultSortingAt = lastDate
+        }
     }
 
     /// The fetch request that returns all existed channels from the database

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
@@ -43,13 +43,6 @@ class ChannelDTO_Tests: XCTestCase {
             database.viewContext.channel(cid: channelId)?.asModel()
         )
         
-        // Prepare async computation of lastmessageAt to be used in Assert.willBeEqual
-        let computedLoadedChannel: () -> Date = {
-            // Channel.lastMessageAt is updated in write transaction by the message date. Simulate the same here.
-            let latestMessageAt: Date = loadedChannel.latestMessages[0].createdAt
-            return max(loadedChannel.lastMessageAt ?? latestMessageAt, latestMessageAt)
-        }
-        
         AssertAsync {
             // Channel details
             Assert.willBeEqual(channelId, loadedChannel.cid)
@@ -61,7 +54,7 @@ class ChannelDTO_Tests: XCTestCase {
             Assert.willBeEqual(payload.channel.memberCount, loadedChannel.memberCount)
             Assert.willBeEqual(payload.channel.extraData, loadedChannel.extraData)
             Assert.willBeEqual(payload.channel.typeRawValue, loadedChannel.type.rawValue)
-            Assert.willBeEqual(computedLoadedChannel(), loadedChannel.lastMessageAt)
+            Assert.willBeEqual(payload.channel.lastMessageAt, loadedChannel.lastMessageAt)
             Assert.willBeEqual(payload.channel.createdAt, loadedChannel.createdAt)
             Assert.willBeEqual(payload.channel.updatedAt, loadedChannel.updatedAt)
             Assert.willBeEqual(payload.channel.deletedAt, loadedChannel.deletedAt)

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -273,8 +273,6 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         message.user = currentUserDTO.user
         message.channel = channelDTO
         
-        // We should update the channel dates so the list of channels ordering is updated.
-        // Updating it locally, makes it work also in offline.
         channelDTO.lastMessageAt = createdDate
         channelDTO.defaultSortingAt = createdDate
         
@@ -350,11 +348,14 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         }
 
         if let channelDTO = channelDTO {
+            channelDTO.lastMessageAt = max(channelDTO.lastMessageAt ?? payload.createdAt, payload.createdAt)
+            
             if dto.pinned {
                 channelDTO.pinnedMessages.insert(dto)
             } else {
                 channelDTO.pinnedMessages.remove(dto)
             }
+            
             dto.channel = channelDTO
         } else {
             log.assertionFailure("Should never happen, a channel should have been fetched.")

--- a/Tests/Shared/TemporaryData.swift
+++ b/Tests/Shared/TemporaryData.swift
@@ -60,7 +60,15 @@ extension AttachmentId {
 
 extension Date {
     /// Returns a new random date
-    static var unique: Date { Date(timeIntervalSince1970: .random(in: 1...1_500_000_000)) }
+    static var unique: Date { Date(timeIntervalSince1970: .random(in: 1_000_000...1_500_000_000)) }
+   
+    static func unique(before date: Date) -> Date {
+        Date(timeIntervalSince1970: .random(in: 1..<date.timeIntervalSince1970))
+    }
+    
+    static func unique(after date: Date) -> Date {
+        Date(timeIntervalSince1970: .random(in: (date.timeIntervalSince1970 + 1)...1_500_000_000))
+    }
 }
 
 extension Int {


### PR DESCRIPTION
## Description of the pull request
update the `channelDTO.lastMessageAt` based on this recommendation https://getstream.slack.com/archives/CE5N802GP/p1617215048066400?thread_ts=1617214945.066200&cid=CE5N802GP

Add calculation of `channelDTO.defaultSortingAt` to `channelDTO.willSave` to update this walue every time the messages are updated.


## Links
https://stream-io.atlassian.net/browse/CIS-780