### PR TITLE
[CIS-528] Add connection status banner to DemoApp

### DIFF
--- a/DemoApp/BannerShowingConnectionDelegate.swift
+++ b/DemoApp/BannerShowingConnectionDelegate.swift
@@ -1,0 +1,78 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+final class BannerShowingConnectionDelegate {
+    // MARK: - Private Properties
+    
+    private let view: UIView
+    private let bannerView = BannerView()
+    private let bannerAppearanceDuration: TimeInterval = 0.5
+    
+    // MARK: -
+    
+    init(showUnder view: UIView) {
+        self.view = view
+        setupViews()
+    }
+}
+
+// MARK: - ChatConnectionControllerDelegate
+
+extension BannerShowingConnectionDelegate: ChatConnectionControllerDelegate {
+    public func connectionController(_ controller: ChatConnectionController, didUpdateConnectionStatus status: ConnectionStatus) {
+        switch status {
+        case .disconnected:
+            showBanner()
+        case .connected:
+            hideBanner()
+        case .initialized,
+             .disconnecting,
+             .connecting:
+            break
+        }
+    }
+}
+
+// MARK: - Private Methods
+
+private extension BannerShowingConnectionDelegate {
+    func setupViews() {
+        attachToTopViewIfNeeded()
+        bannerView.alpha = 0
+        bannerView.update(text: "Connecting...")
+    }
+    
+    func attachToTopViewIfNeeded() {
+        guard bannerView.superview != view else { return }
+        
+        view.addSubview(bannerView)
+        
+        bannerView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate(
+            [
+                bannerView.topAnchor.constraint(equalTo: view.bottomAnchor),
+                bannerView.widthAnchor.constraint(equalTo: view.widthAnchor),
+                bannerView.heightAnchor.constraint(equalToConstant: 28)
+            ]
+        )
+    }
+    
+    func showBanner() {
+        attachToTopViewIfNeeded()
+        animateBannerAlpha(to: 1)
+    }
+    
+    func hideBanner() {
+        animateBannerAlpha(to: 0)
+    }
+    
+    func animateBannerAlpha(to value: CGFloat) {
+        UIView.animate(withDuration: bannerAppearanceDuration) {
+            self.bannerView.alpha = value
+        }
+    }
+}

