### PR TITLE
Support mentioned users

### DIFF
--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
@@ -183,6 +183,7 @@ struct MessageRequestBody<ExtraData: ExtraDataTypes>: Encodable {
     let parentId: String?
     let showReplyInChannel: Bool
     let quotedMessageId: String?
+    let mentionedUsers: [String]
     let attachments: [Encodable]
     var pinned: Bool
     var pinExpires: Date?
@@ -197,6 +198,7 @@ struct MessageRequestBody<ExtraData: ExtraDataTypes>: Encodable {
         parentId: String? = nil,
         showReplyInChannel: Bool = false,
         quotedMessageId: String? = nil,
+        mentionedUsers: [String] = [],
         attachments: [Encodable] = [],
         pinned: Bool = false,
         pinExpires: Date? = nil,
@@ -210,6 +212,7 @@ struct MessageRequestBody<ExtraData: ExtraDataTypes>: Encodable {
         self.parentId = parentId
         self.showReplyInChannel = showReplyInChannel
         self.quotedMessageId = quotedMessageId
+        self.mentionedUsers = mentionedUsers
         self.attachments = attachments
         self.pinned = pinned
         self.pinExpires = pinExpires
@@ -225,6 +228,7 @@ struct MessageRequestBody<ExtraData: ExtraDataTypes>: Encodable {
         try container.encodeIfPresent(parentId, forKey: .parentId)
         try container.encodeIfPresent(showReplyInChannel, forKey: .showReplyInChannel)
         try container.encodeIfPresent(quotedMessageId, forKey: .quotedMessageId)
+        try container.encodeIfPresent(mentionedUsers, forKey: .mentionedUsers)
         try container.encode(pinned, forKey: .pinned)
         try container.encodeIfPresent(pinExpires, forKey: .pinExpires)
 

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -731,6 +731,7 @@ public extension _ChatChannelController {
 //        arguments: String? = nil,
         attachments: [AttachmentEnvelope] = [],
         quotedMessageId: MessageId? = nil,
+        mentionedUsers: [String] = [],
         extraData: ExtraData.Message = .defaultValue,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -753,6 +754,7 @@ public extension _ChatChannelController {
             arguments: nil,
             attachments: attachments,
             quotedMessageId: quotedMessageId,
+            mentionedUsers: mentionedUsers,
             extraData: extraData
         ) { result in
             self.callback {

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -226,6 +226,7 @@ public extension _ChatMessageController {
         attachments: [AttachmentEnvelope] = [],
         showReplyInChannel: Bool = false,
         quotedMessageId: MessageId? = nil,
+        mentionedUsers: [String] = [],
         extraData: ExtraData.Message = .defaultValue,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -239,6 +240,7 @@ public extension _ChatMessageController {
             attachments: attachments,
             showReplyInChannel: showReplyInChannel,
             quotedMessageId: quotedMessageId,
+            mentionedUsers: mentionedUsers,
             extraData: extraData
         ) { result in
             self.callback {

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -444,6 +444,7 @@ extension MessageDTO {
             parentId: parentMessageId,
             showReplyInChannel: showReplyInChannel,
             quotedMessageId: quotedMessage?.id,
+            mentionedUsers: mentionedUsers.map { $0.id },
             attachments: attachments
                 .sorted { $0.attachmentID.index < $1.attachmentID.index }
                 .map { $0.asRequestPayload() },

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -217,6 +217,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         attachments: [AttachmentEnvelope],
         showReplyInChannel: Bool,
         quotedMessageId: MessageId?,
+        mentionedUsers: [String],
         extraData: ExtraData
     ) throws -> MessageDTO {
         guard let currentUserDTO = currentUser() else {
@@ -269,6 +270,9 @@ extension NSManagedObjectContext: MessageDatabaseSession {
                 
         message.showReplyInChannel = showReplyInChannel
         message.quotedMessage = quotedMessageId.flatMap { MessageDTO.load(id: $0, context: self) }
+        
+        let mentionedUserDTOsFromMentionedUserIds = mentionedUsers.map { UserDTO.loadOrCreate(id: $0, context: self) }
+        message.mentionedUsers = Set(mentionedUserDTOsFromMentionedUserIds)
         
         message.user = currentUserDTO.user
         message.channel = channelDTO

--- a/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
@@ -345,6 +345,7 @@ class MessageDTO_Tests: XCTestCase {
         let channelId: ChannelId = .unique
         let quotedMessageId: MessageId = .unique
         let quotedMessageAuthorId: UserId = .unique
+        let mentionedUsers: [String] = [.unique]
 
         try database.createCurrentUser(id: currentUserId)
         try database.createChannel(cid: channelId, withMessages: false)
@@ -355,6 +356,7 @@ class MessageDTO_Tests: XCTestCase {
                 messageId: quotedMessageId,
                 authorUserId: quotedMessageAuthorId
             ),
+            mentionedUsers: mentionedUsers,
             authorUserId: messageAuthorId,
             latestReactions: (0..<3).map { _ in
                 .dummy(messageId: messageId, user: .dummy(userId: .unique))
@@ -452,6 +454,7 @@ class MessageDTO_Tests: XCTestCase {
         let messageAttachmentSeeds: [ChatMessageAttachmentSeed] = [.dummy(), .dummy(), .dummy()]
         let messageShowReplyInChannel = true
         let messageExtraData: NoExtraData = .defaultValue
+        let messageMentionedUsers: [String] = [.unique]
 
         // Create message with attachments in the database.
         try database.writeSynchronously { session in
@@ -465,6 +468,7 @@ class MessageDTO_Tests: XCTestCase {
                 attachments: messageAttachments + messageAttachmentSeeds,
                 showReplyInChannel: true,
                 quotedMessageId: nil,
+                mentionedUsers: messageMentionedUsers,
                 extraData: messageExtraData
             ).id
         }
@@ -483,6 +487,7 @@ class MessageDTO_Tests: XCTestCase {
         XCTAssertEqual(requestBody.parentId, parentMessageId)
         XCTAssertEqual(requestBody.showReplyInChannel, messageShowReplyInChannel)
         XCTAssertEqual(requestBody.extraData, messageExtraData)
+        XCTAssertEqual(requestBody.mentionedUsers, messageMentionedUsers)
         XCTAssertEqual(requestBody.pinned, true)
         XCTAssertEqual(requestBody.pinExpires, messagePinning!.expirationDate)
 
@@ -574,6 +579,7 @@ class MessageDTO_Tests: XCTestCase {
                     attachments: [TestAttachmentEnvelope](),
                     showReplyInChannel: false,
                     quotedMessageId: nil,
+                    mentionedUsers: [],
                     extraData: NoExtraData.defaultValue
                 )
                 message1Id = message1DTO.id
@@ -590,6 +596,7 @@ class MessageDTO_Tests: XCTestCase {
                     attachments: [TestAttachmentEnvelope](),
                     showReplyInChannel: false,
                     quotedMessageId: nil,
+                    mentionedUsers: [],
                     extraData: NoExtraData.defaultValue
                 )
                 message2Id = message2DTO.id
@@ -673,6 +680,7 @@ class MessageDTO_Tests: XCTestCase {
             .dummy()
         ]
         let newMessagePinning: MessagePinning? = MessagePinning(expirationDate: .unique)
+        let newMentionedUsers: [String] = [.unique]
                 
         _ = try await { completion in
             database.write({
@@ -686,6 +694,7 @@ class MessageDTO_Tests: XCTestCase {
                     attachments: newMessageAttachments + newMessageAttachmentSeeds,
                     showReplyInChannel: true,
                     quotedMessageId: nil,
+                    mentionedUsers: newMentionedUsers,
                     extraData: NoExtraData.defaultValue
                 )
                 newMessageId = messageDTO.id
@@ -734,6 +743,7 @@ class MessageDTO_Tests: XCTestCase {
                     attachments: [TestAttachmentEnvelope](),
                     showReplyInChannel: true,
                     quotedMessageId: nil,
+                    mentionedUsers: [.unique],
                     extraData: NoExtraData.defaultValue
                 )
             }, completion: completion)
@@ -769,6 +779,7 @@ class MessageDTO_Tests: XCTestCase {
                     attachments: [TestAttachmentEnvelope](),
                     showReplyInChannel: true,
                     quotedMessageId: nil,
+                    mentionedUsers: [.unique],
                     extraData: NoExtraData.defaultValue
                 )
             }, completion: completion)
@@ -844,6 +855,7 @@ class MessageDTO_Tests: XCTestCase {
                 attachments: [TestAttachmentEnvelope](),
                 showReplyInChannel: false,
                 quotedMessageId: nil,
+                mentionedUsers: [],
                 extraData: NoExtraData.defaultValue
             )
             // Get reply messageId

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -64,6 +64,7 @@ protocol MessageDatabaseSession {
         attachments: [AttachmentEnvelope],
         showReplyInChannel: Bool,
         quotedMessageId: MessageId?,
+        mentionedUsers: [String],
         extraData: ExtraData
     ) throws -> MessageDTO
     
@@ -116,6 +117,7 @@ extension MessageDatabaseSession {
         text: String,
         pinning: MessagePinning?,
         quotedMessageId: MessageId?,
+        mentionedUsers: [String] = [],
         attachments: [AttachmentEnvelope] = [],
         attachmentSeeds: [ChatMessageAttachmentSeed] = [],
         extraData: ExtraData = .defaultValue
@@ -130,6 +132,7 @@ extension MessageDatabaseSession {
             attachments: attachments,
             showReplyInChannel: false,
             quotedMessageId: quotedMessageId,
+            mentionedUsers: mentionedUsers,
             extraData: extraData
         )
     }

--- a/Sources/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Mock.swift
@@ -82,6 +82,7 @@ extension DatabaseSessionMock {
         attachments: [AttachmentEnvelope],
         showReplyInChannel: Bool,
         quotedMessageId: MessageId?,
+        mentionedUsers: [String],
         extraData: ExtraData
     ) throws -> MessageDTO where ExtraData: MessageExtraData {
         try throwErrorIfNeeded()
@@ -96,6 +97,7 @@ extension DatabaseSessionMock {
             attachments: attachments,
             showReplyInChannel: showReplyInChannel,
             quotedMessageId: quotedMessageId,
+            mentionedUsers: mentionedUsers,
             extraData: extraData
         )
     }

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -115,6 +115,7 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
         arguments: String?,
         attachments: [AttachmentEnvelope] = [],
         quotedMessageId: MessageId?,
+        mentionedUsers: [String] = [],
         extraData: ExtraData.Message,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -130,6 +131,7 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
                 attachments: attachments,
                 showReplyInChannel: false,
                 quotedMessageId: quotedMessageId,
+                mentionedUsers: mentionedUsers,
                 extraData: extraData
             )
             

--- a/Sources/StreamChat/Workers/ChannelUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Mock.swift
@@ -46,6 +46,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
     @Atomic var createNewMessage_attachments: [AttachmentEnvelope]?
     @Atomic var createNewMessage_attachmentSeeds: [ChatMessageAttachmentSeed]?
     @Atomic var createNewMessage_quotedMessageId: MessageId?
+    @Atomic var createNewMessage_mentionedUsers: [String]?
     @Atomic var createNewMessage_pinning: MessagePinning?
     @Atomic var createNewMessage_extraData: ExtraData.Message?
     @Atomic var createNewMessage_completion: ((Result<MessageId, Error>) -> Void)?
@@ -106,6 +107,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         createNewMessage_arguments = nil
         createNewMessage_attachments = nil
         createNewMessage_attachmentSeeds = nil
+        createNewMessage_mentionedUsers = nil
         createNewMessage_extraData = nil
         createNewMessage_completion = nil
         
@@ -176,6 +178,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         arguments: String?,
         attachments: [AttachmentEnvelope],
         quotedMessageId: MessageId?,
+        mentionedUsers: [String],
         extraData: ExtraData.Message,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -185,6 +188,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         createNewMessage_arguments = arguments
         createNewMessage_attachments = attachments
         createNewMessage_quotedMessageId = quotedMessageId
+        createNewMessage_mentionedUsers = mentionedUsers
         createNewMessage_pinning = pinning
         createNewMessage_extraData = extraData
         createNewMessage_completion = completion

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -132,6 +132,7 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
         attachments: [AttachmentEnvelope],
         showReplyInChannel: Bool,
         quotedMessageId: MessageId?,
+        mentionedUsers: [String],
         extraData: ExtraData.Message,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -147,6 +148,7 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
                 attachments: attachments,
                 showReplyInChannel: showReplyInChannel,
                 quotedMessageId: quotedMessageId,
+                mentionedUsers: mentionedUsers,
                 extraData: extraData
             )
             

--- a/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -26,6 +26,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
     @Atomic var createNewReply_attachments: [AttachmentEnvelope]?
     @Atomic var createNewReply_showReplyInChannel: Bool?
     @Atomic var createNewReply_quotedMessageId: MessageId?
+    @Atomic var createNewReply_mentionedUsers: [String]?
     @Atomic var createNewReply_pinning: MessagePinning?
     @Atomic var createNewReply_extraData: ExtraData.Message?
     @Atomic var createNewReply_completion: ((Result<MessageId, Error>) -> Void)?
@@ -89,6 +90,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         createNewReply_parentMessageId = nil
         createNewReply_attachments = nil
         createNewReply_showReplyInChannel = nil
+        createNewReply_mentionedUsers = nil
         createNewReply_extraData = nil
         createNewReply_completion = nil
         
@@ -163,6 +165,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         attachments: [AttachmentEnvelope],
         showReplyInChannel: Bool,
         quotedMessageId: MessageId?,
+        mentionedUsers: [String],
         extraData: ExtraData.Message,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -174,6 +177,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         createNewReply_attachments = attachments
         createNewReply_showReplyInChannel = showReplyInChannel
         createNewReply_quotedMessageId = quotedMessageId
+        createNewReply_mentionedUsers = mentionedUsers
         createNewReply_pinning = pinning
         createNewReply_extraData = extraData
         createNewReply_completion = completion

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -397,6 +397,7 @@ final class MessageUpdater_Tests: StressTestCase {
             .dummy(),
             .dummy()
         ]
+        let mentionedUsers: [String] = [.unique]
         let extraData: NoExtraData = .defaultValue
         
         // Create new reply message
@@ -411,6 +412,7 @@ final class MessageUpdater_Tests: StressTestCase {
                 attachments: attachments + attachmentSeeds,
                 showReplyInChannel: showReplyInChannel,
                 quotedMessageId: nil,
+                mentionedUsers: mentionedUsers,
                 extraData: extraData
             ) { result in
                 if let newMessageId = try? result.get() {
@@ -470,6 +472,7 @@ final class MessageUpdater_Tests: StressTestCase {
                 attachments: [],
                 showReplyInChannel: false,
                 quotedMessageId: nil,
+                mentionedUsers: [.unique],
                 extraData: .defaultValue
             ) { completion($0) }
         }

--- a/Sources/StreamChatTestTools/DummyData/MessagePayload.swift
+++ b/Sources/StreamChatTestTools/DummyData/MessagePayload.swift
@@ -15,6 +15,7 @@ extension MessagePayload {
         showReplyInChannel: Bool = false,
         quotedMessageId: MessageId? = nil,
         quotedMessage: MessagePayload<T>? = nil,
+        mentionedUsers: [String] = [],
         attachments: [AttachmentPayload] = [
             .dummy(),
             .dummy(),

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
@@ -475,13 +475,14 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
 
                 let oldPositionTillTheEnd = (textView.text as NSString).length - cursorPosition.location
 
+                let mentionText = "@\(user.id) "
                 textView.textStorage.replaceCharacters(
                     in: NSRange(location: atRange.location, length: cursorPosition.location - atRange.location),
-                    with: "@\(user.id) "
+                    with: mentionText
                 )
 
                 // Add to mentioned users
-                self.mentionedUsers[user.id] = user.id
+                self.mentionedUsers[user.id] = mentionText
                 
                 let newPosition = (textView.text as NSString).length - oldPositionTillTheEnd
                 textView.selectedRange = NSRange(location: newPosition, length: 0)

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
@@ -219,14 +219,16 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
                 pinning: nil,
                 attachments: attachments + attachmentSeeds,
                 showReplyInChannel: composerView.checkmarkControl.isSelected,
-                quotedMessageId: quotedMessageId
+                quotedMessageId: quotedMessageId,
+                mentionedUsers: Array(mentionedUsers.keys)
             )
         } else {
             controller?.createNewMessage(
                 text: text,
                 pinning: nil,
                 attachments: attachments + attachmentSeeds,
-                quotedMessageId: quotedMessageId
+                quotedMessageId: quotedMessageId,
+                mentionedUsers: Array(mentionedUsers.keys)
             )
         }
     }
@@ -478,6 +480,9 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
                     with: "@\(user.id) "
                 )
 
+                // Add to mentioned users
+                self.mentionedUsers[user.id] = user.id
+                
                 let newPosition = (textView.text as NSString).length - oldPositionTillTheEnd
                 textView.selectedRange = NSRange(location: newPosition, length: 0)
                 
@@ -493,6 +498,9 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
             }
         )
     }
+
+    /// Dictionary mapping user ids to mention text.
+    private(set) var mentionedUsers: [String: String] = [:]
 
     func replaceTextWithSlashCommandViewIfNeeded() {
         // Extract potential command name from input text
@@ -518,6 +526,13 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
         updateMentionFlag(with: textView.text as NSString, till: textView.selectedRange.location)
 
         promptSuggestionIfNeeded(for: textView.text!)
+
+        // remove any users where the mention text is no longer present
+        mentionedUsers.forEach { userMap in
+          if !textView.text.contains(userMap.value) {
+            mentionedUsers.removeValue(forKey: userMap.key)
+          }
+        }
     }
 
     func updateMentionFlag(with text: NSString, till caret: Int) {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

This PR adds support for mentioned users when sending a message. Currently, the UI supports searching for and displaying mentioned users, however those mentions do not translate through to the message payload.

### Design

`ChatMessageComposerVC` gains a `mentionedUsers` dictionary to keep track of the mentioned users. The dictionary maps the user id to the mention text (since this is not always the same). The removal of mentioned users from the dictionary is handled in `textViewDidChange(_ textView:)`, e.g. user deletes characters.

### Testing

I have had a go at updating the tests to include the `mentionedUsers` property. I'm getting a crash running `test_newMessage_asRequestBody`. 

Would someone please give me a steer on 1) the overall PR and 2) the crash in `test_newMessage_asRequestBody`.