### PR TITLE
Message list thread

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/DefaultMessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/DefaultMessageLayoutOptionsResolver.swift
@@ -5,10 +5,26 @@
 import StreamChat
 
 public typealias _LayoutOptionsResolver<ExtraData: ExtraDataTypes> =
-    (_ message: _ChatMessage<ExtraData>, _ isLastInGroup: Bool) -> ChatMessageLayoutOptions
+    (_ indexPath: IndexPath, _ messages: [_ChatMessage<ExtraData>]) -> ChatMessageLayoutOptions
 
-public func DefaultLayoutOptionsResolver<ExtraData: ExtraDataTypes>() -> _LayoutOptionsResolver<ExtraData> {
-    { message, isLastInGroup in
+public func DefaultLayoutOptionsResolver<ExtraData: ExtraDataTypes>(
+    minTimeIntervalBetweenMessagesInGroup: Double = 10
+) -> _LayoutOptionsResolver<ExtraData> {
+    { indexPath, messages in
+        let message = messages[indexPath.item]
+
+        let isLastInGroup: Bool = {
+            guard indexPath.item > 0 else { return true }
+            
+            let nextMessage = messages[indexPath.item - 1]
+
+            guard nextMessage.author == message.author else { return true }
+            
+            let delay = nextMessage.createdAt.timeIntervalSince(message.createdAt)
+            
+            return delay > minTimeIntervalBetweenMessagesInGroup
+        }()
+        
         var options: ChatMessageLayoutOptions = []
         
         if message.isSentByCurrentUser {

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/DefaultMessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/DefaultMessageLayoutOptionsResolver.swift
@@ -1,0 +1,81 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+
+public typealias _LayoutOptionsResolver<ExtraData: ExtraDataTypes> =
+    (_ message: _ChatMessage<ExtraData>, _ isLastInGroup: Bool) -> ChatMessageLayoutOptions
+
+public func DefaultLayoutOptionsResolver<ExtraData: ExtraDataTypes>() -> _LayoutOptionsResolver<ExtraData> {
+    { message, isLastInGroup in
+        var options: ChatMessageLayoutOptions = []
+        
+        if message.isSentByCurrentUser {
+            options.insert(.flipped)
+        }
+        if !isLastInGroup {
+            options.insert(.continuousBubble)
+        }
+        if !isLastInGroup && !message.isSentByCurrentUser {
+            options.insert(.avatarSizePadding)
+        }
+        if isLastInGroup {
+            options.insert(.metadata)
+        }
+        if !message.textContent.isEmpty {
+            options.insert(.text)
+        }
+        
+        guard message.deletedAt == nil else {
+            return options
+        }
+        
+        if isLastInGroup && !message.isSentByCurrentUser {
+            options.insert(.avatar)
+        }
+        if message.quotedMessageId != nil {
+            options.insert(.quotedMessage)
+        }
+        if message.isPartOfThread {
+            options.insert(.threadInfo)
+            // The bubbles with thread look like continuous bubbles
+            options.insert(.continuousBubble)
+        }
+        if !message.reactionScores.isEmpty {
+            options.insert(.reactions)
+        }
+        if message.lastActionFailed {
+            options.insert(.error)
+        }
+
+        let attachmentOptions: ChatMessageLayoutOptions = message.attachments.reduce([]) { options, attachment in
+            if (attachment as? ChatMessageDefaultAttachment)?.actions.isEmpty == false {
+                return options.union(.actions)
+            }
+            
+            switch attachment.type {
+            case .image:
+                return options.union(.photoPreview)
+            case .giphy:
+                return options.union(.giphy)
+            case .file:
+                return options.union(.filePreview)
+            case .link:
+                return options.union(.linkPreview)
+            default:
+                return options
+            }
+        }
+        
+        if attachmentOptions.contains(.actions) {
+            options.insert(.actions)
+        } else if attachmentOptions.intersection([.photoPreview, .giphy, .filePreview]).isEmpty == false {
+            options.formUnion(attachmentOptions.subtracting(.linkPreview))
+        } else if attachmentOptions.contains(.linkPreview) {
+            options.insert(.linkPreview)
+        }
+        
+        return options
+    }
+}

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/DefaultMessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/DefaultMessageLayoutOptionsResolver.swift
@@ -4,19 +4,21 @@
 
 import StreamChat
 
-public typealias _LayoutOptionsResolver<ExtraData: ExtraDataTypes> =
-    (_ indexPath: IndexPath, _ messages: [_ChatMessage<ExtraData>]) -> ChatMessageLayoutOptions
+public typealias MessageLayoutOptionsResolver<ExtraData: ExtraDataTypes> =
+    (_ indexPath: IndexPath, _ messages: AnyRandomAccessCollection<_ChatMessage<ExtraData>>) -> ChatMessageLayoutOptions
 
-public func DefaultLayoutOptionsResolver<ExtraData: ExtraDataTypes>(
-    minTimeIntervalBetweenMessagesInGroup: Double = 10
-) -> _LayoutOptionsResolver<ExtraData> {
+public func DefaultMessageLayoutOptionsResolver<ExtraData: ExtraDataTypes>(
+    minTimeIntervalBetweenMessagesInGroup: TimeInterval = 10
+) -> MessageLayoutOptionsResolver<ExtraData> {
     { indexPath, messages in
-        let message = messages[indexPath.item]
+        let messageIndex = messages.index(messages.startIndex, offsetBy: indexPath.item)
+        let message = messages[messageIndex]
 
         let isLastInGroup: Bool = {
             guard indexPath.item > 0 else { return true }
             
-            let nextMessage = messages[indexPath.item - 1]
+            let nextMessageIndex = messages.index(messages.startIndex, offsetBy: indexPath.item - 1)
+            let nextMessage = messages[nextMessageIndex]
 
             guard nextMessage.author == message.author else { return true }
             

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageContentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageContentView.swift
@@ -46,7 +46,7 @@ class MessageContentView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     var reactionsView: _ReactionsCompactView<ExtraData>?
     var errorIndicatorView: _ChatMessageErrorIndicator<ExtraData>?
 
-    var threadReplyCountLabel: UILabel?
+    var threadReplyCountButton: UIButton?
     var threadAvatarView: ChatAvatarView?
     var threadArrowView: _SimpleChatMessageThreadArrowView<ExtraData>?
     
@@ -145,7 +145,9 @@ class MessageContentView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
                 threadAvatarView.widthAnchor.constraint(equalToConstant: 16)
             ]
             
-            threadInfoContainer.addArrangedSubview(createThreadReplyCountLabel())
+            let threadReplyCountButton = createThreadReplyCountButton()
+            threadReplyCountButton.addTarget(self, action: #selector(didTapOnThread), for: .touchUpInside)
+            threadInfoContainer.addArrangedSubview(threadReplyCountButton)
             
             if options.contains(.flipped) {
                 arrowView.direction = .toLeading
@@ -317,9 +319,9 @@ class MessageContentView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
 
         // Thread info
         if let replyCount = content?.replyCount {
-            threadReplyCountLabel?.text = L10n.Message.Threads.count(replyCount)
+            threadReplyCountButton?.setTitle(L10n.Message.Threads.count(replyCount), for: .normal)
         } else {
-            threadReplyCountLabel?.text = L10n.Message.Threads.reply
+            threadReplyCountButton?.setTitle(L10n.Message.Threads.reply, for: .normal)
         }
         let latestReplyAuthorAvatar = content?.latestReplies.first?.author.imageURL
         threadAvatarView?.imageView.loadImage(from: latestReplyAuthorAvatar)
@@ -407,16 +409,17 @@ private extension MessageContentView {
         return threadArrowView!
     }
     
-    func createThreadReplyCountLabel() -> UILabel {
-        if threadReplyCountLabel == nil {
-            let label = UILabel().withoutAutoresizingMaskConstraints
-            label.font = uiConfig.font.footnoteBold
-            label.adjustsFontForContentSizeCategory = true
-            label.text = L10n.Message.Threads.reply
-            label.textColor = tintColor
-            threadReplyCountLabel = label.withBidirectionalLanguagesSupport
+    func createThreadReplyCountButton() -> UIButton {
+        if threadReplyCountButton == nil {
+            let button = UIButton(type: .system)
+            button.setTitle(L10n.Message.Threads.reply, for: [])
+            button.setTitleColor(tintColor, for: .normal)
+            button.titleLabel?.font = uiConfig.font.footnoteBold
+            button.titleLabel?.adjustsFontForContentSizeCategory = true
+            button.titleLabel?.textAlignment = .natural
+            threadReplyCountButton = button
         }
-        return threadReplyCountLabel!
+        return threadReplyCountButton!
     }
 
     func createBubbleView() -> BubbleView<ExtraData> {

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -9,8 +9,6 @@ import UIKit
 class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionViewDelegate, UICollectionViewDataSource,
     UIConfigProvider {
     var channelController: _ChatChannelController<ExtraData>!
-
-    var minTimeIntervalBetweenMessagesInGroup: TimeInterval = 10
     
     /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
     public private(set) var needsToScrollToMostRecentMessage = true
@@ -56,8 +54,6 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
 
 //    public lazy var router = uiConfig.navigation.messageListRouter.init(rootViewController: self)
     public lazy var router = MessageListRouter(rootViewController: self)
-    
-    public private(set) lazy var layoutOptionsResolver = uiConfig.messageList.layoutOptionsResolver
     
     override func setUp() {
         super.setUp()
@@ -159,6 +155,10 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         MessageCell<ExtraData>.reuseId
     }
     
+    func cellLayoutOptionsForMessage(at indexPath: IndexPath) -> ChatMessageLayoutOptions {
+        uiConfig.messageList.layoutOptionsResolver(indexPath, AnyRandomAccessCollection(channelController.messages))
+    }
+    
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         channelController.messages.count
     }
@@ -166,12 +166,9 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let message = channelController.messages[indexPath.item]
         
-        let reuseId = cellReuseIdentifier(for: message)
-        let layoutOptions = layoutOptionsResolver(indexPath, Array(channelController.messages))
-        
         let cell: MessageCell<ExtraData> = self.collectionView.dequeueReusableCell(
-            withReuseIdentifier: reuseId,
-            layoutOptions: layoutOptions,
+            withReuseIdentifier: cellReuseIdentifier(for: message),
+            layoutOptions: cellLayoutOptionsForMessage(at: indexPath),
             for: indexPath
         )
 

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -267,6 +267,12 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
             },
             didTapOnThread: { [weak self] in
                 self?.handleTapOnThread(forCellAt: indexPath)
+//        guard let self = self, let channel = self.channelController.channel else { return }
+//
+//        let controller = MessageThreadVC<ExtraData>()
+//        controller.channelController = self.channelController
+//        controller.messageController = self.channelController.client.messageController(cid: channel.cid, messageId: message.id)
+//        self.navigationController?.show(controller, sender: self)
             },
             didTapOnAttachment: { [weak self] in
                 self?.handleTapOnAttachment($0, forCellAt: indexPath)

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -57,6 +57,8 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
 //    public lazy var router = uiConfig.navigation.messageListRouter.init(rootViewController: self)
     public lazy var router = MessageListRouter(rootViewController: self)
     
+    public private(set) lazy var layoutOptionsResolver = uiConfig.messageList.layoutOptionsResolver
+    
     override func setUp() {
         super.setUp()
         
@@ -167,80 +169,6 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         return delay > minTimeIntervalBetweenMessagesInGroup
     }
     
-    func cellLayoutOptionsForMessage(at indexPath: IndexPath) -> ChatMessageLayoutOptions {
-        let message = channelController.messages[indexPath.row]
-        let isLastInGroup = isMessageLastInGroup(at: indexPath)
-
-        var options: ChatMessageLayoutOptions = []
-
-        if message.isSentByCurrentUser {
-            options.insert(.flipped)
-        }
-        if !isLastInGroup {
-            options.insert(.continuousBubble)
-        }
-        if !isLastInGroup && !message.isSentByCurrentUser {
-            options.insert(.avatarSizePadding)
-        }
-        if isLastInGroup {
-            options.insert(.metadata)
-        }
-        if !message.textContent.isEmpty {
-            options.insert(.text)
-        }
-
-        guard message.deletedAt == nil else {
-            return options
-        }
-
-        if isLastInGroup && !message.isSentByCurrentUser {
-            options.insert(.avatar)
-        }
-        if message.quotedMessageId != nil {
-            options.insert(.quotedMessage)
-        }
-        if message.isPartOfThread {
-            options.insert(.threadInfo)
-            // The bubbles with thread look like continuous bubbles
-            options.insert(.continuousBubble)
-        }
-        if !message.reactionScores.isEmpty {
-            options.insert(.reactions)
-        }
-        if message.lastActionFailed {
-            options.insert(.error)
-        }
-
-        let attachmentOptions: ChatMessageLayoutOptions = message.attachments.reduce([]) { options, attachment in
-            if (attachment as? ChatMessageDefaultAttachment)?.actions.isEmpty == false {
-                return options.union(.actions)
-            }
-
-            switch attachment.type {
-            case .image:
-                return options.union(.photoPreview)
-            case .giphy:
-                return options.union(.giphy)
-            case .file:
-                return options.union(.filePreview)
-            case .link:
-                return options.union(.linkPreview)
-            default:
-                return options
-            }
-        }
-
-        if attachmentOptions.contains(.actions) {
-            options.insert(.actions)
-        } else if attachmentOptions.intersection([.photoPreview, .giphy, .filePreview]).isEmpty == false {
-            options.formUnion(attachmentOptions.subtracting(.linkPreview))
-        } else if attachmentOptions.contains(.linkPreview) {
-            options.insert(.linkPreview)
-        }
-
-        return options
-    }
-    
     func cellReuseIdentifier(for message: _ChatMessage<ExtraData>) -> String {
         MessageCell<ExtraData>.reuseId
     }
@@ -253,7 +181,8 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         let message = channelController.messages[indexPath.item]
         
         let reuseId = cellReuseIdentifier(for: message)
-        let layoutOptions = cellLayoutOptionsForMessage(at: indexPath)
+        let isLastInGroup = isMessageLastInGroup(at: indexPath)
+        let layoutOptions = layoutOptionsResolver(message, isLastInGroup)
         
         let cell: MessageCell<ExtraData> = self.collectionView.dequeueReusableCell(
             withReuseIdentifier: reuseId,

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -155,20 +155,6 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         keyboardObserver.unregister()
     }
     
-    func isMessageLastInGroup(at indexPath: IndexPath) -> Bool {
-        let message = channelController.messages[indexPath.row]
-
-        guard indexPath.row > 0 else { return true }
-
-        let nextMessage = channelController.messages[indexPath.row - 1]
-
-        guard nextMessage.author == message.author else { return true }
-
-        let delay = nextMessage.createdAt.timeIntervalSince(message.createdAt)
-
-        return delay > minTimeIntervalBetweenMessagesInGroup
-    }
-    
     func cellReuseIdentifier(for message: _ChatMessage<ExtraData>) -> String {
         MessageCell<ExtraData>.reuseId
     }
@@ -181,8 +167,7 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         let message = channelController.messages[indexPath.item]
         
         let reuseId = cellReuseIdentifier(for: message)
-        let isLastInGroup = isMessageLastInGroup(at: indexPath)
-        let layoutOptions = layoutOptionsResolver(message, isLastInGroup)
+        let layoutOptions = layoutOptionsResolver(indexPath, Array(channelController.messages))
         
         let cell: MessageCell<ExtraData> = self.collectionView.dequeueReusableCell(
             withReuseIdentifier: reuseId,

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -178,12 +178,6 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
             },
             didTapOnThread: { [weak self] in
                 self?.handleTapOnThread(forCellAt: indexPath)
-//        guard let self = self, let channel = self.channelController.channel else { return }
-//
-//        let controller = MessageThreadVC<ExtraData>()
-//        controller.channelController = self.channelController
-//        controller.messageController = self.channelController.client.messageController(cid: channel.cid, messageId: message.id)
-//        self.navigationController?.show(controller, sender: self)
             },
             didTapOnAttachment: { [weak self] in
                 self?.handleTapOnAttachment($0, forCellAt: indexPath)
@@ -392,7 +386,15 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
     }
 
     open func handleTapOnThread(forCellAt indexPath: IndexPath) {
-        didSelectMessageCell(at: indexPath)
+        guard let channel = channelController.channel else { return }
+        
+        let controller = MessageThreadVC<ExtraData>()
+        controller.channelController = channelController
+        controller.messageController = channelController.client.messageController(
+            cid: channel.cid,
+            messageId: channelController.messages[indexPath.item].id
+        )
+        navigationController?.show(controller, sender: self)
     }
 }
 

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -16,8 +16,10 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
     /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
     public private(set) var needsToScrollToMostRecentMessageAnimated = false
     
+    private lazy var messageListLayout = ChatMessageListCollectionViewLayout()
+    
     public private(set) lazy var collectionView: MessageCollectionView = {
-        let collection = MessageCollectionView(frame: .zero, collectionViewLayout: ChatMessageListCollectionViewLayout())
+        let collection = MessageCollectionView(frame: .zero, collectionViewLayout: messageListLayout)
 
         collection.isPrefetchingEnabled = false
         collection.showsHorizontalScrollIndicator = false
@@ -94,9 +96,10 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
                 withHorizontalFittingPriority: .required,
                 verticalFittingPriority: .defaultLow
             )
-            collectionView.contentInset = UIEdgeInsets(top: messageViewSize.height, left: 0, bottom: 0, right: 0)
+            let topInset = messageViewSize.height + messageListLayout.spacing
+            collectionView.contentInset = UIEdgeInsets(top: topInset, left: 0, bottom: 0, right: 0)
 
-            messageView.topAnchor.pin(equalTo: collectionView.topAnchor, constant: -messageViewSize.height).isActive = true
+            messageView.topAnchor.pin(equalTo: collectionView.topAnchor, constant: -topInset).isActive = true
             messageView.pin(anchors: [.leading, .trailing], to: collectionView.safeAreaLayoutGuide)
         }
 

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -73,6 +73,25 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
         
         messageComposerViewController.view.translatesAutoresizingMaskIntoConstraints = false
         addChildViewController(messageComposerViewController, targetView: view)
+        
+        if let message = messageController.message {
+            let messageView = MessageContentView<ExtraData>().withoutAutoresizingMaskConstraints
+            var layoutOptions = uiConfig.messageList.layoutOptionsResolver(
+                IndexPath(item: 0, section: 0),
+                AnyRandomAccessCollection([message])
+            )
+            layoutOptions.remove(.threadInfo)
+            
+            messageView.setUpLayoutIfNeeded(options: layoutOptions)
+
+            let messageViewSize = messageView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+            collectionView.contentInset = UIEdgeInsets(top: messageViewSize.height, left: 0, bottom: 0, right: 0)
+
+            collectionView.addSubview(messageView)
+            messageView.topAnchor.pin(equalTo: collectionView.topAnchor, constant: -messageViewSize.height).isActive = true
+            messageView.pin(anchors: [.leading, .trailing], to: collectionView.safeAreaLayoutGuide)
+            messageView.content = message
+        }
 
         messageComposerViewController.view.topAnchor.pin(equalTo: collectionView.bottomAnchor).isActive = true
         messageComposerViewController.view.leadingAnchor.pin(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
@@ -108,7 +127,9 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
         
         keyboardObserver.register()
         
-        scrollToMostRecentMessageIfNeeded()
+        if !messageController.replies.isEmpty {
+            scrollToMostRecentMessageIfNeeded()
+        }
     }
 
     override open func viewDidDisappear(_ animated: Bool) {

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -38,8 +38,6 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
     
     private var messageComposerBottomConstraint: NSLayoutConstraint?
     
-    private var timer: Timer?
-    
     private lazy var keyboardObserver = ChatMessageListKeyboardObserver(
         containerView: view,
         scrollView: collectionView,

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -66,6 +66,7 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
         channelController.synchronize()
         
         messageController.setDelegate(self)
+        messageController.synchronize()
     }
     
     override func setUpLayout() {

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -48,10 +48,6 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
     // Load from UIConfig
     public lazy var titleView = ChatMessageListTitleView<ExtraData>()
     
-    private lazy var messages: [_ChatMessage<ExtraData>] = {
-        messageController.replies + [messageController.message!]
-    }()
-    
     override func setUp() {
         super.setUp()
         
@@ -128,17 +124,20 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
     }
     
     func cellLayoutOptionsForMessage(at indexPath: IndexPath) -> ChatMessageLayoutOptions {
-        var layoutOptions = uiConfig.messageList.layoutOptionsResolver(indexPath, AnyRandomAccessCollection(messages))
+        var layoutOptions = uiConfig.messageList.layoutOptionsResolver(
+            indexPath,
+            AnyRandomAccessCollection(messageController.replies)
+        )
         layoutOptions.remove(.threadInfo)
         return layoutOptions
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        messages.count
+        messageController.replies.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let message = messages[indexPath.item]
+        let message = messageController.replies[indexPath.item]
         
         let cell: MessageCell<ExtraData> = self.collectionView.dequeueReusableCell(
             withReuseIdentifier: cellReuseIdentifier(for: message),
@@ -146,7 +145,7 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
             for: indexPath
         )
         
-        cell.content = message
+        cell.messageContentView.content = message
         
         return cell
     }
@@ -223,7 +222,5 @@ extension MessageThreadVC: _ChatMessageControllerDelegate {
         didChangeReplies changes: [ListChange<_ChatMessage<ExtraData>>]
     ) {
         updateMessages(with: changes)
-        LazyCachedMapCollection(source: messageController.replies + [messageController.message!], map: { $0 })
-        messages = messageController.replies + [messageController.message!]
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -83,14 +83,21 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
             layoutOptions.remove(.threadInfo)
             
             messageView.setUpLayoutIfNeeded(options: layoutOptions)
+            collectionView.addSubview(messageView)
+            messageView.content = message
 
-            let messageViewSize = messageView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+            let messageViewSize = messageView.systemLayoutSizeFitting(
+                CGSize(
+                    width: UIScreen.main.bounds.size.width,
+                    height: UIView.layoutFittingCompressedSize.height
+                ),
+                withHorizontalFittingPriority: .required,
+                verticalFittingPriority: .defaultLow
+            )
             collectionView.contentInset = UIEdgeInsets(top: messageViewSize.height, left: 0, bottom: 0, right: 0)
 
-            collectionView.addSubview(messageView)
             messageView.topAnchor.pin(equalTo: collectionView.topAnchor, constant: -messageViewSize.height).isActive = true
             messageView.pin(anchors: [.leading, .trailing], to: collectionView.safeAreaLayoutGuide)
-            messageView.content = message
         }
 
         messageComposerViewController.view.topAnchor.pin(equalTo: collectionView.bottomAnchor).isActive = true

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -1,0 +1,323 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamChat
+import UIKit
+
+class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionViewDelegate, UICollectionViewDataSource,
+    UIConfigProvider {
+    var channelController: _ChatChannelController<ExtraData>!
+    var messageController: _ChatMessageController<ExtraData>!
+
+    var minTimeIntervalBetweenMessagesInGroup: TimeInterval = 10
+    
+    /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
+    public private(set) var needsToScrollToMostRecentMessage = true
+    /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
+    public private(set) var needsToScrollToMostRecentMessageAnimated = false
+    
+    public private(set) lazy var collectionView: MessageCollectionView = {
+        let collection = MessageCollectionView(frame: .zero, collectionViewLayout: ChatMessageListCollectionViewLayout())
+
+        collection.isPrefetchingEnabled = false
+        collection.showsHorizontalScrollIndicator = false
+        collection.alwaysBounceVertical = true
+        collection.keyboardDismissMode = .onDrag
+        collection.dataSource = self
+        collection.delegate = self
+
+        return collection.withoutAutoresizingMaskConstraints
+    }()
+    
+    public private(set) lazy var messageComposerViewController = uiConfig
+        .messageComposer
+        .messageComposerViewController
+        .init()
+    
+    private var messageComposerBottomConstraint: NSLayoutConstraint?
+    
+    private var timer: Timer?
+    
+    private lazy var keyboardObserver = ChatMessageListKeyboardObserver(
+        containerView: view,
+        scrollView: collectionView,
+        composerBottomConstraint: messageComposerBottomConstraint
+    )
+
+    public lazy var userSuggestionSearchController: _ChatUserSearchController<ExtraData> = {
+        channelController.client.userSearchController()
+    }()
+    
+    // Load from UIConfig
+    public lazy var titleView = ChatMessageListTitleView<ExtraData>()
+    
+    override func setUp() {
+        super.setUp()
+        
+        messageComposerViewController.delegate = .wrap(self)
+        messageComposerViewController.controller = channelController
+        messageComposerViewController.userSuggestionSearchController = userSuggestionSearchController
+        messageComposerViewController.threadParentMessage = messageController.message
+
+        userSuggestionSearchController.search(term: nil)
+        
+        channelController.setDelegate(self)
+        channelController.synchronize()
+        
+        if channelController.channel?.isDirectMessageChannel == true {
+            timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+                self?.updateNavigationTitle()
+            }
+        }
+        
+        messageController.setDelegate(self)
+    }
+    
+    override func setUpLayout() {
+        super.setUpLayout()
+        
+        view.addSubview(collectionView)
+        collectionView.pin(anchors: [.top, .leading, .trailing], to: view.safeAreaLayoutGuide)
+        
+        messageComposerViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        addChildViewController(messageComposerViewController, targetView: view)
+
+        messageComposerViewController.view.topAnchor.pin(equalTo: collectionView.bottomAnchor).isActive = true
+        messageComposerViewController.view.leadingAnchor.pin(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
+        messageComposerViewController.view.trailingAnchor.pin(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+        messageComposerBottomConstraint = messageComposerViewController.view.bottomAnchor.pin(equalTo: view.bottomAnchor)
+        messageComposerBottomConstraint?.isActive = true
+    }
+    
+    override func defaultAppearance() {
+        super.defaultAppearance()
+        
+        view.backgroundColor = .white
+        
+        collectionView.backgroundColor = .white
+        
+        navigationItem.titleView = titleView
+    }
+    
+    private func updateNavigationTitle() {
+        let channelName = channelController.channel?.name ?? "love"
+        titleView.title = "Thread Reply"
+        titleView.subtitle = "with \(channelName)"
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        navigationItem.largeTitleDisplayMode = .never
+    }
+    
+    override open func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        keyboardObserver.register()
+        
+        scrollToMostRecentMessageIfNeeded()
+    }
+
+    override open func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        resignFirstResponder()
+        
+        keyboardObserver.unregister()
+    }
+    
+    func isMessageLastInGroup(at indexPath: IndexPath) -> Bool {
+        let message = channelController.messages[indexPath.row]
+
+        guard indexPath.row > 0 else { return true }
+
+        let nextMessage = channelController.messages[indexPath.row - 1]
+
+        guard nextMessage.author == message.author else { return true }
+
+        let delay = nextMessage.createdAt.timeIntervalSince(message.createdAt)
+
+        return delay > minTimeIntervalBetweenMessagesInGroup
+    }
+    
+    func cellLayoutOptionsForMessage(at indexPath: IndexPath) -> ChatMessageLayoutOptions {
+        let message = channelController.messages[indexPath.row]
+        let isLastInGroup = isMessageLastInGroup(at: indexPath)
+
+        var options: ChatMessageLayoutOptions = []
+
+        if message.isSentByCurrentUser {
+            options.insert(.flipped)
+        }
+        if !isLastInGroup {
+            options.insert(.continuousBubble)
+        }
+        if !isLastInGroup && !message.isSentByCurrentUser {
+            options.insert(.avatarSizePadding)
+        }
+        if isLastInGroup {
+            options.insert(.metadata)
+        }
+        if !message.textContent.isEmpty {
+            options.insert(.text)
+        }
+
+        guard message.deletedAt == nil else {
+            return options
+        }
+
+        if isLastInGroup && !message.isSentByCurrentUser {
+            options.insert(.avatar)
+        }
+        if message.quotedMessageId != nil {
+            options.insert(.quotedMessage)
+        }
+        if message.isPartOfThread {
+            options.insert(.threadInfo)
+            // The bubbles with thread look like continuous bubbles
+            options.insert(.continuousBubble)
+        }
+        if !message.reactionScores.isEmpty {
+            options.insert(.reactions)
+        }
+        if message.lastActionFailed {
+            options.insert(.error)
+        }
+
+        let attachmentOptions: ChatMessageLayoutOptions = message.attachments.reduce([]) { options, attachment in
+            if (attachment as? ChatMessageDefaultAttachment)?.actions.isEmpty == false {
+                return options.union(.actions)
+            }
+
+            switch attachment.type {
+            case .image:
+                return options.union(.photoPreview)
+            case .giphy:
+                return options.union(.giphy)
+            case .file:
+                return options.union(.filePreview)
+            case .link:
+                return options.union(.linkPreview)
+            default:
+                return options
+            }
+        }
+
+        if attachmentOptions.contains(.actions) {
+            options.insert(.actions)
+        } else if attachmentOptions.intersection([.photoPreview, .giphy, .filePreview]).isEmpty == false {
+            options.formUnion(attachmentOptions.subtracting(.linkPreview))
+        } else if attachmentOptions.contains(.linkPreview) {
+            options.insert(.linkPreview)
+        }
+
+        return options
+    }
+    
+    func cellReuseIdentifier(for message: _ChatMessage<ExtraData>) -> String {
+        MessageCell<ExtraData>.reuseId
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        messageController.replies.count + 1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let message: _ChatMessage<ExtraData> = {
+            if indexPath.item == messageController.replies.count {
+                return messageController.message!
+            }
+            return messageController.replies[indexPath.item]
+        }()
+        
+        let reuseId = cellReuseIdentifier(for: message)
+        let layoutOptions = cellLayoutOptionsForMessage(at: indexPath)
+        
+        let cell: MessageCell<ExtraData> = self.collectionView.dequeueReusableCell(
+            withReuseIdentifier: reuseId,
+            layoutOptions: layoutOptions,
+            for: indexPath
+        )
+        
+        cell.content = message
+        
+        return cell
+    }
+    
+    public func collectionView(
+        _ collectionView: UICollectionView,
+        willDisplay cell: UICollectionViewCell,
+        forItemAt indexPath: IndexPath
+    ) {
+        if indexPath.row + 1 >= collectionView.numberOfItems(inSection: 0) {
+            messageController.loadPreviousReplies()
+        }
+    }
+    
+    /// Will scroll to most recent message on next `updateMessages` call
+    public func setNeedsScrollToMostRecentMessage(animated: Bool = true) {
+        needsToScrollToMostRecentMessage = true
+        needsToScrollToMostRecentMessageAnimated = animated
+    }
+
+    /// Force scroll to most recent message check without waiting for `updateMessages`
+    public func scrollToMostRecentMessageIfNeeded() {
+        guard needsToScrollToMostRecentMessage else { return }
+        
+        scrollToMostRecentMessage(animated: needsToScrollToMostRecentMessageAnimated)
+    }
+
+    public func scrollToMostRecentMessage(animated: Bool = true) {
+        needsToScrollToMostRecentMessage = false
+
+        // our collection is flipped, so (0; 0) item is most recent one
+        collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: animated)
+    }
+
+    public func updateMessages(with changes: [ListChange<_ChatMessage<ExtraData>>], completion: ((Bool) -> Void)? = nil) {
+        collectionView.performBatchUpdates {
+            for change in changes {
+                switch change {
+                case let .insert(_, index):
+                    collectionView.insertItems(at: [index])
+                case let .move(_, fromIndex, toIndex):
+                    collectionView.moveItem(at: fromIndex, to: toIndex)
+                case let .remove(_, index):
+                    collectionView.deleteItems(at: [index])
+                case let .update(_, index):
+                    collectionView.reloadItems(at: [index])
+                }
+            }
+        } completion: { flag in
+            completion?(flag)
+            self.scrollToMostRecentMessageIfNeeded()
+        }
+    }
+}
+
+extension MessageThreadVC: _ChatMessageComposerViewControllerDelegate {
+    public func messageComposerViewControllerDidSendMessage(_ vc: _ChatMessageComposerVC<ExtraData>) {
+        setNeedsScrollToMostRecentMessage()
+    }
+}
+
+extension MessageThreadVC: _ChatChannelControllerDelegate {
+    func channelController(
+        _ channelController: _ChatChannelController<ExtraData>,
+        didUpdateChannel channel: EntityChange<_ChatChannel<ExtraData>>
+    ) {
+        updateNavigationTitle()
+    }
+}
+
+extension MessageThreadVC: _ChatMessageControllerDelegate {
+    func messageController(
+        _ controller: _ChatMessageController<ExtraData>,
+        didChangeReplies changes: [ListChange<_ChatMessage<ExtraData>>]
+    ) {
+        updateMessages(with: changes)
+    }
+}

--- a/Sources/StreamChatUI/UIConfig+MessageList.swift
+++ b/Sources/StreamChatUI/UIConfig+MessageList.swift
@@ -19,7 +19,7 @@ public extension _UIConfig {
         public var messageContentSubviews = MessageContentViewSubviews()
         public var messageActionsSubviews = MessageActionsSubviews()
         public var messageReactions = MessageReactions()
-        public var layoutOptionsResolver: _LayoutOptionsResolver<ExtraData> = DefaultLayoutOptionsResolver()
+        public var layoutOptionsResolver: MessageLayoutOptionsResolver<ExtraData> = DefaultMessageLayoutOptionsResolver()
     }
 
     struct MessageActionsSubviews {

--- a/Sources/StreamChatUI/UIConfig+MessageList.swift
+++ b/Sources/StreamChatUI/UIConfig+MessageList.swift
@@ -19,6 +19,7 @@ public extension _UIConfig {
         public var messageContentSubviews = MessageContentViewSubviews()
         public var messageActionsSubviews = MessageActionsSubviews()
         public var messageReactions = MessageReactions()
+        public var layoutOptionsResolver: _LayoutOptionsResolver<ExtraData> = DefaultLayoutOptionsResolver()
     }
 
     struct MessageActionsSubviews {

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -683,6 +683,7 @@
 		8AE8950D24D8660800E852EC /* PingPongEmojiFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */; };
 		A35757C72613081B00DC914C /* ChatMessageListKeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35757C62613081B00DC914C /* ChatMessageListKeyboardObserver.swift */; };
 		A35757D12613082B00DC914C /* ChatMessageListTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35757D02613082B00DC914C /* ChatMessageListTitleView.swift */; };
+		A37DD35526244E1D006C16B3 /* MessageThreadVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37DD35426244E1D006C16B3 /* MessageThreadVC.swift */; };
 		A3BB3FFF261DA74D00365496 /* ContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BB3FFE261DA74D00365496 /* ContainerView.swift */; };
 		A3C0D774261CA25700A8A1A2 /* ContainerView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C0D773261CA25700A8A1A2 /* ContainerView_Tests.swift */; };
 		AD0169CB25CAEDC0009EBAD2 /* yoda.jpg in Resources */ = {isa = PBXBuildFile; fileRef = AD0169CA25CAEDC0009EBAD2 /* yoda.jpg */; };
@@ -1815,6 +1816,7 @@
 		8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingPongEmojiFormatter.swift; sourceTree = "<group>"; };
 		A35757C62613081B00DC914C /* ChatMessageListKeyboardObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageListKeyboardObserver.swift; sourceTree = "<group>"; };
 		A35757D02613082B00DC914C /* ChatMessageListTitleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageListTitleView.swift; sourceTree = "<group>"; };
+		A37DD35426244E1D006C16B3 /* MessageThreadVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageThreadVC.swift; sourceTree = "<group>"; };
 		A3BB3FFE261DA74D00365496 /* ContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerView.swift; sourceTree = "<group>"; };
 		A3C0D773261CA25700A8A1A2 /* ContainerView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerView_Tests.swift; sourceTree = "<group>"; };
 		AD0169CA25CAEDC0009EBAD2 /* yoda.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = yoda.jpg; sourceTree = "<group>"; };
@@ -2726,6 +2728,7 @@
 			isa = PBXGroup;
 			children = (
 				79776F55261DB96F00C96A98 /* MessageListVC.swift */,
+				A37DD35426244E1D006C16B3 /* MessageThreadVC.swift */,
 				79776F67261DB97C00C96A98 /* MessageCollectionView.swift */,
 				79776F71261DB98500C96A98 /* MessageContentView.swift */,
 				F6D7407326259E3300153E6E /* MessageCell.swift */,
@@ -4876,6 +4879,7 @@
 				DB70CFFB25702EB900DDF436 /* ChatMessagePopupVC.swift in Sources */,
 				7844B14E25EF9F5700B87E89 /* ChatChannelAvatarView+SwiftUI.swift in Sources */,
 				ADB22F7D25F1626200853C92 /* ChatPresenceAvatarView.swift in Sources */,
+				A37DD35526244E1D006C16B3 /* MessageThreadVC.swift in Sources */,
 				2245B2B625602465006A612D /* ChatChannelAvatarView.swift in Sources */,
 				88EF29FF2571288600B06EF1 /* Array+Extensions.swift in Sources */,
 				A35757C72613081B00DC914C /* ChatMessageListKeyboardObserver.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -684,6 +684,7 @@
 		A35757C72613081B00DC914C /* ChatMessageListKeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35757C62613081B00DC914C /* ChatMessageListKeyboardObserver.swift */; };
 		A35757D12613082B00DC914C /* ChatMessageListTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35757D02613082B00DC914C /* ChatMessageListTitleView.swift */; };
 		A37DD35526244E1D006C16B3 /* MessageThreadVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37DD35426244E1D006C16B3 /* MessageThreadVC.swift */; };
+		A37DD35F2624844B006C16B3 /* DefaultMessageLayoutOptionsResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37DD35E2624844B006C16B3 /* DefaultMessageLayoutOptionsResolver.swift */; };
 		A3BB3FFF261DA74D00365496 /* ContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BB3FFE261DA74D00365496 /* ContainerView.swift */; };
 		A3C0D774261CA25700A8A1A2 /* ContainerView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C0D773261CA25700A8A1A2 /* ContainerView_Tests.swift */; };
 		AD0169CB25CAEDC0009EBAD2 /* yoda.jpg in Resources */ = {isa = PBXBuildFile; fileRef = AD0169CA25CAEDC0009EBAD2 /* yoda.jpg */; };