--- a/DemoApp/BannerView.swift
+++ b/DemoApp/BannerView.swift
@@ -8,28 +8,30 @@ import UIKit
 final class BannerView: UIView {
     private let label = UILabel()
     
-    override func didMoveToSuperview() {
-        super.didMoveToSuperview()
-        setUpLayout()
-        defaultAppearance()
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     func update(text: String) {
         label.text = text
     }
     
+    private func commonInit() {
+        setUpLayout()
+        defaultAppearance()
+    }
+    
     private func setUpLayout() {
-        guard let superview = superview else { return }
-        
         addSubview(label)
-        
-        translatesAutoresizingMaskIntoConstraints = false
         label.translatesAutoresizingMaskIntoConstraints = false
-        
         NSLayoutConstraint.activate(
             [
-                widthAnchor.constraint(equalTo: superview.widthAnchor),
-                heightAnchor.constraint(equalToConstant: 28),
                 label.trailingAnchor.constraint(equalTo: trailingAnchor),
                 label.leadingAnchor.constraint(equalTo: leadingAnchor),
                 label.topAnchor.constraint(equalTo: topAnchor),

--- a/DemoApp/BannerView.swift
+++ b/DemoApp/BannerView.swift
@@ -1,0 +1,47 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChatUI
+import UIKit
+
+final class BannerView: UIView {
+    private let label = UILabel()
+    
+    override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        setUpLayout()
+        defaultAppearance()
+    }
+    
+    func update(text: String) {
+        label.text = text
+    }
+    
+    private func setUpLayout() {
+        guard let superview = superview else { return }
+        
+        addSubview(label)
+        
+        translatesAutoresizingMaskIntoConstraints = false
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate(
+            [
+                widthAnchor.constraint(equalTo: superview.widthAnchor),
+                heightAnchor.constraint(equalToConstant: 28),
+                label.trailingAnchor.constraint(equalTo: trailingAnchor),
+                label.leadingAnchor.constraint(equalTo: leadingAnchor),
+                label.topAnchor.constraint(equalTo: topAnchor),
+                label.bottomAnchor.constraint(equalTo: bottomAnchor)
+            ]
+        )
+    }
+    
+    private func defaultAppearance() {
+        backgroundColor = UIConfig.default.colorPalette.border2.withAlphaComponent(0.9)
+        label.textAlignment = .center
+        label.font = UIConfig.default.font.body
+        label.textColor = UIConfig.default.colorPalette.popoverBackground
+    }
+}

--- a/DemoApp/ChatPresenter.swift
+++ b/DemoApp/ChatPresenter.swift
@@ -6,34 +6,6 @@ import StreamChat
 import StreamChatUI
 import UIKit
 
-extension UIViewController {
-    // TODO: Where to put this???
-    func presentChat(userCredentials: UserCredentials) {
-        LogConfig.level = .error
-
-        // Create a token
-        let token = try! Token(rawValue: userCredentials.token)
-        
-        // Create client
-        let config = ChatClientConfig(apiKey: .init(userCredentials.apiKey))
-        let client = ChatClient(config: config, tokenProvider: .static(token))
-
-        // Config
-        UIConfig.default.navigation.channelListRouter = DemoChatChannelListRouter.self
-
-        // Channels with the current user
-        let controller = client.channelListController(query: .init(filter: .containMembers(userIds: [userCredentials.id])))
-        let chatList = ChatChannelListVC()
-        chatList.controller = controller
-        
-        let chatNavigationController = UINavigationController(rootViewController: chatList)
-        
-        UIView.transition(with: view.window!, duration: 0.3, options: .transitionFlipFromRight, animations: {
-            self.view.window!.rootViewController = chatNavigationController
-        })
-    }
-}
-
 class DemoChatChannelListRouter: _ChatChannelListRouter<NoExtraData> {
     override func openCreateNewChannel() {
         let storyboard = UIStoryboard(name: "Main", bundle: .main)

--- a/DemoApp/DemoAppCoordinator.swift
+++ b/DemoApp/DemoAppCoordinator.swift
@@ -1,0 +1,60 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import StreamChatUI
+import UIKit
+
+final class DemoAppCoordinator {
+    private var connectionController: ChatConnectionController?
+    private let navigationController: UINavigationController
+    private let connectionDelegate: BannerShowingConnectionDelegate
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+        connectionDelegate = BannerShowingConnectionDelegate(
+            showUnder: navigationController.navigationBar
+        )
+        injectActions()
+    }
+    
+    func presentChat(userCredentials: UserCredentials) {
+        LogConfig.level = .error
+        
+        // Create a token
+        let token = try! Token(rawValue: userCredentials.token)
+        
+        // Create client
+        let config = ChatClientConfig(apiKey: .init(userCredentials.apiKey))
+        let client = ChatClient(config: config, tokenProvider: .static(token))
+        
+        // Config
+        UIConfig.default.navigation.channelListRouter = DemoChatChannelListRouter.self
+        
+        // Channels with the current user
+        let controller = client.channelListController(query: .init(filter: .containMembers(userIds: [userCredentials.id])))
+        let chatList = ChatChannelListVC()
+        chatList.controller = controller
+        
+        connectionController = client.connectionController()
+        connectionController?.delegate = connectionDelegate
+        
+        navigationController.viewControllers = [chatList]
+        navigationController.isNavigationBarHidden = false
+        
+        let window = navigationController.view.window!
+        
+        UIView.transition(with: window, duration: 0.3, options: .transitionFlipFromRight, animations: {
+            window.rootViewController = self.navigationController
+        })
+    }
+    
+    private func injectActions() {
+        if let loginViewController = navigationController.topViewController as? LoginViewController {
+            loginViewController.didRequestChatPresentation = { [weak self] in
+                self?.presentChat(userCredentials: $0)
+            }
+        }
+    }
+}

--- a/DemoApp/Info.plist
+++ b/DemoApp/Info.plist
@@ -33,8 +33,6 @@
 					<string>Default Configuration</string>
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
 				</dict>
 			</array>
 		</dict>
@@ -43,8 +41,6 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/DemoApp/LoginViewController.swift
+++ b/DemoApp/LoginViewController.swift
@@ -39,6 +39,7 @@ class UserCredentialsCell: UITableViewCell {
 
 class LoginViewController: UIViewController {
     @IBOutlet var tableView: UITableView!
+    var didRequestChatPresentation: ((UserCredentials) -> Void)!
     
     let builtInUsers = UserCredentials.builtInUsers
     
@@ -95,6 +96,6 @@ extension LoginViewController: UITableViewDelegate, UITableViewDataSource {
             return
         }
         
-        presentChat(userCredentials: builtInUsers[indexPath.row])
+        didRequestChatPresentation(builtInUsers[indexPath.row])
     }
 }

--- a/DemoApp/SceneDelegate.swift
+++ b/DemoApp/SceneDelegate.swift
@@ -9,10 +9,21 @@ extension UIColor {
 }
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    private var coordinator: DemoAppCoordinator!
     var window: UIWindow?
-
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let scene = scene as? UIWindowScene else { return }
+        let window = UIWindow(windowScene: scene)
+        
+        guard let navigationController = UIStoryboard(
+            name: "Main",
+            bundle: nil
+        ).instantiateInitialViewController() as? UINavigationController else { return }
+        window.rootViewController = navigationController
+        coordinator = DemoAppCoordinator(navigationController: navigationController)
+        self.window = window
+        window.makeKeyAndVisible()
         scene.windows.forEach { $0.tintColor = .streamBlue }
     }
 

--- a/Package.swift
+++ b/Package.swift
@@ -126,6 +126,7 @@ var streamChatSourcesExcluded: [String] { [
     "Utils/Database/NSManagedObject_Tests.swift",
     "Utils/MulticastDelegate_Tests.swift",
     "Utils/InternetConnection/InternetConnection_Tests.swift",
+    "Utils/InternetConnection/Error+InternetNotAvailable_Tests.swift",
     "Utils/Atomic_Tests.swift",
     "Utils/CoreDataLazy_Tests.swift",
     "Utils/LazyCachedMapCollection_Tests.swift",

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -193,7 +193,7 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
     /// required header auth parameters to make a successful request.
     private var urlSessionConfiguration: URLSessionConfiguration {
         let config = URLSessionConfiguration.default
-        config.waitsForConnectivity = true
+        config.waitsForConnectivity = false
         config.httpAdditionalHeaders = sessionHeaders
         return config
     }

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -188,6 +188,7 @@ class ChatClient_Tests: StressTestCase {
         // Assert the init parameters are correct
         let webSocket = testEnv.webSocketClient
         assertMandatoryHeaderFields(webSocket?.init_sessionConfiguration)
+        XCTAssertEqual(webSocket?.init_sessionConfiguration.waitsForConnectivity, false)
         XCTAssert(webSocket?.init_requestEncoder is TestRequestEncoder)
         XCTAssert(webSocket?.init_eventNotificationCenter.database === client.databaseContainer)
         XCTAssertNotNil(webSocket?.init_eventDecoder)

--- a/Sources/StreamChat/Utils/InternetConnection/Error+InternetNotAvailable.swift
+++ b/Sources/StreamChat/Utils/InternetConnection/Error+InternetNotAvailable.swift
@@ -14,7 +14,14 @@ private let offlineErrors: [(domain: String, errorCode: Int)] = [
 extension Error {
     /// Returns `true` if the error is one of the known errors for internet connection not being available.
     var isInternetOfflineError: Bool {
+        let engineError = (self as? WebSocketEngineError)?.engineError
+        return offlineErrors.contains {
+            self.has(parameters: $0) || (engineError?.has(parameters: $0) ?? false)
+        }
+    }
+    
+    private func has(parameters: (domain: String, errorCode: Int)) -> Bool {
         let error = self as NSError
-        return offlineErrors.contains { $0.domain == error.domain && $0.errorCode == error.code }
+        return error.domain == parameters.domain && error.code == parameters.errorCode
     }
 }

--- a/Sources/StreamChat/Utils/InternetConnection/Error+InternetNotAvailable_Tests.swift
+++ b/Sources/StreamChat/Utils/InternetConnection/Error+InternetNotAvailable_Tests.swift
@@ -1,0 +1,90 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class ErrorInternetNotAvailable_Tests: XCTestCase {
+    func test_errorIsNSURLErrorNotConnectedToInternet() throws {
+        let error = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorNotConnectedToInternet,
+            userInfo: nil
+        )
+        
+        XCTAssertTrue(error.isInternetOfflineError)
+    }
+    
+    func test_errorIsNSPOSIXErrorDomain50() throws {
+        let error = NSError(
+            domain: NSPOSIXErrorDomain,
+            code: 50,
+            userInfo: nil
+        )
+        
+        XCTAssertTrue(error.isInternetOfflineError)
+    }
+    
+    func test_errorDomainIsNotOneOfInternetOfflineError() throws {
+        let error = NSError(
+            domain: "Some domain",
+            code: 50,
+            userInfo: nil
+        )
+        
+        XCTAssertFalse(error.isInternetOfflineError)
+    }
+    
+    func test_errorCodeIsNotOneOfInternetOfflineError() throws {
+        let error = NSError(
+            domain: NSURLErrorDomain,
+            code: 50,
+            userInfo: nil
+        )
+        
+        XCTAssertFalse(error.isInternetOfflineError)
+    }
+    
+    func test_websocketEngineErrorInternetIsOffline() throws {
+        let error = WebSocketEngineError(
+            reason: "",
+            code: -1009,
+            engineError: NSError(
+                domain: NSURLErrorDomain,
+                code: NSURLErrorNotConnectedToInternet,
+                userInfo: nil
+            )
+        )
+        
+        XCTAssertTrue(error.isInternetOfflineError)
+    }
+    
+    func test_websocketEngineErrorDomainIsNotInternetIsOffline() throws {
+        let error = WebSocketEngineError(
+            reason: "",
+            code: 304,
+            engineError: NSError(
+                domain: "Some domain",
+                code: NSURLErrorNotConnectedToInternet,
+                userInfo: nil
+            )
+        )
+        
+        XCTAssertFalse(error.isInternetOfflineError)
+    }
+    
+    func test_websocketEngineErrorCodeIsNotInternetIsOffline() throws {
+        let error = WebSocketEngineError(
+            reason: "",
+            code: 304,
+            engineError: NSError(
+                domain: NSURLErrorDomain,
+                code: 304,
+                userInfo: nil
+            )
+        )
+        
+        XCTAssertFalse(error.isInternetOfflineError)
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		22C2359A259CA87B00DC805A /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C23599259CA87B00DC805A /* Animation.swift */; };
 		22CAFA7625CAE278005935D9 /* RawJSON_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */; };
 		22FF4365256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */; };
+		647F66D5261E22C200111B19 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F66D4261E22C200111B19 /* BannerView.swift */; };
 		64F70D4B26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F70D4A26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift */; };
 		6971257E260CA503003C7B47 /* NSManagedObjectContext+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6971256C260CA4CB003C7B47 /* NSManagedObjectContext+Extensions.swift */; };
 		697C6F90260CFA37000E9023 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69712522260BC9B4003C7B47 /* Deprecations.swift */; };
@@ -1180,6 +1181,7 @@
 		22C23599259CA87B00DC805A /* Animation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
 		22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawJSON_Tests.swift; sourceTree = "<group>"; };
 		22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageComposerSuggestionsViewController.swift; sourceTree = "<group>"; };
+		647F66D4261E22C200111B19 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
 		64F70D4A26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+InternetNotAvailable_Tests.swift"; sourceTree = "<group>"; };
 		69712522260BC9B4003C7B47 /* Deprecations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecations.swift; sourceTree = "<group>"; };
 		6971256C260CA4CB003C7B47 /* NSManagedObjectContext+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Extensions.swift"; sourceTree = "<group>"; };
@@ -2571,6 +2573,7 @@
 				792DDAA025711AF2001DB91B /* CreateChatViewController.swift */,
 				792DDAA725753BEA001DB91B /* CreateGroupViewController.swift */,
 				794E20F42577DF4D00790DAB /* NameGroupViewController.swift */,
+				647F66D4261E22C200111B19 /* BannerView.swift */,
 			);
 			path = DemoApp;
 			sourceTree = "<group>";
@@ -5050,6 +5053,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				647F66D5261E22C200111B19 /* BannerView.swift in Sources */,
 				792DDA5E256FB69E001DB91B /* LoginViewController.swift in Sources */,
 				792DDAA825753BEA001DB91B /* CreateGroupViewController.swift in Sources */,
 				7933064925712C8B00FBB586 /* DemoUsers.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		22FF4365256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */; };
 		6428DD5526201DCC0065DA1D /* BannerShowingConnectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */; };
 		647F66D5261E22C200111B19 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F66D4261E22C200111B19 /* BannerView.swift */; };
