### PR TITLE
Fix CoreData concurrency

### DIFF
--- a/Sources/StreamChat/Controllers/EntityDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/EntityDatabaseObserver.swift
@@ -144,7 +144,13 @@ class EntityDatabaseObserver<Item, DTO: NSManagedObject> {
                 "EntityDatabaseObserver predicate must match exactly 0 or 1 entities. Matched: \(fetchedObjects)"
             )
             
-            return fetchedObjects.first.flatMap(itemCreator)
+            return fetchedObjects.first.flatMap { dto in
+                var result: Item?
+                context.performAndWait {
+                    result = itemCreator(dto)
+                }
+                return result
+            }
         }
         
         listenForRemoveAllDataNotifications()

--- a/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
@@ -382,15 +382,15 @@ final class MessageController_Tests: StressTestCase {
             authorUserId: .unique
         )
         
-        var replyDTO: MessageDTO?
+        var replyModel: ChatMessage?
         try client.databaseContainer.writeSynchronously { session in
-            replyDTO = try session.saveMessage(payload: reply, for: self.cid)
+            replyModel = try session.saveMessage(payload: reply, for: self.cid).asModel()
         }
     
         // Assert `insert` entity change is received by the delegate
         AssertAsync.willBeEqual(
             delegate.didChangeReplies_changes,
-            [.insert((replyDTO?.asModel())!, index: [0, 0])]
+            [.insert(replyModel!, index: [0, 0])]
         )
     }
     

--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -41,7 +41,9 @@ class DatabaseContainer: NSPersistentContainer {
         let context = newBackgroundContext()
         context.automaticallyMergesChangesFromParent = true
         context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
-        context.localCachingSettings = localCachingSettings
+        context.perform { [localCachingSettings] in
+            context.localCachingSettings = localCachingSettings
+        }
         return context
     }()
     
@@ -57,7 +59,9 @@ class DatabaseContainer: NSPersistentContainer {
         let context = newBackgroundContext()
         context.automaticallyMergesChangesFromParent = true
         context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
-        context.localCachingSettings = localCachingSettings
+        context.perform { [localCachingSettings] in
+            context.localCachingSettings = localCachingSettings
+        }
         return context
     }()
     
