### PR TITLE
[CIS-805] Refresh channel list queries when current user membership changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `ChatChannelListController` removes hidden channels from the list in the real time [#1013](https://github.com/GetStream/stream-chat-swift/pull/1013)
 - `CurrentChatUser` contains `mutedChannels` field with the muted channels [#1011](https://github.com/GetStream/stream-chat-swift/pull/1011)
 - `ChatChannel` contains `isMuted` and `muteDetails` fields with the information about the mute state of the channel [#1011](https://github.com/GetStream/stream-chat-swift/pull/1011)
+- Existing `ChatChannelListController` queries get invalidated when the current user membership changes, i.e. when the current users stops being a member of a channel, the channel stop being visible in the query [#1016](https://github.com/GetStream/stream-chat-swift/pull/1016)
 
 ### 🔄 Changed
 - Updating the current user devices is now done manually by calling `CurrentUserController.synchronizeDevices()` instead of being automatically called on `CurrentUserController.synchronize()`[#1010](https://github.com/GetStream/stream-chat-swift/pull/1010)

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -44,7 +44,12 @@ class ChannelDTO: NSManagedObject {
     
     @NSManaged var isFrozen: Bool
     @NSManaged var cooldownDuration: Int
-    
+
+    // MARK: - Queries
+
+    // The channel list queries the channel is a part of
+    @NSManaged var queries: Set<ChannelListQueryDTO>
+
     // MARK: - Relationships
     
     @NSManaged var createdBy: UserDTO

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -261,7 +261,10 @@ extension ChannelDTO {
     static var channelWithoutQueryFetchRequest: NSFetchRequest<ChannelDTO> {
         let request = NSFetchRequest<ChannelDTO>(entityName: ChannelDTO.entityName)
         request.sortDescriptors = [ChannelListSortingKey.defaultSortDescriptor]
-        request.predicate = NSPredicate(format: "queries.@count == 0")
+        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            NSPredicate(format: "queries.@count == 0"),
+            NSPredicate(format: "needsRefreshQueries == YES")
+        ])
         return request
     }
 }

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -49,6 +49,9 @@ class ChannelDTO: NSManagedObject {
 
     // The channel list queries the channel is a part of
     @NSManaged var queries: Set<ChannelListQueryDTO>
+    // A local flag which can be used to force refreshing the queries with the backend. This is useful for example when
+    // the members of the channel change, and we want to be sure the channel still belongs to the existing queries.
+    @NSManaged var needsRefreshQueries: Bool
 
     // MARK: - Relationships
     

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -30,6 +30,7 @@
         <attribute name="lastMessageAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="memberCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="needsRefreshQueries" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
         <attribute name="oldestMessageAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="truncatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="typeRawValue" optional="YES" attributeType="String"/>

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware.swift
@@ -7,10 +7,8 @@ import Foundation
 /// The middleware listens for `MemberEvent`s and updates `ChannelDTO`s accordingly.
 struct MemberEventMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
     func handle(event: Event, session: DatabaseSession) -> Event? {
-        guard let memberEvent = event as? MemberEvent else { return event }
-        
         do {
-            switch memberEvent {
+            switch event {
             case is MemberAddedEvent, is MemberUpdatedEvent:
                 guard let eventWithMemberPayload = event as? EventWithMemberPayload,
                       let eventPayload = eventWithMemberPayload.payload as? EventPayload<ExtraData>,
@@ -18,22 +16,47 @@ struct MemberEventMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
                 else {
                     break
                 }
-                try session.saveMember(payload: memberPayload, channelId: memberEvent.cid)
-            case is MemberRemovedEvent:
-                guard let channel = session.channel(cid: memberEvent.cid) else {
+                try session.saveMember(payload: memberPayload, channelId: (event as! EventWithChannelId).cid)
+
+            case let event as MemberRemovedEvent:
+                guard let channel = session.channel(cid: event.cid) else {
                     // No need to throw ChannelNotFound error here
                     break
                 }
                 
-                guard let member = channel.members.first(where: { $0.user.id == memberEvent.memberUserId }) else {
+                guard let member = channel.members.first(where: { $0.user.id == event.memberUserId }) else {
                     // No need to throw MemberNotFound error here
                     break
                 }
-                
                 channel.members.remove(member)
+
             default:
                 break
             }
+
+            // If the added/remove member was the current user, we should also reset the channel list queries, because
+            // they usually depend on this.
+
+            // Notification events are always about the current user
+            let isMemberNotificationEvent = event is NotificationAddedToChannelEvent || event is NotificationRemovedFromChannelEvent
+
+            // If we watch the channel, we don't receive notification events, but "normal" member events
+            var isCurrentUserMemberEvent = false
+            if let currentUserId = session.currentUser()?.user.id {
+                if event is MemberAddedEvent || event is MemberRemovedEvent,
+                   (event as? MemberEvent)?.memberUserId == currentUserId {
+                    isCurrentUserMemberEvent = true
+                }
+            }
+
+            if isMemberNotificationEvent || isCurrentUserMemberEvent, let cid = (event as? EventWithChannelId)?.cid {
+                guard let channelDTO = session.channel(cid: cid) else {
+                    throw ClientError.ChannelDoesNotExist(cid: cid)
+                }
+                channelDTO.queries = []
+                channelDTO.needsRefreshQueries = true
+            }
+
         } catch {
             log.error("Failed to update channel members in the database, error: \(error)")
         }

--- a/Sources/StreamChat/WebSocketClient/Events/ConnectionEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/ConnectionEvents.swift
@@ -8,9 +8,8 @@ public protocol ConnectionEvent: Event {
     var connectionId: String { get }
 }
 
-public struct HealthCheckEvent: ConnectionEvent, EventWithPayload, EventWithCurrentUserPayload {
+public struct HealthCheckEvent: ConnectionEvent, EventWithPayload {
     public let connectionId: String
-    public let currentUserId: UserId
     
     var payload: Any
     
@@ -20,13 +19,11 @@ public struct HealthCheckEvent: ConnectionEvent, EventWithPayload, EventWithCurr
         }
         
         self.connectionId = connectionId
-        currentUserId = try eventResponse.value(at: \.currentUser?.id)
         payload = eventResponse as Any
     }
     
-    init(connectionId: String, currentUserId: UserId) {
+    init(connectionId: String) {
         self.connectionId = connectionId
-        self.currentUserId = currentUserId
         payload = EventPayload<NoExtraData>(
             eventType: .healthCheck,
             connectionId: connectionId,

--- a/Sources/StreamChat/WebSocketClient/Events/MemberEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/MemberEvents.swift
@@ -35,7 +35,7 @@ public struct MemberUpdatedEvent: EventWithMemberPayload, EventWithChannelId, Me
     }
 }
 
-public struct MemberRemovedEvent: MemberEvent {
+public struct MemberRemovedEvent: MemberEvent, EventWithChannelId {
     public var memberUserId: UserId
     public let cid: ChannelId
     

--- a/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
@@ -76,7 +76,7 @@ public struct NotificationRemovedFromChannelEvent: EventWithChannelId {
     let payload: Any
     
     init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
-        cid = try response.value(at: \.channel?.cid)
+        cid = try response.value(at: \.cid)
         payload = response
     }
 }

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
@@ -166,7 +166,7 @@ class WebSocketClient_Tests: StressTestCase {
         AssertAsync.willBeEqual(webSocketClient.connectionState, .waitingForConnectionId)
         
         // Simulate a health check event is received and the connection state is updated
-        decoder.decodedEvent = .success(HealthCheckEvent(connectionId: connectionId, currentUserId: "userId"))
+        decoder.decodedEvent = .success(HealthCheckEvent(connectionId: connectionId))
         engine!.simulateMessageReceived()
         
         AssertAsync.willBeEqual(webSocketClient.connectionState, .connected(connectionId: connectionId))
@@ -240,7 +240,7 @@ class WebSocketClient_Tests: StressTestCase {
         AssertAsync.staysTrue(reconnectionStrategy.sucessfullyConnected_calledCount == 0)
         
         // Simulate a health check event
-        decoder.decodedEvent = .success(HealthCheckEvent(connectionId: connectionId, currentUserId: "userId"))
+        decoder.decodedEvent = .success(HealthCheckEvent(connectionId: connectionId))
         engine!.simulateMessageReceived()
         
         // `sucessfullyConnected` should be called now
@@ -355,7 +355,7 @@ class WebSocketClient_Tests: StressTestCase {
         assert(pingController.pongRecievedCount == 1)
         
         // Simulate a health check (pong) event is received
-        decoder.decodedEvent = .success(HealthCheckEvent(connectionId: connectionId, currentUserId: "userId"))
+        decoder.decodedEvent = .success(HealthCheckEvent(connectionId: connectionId))
         engine!.simulateMessageReceived()
         
         AssertAsync.willBeEqual(pingController.pongRecievedCount, 2)
@@ -679,7 +679,7 @@ final class HealthCheckMiddleware_Tests: XCTestCase {
     }
     
     func test_middleware_filtersHealthCheckEvents_ifClientIsDeallocated() throws {
-        let event = HealthCheckEvent(connectionId: .unique, currentUserId: "userId")
+        let event = HealthCheckEvent(connectionId: .unique)
         
         // Deallocate the client
         AssertAsync.canBeReleased(&webSocketClient)
@@ -692,7 +692,7 @@ final class HealthCheckMiddleware_Tests: XCTestCase {
     }
     
     func test_middleware_handlesHealthCheckEvents() throws {
-        let event = HealthCheckEvent(connectionId: .unique, currentUserId: "userId")
+        let event = HealthCheckEvent(connectionId: .unique)
         
         // Simulate `HealthCheckEvent`
         let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
@@ -709,7 +709,6 @@ final class HealthCheckMiddleware_Tests: XCTestCase {
         let json = XCTestCase.mockData(fromFile: "HealthCheck")
         let event = try eventDecoder.decode(from: json) as? HealthCheckEvent
         
-        XCTAssertEqual(event?.currentUserId, "luke_skywalker")
         XCTAssertEqual(event?.connectionId, "60782eca-0a05-154b-0000-000000a85747")
     }
 }

--- a/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
@@ -72,7 +72,14 @@ final class NewChannelQueryUpdater<ExtraData: ExtraDataTypes>: Worker {
         changes.forEach { change in
             switch change {
             case let .insert(channelDTO, _):
-                updateChannelListQuery(for: channelDTO)
+                database.write {
+                    let dto = $0.channel(cid: try! ChannelId(cid: channelDTO.cid))
+                    dto?.needsRefreshQueries = false
+
+                } completion: { _ in
+                    self.updateChannelListQuery(for: channelDTO)
+                }
+
             default: return
             }
         }

--- a/Sources/StreamChat/Workers/EventObservers/EventObserver_Tests.swift
+++ b/Sources/StreamChat/Workers/EventObservers/EventObserver_Tests.swift
@@ -19,7 +19,7 @@ final class EventObserver_Tests: XCTestCase {
         super.setUp()
 
         notificationCenter = NotificationCenter()
-        eventToDeliver = HealthCheckEvent(connectionId: .unique, currentUserId: "userId")
+        eventToDeliver = HealthCheckEvent(connectionId: .unique)
     }
 
     override func tearDown() {


### PR DESCRIPTION
This PR makes the existing queries for a channel invalidated when the current user membership changes. In other words - when you stop being a member of a channel, you won't see it in the list :) 