+		648EC576261EF9D400B8F05F /* DemoAppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648EC575261EF9D400B8F05F /* DemoAppCoordinator.swift */; };
 		64F70D4B26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F70D4A26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift */; };
 		6971257E260CA503003C7B47 /* NSManagedObjectContext+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6971256C260CA4CB003C7B47 /* NSManagedObjectContext+Extensions.swift */; };
 		697C6F90260CFA37000E9023 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69712522260BC9B4003C7B47 /* Deprecations.swift */; };
@@ -1184,6 +1185,7 @@
 		22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageComposerSuggestionsViewController.swift; sourceTree = "<group>"; };
 		6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerShowingConnectionDelegate.swift; sourceTree = "<group>"; };
 		647F66D4261E22C200111B19 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
+		648EC575261EF9D400B8F05F /* DemoAppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppCoordinator.swift; sourceTree = "<group>"; };
 		64F70D4A26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+InternetNotAvailable_Tests.swift"; sourceTree = "<group>"; };
 		69712522260BC9B4003C7B47 /* Deprecations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecations.swift; sourceTree = "<group>"; };
 		6971256C260CA4CB003C7B47 /* NSManagedObjectContext+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Extensions.swift"; sourceTree = "<group>"; };
@@ -2567,6 +2569,7 @@
 				792DDA5D256FB69E001DB91B /* LoginViewController.swift */,
 				7933064825712C8B00FBB586 /* DemoUsers.swift */,
 				7933060A256FF94800FBB586 /* ChatPresenter.swift */,