@@ -123,7 +127,13 @@ class DatabaseContainer: NSPersistentContainer {
         
         viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
         viewContext.automaticallyMergesChangesFromParent = true
-        viewContext.localCachingSettings = localCachingSettings
+        if Thread.current.isMainThread {
+            viewContext.localCachingSettings = localCachingSettings
+        } else {
+            viewContext.perform { [viewContext, localCachingSettings] in
+                viewContext.localCachingSettings = localCachingSettings
+            }
+        }
         
         setupLoggerForDatabaseChanges()
         

--- a/Sources/StreamChat/Utils/CoreDataLazy_Tests.swift
+++ b/Sources/StreamChat/Utils/CoreDataLazy_Tests.swift
@@ -79,7 +79,11 @@ class CoreDataLazy_Tests: StressTestCase {
         try database.createChannel(cid: cid, withMessages: true)
         
         // Get the DTO for the channel from the background context
-        let channelDTO = database.backgroundReadOnlyContext.channel(cid: cid)!
+        var channelDTO: ChannelDTO!
+        
+        database.backgroundReadOnlyContext.performAndWait {
+            channelDTO = database.backgroundReadOnlyContext.channel(cid: cid)!
+        }
         
         // Read and write randomly to the DB and test it doesn't crash
         let group = DispatchGroup()

--- a/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
@@ -72,10 +72,11 @@ final class NewChannelQueryUpdater<ExtraData: ExtraDataTypes>: Worker {
         changes.forEach { change in
             switch change {
             case let .insert(channelDTO, _):
+                let cid = channelDTO.cid
+                
                 database.write {
-                    let dto = $0.channel(cid: try! ChannelId(cid: channelDTO.cid))
+                    let dto = $0.channel(cid: try! ChannelId(cid: cid))
                     dto?.needsRefreshQueries = false
-
                 } completion: { _ in
                     self.updateChannelListQuery(for: channelDTO)
                 }

--- a/Sources/StreamChat/Workers/UserListUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/UserListUpdater_Tests.swift
@@ -120,6 +120,8 @@ class UserListUpdater_Tests: StressTestCase {
         // Assert new user is inserted into DB
         AssertAsync.willBeTrue(newUser != nil)
         
+        let userIds = [user!, newUser!].map(\.id)
+        
         // Assert both users are linked to the same query now
         try database.writeSynchronously { session in
             do {
@@ -127,7 +129,7 @@ class UserListUpdater_Tests: StressTestCase {
                 XCTAssertEqual(dto!.users.count, 2)
                 XCTAssertEqual(
                     dto!.users.map(\.id).sorted(),
-                    [user!, newUser!].map(\.id).sorted()
+                    userIds.sorted()
                 )
             } catch {
                 XCTFail("Error trying to get query: \(error)")

--- a/Sources/StreamChatTestTools/NSManagedObject+ContextChange.swift
+++ b/Sources/StreamChatTestTools/NSManagedObject+ContextChange.swift
@@ -1,0 +1,15 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+
+public extension NSManagedObject {
+    /// Shortcut for transfering objects between contexts
+    ///
+    /// Returns implicitly unwrapped optional as it is possible for this operation to fail,
+    /// this extension is **intended to be used in tests** so it should not be an issue
+    func inContext(_ context: NSManagedObjectContext) -> Self! {
+        context.object(with: objectID) as? Self
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		64F70D4B26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F70D4A26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift */; };
 		6971257E260CA503003C7B47 /* NSManagedObjectContext+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6971256C260CA4CB003C7B47 /* NSManagedObjectContext+Extensions.swift */; };
 		697C6F90260CFA37000E9023 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69712522260BC9B4003C7B47 /* Deprecations.swift */; };
+		698E483E2639720B00E702C6 /* NSManagedObject+ContextChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698E483D2639720B00E702C6 /* NSManagedObject+ContextChange.swift */; };
 		780057FF25F6353600D21095 /* ChatChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780057F625F634FC00D21095 /* ChatChannel.swift */; };
 		780DFCFC25EF7DA500A39A6E /* ChatChannelListVC+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780DFCFB25EF7DA500A39A6E /* ChatChannelListVC+SwiftUI.swift */; };
 		7844B10C25EF92B600B87E89 /* ChatChannelListItemView+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7844B10B25EF92B600B87E89 /* ChatChannelListItemView+SwiftUI.swift */; };
@@ -1217,6 +1218,7 @@
 		69712522260BC9B4003C7B47 /* Deprecations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecations.swift; sourceTree = "<group>"; };
 		6971256C260CA4CB003C7B47 /* NSManagedObjectContext+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Extensions.swift"; sourceTree = "<group>"; };
 		698E2A3425F7C8AF00ED9CCC /* APIPathConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPathConvertible.swift; sourceTree = "<group>"; };
+		698E483D2639720B00E702C6 /* NSManagedObject+ContextChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+ContextChange.swift"; sourceTree = "<group>"; };
 		69DE605925F39E6000DC187F /* ChatMessageListCollectionViewLayout_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListCollectionViewLayout_Tests.swift; sourceTree = "<group>"; };
 		780057F625F634FC00D21095 /* ChatChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannel.swift; sourceTree = "<group>"; };
 		780DFCFB25EF7DA500A39A6E /* ChatChannelListVC+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatChannelListVC+SwiftUI.swift"; sourceTree = "<group>"; };
@@ -2668,6 +2670,7 @@
 				793060E925778896005CF846 /* Info.plist */,
 				F8788EC9261D9AC8006019DD /* DatabaseContainer_Mock.swift */,
 				F8788EE4261D9BF0006019DD /* ChatClientUpdater_Mock.swift */,
+				698E483D2639720B00E702C6 /* NSManagedObject+ContextChange.swift */,
 			);
 			path = StreamChatTestTools;
 			sourceTree = "<group>";
@@ -5211,6 +5214,7 @@
 				793061602577A39D005CF846 /* ChatMessage_Mock.swift in Sources */,
 				F8788F00261D9D53006019DD /* UserPayload.swift in Sources */,
 				F8788F2D261D9FEF006019DD /* MessagePayload.swift in Sources */,
+				698E483E2639720B00E702C6 /* NSManagedObject+ContextChange.swift in Sources */,
 				F8677F0F2624466200743078 /* XCTestCase+Dummy.swift in Sources */,
 				ADFCCD5F25C9D4350024505D /* ChatUserSearchController_Mock.swift in Sources */,
 				F8788F09261D9D81006019DD /* CurrentUserPayload.swift in Sources */,

--- a/StreamChat.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
+++ b/StreamChat.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
@@ -55,6 +55,10 @@
             argument = "-UIViewLayoutFeedbackLoopDebuggingThreshold 100"
             isEnabled = "YES">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1 "
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction

--- a/Tests/StreamChatTests/StreamChatStressTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatStressTestPlan.xctestplan
@@ -10,6 +10,11 @@
   ],
   "defaultOptions" : {
     "codeCoverage" : false,
+    "commandLineArgumentEntries" : [
+      {
+        "argument" : "-com.apple.CoreData.ConcurrencyDebug 1"
+      }
+    ],
     "environmentVariableEntries" : [
       {
         "key" : "TEST_INVOCATIONS",

--- a/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
@@ -17,7 +17,12 @@
           "name" : "StreamChat"
         }
       ]
-    }
+    },
+    "commandLineArgumentEntries" : [
+      {
+        "argument" : "-com.apple.CoreData.ConcurrencyDebug 1"
+      }
+    ]
   },
   "testTargets" : [
     {


### PR DESCRIPTION
This PR fixes CoreData concurrency issues found by enabling `-com.apple.CoreData.ConcurrencyDebug` launch argument for demo app and for `StreamChat` test plans.

- I kept the launch argument for demo app and for both LLC test plans as I think it is useful to know about those issues
- fix issues in demo app
- fix issues in LLC tests

---

Closes #954