### PR TITLE
Fix Application Crash for ChatMessageCollectionViewCell unknown ReuseID

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.swift
@@ -12,6 +12,7 @@ open class _СhatMessageCollectionViewCell<ExtraData: ExtraDataTypes>: _Collecti
 
     class var reuseId: String { String(describing: self) + String(describing: Self.messageContentViewClass) }
     
+    public static var incomingMessage0ReuseId: String { "incoming_0_\(reuseId)" }
     public static var incomingMessage2ReuseId: String { "incoming_2_\(reuseId)" }
     public static var incomingMessage3ReuseId: String { "incoming_3_\(reuseId)" }
     public static var incomingMessage6ReuseId: String { "incoming_6_\(reuseId)" }
@@ -22,6 +23,7 @@ open class _СhatMessageCollectionViewCell<ExtraData: ExtraDataTypes>: _Collecti
     public static var incomingMessage5ReuseId: String { "incoming_5_\(reuseId)" }
     public static var incomingMessage13ReuseId: String { "incoming_13_\(reuseId)" }
     
+    public static var outgoingMessage0ReuseId: String { "outgoing_0_\(reuseId)" }
     public static var outgoingMessage2ReuseId: String { "outgoing_2_\(reuseId)" }
     public static var outgoingMessage3ReuseId: String { "outgoing_3_\(reuseId)" }
     public static var outgoingMessage6ReuseId: String { "outgoing_6_\(reuseId)" }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -73,6 +73,7 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: _ViewController,
     /// - Parameter cellType: The cell type to be registered.
     ///
     open func registerMessageCell(_ cellType: _СhatMessageCollectionViewCell<ExtraData>.Type) {
+        collectionView.register(cellType, forCellWithReuseIdentifier: cellType.incomingMessage0ReuseId)
         collectionView.register(cellType, forCellWithReuseIdentifier: cellType.incomingMessage2ReuseId)
         collectionView.register(cellType, forCellWithReuseIdentifier: cellType.incomingMessage3ReuseId)
         collectionView.register(cellType, forCellWithReuseIdentifier: cellType.incomingMessage6ReuseId)
@@ -83,6 +84,7 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>: _ViewController,
         collectionView.register(cellType, forCellWithReuseIdentifier: cellType.incomingMessage5ReuseId)
         collectionView.register(cellType, forCellWithReuseIdentifier: cellType.incomingMessage13ReuseId)
         
+        collectionView.register(cellType, forCellWithReuseIdentifier: cellType.outgoingMessage0ReuseId)
         collectionView.register(cellType, forCellWithReuseIdentifier: cellType.outgoingMessage2ReuseId)
         collectionView.register(cellType, forCellWithReuseIdentifier: cellType.outgoingMessage3ReuseId)
         collectionView.register(cellType, forCellWithReuseIdentifier: cellType.outgoingMessage6ReuseId)


### PR DESCRIPTION
TL;DR of this PR is That there is no Cell Reuse identifier for message cell with no `layoutOptions`. This PR add support for this. 

# What this PR do:
- Fixes issue where application could crash when the cell has no layout options and there is no reuse identifier for such cell because there is no explicit 0 rawValue option.
# How to test it
- Right now if you go to Dem App -> Luke Skywalker -> C-3PO conversation, you will experience a crash associated with no reuse identifier, try this PR and see if it works.
 