+				648EC575261EF9D400B8F05F /* DemoAppCoordinator.swift */,
 				6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */,
 				79330603256FEBE600FBB586 /* AdvancedOptionsViewController.swift */,
 				792DDA5F256FB69E001DB91B /* Main.storyboard */,
@@ -5058,6 +5061,7 @@
 			files = (
 				6428DD5526201DCC0065DA1D /* BannerShowingConnectionDelegate.swift in Sources */,
 				647F66D5261E22C200111B19 /* BannerView.swift in Sources */,
+				648EC576261EF9D400B8F05F /* DemoAppCoordinator.swift in Sources */,
 				792DDA5E256FB69E001DB91B /* LoginViewController.swift in Sources */,
 				792DDAA825753BEA001DB91B /* CreateGroupViewController.swift in Sources */,
 				7933064925712C8B00FBB586 /* DemoUsers.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		22C2359A259CA87B00DC805A /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C23599259CA87B00DC805A /* Animation.swift */; };
 		22CAFA7625CAE278005935D9 /* RawJSON_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */; };
 		22FF4365256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */; };
+		6428DD5526201DCC0065DA1D /* BannerShowingConnectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */; };
 		647F66D5261E22C200111B19 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F66D4261E22C200111B19 /* BannerView.swift */; };
 		64F70D4B26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F70D4A26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift */; };
 		6971257E260CA503003C7B47 /* NSManagedObjectContext+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6971256C260CA4CB003C7B47 /* NSManagedObjectContext+Extensions.swift */; };
