### PR TITLE
Implement MessageListCollectionView reuse mechanism

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageCell.swift
@@ -8,6 +8,8 @@ import UIKit
 class MessageCell<ExtraData: ExtraDataTypes>: _CollectionViewCell {
     static var reuseId: String { "message_cell" }
     
+    private var isInitialized = false
+    
     var content: _ChatMessage<ExtraData>? {
         didSet {
             updateContentIfNeeded()
@@ -42,7 +44,14 @@ class MessageCell<ExtraData: ExtraDataTypes>: _CollectionViewCell {
         ])
     }
     
+    func setUpLayoutIfNeeded(options: ChatMessageLayoutOptions) {
+        guard !isInitialized else { return }
+        setUpLayout(options: options)
+    }
+    
     func setUpLayout(options: ChatMessageLayoutOptions) {
+        isInitialized = true
+        
         if options.contains(.text) {
             textView.setContentCompressionResistancePriority(.required, for: .horizontal)
             textView.setContentCompressionResistancePriority(.required, for: .vertical)

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageCollectionView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageCollectionView.swift
@@ -7,17 +7,25 @@ import StreamChat
 import UIKit
 
 class MessageCollectionView: UICollectionView {
-    func dequeueReusableCell(
+    private var identifiers: Set<String> = .init()
+    
+    func dequeueReusableCell<ExtraData: ExtraDataTypes>(
         withReuseIdentifier identifier: String,
         layoutOptions: ChatMessageLayoutOptions,
         for indexPath: IndexPath
-    ) -> UICollectionViewCell {
-        // TODO: implement
-        let cell = dequeueReusableCell(withReuseIdentifier: identifier, for: indexPath) as! MessageCell<NoExtraData>
+    ) -> MessageCell<ExtraData> {
+        let reuseIdentifier = "\(identifier)_\(layoutOptions.rawValue)"
         
-        if cell.content == nil { // this is wrong :)
-            cell.setUpLayout(options: layoutOptions)
+        // There is no public API to find out
+        // if the given `identifier` is registered.
+        if !identifiers.contains(reuseIdentifier) {
+            identifiers.insert(reuseIdentifier)
+            
+            register(MessageCell<ExtraData>.self, forCellWithReuseIdentifier: reuseIdentifier)
         }
+            
+        let cell = dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as! MessageCell<ExtraData>
+        cell.setUpLayoutIfNeeded(options: layoutOptions)
         
         return cell
     }

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -108,11 +108,11 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         let reuseId = cellReuseIdentifier(for: message)
         let layoutOptions = cellLayoutOptionsForMessage(at: indexPath)
         
-        let cell = self.collectionView.dequeueReusableCell(
+        let cell: MessageCell<ExtraData> = self.collectionView.dequeueReusableCell(
             withReuseIdentifier: reuseId,
             layoutOptions: layoutOptions,
             for: indexPath
-        ) as! MessageCell<ExtraData>
+        )
         
         cell.content = message
         


### PR DESCRIPTION
# Description

System's `dequeueReusableCell(withReuseIdentifier:for:)` creates new cell or uses already created one if possible. Thererore the underlying cell has to be responsible for calling `setUpLayout(options:)` if needed. I created a new method `setUpLayoutIfNeeded` which determines if `setUpLayout` should be called or not.

From my experience we should be safe to call the cell registration on each dequeue but there is no documentation for this behavior. That's the reason why`identifiers: Set<String>` is used.