@@ -1817,6 +1818,7 @@
 		A35757C62613081B00DC914C /* ChatMessageListKeyboardObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageListKeyboardObserver.swift; sourceTree = "<group>"; };
 		A35757D02613082B00DC914C /* ChatMessageListTitleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageListTitleView.swift; sourceTree = "<group>"; };
 		A37DD35426244E1D006C16B3 /* MessageThreadVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageThreadVC.swift; sourceTree = "<group>"; };
+		A37DD35E2624844B006C16B3 /* DefaultMessageLayoutOptionsResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMessageLayoutOptionsResolver.swift; sourceTree = "<group>"; };
 		A3BB3FFE261DA74D00365496 /* ContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerView.swift; sourceTree = "<group>"; };
 		A3C0D773261CA25700A8A1A2 /* ContainerView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerView_Tests.swift; sourceTree = "<group>"; };
 		AD0169CA25CAEDC0009EBAD2 /* yoda.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = yoda.jpg; sourceTree = "<group>"; };
@@ -2733,6 +2735,7 @@
 				79776F71261DB98500C96A98 /* MessageContentView.swift */,
 				F6D7407326259E3300153E6E /* MessageCell.swift */,
 				88D95129261DE56100509896 /* BubbleView.swift */,
+				A37DD35E2624844B006C16B3 /* DefaultMessageLayoutOptionsResolver.swift */,
 			);
 			path = RETHINK;
 			sourceTree = "<group>";
@@ -4828,6 +4831,7 @@
 				79776F72261DB98500C96A98 /* MessageContentView.swift in Sources */,
 				8850FE87256558A200C8D534 /* ChatChannelListRouter.swift in Sources */,
 				888ABA072594FDE30015937E /* ChatMessageInteractiveAttachmentView.swift in Sources */,
+				A37DD35F2624844B006C16B3 /* DefaultMessageLayoutOptionsResolver.swift in Sources */,
 				88BD82B02549D18F00369074 /* ChatChannelListItemView.swift in Sources */,
 				8825334C258CE82500B77352 /* ChatMessageActionsRouter.swift in Sources */,
 				DB9A3D662582783F00555D36 /* ChatVC.swift in Sources */,


### PR DESCRIPTION
# Description

This PR creates detail of thread.

* Message cell now contains thread reply button to display the detail
* Messages in ThreadVC don't contain `threadInfo` layout option
* Only replies are used in ThreadVC as dataSource. Parent message is inserted as a subview to the collectionView and its content has inset equal to the parent message height + spacing