### PR TITLE
[CIS-741] Fix incorrect new message position in empty channel

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
@@ -86,6 +86,10 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
     /// contentOffset and set it when batch updates end
     open var restoreOffset: CGFloat?
 
+    /// Flag to make sure the `prepare()` function is only executed when the collection view had been loaded.
+    /// The rest of the updates should come from `prepare(forCollectionViewUpdates:)`.
+    private var didPerformInitialLayout = false
+
     // MARK: - Initialization
 
     override public required init() {
@@ -256,6 +260,9 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
 
     override open func prepare() {
         super.prepare()
+
+        guard !didPerformInitialLayout else { return }
+        didPerformInitialLayout = true
 
         guard currentItems.isEmpty else { return }
         guard let cv = collectionView else { return }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
@@ -249,8 +249,9 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
     }
     
     override open func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint) -> CGPoint {
-        // if we have any content offset to restore, restore it
-        if let restore = restoreOffset {
+        guard let collectionView = self.collectionView else { return proposedContentOffset }
+        // if we have any content offset to restore and if the collection view has enough items to scroll, restore it
+        if let restore = restoreOffset, collectionView.contentSize.height > collectionView.bounds.height {
             return CGPoint(x: 0, y: collectionViewContentSize.height - restore)
         }
         return proposedContentOffset


### PR DESCRIPTION
# In this PR
- Fixes incorrect position of new message in an empty channel. 
- Fixes jumps when new messages were added caused by not having enough items to scroll.

### Before: 
https://user-images.githubusercontent.com/12814114/113628096-501a7180-965c-11eb-8b6b-736f771b7b58.mov


### After: 
https://user-images.githubusercontent.com/12814114/113628064-45f87300-965c-11eb-840d-91924475a0e3.mov

