### PR TITLE
[CIS-803] Change fetching devices to be called explicitly

### DIFF
--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -386,9 +386,9 @@ extension ClientError {
         override public var localizedDescription: String { "The URL provided in ChatClientConfig is `nil`." }
     }
     
-    public class ConnectionNotSuccessfull: ClientError {
+    public class ConnectionNotSuccessful: ClientError {
         override public var localizedDescription: String {
-            "Connecting to the chat servers wasn't successfull. Please check the console log for additional info."
+            "Connecting to the chat servers wasn't successful. Please check the console log for additional info."
         }
     }
     

--- a/Sources/StreamChat/ChatClient_Mock.swift
+++ b/Sources/StreamChat/ChatClient_Mock.swift
@@ -29,6 +29,14 @@ extension _ChatClient {
     var mockDatabaseContainer: DatabaseContainerMock {
         databaseContainer as! DatabaseContainerMock
     }
+
+    func simulateProvidedConnectionId(connectionId: ConnectionId?) {
+        guard let connectionId = connectionId else {
+            webSocketClient(mockWebSocketClient, didUpdateConectionState: .disconnected(error: nil))
+            return
+        }
+        webSocketClient(mockWebSocketClient, didUpdateConectionState: .connected(connectionId: connectionId))
+    }
 }
 
 class ChatClientMock<ExtraData: ExtraDataTypes>: _ChatClient<ExtraData> {

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -119,7 +119,7 @@ public class _CurrentChatUserController<ExtraData: ExtraDataTypes>: DataControll
         client.provideConnectionId { [weak self] connectionId in
             var error: ClientError?
             if connectionId == nil {
-                error = ClientError.ConnectionNotSuccessfull()
+                error = ClientError.ConnectionNotSuccessful()
             }
             self?.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(error!)
             self?.callback { completion?(error) }

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -196,6 +196,19 @@ public extension _CurrentChatUserController {
             }
         }
     }
+
+    /// Fetches the most updated devices and syncs with the local database.
+    /// - Parameter completion: Called when the devices are synced successfully, or with error.
+    func synchronizeDevices(completion: ((Error?) -> Void)? = nil) {
+        guard let currentUserId = currentUser?.id else {
+            completion?(ClientError.CurrentUserDoesNotExist())
+            return
+        }
+
+        currentUserUpdater.fetchDevices(currentUserId: currentUserId) { error in
+            self.callback { completion?(error) }
+        }
+    }
     
     /// Registers a device to the current user.
     /// `setUser` must be called before calling this.

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -130,7 +130,7 @@ final class CurrentUserController_Tests: StressTestCase {
         // Simulate connection not successful
         client.simulateProvidedConnectionId(connectionId: nil)
 
-        XCTAssertEqual(controller.state, .remoteDataFetchFailed(.ConnectionNotSuccessfull()))
+        XCTAssertEqual(controller.state, .remoteDataFetchFailed(.ConnectionNotSuccessful()))
         XCTAssertNotNil(synchronizeError)
     }
 

--- a/Sources/StreamChat/Workers/ChatClientUpdater.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater.swift
@@ -125,9 +125,9 @@ class ChatClientUpdater<ExtraData: ExtraDataTypes> {
             } else {
                 // Try to get a concrete error
                 if case let .disconnected(error) = client?.webSocketClient?.connectionState {
-                    completion?(ClientError.ConnectionNotSuccessfull(with: error))
+                    completion?(ClientError.ConnectionNotSuccessful(with: error))
                 } else {
-                    completion?(ClientError.ConnectionNotSuccessfull())
+                    completion?(ClientError.ConnectionNotSuccessful())
                 }
             }
         }

--- a/Sources/StreamChat/Workers/ChatClientUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater_Tests.swift
@@ -169,10 +169,10 @@ final class ChatClientUpdater_Tests_Tests: StressTestCase {
 
             if connectionError == nil {
                 // Assert `ClientError.ConnectionNotSuccessful` error is propagated.
-                XCTAssertTrue(connectCompletionError is ClientError.ConnectionNotSuccessfull)
+                XCTAssertTrue(connectCompletionError is ClientError.ConnectionNotSuccessful)
             } else {
                 // Assert `ClientError.ConnectionNotSuccessful` error with underlaying error is propagated.
-                let clientError = connectCompletionError as! ClientError.ConnectionNotSuccessfull
+                let clientError = connectCompletionError as! ClientError.ConnectionNotSuccessful
                 XCTAssertTrue(clientError.underlyingError is ClientError.Unexpected)
             }
         }
@@ -468,7 +468,7 @@ final class ChatClientUpdater_Tests_Tests: StressTestCase {
         // Wait completion is called.
         AssertAsync.willBeTrue(reloadUserIfNeededCompletionCalled)
         // Assert `ClientError.ConnectionNotSuccessfull` is propagated.
-        XCTAssertTrue(reloadUserIfNeededCompletionError is ClientError.ConnectionNotSuccessfull)
+        XCTAssertTrue(reloadUserIfNeededCompletionError is ClientError.ConnectionNotSuccessful)
     }
 
     func test_reloadUserIfNeeded_keepsUpdaterAlive() {


### PR DESCRIPTION
# In this PR

- Removes `CurrentUserUpdater.fetchDevices()` call from `CurrentUserController.synchronize()`
- Adds `CurrentUserController.synchronizeDevices()`
