### PR TITLE
Optimize current user fetch

### DIFF
--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -302,10 +302,10 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
 
         let context = databaseContainer.viewContext
         if Thread.isMainThread {
-            currentUserId = context.currentUser()?.user.id
+            currentUserId = context.currentUser?.user.id
         } else {
             context.performAndWait {
-                currentUserId = context.currentUser()?.user.id
+                currentUserId = context.currentUser?.user.id
             }
         }
 

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -297,7 +297,7 @@ extension _ChatChannel {
         let reads: [_ChatChannelRead<ExtraData>] = dto.reads.map { $0.asModel() }
         
         let unreadCount: () -> ChannelUnreadCount = {
-            guard let currentUser = context.currentUser() else { return .noUnread }
+            guard let currentUser = context.currentUser else { return .noUnread }
             
             let currentUserRead = reads.first(where: { $0.user.id == currentUser.user.id })
             
@@ -347,7 +347,7 @@ extension _ChatChannel {
 
         let fetchMuteDetails: () -> MuteDetails? = {
             guard
-                let currentUser = context.currentUser(),
+                let currentUser = context.currentUser,
                 let mute = ChannelMuteDTO.load(cid: cid, userId: currentUser.user.id, context: context)
             else { return nil }
 

--- a/Sources/StreamChat/Database/DTOs/ChannelMuteDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelMuteDTO_Tests.swift
@@ -43,7 +43,7 @@ final class ChannelMuteDTO_Tests: XCTestCase {
         XCTAssertEqual(channel.muteDetails?.createdAt, mutePayload.createdAt)
         XCTAssertEqual(channel.muteDetails?.updatedAt, mutePayload.updatedAt)
 
-        let currentUser: CurrentChatUser = try XCTUnwrap(database.viewContext.currentUser()?.asModel())
+        let currentUser: CurrentChatUser = try XCTUnwrap(database.viewContext.currentUser?.asModel())
         XCTAssertEqual(currentUser.mutedChannels, [channel])
     }
 

--- a/Sources/StreamChat/Database/DTOs/CurrentUserDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/CurrentUserDTO_Tests.swift
@@ -57,7 +57,7 @@ class CurrentUserModelDTO_Tests: XCTestCase {
         
         // Load the user from the db and check the fields are correct
         let loadedCurrentUser: CurrentChatUser = try XCTUnwrap(
-            database.viewContext.currentUser()?.asModel()
+            database.viewContext.currentUser?.asModel()
         )
         
         XCTAssertEqual(payload.id, loadedCurrentUser.id)
@@ -131,7 +131,7 @@ class CurrentUserModelDTO_Tests: XCTestCase {
             userDTO.user.extraData = #"{"invalid": json}"#.data(using: .utf8)!
         }
         
-        let loadedUser: CurrentChatUser? = database.viewContext.currentUser()?.asModel()
+        let loadedUser: CurrentChatUser? = database.viewContext.currentUser?.asModel()
         XCTAssertEqual(loadedUser?.extraData, .defaultValue)
     }
 }

--- a/Sources/StreamChat/Database/DTOs/DeviceDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/DeviceDTO_Tests.swift
@@ -31,7 +31,7 @@ class DeviceDTO_Tests: XCTestCase {
         }
         
         // Get current user from DB
-        let loadedCurrentUser: CurrentChatUser? = database.viewContext.currentUser()?.asModel()
+        let loadedCurrentUser: CurrentChatUser? = database.viewContext.currentUser?.asModel()
         
         // Check if fields are correct
         XCTAssertEqual(loadedCurrentUser?.devices.count, 2)

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -219,7 +219,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         quotedMessageId: MessageId?,
         extraData: ExtraData
     ) throws -> MessageDTO {
-        guard let currentUserDTO = currentUser() else {
+        guard let currentUserDTO = currentUser else {
             throw ClientError.CurrentUserDoesNotExist()
         }
         
@@ -397,7 +397,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
     }
 
     func pin(message: MessageDTO, pinning: MessagePinning) throws {
-        guard let currentUserDTO = currentUser() else {
+        guard let currentUserDTO = currentUser else {
             throw ClientError.CurrentUserDoesNotExist()
         }
         let pinnedDate = Date()
@@ -493,7 +493,7 @@ private extension _ChatMessage {
             pinDetails = nil
         }
         
-        if let currentUser = context.currentUser() {
+        if let currentUser = context.currentUser {
             isSentByCurrentUser = currentUser.user.id == dto.user.id
             
             if dto.reactions.isEmpty {

--- a/Sources/StreamChat/Database/DataStore.swift
+++ b/Sources/StreamChat/Database/DataStore.swift
@@ -47,7 +47,7 @@ public struct DataStore<ExtraData: ExtraDataTypes> {
     /// - Returns: If there's a current user object in the locally cached data, returns the matching
     /// model object. If a user object doesn't exist locally, returns `nil`.
     public func currentUser() -> _CurrentChatUser<ExtraData>? {
-        database.viewContext.currentUser()?.asModel()
+        database.viewContext.currentUser?.asModel()
     }
 
     /// Loads a channel model with a matching `cid` from the **local data store**.

--- a/Sources/StreamChat/Database/DataStore_Tests.swift
+++ b/Sources/StreamChat/Database/DataStore_Tests.swift
@@ -30,7 +30,7 @@ class DataStore_Tests: StressTestCase {
     func test_currentUserIsLoaded() throws {
         XCTAssertNil(dataStore.currentUser())
         try _client.databaseContainer.createCurrentUser()
-        XCTAssertNotNil(dataStore.currentUser())
+        XCTAssertNotNil(dataStore.currentUser)
     }
 
     func test_channelIsLoaded() throws {

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -42,7 +42,7 @@ protocol CurrentUserDatabaseSession {
     func deleteDevice(id: DeviceId)
     
     /// Returns `CurrentUserDTO` from the DB. Returns `nil` if no `CurrentUserDTO` exists.
-    func currentUser() -> CurrentUserDTO?
+    var currentUser: CurrentUserDTO? { get }
 }
 
 extension CurrentUserDatabaseSession {
@@ -289,7 +289,7 @@ extension DatabaseSession {
             try saveCurrentUserUnreadCount(count: unreadCount)
         }
         
-        if let currentUser = currentUser(), let date = payload.createdAt {
+        if let currentUser = currentUser, let date = payload.createdAt {
             currentUser.lastReceivedEventDate = date
         }
         

--- a/Sources/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Mock.swift
@@ -68,9 +68,7 @@ extension DatabaseSessionMock {
         underlyingSession.deleteDevice(id: id)
     }
     
-    func currentUser() -> CurrentUserDTO? {
-        underlyingSession.currentUser()
-    }
+    var currentUser: CurrentUserDTO? { underlyingSession.currentUser }
     
     func createNewMessage<ExtraData>(
         in cid: ChannelId,

--- a/Sources/StreamChat/Database/DatabaseSession_Tests.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Tests.swift
@@ -253,7 +253,7 @@ class DatabaseSession_Tests: StressTestCase {
         }
         
         // Load current user
-        let currentUser = database.viewContext.currentUser()
+        let currentUser = database.viewContext.currentUser
         
         // Assert unread count is taken from event payload
         XCTAssertEqual(Int64(eventPayload.unreadCount!.messages), currentUser?.unreadMessagesCount)
@@ -293,7 +293,7 @@ class DatabaseSession_Tests: StressTestCase {
         }
         
         // Load current user
-        let currentUser = database.viewContext.currentUser()
+        let currentUser = database.viewContext.currentUser
         
         // Assert `eventPayload.createdAt` is taked as last received event date
         XCTAssertEqual(currentUser?.lastReceivedEventDate, eventPayload.createdAt)
@@ -320,7 +320,7 @@ class DatabaseSession_Tests: StressTestCase {
         }
         
         // Load current user
-        let currentUser = database.viewContext.currentUser()
+        let currentUser = database.viewContext.currentUser
         
         // Assert `lastReceivedEventDate` is nil
         XCTAssertNil(currentUser?.lastReceivedEventDate)

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware.swift
@@ -63,7 +63,7 @@ struct ChannelReadUpdaterMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware 
         newMessageAt: Date,
         session: DatabaseSession
     ) {
-        guard let currentUserId = session.currentUser()?.user.id, currentUserId != userId else {
+        guard let currentUserId = session.currentUser?.user.id, currentUserId != userId else {
             // Own messages don't increase unread count
             return
         }

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware.swift
@@ -42,7 +42,7 @@ struct MemberEventMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
 
             // If we watch the channel, we don't receive notification events, but "normal" member events
             var isCurrentUserMemberEvent = false
-            if let currentUserId = session.currentUser()?.user.id {
+            if let currentUserId = session.currentUser?.user.id {
                 if event is MemberAddedEvent || event is MemberRemovedEvent,
                    (event as? MemberEvent)?.memberUserId == currentUserId {
                     isCurrentUserMemberEvent = true

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/UserWatchingEventMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/UserWatchingEventMiddleware.swift
@@ -11,7 +11,7 @@ struct UserWatchingEventMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
         
         do {
             guard let channelDTO = session.channel(cid: userWatchingEvent.cid) else {
-                let currentUserId = session.currentUser()?.user.id
+                let currentUserId = session.currentUser?.user.id
                 if userWatchingEvent.userId == currentUserId {
                     log.info(
                         "Ignoring watcher event for channel \(userWatchingEvent.cid) and current user"

--- a/Sources/StreamChat/Workers/Background/MissingEventsPublisher.swift
+++ b/Sources/StreamChat/Workers/Background/MissingEventsPublisher.swift
@@ -59,7 +59,7 @@ class MissingEventsPublisher<ExtraData: ExtraDataTypes>: EventWorker {
     
     private func obtainLastSyncDate() {
         database.backgroundReadOnlyContext.perform { [weak self] in
-            self?.lastSyncedAt = self?.database.backgroundReadOnlyContext.currentUser()?.lastReceivedEventDate
+            self?.lastSyncedAt = self?.database.backgroundReadOnlyContext.currentUser?.lastReceivedEventDate
         }
     }
     

--- a/Sources/StreamChat/Workers/Background/MissingEventsPublisher_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/MissingEventsPublisher_Tests.swift
@@ -62,7 +62,7 @@ final class MissingEventsPublisher_Tests: StressTestCase {
         
         // Set `lastReceivedEventDate` field
         try database.writeSynchronously {
-            let dto = try XCTUnwrap($0.currentUser())
+            let dto = try XCTUnwrap($0.currentUser)
             dto.lastReceivedEventDate = Date()
         }
         
@@ -88,7 +88,7 @@ final class MissingEventsPublisher_Tests: StressTestCase {
 
         // Set `lastReceivedEventDate`
         try database.writeSynchronously { session in
-            let currentUser = try XCTUnwrap(session.currentUser())
+            let currentUser = try XCTUnwrap(session.currentUser)
             currentUser.lastReceivedEventDate = lastReceivedEventDate
         }
         
@@ -118,7 +118,7 @@ final class MissingEventsPublisher_Tests: StressTestCase {
         
         // Set `lastReceivedEventDate`
         try database.writeSynchronously { session in
-            let currentUser = try XCTUnwrap(session.currentUser())
+            let currentUser = try XCTUnwrap(session.currentUser)
             currentUser.lastReceivedEventDate = Date()
         }
         
@@ -154,7 +154,7 @@ final class MissingEventsPublisher_Tests: StressTestCase {
         try database.createChannel(cid: (events.first as! EventWithChannelId).cid)
         
         try database.writeSynchronously { session in
-            let currentUser = try XCTUnwrap(session.currentUser())
+            let currentUser = try XCTUnwrap(session.currentUser)
             currentUser.lastReceivedEventDate = .unique
         }
         
@@ -184,7 +184,7 @@ final class MissingEventsPublisher_Tests: StressTestCase {
         
         // Set `lastReceivedEventDate`
         try database.writeSynchronously { session in
-            let currentUser = try XCTUnwrap(session.currentUser())
+            let currentUser = try XCTUnwrap(session.currentUser)
             currentUser.lastReceivedEventDate = Date()
         }
         

--- a/Sources/StreamChat/Workers/CurrentUserUpdater.swift
+++ b/Sources/StreamChat/Workers/CurrentUserUpdater.swift
@@ -43,7 +43,7 @@ class CurrentUserUpdater<ExtraData: ExtraDataTypes>: Worker {
                 case let .success(response):
                     self?.database.write({ (session) in
                         let userDTO = try session.saveUser(payload: response.user)
-                        session.currentUser()?.user = userDTO
+                        session.currentUser?.user = userDTO
                     }) { completion?($0) }
                 case let .failure(error):
                     completion?(error)

--- a/Sources/StreamChat/Workers/CurrentUserUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/CurrentUserUpdater_Tests.swift
@@ -118,7 +118,7 @@ final class CurrentUserUpdater_Tests: StressTestCase {
         apiClient.test_simulateResponse(.success(currentUserUpdateResponse))
         
         var currentUser: CurrentChatUser? {
-            database.viewContext.currentUser()?.asModel()
+            database.viewContext.currentUser?.asModel()
         }
         
         // Check the completion is called and the current user model was updated
@@ -295,7 +295,7 @@ final class CurrentUserUpdater_Tests: StressTestCase {
 
         // Assert data is stored in the DB
         var currentUser: CurrentChatUser? {
-            database.viewContext.currentUser()?.asModel()
+            database.viewContext.currentUser?.asModel()
         }
 
         assert(currentUser?.devices.count == 1)
@@ -404,7 +404,7 @@ final class CurrentUserUpdater_Tests: StressTestCase {
         
         // Assert data is stored in the DB
         var currentUser: CurrentChatUser? {
-            database.viewContext.currentUser()?.asModel()
+            database.viewContext.currentUser?.asModel()
         }
         
         AssertAsync {
@@ -500,7 +500,7 @@ final class CurrentUserUpdater_Tests: StressTestCase {
 
         // Assert data is stored in the DB
         var currentUser: CurrentChatUser? {
-            database.viewContext.currentUser()?.asModel()
+            database.viewContext.currentUser?.asModel()
         }
 
         // Make sure no devices are stored in the DB

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -214,7 +214,7 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
                             throw ClientError.MessageDoesNotExist(messageId: messageId)
                         }
                         
-                        let currentUserDTO = session.currentUser()
+                        let currentUserDTO = session.currentUser
                         if flag {
                             currentUserDTO?.flaggedMessages.insert(messageDTO)
                         } else {
@@ -476,7 +476,7 @@ private extension DatabaseSession {
     /// - Throws: Either `CurrentUserDoesNotExist`/`MessageDoesNotExist`/
     /// - Returns: The message entity.
     func messageEditableByCurrentUser(_ messageId: MessageId) throws -> MessageDTO {
-        guard currentUser() != nil else {
+        guard currentUser != nil else {
             throw ClientError.CurrentUserDoesNotExist()
         }
 

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -574,7 +574,7 @@ final class MessageUpdater_Tests: StressTestCase {
         try database.createCurrentUser(id: currentUserId)
         
         // Load current user.
-        let currentUserDTO = try XCTUnwrap(database.viewContext.currentUser())
+        let currentUserDTO = try XCTUnwrap(database.viewContext.currentUser)
         
         // Create channel in the database.
         try database.createChannel(cid: cid)

--- a/Sources/StreamChat/Workers/UserUpdater.swift
+++ b/Sources/StreamChat/Workers/UserUpdater.swift
@@ -79,7 +79,7 @@ class UserUpdater<ExtraData: ExtraDataTypes>: Worker {
                 self.database.write({ session in
                     let userDTO = try session.saveUser(payload: payload.flaggedUser)
                     
-                    let currentUserDTO = session.currentUser()
+                    let currentUserDTO = session.currentUser
                     if flag {
                         currentUserDTO?.flaggedUsers.insert(userDTO)
                     } else {

--- a/Sources/StreamChat/Workers/UserUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/UserUpdater_Tests.swift
@@ -287,7 +287,7 @@ final class UserUpdater_Tests: StressTestCase {
         apiClient.test_simulateResponse(.success(payload))
         
         // Load current user
-        let currentUser = database.viewContext.currentUser()
+        let currentUser = database.viewContext.currentUser
         // Load flagged user
         var user: UserDTO? {
             database.viewContext.user(id: flaggedUserId)


### PR DESCRIPTION
- fetch `CurrentUserDTO` only once for each context, then rely on CoreData that its properties are up to date
- convert `func currentUser() -> CurrentUserDTO?` to `var currentUser: CurrentUserDTO?` to indicate that it is not fetched on each call
- use context's `userInfo` to store fetched user as I think this is exactly the kind of information that should be stored there (other option would be associated object)
- when `currentUser` is called for the first time (and the fetch from DB is performed) I register for the `DatabaseContainer.WillRemoveAllDataNotification` so I can clear cached user as leaving it there would create inconsistencies - there are apparently other options how to do this, but I think this responsibility should remain in this part of code