### PR TITLE
[CIS-754] Batch processing of events

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,6 +47,7 @@ let package = Package(
 
 var streamChatSourcesExcluded: [String] { [
     "Database/DataStore_Tests.swift",
+    "Database/DatabaseSession_Mock.swift",
     "Database/DatabaseSession_Tests.swift",
     "Database/DTOs/UserDTO_Tests.swift",
     "Database/DTOs/ChannelDTO_Tests.swift",

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -91,7 +91,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         ),
         ChannelReadUpdaterMiddleware<ExtraData>(),
         ChannelMemberTypingStateUpdaterMiddleware<ExtraData>(),
-        MessageReactionsMiddleware<ExtraData>(database: databaseContainer),
+        MessageReactionsMiddleware<ExtraData>(),
         ChannelTruncatedEventMiddleware<ExtraData>(database: databaseContainer),
         MemberEventMiddleware<ExtraData>(database: databaseContainer),
         UserChannelBanEventsMiddleware<ExtraData>(database: databaseContainer),

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -93,7 +93,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         ChannelMemberTypingStateUpdaterMiddleware<ExtraData>(),
         MessageReactionsMiddleware<ExtraData>(),
         ChannelTruncatedEventMiddleware<ExtraData>(),
-        MemberEventMiddleware<ExtraData>(database: databaseContainer),
+        MemberEventMiddleware<ExtraData>(),
         UserChannelBanEventsMiddleware<ExtraData>(database: databaseContainer),
         UserWatchingEventMiddleware<ExtraData>(database: databaseContainer)
     ], databaseContainer)

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -95,7 +95,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         ChannelTruncatedEventMiddleware<ExtraData>(),
         MemberEventMiddleware<ExtraData>(),
         UserChannelBanEventsMiddleware<ExtraData>(),
-        UserWatchingEventMiddleware<ExtraData>(database: databaseContainer)
+        UserWatchingEventMiddleware<ExtraData>()
     ], databaseContainer)
     
     /// The `APIClient` instance `Client` uses to communicate with Stream REST API.

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -85,7 +85,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
 
     /// The notification center used to send and receive notifications about incoming events.
     private(set) lazy var eventNotificationCenter = environment.notificationCenterBuilder([
-        EventDataProcessorMiddleware<ExtraData>(database: databaseContainer),
+        EventDataProcessorMiddleware<ExtraData>(),
         TypingStartCleanupMiddleware<ExtraData>(
             excludedUserIds: { [weak self] in Set([self?.currentUserId].compactMap { $0 }) }
         ),

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -94,7 +94,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         MessageReactionsMiddleware<ExtraData>(),
         ChannelTruncatedEventMiddleware<ExtraData>(),
         MemberEventMiddleware<ExtraData>(),
-        UserChannelBanEventsMiddleware<ExtraData>(database: databaseContainer),
+        UserChannelBanEventsMiddleware<ExtraData>(),
         UserWatchingEventMiddleware<ExtraData>(database: databaseContainer)
     ], databaseContainer)
     

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -96,7 +96,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         MemberEventMiddleware<ExtraData>(database: databaseContainer),
         UserChannelBanEventsMiddleware<ExtraData>(database: databaseContainer),
         UserWatchingEventMiddleware<ExtraData>(database: databaseContainer)
