### PR TITLE
[CIS-792] Make models thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- It's safe now to use `ChatChannel` and `ChatMessage` across multiple threads [#984](https://github.com/GetStream/stream-chat-swift/pull/984)
 
 # [3.1.5](https://github.com/GetStream/stream-chat-swift/releases/tag/3.1.5)
 _April 09, 2021_

--- a/Package.swift
+++ b/Package.swift
@@ -127,6 +127,7 @@ var streamChatSourcesExcluded: [String] { [
     "Utils/MulticastDelegate_Tests.swift",
     "Utils/InternetConnection/InternetConnection_Tests.swift",
     "Utils/Atomic_Tests.swift",
+    "Utils/CoreDataLazy_Tests.swift",
     "Utils/LazyCachedMapCollection_Tests.swift",
     "Utils/Dictionary_Tests.swift",
     "Utils/Cached_Tests.swift",

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController+Combine_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController+Combine_Tests.swift
@@ -58,7 +58,7 @@ class ChannelController_Combine_Tests: iOS13TestCase {
         weak var controller: ChannelControllerMock? = channelController
         channelController = nil
 
-        let newChannel: ChatChannel = .init(cid: .unique, name: .unique, imageURL: .unique(), extraData: .defaultValue)
+        let newChannel: ChatChannel = .mock(cid: .unique, name: .unique, imageURL: .unique(), extraData: .defaultValue)
         controller?.channel_simulated = newChannel
         controller?.delegateCallback {
             $0.channelController(controller!, didUpdateChannel: .create(newChannel))

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -176,7 +176,8 @@ extension _ChatMessage {
             latestReactions: { [] },
             currentUserReactions: { [] },
             isSentByCurrentUser: false,
-            pinDetails: nil
+            pinDetails: nil,
+            underlyingContext: nil
         )
     }
 }

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -22,7 +22,7 @@ class ChannelController_SwiftUI_Tests: iOS13TestCase {
     
     func test_controllerInitialValuesAreLoaded() {
         channelController.state_simulated = .localDataFetched
-        channelController.channel_simulated = .init(cid: .unique, name: .unique, imageURL: .unique(), extraData: .defaultValue)
+        channelController.channel_simulated = .mock(cid: .unique, name: .unique, imageURL: .unique(), extraData: .defaultValue)
         channelController.messages_simulated = [.unique]
         
         let observableObject = channelController.observableObject
@@ -36,7 +36,7 @@ class ChannelController_SwiftUI_Tests: iOS13TestCase {
         let observableObject = channelController.observableObject
         
         // Simulate channel change
-        let newChannel: ChatChannel = .init(cid: .unique, name: .unique, imageURL: .unique(), extraData: .defaultValue)
+        let newChannel: ChatChannel = .mock(cid: .unique, name: .unique, imageURL: .unique(), extraData: .defaultValue)
         channelController.channel_simulated = newChannel
         channelController.delegateCallback {
             $0.channelController(

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController+Combine_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController+Combine_Tests.swift
@@ -58,7 +58,7 @@ class ChannelListController_Combine_Tests: iOS13TestCase {
         weak var controller: ChannelListControllerMock? = channelListController
         channelListController = nil
 
-        let newChannel: ChatChannel = .init(cid: .unique, name: .unique, imageURL: .unique(), extraData: .defaultValue)
+        let newChannel: ChatChannel = .mock(cid: .unique, name: .unique, imageURL: .unique(), extraData: .defaultValue)
         controller?.channels_simulated = [newChannel]
         controller?.delegateCallback {
             $0.controller(controller!, didChangeChannels: [.insert(newChannel, index: [0, 1])])

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController+SwiftUI_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController+SwiftUI_Tests.swift
@@ -22,7 +22,7 @@ class ChannelListController_SwiftUI_Tests: iOS13TestCase {
     func test_controllerInitialValuesAreLoaded() {
         channelListController.state_simulated = .localDataFetched
         channelListController
-            .channels_simulated = [.init(cid: .unique, name: .unique, imageURL: .unique(), extraData: .defaultValue)]
+            .channels_simulated = [.mock(cid: .unique, name: .unique, imageURL: .unique(), extraData: .defaultValue)]
         
         let observableObject = channelListController.observableObject
         
@@ -34,7 +34,7 @@ class ChannelListController_SwiftUI_Tests: iOS13TestCase {
         let observableObject = channelListController.observableObject
         
         // Simulate channel change
-        let newChannel: ChatChannel = .init(cid: .unique, name: .unique, imageURL: .unique(), extraData: .defaultValue)
+        let newChannel: ChatChannel = .mock(cid: .unique, name: .unique, imageURL: .unique(), extraData: .defaultValue)
         channelListController.channels_simulated = [newChannel]
         channelListController.delegateCallback {
             $0.controller(

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -338,7 +338,8 @@ extension _ChatChannel {
             extraData: extraData,
             //            invitedMembers: [],
             latestMessages: { fetchMessages() },
-            pinnedMessages: { dto.pinnedMessages.map { $0.asModel() } }
+            pinnedMessages: { dto.pinnedMessages.map { $0.asModel() } },
+            underlyingContext: dto.managedObjectContext
         )
     }
 }

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -500,24 +500,24 @@ private extension _ChatMessage {
             isSentByCurrentUser = currentUser.user.id == dto.user.id
             
             if dto.reactions.isEmpty {
-                $_currentUserReactions = { [] }
+                $_currentUserReactions = ({ [] }, nil)
             } else {
-                $_currentUserReactions = {
+                $_currentUserReactions = ({
                     Set(
                         MessageReactionDTO
                             .loadReactions(for: dto.id, authoredBy: currentUser.user.id, context: context)
                             .map { $0.asModel() }
                     )
-                }
+                }, dto.managedObjectContext)
             }
         } else {
             isSentByCurrentUser = false
-            $_currentUserReactions = { [] }
+            $_currentUserReactions = ({ [] }, nil)
         }
         
-        $_mentionedUsers = { Set(dto.mentionedUsers.map { $0.asModel() }) }
-        $_author = { dto.user.asModel() }
-        $_attachments = {
+        $_mentionedUsers = ({ Set(dto.mentionedUsers.map { $0.asModel() }) }, dto.managedObjectContext)
+        $_author = ({ dto.user.asModel() }, dto.managedObjectContext)
+        $_attachments = ({
             dto.attachments
                 .map { $0.asModel() }
                 .sorted {
@@ -525,28 +525,28 @@ private extension _ChatMessage {
                     let index2 = $1.id?.index ?? Int.max
                     return index1 < index2
                 }
-        }
+        }, dto.managedObjectContext)
         
         if dto.replies.isEmpty {
-            $_latestReplies = { [] }
+            $_latestReplies = ({ [] }, nil)
         } else {
-            $_latestReplies = {
+            $_latestReplies = ({
                 MessageDTO
                     .loadReplies(for: dto.id, limit: 5, context: context)
                     .map(_ChatMessage.init)
-            }
+            }, dto.managedObjectContext)
         }
         
         if dto.reactions.isEmpty {
-            $_latestReactions = { [] }
+            $_latestReactions = ({ [] }, nil)
         } else {
-            $_latestReactions = {
+            $_latestReactions = ({
                 Set(
                     MessageReactionDTO
                         .loadLatestReactions(for: dto.id, limit: 5, context: context)
                         .map { $0.asModel() }
                 )
-            }
+            }, dto.managedObjectContext)
         }
     }
 }

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -2,6 +2,7 @@
 // Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
+import CoreData
 import Foundation
 
 /// A type representing a chat channel. `ChatChannel` is an immutable snapshot of a channel entity at the given time.
@@ -68,7 +69,7 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
     /// - Note: This property will contain no more than `ChatClientConfig.channel.lastActiveMembersLimit` members.
     ///
     public var lastActiveMembers: [_ChatChannelMember<ExtraData.User>] { _lastActiveMembers }
-    @Cached private var _lastActiveMembers: [_ChatChannelMember<ExtraData.User>]
+    @CoreDataLazy private var _lastActiveMembers: [_ChatChannelMember<ExtraData.User>]
     
     /// A list of currently typing channel members.
     public let currentlyTypingMembers: Set<_ChatChannelMember<ExtraData.User>>
@@ -86,7 +87,7 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
     /// - Note: This property will contain no more than `ChatClientConfig.channel.lastActiveWatchersLimit` members.
     ///
     public var lastActiveWatchers: [_ChatUser<ExtraData.User>] { _lastActiveWatchers }
-    @Cached private var _lastActiveWatchers: [_ChatUser<ExtraData.User>]
+    @CoreDataLazy private var _lastActiveWatchers: [_ChatUser<ExtraData.User>]
 
     /// The total number of online members watching this channel.
     public let watcherCount: Int
@@ -100,7 +101,7 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
     
     /// The unread counts for the channel.
     public var unreadCount: ChannelUnreadCount { _unreadCount }
-    @Cached private var _unreadCount: ChannelUnreadCount
+    @CoreDataLazy private var _unreadCount: ChannelUnreadCount
     
     /// An option to enable ban users.
 //    public let banEnabling: BanEnabling
@@ -112,7 +113,7 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
     ///
     /// - Important: The `latestMessages` property is loaded and evaluated lazily to maintain high performance.
     public var latestMessages: [_ChatMessage<ExtraData>] { _latestMessages }
-    @Cached private var _latestMessages: [_ChatMessage<ExtraData>]
+    @CoreDataLazy private var _latestMessages: [_ChatMessage<ExtraData>]
     
     /// Pinned messages present on the channel.
     ///
@@ -121,7 +122,7 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
     ///
     /// - Important: The `pinnedMessages` property is loaded and evaluated lazily to maintain high performance.
     public var pinnedMessages: [_ChatMessage<ExtraData>] { _pinnedMessages }
-    @Cached private var _pinnedMessages: [_ChatMessage<ExtraData>]
+    @CoreDataLazy private var _pinnedMessages: [_ChatMessage<ExtraData>]
     
     /// Read states of the users for this channel.
     ///
@@ -174,7 +175,8 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
         extraData: ExtraData.Channel,
 //        invitedMembers: Set<_ChatChannelMember<ExtraData.User>> = [],
         latestMessages: @escaping (() -> [_ChatMessage<ExtraData>]) = { [] },
-        pinnedMessages: @escaping (() -> [_ChatMessage<ExtraData>]) = { [] }
+        pinnedMessages: @escaping (() -> [_ChatMessage<ExtraData>]) = { [] },
+        underlyingContext: NSManagedObjectContext?
     ) {
         self.cid = cid
         self.name = name
@@ -197,11 +199,11 @@ public struct _ChatChannel<ExtraData: ExtraDataTypes> {
         self.extraData = extraData
 //        self.invitedMembers = invitedMembers
         
-        $_unreadCount = unreadCount
-        $_latestMessages = latestMessages
-        $_lastActiveMembers = lastActiveMembers
-        $_lastActiveWatchers = lastActiveWatchers
-        $_pinnedMessages = pinnedMessages
+        $_unreadCount = (unreadCount, underlyingContext)
+        $_latestMessages = (latestMessages, underlyingContext)
+        $_lastActiveMembers = (lastActiveMembers, underlyingContext)
+        $_lastActiveWatchers = (lastActiveWatchers, underlyingContext)
+        $_pinnedMessages = (pinnedMessages, underlyingContext)
     }
 }
 

--- a/Sources/StreamChat/Models/Message.swift
+++ b/Sources/StreamChat/Models/Message.swift
@@ -2,6 +2,7 @@
 // Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
+import CoreData
 import Foundation
 
 /// A unique identifier of a message.
@@ -88,14 +89,14 @@ public struct _ChatMessage<ExtraData: ExtraDataTypes> {
     /// - Important: The `author` property is loaded and evaluated lazily to maintain high performance.
     public var author: _ChatUser<ExtraData.User> { _author }
     
-    @Cached internal var _author: _ChatUser<ExtraData.User>
+    @CoreDataLazy internal var _author: _ChatUser<ExtraData.User>
     
     /// A list of users that are mentioned in this message.
     ///
     /// - Important: The `mentionedUsers` property is loaded and evaluated lazily to maintain high performance.
     public var mentionedUsers: Set<_ChatUser<ExtraData.User>> { _mentionedUsers }
     
-    @Cached internal var _mentionedUsers: Set<_ChatUser<ExtraData.User>>
+    @CoreDataLazy internal var _mentionedUsers: Set<_ChatUser<ExtraData.User>>
 
     /// A list of users that participated in this message thread
     public let threadParticipants: Set<UserId>
@@ -105,14 +106,14 @@ public struct _ChatMessage<ExtraData: ExtraDataTypes> {
     /// - Important: The `attachments` property is loaded and evaluated lazily to maintain high performance.
     public var attachments: [ChatMessageAttachment] { _attachments }
     
-    @Cached internal var _attachments: [ChatMessageAttachment]
+    @CoreDataLazy internal var _attachments: [ChatMessageAttachment]
         
     /// A list of latest 25 replies to this message.
     ///
     /// - Important: The `latestReplies` property is loaded and evaluated lazily to maintain high performance.
     public var latestReplies: [_ChatMessage<ExtraData>] { _latestReplies }
     
-    @Cached internal var _latestReplies: [_ChatMessage<ExtraData>]
+    @CoreDataLazy internal var _latestReplies: [_ChatMessage<ExtraData>]
     
     /// A possible additional local state of the message. Applies only for the messages of the current user.
     ///
@@ -133,14 +134,14 @@ public struct _ChatMessage<ExtraData: ExtraDataTypes> {
     /// - Important: The `latestReactions` property is loaded and evaluated lazily to maintain high performance.
     public var latestReactions: Set<_ChatMessageReaction<ExtraData>> { _latestReactions }
     
-    @Cached internal var _latestReactions: Set<_ChatMessageReaction<ExtraData>>
+    @CoreDataLazy internal var _latestReactions: Set<_ChatMessageReaction<ExtraData>>
     
     /// The entire list of reactions to the message left by the current user.
     ///
     /// - Important: The `currentUserReactions` property is loaded and evaluated lazily to maintain high performance.
     public var currentUserReactions: Set<_ChatMessageReaction<ExtraData>> { _currentUserReactions }
     
-    @Cached internal var _currentUserReactions: Set<_ChatMessageReaction<ExtraData>>
+    @CoreDataLazy internal var _currentUserReactions: Set<_ChatMessageReaction<ExtraData>>
     
     /// `true` if the author of the message is the currently logged-in user.
     public let isSentByCurrentUser: Bool
@@ -175,7 +176,8 @@ public struct _ChatMessage<ExtraData: ExtraDataTypes> {
         latestReactions: @escaping () -> Set<_ChatMessageReaction<ExtraData>>,
         currentUserReactions: @escaping () -> Set<_ChatMessageReaction<ExtraData>>,
         isSentByCurrentUser: Bool,
-        pinDetails: _MessagePinDetails<ExtraData>?
+        pinDetails: _MessagePinDetails<ExtraData>?,
+        underlyingContext: NSManagedObjectContext?
     ) {
         self.id = id
         self.text = text
@@ -199,12 +201,12 @@ public struct _ChatMessage<ExtraData: ExtraDataTypes> {
         self.isSentByCurrentUser = isSentByCurrentUser
         self.pinDetails = pinDetails
         
-        self.$_author = author
-        self.$_mentionedUsers = mentionedUsers
-        self.$_attachments = attachments
-        self.$_latestReplies = latestReplies
-        self.$_latestReactions = latestReactions
-        self.$_currentUserReactions = currentUserReactions
+        self.$_author = (author, underlyingContext)
+        self.$_mentionedUsers = (mentionedUsers, underlyingContext)
+        self.$_attachments = (attachments, underlyingContext)
+        self.$_latestReplies = (latestReplies, underlyingContext)
+        self.$_latestReactions = (latestReactions, underlyingContext)
+        self.$_currentUserReactions = (currentUserReactions, underlyingContext)
     }
 }
 

--- a/Sources/StreamChat/Utils/CoreDataLazy.swift
+++ b/Sources/StreamChat/Utils/CoreDataLazy.swift
@@ -1,0 +1,65 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+/// Makes it possible to lazily evaluate properties of `NSManagedObject`s.
+///
+/// Works like a "classic" lazy wrapper. The only different is that the `computeValue` closure is evaluated on the queue
+/// of the provided `NSManagedObjectContext`.
+///
+@propertyWrapper
+class CoreDataLazy<T> {
+    /// When the cached value is reset, this closure is used to lazily get a new value which is then cached again.
+    var computeValue: (() -> T)!
+    
+    /// The context on whose queue is the `computeValue` closure evaluated.
+    weak var context: NSManagedObjectContext?
+    
+    var wrappedValue: T {
+        var returnValue: T!
+
+        // We need to make the changes inside the `mutate` block to ensure the wrapper is thread-safe.
+        __cached.mutate { value in
+            
+            if let value = value {
+                returnValue = value
+                return
+            }
+
+            let perform = {
+                log.assert(self.computeValue != nil, "You must set the `computeValue` closure before accessing the cached value.")
+                returnValue = self.computeValue()
+            }
+            
+            if let context = context {
+                context.performAndWait { perform() }
+            } else {
+                // This is a fallback for cases like tests, mocks, and other cases where it's known `computeValue` doesn't need to
+                // evaluated using `context.performAndWait {}`.
+                perform()
+            }
+            
+            value = returnValue
+        }
+        
+        return returnValue
+    }
+    
+    /// A tuple container the closure which evaluates the lazy value, and the managed object context on which the closure should be performed.
+    var projectedValue: (() -> T, NSManagedObjectContext?) {
+        get {
+            log.assert(computeValue != nil, "You must set the `computeValue` closure before accessing it.")
+            return (computeValue, context)
+        }
+        set {
+            computeValue = newValue.0
+            context = newValue.1
+        }
+    }
+    
+    /// The previously evaluated value. `nil` if the wrapper hasn't been evaluated yet.
+    @Atomic private var _cached: T?
+}

--- a/Sources/StreamChat/Utils/CoreDataLazy_Tests.swift
+++ b/Sources/StreamChat/Utils/CoreDataLazy_Tests.swift
@@ -1,0 +1,117 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+class CoreDataLazy_Tests: StressTestCase {
+    @CoreDataLazy var value: Int
+    
+    var database: DatabaseContainerMock!
+    
+    override func setUp() {
+        super.setUp()
+        
+        database = DatabaseContainerMock()
+    }
+    
+    override func tearDown() {
+        AssertAsync.canBeReleased(&database)
+        super.tearDown()
+    }
+    
+    func test_theValueIsCached() {
+        var counter = 0
+        
+        let result = Int.random(in: Int.min...Int.max)
+        
+        // Every time the lazy closure is accessed it increases the counter
+        $value = ({
+            counter += 1
+            return result
+        }, nil)
+        
+        // Assert the value hasn't been evaluated yet
+        XCTAssertEqual(counter, 0)
+        
+        // Evaluate the value and check the result is correct a couple of times
+        XCTAssertEqual(value, result)
+        XCTAssertEqual(value, result)
+        XCTAssertEqual(value, result)
+        XCTAssertEqual(value, result)
+        
+        // Assert the value was evaluated just once
+        XCTAssertEqual(counter, 1)
+    }
+    
+    func test_theClosureIsEvaluatedOnTheContextQueue() {
+        class SpyContext: NSManagedObjectContext {
+            @Atomic var isRunningInsidePerformAndWaitBlock: Bool = false
+            override func performAndWait(_ block: () -> Void) {
+                isRunningInsidePerformAndWaitBlock = true
+                block()
+                isRunningInsidePerformAndWaitBlock = false
+            }
+        }
+        
+        var context: SpyContext! = SpyContext(concurrencyType: .privateQueueConcurrencyType)
+        let result = Int.random(in: Int.min...Int.max)
+        
+        // Every time the lazy closure is accessed it increases the counter
+        $value = ({
+            XCTAssertTrue(context.isRunningInsidePerformAndWaitBlock)
+            return result
+        }, context)
+        
+        // Evaluate the value
+        XCTAssertEqual(value, result)
+        AssertAsync.canBeReleased(&context)
+    }
+    
+    func test_behavesCorrectly_whenAccessedFromMultipleThreads() throws {
+        // This has to be tested on some more complex object, so we use `ChannelDTO`.
+        
+        // Create a channel in the DB
+        let cid = ChannelId.unique
+        try database.createChannel(cid: cid, withMessages: true)
+        
+        // Get the DTO for the channel from the background context
+        let channelDTO = database.backgroundReadOnlyContext.channel(cid: cid)!
+        
+        // Read and write randomly to the DB and test it doesn't crash
+        let group = DispatchGroup()
+        for _ in 0...100 {
+            group.enter()
+            DispatchQueue.random.async {
+                self.database.write { session in
+                    // This completely replaces the existing channel data with new data
+                    try session.saveChannel(payload: XCTestCase().dummyPayload(with: cid))
+                    group.enter()
+                
+                    DispatchQueue.random.async {
+                        // Serialize the DTO into a new model. This needs to be done on the valid queue for the DTO.
+                        var channel: ChatChannel!
+                        self.database.backgroundReadOnlyContext.performAndWait {
+                            channel = channelDTO.asModel()
+                        }
+                        
+                        // Access some lazy properties. This should be already thread safe.
+                        _ = channel.lastActiveMembers.randomElement()
+                        _ = channel.lastActiveWatchers.randomElement()
+                        _ = channel.latestMessages.randomElement()?.latestReactions.randomElement()
+                        
+                        group.leave()
+                    }
+
+                } completion: { error in
+                    XCTAssertNil(error)
+                    group.leave()
+                }
+            }
+        }
+        group.wait()
+    }
+}

--- a/Sources/StreamChatTestTools/Models/ChatChannel_Mock.swift
+++ b/Sources/StreamChatTestTools/Models/ChatChannel_Mock.swift
@@ -101,7 +101,8 @@ public extension _ChatChannel {
             memberCount: memberCount,
             reads: reads,
             extraData: extraData,
-            latestMessages: { latestMessages }
+            latestMessages: { latestMessages },
+            underlyingContext: nil
         )
     }
     
@@ -145,7 +146,8 @@ public extension _ChatChannel {
             memberCount: memberCount,
             reads: reads,
             extraData: extraData,
-            latestMessages: { latestMessages }
+            latestMessages: { latestMessages },
+            underlyingContext: nil
         )
     }
 }

--- a/Sources/StreamChatTestTools/Models/ChatMessage_Mock.swift
+++ b/Sources/StreamChatTestTools/Models/ChatMessage_Mock.swift
@@ -63,7 +63,8 @@ public extension _ChatMessage {
             latestReactions: { latestReactions },
             currentUserReactions: { currentUserReactions },
             isSentByCurrentUser: isSentByCurrentUser,
-            pinDetails: pinDetails
+            pinDetails: pinDetails,
+            underlyingContext: nil
         )
     }
 }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -291,6 +291,8 @@
 		79A0E9BE2498C33100E9BD50 /* TypingEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9BD2498C33100E9BD50 /* TypingEvent.swift */; };
 		79A4AE112536EE5500C32A74 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = 79A4AE102536EE5500C32A74 /* Starscream */; };
 		79A9EAC3262045DC00F2A72D /* MessageRead+MissingUnreadCount.json in Resources */ = {isa = PBXBuildFile; fileRef = 79A9EAC2262045DC00F2A72D /* MessageRead+MissingUnreadCount.json */; };
+		79A9EB4D2625793000F2A72D /* CoreDataLazy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9EB4C2625793000F2A72D /* CoreDataLazy.swift */; };
+		79A9EB572625798000F2A72D /* CoreDataLazy_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9EB562625798000F2A72D /* CoreDataLazy_Tests.swift */; };
 		79B4F0E625D305D40063FFB5 /* CurrentChatUserAvatarView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B4F0DE25D305CD0063FFB5 /* CurrentChatUserAvatarView_Tests.swift */; };
 		79B4F14325D3F0F70063FFB5 /* ChannelId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A71E22578EF650082498D /* ChannelId.swift */; };
 		79B4F14A25D3F1120063FFB5 /* TemporaryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C9474247D7D41001F1104 /* TemporaryData.swift */; };
@@ -1419,6 +1421,8 @@
 		79A0E9B92498C31300E9BD50 /* TypingStartCleanupMiddleware.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypingStartCleanupMiddleware.swift; sourceTree = "<group>"; };
 		79A0E9BD2498C33100E9BD50 /* TypingEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypingEvent.swift; sourceTree = "<group>"; };
 		79A9EAC2262045DC00F2A72D /* MessageRead+MissingUnreadCount.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "MessageRead+MissingUnreadCount.json"; sourceTree = "<group>"; };
+		79A9EB4C2625793000F2A72D /* CoreDataLazy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataLazy.swift; sourceTree = "<group>"; };
+		79A9EB562625798000F2A72D /* CoreDataLazy_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataLazy_Tests.swift; sourceTree = "<group>"; };
 		79B4F0DE25D305CD0063FFB5 /* CurrentChatUserAvatarView_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrentChatUserAvatarView_Tests.swift; sourceTree = "<group>"; };
 		79B5517024E593C200CE9FEC /* UserPayloads_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserPayloads_Tests.swift; sourceTree = "<group>"; };
 		79B5517124E593C200CE9FEC /* UserPayloads.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserPayloads.swift; sourceTree = "<group>"; };
@@ -2482,6 +2486,8 @@
 				792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */,
 				792B804F24D95B5D00C2963E /* Cached.swift */,
 				792B805124D95D4300C2963E /* Cached_Tests.swift */,
+				79A9EB4C2625793000F2A72D /* CoreDataLazy.swift */,
+				79A9EB562625798000F2A72D /* CoreDataLazy_Tests.swift */,
 				DAFAD6A024DC476A0043ED06 /* Result+Extensions.swift */,
 				DA4AA3B92502731900FAAF6E /* Publisher+Extensions.swift */,
 				797E10A724EAF6DE00353791 /* UniqueId.swift */,
@@ -5124,6 +5130,7 @@
 				88EA9AEE254721C0007EE76B /* MessageReactionType.swift in Sources */,
 				79E2B84024CAC8D60024752F /* ListDatabaseObserver.swift in Sources */,
 				796610B9248E651800761629 /* EventMiddleware.swift in Sources */,
+				79A9EB4D2625793000F2A72D /* CoreDataLazy.swift in Sources */,
 				DABC6AC22546FFB600A8FC78 /* AttachmentTypes.swift in Sources */,
 				7964F3B9249A314D002A09EC /* BaseLogDestination.swift in Sources */,
 				792AF91624D812440010097B /* EntityDatabaseObserver.swift in Sources */,
@@ -5503,6 +5510,7 @@
 				889062432548387D00E1898E /* MessageReactionsMiddleware_Tests.swift in Sources */,
 				DA4EE5B5252B680700CB26D4 /* UserListController+SwiftUI_Tests.swift in Sources */,
 				8A0D649824E579AB0017A3C0 /* GuestEndpoints_Tests.swift in Sources */,
+				79A9EB572625798000F2A72D /* CoreDataLazy_Tests.swift in Sources */,
 				792A71E32578EF650082498D /* ChannelId.swift in Sources */,
 				DAF1BED92506612F003CEDC0 /* MessageController+SwiftUI_Tests.swift in Sources */,
 				7988F6B724D15F100004219B /* StressTestCase.swift in Sources */,

--- a/Tests/Shared/RandomDispatchQueue.swift
+++ b/Tests/Shared/RandomDispatchQueue.swift
@@ -10,7 +10,9 @@ extension DispatchQueue {
         let allQoS: [DispatchQoS.QoSClass] = [
             .userInteractive,
             .userInitiated,
-            .default
+            .default,
+            .utility,
+            .background
         ]
         return DispatchQueue.global(qos: allQoS.randomElement()!)
     }


### PR DESCRIPTION
There was a regression introduced by #906 which made our models thread-unsafe. This PR fixes the problem. Instead of the `@Cached` wrapper, we're using `@CoreDataLazy` which evaluates the values on the correct `NSManagedObjectContext`.