### PR TITLE
Explicitly pin `StreamChat` version in `StreamChatUI` podspec

### DIFF
--- a/StreamChatUI.podspec
+++ b/StreamChatUI.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |spec|
   
     spec.framework = "Foundation", "UIKit"
   
-    spec.dependency "StreamChat", "~> 3.0"
+    spec.dependency "StreamChat", "#{spec.version}"
     spec.dependency "Nuke", "~> 9.0"
     spec.dependency "SwiftyGif", "~> 5.0"
   end


### PR DESCRIPTION
`StreamChatUI` podspec didn't specify the version of `StreamChat` explicitly which could lead to having an incompatible configuration of the frameworks resolved. By pinning the dependency explicitly to the same version as `StreamChat` we're fixing this issue + it replicates the same behavior as SPM has.

---

This was the issue behind https://github.com/GetStream/stream-chat-swift/issues/1015