@@ -1181,6 +1182,7 @@
 		22C23599259CA87B00DC805A /* Animation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
 		22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawJSON_Tests.swift; sourceTree = "<group>"; };
 		22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageComposerSuggestionsViewController.swift; sourceTree = "<group>"; };
+		6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerShowingConnectionDelegate.swift; sourceTree = "<group>"; };
 		647F66D4261E22C200111B19 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
 		64F70D4A26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+InternetNotAvailable_Tests.swift"; sourceTree = "<group>"; };
 		69712522260BC9B4003C7B47 /* Deprecations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecations.swift; sourceTree = "<group>"; };
@@ -2565,6 +2567,7 @@
 				792DDA5D256FB69E001DB91B /* LoginViewController.swift */,
 				7933064825712C8B00FBB586 /* DemoUsers.swift */,
 				7933060A256FF94800FBB586 /* ChatPresenter.swift */,
+				6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */,
 				79330603256FEBE600FBB586 /* AdvancedOptionsViewController.swift */,
 				792DDA5F256FB69E001DB91B /* Main.storyboard */,
 				792DDA62256FB69F001DB91B /* Assets.xcassets */,
@@ -5053,6 +5056,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6428DD5526201DCC0065DA1D /* BannerShowingConnectionDelegate.swift in Sources */,
 				647F66D5261E22C200111B19 /* BannerView.swift in Sources */,
 				792DDA5E256FB69E001DB91B /* LoginViewController.swift in Sources */,
 				792DDAA825753BEA001DB91B /* CreateGroupViewController.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		22C2359A259CA87B00DC805A /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C23599259CA87B00DC805A /* Animation.swift */; };
 		22CAFA7625CAE278005935D9 /* RawJSON_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */; };
 		22FF4365256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */; };
