### PR TITLE
[CIS-783] Fix missing `startObservingIfNeeded` calls in some controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `ChannelController`s created with `createChannelWithId` and `createChannelWithMembers` functions not reporting their initial values [#945](https://github.com/GetStream/stream-chat-swift/pull/945)
 - Fix issue where channel `lastMessageDate` was not updated when new message arrived [#949](https://github.com/GetStream/stream-chat-swift/pull/949)
 - Fix channel unread count not being updated in the real time [#969](https://github.com/GetStream/stream-chat-swift/pull/969)
+- Fix updated values not reported for some controllers if the properties were accessed for the first time after `synchronize` has finished. Affected controllers were `ChatUserListController`, `ChatChannelListController`, `ChatUserSearchController` [#974](https://github.com/GetStream/stream-chat-swift/pull/974)
 
 ### 🔄 Changed
 - `Logger.assertationFailure` was renamed to `Logger.assertionFailure` [#935](https://github.com/GetStream/stream-chat-swift/pull/935)

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -112,6 +112,8 @@ public class _ChatChannelListController<ExtraData: ExtraDataTypes>: DataControll
     }
     
     override public func synchronize(_ completion: ((_ error: Error?) -> Void)? = nil) {
+        startChannelListObserverIfNeeded()
+        
         worker.update(channelListQuery: query) { error in
             self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
             self.callback { completion?(error) }

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -177,6 +177,25 @@ class ChannelListController_Tests: StressTestCase {
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
     }
     
+    /// This test simulates a bug where the `channels` field was not updated if it wasn't
+    /// touched before calling synchronize.
+    func test_channelsAreFetched_afterCallingSynchronize() throws {
+        // Simulate `synchronize` call
+        controller.synchronize()
+        
+        // Create a channel in the DB matching the query
+        let channelId = ChannelId.unique
+        try client.databaseContainer.writeSynchronously {
+            try $0.saveChannel(payload: .dummy(cid: channelId), query: self.query)
+        }
+        
+        // Simulate successful network call.
+        env.channelListUpdater?.update_completion?(nil)
+
+        // Assert the channels are loaded
+        XCTAssertEqual(controller.channels.map(\.cid), [channelId])
+    }
+
     // MARK: - Change propagation tests
     
     func test_changesInTheDatabase_arePropagated() throws {

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -167,6 +167,20 @@ final class CurrentUserController_Tests: StressTestCase {
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
     }
     
+    /// This test simulates a bug where the `currentUser` field was not updated if it wasn't
+    /// touched before calling synchronize.
+    func test_currentUserIsFetched_afterCallingSynchronize() throws {
+        // Simulate `synchronize` call
+        controller.synchronize()
+                
+        // Create the current user in the DB
+        let userId = UserId.unique
+        try client.databaseContainer.createCurrentUser(id: userId)
+        
+        // Assert the existing user is loaded
+        XCTAssertEqual(controller.currentUser?.id, userId)
+    }
+    
     // MARK: - Delegate
     
     func test_delegate_isAssignedCorrectly() {

--- a/Sources/StreamChat/Controllers/MemberController/MemberController_Tests.swift
+++ b/Sources/StreamChat/Controllers/MemberController/MemberController_Tests.swift
@@ -170,6 +170,22 @@ final class MemberController_Tests: StressTestCase {
         XCTAssertEqual(env.memberListUpdater!.load_query!.cid, controller.cid)
         XCTAssertNotNil(env.memberListUpdater!.load_completion)
     }
+    
+    /// This test simulates a bug where the `member` field was not updated if it wasn't
+    /// touched before calling synchronize.
+    func test_memberIsFetched_evenAfterCallingSynchronize() throws {
+        // Simulate `synchronize` call.
+        controller.synchronize()
+        
+        // Create a user in the DB
+        try client.databaseContainer.createMember(userId: userId, cid: cid)
+        
+        // Simulate updater callback
+        env.memberListUpdater?.load_completion?(nil)
+        
+        // Assert the user is loaded
+        XCTAssertEqual(controller.member?.id, userId)
+    }
 
     // MARK: - Local data fetching triggers
 

--- a/Sources/StreamChat/Controllers/MemberListController/MemberListController_Tests.swift
+++ b/Sources/StreamChat/Controllers/MemberListController/MemberListController_Tests.swift
@@ -161,6 +161,29 @@ final class MemberListController_Tests: StressTestCase {
         XCTAssertNotNil(env.memberListUpdater!.load_completion)
     }
     
+    /// This test simulates a bug where the `members` field was not updated if it wasn't
+    /// touched before calling synchronize.
+    func test_membersAreFetched_evenAfterCallingSynchronize() throws {
+        // Simulate `synchronize` call.
+        controller.synchronize()
+        
+        let userId: UserId = .unique
+        
+        // Create a channel and a member in the database.
+        try client.databaseContainer.createChannel(cid: query.cid)
+        try client.databaseContainer.createMember(
+            userId: userId,
+            cid: query.cid,
+            query: query
+        )
+        
+        // Simulate updater callback
+        env.memberListUpdater?.load_completion?(nil)
+        
+        // Assert the user is loaded
+        XCTAssertEqual(controller.members.map(\.id), [userId])
+    }
+
     // MARK: - Local data fetching triggers
     
     func test_observerIsTriggeredOnlyOnce() {

--- a/Sources/StreamChat/Controllers/SearchControllers/UserSearchController.swift
+++ b/Sources/StreamChat/Controllers/SearchControllers/UserSearchController.swift
@@ -161,6 +161,8 @@ public class _ChatUserSearchController<ExtraData: ExtraDataTypes>: DataControlle
     ///   - completion: Called when the controller has finished fetching remote data.
     ///   If the data fetching fails, the error variable contains more details about the problem.
     public func search(term: String?, completion: ((_ error: Error?) -> Void)? = nil) {
+        startUserListObserverIfNeeded()
+        
         var query = _UserListQuery<ExtraData.User>(sort: [.init(key: .name, isAscending: true)])
         if let term = term, !term.isEmpty {
             query.filter = .or([

--- a/Sources/StreamChat/Controllers/UserController/UserController_Tests.swift
+++ b/Sources/StreamChat/Controllers/UserController/UserController_Tests.swift
@@ -162,6 +162,22 @@ final class UserController_Tests: StressTestCase {
         XCTAssertNotNil(env.userUpdater!.loadUser_completion)
     }
     
+    /// This test simulates a bug where the `user` field was not updated if it wasn't
+    /// touched before calling synchronize.
+    func test_userIsFetched_evenAfterCallingSynchronize() throws {
+        // Simulate `synchronize` call.
+        controller.synchronize()
+        
+        // Create a user in the DB
+        try client.databaseContainer.createUser(id: userId, extraData: .defaultValue)
+        
+        // Simulate updater callback
+        env.userUpdater?.loadUser_completion?(nil)
+        
+        // Assert the user is loaded
+        XCTAssertEqual(controller.user?.id, userId)
+    }
+    
     // MARK: - Mute user
     
     func test_muteUser_propagatesError() {

--- a/Sources/StreamChat/Controllers/UserListController/UserListController.swift
+++ b/Sources/StreamChat/Controllers/UserListController/UserListController.swift
@@ -112,6 +112,8 @@ public class _ChatUserListController<ExtraData: ExtraDataTypes>: DataController,
     }
     
     override public func synchronize(_ completion: ((_ error: Error?) -> Void)? = nil) {
+        startUserListObserverIfNeeded()
+        
         worker.update(userListQuery: query) { error in
             self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
             self.callback { completion?(error) }

--- a/Sources/StreamChat/Database/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer_Mock.swift
@@ -190,7 +190,8 @@ extension DatabaseContainer {
         pinExpires: Date? = nil,
         attachments: [AttachmentPayload] = [],
         localState: LocalMessageState? = nil,
-        type: MessageType? = nil
+        type: MessageType? = nil,
+        numberOfReplies: Int = 0
     ) throws {
         try writeSynchronously { session in
             try session.saveChannel(payload: XCTestCase().dummyPayload(with: cid))
@@ -209,6 +210,19 @@ extension DatabaseContainer {
             
             let messageDTO = try session.saveMessage(payload: message, for: cid)
             messageDTO.localMessageState = localState
+            
+            for idx in 0..<numberOfReplies {
+                let reply: MessagePayload<NoExtraData> = .dummy(
+                    type: .reply,
+                    messageId: .unique,
+                    parentId: id,
+                    authorUserId: authorId,
+                    text: "Reply \(idx)"
+                )
+                
+                let replyDTO = try session.saveMessage(payload: reply, for: cid)
+                messageDTO.replies.insert(replyDTO)
+            }
         }
     }
     


### PR DESCRIPTION
This was a bug in `UserListController` reported by a customer. I added tests for this case to all controllers and found the same issue in more controllers.