### PR TITLE
MessageListVC + MessageThreadVC

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListKeyboardObserver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListKeyboardObserver.swift
@@ -5,12 +5,12 @@
 import StreamChat
 import UIKit
 
-final class ChatMessageListKeyboardObserver {
+public final class ChatMessageListKeyboardObserver {
     weak var containerView: UIView!
     weak var scrollView: UIScrollView!
     weak var composerBottomConstraint: NSLayoutConstraint?
     
-    init(containerView: UIView, scrollView: UIScrollView, composerBottomConstraint: NSLayoutConstraint?) {
+    public init(containerView: UIView, scrollView: UIScrollView, composerBottomConstraint: NSLayoutConstraint?) {
         self.containerView = containerView
         self.scrollView = scrollView
         self.composerBottomConstraint = composerBottomConstraint

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListRouter.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListRouter.swift
@@ -7,45 +7,13 @@ import UIKit
 
 public typealias ChatMessageListRouter = _ChatMessageListRouter<NoExtraData>
 
-open class _ChatMessageListRouter<ExtraData: ExtraDataTypes>: ChatRouter<_ChatMessageListVC<ExtraData>> {
-    open func showMessageActionsPopUp(
-        messageContentViewClass: _ChatMessageContentView<ExtraData>.Type,
-        messageContentFrame: CGRect,
-        messageData: _ChatMessageGroupPart<ExtraData>,
-        messageActionsController: _ChatMessageActionsVC<ExtraData>,
-        messageReactionsController: _ChatMessageReactionsVC<ExtraData>?
-    ) {
-        let popup = _ChatMessagePopupVC<ExtraData>()
-        popup.messageContentViewClass = messageContentViewClass
-        popup.message = messageData
-        popup.messageViewFrame = messageContentFrame
-        popup.actionsController = messageActionsController
-        popup.reactionsController = messageReactionsController
-        popup.modalPresentationStyle = .overFullScreen
-        popup.modalTransitionStyle = .crossDissolve
-
-        rootViewController.present(popup, animated: false)
+open class _ChatMessageListRouter<ExtraData: ExtraDataTypes> {
+    private let rootViewController: UIViewController
+    
+    public required init(rootViewController: UIViewController) {
+        self.rootViewController = rootViewController
     }
     
-    open func showPreview(for attachment: ChatMessageDefaultAttachment) {
-        let preview = ChatMessageAttachmentPreviewVC<ExtraData>()
-        preview.content = attachment.type == .file ? attachment.url : attachment.imageURL
-        
-        let navigation = UINavigationController(rootViewController: preview)
-        rootViewController.present(navigation, animated: true)
-    }
-
-    open func openLink(_ link: ChatMessageDefaultAttachment) {
-        let preview = ChatMessageAttachmentPreviewVC<ExtraData>()
-        preview.content = link.url
-
-        let navigation = UINavigationController(rootViewController: preview)
-        rootViewController.present(navigation, animated: true)
-    }
-}
-
-// Exact copy of `_ChatMessageListRouter` but we need correct generic controller passed to `ChatRouter`
-public class MessageListRouter<ExtraData: ExtraDataTypes>: ChatRouter<MessageListVC<ExtraData>> {
     open func showMessageActionsPopUp(
         messageContentFrame: CGRect,
         messageData: _ChatMessageGroupPart<ExtraData>,
@@ -64,7 +32,9 @@ public class MessageListRouter<ExtraData: ExtraDataTypes>: ChatRouter<MessageLis
         rootViewController.present(popup, animated: false)
     }
     
-    open func showPreview(for attachment: ChatMessageDefaultAttachment) {
+    open func showPreview(
+        for attachment: ChatMessageDefaultAttachment
+    ) {
         let preview = ChatMessageAttachmentPreviewVC<ExtraData>()
         preview.content = attachment.type == .file ? attachment.url : attachment.imageURL
         
@@ -72,7 +42,9 @@ public class MessageListRouter<ExtraData: ExtraDataTypes>: ChatRouter<MessageLis
         rootViewController.present(navigation, animated: true)
     }
 
-    open func openLink(_ link: ChatMessageDefaultAttachment) {
+    open func openLink(
+        _ link: ChatMessageDefaultAttachment
+    ) {
         let preview = ChatMessageAttachmentPreviewVC<ExtraData>()
         preview.content = link.url
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListRouter.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListRouter.swift
@@ -45,7 +45,7 @@ open class _ChatMessageListRouter<ExtraData: ExtraDataTypes>: ChatRouter<_ChatMe
 }
 
 // Exact copy of `_ChatMessageListRouter` but we need correct generic controller passed to `ChatRouter`
-class MessageListRouter<ExtraData: ExtraDataTypes>: ChatRouter<MessageListVC<ExtraData>> {
+public class MessageListRouter<ExtraData: ExtraDataTypes>: ChatRouter<MessageListVC<ExtraData>> {
     open func showMessageActionsPopUp(
         messageContentFrame: CGRect,
         messageData: _ChatMessageGroupPart<ExtraData>,

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListRouter.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListRouter.swift
@@ -15,6 +15,7 @@ open class _ChatMessageListRouter<ExtraData: ExtraDataTypes> {
     }
     
     open func showMessageActionsPopUp(
+        messageContentViewClass: _ChatMessageContentView<ExtraData>.Type,
         messageContentFrame: CGRect,
         messageData: _ChatMessageGroupPart<ExtraData>,
         messageActionsController: _ChatMessageActionsVC<ExtraData>,
@@ -23,6 +24,7 @@ open class _ChatMessageListRouter<ExtraData: ExtraDataTypes> {
         let popup = _ChatMessagePopupVC<ExtraData>()
         popup.messageContentViewClass = _ChatMessageContentView<ExtraData>.self
         popup.message = messageData
+        popup.messageContentViewClass = messageContentViewClass
         popup.messageViewFrame = messageContentFrame
         popup.actionsController = messageActionsController
         popup.reactionsController = messageReactionsController

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -58,7 +58,9 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: _ViewController,
 
     public lazy var impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
 
-    public lazy var router = uiConfig.navigation._messageListRouter(rootViewController: self)
+    public lazy var router = uiConfig.navigation
+        ._messageListRouter
+    (rootViewController: self)
 
     public private(set) lazy var collectionViewLayout = uiConfig
         .messageList

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -58,7 +58,7 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: _ViewController,
 
     public lazy var impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
 
-    public lazy var router = uiConfig.navigation.messageListRouter.init(rootViewController: self)
+    public lazy var router = uiConfig.navigation._messageListRouter(rootViewController: self)
 
     public private(set) lazy var collectionViewLayout = uiConfig
         .messageList

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -58,9 +58,8 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: _ViewController,
 
     public lazy var impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
 
-    public lazy var router = uiConfig.navigation
-        ._messageListRouter
-    (rootViewController: self)
+    // TODO: Will be removed soon. Swiftformat deletes everytime the explicit init.
+    public lazy var router = _ChatMessageListRouter<ExtraData>(rootViewController: self)
 
     public private(set) lazy var collectionViewLayout = uiConfig
         .messageList

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageCell.swift
@@ -5,7 +5,7 @@
 import StreamChat
 import UIKit
 
-class MessageCell<ExtraData: ExtraDataTypes>: _CollectionViewCell, UIConfigProvider {
+public class MessageCell<ExtraData: ExtraDataTypes>: _CollectionViewCell, UIConfigProvider {
     static var reuseId: String { "message_cell" }
 
     class var messageContentViewClass: MessageContentView<ExtraData>.Type {
@@ -16,13 +16,13 @@ class MessageCell<ExtraData: ExtraDataTypes>: _CollectionViewCell, UIConfigProvi
         .init()
         .withoutAutoresizingMaskConstraints
 
-    override func setUpLayout() {
+    override public func setUpLayout() {
         super.setUpLayout()
 
         contentView.embed(messageContentView)
     }
 
-    override func prepareForReuse() {
+    override public func prepareForReuse() {
         super.prepareForReuse()
 
         messageContentView.delegate = nil

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageCollectionView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageCollectionView.swift
@@ -6,10 +6,10 @@ import Foundation
 import StreamChat
 import UIKit
 
-class MessageCollectionView: UICollectionView {
+open class MessageCollectionView: UICollectionView {
     private var identifiers: Set<String> = .init()
     
-    func dequeueReusableCell<ExtraData: ExtraDataTypes>(
+    public func dequeueReusableCell<ExtraData: ExtraDataTypes>(
         withReuseIdentifier identifier: String,
         layoutOptions: ChatMessageLayoutOptions,
         for indexPath: IndexPath

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageCollectionView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageCollectionView.swift
@@ -9,7 +9,10 @@ import UIKit
 open class MessageCollectionView: UICollectionView {
     private var identifiers: Set<String> = .init()
     
-    public func dequeueReusableCell<ExtraData: ExtraDataTypes>(
+    open var needsToScrollToMostRecentMessage = false
+    open var needsToScrollToMostRecentMessageAnimated = false
+    
+    open func dequeueReusableCell<ExtraData: ExtraDataTypes>(
         withReuseIdentifier identifier: String,
         layoutOptions: ChatMessageLayoutOptions,
         for indexPath: IndexPath
@@ -28,5 +31,49 @@ open class MessageCollectionView: UICollectionView {
         cell.messageContentView.setUpLayoutIfNeeded(options: layoutOptions)
         
         return cell
+    }
+    
+    /// Updates the collection view data with given `changes`.
+    open func updateMessages<ExtraData: ExtraDataTypes>(
+        with changes: [ListChange<_ChatMessage<ExtraData>>],
+        completion: ((Bool) -> Void)? = nil
+    ) {
+        performBatchUpdates {
+            for change in changes {
+                switch change {
+                case let .insert(_, index):
+                    insertItems(at: [index])
+                case let .move(_, fromIndex, toIndex):
+                    moveItem(at: fromIndex, to: toIndex)
+                case let .remove(_, index):
+                    deleteItems(at: [index])
+                case let .update(_, index):
+                    reloadItems(at: [index])
+                }
+            }
+        } completion: { flag in
+            completion?(flag)
+        }
+    }
+    
+    /// Will scroll to most recent message on next `updateMessages` call
+    open func setNeedsScrollToMostRecentMessage(animated: Bool = true) {
+        needsToScrollToMostRecentMessage = true
+        needsToScrollToMostRecentMessageAnimated = animated
+    }
+
+    /// Force scroll to most recent message check without waiting for `updateMessages`
+    open func scrollToMostRecentMessageIfNeeded() {
+        guard needsToScrollToMostRecentMessage else { return }
+        
+        scrollToMostRecentMessage(animated: needsToScrollToMostRecentMessageAnimated)
+    }
+
+    /// Scrolls to most recent message
+    open func scrollToMostRecentMessage(animated: Bool = true) {
+        needsToScrollToMostRecentMessage = false
+
+        // our collection is flipped, so (0; 0) item is most recent one
+        scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: animated)
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageContentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageContentView.swift
@@ -15,7 +15,7 @@ extension MessageContentView {
     }
 }
 
-class MessageContentView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
+public class MessageContentView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     var content: _ChatMessage<ExtraData>? {
         didSet {
             updateContentIfNeeded()
@@ -57,7 +57,7 @@ class MessageContentView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
     lazy var mainContainer = ContainerStackView(axis: .horizontal)
         .withoutAutoresizingMaskConstraints
 
-    override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
 
         maskContainerByReactionsBubble()
@@ -304,7 +304,7 @@ class MessageContentView<ExtraData: ExtraDataTypes>: _View, UIConfigProvider {
         NSLayoutConstraint.activate(constraintsToActivate)
     }
 
-    override func updateContent() {
+    override public func updateContent() {
         // Text
         textView?.text = content?.text
         

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -231,15 +231,15 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
                 if member.isOnline {
                     // ReallyNotATODO: Missing API GroupA.m1
                     // need to specify how long user have been online
-                    return "Online"
+                    return L10n.Message.Title.online
                 } else if let minutes = member.lastActiveAt
                     .flatMap({ DateComponentsFormatter.minutes.string(from: $0, to: Date()) }) {
-                    return "Seen \(minutes) ago"
+                    return L10n.Message.Title.seeMinutesAgo(minutes)
                 } else {
-                    return "Offline"
+                    return L10n.Message.Title.offline
                 }
             } else {
-                return channelController.channel.map { "\($0.memberCount) members, \($0.watcherCount) online" }
+                return channelController.channel.map { L10n.Message.Title.group($0.memberCount, $0.watcherCount) }
             }
         }()
         

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -254,10 +254,7 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
 
     /// Updates the collection view data with given `changes`.
     open func updateMessages(with changes: [ListChange<_ChatMessage<ExtraData>>], completion: ((Bool) -> Void)? = nil) {
-        collectionView.updateMessages(with: changes) {
-            completion?($0)
-            self.scrollToMostRecentMessage()
-        }
+        collectionView.updateMessages(with: changes, completion: completion)
     }
     
     open func messageForIndexPath(_ indexPath: IndexPath) -> _ChatMessage<ExtraData> {

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -11,11 +11,16 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
     /// Controller for observing data changes within the channel
     public var channelController: _ChatChannelController<ExtraData>!
     
-    /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
-    public private(set) var needsToScrollToMostRecentMessage = true
-    
-    /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
-    public private(set) var needsToScrollToMostRecentMessageAnimated = false
+    /// Observer responsible for setting the correct offset when keyboard frame is changed
+    public lazy var keyboardObserver = ChatMessageListKeyboardObserver(
+        containerView: view,
+        scrollView: collectionView,
+        composerBottomConstraint: messageComposerBottomConstraint
+    )
+
+    /// User search controller passed directly to the composer
+    public lazy var userSuggestionSearchController: _ChatUserSearchController<ExtraData> =
+        channelController.client.userSearchController()
     
     /// View used to display the messages
     public private(set) lazy var collectionView: MessageCollectionView = {
@@ -37,26 +42,14 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
         .messageComposerViewController
         .init()
     
-    /// Constraint connection list of messages and composer controller.
-    /// It's used to change the message list's height based on the keyboard visibility.
-    private var messageComposerBottomConstraint: NSLayoutConstraint?
-    
-    /// Timer used to update the online status of member in the chat channel
-    private var timer: Timer?
-    
-    /// Observer responsible for setting the correct offset when keyboard frame is changed
-    private lazy var keyboardObserver = ChatMessageListKeyboardObserver(
-        containerView: view,
-        scrollView: collectionView,
-        composerBottomConstraint: messageComposerBottomConstraint
-    )
-
-    /// User search controller passed directly to the composer
-    public lazy var userSuggestionSearchController: _ChatUserSearchController<ExtraData> =
-        channelController.client.userSearchController()
-    
     // Load from UIConfig
     public lazy var titleView = ChatMessageListTitleView<ExtraData>()
+    
+    /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
+    public private(set) var needsToScrollToMostRecentMessage = true
+    
+    /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
+    public private(set) var needsToScrollToMostRecentMessageAnimated = false
     
     /// Feedback generator used when presenting actions controller on selected message
     public lazy var impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
@@ -66,6 +59,13 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
         .navigation
         .messageListRouter
         .init(rootViewController: self)
+    
+    /// Constraint connection list of messages and composer controller.
+    /// It's used to change the message list's height based on the keyboard visibility.
+    private var messageComposerBottomConstraint: NSLayoutConstraint?
+    
+    /// Timer used to update the online status of member in the chat channel
+    private var timer: Timer?
     
     override open func setUp() {
         super.setUp()
@@ -404,23 +404,27 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
         }
     }
 
+    /// Executes the provided action on the message
     open func handleTapOnAttachmentAction(
         _ action: AttachmentAction,
         for attachment: ChatMessageAttachment,
         forCellAt indexPath: IndexPath
     ) {
         // Can we have a helper on `ChannelController` returning a `messageController` for the provided message id?
-        let messageController = channelController.client.messageController(
-            cid: channelController.cid!,
-            messageId: channelController.messages[indexPath.row].id
-        )
-        messageController.dispatchEphemeralMessageAction(action)
+        channelController.client
+            .messageController(
+                cid: channelController.cid!,
+                messageId: channelController.messages[indexPath.row].id
+            )
+            .dispatchEphemeralMessageAction(action)
     }
 
-    open func handleTapOnQuotedMessage(_ quotedMessage: _ChatMessage<ExtraData>, forCellAt indexPath: IndexPath) {
-        didSelectMessageCell(at: indexPath)
+    // TODO: Currently not supported
+    private func handleTapOnQuotedMessage(_ quotedMessage: _ChatMessage<ExtraData>, forCellAt indexPath: IndexPath) {
+        print(#function, quotedMessage)
     }
 
+    /// Opens the action menu with action to resend the message
     open func handleTapOnErrorIndicator(forCellAt indexPath: IndexPath) {
         didSelectMessageCell(at: indexPath)
     }

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -22,9 +22,12 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
     open lazy var userSuggestionSearchController: _ChatUserSearchController<ExtraData> =
         channelController.client.userSearchController()
     
+    // TODO: Documentation
+    open lazy var messageListLayout = ChatMessageListCollectionViewLayout()
+    
     /// View used to display the messages
     open private(set) lazy var collectionView: MessageCollectionView = {
-        let collection = MessageCollectionView(frame: .zero, collectionViewLayout: ChatMessageListCollectionViewLayout())
+        let collection = MessageCollectionView(frame: .zero, collectionViewLayout: messageListLayout)
 
         collection.isPrefetchingEnabled = false
         collection.showsHorizontalScrollIndicator = false
@@ -500,7 +503,9 @@ extension MessageListVC: _ChatMessageActionsVCDelegate {
         }
     }
 
-    open func chatMessageActionsVCDidFinish(_ vc: _ChatMessageActionsVC<ExtraData>) {
+    open func chatMessageActionsVCDidFinish(
+        _ vc: _ChatMessageActionsVC<ExtraData>
+    ) {
         dismiss(animated: true)
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -2,19 +2,22 @@
 // Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
 import StreamChat
 import UIKit
 
-class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionViewDelegate, UICollectionViewDataSource,
+/// Controller that shows list of messages and composer together in the selected channel.
+open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionViewDelegate, UICollectionViewDataSource,
     UIConfigProvider {
-    var channelController: _ChatChannelController<ExtraData>!
+    /// Controller for observing data changes within the channel
+    public var channelController: _ChatChannelController<ExtraData>!
     
     /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
     public private(set) var needsToScrollToMostRecentMessage = true
+    
     /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
     public private(set) var needsToScrollToMostRecentMessageAnimated = false
     
+    /// View used to display the messages
     public private(set) lazy var collectionView: MessageCollectionView = {
         let collection = MessageCollectionView(frame: .zero, collectionViewLayout: ChatMessageListCollectionViewLayout())
 
@@ -28,37 +31,46 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         return collection.withoutAutoresizingMaskConstraints
     }()
     
+    /// Controller that handles the composer view
     public private(set) lazy var messageComposerViewController = uiConfig
         .messageComposer
         .messageComposerViewController
         .init()
     
+    /// Constraint connection list of messages and composer controller.
+    /// It's used to change the message list's height based on the keyboard visibility.
     private var messageComposerBottomConstraint: NSLayoutConstraint?
     
+    /// Timer used to update the online status of member in the chat channel
     private var timer: Timer?
     
+    /// Observer responsible for setting the correct offset when keyboard frame is changed
     private lazy var keyboardObserver = ChatMessageListKeyboardObserver(
         containerView: view,
         scrollView: collectionView,
         composerBottomConstraint: messageComposerBottomConstraint
     )
 
-    public lazy var userSuggestionSearchController: _ChatUserSearchController<ExtraData> = {
+    /// User search controller passed directly to the composer
+    public lazy var userSuggestionSearchController: _ChatUserSearchController<ExtraData> =
         channelController.client.userSearchController()
-    }()
     
     // Load from UIConfig
     public lazy var titleView = ChatMessageListTitleView<ExtraData>()
     
+    /// Feedback generator used when presenting actions controller on selected message
     public lazy var impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
 
-//    public lazy var router = uiConfig.navigation.messageListRouter.init(rootViewController: self)
-    public lazy var router = MessageListRouter(rootViewController: self)
+    /// Handles navigation actions from messages
+    public lazy var router = uiConfig
+        .navigation
+        .messageListRouter
+        .init(rootViewController: self)
     
-    override func setUp() {
+    override open func setUp() {
         super.setUp()
         
-        let longPress = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress(_:)))
+        let longPress = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress))
         longPress.minimumPressDuration = 0.33
         collectionView.addGestureRecognizer(longPress)
         
@@ -78,7 +90,7 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         }
     }
     
-    override func setUpLayout() {
+    override open func setUpLayout() {
         super.setUpLayout()
         
         view.addSubview(collectionView)
@@ -104,7 +116,12 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         navigationItem.titleView = titleView
     }
     
-    private func updateNavigationTitle() {
+    /// Updates the status data in `titleView`.
+    ///
+    /// If the channel is direct between two people this method is called repeatedly every minute
+    /// to update the online status of the members.
+    /// For group chat is called everytime the channel changes.
+    open func updateNavigationTitle() {
         let title = channelController.channel
             .flatMap { uiConfig.channelList.channelNamer($0, channelController.client.currentUserId) }
         
@@ -131,7 +148,7 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         titleView.subtitle = subtitle
     }
 
-    override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
         
         navigationItem.largeTitleDisplayMode = .never
@@ -151,11 +168,17 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         keyboardObserver.unregister()
     }
     
-    func cellReuseIdentifier(for message: _ChatMessage<ExtraData>) -> String {
+    /// Returns the reuse identifier for the given message
+    open func cellReuseIdentifier(for message: _ChatMessage<ExtraData>) -> String {
         MessageCell<ExtraData>.reuseId
     }
     
-    func cellLayoutOptionsForMessage(at indexPath: IndexPath) -> ChatMessageLayoutOptions {
+    /// Returns layout options for the message on given `indexPath`.
+    ///
+    /// Layout options are used to determine the layout of the message.
+    /// By default there is one message with all possible layout and layout options
+    /// determines which parts of the message are visible for the given message.
+    open func cellLayoutOptionsForMessage(at indexPath: IndexPath) -> ChatMessageLayoutOptions {
         guard let channel = channelController.channel else { return [] }
 
         return uiConfig.messageList.layoutOptionsResolver(
@@ -165,11 +188,11 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         )
     }
     
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         channelController.messages.count
     }
     
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let message = channelController.messages[indexPath.item]
         
         let cell: MessageCell<ExtraData> = self.collectionView.dequeueReusableCell(
@@ -213,6 +236,7 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         scrollToMostRecentMessage(animated: needsToScrollToMostRecentMessageAnimated)
     }
 
+    /// Scrolls to most recent message
     public func scrollToMostRecentMessage(animated: Bool = true) {
         needsToScrollToMostRecentMessage = false
 
@@ -232,6 +256,7 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         didSelectMessageCell(at: ip)
     }
 
+    /// Updates the collection view data with given `changes`.
     public func updateMessages(with changes: [ListChange<_ChatMessage<ExtraData>>], completion: ((Bool) -> Void)? = nil) {
         collectionView.performBatchUpdates {
             for change in changes {
@@ -299,6 +324,7 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         )
     }
 
+    /// Presents custom actions controller with all possible actions with the selected message.
     private func didSelectMessageCell(at indexPath: IndexPath) {
         let message = channelController.messages[indexPath.item]
         
@@ -338,18 +364,26 @@ class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionVie
         )
     }
 
+    /// Restarts upload of given `attachment` in case of failure
     open func restartUploading(for attachment: ChatMessageDefaultAttachment) {
         guard let id = attachment.id else {
             assertionFailure("Uploading cannot be restarted for attachment without `id`")
             return
         }
 
-        let messageController = channelController.client.messageController(cid: id.cid, messageId: id.messageId)
-        messageController.restartFailedAttachmentUploading(with: id)
+        channelController.client
+            .messageController(cid: id.cid, messageId: id.messageId)
+            .restartFailedAttachmentUploading(with: id)
     }
 
     // MARK: Cell action handlers
 
+    /// Handles the tap on an attachment.
+    ///
+    /// Default implementation tries to restart the upload in case of failure.
+    /// If the attachment is correctly uploaded and displayed
+    /// then for image or file it shows the preview.
+    /// For link it tries to open it.
     open func handleTapOnAttachment(_ attachment: ChatMessageAttachment, forCellAt indexPath: IndexPath) {
         guard let attachment = attachment as? ChatMessageDefaultAttachment else {
             return
@@ -424,7 +458,7 @@ extension MessageListVC: _ChatChannelControllerDelegate {
         updateMessages(with: changes)
     }
     
-    func channelController(
+    public func channelController(
         _ channelController: _ChatChannelController<ExtraData>,
         didUpdateChannel channel: EntityChange<_ChatChannel<ExtraData>>
     ) {

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -9,21 +9,21 @@ import UIKit
 open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionViewDelegate, UICollectionViewDataSource,
     UIConfigProvider {
     /// Controller for observing data changes within the channel
-    public var channelController: _ChatChannelController<ExtraData>!
+    open var channelController: _ChatChannelController<ExtraData>!
     
     /// Observer responsible for setting the correct offset when keyboard frame is changed
-    public lazy var keyboardObserver = ChatMessageListKeyboardObserver(
+    open lazy var keyboardObserver = ChatMessageListKeyboardObserver(
         containerView: view,
         scrollView: collectionView,
         composerBottomConstraint: messageComposerBottomConstraint
     )
 
     /// User search controller passed directly to the composer
-    public lazy var userSuggestionSearchController: _ChatUserSearchController<ExtraData> =
+    open lazy var userSuggestionSearchController: _ChatUserSearchController<ExtraData> =
         channelController.client.userSearchController()
     
     /// View used to display the messages
-    public private(set) lazy var collectionView: MessageCollectionView = {
+    open private(set) lazy var collectionView: MessageCollectionView = {
         let collection = MessageCollectionView(frame: .zero, collectionViewLayout: ChatMessageListCollectionViewLayout())
 
         collection.isPrefetchingEnabled = false
@@ -37,7 +37,7 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
     }()
     
     /// Controller that handles the composer view
-    public private(set) lazy var messageComposerViewController = uiConfig
+    open private(set) lazy var messageComposerViewController = uiConfig
         .messageComposer
         .messageComposerViewController
         .init()
@@ -46,19 +46,19 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
     /// View displaying status of the channel.
     ///
     /// The status differs based on the fact if the channel is direct or not.
-    public lazy var titleView = ChatMessageListTitleView<ExtraData>()
+    open lazy var titleView = ChatMessageListTitleView<ExtraData>()
     
     /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
-    public private(set) var needsToScrollToMostRecentMessage = true
+    open private(set) var needsToScrollToMostRecentMessage = true
     
     /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
-    public private(set) var needsToScrollToMostRecentMessageAnimated = false
+    open private(set) var needsToScrollToMostRecentMessageAnimated = false
     
     /// Feedback generator used when presenting actions controller on selected message
-    public lazy var impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
+    open lazy var impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
 
     /// Handles navigation actions from messages
-    public lazy var router = uiConfig
+    open lazy var router = uiConfig
         .navigation
         .messageListRouter
         .init(rootViewController: self)
@@ -159,11 +159,11 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
         )
     }
     
-    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         channelController.messages.count
     }
     
-    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    open func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let message = channelController.messages[indexPath.item]
         
         let cell: MessageCell<ExtraData> = self.collectionView.dequeueReusableCell(
@@ -195,20 +195,20 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
     }
     
     /// Will scroll to most recent message on next `updateMessages` call
-    public func setNeedsScrollToMostRecentMessage(animated: Bool = true) {
+    open func setNeedsScrollToMostRecentMessage(animated: Bool = true) {
         needsToScrollToMostRecentMessage = true
         needsToScrollToMostRecentMessageAnimated = animated
     }
 
     /// Force scroll to most recent message check without waiting for `updateMessages`
-    public func scrollToMostRecentMessageIfNeeded() {
+    open func scrollToMostRecentMessageIfNeeded() {
         guard needsToScrollToMostRecentMessage else { return }
         
         scrollToMostRecentMessage(animated: needsToScrollToMostRecentMessageAnimated)
     }
 
     /// Scrolls to most recent message
-    public func scrollToMostRecentMessage(animated: Bool = true) {
+    open func scrollToMostRecentMessage(animated: Bool = true) {
         needsToScrollToMostRecentMessage = false
 
         // our collection is flipped, so (0; 0) item is most recent one
@@ -263,7 +263,7 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
     }
 
     /// Updates the collection view data with given `changes`.
-    public func updateMessages(with changes: [ListChange<_ChatMessage<ExtraData>>], completion: ((Bool) -> Void)? = nil) {
+    open func updateMessages(with changes: [ListChange<_ChatMessage<ExtraData>>], completion: ((Bool) -> Void)? = nil) {
         collectionView.performBatchUpdates {
             for change in changes {
                 switch change {
@@ -455,20 +455,20 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
 }
 
 extension MessageListVC: _ChatMessageComposerViewControllerDelegate {
-    public func messageComposerViewControllerDidSendMessage(_ vc: _ChatMessageComposerVC<ExtraData>) {
+    open func messageComposerViewControllerDidSendMessage(_ vc: _ChatMessageComposerVC<ExtraData>) {
         setNeedsScrollToMostRecentMessage()
     }
 }
 
 extension MessageListVC: _ChatChannelControllerDelegate {
-    public func channelController(
+    open func channelController(
         _ channelController: _ChatChannelController<ExtraData>,
         didUpdateMessages changes: [ListChange<_ChatMessage<ExtraData>>]
     ) {
         updateMessages(with: changes)
     }
     
-    public func channelController(
+    open func channelController(
         _ channelController: _ChatChannelController<ExtraData>,
         didUpdateChannel channel: EntityChange<_ChatChannel<ExtraData>>
     ) {

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -50,12 +50,6 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
     ///
     /// The status differs based on the fact if the channel is direct or not.
     open lazy var titleView = ChatMessageListTitleView<ExtraData>()
-    
-    /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
-    open private(set) var needsToScrollToMostRecentMessage = true
-    
-    /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
-    open private(set) var needsToScrollToMostRecentMessageAnimated = false
 
     /// Handles navigation actions from messages
     open lazy var router = uiConfig
@@ -270,7 +264,7 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
         channelController.messages[indexPath.item]
     }
     
-    private func didSelectMessageCell(at indexPath: IndexPath) {
+    open func didSelectMessageCell(at indexPath: IndexPath) {
         let message = channelController.messages[indexPath.item]
         
         guard
@@ -287,7 +281,7 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
     }
 
     /// Presents custom actions controller with all possible actions with the selected message.
-    private func presentActionsForMessage(
+    open func presentActionsForMessage(
         _ message: _ChatMessage<ExtraData>,
         cell: MessageCell<ExtraData>,
         messageController: _ChatMessageController<ExtraData>

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -105,7 +105,7 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
         messageComposerBottomConstraint?.isActive = true
     }
 
-    override func setUpAppearance() {
+    override open func setUpAppearance() {
         super.setUpAppearance()
         
         view.backgroundColor = .white
@@ -413,7 +413,7 @@ extension MessageListVC: _ChatChannelControllerDelegate {
 }
 
 extension MessageListVC: _ChatMessageActionsVCDelegate {
-    func chatMessageActionsVC(
+    open func chatMessageActionsVC(
         _ vc: _ChatMessageActionsVC<ExtraData>,
         message: _ChatMessage<ExtraData>,
         didTapOnActionItem actionItem: ChatMessageActionItem

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -287,10 +287,7 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
 
     /// Updates the collection view data with given `changes`.
     open func updateMessages(with changes: [ListChange<_ChatMessage<ExtraData>>], completion: ((Bool) -> Void)? = nil) {
-        collectionView.updateMessages(with: changes) {
-            completion?($0)
-            self.scrollToMostRecentMessageIfNeeded()
-        }
+        collectionView.updateMessages(with: changes, completion: completion)
     }
 
     /// Presents custom actions controller with all possible actions with the selected message.

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -2,23 +2,34 @@
 // Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
 import StreamChat
 import UIKit
 
-class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionViewDelegate, UICollectionViewDataSource,
+/// Controller responsible for displaying message thread.
+open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionViewDelegate, UICollectionViewDataSource,
     UIConfigProvider {
-    var channelController: _ChatChannelController<ExtraData>!
-    var messageController: _ChatMessageController<ExtraData>!
+    /// Controller for observing data changes within the channel
+    open var channelController: _ChatChannelController<ExtraData>!
     
-    /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
-    public private(set) var needsToScrollToMostRecentMessage = true
-    /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
-    public private(set) var needsToScrollToMostRecentMessageAnimated = false
+    // TODO: Documentation
+    open var messageController: _ChatMessageController<ExtraData>!
+
+    /// Observer responsible for setting the correct offset when keyboard frame is changed
+    open lazy var keyboardObserver = ChatMessageListKeyboardObserver(
+        containerView: view,
+        scrollView: collectionView,
+        composerBottomConstraint: messageComposerBottomConstraint
+    )
+
+    /// User search controller passed directly to the composer
+    open lazy var userSuggestionSearchController: _ChatUserSearchController<ExtraData> =
+        channelController.client.userSearchController()
     
-    private lazy var messageListLayout = ChatMessageListCollectionViewLayout()
+    // TODO: Documentation
+    open lazy var messageListLayout = ChatMessageListCollectionViewLayout()
     
-    public private(set) lazy var collectionView: MessageCollectionView = {
+    /// View used to display the messages
+    open private(set) lazy var collectionView: MessageCollectionView = {
         let collection = MessageCollectionView(frame: .zero, collectionViewLayout: messageListLayout)
 
         collection.isPrefetchingEnabled = false
@@ -31,27 +42,43 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
         return collection.withoutAutoresizingMaskConstraints
     }()
     
-    public private(set) lazy var messageComposerViewController = uiConfig
+    /// Controller that handles the composer view
+    open private(set) lazy var messageComposerViewController = uiConfig
         .messageComposer
         .messageComposerViewController
         .init()
     
+    // TODO: Load from UIConfig, seperate PR for this component is already created
+    /// View displaying status of the channel.
+    ///
+    /// The status differs based on the fact if the channel is direct or not.
+    open lazy var titleView = ChatMessageListTitleView<ExtraData>()
+    
+    /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
+    open private(set) var needsToScrollToMostRecentMessage = true
+
+    /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
+    open private(set) var needsToScrollToMostRecentMessageAnimated = false
+    
+    /// Feedback generator used when presenting actions controller on selected message
+    open lazy var impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
+    
+    /// Handles navigation actions from messages
+    open lazy var router = uiConfig
+        .navigation
+        .messageListRouter
+        .init(rootViewController: self)
+    
+    /// Constraint connection list of messages and composer controller.
+    /// It's used to change the message list's height based on the keyboard visibility.
     private var messageComposerBottomConstraint: NSLayoutConstraint?
     
-    private lazy var keyboardObserver = ChatMessageListKeyboardObserver(
-        containerView: view,
-        scrollView: collectionView,
-        composerBottomConstraint: messageComposerBottomConstraint
-    )
-
-    public lazy var userSuggestionSearchController: _ChatUserSearchController<ExtraData> = channelController.client
-        .userSearchController()
-    
-    // Load from UIConfig
-    public lazy var titleView = ChatMessageListTitleView<ExtraData>()
-    
-    override func setUp() {
+    override open func setUp() {
         super.setUp()
+        
+        let longPress = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress))
+        longPress.minimumPressDuration = 0.33
+        collectionView.addGestureRecognizer(longPress)
         
         messageComposerViewController.delegate = .wrap(self)
         messageComposerViewController.controller = channelController
@@ -67,7 +94,7 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
         messageController.synchronize()
     }
     
-    override func setUpLayout() {
+    override open func setUpLayout() {
         super.setUpLayout()
         
         view.addSubview(collectionView)
@@ -76,12 +103,157 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
         messageComposerViewController.view.translatesAutoresizingMaskIntoConstraints = false
         addChildViewController(messageComposerViewController, targetView: view)
         
-        if let message = messageController.message, let channel = channelController.channel {
+        addHeaderMessage()
+
+        messageComposerViewController.view.topAnchor.pin(equalTo: collectionView.bottomAnchor).isActive = true
+        messageComposerViewController.view.leadingAnchor.pin(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
+        messageComposerViewController.view.trailingAnchor.pin(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+        messageComposerBottomConstraint = messageComposerViewController.view.bottomAnchor.pin(equalTo: view.bottomAnchor)
+        messageComposerBottomConstraint?.isActive = true
+    }
+
+    override func setUpAppearance() {
+        super.setUpAppearance()
+        
+        view.backgroundColor = .white
+        
+        collectionView.backgroundColor = .white
+        
+        navigationItem.titleView = titleView
+    }
+
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        
+        navigationItem.largeTitleDisplayMode = .never
+    }
+    
+    override open func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        keyboardObserver.register()
+        
+        // Scroll to newest message when there are no replies
+        // breaks the `contentOffset` set by parent message
+        if !messageController.replies.isEmpty {
+            scrollToMostRecentMessageIfNeeded()
+        }
+    }
+
+    override open func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        resignFirstResponder()
+        
+        keyboardObserver.unregister()
+    }
+    
+    /// Returns the reuse identifier for the given message
+    open func cellReuseIdentifier(for message: _ChatMessage<ExtraData>) -> String {
+        MessageCell<ExtraData>.reuseId
+    }
+    
+    /// Returns layout options for the message on given `indexPath`.
+    ///
+    /// Layout options are used to determine the layout of the message.
+    /// By default there is one message with all possible layout and layout options
+    /// determines which parts of the message are visible for the given message.
+    open func cellLayoutOptionsForMessage(at indexPath: IndexPath) -> ChatMessageLayoutOptions {
+        guard let channel = channelController.channel else { return [] }
+
+        var layoutOptions = uiConfig.messageList.layoutOptionsResolver(
+            indexPath,
+            AnyRandomAccessCollection(messageController.replies),
+            channel
+        )
+        layoutOptions.remove(.threadInfo)
+        return layoutOptions
+    }
+    
+    open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        messageController.replies.count
+    }
+    
+    open func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let message = messageController.replies[indexPath.item]
+        
+        let cell: MessageCell<ExtraData> = self.collectionView.dequeueReusableCell(
+            withReuseIdentifier: cellReuseIdentifier(for: message),
+            layoutOptions: cellLayoutOptionsForMessage(at: indexPath),
+            for: indexPath
+        )
+        
+        cell.messageContentView.delegate = .init(
+            didTapOnErrorIndicator: { [weak self] in
+                self?.handleTapOnErrorIndicator(forCellAt: indexPath)
+            },
+            didTapOnThread: { [weak self] in
+                self?.handleTapOnThread(forCellAt: indexPath)
+            },
+            didTapOnAttachment: { [weak self] in
+                self?.handleTapOnAttachment($0, forCellAt: indexPath)
+            },
+            didTapOnAttachmentAction: { [weak self] attachment, action in
+                self?.handleTapOnAttachmentAction(action, for: attachment, forCellAt: indexPath)
+            },
+            didTapOnQuotedMessage: { [weak self] in
+                self?.handleTapOnQuotedMessage($0, forCellAt: indexPath)
+            }
+        )
+        cell.messageContentView.content = message
+        
+        return cell
+    }
+    
+    open func collectionView(
+        _ collectionView: UICollectionView,
+        willDisplay cell: UICollectionViewCell,
+        forItemAt indexPath: IndexPath
+    ) {
+        if indexPath.row + 1 >= collectionView.numberOfItems(inSection: 0) {
+            messageController.loadPreviousReplies()
+        }
+    }
+    
+    /// Will scroll to most recent message on next `updateMessages` call
+    open func setNeedsScrollToMostRecentMessage(animated: Bool = true) {
+        needsToScrollToMostRecentMessage = true
+        needsToScrollToMostRecentMessageAnimated = animated
+    }
+
+    /// Force scroll to most recent message check without waiting for `updateMessages`
+    open func scrollToMostRecentMessageIfNeeded() {
+        guard needsToScrollToMostRecentMessage else { return }
+        
+        scrollToMostRecentMessage(animated: needsToScrollToMostRecentMessageAnimated)
+    }
+
+    open func scrollToMostRecentMessage(animated: Bool = true) {
+        needsToScrollToMostRecentMessage = false
+
+        // our collection is flipped, so (0; 0) item is most recent one
+        collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: animated)
+    }
+    
+    // TODO: L10n
+    /// Updates the status data in `titleView`.
+    ///
+    /// If the channel is direct between two people this method is called repeatedly every minute
+    /// to update the online status of the members.
+    /// For group chat is called everytime the channel changes.
+    open func updateNavigationTitle() {
+        let channelName = channelController.channel?.name ?? "love"
+        titleView.title = "Thread Reply"
+        titleView.subtitle = "with \(channelName)"
+    }
+    
+    // TODO: Documentation
+    open func addHeaderMessage() {
+        if let message = messageController.message {
             let messageView = MessageContentView<ExtraData>().withoutAutoresizingMaskConstraints
             var layoutOptions = uiConfig.messageList.layoutOptionsResolver(
                 IndexPath(item: 0, section: 0),
-                AnyRandomAccessCollection([message]),
-                channel
+                AnyRandomAccessCollection([message])
             )
             layoutOptions.remove(.threadInfo)
             
@@ -103,119 +275,25 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
             messageView.topAnchor.pin(equalTo: collectionView.topAnchor, constant: -topInset).isActive = true
             messageView.pin(anchors: [.leading, .trailing], to: collectionView.safeAreaLayoutGuide)
         }
-
-        messageComposerViewController.view.topAnchor.pin(equalTo: collectionView.bottomAnchor).isActive = true
-        messageComposerViewController.view.leadingAnchor.pin(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
-        messageComposerViewController.view.trailingAnchor.pin(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
-        messageComposerBottomConstraint = messageComposerViewController.view.bottomAnchor.pin(equalTo: view.bottomAnchor)
-        messageComposerBottomConstraint?.isActive = true
-    }
-
-    override func setUpAppearance() {
-        super.setUpAppearance()
-        
-        view.backgroundColor = .white
-        
-        collectionView.backgroundColor = .white
-        
-        navigationItem.titleView = titleView
     }
     
-    private func updateNavigationTitle() {
-        let channelName = channelController.channel?.name ?? "love"
-        titleView.title = "Thread Reply"
-        titleView.subtitle = "with \(channelName)"
+    /// Handles long press action on collection view.
+    ///
+    /// Default implementation will convert the gesture location to collection view's `indexPath`
+    /// and then call selection action on the selected cell.
+    @objc open func didLongPress(_ gesture: UILongPressGestureRecognizer) {
+        let location = gesture.location(in: collectionView)
+
+        guard
+            gesture.state == .began,
+            let ip = collectionView.indexPathForItem(at: location)
+        else { return }
+        
+        didSelectMessageCell(at: ip)
     }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        navigationItem.largeTitleDisplayMode = .never
-    }
-    
-    override open func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        keyboardObserver.register()
-        
-        if !messageController.replies.isEmpty {
-            scrollToMostRecentMessageIfNeeded()
-        }
-    }
-
-    override open func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        
-        resignFirstResponder()
-        
-        keyboardObserver.unregister()
-    }
-    
-    func cellReuseIdentifier(for message: _ChatMessage<ExtraData>) -> String {
-        MessageCell<ExtraData>.reuseId
-    }
-    
-    func cellLayoutOptionsForMessage(at indexPath: IndexPath) -> ChatMessageLayoutOptions {
-        guard let channel = channelController.channel else { return [] }
-
-        var layoutOptions = uiConfig.messageList.layoutOptionsResolver(
-            indexPath,
-            AnyRandomAccessCollection(messageController.replies),
-            channel
-        )
-        layoutOptions.remove(.threadInfo)
-        return layoutOptions
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        messageController.replies.count
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let message = messageController.replies[indexPath.item]
-        
-        let cell: MessageCell<ExtraData> = self.collectionView.dequeueReusableCell(
-            withReuseIdentifier: cellReuseIdentifier(for: message),
-            layoutOptions: cellLayoutOptionsForMessage(at: indexPath),
-            for: indexPath
-        )
-        
-        cell.messageContentView.content = message
-        
-        return cell
-    }
-    
-    public func collectionView(
-        _ collectionView: UICollectionView,
-        willDisplay cell: UICollectionViewCell,
-        forItemAt indexPath: IndexPath
-    ) {
-        if indexPath.row + 1 >= collectionView.numberOfItems(inSection: 0) {
-            messageController.loadPreviousReplies()
-        }
-    }
-    
-    /// Will scroll to most recent message on next `updateMessages` call
-    public func setNeedsScrollToMostRecentMessage(animated: Bool = true) {
-        needsToScrollToMostRecentMessage = true
-        needsToScrollToMostRecentMessageAnimated = animated
-    }
-
-    /// Force scroll to most recent message check without waiting for `updateMessages`
-    public func scrollToMostRecentMessageIfNeeded() {
-        guard needsToScrollToMostRecentMessage else { return }
-        
-        scrollToMostRecentMessage(animated: needsToScrollToMostRecentMessageAnimated)
-    }
-
-    public func scrollToMostRecentMessage(animated: Bool = true) {
-        needsToScrollToMostRecentMessage = false
-
-        // our collection is flipped, so (0; 0) item is most recent one
-        collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: animated)
-    }
-
-    public func updateMessages(with changes: [ListChange<_ChatMessage<ExtraData>>], completion: ((Bool) -> Void)? = nil) {
+    /// Updates the collection view data with given `changes`.
+    open func updateMessages(with changes: [ListChange<_ChatMessage<ExtraData>>], completion: ((Bool) -> Void)? = nil) {
         collectionView.performBatchUpdates {
             for change in changes {
                 switch change {
@@ -234,16 +312,181 @@ class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionV
             self.scrollToMostRecentMessageIfNeeded()
         }
     }
+    
+    private func presentReactionsControllerAnimated(
+        for cell: MessageCell<ExtraData>,
+        with messageData: _ChatMessageGroupPart<ExtraData>,
+        actionsController: _ChatMessageActionsVC<ExtraData>,
+        reactionsController: _ChatMessageReactionsVC<ExtraData>?
+    ) {
+        // TODO: for PR: This should be doable via:
+        // 1. options: [.autoreverse, .repeat] and
+        // 2. `UIView.setAnimationRepeatCount(0)` inside the animation block...
+        //
+        // and then just set completion to the animation to transform this back. aka `cell.messageView.transform = .identity`
+        // however, this doesn't work as after the animation is done, it clips back to the value set in animation block
+        // and then on completion goes back to `.identity`... This is really strange, but I was fighting it for some time
+        // and couldn't find proper solution...
+        // Also there are some limitations to the current solution ->
+        // According to my debug view hiearchy, the content inside `messageView.messageBubbleView` is not constrainted to the
+        // bubble view itself, meaning right now if we want to scale the view of incoming message, we scale the avatarView
+        // of the sender as well...
+        UIView.animate(
+            withDuration: 0.2,
+            delay: 0,
+            options: [.curveEaseIn],
+            animations: {
+                cell.messageContentView.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
+            },
+            completion: { _ in
+                self.impactFeedbackGenerator.impactOccurred()
+
+                UIView.animate(
+                    withDuration: 0.1,
+                    delay: 0,
+                    options: [.curveEaseOut],
+                    animations: {
+                        cell.messageContentView.transform = .identity
+                    }
+                )
+                
+                self.router.showMessageActionsPopUp(
+                    messageContentFrame: cell.messageContentView.superview!.convert(cell.messageContentView.frame, to: nil),
+                    messageData: messageData,
+                    messageActionsController: actionsController,
+                    messageReactionsController: reactionsController
+                )
+            }
+        )
+    }
+
+    /// Presents custom actions controller with all possible actions with the selected message.
+    private func didSelectMessageCell(at indexPath: IndexPath) {
+        let message = messageController.replies[indexPath.item]
+        
+        guard let cell = collectionView.cellForItem(at: indexPath) as? MessageCell<ExtraData> else { return }
+        guard message.isInteractionEnabled else { return }
+        
+        let messageController = channelController.client.messageController(
+            cid: channelController.cid!,
+            messageId: message.id
+        )
+
+        let actionsController = _ChatMessageActionsVC<ExtraData>()
+        actionsController.messageController = messageController
+        actionsController.delegate = .init(delegate: self)
+
+        var reactionsController: _ChatMessageReactionsVC<ExtraData>? {
+            guard message.localState == nil else { return nil }
+
+            let controller = _ChatMessageReactionsVC<ExtraData>()
+            controller.messageController = messageController
+            return controller
+        }
+
+        presentReactionsControllerAnimated(
+            for: cell,
+            // only `message` is used but I don't want to break current implementation
+            with: _ChatMessageGroupPart(
+                message: message,
+                quotedMessage: nil,
+                isFirstInGroup: true,
+                isLastInGroup: true,
+                didTapOnAttachment: nil,
+                didTapOnAttachmentAction: nil
+            ),
+            actionsController: actionsController,
+            reactionsController: reactionsController
+        )
+    }
+
+    /// Restarts upload of given `attachment` in case of failure
+    open func restartUploading(for attachment: ChatMessageDefaultAttachment) {
+        guard let id = attachment.id else {
+            assertionFailure("Uploading cannot be restarted for attachment without `id`")
+            return
+        }
+
+        channelController.client
+            .messageController(cid: id.cid, messageId: id.messageId)
+            .restartFailedAttachmentUploading(with: id)
+    }
+    
+    // MARK: Cell action handlers
+
+    /// Handles the tap on an attachment.
+    ///
+    /// Default implementation tries to restart the upload in case of failure.
+    /// If the attachment is correctly uploaded and displayed
+    /// then for image or file it shows the preview.
+    /// For link it tries to open it.
+    open func handleTapOnAttachment(_ attachment: ChatMessageAttachment, forCellAt indexPath: IndexPath) {
+        guard let attachment = attachment as? ChatMessageDefaultAttachment else {
+            return
+        }
+
+        guard attachment.localState != .uploadingFailed else {
+            restartUploading(for: attachment)
+            return
+        }
+
+        switch attachment.type {
+        case .image, .file:
+            router.showPreview(for: attachment)
+        case .link:
+            router.openLink(attachment)
+        default:
+            break
+        }
+    }
+
+    /// Executes the provided action on the message
+    open func handleTapOnAttachmentAction(
+        _ action: AttachmentAction,
+        for attachment: ChatMessageAttachment,
+        forCellAt indexPath: IndexPath
+    ) {
+        // Can we have a helper on `ChannelController` returning a `messageController` for the provided message id?
+        channelController.client
+            .messageController(
+                cid: channelController.cid!,
+                messageId: channelController.messages[indexPath.row].id
+            )
+            .dispatchEphemeralMessageAction(action)
+    }
+
+    // TODO: Currently not supported
+    private func handleTapOnQuotedMessage(_ quotedMessage: _ChatMessage<ExtraData>, forCellAt indexPath: IndexPath) {
+        print(#function, quotedMessage)
+    }
+
+    /// Opens the action menu with action to resend the message
+    open func handleTapOnErrorIndicator(forCellAt indexPath: IndexPath) {
+        didSelectMessageCell(at: indexPath)
+    }
+
+    /// Opens thread detail for cell at `indexPath`
+    open func handleTapOnThread(forCellAt indexPath: IndexPath) {
+        guard let channel = channelController.channel else { return }
+        
+        let controller = MessageThreadVC<ExtraData>()
+        controller.channelController = channelController
+        controller.messageController = channelController.client.messageController(
+            cid: channel.cid,
+            messageId: channelController.messages[indexPath.item].id
+        )
+        navigationController?.show(controller, sender: self)
+    }
 }
 
 extension MessageThreadVC: _ChatMessageComposerViewControllerDelegate {
-    public func messageComposerViewControllerDidSendMessage(_ vc: _ChatMessageComposerVC<ExtraData>) {
+    open func messageComposerViewControllerDidSendMessage(_ vc: _ChatMessageComposerVC<ExtraData>) {
         setNeedsScrollToMostRecentMessage()
     }
 }
 
 extension MessageThreadVC: _ChatChannelControllerDelegate {
-    func channelController(
+    open func channelController(
         _ channelController: _ChatChannelController<ExtraData>,
         didUpdateChannel channel: EntityChange<_ChatChannel<ExtraData>>
     ) {
@@ -252,7 +495,7 @@ extension MessageThreadVC: _ChatChannelControllerDelegate {
 }
 
 extension MessageThreadVC: _ChatMessageControllerDelegate {
-    func messageController(
+    open func messageController(
         _ controller: _ChatMessageController<ExtraData>,
         didChangeReplies changes: [ListChange<_ChatMessage<ExtraData>>]
     ) {
@@ -260,7 +503,6 @@ extension MessageThreadVC: _ChatMessageControllerDelegate {
     }
 }
 
-// It's not implemented in current version :(
 extension MessageThreadVC: _ChatMessageActionsVCDelegate {
     open func chatMessageActionsVC(
         _ vc: _ChatMessageActionsVC<ExtraData>,

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -152,13 +152,19 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
     /// By default there is one message with all possible layout and layout options
     /// determines which parts of the message are visible for the given message.
     open func cellLayoutOptionsForMessage(at indexPath: IndexPath) -> ChatMessageLayoutOptions {
-        guard let channel = channelController.channel else { return [] }
-
-        var layoutOptions = uiConfig.messageList.layoutOptionsResolver(
-            indexPath,
-            AnyRandomAccessCollection(messageController.replies),
-            channel
+        cellLayoutOptionsForMessage(
+            at: indexPath,
+            messages: AnyRandomAccessCollection(messageController.replies)
         )
+    }
+    
+    open func cellLayoutOptionsForMessage(
+        at indexPath: IndexPath,
+        messages: AnyRandomAccessCollection<_ChatMessage<ExtraData>>
+    ) -> ChatMessageLayoutOptions {
+        guard let channel = channelController.channel else { return [] }
+        
+        var layoutOptions = uiConfig.messageList.layoutOptionsResolver(indexPath, messages, channel)
         layoutOptions.remove(.threadInfo)
         return layoutOptions
     }
@@ -239,11 +245,10 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
     open func addHeaderMessage() {
         if let message = messageController.message {
             let messageView = MessageContentView<ExtraData>().withoutAutoresizingMaskConstraints
-            var layoutOptions = uiConfig.messageList.layoutOptionsResolver(
-                IndexPath(item: 0, section: 0),
-                AnyRandomAccessCollection([message])
+            let layoutOptions = cellLayoutOptionsForMessage(
+                at: IndexPath(item: 0, section: 0),
+                messages: AnyRandomAccessCollection([message])
             )
-            layoutOptions.remove(.threadInfo)
             
             messageView.setUpLayoutIfNeeded(options: layoutOptions)
             collectionView.addSubview(messageView)

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -289,7 +289,7 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
     }
 
     /// Presents custom actions controller with all possible actions with the selected message.
-    private func didSelectMessageCell(at indexPath: IndexPath) {
+    open func didSelectMessageCell(at indexPath: IndexPath) {
         let message = messageController.replies[indexPath.item]
         
         guard
@@ -306,7 +306,7 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
     }
     
     /// Presents custom actions controller with all possible actions with the selected message.
-    private func presentActionsForMessage(
+    open func presentActionsForMessage(
         _ message: _ChatMessage<ExtraData>,
         cell: MessageCell<ExtraData>,
         messageController: _ChatMessageController<ExtraData>

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -105,7 +105,7 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
         messageComposerBottomConstraint?.isActive = true
     }
 
-    override func setUpAppearance() {
+    override open func setUpAppearance() {
         super.setUpAppearance()
         
         view.backgroundColor = .white

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -228,6 +228,7 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
         scrollToMostRecentMessage(animated: needsToScrollToMostRecentMessageAnimated)
     }
 
+    /// Scrolls to most recent message
     open func scrollToMostRecentMessage(animated: Bool = true) {
         needsToScrollToMostRecentMessage = false
 
@@ -359,10 +360,14 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
             }
         )
     }
+    
+    func messageForIndexPath(_ indexPath: IndexPath) -> _ChatMessage<ExtraData> {
+        messageController.replies[indexPath.item]
+    }
 
     /// Presents custom actions controller with all possible actions with the selected message.
     private func didSelectMessageCell(at indexPath: IndexPath) {
-        let message = messageController.replies[indexPath.item]
+        let message = messageForIndexPath(indexPath)
         
         guard let cell = collectionView.cellForItem(at: indexPath) as? MessageCell<ExtraData> else { return }
         guard message.isInteractionEnabled else { return }

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -48,20 +48,13 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
         .messageComposerViewController
         .init()
     
+    open lazy var popupPresenter = PopupPresenter(rootViewController: self)
+    
     // TODO: Load from UIConfig, seperate PR for this component is already created
     /// View displaying status of the channel.
     ///
     /// The status differs based on the fact if the channel is direct or not.
     open lazy var titleView = ChatMessageListTitleView<ExtraData>()
-    
-    /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
-    open private(set) var needsToScrollToMostRecentMessage = true
-
-    /// Consider to call `setNeedsScrollToMostRecentMessage(animated:)` instead
-    open private(set) var needsToScrollToMostRecentMessageAnimated = false
-    
-    /// Feedback generator used when presenting actions controller on selected message
-    open lazy var impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
     
     /// Handles navigation actions from messages
     open lazy var router = uiConfig
@@ -217,23 +210,17 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
     
     /// Will scroll to most recent message on next `updateMessages` call
     open func setNeedsScrollToMostRecentMessage(animated: Bool = true) {
-        needsToScrollToMostRecentMessage = true
-        needsToScrollToMostRecentMessageAnimated = animated
+        collectionView.setNeedsScrollToMostRecentMessage(animated: animated)
     }
 
     /// Force scroll to most recent message check without waiting for `updateMessages`
     open func scrollToMostRecentMessageIfNeeded() {
-        guard needsToScrollToMostRecentMessage else { return }
-        
-        scrollToMostRecentMessage(animated: needsToScrollToMostRecentMessageAnimated)
+        collectionView.scrollToMostRecentMessageIfNeeded()
     }
 
     /// Scrolls to most recent message
     open func scrollToMostRecentMessage(animated: Bool = true) {
-        needsToScrollToMostRecentMessage = false
-
-        // our collection is flipped, so (0; 0) item is most recent one
-        collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: animated)
+        collectionView.scrollToMostRecentMessage(animated: animated)
     }
     
     // TODO: L10n
@@ -295,88 +282,35 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
 
     /// Updates the collection view data with given `changes`.
     open func updateMessages(with changes: [ListChange<_ChatMessage<ExtraData>>], completion: ((Bool) -> Void)? = nil) {
-        collectionView.performBatchUpdates {
-            for change in changes {
-                switch change {
-                case let .insert(_, index):
-                    collectionView.insertItems(at: [index])
-                case let .move(_, fromIndex, toIndex):
-                    collectionView.moveItem(at: fromIndex, to: toIndex)
-                case let .remove(_, index):
-                    collectionView.deleteItems(at: [index])
-                case let .update(_, index):
-                    collectionView.reloadItems(at: [index])
-                }
-            }
-        } completion: { flag in
-            completion?(flag)
+        collectionView.updateMessages(with: changes) {
+            completion?($0)
             self.scrollToMostRecentMessageIfNeeded()
         }
-    }
-    
-    private func presentReactionsControllerAnimated(
-        for cell: MessageCell<ExtraData>,
-        with messageData: _ChatMessageGroupPart<ExtraData>,
-        actionsController: _ChatMessageActionsVC<ExtraData>,
-        reactionsController: _ChatMessageReactionsVC<ExtraData>?
-    ) {
-        // TODO: for PR: This should be doable via:
-        // 1. options: [.autoreverse, .repeat] and
-        // 2. `UIView.setAnimationRepeatCount(0)` inside the animation block...
-        //
-        // and then just set completion to the animation to transform this back. aka `cell.messageView.transform = .identity`
-        // however, this doesn't work as after the animation is done, it clips back to the value set in animation block
-        // and then on completion goes back to `.identity`... This is really strange, but I was fighting it for some time
-        // and couldn't find proper solution...
-        // Also there are some limitations to the current solution ->
-        // According to my debug view hiearchy, the content inside `messageView.messageBubbleView` is not constrainted to the
-        // bubble view itself, meaning right now if we want to scale the view of incoming message, we scale the avatarView
-        // of the sender as well...
-        UIView.animate(
-            withDuration: 0.2,
-            delay: 0,
-            options: [.curveEaseIn],
-            animations: {
-                cell.messageContentView.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
-            },
-            completion: { _ in
-                self.impactFeedbackGenerator.impactOccurred()
-
-                UIView.animate(
-                    withDuration: 0.1,
-                    delay: 0,
-                    options: [.curveEaseOut],
-                    animations: {
-                        cell.messageContentView.transform = .identity
-                    }
-                )
-                
-                self.router.showMessageActionsPopUp(
-                    messageContentFrame: cell.messageContentView.superview!.convert(cell.messageContentView.frame, to: nil),
-                    messageData: messageData,
-                    messageActionsController: actionsController,
-                    messageReactionsController: reactionsController
-                )
-            }
-        )
-    }
-    
-    func messageForIndexPath(_ indexPath: IndexPath) -> _ChatMessage<ExtraData> {
-        messageController.replies[indexPath.item]
     }
 
     /// Presents custom actions controller with all possible actions with the selected message.
     private func didSelectMessageCell(at indexPath: IndexPath) {
-        let message = messageForIndexPath(indexPath)
+        let message = messageController.replies[indexPath.item]
         
-        guard let cell = collectionView.cellForItem(at: indexPath) as? MessageCell<ExtraData> else { return }
-        guard message.isInteractionEnabled else { return }
+        guard
+            let cell = collectionView.cellForItem(at: indexPath) as? MessageCell<ExtraData>,
+            message.isInteractionEnabled
+        else { return }
         
         let messageController = channelController.client.messageController(
             cid: channelController.cid!,
             messageId: message.id
         )
-
+        
+        presentActionsForMessage(message, cell: cell, messageController: messageController)
+    }
+    
+    /// Presents custom actions controller with all possible actions with the selected message.
+    private func presentActionsForMessage(
+        _ message: _ChatMessage<ExtraData>,
+        cell: MessageCell<ExtraData>,
+        messageController: _ChatMessageController<ExtraData>
+    ) {
         let actionsController = _ChatMessageActionsVC<ExtraData>()
         actionsController.messageController = messageController
         actionsController.delegate = .init(delegate: self)
@@ -388,18 +322,10 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
             controller.messageController = messageController
             return controller
         }
-
-        presentReactionsControllerAnimated(
-            for: cell,
-            // only `message` is used but I don't want to break current implementation
-            with: _ChatMessageGroupPart(
-                message: message,
-                quotedMessage: nil,
-                isFirstInGroup: true,
-                isLastInGroup: true,
-                didTapOnAttachment: nil,
-                didTapOnAttachmentAction: nil
-            ),
+        
+        popupPresenter.present(
+            targetView: cell.messageContentView,
+            message: message,
             actionsController: actionsController,
             reactionsController: reactionsController
         )
@@ -455,7 +381,7 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
         channelController.client
             .messageController(
                 cid: channelController.cid!,
-                messageId: channelController.messages[indexPath.row].id
+                messageId: messageController.replies[indexPath.item].id
             )
             .dispatchEphemeralMessageAction(action)
     }
@@ -478,7 +404,7 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
         controller.channelController = channelController
         controller.messageController = channelController.client.messageController(
             cid: channel.cid,
-            messageId: channelController.messages[indexPath.item].id
+            messageId: messageController.replies[indexPath.item].id
         )
         navigationController?.show(controller, sender: self)
     }

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/PopupPresenter.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/PopupPresenter.swift
@@ -1,0 +1,75 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+open class PopupPresenter {
+    /// Feedback generator used when presenting actions controller on selected message
+    open var impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
+    
+    public let rootViewController: UIViewController
+    
+    public init(rootViewController: UIViewController) {
+        self.rootViewController = rootViewController
+    }
+    
+    open func present<ExtraData>(
+        targetView: UIView,
+        message: _ChatMessage<ExtraData>,
+        actionsController: _ChatMessageActionsVC<ExtraData>,
+        reactionsController: _ChatMessageReactionsVC<ExtraData>?
+    ) {
+        // TODO: for PR: This should be doable via:
+        // 1. options: [.autoreverse, .repeat] and
+        // 2. `UIView.setAnimationRepeatCount(0)` inside the animation block...
+        //
+        // and then just set completion to the animation to transform this back. aka `cell.messageView.transform = .identity`
+        // however, this doesn't work as after the animation is done, it clips back to the value set in animation block
+        // and then on completion goes back to `.identity`... This is really strange, but I was fighting it for some time
+        // and couldn't find proper solution...
+        // Also there are some limitations to the current solution ->
+        // According to my debug view hiearchy, the content inside `messageView.messageBubbleView` is not constrainted to the
+        // bubble view itself, meaning right now if we want to scale the view of incoming message, we scale the avatarView
+        // of the sender as well...
+        UIView.animate(
+            withDuration: 0.2,
+            delay: 0,
+            options: [.curveEaseIn],
+            animations: {
+                targetView.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
+            },
+            completion: { _ in
+                self.impactFeedbackGenerator.impactOccurred()
+
+                UIView.animate(
+                    withDuration: 0.1,
+                    delay: 0,
+                    options: [.curveEaseOut],
+                    animations: {
+                        targetView.transform = .identity
+                    }
+                )
+                
+                let popup = _ChatMessagePopupVC<ExtraData>()
+                // only `message` is used but I don't want to break current implementation
+                popup.message = _ChatMessageGroupPart(
+                    message: message,
+                    quotedMessage: nil,
+                    isFirstInGroup: true,
+                    isLastInGroup: true,
+                    didTapOnAttachment: nil,
+                    didTapOnAttachmentAction: nil
+                )
+                popup.messageViewFrame = targetView.superview!.convert(targetView.frame, to: nil)
+                popup.actionsController = actionsController
+                popup.reactionsController = reactionsController
+                popup.modalPresentationStyle = .overFullScreen
+                popup.modalTransitionStyle = .crossDissolve
+
+                self.rootViewController.present(popup, animated: false)
+            }
+        )
+    }
+}

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/PopupPresenter.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/PopupPresenter.swift
@@ -62,6 +62,8 @@ open class PopupPresenter {
                     didTapOnAttachment: nil,
                     didTapOnAttachmentAction: nil
                 )
+                // TODO: Whole PopupVC has to be updated for the new MessageCell
+                popup.messageContentViewClass = _ChatMessageContentView<ExtraData>.self
                 popup.messageViewFrame = targetView.superview!.convert(targetView.frame, to: nil)
                 popup.actionsController = actionsController
                 popup.reactionsController = reactionsController

--- a/Sources/StreamChatUI/Generated/L10n.swift
+++ b/Sources/StreamChatUI/Generated/L10n.swift
@@ -119,6 +119,20 @@ internal enum L10n {
       /// Thread Reply
       internal static let reply = L10n.tr("Localizable", "message.threads.reply")
     }
+    internal enum Title {
+      /// %d members, %d online
+      internal static func group(_ p1: Int, _ p2: Int) -> String {
+        return L10n.tr("Localizable", "message.title.group", p1, p2)
+      }
+      /// Offline
+      internal static let offline = L10n.tr("Localizable", "message.title.offline")
+      /// Online
+      internal static let online = L10n.tr("Localizable", "message.title.online")
+      /// Seen %@ ago
+      internal static func seeMinutesAgo(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "message.title.see-minutes-ago", String(describing: p1))
+      }
+    }
   }
 
   internal enum MessageList {

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
@@ -83,10 +83,14 @@ open class _ChatMessageActionsVC<ExtraData: ExtraDataTypes>: _ViewController, UI
         switch message.localState {
         case nil:
             var actions: [ChatMessageActionItem] = [
-                inlineReplyActionItem(),
-                threadReplyActionItem(),
-                copyActionItem()
+                inlineReplyActionItem()
             ]
+            
+            if message.type != .reply {
+                actions.append(threadReplyActionItem())
+            }
+            
+            actions.append(copyActionItem())
 
             if message.isSentByCurrentUser {
                 actions += [editActionItem(), deleteActionItem()]

--- a/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
@@ -45,3 +45,8 @@
 
 "composer.suggestions.commands.header" = "Instant Commands";
 "message.sending.attachment-uploading-failed" = "UPLOADING FAILED";
+
+"message.title.online" = "Online";
+"message.title.see-minutes-ago" = "Seen %@ ago";
+"message.title.offline" = "Offline";
+"message.title.group" = "%d members, %d online";

--- a/Sources/StreamChatUI/UIConfig+Navigation.swift
+++ b/Sources/StreamChatUI/UIConfig+Navigation.swift
@@ -6,7 +6,9 @@ public extension _UIConfig {
     struct Navigation {
         public var navigationBar: ChatNavigationBar<ExtraData>.Type = ChatNavigationBar<ExtraData>.self
         public var channelListRouter: _ChatChannelListRouter<ExtraData>.Type = _ChatChannelListRouter<ExtraData>.self
-        public var messageListRouter: _ChatMessageListRouter<ExtraData>.Type = _ChatMessageListRouter<ExtraData>.self
+        // TODO: Remove
+        public var _messageListRouter: _ChatMessageListRouter<ExtraData>.Type = _ChatMessageListRouter<ExtraData>.self
+        public var messageListRouter: MessageListRouter<ExtraData>.Type = MessageListRouter<ExtraData>.self
         public var channelDetailRouter: _ChatChannelRouter<ExtraData>.Type = _ChatChannelRouter<ExtraData>.self
         public var messageActionsRouter: _ChatMessageActionsRouter<ExtraData>.Type = _ChatMessageActionsRouter<ExtraData>.self
     }

--- a/Sources/StreamChatUI/UIConfig+Navigation.swift
+++ b/Sources/StreamChatUI/UIConfig+Navigation.swift
@@ -8,7 +8,7 @@ public extension _UIConfig {
         public var channelListRouter: _ChatChannelListRouter<ExtraData>.Type = _ChatChannelListRouter<ExtraData>.self
         // TODO: Remove
         public var _messageListRouter: _ChatMessageListRouter<ExtraData>.Type = _ChatMessageListRouter<ExtraData>.self
-        public var messageListRouter: MessageListRouter<ExtraData>.Type = MessageListRouter<ExtraData>.self
+        public var messageListRouter: _ChatMessageListRouter<ExtraData>.Type = _ChatMessageListRouter<ExtraData>.self
         public var channelDetailRouter: _ChatChannelRouter<ExtraData>.Type = _ChatChannelRouter<ExtraData>.self
         public var messageActionsRouter: _ChatMessageActionsRouter<ExtraData>.Type = _ChatMessageActionsRouter<ExtraData>.self
     }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -677,6 +677,7 @@
 		8AE335A924FCF999002B6677 /* InternetConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE335A624FCF999002B6677 /* InternetConnection.swift */; };
 		8AE335AA24FCF99E002B6677 /* InternetConnection_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE335A424FCF999002B6677 /* InternetConnection_Tests.swift */; };
 		8AE8950D24D8660800E852EC /* PingPongEmojiFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */; };
+		A32FF7BA262F11E5004453A3 /* PopupPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32FF7B9262F11E5004453A3 /* PopupPresenter.swift */; };
 		A35757C72613081B00DC914C /* ChatMessageListKeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35757C62613081B00DC914C /* ChatMessageListKeyboardObserver.swift */; };
 		A35757D12613082B00DC914C /* ChatMessageListTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35757D02613082B00DC914C /* ChatMessageListTitleView.swift */; };
 		A3BB3FFF261DA74D00365496 /* ContainerStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BB3FFE261DA74D00365496 /* ContainerStackView.swift */; };
@@ -1835,6 +1836,7 @@
 		8AE335A524FCF999002B6677 /* Reachability_Vendor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability_Vendor.swift; sourceTree = "<group>"; };
 		8AE335A624FCF999002B6677 /* InternetConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternetConnection.swift; sourceTree = "<group>"; };
 		8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingPongEmojiFormatter.swift; sourceTree = "<group>"; };
+		A32FF7B9262F11E5004453A3 /* PopupPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupPresenter.swift; sourceTree = "<group>"; };
 		A35757C62613081B00DC914C /* ChatMessageListKeyboardObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageListKeyboardObserver.swift; sourceTree = "<group>"; };
 		A35757D02613082B00DC914C /* ChatMessageListTitleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageListTitleView.swift; sourceTree = "<group>"; };
 		A3BB3FFE261DA74D00365496 /* ContainerStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerStackView.swift; sourceTree = "<group>"; };
@@ -2769,6 +2771,7 @@
 			isa = PBXGroup;
 			children = (
 				79776F55261DB96F00C96A98 /* MessageListVC.swift */,
+				A32FF7B9262F11E5004453A3 /* PopupPresenter.swift */,
 				A37DD35426244E1D006C16B3 /* MessageThreadVC.swift */,
 				79776F67261DB97C00C96A98 /* MessageCollectionView.swift */,
 				79776F71261DB98500C96A98 /* MessageContentView.swift */,
@@ -4923,6 +4926,7 @@
 				792DD9D9256BC542001DB91B /* BaseViews.swift in Sources */,
 				79088334254876EA00896F03 /* ChatChannelVC.swift in Sources */,
 				88CABC4425933EE70061BB67 /* ChatMessageReactionsBubbleView+Default.swift in Sources */,
+				A32FF7BA262F11E5004453A3 /* PopupPresenter.swift in Sources */,
 				79CCB66E259CBC4F0082F172 /* ChatChannelNamer.swift in Sources */,
 				79F691B22604C10A000AE89B /* SystemEnvironment.swift in Sources */,
 				88AD1D5E2588B87C00ECED5B /* ChatFileAttachmentListView+ItemView.swift in Sources */,


### PR DESCRIPTION
# Description

Beginning of something new.

## Changes

* Only view controllers are open by default and from 90 % documented, the rest is just public to make compiler happy
* `ChatMessageRouter` has no parent class
* `MessageListCollectionView` is now responsible for scrolling and updating the content. Scrolling methods are still called from the VCs but than passed directly to collection view
* `ThreadVC` has the parent message as a header
* `PopupPresenter` class is created to extract the presenting logic from both controller to one place
* Long press on ThreadVC doesn't show reply in thread option