+		64F70D4B26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F70D4A26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift */; };
 		6971257E260CA503003C7B47 /* NSManagedObjectContext+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6971256C260CA4CB003C7B47 /* NSManagedObjectContext+Extensions.swift */; };
 		697C6F90260CFA37000E9023 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69712522260BC9B4003C7B47 /* Deprecations.swift */; };
 		780057FF25F6353600D21095 /* ChatChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780057F625F634FC00D21095 /* ChatChannel.swift */; };
@@ -1179,6 +1180,7 @@
 		22C23599259CA87B00DC805A /* Animation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
 		22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawJSON_Tests.swift; sourceTree = "<group>"; };
 		22FF4364256E943F00133910 /* ChatMessageComposerSuggestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageComposerSuggestionsViewController.swift; sourceTree = "<group>"; };
+		64F70D4A26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+InternetNotAvailable_Tests.swift"; sourceTree = "<group>"; };
 		69712522260BC9B4003C7B47 /* Deprecations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecations.swift; sourceTree = "<group>"; };
 		6971256C260CA4CB003C7B47 /* NSManagedObjectContext+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Extensions.swift"; sourceTree = "<group>"; };
 		698E2A3425F7C8AF00ED9CCC /* APIPathConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPathConvertible.swift; sourceTree = "<group>"; };
@@ -3861,6 +3863,7 @@
 				8AE335A424FCF999002B6677 /* InternetConnection_Tests.swift */,
 				8AE335A524FCF999002B6677 /* Reachability_Vendor.swift */,
 				79200D4B25025B81002F4EB1 /* Error+InternetNotAvailable.swift */,
+				64F70D4A26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift */,
 			);
 			path = InternetConnection;
 			sourceTree = "<group>";
@@ -5360,6 +5363,7 @@
 				8A62705E24BE2CD70040BFD6 /* XCTestCase+MockJSON.swift in Sources */,
 				DA84074B2526417B005A0F62 /* JSONEncoder+Extensions.swift in Sources */,
 				88381E6E258259310047A6A3 /* FileUploadPayload_Tests.swift in Sources */,
+				64F70D4B26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift in Sources */,
 				F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */,
 				22CAFA7625CAE278005935D9 /* RawJSON_Tests.swift in Sources */,
 				795297062583B52000435B2E /* UserSearchController_Tests.swift in Sources */,


### PR DESCRIPTION
Mostly this change is about:
* Adding a view for displaying the banner
* Fixing an issue with `internetIsOfflineError` that prevented web socket client from reconnecting
* Fixing URLSession configuration to make reconnection logic work
* Implementing banner logic in DemoApp
* Rehauling navigation in DemoApp a bit to support presenting banner on any screen
![banner](https://user-images.githubusercontent.com/7489425/114145511-280e6500-991f-11eb-89ed-cf987c987cff.gif)

