### PR TITLE
Allow subclasses to customise mention text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 
 # Upcoming
+- Introduce `mentionText(forUser:)` on `ChatMessageComposerVC` to allow subclasses to provide custom @ mention text.
+   [#1000](https://github.com/GetStream/stream-chat-swift/pull/1000)
 
 ### 🐞 Fixed
 - It's safe now to use `ChatChannel` and `ChatMessage` across multiple threads [#984](https://github.com/GetStream/stream-chat-swift/pull/984)

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
@@ -475,7 +475,7 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
 
                 textView.textStorage.replaceCharacters(
                     in: NSRange(location: atRange.location, length: cursorPosition.location - atRange.location),
-                    with: "@\(user.id) "
+                    with: self.mentionText(forUser: user)
                 )
 
                 let newPosition = (textView.text as NSString).length - oldPositionTillTheEnd
@@ -492,6 +492,10 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
                 self.dismissSuggestionsViewController()
             }
         )
+    }
+
+    open func mentionText(forUser user: _ChatUser<ExtraData.User>) -> String {
+      "@\(user.id) "
     }
 
     func replaceTextWithSlashCommandViewIfNeeded() {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

This PR adds the method `mentionText(forUser:)` to `ChatMessageComposerVC` which allows subclasses to provide the text used for an @-mention within the message text. Currently, the text is restricted to `@<user.id>`.

This is particularly useful when also subclassing `ChatMessageComposerMentionCellView` in order to display some custom mention text in the mention composer cell view (as shown below). With this PR, `mentionText(forUser:)` can be used to match the custom mention composer text.

```swift
class CustomChatMessageComposerMentionCellView: ChatMessageComposerMentionCellView {
  
  override func updateContent() {
    usernameLabel.text = content?.name
    if let username  = content?.extraData.username {
      usernameTagLabel.text = "@" + username
    } else {
        usernameTagLabel.text = ""
    }
    avatarView.content = content
  }
  
}
```