### PR TITLE
[CIS-802] `ChatChannelWatcherListController` fixes

### DIFF
--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
@@ -173,7 +173,7 @@ extension Endpoint {
             path: "channels/" + query.cid.apiPath + "/query",
             method: .post,
             queryItems: nil,
-            requiresConnectionId: false,
+            requiresConnectionId: true,
             body: query
         )
     }

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -350,7 +350,7 @@ final class ChannelEndpoints_Tests: XCTestCase {
             path: "channels/\(query.cid.type.rawValue)/\(query.cid.id)/query",
             method: .post,
             queryItems: nil,
-            requiresConnectionId: false,
+            requiresConnectionId: true, // Observing watchers always requires connection id
             body: query
         )
         

--- a/Sources/StreamChat/Query/ChannelWatcherListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelWatcherListQuery.swift
@@ -19,8 +19,8 @@ public struct ChannelWatcherListQuery: Encodable {
     /// `ChannelId` this query handles.
     public var cid: ChannelId
     
-    /// Query options. We watch the channel automatically.
-    var options: QueryOptions = .watch
+    /// Query options. We want to get the current state and watch the channel automatically.
+    private let options: QueryOptions = [.watch, .state]
     
     /// Creates new `ChannelWatcherListQuery` instance.
     /// - Parameters:

--- a/Sources/StreamChat/Query/ChannelWatcherListQuery_Tests.swift
+++ b/Sources/StreamChat/Query/ChannelWatcherListQuery_Tests.swift
@@ -21,6 +21,7 @@ final class ChannelWatcherListQuery_Tests: XCTestCase {
         
         // Assert query is encoded correctly.
         AssertJSONEqual(json, [
+            "state": true,
             "watch": true,
             "watchers": ["limit": query.pagination.pageSize, "offset": query.pagination.offset]
         ])
@@ -35,6 +36,7 @@ final class ChannelWatcherListQuery_Tests: XCTestCase {
         
         // Assert query is encoded correctly.
         AssertJSONEqual(json, [
+            "state": true,
             "watch": true,
             "watchers": ["limit": Int.channelWatchersPageSize]
         ])

--- a/StreamChat.playground/Contents.swift
+++ b/StreamChat.playground/Contents.swift
@@ -1,0 +1,41 @@
+import StreamChat
+
+// ⚠️ This is a Stream internal playground for testing interactions with StreamChat.
+
+let apiKeyString = "8br4watad788"
+
+LogConfig.level = .debug
+
+let client = ChatClient(
+    config: .init(apiKeyString: apiKeyString),
+    tokenProvider:
+        // luke_skywalker
+        .static("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIifQ.kFSLHRB5X62t0Zlc7nwczWUfsQMwfkpylC6jCUZ6Mc0")
+)
+
+// // // // // // // // // // // // // // // // // //
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// // // // // // // // // // // // // // // // // //
+
+import PlaygroundSupport
+PlaygroundPage.current.needsIndefiniteExecution = true

--- a/StreamChat.playground/contents.xcplayground
+++ b/StreamChat.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='ios' buildActiveScheme='true'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1432,6 +1432,7 @@
 		79A9EAC2262045DC00F2A72D /* MessageRead+MissingUnreadCount.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "MessageRead+MissingUnreadCount.json"; sourceTree = "<group>"; };
 		79A9EB4C2625793000F2A72D /* CoreDataLazy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataLazy.swift; sourceTree = "<group>"; };
 		79A9EB562625798000F2A72D /* CoreDataLazy_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataLazy_Tests.swift; sourceTree = "<group>"; };
+		79AF43922631692D00E75CDA /* StreamChat.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = StreamChat.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		79B4F0DE25D305CD0063FFB5 /* CurrentChatUserAvatarView_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrentChatUserAvatarView_Tests.swift; sourceTree = "<group>"; };
 		79B5517024E593C200CE9FEC /* UserPayloads_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserPayloads_Tests.swift; sourceTree = "<group>"; };
 		79B5517124E593C200CE9FEC /* UserPayloads.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserPayloads.swift; sourceTree = "<group>"; };
@@ -3804,6 +3805,7 @@
 		8AD5EC8522E9A3E8005CFAC9 = {
 			isa = PBXGroup;
 			children = (
+				79AF43922631692D00E75CDA /* StreamChat.playground */,
 				792E3D6A25C97D920040B0C2 /* Package.swift */,
 				799C9415247D2F38001F1104 /* Sources */,
 				799C9452247D59B1001F1104 /* Tests */,


### PR DESCRIPTION
- The query endpoint had the `requiresConnectionId` incorrectly set to `false`
- Add `state` to `ChannelWatcherQuery` to make sure we always fetch all initial-state watchers

---

I also added a Playground with some basic setup to make it easier in the future to quickly test controllers and basic interactions.