-    ])
+    ], databaseContainer)
     
     /// The `APIClient` instance `Client` uses to communicate with Stream REST API.
     lazy var apiClient: APIClient = {
@@ -364,7 +364,8 @@ extension _ChatClient {
         
         var eventDecoderBuilder: () -> EventDecoder<ExtraData> = EventDecoder<ExtraData>.init
         
-        var notificationCenterBuilder: ([EventMiddleware]) -> EventNotificationCenter = EventNotificationCenter.init
+        var notificationCenterBuilder: ([EventMiddleware], DatabaseContainer) -> EventNotificationCenter = EventNotificationCenter
+            .init
         
         var internetConnection: () -> InternetConnection = { InternetConnection() }
 

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -92,7 +92,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         ChannelReadUpdaterMiddleware<ExtraData>(),
         ChannelMemberTypingStateUpdaterMiddleware<ExtraData>(),
         MessageReactionsMiddleware<ExtraData>(),
-        ChannelTruncatedEventMiddleware<ExtraData>(database: databaseContainer),
+        ChannelTruncatedEventMiddleware<ExtraData>(),
         MemberEventMiddleware<ExtraData>(database: databaseContainer),
         UserChannelBanEventsMiddleware<ExtraData>(database: databaseContainer),
         UserWatchingEventMiddleware<ExtraData>(database: databaseContainer)

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -90,7 +90,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
             excludedUserIds: { [weak self] in Set([self?.currentUserId].compactMap { $0 }) }
         ),
         ChannelReadUpdaterMiddleware<ExtraData>(),
-        ChannelMemberTypingStateUpdaterMiddleware<ExtraData>(database: databaseContainer),
+        ChannelMemberTypingStateUpdaterMiddleware<ExtraData>(),
         MessageReactionsMiddleware<ExtraData>(database: databaseContainer),
         ChannelTruncatedEventMiddleware<ExtraData>(database: databaseContainer),
         MemberEventMiddleware<ExtraData>(database: databaseContainer),

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -89,7 +89,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         TypingStartCleanupMiddleware<ExtraData>(
             excludedUserIds: { [weak self] in Set([self?.currentUserId].compactMap { $0 }) }
         ),
-        ChannelReadUpdaterMiddleware<ExtraData>(database: databaseContainer),
+        ChannelReadUpdaterMiddleware<ExtraData>(),
         ChannelMemberTypingStateUpdaterMiddleware<ExtraData>(database: databaseContainer),
         MessageReactionsMiddleware<ExtraData>(database: databaseContainer),
         ChannelTruncatedEventMiddleware<ExtraData>(database: databaseContainer),

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -90,7 +90,8 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         let middlewares: [EventMiddleware] = [
             EventDataProcessorMiddleware<ExtraData>(),
             TypingStartCleanupMiddleware<ExtraData>(
-                excludedUserIds: { [weak self] in Set([self?.currentUserId].compactMap { $0 }) }
+                excludedUserIds: { [weak self] in Set([self?.currentUserId].compactMap { $0 }) },
+                emitEvent: { [weak center] in center?.process($0) }
             ),
             ChannelReadUpdaterMiddleware<ExtraData>(),
             ChannelMemberTypingStateUpdaterMiddleware<ExtraData>(),

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -188,6 +188,7 @@ class ChatClient_Tests: StressTestCase {
         let webSocket = testEnv.webSocketClient
         assertMandatoryHeaderFields(webSocket?.init_sessionConfiguration)
         XCTAssert(webSocket?.init_requestEncoder is TestRequestEncoder)
+        XCTAssert(webSocket?.init_eventNotificationCenter.database === client.databaseContainer)
         XCTAssertNotNil(webSocket?.init_eventDecoder)
         
         // EventDataProcessorMiddleware must be always first
@@ -670,7 +671,7 @@ private class TestEnvironment<ExtraData: ExtraDataTypes> {
                 return self.eventDecoder!
             },
             notificationCenterBuilder: {
-                self.notificationCenter = EventNotificationCenterMock(middlewares: $0)
+                self.notificationCenter = EventNotificationCenterMock(middlewares: $0, database: $1)
                 return self.notificationCenter!
             },
             clientUpdaterBuilder: {

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -726,4 +726,12 @@ private extension ChatClientConfig {
 
 // MARK: - Mock
 
-class EventNotificationCenterMock: EventNotificationCenter {}
+class EventNotificationCenterMock: EventNotificationCenter {
+    /// Logs all events the `process` method was called with
+    @Atomic var process_loggedEvents: [Event] = []
+    
+    override func process(_ event: Event) {
+        super.process(event)
+        _process_loggedEvents { $0.append(event) }
+    }
+}

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -671,7 +671,7 @@ private class TestEnvironment<ExtraData: ExtraDataTypes> {
                 return self.eventDecoder!
             },
             notificationCenterBuilder: {
-                self.notificationCenter = EventNotificationCenterMock(middlewares: $0, database: $1)
+                self.notificationCenter = EventNotificationCenterMock(database: $0)
                 return self.notificationCenter!
             },
             clientUpdaterBuilder: {

--- a/Sources/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Mock.swift
@@ -1,0 +1,214 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+
+/// This class allows you to wrap an existing `DatabaseSession` and adjust the behavior of its methods.
+class DatabaseSessionMock: DatabaseSession {
+    /// The wrapped session
+    let underlyingSession: DatabaseSession
+
+    /// If set to a non-nil value, the error is returned from all throwing methods of the session
+    @Atomic var errorToReturn: Error?
+    
+    init(underlyingSession: DatabaseSession) {
+        self.underlyingSession = underlyingSession
+    }
+}
+
+// Here start the boilerplate that forwards and intercepts the session calls if needed
+
+extension DatabaseSessionMock {
+    func saveCurrentUserDevices(_ devices: [DevicePayload], clearExisting: Bool) throws {
+        try throwErrorIfNeeded()
+        try underlyingSession.saveCurrentUserDevices(devices, clearExisting: clearExisting)
+    }
+    
+    func saveChannel<ExtraData>(
+        payload: ChannelDetailPayload<ExtraData>,
+        query: _ChannelListQuery<ExtraData.Channel>?
+    ) throws -> ChannelDTO where ExtraData: ExtraDataTypes {
+        try throwErrorIfNeeded()
+        return try underlyingSession.saveChannel(payload: payload, query: query)
+    }
+    
+    func saveUser<ExtraData>(payload: UserPayload<ExtraData>, query: _UserListQuery<ExtraData>?) throws -> UserDTO
+        where ExtraData: UserExtraData {
+        try throwErrorIfNeeded()
+        return try underlyingSession.saveUser(payload: payload, query: query)
+    }
+    
+    func saveQuery<ExtraData>(query: _UserListQuery<ExtraData>) throws -> UserListQueryDTO? where ExtraData: UserExtraData {
+        try throwErrorIfNeeded()
+        return try underlyingSession.saveQuery(query: query)
+    }
+    
+    func user(id: UserId) -> UserDTO? {
+        underlyingSession.user(id: id)
+    }
+    
+    func deleteQuery<ExtraData>(_ query: _UserListQuery<ExtraData>) where ExtraData: UserExtraData {
+        underlyingSession.deleteQuery(query)
+    }
+    
+    func saveCurrentUser<ExtraData>(payload: CurrentUserPayload<ExtraData>) throws -> CurrentUserDTO
+        where ExtraData: UserExtraData {
+        try throwErrorIfNeeded()
+        return try saveCurrentUser(payload: payload)
+    }
+    
+    func saveCurrentUserUnreadCount(count: UnreadCount) throws {
+        try throwErrorIfNeeded()
+        try saveCurrentUserUnreadCount(count: count)
+    }
+    
+    func deleteDevice(id: DeviceId) {
+        underlyingSession.deleteDevice(id: id)
+    }
+    
+    func currentUser() -> CurrentUserDTO? {
+        underlyingSession.currentUser()
+    }
+    
+    func createNewMessage<ExtraData>(
+        in cid: ChannelId,
+        text: String,
+        pinning: MessagePinning?,
+        command: String?,
+        arguments: String?,
+        parentMessageId: MessageId?,
+        attachments: [AttachmentEnvelope],
+        showReplyInChannel: Bool,
+        quotedMessageId: MessageId?,
+        extraData: ExtraData
+    ) throws -> MessageDTO where ExtraData: MessageExtraData {
+        try throwErrorIfNeeded()
+
+        return try underlyingSession.createNewMessage(
+            in: cid,
+            text: text,
+            pinning: pinning,
+            command: command,
+            arguments: arguments,
+            parentMessageId: parentMessageId,
+            attachments: attachments,
+            showReplyInChannel: showReplyInChannel,
+            quotedMessageId: quotedMessageId,
+            extraData: extraData
+        )
+    }
+    
+    func saveMessage<ExtraData>(payload: MessagePayload<ExtraData>, for cid: ChannelId?) throws -> MessageDTO
+        where ExtraData: ExtraDataTypes {
+        try throwErrorIfNeeded()
+        return try underlyingSession.saveMessage(payload: payload, for: cid)
+    }
+    
+    func pin(message: MessageDTO, pinning: MessagePinning) throws {
+        try throwErrorIfNeeded()
+        return try underlyingSession.pin(message: message, pinning: pinning)
+    }
+    
+    func unpin(message: MessageDTO) {
+        underlyingSession.unpin(message: message)
+    }
+    
+    func message(id: MessageId) -> MessageDTO? {
+        underlyingSession.message(id: id)
+    }
+    
+    func delete(message: MessageDTO) {
+        underlyingSession.delete(message: message)
+    }
+    
+    func reaction(messageId: MessageId, userId: UserId, type: MessageReactionType) -> MessageReactionDTO? {
+        underlyingSession.reaction(messageId: messageId, userId: userId, type: type)
+    }
+    
+    func saveReaction<ExtraData>(payload: MessageReactionPayload<ExtraData>) throws -> MessageReactionDTO
+        where ExtraData: ExtraDataTypes {
+        try throwErrorIfNeeded()
+        return try underlyingSession.saveReaction(payload: payload)
+    }
+    
+    func delete(reaction: MessageReactionDTO) {
+        underlyingSession.delete(reaction: reaction)
+    }
+    
+    func saveChannelRead<ExtraData>(payload: ChannelReadPayload<ExtraData>, for cid: ChannelId) throws -> ChannelReadDTO
+        where ExtraData: ExtraDataTypes {
+        try throwErrorIfNeeded()
+        return try underlyingSession.saveChannelRead(payload: payload, for: cid)
+    }
+    
+    func loadChannelRead(cid: ChannelId, userId: String) -> ChannelReadDTO? {
+        underlyingSession.loadChannelRead(cid: cid, userId: userId)
+    }
+    
+    func loadChannelReads(for userId: UserId) -> [ChannelReadDTO] {
+        underlyingSession.loadChannelReads(for: userId)
+    }
+    
+    func saveChannel<ExtraData>(
+        payload: ChannelPayload<ExtraData>,
+        query: _ChannelListQuery<ExtraData.Channel>?
+    ) throws -> ChannelDTO where ExtraData: ExtraDataTypes {
+        try throwErrorIfNeeded()
+        return try underlyingSession.saveChannel(payload: payload, query: query)
+    }
+    
+    func channel(cid: ChannelId) -> ChannelDTO? {
+        underlyingSession.channel(cid: cid)
+    }
+    
+    func saveMember<ExtraData>(
+        payload: MemberPayload<ExtraData>,
+        channelId: ChannelId,
+        query: _ChannelMemberListQuery<ExtraData>?
+    ) throws -> MemberDTO where ExtraData: UserExtraData {
+        try throwErrorIfNeeded()
+        return try underlyingSession.saveMember(payload: payload, channelId: channelId, query: query)
+    }
+    
+    func member(userId: UserId, cid: ChannelId) -> MemberDTO? {
+        underlyingSession.member(userId: userId, cid: cid)
+    }
+    
+    func channelMemberListQuery(queryHash: String) -> ChannelMemberListQueryDTO? {
+        underlyingSession.channelMemberListQuery(queryHash: queryHash)
+    }
+    
+    func saveQuery<ExtraData>(_ query: _ChannelMemberListQuery<ExtraData>) throws -> ChannelMemberListQueryDTO
+        where ExtraData: UserExtraData {
+        try throwErrorIfNeeded()
+        return try underlyingSession.saveQuery(query)
+    }
+    
+    func attachment(id: AttachmentId) -> AttachmentDTO? {
+        underlyingSession.attachment(id: id)
+    }
+    
+    func saveAttachment(payload: AttachmentPayload, id: AttachmentId) throws -> AttachmentDTO {
+        try throwErrorIfNeeded()
+        return try underlyingSession.saveAttachment(payload: payload, id: id)
+    }
+    
+    func createNewAttachment(seed: ChatMessageAttachmentSeed, id: AttachmentId) throws -> AttachmentDTO {
+        try throwErrorIfNeeded()
+        return try underlyingSession.createNewAttachment(seed: seed, id: id)
+    }
+    
+    func createNewAttachment(attachment: AttachmentEnvelope, id: AttachmentId) throws -> AttachmentDTO {
+        try throwErrorIfNeeded()
+        return try underlyingSession.createNewAttachment(attachment: attachment, id: id)
+    }
+}
+
+private extension DatabaseSessionMock {
+    func throwErrorIfNeeded() throws {
+        guard let error = errorToReturn else { return }
+        throw error
+    }
+}

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware.swift
@@ -6,31 +6,19 @@ import CoreData
 
 /// A middleware which updates `currentlyTypingMembers` for a specific channel based on received `TypingEvent`.
 struct ChannelMemberTypingStateUpdaterMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
-    let database: DatabaseContainer
-    
-    func handle(event: Event, completion: @escaping (Event?) -> Void) {
-        guard let typingEvent = event as? TypingEvent else {
-            completion(event)
-            return
+    func handle(event: Event, session: DatabaseSession) -> Event? {
+        guard
+            let typingEvent = event as? TypingEvent,
+            let channelDTO = session.channel(cid: typingEvent.cid),
+            let memberDTO = session.member(userId: typingEvent.userId, cid: typingEvent.cid)
+        else { return event }
+
+        if typingEvent.isTyping {
+            channelDTO.currentlyTypingMembers.insert(memberDTO)
+        } else {
+            channelDTO.currentlyTypingMembers.remove(memberDTO)
         }
         
-        database.write({ session in
-            guard
-                let channelDTO = session.channel(cid: typingEvent.cid),
-                let memberDTO = session.member(userId: typingEvent.userId, cid: typingEvent.cid)
-            else { return }
-            
-            if typingEvent.isTyping {
-                channelDTO.currentlyTypingMembers.insert(memberDTO)
-            } else {
-                channelDTO.currentlyTypingMembers.remove(memberDTO)
-            }
-        }, completion: { error in
-            if let error = error {
-                log.error("Failed saving incoming `TypingEvent` data to DB. Error: \(error)")
-            }
-            
-            completion(event)
-        })
+        return event
     }
 }

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelMemberTypingStateUpdaterMiddleware_Tests.swift
@@ -15,7 +15,7 @@ final class ChannelMemberTypingStateUpdaterMiddleware_Tests: XCTestCase {
         super.setUp()
         
         database = DatabaseContainerMock()
-        middleware = ChannelMemberTypingStateUpdaterMiddleware(database: database)
+        middleware = ChannelMemberTypingStateUpdaterMiddleware()
     }
     
     override func tearDown() {
@@ -31,9 +31,7 @@ final class ChannelMemberTypingStateUpdaterMiddleware_Tests: XCTestCase {
         let event = TestEvent()
         
         // Handle non-typing event
-        let forwardedEvent = try await {
-            self.middleware.handle(event: event, completion: $0)
-        }
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
         
         // Assert event is forwarded as it is
         XCTAssertEqual(forwardedEvent as! TestEvent, event)
@@ -55,9 +53,7 @@ final class ChannelMemberTypingStateUpdaterMiddleware_Tests: XCTestCase {
         
         // Simulate typing event
         let event = TypingEvent(isTyping: true, cid: cid, userId: memberId)
-        let forwardedEvent = try await {
-            self.middleware.handle(event: event, completion: $0)
-        }
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
         
         // Assert `TypingEvent` is forwarded even though database error happened
         XCTAssertEqual(forwardedEvent as! TypingEvent, event)
@@ -83,9 +79,7 @@ final class ChannelMemberTypingStateUpdaterMiddleware_Tests: XCTestCase {
         
         // Simulate start typing event
         let event = TypingEvent(isTyping: true, cid: cid, userId: memberId)
-        let forwardedEvent = try await {
-            self.middleware.handle(event: event, completion: $0)
-        }
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
         
         // Assert `TypingEvent` is forwarded as it is
         XCTAssertEqual(forwardedEvent as! TypingEvent, event)
@@ -116,9 +110,7 @@ final class ChannelMemberTypingStateUpdaterMiddleware_Tests: XCTestCase {
         
         // Simulate stop typing events
         let event = TypingEvent(isTyping: false, cid: cid, userId: memberId)
-        let forwardedEvent = try await {
-            self.middleware.handle(event: event, completion: $0)
-        }
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
         
         // Assert `TypingEvent` is forwarded as it is
         XCTAssertEqual(forwardedEvent as! TypingEvent, event)

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware.swift
@@ -6,41 +6,32 @@ import Foundation
 
 /// A middleware which updates a channel's read events as websocket events arrive.
 struct ChannelReadUpdaterMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
-    let database: DatabaseContainer
-    
-    func handle(event: Event, completion: @escaping (Event?) -> Void) {
+    func handle(event: Event, session: DatabaseSession) -> Event? {
         if let event = event as? MessageReadEvent<ExtraData> {
-            updateReadEvent(for: event.cid, userId: event.userId, lastReadAt: event.readAt) { completion(event) }
+            updateReadEvent(for: event.cid, userId: event.userId, lastReadAt: event.readAt, session: session)
         } else if let event = event as? NotificationMarkReadEvent<ExtraData> {
-            updateReadEvent(for: event.cid, userId: event.userId, lastReadAt: event.readAt) { completion(event) }
+            updateReadEvent(for: event.cid, userId: event.userId, lastReadAt: event.readAt, session: session)
         } else if let event = event as? NotificationMarkAllReadEvent<ExtraData> {
-            database.write({ session in
-                session.loadChannelReads(for: event.userId).forEach { read in
-                    read.lastReadAt = event.readAt
-                    read.unreadMessageCount = 0
-                }
-            }, completion: { error in
-                if let error = error {
-                    log.error("Failed to update channel reads for userId \(event.userId), error: \(error)")
-                }
-                completion(event)
-            })
-        } else {
-            completion(event)
-        }
-    }
-    
-    private func updateReadEvent(for cid: ChannelId, userId: UserId, lastReadAt: Date, completion: @escaping () -> Void) {
-        database.write({ session in
-            if let read = session.loadChannelRead(cid: cid, userId: userId) {
-                read.lastReadAt = lastReadAt
+            session.loadChannelReads(for: event.userId).forEach { read in
+                read.lastReadAt = event.readAt
                 read.unreadMessageCount = 0
             }
-        }, completion: { error in
-            if let error = error {
-                log.error("Failed to update channel read for cid \(cid) and userId \(userId), error: \(error)")
-            }
-            completion()
-        })
+        }
+
+        return event
+    }
+    
+    private func updateReadEvent(
+        for cid: ChannelId,
+        userId: UserId,
+        lastReadAt: Date,
+        session: DatabaseSession
+    ) {
+        if let read = session.loadChannelRead(cid: cid, userId: userId) {
+            read.lastReadAt = lastReadAt
+            read.unreadMessageCount = 0
+        } else {
+            log.error("Failed to update channel read for cid \(cid) and userId \(userId).")
+        }
     }
 }

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
@@ -12,7 +12,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
     override func setUp() {
         super.setUp()
         database = DatabaseContainerMock()
-        middleware = ChannelReadUpdaterMiddleware(database: database)
+        middleware = ChannelReadUpdaterMiddleware()
     }
     
     override func tearDown() {
@@ -56,8 +56,8 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         
         // Let the middleware handle the event
         // Middleware should mutate the loadedChannel's read
-        let handledEvent = try await { middleware.handle(event: messageReadEvent, completion: $0) }
-        
+        let handledEvent = middleware.handle(event: messageReadEvent, session: database.viewContext)
+
         XCTAssertEqual(handledEvent?.asEquatable, messageReadEvent.asEquatable)
         
         // Assert that the read event entity is updated
@@ -120,7 +120,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         let notificationMarkReadEvent = try NotificationMarkReadEvent<NoExtraData>(from: eventPayload)
         
         // Let the middleware handle the event
-        let handledEvent = try await { middleware.handle(event: notificationMarkReadEvent, completion: $0) }
+        let handledEvent = middleware.handle(event: notificationMarkReadEvent, session: database.viewContext)
         
         XCTAssertEqual(handledEvent?.asEquatable, notificationMarkReadEvent.asEquatable)
         
@@ -164,7 +164,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         let notificationMarkAllReadEvent = try NotificationMarkAllReadEvent(from: eventPayload)
         
         // Let the middleware handle the event
-        let handledEvent = try await { middleware.handle(event: notificationMarkAllReadEvent, completion: $0) }
+        let handledEvent = middleware.handle(event: notificationMarkAllReadEvent, session: database.viewContext)
         
         XCTAssertEqual(handledEvent?.asEquatable, notificationMarkAllReadEvent.asEquatable)
         
@@ -200,7 +200,7 @@ class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         let startTypingEvent = TypingEvent(isTyping: true, cid: channelId, userId: payload.members.first!.user.id)
         
         // Let the middleware handle the event
-        let handledEvent = try await { middleware.handle(event: startTypingEvent, completion: $0) }
+        let handledEvent = middleware.handle(event: startTypingEvent, session: database.viewContext)
         
         XCTAssertEqual(handledEvent?.asEquatable, startTypingEvent.asEquatable)
         

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/EventMiddleware_Mock.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/EventMiddleware_Mock.swift
@@ -7,13 +7,13 @@ import Foundation
 
 /// A test middleware that can be initiated with a closure
 final class EventMiddlewareMock: EventMiddleware {
-    var closure: (Event, @escaping (Event?) -> Void) -> Void
+    var closure: (Event, DatabaseSession) -> Event?
     
-    init(closure: @escaping (Event, @escaping (Event?) -> Void) -> Void = { $1($0) }) {
+    init(closure: @escaping (Event, DatabaseSession) -> Event? = { event, _ in event }) {
         self.closure = closure
     }
     
-    func handle(event: Event, completion: @escaping (Event?) -> Void) {
-        closure(event, completion)
+    func handle(event: Event, session: DatabaseSession) -> Event? {
+        closure(event, session)
     }
 }

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/EventMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/EventMiddleware_Tests.swift
@@ -6,15 +6,6 @@
 import XCTest
 
 class EventMiddleware_Tests: XCTestCase {
-    /// A test middleware that can be initiated with a closure/
-    struct ClosureBasedMiddleware: EventMiddleware {
-        let closure: (_ event: Event, _ completion: @escaping (Event?) -> Void) -> Void
-        
-        func handle(event: Event, completion: @escaping (Event?) -> Void) {
-            closure(event, completion)
-        }
-    }
-    
     /// A test event holding an `Int` value.
     struct IntBasedEvent: Event, Equatable {
         let value: Int
@@ -23,13 +14,13 @@ class EventMiddleware_Tests: XCTestCase {
     func test_middlewareEvaluation() throws {
         let chain: [EventMiddleware] = [
             // Adds `1` to the event synchronously
-            ClosureBasedMiddleware { event, completion in
+            EventMiddlewareMock { event, completion in
                 let event = event as! IntBasedEvent
                 completion(IntBasedEvent(value: event.value + 1))
             },
             
             // Adds `1` to the event synchronously and resets it to `0` asynchronously
-            ClosureBasedMiddleware { event, completion in
+            EventMiddlewareMock { event, completion in
                 let event = event as! IntBasedEvent
                 DispatchQueue.main.async {
                     completion(IntBasedEvent(value: 0))

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware.swift
@@ -6,44 +6,38 @@ import Foundation
 
 /// The middleware listens for `MemberEvent`s and updates `ChannelDTO`s accordingly.
 struct MemberEventMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
-    let database: DatabaseContainer
-    
-    func handle(event: Event, completion: @escaping (Event?) -> Void) {
-        guard let memberEvent = event as? MemberEvent else {
-            completion(event)
-            return
-        }
+    func handle(event: Event, session: DatabaseSession) -> Event? {
+        guard let memberEvent = event as? MemberEvent else { return event }
         
-        database.write { session in
+        do {
             switch memberEvent {
             case is MemberAddedEvent, is MemberUpdatedEvent:
                 guard let eventWithMemberPayload = event as? EventWithMemberPayload,
                       let eventPayload = eventWithMemberPayload.payload as? EventPayload<ExtraData>,
                       let memberPayload = eventPayload.memberContainer?.member
                 else {
-                    return
+                    break
                 }
                 try session.saveMember(payload: memberPayload, channelId: memberEvent.cid)
             case is MemberRemovedEvent:
                 guard let channel = session.channel(cid: memberEvent.cid) else {
                     // No need to throw ChannelNotFound error here
-                    return
+                    break
                 }
                 
                 guard let member = channel.members.first(where: { $0.user.id == memberEvent.userId }) else {
                     // No need to throw MemberNotFound error here
-                    return
+                    break
                 }
                 
                 channel.members.remove(member)
             default:
                 break
             }
-        } completion: { error in
-            if let error = error {
-                log.error("Failed to update channel members in the database, error: \(error)")
-            }
-            completion(event)
+        } catch {
+            log.error("Failed to update channel members in the database, error: \(error)")
         }
+
+        return event
     }
 }

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/MessageReactionsMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/MessageReactionsMiddleware.swift
@@ -6,41 +6,35 @@ import Foundation
 
 /// The middleware listens for `EventWithReactionPayload` events and updates `MessageReactionDTO` accordingly.
 struct MessageReactionsMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
-    let database: DatabaseContainer
-    
-    func handle(event: Event, completion: @escaping (Event?) -> Void) {
+    func handle(event: Event, session: DatabaseSession) -> Event? {
         guard
             let reactionEvent = event as? EventWithReactionPayload,
             let payload = reactionEvent.payload as? EventPayload<ExtraData>,
             let reaction = payload.reaction
         else {
-            completion(event)
-            return
+            return event
         }
         
-        database.write({ session in
+        do {
             if reactionEvent is ReactionNewEvent {
                 try session.saveReaction(payload: reaction)
             } else if reactionEvent is ReactionUpdatedEvent {
                 try session.saveReaction(payload: reaction)
             } else if reactionEvent is ReactionDeletedEvent {
-                guard
-                    let dto = session.reaction(
-                        messageId: reaction.messageId,
-                        userId: reaction.user.id,
-                        type: reaction.type
-                    )
-                else { return }
-                
-                session.delete(reaction: dto)
+                if let dto = session.reaction(
+                    messageId: reaction.messageId,
+                    userId: reaction.user.id,
+                    type: reaction.type
+                ) {
+                    session.delete(reaction: dto)
+                }
             } else {
                 throw ClientError.Unexpected("Middleware has tried to handle unsupported event type.")
             }
-        }, completion: { error in
-            if let error = error {
-                log.error("Failed to update message reaction in the database, error: \(error)")
-            }
-            completion(event)
-        })
+        } catch {
+            log.error("Failed to update message reaction in the database, error: \(error)")
+        }
+        
+        return event
     }
 }

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/MessageReactionsMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/MessageReactionsMiddleware_Tests.swift
@@ -15,7 +15,7 @@ final class MessageReactionsMiddleware_Tests: XCTestCase {
         super.setUp()
         
         database = DatabaseContainerMock()
-        middleware = .init(database: database)
+        middleware = .init()
     }
     
     override func tearDown() {
@@ -31,9 +31,7 @@ final class MessageReactionsMiddleware_Tests: XCTestCase {
         let event = TestEvent()
         
         // Handle non-reaction event
-        let forwardedEvent = try await {
-            self.middleware.handle(event: event, completion: $0)
-        }
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
         
         // Assert event is forwarded as it is
         XCTAssertEqual(forwardedEvent as! TestEvent, event)
@@ -55,9 +53,7 @@ final class MessageReactionsMiddleware_Tests: XCTestCase {
         
         // Simulate and handle reaction event.
         let event = try ReactionNewEvent(from: eventPayload)
-        let forwardedEvent = try await {
-            self.middleware.handle(event: event, completion: $0)
-        }
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
         
         // Assert `ReactionNewEvent` is forwarded even though database error happened.
         XCTAssertTrue(forwardedEvent is ReactionNewEvent)
@@ -84,9 +80,7 @@ final class MessageReactionsMiddleware_Tests: XCTestCase {
         try database.createMessage(id: reactionPayload.messageId)
 
         // Simulate `ReactionNewEvent` event.
-        let forwardedEvent = try await {
-            self.middleware.handle(event: event, completion: $0)
-        }
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
         
         // Load the message.
         let message = try XCTUnwrap(
@@ -129,9 +123,7 @@ final class MessageReactionsMiddleware_Tests: XCTestCase {
         try database.createMessage(id: reactionPayload.messageId)
 
         // Simulate `ReactionNewEvent` event.
-        let forwardedEvent = try await {
-            self.middleware.handle(event: event, completion: $0)
-        }
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
         
         // Load the message.
         let message = try XCTUnwrap(
@@ -177,9 +169,7 @@ final class MessageReactionsMiddleware_Tests: XCTestCase {
 
         // Simulate `ReactionDeletedEvent` event.
         let event = try ReactionDeletedEvent(from: eventPayload)
-        let forwardedEvent = try await {
-            self.middleware.handle(event: event, completion: $0)
-        }
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
         
         // Load the message.
         let message = try XCTUnwrap(

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware.swift
@@ -11,6 +11,9 @@ extension TimeInterval {
 
 /// Automatically sends a `TypingStop` event if it hasn't come in a specified time after `TypingStart`.
 class TypingStartCleanupMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
+    /// A closure that will be invoked with `stop typing` event when the `incomingTypingStartEventTimeout` has passed
+    /// after `start typing` event.
+    let emitEvent: (Event) -> Void
     /// A closure to get a list of user ids to skip typing events for them.
     let excludedUserIds: () -> Set<UserId>
     /// A timer type.
@@ -22,40 +25,35 @@ class TypingStartCleanupMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
     /// Creates a new `TypingStartCleanupMiddleware`
     ///
     /// - Parameter excludedUsers: A set of users for which the `typingStart` event shouldn't be cleaned up automatically.
-    init(excludedUserIds: @escaping () -> Set<UserId>) {
+    init(excludedUserIds: @escaping () -> Set<UserId>, emitEvent: @escaping (Event) -> Void) {
         self.excludedUserIds = excludedUserIds
+        self.emitEvent = emitEvent
     }
-    
-    func handle(event: Event, completion: @escaping (Event?) -> Void) {
-        defer { completion(event) }
-        
+
+    func handle(event: Event, session: DatabaseSession) -> Event? {
         // Skip other events and typing events from `excludedUserIds`.
         guard let typingEvent = event as? TypingEvent, excludedUserIds().contains(typingEvent.userId) == false else {
-            return
+            return event
         }
-        
-        guard typingEvent.isTyping else {
-            // User stops typing.
-            _typingEventTimeoutTimerControls {
-                $0[typingEvent.userId]?.cancel()
-                $0[typingEvent.userId] = nil
+
+        _typingEventTimeoutTimerControls {
+            $0[typingEvent.userId]?.cancel()
+            $0[typingEvent.userId] = nil
+
+            guard typingEvent.isTyping else { return }
+
+            let stopTyping = { [emitEvent] in
+                let typingStopEvent = TypingEvent(isTyping: false, cid: typingEvent.cid, userId: typingEvent.userId)
+                emitEvent(typingStopEvent)
             }
-            return
-        }
-        
-        // User is typing.
-        let userId = typingEvent.userId
-        _typingEventTimeoutTimerControls.mutate { typingEventTimeoutTimerControls in
 
-            typingEventTimeoutTimerControls[userId]?.cancel()
-
-            let stopTypingEventTimerControl =
-                timer.schedule(timeInterval: .incomingTypingStartEventTimeout, queue: .global()) {
-                    let typingStopEvent = TypingEvent(isTyping: false, cid: typingEvent.cid, userId: userId)
-                    completion(typingStopEvent)
-                }
-            
-            typingEventTimeoutTimerControls[userId] = stopTypingEventTimerControl
+            $0[typingEvent.userId] = timer.schedule(
+                timeInterval: .incomingTypingStartEventTimeout,
+                queue: .global(),
+                onFire: stopTyping
+            )
         }
+
+        return event
     }
 }

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/TypingStartCleanupMiddleware_Tests.swift
@@ -7,59 +7,86 @@ import StreamChatTestTools
 import XCTest
 
 class TypingStartCleanupMiddleware_Tests: XCTestCase {
-    var middleware: TypingStartCleanupMiddleware<NoExtraData>!
     var currentUser: ChatUser!
-    
     var time: VirtualTime!
+    // The database is not really used in the middleware but it's a requirement by the protocol
+    // to provide a database session
+    var database: DatabaseContainer!
     
     override func setUp() {
         super.setUp()
 
         currentUser = .mock(id: "Luke")
-        middleware = TypingStartCleanupMiddleware(excludedUserIds: { [self.currentUser.id] })
         
         time = VirtualTime()
         VirtualTimeTimer.time = time
-        middleware.timer = VirtualTimeTimer.self
+
+        database = DatabaseContainerMock()
     }
-    
+
+    override func tearDown() {
+        AssertAsync.canBeReleased(&database)
+
+        super.tearDown()
+    }
+
     func test_stopTypingEvent_notSentForExcludedUsers() {
-        var result: [EquatableEvent?] = []
-        let typingStartEvent = TypingEvent(isTyping: true, cid: .unique, userId: currentUser.id)
+        // Create a middleware and store emitted events.
+        var emittedEvents: [Event] = []
+        var middleware: TypingStartCleanupMiddleware<NoExtraData>! = .init(
+            excludedUserIds: { [self.currentUser.id] },
+            emitEvent: { emittedEvents.append($0) }
+        )
+        middleware.timer = VirtualTimeTimer.self
+
         // Handle a new TypingStart event for the current user and collect resulting events
-        middleware.handle(event: typingStartEvent) {
-            result.append($0.map(EquatableEvent.init))
-        }
-        
+        let typingStartEvent = TypingEvent(isTyping: true, cid: .unique, userId: currentUser.id)
+        let forwardedEvent = middleware.handle(event: typingStartEvent, session: database.viewContext)
+        XCTAssertEqual(forwardedEvent?.asEquatable, typingStartEvent.asEquatable)
+
         // Simulate time passed for the `typingStartTimeout` period
         time.run(numberOfSeconds: .incomingTypingStartEventTimeout + 1)
-        
-        XCTAssertEqual(result, [typingStartEvent].asEquatable())
+
+        // Assert no events are emitted.
+        XCTAssertTrue(emittedEvents.isEmpty)
+
+        // Assert the middleware can be released.
+        AssertAsync.canBeReleased(&middleware)
     }
-    
+
     func test_stopTypingEvent_sentAfterTimeout() {
+        // Create a middleware and store emitted events.
+        var emittedEvents: [Event] = []
+        var middleware: TypingStartCleanupMiddleware<NoExtraData>! = .init(
+            excludedUserIds: { [self.currentUser.id] },
+            emitEvent: { emittedEvents.append($0) }
+        )
+        middleware.timer = VirtualTimeTimer.self
+
         // Simulate some user started typing
         let otherUser = ChatUser.mock(id: .unique)
         let cid = ChannelId.unique
-        
-        var result: [EquatableEvent?] = []
+
         let startTyping = TypingEvent(isTyping: true, cid: cid, userId: otherUser.id)
         // Handle a new TypingStart event for the current user and collect resulting events
-        middleware.handle(event: startTyping) {
-            result.append($0.map(EquatableEvent.init))
-        }
-        
-        // Wait for some timeout shorter than `typingStartTimeout` and assert only `TypingStart` event is sent
+        let forwardedEvent = middleware.handle(event: startTyping, session: database.viewContext)
+        // Assert `TypingStart` event is propagated synchronously
+        XCTAssertEqual(forwardedEvent?.asEquatable, startTyping.asEquatable)
+
+        // Wait for some timeout shorter than `typingStartTimeout` and assert no events are emitted
         time.run(numberOfSeconds: .incomingTypingStartEventTimeout - 1)
-        XCTAssertEqual(result, [startTyping.asEquatable])
-        
+        XCTAssertTrue(emittedEvents.isEmpty)
+
         // Wait for more time and expect a `typingStop` event.
         time.run(numberOfSeconds: 2)
         let stopTyping = TypingEvent(isTyping: false, cid: cid, userId: otherUser.id)
-        XCTAssertEqual(result, [startTyping.asEquatable, stopTyping.asEquatable])
-        
+        XCTAssertEqual(emittedEvents.map(\.asEquatable), [stopTyping.asEquatable])
+
         // Wait much longer and assert no more `typingStop` events.
         time.run(numberOfSeconds: 5 + .incomingTypingStartEventTimeout)
-        XCTAssertEqual(result, [startTyping.asEquatable, stopTyping.asEquatable])
+        XCTAssertEqual(emittedEvents.map(\.asEquatable), [stopTyping.asEquatable])
+
+        // Assert the middleware can be released.
+        AssertAsync.canBeReleased(&middleware)
     }
 }

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/UserChannelBanEventsMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/UserChannelBanEventsMiddleware_Tests.swift
@@ -15,7 +15,7 @@ final class UserChannelBanEventsMiddleware_Tests: XCTestCase {
         super.setUp()
 
         database = DatabaseContainerMock()
-        middleware = .init(database: database)
+        middleware = .init()
     }
 
     override func tearDown() {
@@ -31,9 +31,7 @@ final class UserChannelBanEventsMiddleware_Tests: XCTestCase {
         let event = TestEvent()
 
         // Handle non-banned event
-        let forwardedEvent = try await {
-            self.middleware.handle(event: event, completion: $0)
-        }
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
 
         // Assert event is forwarded as it is
         XCTAssertEqual(forwardedEvent as! TestEvent, event)
@@ -54,9 +52,7 @@ final class UserChannelBanEventsMiddleware_Tests: XCTestCase {
 
         // Simulate and handle banned event.
         let event = try UserBannedEvent(from: eventPayload)
-        let forwardedEvent = try await {
-            self.middleware.handle(event: event, completion: $0)
-        }
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
 
         // Assert `UserBannedEvent` is forwarded even though database error happened.
         XCTAssertTrue(forwardedEvent is UserBannedEvent)
@@ -75,9 +71,7 @@ final class UserChannelBanEventsMiddleware_Tests: XCTestCase {
 
         // Simulate and handle banned event.
         let event = try UserUnbannedEvent(from: eventPayload)
-        let forwardedEvent = try await {
-            self.middleware.handle(event: event, completion: $0)
-        }
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
 
         // Assert `UserUnbannedEvent` is forwarded even though database error happened.
         XCTAssertTrue(forwardedEvent is UserUnbannedEvent)
@@ -105,9 +99,7 @@ final class UserChannelBanEventsMiddleware_Tests: XCTestCase {
         XCTAssertEqual(member.banExpiresAt, nil)
 
         // Simulate `UserBannedEvent` event.
-        let forwardedEvent = try await {
-            self.middleware.handle(event: event, completion: $0)
-        }
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
 
         // Assert the member ban information is updated
         XCTAssertEqual(member.isBanned, true)
@@ -147,9 +139,7 @@ final class UserChannelBanEventsMiddleware_Tests: XCTestCase {
         XCTAssertNotEqual(member.banExpiresAt, nil)
 
         // Simulate `UserUnbannedEvent` event.
-        let forwardedEvent = try await {
-            self.middleware.handle(event: event, completion: $0)
-        }
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
 
         // Assert the member ban information is updated
         XCTAssertEqual(member.isBanned, false)

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -385,11 +385,10 @@ extension UIApplication: BackgroundTaskScheduler {}
 struct HealthCheckMiddleware: EventMiddleware {
     private(set) weak var webSocketClient: WebSocketClient?
 
-    func handle(event: Event, completion: @escaping (Event?) -> Void) {
+    func handle(event: Event, session: DatabaseSession) -> Event? {
         guard let healthCheckEvent = event as? HealthCheckEvent else {
             // Do nothing and forward the event
-            completion(event)
-            return
+            return event
         }
         
         if let webSocketClient = webSocketClient {
@@ -400,6 +399,6 @@ struct HealthCheckMiddleware: EventMiddleware {
         }
         
         // Don't forward the event
-        completion(nil)
+        return nil
     }
 }

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient_Mock.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient_Mock.swift
@@ -61,7 +61,7 @@ extension WebSocketClientMock {
             sessionConfiguration: .default,
             requestEncoder: DefaultRequestEncoder(baseURL: .unique(), apiKey: .init(.unique)),
             eventDecoder: EventDecoder<NoExtraData>(),
-            eventNotificationCenter: .init(),
+            eventNotificationCenter: EventNotificationCenterMock(database: DatabaseContainerMock()),
             internetConnection: InternetConnection()
         )
     }

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
@@ -437,10 +437,10 @@ class WebSocketClient_Tests: StressTestCase {
         decoder.decodedEvent = incomingEvent
         
         let processedEvent = TestEvent()
-        eventNotificationCenterMiddleware.closure = { middlewareIncomingEvent, session, completion in
+        eventNotificationCenterMiddleware.closure = { middlewareIncomingEvent, session in
             XCTAssertEqual(incomingEvent.asEquatable, middlewareIncomingEvent.asEquatable)
             XCTAssertEqual(session as? NSManagedObjectContext, self.database.writableContext)
-            completion(processedEvent)
+            return processedEvent
         }
         
         // Start logging events

--- a/Sources/StreamChat/Workers/EventNotificationCenter.swift
+++ b/Sources/StreamChat/Workers/EventNotificationCenter.swift
@@ -8,7 +8,11 @@ import Foundation
 class EventNotificationCenter: NotificationCenter {
     private(set) var middlewares: [EventMiddleware] = []
     
-    init(middlewares: [EventMiddleware] = []) {
+    /// The database used when evaluating middlewares.
+    let database: DatabaseContainer
+    
+    init(middlewares: [EventMiddleware] = [], database: DatabaseContainer) {
+        self.database = database
         super.init()
         middlewares.forEach(add)
     }

--- a/Sources/StreamChat/Workers/EventNotificationCenter.swift
+++ b/Sources/StreamChat/Workers/EventNotificationCenter.swift
@@ -11,16 +11,19 @@ class EventNotificationCenter: NotificationCenter {
     /// The database used when evaluating middlewares.
     let database: DatabaseContainer
     
-    init(middlewares: [EventMiddleware] = [], database: DatabaseContainer) {
+    init(database: DatabaseContainer) {
         self.database = database
         super.init()
-        middlewares.forEach(add)
+    }
+
+    func add(middlewares: [EventMiddleware]) {
+        self.middlewares.append(contentsOf: middlewares)
     }
 
     func add(middleware: EventMiddleware) {
         middlewares.append(middleware)
     }
-    
+
     func process(_ event: Event) {
         middlewares.process(event: event) { [weak self] in
             guard let self = self, let eventToPublish = $0 else { return }

--- a/Sources/StreamChat/Workers/EventNotificationCenter.swift
+++ b/Sources/StreamChat/Workers/EventNotificationCenter.swift
@@ -11,6 +11,15 @@ class EventNotificationCenter: NotificationCenter {
     /// The database used when evaluating middlewares.
     let database: DatabaseContainer
     
+    /// Events are processed in batches to reduce database writes. This interval is the max number of seconds
+    /// an event can wait before its processing started.
+    ///
+    /// Mutating this value doesn't affect the existing batch and the new value is applied for the following batch.
+    ///
+    var eventBatchPeriod: TimeInterval = 0.5
+    
+    @Atomic var pendingEvents: [Event] = []
+    
     init(database: DatabaseContainer) {
         self.database = database
         super.init()
@@ -25,9 +34,37 @@ class EventNotificationCenter: NotificationCenter {
     }
 
     func process(_ event: Event) {
-        middlewares.process(event: event) { [weak self] in
-            guard let self = self, let eventToPublish = $0 else { return }
-            self.post(Notification(newEventReceived: eventToPublish, sender: self))
+        var shouldScheduleProcessing = false
+        _pendingEvents {
+            shouldScheduleProcessing = $0.isEmpty
+            $0.append(event)
+        }
+        
+        if shouldScheduleProcessing {
+            scheduleProcessing()
+        }
+    }
+    
+    /// Starts the timer and schedules the processing of events
+    private func scheduleProcessing() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + eventBatchPeriod) { [weak self] in
+            guard let self = self else { return }
+
+            self.database.write { session in
+                var eventsToProcess: [Event] = []
+                self._pendingEvents {
+                    eventsToProcess = $0
+                    $0.removeAll()
+                }
+                
+                eventsToProcess.forEach { event in
+                    guard
+                        let eventToPublish = self.middlewares.process(event: event, session: session)
+                    else { return }
+
+                    self.post(Notification(newEventReceived: eventToPublish, sender: self))
+                }
+            }
         }
     }
 }

--- a/Sources/StreamChat/Workers/EventNotificationCenter_Tests.swift
+++ b/Sources/StreamChat/Workers/EventNotificationCenter_Tests.swift
@@ -6,6 +6,18 @@
 import XCTest
 
 final class EventNotificationCenter_Tests: XCTestCase {
+    var database: DatabaseContainer!
+    
+    override func setUp() {
+        super.setUp()
+        database = DatabaseContainerMock()
+    }
+    
+    override func tearDown() {
+        AssertAsync.canBeReleased(&database)
+        super.tearDown()
+    }
+    
     func test_init_worksCorrectly() {
         // Create middlewares
         let middlewares: [EventMiddlewareMock] = [
@@ -15,7 +27,7 @@ final class EventNotificationCenter_Tests: XCTestCase {
         ]
         
         // Create notication center with middlewares
-        let center = EventNotificationCenter(middlewares: middlewares)
+        let center = EventNotificationCenter(middlewares: middlewares, database: database)
 
         // Assert middlewares are assigned correctly
         let centerMiddlewares = center.middlewares as! [EventMiddlewareMock]
@@ -34,7 +46,7 @@ final class EventNotificationCenter_Tests: XCTestCase {
         ]
         
         // Create notication center without any middlewares
-        let center = EventNotificationCenter()
+        let center = EventNotificationCenter(database: database)
         
         // Add middlewares via `add` method
         middlewares.forEach(center.add)
@@ -50,8 +62,8 @@ final class EventNotificationCenter_Tests: XCTestCase {
     func test_eventIsNotPublished_ifSomeMiddlewareDoesNotForwardEvent() {
         // Create notication center with blocking middleware
         let center = EventNotificationCenter(middlewares: [
-            EventMiddlewareMock { $1(nil) }
-        ])
+            EventMiddlewareMock { $2(nil) }
+        ], database: database)
 
         // Create event logger to check published events
         let eventLogger = EventLogger(center)
@@ -65,7 +77,7 @@ final class EventNotificationCenter_Tests: XCTestCase {
     
     func test_eventIsPublishedAsItIs_ifThereAreNoMiddlewares() {
         // Create notication center without any middlewares
-        let center = EventNotificationCenter()
+        let center = EventNotificationCenter(database: database)
         
         // Create event logger to check published events
         let eventLogger = EventLogger(center)

--- a/Sources/StreamChat/Workers/EventNotificationCenter_Tests.swift
+++ b/Sources/StreamChat/Workers/EventNotificationCenter_Tests.swift
@@ -2,11 +2,12 @@
 // Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
+import CoreData
 @testable import StreamChat
 import XCTest
 
 final class EventNotificationCenter_Tests: XCTestCase {
-    var database: DatabaseContainer!
+    var database: DatabaseContainerMock!
     
     override func setUp() {
         super.setUp()
@@ -46,7 +47,7 @@ final class EventNotificationCenter_Tests: XCTestCase {
             .init()
         ]
         
-        // Create notication center without any middlewares
+        // Create notification center without any middlewares
         let center = EventNotificationCenter(database: database)
         
         // Add middlewares via `add` method
@@ -74,11 +75,11 @@ final class EventNotificationCenter_Tests: XCTestCase {
         center.process(TestEvent())
         
         // Assert event is published as it is
-        AssertAsync.willBeTrue(eventLogger.equatableEvents.isEmpty)
+        AssertAsync.staysTrue(eventLogger.equatableEvents.isEmpty)
     }
     
     func test_eventIsPublishedAsItIs_ifThereAreNoMiddlewares() {
-        // Create notication center without any middlewares
+        // Create a notification center without any middlewares
         let center = EventNotificationCenter(database: database)
         
         // Create event logger to check published events
@@ -90,6 +91,87 @@ final class EventNotificationCenter_Tests: XCTestCase {
         
         // Assert event is published as it is
         AssertAsync.willBeEqual(eventLogger.events as? [TestEvent], [event])
+    }
+    
+    func test_eventsAreProcessed_fromWithinTheWriteClosure() {
+        // Create a notification center without any middlewares
+        let center = EventNotificationCenter(database: database)
+        
+        // Create event logger to check published events
+        let eventLogger = EventLogger(center)
+
+        // Create incoming event
+        let event = TestEvent()
+
+        var usedSession: DatabaseSession?
+        
+        // Inject spy middleware
+        center.add(middleware: EventMiddlewareMock(closure: { event, session in
+            usedSession = session
+            XCTAssertTrue(self.database.isWriteSessionInProgress)
+            return event
+        }))
+        
+        // Submit event to processing
+        center.process(event)
+        
+        // Assert the event is processed and the correct session is used
+        AssertAsync {
+            Assert.willBeEqual(usedSession as? NSManagedObjectContext, self.database.writableContext)
+            Assert.willBeEqual(eventLogger.events as? [TestEvent], [event])
+        }
+    }
+    
+    func test_eventsAreBatched() {
+        // Create a notification center with just a forwarding middleware
+        let center = EventNotificationCenter(database: database)
+
+        // Create event logger to check published events
+        let eventLogger = EventLogger(center)
+
+        // Prepare test events
+        let testEvents = [TestEvent(), TestEvent(), TestEvent(), TestEvent()]
+        
+        // Note: The most correct approach would be to mock the timer and mock this whole thing. However
+        // it's just a couple of milliseconds and it safes us a lot of complexity, so I decided to do it
+        // directly like this. Let's see it bites back 🤞.
+        center.eventBatchPeriod = 0.2
+
+        // Assert no write sessions exist yet
+        XCTAssertEqual(database.writeSessionCounter, 0)
+        
+        // Submit some events
+        center.process(testEvents[0])
+        center.process(testEvents[1])
+        
+        // Wait a bit and assert no write sessions happen
+        wait(0.1)
+        XCTAssertEqual(database.writeSessionCounter, 0)
+
+        // Wait another bit and assert the events were processed in a single session
+        wait(0.3)
+        XCTAssertEqual(database.writeSessionCounter, 1)
+        XCTAssertEqual(eventLogger.events as! [TestEvent], Array(testEvents[0...1]))
+        
+        // Submit more events
+        center.process(testEvents[2])
+        center.process(testEvents[3])
+        
+        // Wait a bit and assert no additional write sessions happen
+        wait(0.1)
+        XCTAssertEqual(database.writeSessionCounter, 1)
+        
+        // Wait another bit and assert the events were processed in another session
+        wait(0.3)
+        XCTAssertEqual(database.writeSessionCounter, 2)
+        XCTAssertEqual(eventLogger.events as! [TestEvent], testEvents)
+    }
+}
+
+private extension EventNotificationCenter_Tests {
+    func wait(_ time: TimeInterval) {
+        let start = Date()
+        AssertAsync.willBeTrue(Date().timeIntervalSince(start) >= time)
     }
 }
 

--- a/Sources/StreamChat/Workers/EventNotificationCenter_Tests.swift
+++ b/Sources/StreamChat/Workers/EventNotificationCenter_Tests.swift
@@ -62,7 +62,7 @@ final class EventNotificationCenter_Tests: XCTestCase {
     func test_eventIsNotPublished_ifSomeMiddlewareDoesNotForwardEvent() {
         // Create notication center with blocking middleware
         let center = EventNotificationCenter(middlewares: [
-            EventMiddlewareMock { $2(nil) }
+            EventMiddlewareMock { event, _ in event }
         ], database: database)
 
         // Create event logger to check published events

--- a/Sources/StreamChat/Workers/EventNotificationCenter_Tests.swift
+++ b/Sources/StreamChat/Workers/EventNotificationCenter_Tests.swift
@@ -26,8 +26,9 @@ final class EventNotificationCenter_Tests: XCTestCase {
             .init()
         ]
         
-        // Create notication center with middlewares
-        let center = EventNotificationCenter(middlewares: middlewares, database: database)
+        // Create notification center with middlewares
+        let center = EventNotificationCenter(database: database)
+        middlewares.forEach(center.add)
 
         // Assert middlewares are assigned correctly
         let centerMiddlewares = center.middlewares as! [EventMiddlewareMock]
@@ -60,10 +61,11 @@ final class EventNotificationCenter_Tests: XCTestCase {
     }
     
     func test_eventIsNotPublished_ifSomeMiddlewareDoesNotForwardEvent() {
-        // Create notication center with blocking middleware
-        let center = EventNotificationCenter(middlewares: [
-            EventMiddlewareMock { event, _ in event }
-        ], database: database)
+        let consumingMiddleware = EventMiddlewareMock { _, _ in nil }
+
+        // Create a notification center with blocking middleware
+        let center = EventNotificationCenter(database: database)
+        center.add(middleware: consumingMiddleware)
 
         // Create event logger to check published events
         let eventLogger = EventLogger(center)

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		794927ED249E0BE2009D7EB7 /* ExtraData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794927EC249E0BE2009D7EB7 /* ExtraData.swift */; };
 		794927F3249E3F77009D7EB7 /* NotificationAddedToChannel.json in Resources */ = {isa = PBXBuildFile; fileRef = 794927EE249E3D37009D7EB7 /* NotificationAddedToChannel.json */; };
 		794E20F52577DF4D00790DAB /* NameGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794E20F42577DF4D00790DAB /* NameGroupViewController.swift */; };
+		794F105C2615BC4D00C0D52F /* DatabaseSession_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794F105B2615BC4D00C0D52F /* DatabaseSession_Mock.swift */; };
 		795296C12582494000435B2E /* UIConfigProvider_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795296C02582494000435B2E /* UIConfigProvider_Tests.swift */; };
 		795296FC258264A100435B2E /* UserSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795296FB258264A100435B2E /* UserSearchController.swift */; };
 		795297062583B52000435B2E /* UserSearchController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795297052583B52000435B2E /* UserSearchController_Tests.swift */; };
@@ -1307,6 +1308,7 @@
 		794927EE249E3D37009D7EB7 /* NotificationAddedToChannel.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = NotificationAddedToChannel.json; sourceTree = "<group>"; };
 		794927F0249E3DE6009D7EB7 /* EventPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventPayload_Tests.swift; sourceTree = "<group>"; };
 		794E20F42577DF4D00790DAB /* NameGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameGroupViewController.swift; sourceTree = "<group>"; };
+		794F105B2615BC4D00C0D52F /* DatabaseSession_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSession_Mock.swift; sourceTree = "<group>"; };
 		795296C02582494000435B2E /* UIConfigProvider_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfigProvider_Tests.swift; sourceTree = "<group>"; };
 		795296FB258264A100435B2E /* UserSearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSearchController.swift; sourceTree = "<group>"; };
 		795297052583B52000435B2E /* UserSearchController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSearchController_Tests.swift; sourceTree = "<group>"; };
@@ -2843,6 +2845,7 @@
 				F61ED5A024F3F58400874777 /* DatabaseContainer_Mock.swift */,
 				792FCB4A24A3D52A000290C7 /* DatabaseSession.swift */,
 				792FCB4C24A3D56D000290C7 /* DatabaseSession_Tests.swift */,
+				794F105B2615BC4D00C0D52F /* DatabaseSession_Mock.swift */,
 				797EEA4524FFAF4F00C81203 /* DataStore.swift */,
 				797EEA4724FFB4C200C81203 /* DataStore_Tests.swift */,
 				792A4F18247EA97000EAF71D /* DTOs */,
@@ -5393,6 +5396,7 @@
 				792B805224D95D4300C2963E /* Cached_Tests.swift in Sources */,
 				F62D143E24DD70190081D241 /* ChannelUpdater_Mock.swift in Sources */,
 				8ACFBF652507AA440093C6FD /* EventSender_Mock.swift in Sources */,
+				794F105C2615BC4D00C0D52F /* DatabaseSession_Mock.swift in Sources */,
 				79D6CE8625F7D72800BE2EEC /* ChatChannelWatcherListController_Mock.swift in Sources */,
 				8A62705C24BE2BC00040BFD6 /* TypingEvent_Tests.swift in Sources */,
 				799BE2EC248A8CB300DAC8A0 /* WebSocketReconnectionStrategy_Tests.swift in Sources */,


### PR DESCRIPTION
This PR is a little bit bigger but most of the changes there are just mechanical changes so bear with me :)

**Original state**
- Every middleware created its own write session in the database. This means that each event could generate several db observer updates and cause UI re-rendering.
- This situation got even worse when the app started. The SDK asks the backend for the missing events while it was offline. In combination with the initial channel list query which also generates a lot of watcher events, it was very common that the SDK generated several hundred (❗)  UI update callbacks within the first second or two.

**Changes in the PR**
- All middlewares now share a single database session so it's guaranteed that every event will cause at max one database write.
- We now batch the processing of the events. Currently, the batching window is 0.5s but we should tweak this value and find the sweet spot. Thanks to this change, we have 2-3 UI updates when the app starts, rather than 200-300.

---

_Note:_ The current way we process the events is not exactly safe and we need to change it. The syntax makes it possible to keep the reference to the session and use it in an escaping way. This will be addressed in a follow-up PR.