### PR TITLE
[CIS-807] Add `controllerWillChangeChannels` delegate callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- `ChatChannelListControllerDelegate` now has the `controllerWillChangeChannels` method [#1024](https://github.com/GetStream/stream-chat-swift/pull/1024)
+
 ### 🔄 Changed
 - Split `UIConfig` into `Appearance` and `Components` to improve clarity [#1014](https://github.com/GetStream/stream-chat-swift/pull/1014)
 

--- a/Sources/StreamChat/Controllers/Controller.swift
+++ b/Sources/StreamChat/Controllers/Controller.swift
@@ -16,11 +16,20 @@ public protocol Controller {
 extension Controller {
     /// A helper function to ensure the callback is performed on the callback queue.
     func callback(_ action: @escaping () -> Void) {
-        if callbackQueue == .main, Thread.current.isMainThread {
-            // Perform the action on the main queue synchronously
-            action()
+        if Thread.current.isMainThread {
+            if callbackQueue == .main {
+                // We perform the callback synchronously
+                action()
+            } else {
+                // We dispatch from the main queue, we must perform
+                // the callback must be performed asynchronously
+                callbackQueue.async {
+                    action()
+                }
+            }
         } else {
-            callbackQueue.async {
+            // Dispatching from a background queue, the callback can be performed synchronously
+            callbackQueue.sync {
                 action()
             }
         }

--- a/Sources/StreamChat/Controllers/EntityDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/EntityDatabaseObserver.swift
@@ -261,7 +261,7 @@ extension EntityDatabaseObserver {
 
 private extension ListChangeAggregator {
     func onChange(do action: @escaping ([ListChange<Item>]) -> Void) -> ListChangeAggregator {
-        onChange = action
+        onDidChange = action
         return self
     }
 }

--- a/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
@@ -81,7 +81,7 @@ class ListDatabaseObserver<Item, DTO: NSManagedObject> {
     /// on its delegate.
     var onChange: (([ListChange<Item>]) -> Void)? {
         didSet {
-            changeAggregator.onChange = { [weak self] in
+            changeAggregator.onDidChange = { [weak self] in
                 // Ideally, this should rather be `unowned`, however, `deinit` is not always called on the same thread as this
                 // callback which can cause a race condition when the object is already being deinited on a different thread.
                 guard let self = self else { return }
@@ -156,7 +156,7 @@ class ListDatabaseObserver<Item, DTO: NSManagedObject> {
         _items.reset()
         
         // This is a workaround for the situation when someone wants to observe only the `items` array without
-        // listening to changes. We just need to make sure the `didSet` callback of `onChange` is executed at least once.
+        // listening to changes. We just need to make sure the `didSet` callback of `onDidChange` is executed at least once.
         if onChange == nil {
             onChange = nil
         }
@@ -221,7 +221,7 @@ class ListDatabaseObserver<Item, DTO: NSManagedObject> {
 }
 
 /// When this object is set as `NSFetchedResultsControllerDelegate`, it aggregates the callbacks from the fetched results
-/// controller and forwards them in the way of `[Change<Item>]`. You can set the `onChange` callback to receive these updates.
+/// controller and forwards them in the way of `[Change<Item>]`. You can set the `onDidChange` callback to receive these updates.
 class ListChangeAggregator<DTO: NSManagedObject, Item>: NSObject, NSFetchedResultsControllerDelegate {
     // TODO: Extend this to also provide `CollectionDifference` and `NSDiffableDataSourceSnapshot`
     
@@ -229,7 +229,7 @@ class ListChangeAggregator<DTO: NSManagedObject, Item>: NSObject, NSFetchedResul
     let itemCreator: (DTO) -> Item?
     
     /// Called with the aggregated changes after `FetchResultsController` calls controllerDidChangeContent` on its delegate.
-    var onChange: (([ListChange<Item>]) -> Void)?
+    var onDidChange: (([ListChange<Item>]) -> Void)?
     
     /// An array of changes in the current update. It gets reset every time `controllerWillChangeContent` is called, and
     /// published to the observer when `controllerDidChangeContent` is called.
@@ -315,7 +315,7 @@ class ListChangeAggregator<DTO: NSManagedObject, Item>: NSObject, NSFetchedResul
             return true
         }
         
-        onChange?(currentChanges)
+        onDidChange?(currentChanges)
     }
 }
 

--- a/Sources/StreamChat/Controllers/ListDatabaseObserver_Tests.swift
+++ b/Sources/StreamChat/Controllers/ListDatabaseObserver_Tests.swift
@@ -157,7 +157,7 @@ class ListDatabaseObserver_Tests: XCTestCase {
         XCTAssertEqual(Array(observer.items), reference1.map(\.uniqueValue))
         
         // Simulate the change aggregator callback and check the items get updated
-        observer.changeAggregator.onChange?([])
+        observer.changeAggregator.onDidChange?([])
         XCTAssertEqual(Array(observer.items), reference2.map(\.uniqueValue))
     }
     
@@ -261,7 +261,7 @@ class ListChangeAggregator_Tests: XCTestCase {
     func test_addingItems() {
         // Set up aggregator callback
         var result: [ListChange<String>]?
-        aggregator.onChange = { result = $0 }
+        aggregator.onDidChange = { result = $0 }
         
         // Simulate FRC starts updating
         aggregator.controllerWillChangeContent(fakeController)
@@ -298,7 +298,7 @@ class ListChangeAggregator_Tests: XCTestCase {
     func test_movingItems() {
         // Set up aggregator callback
         var result: [ListChange<String>]?
-        aggregator.onChange = { result = $0 }
+        aggregator.onDidChange = { result = $0 }
         
         // Simulate FRC starts updating
         aggregator.controllerWillChangeContent(fakeController)
@@ -335,7 +335,7 @@ class ListChangeAggregator_Tests: XCTestCase {
     func test_updatingItems() {
         // Set up aggregator callback
         var result: [ListChange<String>]?
-        aggregator.onChange = { result = $0 }
+        aggregator.onDidChange = { result = $0 }
         
         // Simulate FRC starts updating
         aggregator.controllerWillChangeContent(fakeController)
@@ -372,7 +372,7 @@ class ListChangeAggregator_Tests: XCTestCase {
     func test_removingItems() {
         // Set up aggregator callback
         var result: [ListChange<String>]?
-        aggregator.onChange = { result = $0 }
+        aggregator.onDidChange = { result = $0 }
         
         // Simulate FRC starts updating
         aggregator.controllerWillChangeContent(fakeController)
@@ -408,7 +408,7 @@ class ListChangeAggregator_Tests: XCTestCase {
     
     func test_complexUpdate() {
         var result: [ListChange<String>]?
-        aggregator.onChange = { result = $0 }
+        aggregator.onDidChange = { result = $0 }
         
         // Simulate FRC starts updating
         aggregator.controllerWillChangeContent(fakeController)
@@ -464,7 +464,7 @@ class ListChangeAggregator_Tests: XCTestCase {
     
     func test_controllerWillChangeContent_whenUpdatesAndMovesWithSameIndexPath_removeThoseUpdates() {
         var result: [ListChange<String>]?
-        aggregator.onChange = { result = $0 }
+        aggregator.onDidChange = { result = $0 }
         
         // Simulate FRC starts updating
         aggregator.controllerWillChangeContent(fakeController)

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -16,19 +16,6 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
     SwipeableViewDelegate {
     /// The `ChatChannelListController` instance that provides channels data.
     public var controller: _ChatChannelListController<ExtraData>!
-    
-    /// A helper flag to find out if the VC's view is currently layouting its subviews.
-    var isLayoutingSubviews = false
-    
-    override open func viewWillLayoutSubviews() {
-        isLayoutingSubviews = true
-        super.viewWillLayoutSubviews()
-    }
-
-    override open func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        isLayoutingSubviews = false
-    }
 
     open private(set) lazy var loadingIndicator: UIActivityIndicatorView = {
         if #available(iOS 13.0, *) {
@@ -238,16 +225,15 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
 }
 
 extension _ChatChannelListVC: _ChatChannelListControllerDelegate {
+    public func controllerWillChangeChannels(_ controller: _ChatChannelListController<ExtraData>) {
+        // We can't call `performBatchUpdates` unless collection view is properly laid out.
+        collectionView.layoutIfNeeded()
+    }
+
     open func controller(
         _ controller: _ChatChannelListController<ExtraData>,
         didChangeChannels changes: [ListChange<_ChatChannel<ExtraData>>]
     ) {
-        // We can't call `performBatchUpdates` unless all views are properly laid out.
-        guard isLayoutingSubviews == false else {
-            collectionView.reloadData()
-            return
-        }
-        
         var movedItems: [IndexPath] = []
         
         collectionView.performBatchUpdates(


### PR DESCRIPTION
This is mainly to avoid the crashes when `UICollectionView` is updated before it's fully laid out. We already try other (simpler) fixes but none of those worked properly. This is hopefully the last fix of this issue.

- I added `willChange` callback to `ListDatabaseObsever`
- I added `controllerWillChangeChannels` to `ChatChannelListController` delegate
- `ChatChannelListVC` now forces its `UICollectionView` to lay out before the update form the controller comes

---

If we see this pattern works and helps with the issue, we can extend other list controllers, too.