### PR TITLE
Refactor composer view with new container view

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerInputContainerView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerInputContainerView.swift
@@ -11,9 +11,9 @@ open class _ChatMessageComposerInputContainerView<ExtraData: ExtraDataTypes>: _V
     // MARK: - Properties
     
     open var rightAccessoryButtonHeight: CGFloat = 30
-    
+
     // MARK: - Subviews
-    
+
     public private(set) lazy var container = UIStackView().withoutAutoresizingMaskConstraints
         
     public private(set) lazy var textView = uiConfig

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
@@ -101,6 +101,7 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
         super.updateContent()
         switch state {
         case .initial:
+            textView.text = ""
             textView.updateHeightConstraint()
             textView.becomeFirstResponder()
             textView.placeholderLabel.text = L10n.Composer.Placeholder.message

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerView.swift
@@ -9,14 +9,25 @@ public typealias ChatMessageComposerView = _ChatMessageComposerView<NoExtraData>
 
 open class _ChatMessageComposerView<ExtraData: ExtraDataTypes>: _View,
     UIConfigProvider {
-    // MARK: - Properties
-    
-    public var attachmentsViewHeight: CGFloat = .zero
-    public var stateIconHeight: CGFloat = .zero
-    
-    // MARK: - Subviews
+    public private(set) lazy var container = ContainerStackView()
+        .withoutAutoresizingMaskConstraints
 
-    public private(set) lazy var container = DeprecatedContainerStackView()
+    public private(set) lazy var topContainer = ContainerStackView()
+        .withoutAutoresizingMaskConstraints
+
+    public private(set) lazy var bottomContainer = ContainerStackView()
+        .withoutAutoresizingMaskConstraints
+
+    public private(set) lazy var centerContainer = ContainerStackView()
+        .withoutAutoresizingMaskConstraints
+
+    public private(set) lazy var centerContentContainer = ContainerStackView()
+        .withoutAutoresizingMaskConstraints
+
+    public private(set) lazy var centerLeftContainer = ContainerStackView()
+        .withoutAutoresizingMaskConstraints
+
+    public private(set) lazy var centerRightContainer = ContainerStackView()
         .withoutAutoresizingMaskConstraints
     
     public private(set) lazy var messageQuoteView = uiConfig
@@ -97,26 +108,17 @@ open class _ChatMessageComposerView<ExtraData: ExtraDataTypes>: _View,
         updateContent()
     }
     
-    override open var intrinsicContentSize: CGSize {
-        let size = CGSize(
-            width: UIView.noIntrinsicMetric,
-            height: container.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
-        )
-        return size
-    }
-    
     // MARK: - Public
     
     override open func setUpAppearance() {
         super.setUpAppearance()
-        stateIconHeight = 40
         
         backgroundColor = uiConfig.colorPalette.popoverBackground
         
-        container.centerStackView.clipsToBounds = true
-        container.centerStackView.layer.cornerRadius = 25
-        container.centerStackView.layer.borderWidth = 1
-        container.centerStackView.layer.borderColor = uiConfig.colorPalette.border.cgColor
+        centerContentContainer.clipsToBounds = true
+        centerContentContainer.layer.cornerRadius = 25
+        centerContentContainer.layer.borderWidth = 1
+        centerContentContainer.layer.borderColor = uiConfig.colorPalette.border.cgColor
         
         layer.shadowColor = UIColor.systemGray.cgColor
         layer.shadowOpacity = 1
@@ -144,65 +146,70 @@ open class _ChatMessageComposerView<ExtraData: ExtraDataTypes>: _View,
     override open func setUpLayout() {
         super.setUpLayout()
         embed(container)
-                
-        container.preservesSuperviewLayoutMargins = true
-        container.isLayoutMarginsRelativeArrangement = true
-        
-        container.spacing = UIStackView.spacingUseSystem
-        
-        container.topStackView.alignment = .fill
-        container.topStackView.addArrangedSubview(stateIcon)
-        container.topStackView.addArrangedSubview(titleLabel)
-        container.topStackView.addArrangedSubview(dismissButton)
-        
-        stateIcon.heightAnchor.pin(equalToConstant: stateIconHeight).isActive = true
-        
-        container.centerStackView.isHidden = false
-        container.centerStackView.axis = .vertical
-        container.centerStackView.alignment = .fill
-        
-        messageQuoteView.isHidden = true
-        container.centerStackView.addArrangedSubview(messageQuoteView)
-        container.centerStackView.addArrangedSubview(imageAttachmentsView)
-        container.centerStackView.addArrangedSubview(documentAttachmentsView)
 
+        container.isLayoutMarginsRelativeArrangement = true
+        container.spacing = 0
+        container.axis = .vertical
+        container.alignment = .fill
+        container.addArrangedSubview(topContainer)
+        container.addArrangedSubview(centerContainer)
+        container.addArrangedSubview(bottomContainer)
+        container.hideSubview(bottomContainer)
+        container.hideSubview(topContainer)
+
+        bottomContainer.addArrangedSubview(checkmarkControl)
+
+        topContainer.alignment = .fill
+        topContainer.addArrangedSubview(stateIcon)
+        topContainer.addArrangedSubview(titleLabel)
+        topContainer.addArrangedSubview(dismissButton)
+        stateIcon.heightAnchor.pin(equalToConstant: 40).isActive = true
+
+        centerContainer.axis = .horizontal
+        centerContainer.alignment = .fill
+        centerContainer.spacing = .auto
+        centerContainer.addArrangedSubview(centerLeftContainer)
+        centerContainer.addArrangedSubview(centerContentContainer)
+        centerContainer.addArrangedSubview(centerRightContainer)
+
+        centerContentContainer.axis = .vertical
+        centerContentContainer.alignment = .fill
+        centerContentContainer.distribution = .natural
+        centerContentContainer.spacing = 0
+        centerContentContainer.addArrangedSubview(messageQuoteView)
+        centerContentContainer.addArrangedSubview(imageAttachmentsView)
+        centerContentContainer.addArrangedSubview(documentAttachmentsView)
+        centerContentContainer.addArrangedSubview(messageInputView)
+        centerContentContainer.hideSubview(messageQuoteView, animated: false)
+        centerContentContainer.hideSubview(imageAttachmentsView, animated: false)
+        centerContentContainer.hideSubview(documentAttachmentsView, animated: false)
         imageAttachmentsView.heightAnchor.pin(equalToConstant: 120).isActive = true
-        
-        container.centerStackView.addArrangedSubview(messageInputView)
-        messageInputView.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        
-        container.rightStackView.isHidden = false
-        container.rightStackView.alignment = .center
-        container.rightStackView.spacing = UIStackView.spacingUseSystem
-        container.rightStackView.addArrangedSubview(sendButton)
-        container.rightStackView.addArrangedSubview(editButton)
-        
-        container.leftStackView.isHidden = false
-        container.leftStackView.alignment = .center
-        container.leftStackView.addArrangedSubview(shrinkInputButton)
-        container.leftStackView.addArrangedSubview(attachmentButton)
-        container.leftStackView.addArrangedSubview(commandsButton)
-        
-        container.bottomStackView.addArrangedSubview(checkmarkControl)
+
+        centerRightContainer.alignment = .center
+        centerRightContainer.spacing = .auto
+        centerRightContainer.addArrangedSubview(sendButton)
+        centerRightContainer.addArrangedSubview(editButton)
+        centerRightContainer.hideSubview(editButton)
+
+        centerLeftContainer.axis = .horizontal
+        centerLeftContainer.alignment = .center
+        centerLeftContainer.spacing = .auto
+        centerLeftContainer.addArrangedSubview(attachmentButton)
+        centerLeftContainer.addArrangedSubview(commandsButton)
+        centerLeftContainer.addArrangedSubview(shrinkInputButton)
         
         [shrinkInputButton, attachmentButton, commandsButton, sendButton, editButton, dismissButton]
             .forEach { button in
-                // Interim solution for correctly laying out the buttons/input
-                // This will be re-worked during ComposerView audit, when we replace
-                // `ContainerStackView` with `ContainerView`
-                button.pin(anchors: [.width], to: 40)
-                button.pin(anchors: [.height], to: 40)
+                button.pin(anchors: [.width], to: 20)
+                button.pin(anchors: [.height], to: 20)
             }
-
-        imageAttachmentsView.isHidden = true
-        documentAttachmentsView.isHidden = true
-        shrinkInputButton.isHidden = true
-        editButton.isHidden = true
     }
     
     open func setCheckmarkView(hidden: Bool) {
-        if container.bottomStackView.isHidden != hidden {
-            container.bottomStackView.isHidden = hidden
+        if hidden {
+            container.hideSubview(bottomContainer)
+        } else {
+            container.showSubview(bottomContainer)
         }
     }
 }

--- a/Sources/StreamChatUI/CommonViews/ContainerStackView.swift
+++ b/Sources/StreamChatUI/CommonViews/ContainerStackView.swift
@@ -278,7 +278,8 @@ public class ContainerStackView: UIView {
     }
 
     public func hideSubview(_ subview: UIView, animated: Bool = true) {
-        assert(subviews.contains(subview))
+        guard subviews.contains(subview) else { return }
+        guard subview.alpha != 0 else { return }
 
         updateConstraintsIfNeeded()
 
@@ -289,7 +290,10 @@ public class ContainerStackView: UIView {
 
         Animate(isAnimated: animated) {
             subview.alpha = 0
-            self.hideConstraintsByView[subview]?.width.isActive = true
+
+            if self.axis == .horizontal {
+                self.hideConstraintsByView[subview]?.width.isActive = true
+            }
             self.hideConstraintsByView[subview]?.height.isActive = true
 
             self.spacingConstraintsByView[subview]?.setTemporaryConstant(0)
@@ -298,8 +302,9 @@ public class ContainerStackView: UIView {
         }
     }
 
-    func showSubview(_ subview: UIView, animated: Bool = true) {
-        assert(subviews.contains(subview))
+    public func showSubview(_ subview: UIView, animated: Bool = true) {
+        guard subviews.contains(subview) else { return }
+        guard subview.alpha == 0 else { return }
 
         updateConstraintsIfNeeded()
 

--- a/Sources/StreamChatUI/CommonViews/ContainerStackView.swift
+++ b/Sources/StreamChatUI/CommonViews/ContainerStackView.swift
@@ -45,14 +45,14 @@ public class ContainerStackView: UIView {
         views.forEach { addArrangedSubview($0) }
     }
 
-    struct Distribution: Equatable {
-        static let natural = Distribution(rawValue: 0)
-        static let equal = Distribution(rawValue: 1)
+    public struct Distribution: Equatable {
+        public static let natural = Distribution(rawValue: 0)
+        public static let equal = Distribution(rawValue: 1)
 
         private let rawValue: Int
     }
 
-    var distribution: Distribution = .natural {
+    public var distribution: Distribution = .natural {
         didSet {
             invalidateConstraints()
         }
@@ -122,7 +122,7 @@ public class ContainerStackView: UIView {
         invalidateConstraints()
     }
 
-    func addArrangedSubview(_ subview: UIView, respectsLayoutMargins: Bool? = nil) {
+    public func addArrangedSubview(_ subview: UIView, respectsLayoutMargins: Bool? = nil) {
         insertArrangedSubview(subview, at: subviews.count, respectsLayoutMargins: respectsLayoutMargins)
     }
 

--- a/Sources/StreamChatUI/CommonViews/ContainerStackView.swift
+++ b/Sources/StreamChatUI/CommonViews/ContainerStackView.swift
@@ -194,7 +194,6 @@ public class ContainerStackView: UIView {
         }
 
         if distribution == .equal {
-            // Add constraints for distribution
             zip(subviews, subviews.dropFirst()).forEach { lView, rView in
                 if axis == .horizontal {
                     customConstraints.append(

--- a/Sources/StreamChatUI/Utils/UITextView+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/UITextView+Extensions.swift
@@ -20,7 +20,9 @@ extension UITextView {
         layoutManager.addTextContainer(customTextContainer)
         
         textStorage.addLayoutManager(layoutManager)
-        textStorage.addAttribute(.font, value: font!, range: .init(0..<textStorage.length))
+        if let font = font {
+            textStorage.addAttribute(.font, value: font, range: .init(0..<textStorage.length))
+        }
         
         customTextContainer.lineFragmentPadding = textContainer.lineFragmentPadding
         customTextContainer.maximumNumberOfLines = textContainer.maximumNumberOfLines

--- a/iMessageClone/iMessageChatMessageComposerView.swift
+++ b/iMessageClone/iMessageChatMessageComposerView.swift
@@ -10,31 +10,58 @@ final class iMessageChatMessageComposerView: ChatMessageComposerView {
     override func setUpLayout() {
         super.setUpLayout()
 
-        commandsButton.removeFromSuperview()
-        
+        centerLeftContainer.removeArrangedSubview(commandsButton)
+        centerRightContainer.removeArrangedSubview(sendButton)
+        centerContainer.removeArrangedSubview(centerRightContainer)
+
+        centerContentContainer.axis = .horizontal
+        centerContentContainer.distribution = .natural
+        centerContentContainer.alignment = .fill
+        centerContentContainer.subviews.forEach {
+            centerContentContainer.removeArrangedSubview($0)
+        }
+
+        let newStack = ContainerStackView()
+        newStack.translatesAutoresizingMaskIntoConstraints = false
+        newStack.axis = .vertical
+        newStack.alignment = .fill
+        newStack.distribution = .natural
+        newStack.spacing = 0
+        newStack.addArrangedSubview(messageQuoteView)
+        newStack.addArrangedSubview(imageAttachmentsView)
+        newStack.addArrangedSubview(documentAttachmentsView)
+        newStack.addArrangedSubview(messageInputView)
         messageInputView.container.preservesSuperviewLayoutMargins = false
-        
-        container.rightStackView.isHidden = true
-        
-        messageInputView.textView.setContentHuggingPriority(.required, for: .vertical)
-        
-        sendButton.removeFromSuperview()
-        container.centerStackView.addSubview(sendButton)
+
+        let sendButtonContainer = UIView()
+        sendButtonContainer.addSubview(sendButton)
         NSLayoutConstraint.activate([
-            sendButton.trailingAnchor.constraint(equalTo: container.centerStackView.trailingAnchor, constant: -3.5),
-            sendButton.widthAnchor.constraint(equalToConstant: 27),
-            sendButton.bottomAnchor.constraint(equalTo: container.centerStackView.bottomAnchor, constant: -1.5)
+            sendButtonContainer.widthAnchor.constraint(equalToConstant: 30),
+            sendButton.leadingAnchor.constraint(equalTo: sendButtonContainer.leadingAnchor, constant: 0),
+            sendButton.trailingAnchor.constraint(equalTo: sendButtonContainer.trailingAnchor, constant: 0),
+            sendButton.bottomAnchor.constraint(equalTo: sendButtonContainer.bottomAnchor, constant: 0)
+        ])
+
+        centerContentContainer.addArrangedSubview(newStack)
+        centerContentContainer.addArrangedSubview(sendButtonContainer)
+
+        NSLayoutConstraint.activate([
+            sendButton.widthAnchor.constraint(equalToConstant: 30),
+            sendButton.heightAnchor.constraint(equalToConstant: 35)
         ])
     }
     
     override func setUpAppearance() {
         super.setUpAppearance()
-        container.centerStackView.layer.cornerRadius = 20
+
+        centerContentContainer.layer.cornerRadius = 18
         messageInputView.textView.font = .systemFont(ofSize: 15)
         
         attachmentButton.setImage(
             UIImage(systemName: "camera.fill"),
             for: .normal
         )
+        attachmentButton.widthAnchor.constraint(equalToConstant: 30).isActive = true
+        attachmentButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
     }
 }


### PR DESCRIPTION
# In this PR
- Refactors the composer view to use the new container stack view.

**Note:** Right now the composer view controller needs to know about the implementation details of ComposerView in order to use it. This will change in the next PR. 