### PR TITLE
Implementation of MessageListVC and MessageThreadVC

### DIFF
--- a/MessageCell.swift
+++ b/MessageCell.swift
@@ -1,0 +1,50 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+public class MessageCell<ExtraData: ExtraDataTypes>: _CollectionViewCell, UIConfigProvider {
+    static var reuseId: String { "message_cell" }
+
+    class var messageContentViewClass: _MessageContentView<ExtraData>.Type {
+        _MessageContentView<ExtraData>.self
+    }
+
+    let messageContentView = messageContentViewClass
+        .init()
+        .withoutAutoresizingMaskConstraints
+
+    override public func setUpLayout() {
+        super.setUpLayout()
+
+        contentView.embed(messageContentView)
+    }
+
+    override public func prepareForReuse() {
+        super.prepareForReuse()
+
+        messageContentView.delegate = nil
+        messageContentView.content = nil
+    }
+
+    override open func preferredLayoutAttributesFitting(
+        _ layoutAttributes: UICollectionViewLayoutAttributes
+    ) -> UICollectionViewLayoutAttributes {
+        let preferredAttributes = super.preferredLayoutAttributesFitting(layoutAttributes)
+
+        let targetSize = CGSize(
+            width: layoutAttributes.frame.width,
+            height: UIView.layoutFittingCompressedSize.height
+        )
+
+        preferredAttributes.frame.size = contentView.systemLayoutSizeFitting(
+            targetSize,
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+
+        return preferredAttributes
+    }
+}

--- a/MessageCell.swift
+++ b/MessageCell.swift
@@ -5,7 +5,7 @@
 import StreamChat
 import UIKit
 
-public class MessageCell<ExtraData: ExtraDataTypes>: _CollectionViewCell, UIConfigProvider {
+public class MessageCell<ExtraData: ExtraDataTypes>: _CollectionViewCell {
     static var reuseId: String { "message_cell" }
 
     class var messageContentViewClass: _MessageContentView<ExtraData>.Type {

--- a/Sources/StreamChatUI/ChatMessageList/ChatChannelRouter.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatChannelRouter.swift
@@ -7,6 +7,7 @@ import UIKit
 
 public typealias ChatChannelRouter = _ChatChannelRouter<NoExtraData>
 
+// TODO: Remove
 open class _ChatChannelRouter<ExtraData: ExtraDataTypes>: ChatRouter<_ChatChannelVC<ExtraData>> {
     open func showThreadDetail(for message: _ChatMessage<ExtraData>, within channel: _ChatChannelController<ExtraData>) {
         let controller = _ChatThreadVC<ExtraData>()

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListRouter.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListRouter.swift
@@ -7,7 +7,13 @@ import UIKit
 
 public typealias ChatMessageListRouter = _ChatMessageListRouter<NoExtraData>
 
-open class _ChatMessageListRouter<ExtraData: ExtraDataTypes>: ChatRouter<_ChatMessageListVC<ExtraData>> {
+open class _ChatMessageListRouter<ExtraData: ExtraDataTypes> {
+    public unowned var rootViewController: UIViewController
+    
+    public required init(rootViewController: UIViewController) {
+        self.rootViewController = rootViewController
+    }
+    
     open func showMessageActionsPopUp(
         messageContentViewClass: _ChatMessageContentView<ExtraData>.Type,
         messageContentFrame: CGRect,

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageCollectionView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageCollectionView.swift
@@ -1,0 +1,78 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+open class MessageCollectionView: UICollectionView {
+    private var identifiers: Set<String> = .init()
+    
+    open var needsToScrollToMostRecentMessage = false
+    open var needsToScrollToMostRecentMessageAnimated = false
+    
+    open func dequeueReusableCell<ExtraData: ExtraDataTypes>(
+        withReuseIdentifier identifier: String,
+        layoutOptions: MessageLayoutOptions,
+        for indexPath: IndexPath
+    ) -> MessageCell<ExtraData> {
+        let reuseIdentifier = "\(identifier)_\(layoutOptions.rawValue)"
+        
+        // There is no public API to find out
+        // if the given `identifier` is registered.
+        if !identifiers.contains(reuseIdentifier) {
+            identifiers.insert(reuseIdentifier)
+            
+            register(MessageCell<ExtraData>.self, forCellWithReuseIdentifier: reuseIdentifier)
+        }
+            
+        let cell = dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as! MessageCell<ExtraData>
+        cell.messageContentView.setUpLayoutIfNeeded(options: layoutOptions)
+        
+        return cell
+    }
+    
+    /// Updates the collection view data with given `changes`.
+    open func updateMessages<ExtraData: ExtraDataTypes>(
+        with changes: [ListChange<_ChatMessage<ExtraData>>],
+        completion: ((Bool) -> Void)? = nil
+    ) {
+        performBatchUpdates {
+            for change in changes {
+                switch change {
+                case let .insert(_, index):
+                    insertItems(at: [index])
+                case let .move(_, fromIndex, toIndex):
+                    moveItem(at: fromIndex, to: toIndex)
+                case let .remove(_, index):
+                    deleteItems(at: [index])
+                case let .update(_, index):
+                    reloadItems(at: [index])
+                }
+            }
+        } completion: { flag in
+            completion?(flag)
+        }
+    }
+    
+    /// Will scroll to most recent message on next `updateMessages` call
+    open func setNeedsScrollToMostRecentMessage(animated: Bool = true) {
+        needsToScrollToMostRecentMessage = true
+        needsToScrollToMostRecentMessageAnimated = animated
+    }
+
+    /// Force scroll to most recent message check without waiting for `updateMessages`
+    open func scrollToMostRecentMessageIfNeeded() {
+        guard needsToScrollToMostRecentMessage else { return }
+        
+        scrollToMostRecentMessage(animated: needsToScrollToMostRecentMessageAnimated)
+    }
+
+    /// Scrolls to most recent message
+    open func scrollToMostRecentMessage(animated: Bool = true) {
+        needsToScrollToMostRecentMessage = false
+
+        // our collection is flipped, so (0; 0) item is most recent one
+        scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: animated)
+    }
+}

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageLayoutOptionsResolver.swift
@@ -1,0 +1,121 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+
+public typealias MessageLayoutOptionsResolver<ExtraData: ExtraDataTypes> = (
+    _ indexPath: IndexPath,
+    _ messages: AnyRandomAccessCollection<_ChatMessage<ExtraData>>,
+    _ channel: _ChatChannel<ExtraData>
+) -> MessageLayoutOptions
+
+public func DefaultMessageLayoutOptionsResolver<ExtraData: ExtraDataTypes>(
+    minTimeIntervalBetweenMessagesInGroup: TimeInterval = 10
+) -> MessageLayoutOptionsResolver<ExtraData> {
+    { indexPath, messages, channel in
+        let messageIndex = messages.index(messages.startIndex, offsetBy: indexPath.item)
+        let message = messages[messageIndex]
+
+        let isLastInGroup: Bool = {
+            guard indexPath.item > 0 else { return true }
+            
+            let nextMessageIndex = messages.index(messages.startIndex, offsetBy: indexPath.item - 1)
+            let nextMessage = messages[nextMessageIndex]
+
+            guard nextMessage.author == message.author else { return true }
+            
+            let delay = nextMessage.createdAt.timeIntervalSince(message.createdAt)
+            
+            return delay > minTimeIntervalBetweenMessagesInGroup
+        }()
+        
+        var options: MessageLayoutOptions = []
+        
+        if message.isSentByCurrentUser {
+            options.insert(.flipped)
+        }
+        if !isLastInGroup {
+            options.insert(.continuousBubble)
+        }
+        if !isLastInGroup && !message.isSentByCurrentUser {
+            options.insert(.avatarSizePadding)
+        }
+        if isLastInGroup {
+            options.insert(.metadata)
+        }
+        if message.textContent?.isEmpty == false {
+            options.insert(.text)
+        }
+        
+        guard message.deletedAt == nil else {
+            return options
+        }
+        
+        if isLastInGroup && !message.isSentByCurrentUser {
+            options.insert(.avatar)
+        }
+        if isLastInGroup && !message.isSentByCurrentUser && !channel.isDirectMessageChannel {
+            options.insert(.authorName)
+        }
+        if message.quotedMessage?.id != nil {
+            options.insert(.quotedMessage)
+        }
+        if message.isPartOfThread {
+            options.insert(.threadInfo)
+            // The bubbles with thread look like continuous bubbles
+            options.insert(.continuousBubble)
+        }
+        if !message.reactionScores.isEmpty {
+            options.insert(.reactions)
+        }
+        if message.lastActionFailed {
+            options.insert(.errorIndicator)
+        }
+
+        // TODO: Implement
+//        let attachmentOptions: MessageLayoutOptions = message.attachments.reduce([]) { options, attachment in
+//            if (attachment as? ChatMessageDefaultAttachment)?.actions.isEmpty == false {
+//                return options.union(.actions)
+//            }
+//
+//            switch attachment.type {
+//            case .image:
+//                return options.union(.photoPreview)
+//            case .giphy:
+//                return options.union(.giphy)
+//            case .file:
+//                return options.union(.filePreview)
+//            case .link:
+//                return options.union(.linkPreview)
+//            default:
+//                return options
+//            }
+//        }
+//
+//        if attachmentOptions.contains(.actions) {
+//            options.insert(.actions)
+//        } else if attachmentOptions.intersection([.photoPreview, .giphy, .filePreview]).isEmpty == false {
+//            options.formUnion(attachmentOptions.subtracting(.linkPreview))
+//        } else if attachmentOptions.contains(.linkPreview) {
+//            options.insert(.linkPreview)
+//        }
+//
+//        if !options.intersection(.maxWidthRequirments).isEmpty {
+//            options.insert(.maxWidth)
+//        }
+        
+        return options
+    }
+}
+
+// TODO: Implement
+// extension MessageLayoutOptions {
+//    static let maxWidthRequirments: MessageLayoutOptions = [
+//        .photoPreview,
+//        .filePreview,
+//        .linkPreview,
+//        .actions,
+//        .giphy
+//    ]
+// }

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListKeyboardObserver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListKeyboardObserver.swift
@@ -1,0 +1,91 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+public final class MessageListKeyboardObserver {
+    weak var containerView: UIView!
+    weak var scrollView: UIScrollView!
+    weak var composerBottomConstraint: NSLayoutConstraint?
+    
+    public init(containerView: UIView, scrollView: UIScrollView, composerBottomConstraint: NSLayoutConstraint?) {
+        self.containerView = containerView
+        self.scrollView = scrollView
+        self.composerBottomConstraint = composerBottomConstraint
+    }
+    
+    public func register() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillChangeFrame),
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil
+        )
+    }
+    
+    public func unregister() {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    @objc
+    private func keyboardWillChangeFrame(_ notification: Notification) {
+        guard
+            let frame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
+            let oldFrame = (notification.userInfo?[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue,
+            let duration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
+            let curve = notification.userInfo?[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt
+        else { return }
+
+        let localFrame = containerView.convert(frame, from: nil)
+        let localOldFrame = containerView.convert(oldFrame, from: nil)
+
+        // message composer follows keyboard
+        composerBottomConstraint?.constant = -(containerView.bounds.height - localFrame.minY)
+
+        // calculate new contentOffset for message list, so bottom message still visible when keyboard appears
+        var keyboardTop = localFrame.minY
+        if keyboardTop == containerView.bounds.height {
+            keyboardTop -= containerView.safeAreaInsets.bottom
+        }
+
+        var oldKeyboardTop = localOldFrame.minY
+        if oldKeyboardTop == containerView.bounds.height {
+            oldKeyboardTop -= containerView.safeAreaInsets.bottom
+        }
+
+        let keyboardDelta = oldKeyboardTop - keyboardTop
+        // need to calculate delta in content when `contentSize` is smaller than `frame.size`
+        let contentDelta = max(
+            // 8 is just some padding constant to make it look better
+            scrollView.frame.height - scrollView.contentSize.height + scrollView.contentOffset.y - 8,
+            // 0 is for the case when `contentSize` if larger than `frame.size`
+            0
+        )
+        
+        let newContentOffset = CGPoint(
+            x: 0,
+            y: max(
+                scrollView.contentOffset.y + keyboardDelta - contentDelta,
+                // case when keyboard is activated but not shown, probably only on simulator
+                -scrollView.contentInset.top
+            )
+        )
+        
+        // changing contentOffset will cancel any scrolling in collectionView, bad UX
+        let needUpdateContentOffset = !scrollView.isDecelerating && !scrollView.isDragging
+        
+        UIView.animate(
+            withDuration: duration,
+            delay: 0.0,
+            options: UIView.AnimationOptions(rawValue: curve),
+            animations: { [weak self] in
+                self?.containerView.layoutIfNeeded()
+                if needUpdateContentOffset {
+                    self?.scrollView.contentOffset = newContentOffset
+                }
+            }
+        )
+    }
+}

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -1,0 +1,427 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+/// Controller that shows list of messages and composer together in the selected channel.
+open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionViewDelegate, UICollectionViewDataSource,
+    UIConfigProvider {
+    /// Controller for observing data changes within the channel
+    open var channelController: _ChatChannelController<ExtraData>!
+    
+    /// Observer responsible for setting the correct offset when keyboard frame is changed
+    open lazy var keyboardObserver = MessageListKeyboardObserver(
+        containerView: view,
+        scrollView: collectionView,
+        composerBottomConstraint: messageComposerBottomConstraint
+    )
+
+    /// User search controller passed directly to the composer
+    open lazy var userSuggestionSearchController: _ChatUserSearchController<ExtraData> =
+        channelController.client.userSearchController()
+    
+    // TODO: Documentation
+    open lazy var messageListLayout = ChatMessageListCollectionViewLayout()
+    
+    /// View used to display the messages
+    open private(set) lazy var collectionView: MessageCollectionView = {
+        let collection = MessageCollectionView(frame: .zero, collectionViewLayout: messageListLayout)
+
+        collection.isPrefetchingEnabled = false
+        collection.showsHorizontalScrollIndicator = false
+        collection.alwaysBounceVertical = true
+        collection.keyboardDismissMode = .onDrag
+        collection.dataSource = self
+        collection.delegate = self
+
+        return collection.withoutAutoresizingMaskConstraints
+    }()
+    
+    /// Controller that handles the composer view
+    open private(set) lazy var messageComposerViewController = uiConfig
+        .messageComposer
+        .messageComposerViewController
+        .init()
+    
+    // TODO: Load from UIConfig, seperate PR for this component is already created
+    /// View displaying status of the channel.
+    ///
+    /// The status differs based on the fact if the channel is direct or not.
+    open lazy var titleView = ChatMessageListTitleView<ExtraData>()
+
+    /// Handles navigation actions from messages
+    open lazy var router = uiConfig
+        .navigation
+        .messageListRouter
+        .init(rootViewController: self)
+
+    open lazy var popupPresenter = PopupPresenter(rootViewController: self)
+    
+    /// Constraint connection list of messages and composer controller.
+    /// It's used to change the message list's height based on the keyboard visibility.
+    private var messageComposerBottomConstraint: NSLayoutConstraint?
+    
+    /// Timer used to update the online status of member in the chat channel
+    private var timer: Timer?
+    
+    override open func setUp() {
+        super.setUp()
+        
+        let longPress = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress))
+        longPress.minimumPressDuration = 0.33
+        collectionView.addGestureRecognizer(longPress)
+        
+        messageComposerViewController.delegate = .wrap(self)
+        messageComposerViewController.controller = channelController
+        messageComposerViewController.userSuggestionSearchController = userSuggestionSearchController
+
+        userSuggestionSearchController.search(term: nil)
+        
+        channelController.setDelegate(self)
+        channelController.synchronize()
+        
+        if channelController.channel?.isDirectMessageChannel == true {
+            timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+                self?.updateNavigationTitle()
+            }
+        }
+    }
+    
+    override open func setUpLayout() {
+        super.setUpLayout()
+        
+        view.addSubview(collectionView)
+        collectionView.pin(anchors: [.top, .leading, .trailing], to: view.safeAreaLayoutGuide)
+        
+        messageComposerViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        addChildViewController(messageComposerViewController, targetView: view)
+
+        messageComposerViewController.view.topAnchor.pin(equalTo: collectionView.bottomAnchor).isActive = true
+        messageComposerViewController.view.leadingAnchor.pin(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
+        messageComposerViewController.view.trailingAnchor.pin(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+        messageComposerBottomConstraint = messageComposerViewController.view.bottomAnchor.pin(equalTo: view.bottomAnchor)
+        messageComposerBottomConstraint?.isActive = true
+    }
+
+    override open func setUpAppearance() {
+        super.setUpAppearance()
+        
+        view.backgroundColor = .white
+        
+        collectionView.backgroundColor = .white
+        
+        navigationItem.titleView = titleView
+    }
+
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        
+        navigationItem.largeTitleDisplayMode = .never
+    }
+    
+    override open func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        keyboardObserver.register()
+    }
+
+    override open func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        resignFirstResponder()
+        
+        keyboardObserver.unregister()
+    }
+    
+    /// Returns the reuse identifier for the given message
+    open func cellReuseIdentifier(for message: _ChatMessage<ExtraData>) -> String {
+        MessageCell<ExtraData>.reuseId
+    }
+    
+    /// Returns layout options for the message on given `indexPath`.
+    ///
+    /// Layout options are used to determine the layout of the message.
+    /// By default there is one message with all possible layout and layout options
+    /// determines which parts of the message are visible for the given message.
+    open func cellLayoutOptionsForMessage(at indexPath: IndexPath) -> MessageLayoutOptions {
+        guard let channel = channelController.channel else { return [] }
+
+        return uiConfig.messageList.layoutOptionsResolver(
+            indexPath,
+            AnyRandomAccessCollection(channelController.messages),
+            channel
+        )
+    }
+    
+    open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        channelController.messages.count
+    }
+    
+    open func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let message = channelController.messages[indexPath.item]
+        
+        let cell: MessageCell<ExtraData> = self.collectionView.dequeueReusableCell(
+            withReuseIdentifier: cellReuseIdentifier(for: message),
+            layoutOptions: cellLayoutOptionsForMessage(at: indexPath),
+            for: indexPath
+        )
+        cell.messageContentView.indexPath = indexPath
+        cell.messageContentView.delegate = self
+        cell.messageContentView.content = message
+        
+        return cell
+    }
+    
+    /// Will scroll to most recent message on next `updateMessages` call
+    open func setNeedsScrollToMostRecentMessage(animated: Bool = true) {
+        collectionView.setNeedsScrollToMostRecentMessage(animated: animated)
+    }
+
+    /// Force scroll to most recent message check without waiting for `updateMessages`
+    open func scrollToMostRecentMessageIfNeeded() {
+        collectionView.scrollToMostRecentMessageIfNeeded()
+    }
+
+    /// Scrolls to most recent message
+    open func scrollToMostRecentMessage(animated: Bool = true) {
+        collectionView.scrollToMostRecentMessage(animated: animated)
+    }
+    
+    /// Updates the status data in `titleView`.
+    ///
+    /// If the channel is direct between two people this method is called repeatedly every minute
+    /// to update the online status of the members.
+    /// For group chat is called everytime the channel changes.
+    open func updateNavigationTitle() {
+        let title = channelController.channel
+            .flatMap { uiConfig.channelList.channelNamer($0, channelController.client.currentUserId) }
+        
+        let subtitle: String? = {
+            if channelController.channel?.isDirectMessageChannel == true {
+                guard let member = channelController.channel?.lastActiveMembers.first else { return nil }
+                
+                if member.isOnline {
+                    // ReallyNotATODO: Missing API GroupA.m1
+                    // need to specify how long user have been online
+                    return L10n.Message.Title.online
+                } else if let minutes = member.lastActiveAt
+                    .flatMap({ DateComponentsFormatter.minutes.string(from: $0, to: Date()) }) {
+                    return L10n.Message.Title.seeMinutesAgo(minutes)
+                } else {
+                    return L10n.Message.Title.offline
+                }
+            } else {
+                return channelController.channel.map { L10n.Message.Title.group($0.memberCount, $0.watcherCount) }
+            }
+        }()
+        
+        titleView.title = title
+        titleView.subtitle = subtitle
+    }
+
+    /// Handles long press action on collection view.
+    ///
+    /// Default implementation will convert the gesture location to collection view's `indexPath`
+    /// and then call selection action on the selected cell.
+    @objc open func didLongPress(_ gesture: UILongPressGestureRecognizer) {
+        let location = gesture.location(in: collectionView)
+
+        guard
+            gesture.state == .began,
+            let ip = collectionView.indexPathForItem(at: location)
+        else { return }
+        
+        didSelectMessageCell(at: ip)
+    }
+
+    /// Updates the collection view data with given `changes`.
+    open func updateMessages(with changes: [ListChange<_ChatMessage<ExtraData>>], completion: ((Bool) -> Void)? = nil) {
+        collectionView.updateMessages(with: changes, completion: completion)
+    }
+    
+    open func messageForIndexPath(_ indexPath: IndexPath) -> _ChatMessage<ExtraData> {
+        channelController.messages[indexPath.item]
+    }
+    
+    open func didSelectMessageCell(at indexPath: IndexPath) {
+        let message = channelController.messages[indexPath.item]
+        
+        guard
+            let cell = collectionView.cellForItem(at: indexPath) as? MessageCell<ExtraData>,
+            message.isInteractionEnabled
+        else { return }
+        
+        let messageController = channelController.client.messageController(
+            cid: channelController.cid!,
+            messageId: message.id
+        )
+        
+        presentActionsForMessage(message, cell: cell, messageController: messageController)
+    }
+
+    /// Presents custom actions controller with all possible actions with the selected message.
+    open func presentActionsForMessage(
+        _ message: _ChatMessage<ExtraData>,
+        cell: MessageCell<ExtraData>,
+        messageController: _ChatMessageController<ExtraData>
+    ) {
+        let actionsController = _ChatMessageActionsVC<ExtraData>()
+        actionsController.messageController = messageController
+        actionsController.delegate = .init(delegate: self)
+
+        var reactionsController: _ChatMessageReactionsVC<ExtraData>? {
+            guard message.localState == nil else { return nil }
+
+            let controller = _ChatMessageReactionsVC<ExtraData>()
+            controller.messageController = messageController
+            return controller
+        }
+        
+        popupPresenter.present(
+            targetView: cell.messageContentView,
+            message: message,
+            actionsController: actionsController,
+            reactionsController: reactionsController
+        )
+    }
+
+    /// Restarts upload of given `attachment` in case of failure
+    open func restartUploading(for attachment: ChatMessageDefaultAttachment) {
+        guard let id = attachment.id else {
+            assertionFailure("Uploading cannot be restarted for attachment without `id`")
+            return
+        }
+
+        channelController.client
+            .messageController(cid: id.cid, messageId: id.messageId)
+            .restartFailedAttachmentUploading(with: id)
+    }
+
+    // MARK: Cell action handlers
+
+    /// Handles the tap on an attachment.
+    ///
+    /// Default implementation tries to restart the upload in case of failure.
+    /// If the attachment is correctly uploaded and displayed
+    /// then for image or file it shows the preview.
+    /// For link it tries to open it.
+    open func handleTapOnAttachment(_ attachment: ChatMessageAttachment, forCellAt indexPath: IndexPath) {
+        guard let attachment = attachment as? ChatMessageDefaultAttachment else {
+            return
+        }
+
+        guard attachment.localState != .uploadingFailed else {
+            restartUploading(for: attachment)
+            return
+        }
+
+        switch attachment.type {
+        case .image, .file:
+            router.showPreview(for: attachment)
+        case .link:
+            router.openLink(attachment)
+        default:
+            break
+        }
+    }
+
+    /// Executes the provided action on the message
+    open func handleTapOnAttachmentAction(
+        _ action: AttachmentAction,
+        for attachment: ChatMessageAttachment,
+        forCellAt indexPath: IndexPath
+    ) {
+        // Can we have a helper on `ChannelController` returning a `messageController` for the provided message id?
+        channelController.client
+            .messageController(
+                cid: channelController.cid!,
+                messageId: channelController.messages[indexPath.row].id
+            )
+            .dispatchEphemeralMessageAction(action)
+    }
+    
+    /// Opens thread detail for given `message`
+    open func showThread(for message: _ChatMessage<ExtraData>) {
+        guard let channel = channelController.channel else { return }
+        
+        let controller = MessageThreadVC<ExtraData>()
+        controller.channelController = channelController
+        controller.messageController = channelController.client.messageController(
+            cid: channel.cid,
+            messageId: message.id
+        )
+        navigationController?.show(controller, sender: self)
+    }
+}
+
+extension MessageListVC: _ChatMessageComposerViewControllerDelegate {
+    open func messageComposerViewControllerDidSendMessage(_ vc: _ChatMessageComposerVC<ExtraData>) {
+        setNeedsScrollToMostRecentMessage()
+    }
+}
+
+extension MessageListVC: _ChatChannelControllerDelegate {
+    open func channelController(
+        _ channelController: _ChatChannelController<ExtraData>,
+        didUpdateMessages changes: [ListChange<_ChatMessage<ExtraData>>]
+    ) {
+        updateMessages(with: changes)
+    }
+    
+    open func channelController(
+        _ channelController: _ChatChannelController<ExtraData>,
+        didUpdateChannel channel: EntityChange<_ChatChannel<ExtraData>>
+    ) {
+        updateNavigationTitle()
+    }
+}
+
+extension MessageListVC: _ChatMessageActionsVCDelegate {
+    open func chatMessageActionsVC(
+        _ vc: _ChatMessageActionsVC<ExtraData>,
+        message: _ChatMessage<ExtraData>,
+        didTapOnActionItem actionItem: ChatMessageActionItem
+    ) {
+        switch actionItem {
+        case is EditActionItem:
+            dismiss(animated: true) { [weak self] in
+                self?.messageComposerViewController.state = .edit(message)
+            }
+        case is InlineReplyActionItem:
+            dismiss(animated: true) { [weak self] in
+                self?.messageComposerViewController.state = .quote(message)
+            }
+        case is ThreadReplyActionItem:
+            dismiss(animated: true) { [weak self] in
+                self?.showThread(for: message)
+            }
+        default:
+            return
+        }
+    }
+
+    open func chatMessageActionsVCDidFinish(
+        _ vc: _ChatMessageActionsVC<ExtraData>
+    ) {
+        dismiss(animated: true)
+    }
+}
+
+extension MessageListVC: MessageContentViewDelegate {
+    public func messageContentViewDidTapOnErrorIndicator(_ indexPath: IndexPath?) {
+        guard let indexPath = indexPath else { assertionFailure("IndexPath is not available"); return }
+        didSelectMessageCell(at: indexPath)
+    }
+    
+    public func messageContentViewDidTapOnThread(_ indexPath: IndexPath?) {
+        guard let indexPath = indexPath else { assertionFailure("IndexPath is not available"); return }
+        showThread(for: channelController.messages[indexPath.item])
+    }
+    
+    // TODO: Currently not supported
+    public func messageContentViewDidTapOnQuotedMessage(_ indexPath: IndexPath?) {
+        print(#function, indexPath)
+    }
+}

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageListVC.swift
@@ -7,7 +7,7 @@ import UIKit
 
 /// Controller that shows list of messages and composer together in the selected channel.
 open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionViewDelegate, UICollectionViewDataSource,
-    UIConfigProvider {
+    ComponentsProvider {
     /// Controller for observing data changes within the channel
     open var channelController: _ChatChannelController<ExtraData>!
     
@@ -40,7 +40,7 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
     }()
     
     /// Controller that handles the composer view
-    open private(set) lazy var messageComposerViewController = uiConfig
+    open private(set) lazy var messageComposerViewController = components
         .messageComposer
         .messageComposerViewController
         .init()
@@ -52,7 +52,7 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
     open lazy var titleView = ChatMessageListTitleView<ExtraData>()
 
     /// Handles navigation actions from messages
-    open lazy var router = uiConfig
+    open lazy var router = components
         .navigation
         .messageListRouter
         .init(rootViewController: self)
@@ -148,7 +148,7 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
     open func cellLayoutOptionsForMessage(at indexPath: IndexPath) -> MessageLayoutOptions {
         guard let channel = channelController.channel else { return [] }
 
-        return uiConfig.messageList.layoutOptionsResolver(
+        return components.messageList.layoutOptionsResolver(
             indexPath,
             AnyRandomAccessCollection(channelController.messages),
             channel
@@ -196,7 +196,7 @@ open class MessageListVC<ExtraData: ExtraDataTypes>: _ViewController, UICollecti
     /// For group chat is called everytime the channel changes.
     open func updateNavigationTitle() {
         let title = channelController.channel
-            .flatMap { uiConfig.channelList.channelNamer($0, channelController.client.currentUserId) }
+            .flatMap { components.channelList.channelNamer($0, channelController.client.currentUserId) }
         
         let subtitle: String? = {
             if channelController.channel?.isDirectMessageChannel == true {

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -7,7 +7,7 @@ import UIKit
 
 /// Controller responsible for displaying message thread.
 open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionViewDelegate, UICollectionViewDataSource,
-    UIConfigProvider {
+    ComponentsProvider {
     /// Controller for observing data changes within the channel
     open var channelController: _ChatChannelController<ExtraData>!
     
@@ -43,7 +43,7 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
     }()
     
     /// Controller that handles the composer view
-    open private(set) lazy var messageComposerViewController = uiConfig
+    open private(set) lazy var messageComposerViewController = components
         .messageComposer
         .messageComposerViewController
         .init()
@@ -57,7 +57,7 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
     open lazy var titleView = ChatMessageListTitleView<ExtraData>()
     
     /// Handles navigation actions from messages
-    open lazy var router = uiConfig
+    open lazy var router = components
         .navigation
         .messageListRouter
         .init(rootViewController: self)
@@ -164,7 +164,7 @@ open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollec
     ) -> MessageLayoutOptions {
         guard let channel = channelController.channel else { return [] }
         
-        var layoutOptions = uiConfig.messageList.layoutOptionsResolver(indexPath, messages, channel)
+        var layoutOptions = components.messageList.layoutOptionsResolver(indexPath, messages, channel)
         layoutOptions.remove(.threadInfo)
         return layoutOptions
     }

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/MessageThreadVC.swift
@@ -1,0 +1,452 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+/// Controller responsible for displaying message thread.
+open class MessageThreadVC<ExtraData: ExtraDataTypes>: _ViewController, UICollectionViewDelegate, UICollectionViewDataSource,
+    UIConfigProvider {
+    /// Controller for observing data changes within the channel
+    open var channelController: _ChatChannelController<ExtraData>!
+    
+    // TODO: Documentation
+    open var messageController: _ChatMessageController<ExtraData>!
+
+    /// Observer responsible for setting the correct offset when keyboard frame is changed
+    open lazy var keyboardObserver = MessageListKeyboardObserver(
+        containerView: view,
+        scrollView: collectionView,
+        composerBottomConstraint: messageComposerBottomConstraint
+    )
+
+    /// User search controller passed directly to the composer
+    open lazy var userSuggestionSearchController: _ChatUserSearchController<ExtraData> =
+        channelController.client.userSearchController()
+    
+    // TODO: Documentation
+    open lazy var messageListLayout = ChatMessageListCollectionViewLayout()
+    
+    /// View used to display the messages
+    open private(set) lazy var collectionView: MessageCollectionView = {
+        let collection = MessageCollectionView(frame: .zero, collectionViewLayout: messageListLayout)
+
+        collection.isPrefetchingEnabled = false
+        collection.showsHorizontalScrollIndicator = false
+        collection.alwaysBounceVertical = true
+        collection.keyboardDismissMode = .onDrag
+        collection.dataSource = self
+        collection.delegate = self
+
+        return collection.withoutAutoresizingMaskConstraints
+    }()
+    
+    /// Controller that handles the composer view
+    open private(set) lazy var messageComposerViewController = uiConfig
+        .messageComposer
+        .messageComposerViewController
+        .init()
+    
+    open lazy var popupPresenter = PopupPresenter(rootViewController: self)
+    
+    // TODO: Load from UIConfig, seperate PR for this component is already created
+    /// View displaying status of the channel.
+    ///
+    /// The status differs based on the fact if the channel is direct or not.
+    open lazy var titleView = ChatMessageListTitleView<ExtraData>()
+    
+    /// Handles navigation actions from messages
+    open lazy var router = uiConfig
+        .navigation
+        .messageListRouter
+        .init(rootViewController: self)
+    
+    /// Constraint connection list of messages and composer controller.
+    /// It's used to change the message list's height based on the keyboard visibility.
+    private var messageComposerBottomConstraint: NSLayoutConstraint?
+    
+    override open func setUp() {
+        super.setUp()
+        
+        let longPress = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress))
+        longPress.minimumPressDuration = 0.33
+        collectionView.addGestureRecognizer(longPress)
+        
+        messageComposerViewController.delegate = .wrap(self)
+        messageComposerViewController.controller = channelController
+        messageComposerViewController.userSuggestionSearchController = userSuggestionSearchController
+        messageComposerViewController.threadParentMessage = messageController.message
+
+        userSuggestionSearchController.search(term: nil)
+        
+        channelController.setDelegate(self)
+        channelController.synchronize()
+        
+        messageController.setDelegate(self)
+        messageController.synchronize()
+    }
+    
+    override open func setUpLayout() {
+        super.setUpLayout()
+        
+        view.addSubview(collectionView)
+        collectionView.pin(anchors: [.top, .leading, .trailing], to: view.safeAreaLayoutGuide)
+        
+        messageComposerViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        addChildViewController(messageComposerViewController, targetView: view)
+        
+        addHeaderMessage()
+
+        messageComposerViewController.view.topAnchor.pin(equalTo: collectionView.bottomAnchor).isActive = true
+        messageComposerViewController.view.leadingAnchor.pin(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
+        messageComposerViewController.view.trailingAnchor.pin(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+        messageComposerBottomConstraint = messageComposerViewController.view.bottomAnchor.pin(equalTo: view.bottomAnchor)
+        messageComposerBottomConstraint?.isActive = true
+    }
+
+    override open func setUpAppearance() {
+        super.setUpAppearance()
+        
+        view.backgroundColor = .white
+        
+        collectionView.backgroundColor = .white
+        
+        navigationItem.titleView = titleView
+    }
+
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        
+        navigationItem.largeTitleDisplayMode = .never
+    }
+    
+    override open func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        keyboardObserver.register()
+        
+        // Scroll to newest message when there are no replies
+        // breaks the `contentOffset` set by parent message
+        if !messageController.replies.isEmpty {
+            scrollToMostRecentMessageIfNeeded()
+        }
+    }
+
+    override open func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        resignFirstResponder()
+        
+        keyboardObserver.unregister()
+    }
+    
+    /// Returns the reuse identifier for the given message
+    open func cellReuseIdentifier(for message: _ChatMessage<ExtraData>) -> String {
+        MessageCell<ExtraData>.reuseId
+    }
+    
+    /// Returns layout options for the message on given `indexPath`.
+    ///
+    /// Layout options are used to determine the layout of the message.
+    /// By default there is one message with all possible layout and layout options
+    /// determines which parts of the message are visible for the given message.
+    open func cellLayoutOptionsForMessage(at indexPath: IndexPath) -> MessageLayoutOptions {
+        cellLayoutOptionsForMessage(
+            at: indexPath,
+            messages: AnyRandomAccessCollection(messageController.replies)
+        )
+    }
+    
+    open func cellLayoutOptionsForMessage(
+        at indexPath: IndexPath,
+        messages: AnyRandomAccessCollection<_ChatMessage<ExtraData>>
+    ) -> MessageLayoutOptions {
+        guard let channel = channelController.channel else { return [] }
+        
+        var layoutOptions = uiConfig.messageList.layoutOptionsResolver(indexPath, messages, channel)
+        layoutOptions.remove(.threadInfo)
+        return layoutOptions
+    }
+    
+    open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        messageController.replies.count
+    }
+    
+    open func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let message = messageController.replies[indexPath.item]
+        
+        let cell: MessageCell<ExtraData> = self.collectionView.dequeueReusableCell(
+            withReuseIdentifier: cellReuseIdentifier(for: message),
+            layoutOptions: cellLayoutOptionsForMessage(at: indexPath),
+            for: indexPath
+        )
+        cell.messageContentView.indexPath = indexPath
+        cell.messageContentView.delegate = self
+        cell.messageContentView.content = message
+        
+        return cell
+    }
+    
+    open func collectionView(
+        _ collectionView: UICollectionView,
+        willDisplay cell: UICollectionViewCell,
+        forItemAt indexPath: IndexPath
+    ) {
+        if indexPath.row + 1 >= collectionView.numberOfItems(inSection: 0) {
+            messageController.loadPreviousReplies()
+        }
+    }
+    
+    /// Will scroll to most recent message on next `updateMessages` call
+    open func setNeedsScrollToMostRecentMessage(animated: Bool = true) {
+        collectionView.setNeedsScrollToMostRecentMessage(animated: animated)
+    }
+
+    /// Force scroll to most recent message check without waiting for `updateMessages`
+    open func scrollToMostRecentMessageIfNeeded() {
+        collectionView.scrollToMostRecentMessageIfNeeded()
+    }
+
+    /// Scrolls to most recent message
+    open func scrollToMostRecentMessage(animated: Bool = true) {
+        collectionView.scrollToMostRecentMessage(animated: animated)
+    }
+    
+    // TODO: L10n
+    /// Updates the status data in `titleView`.
+    ///
+    /// If the channel is direct between two people this method is called repeatedly every minute
+    /// to update the online status of the members.
+    /// For group chat is called everytime the channel changes.
+    open func updateNavigationTitle() {
+        let channelName = channelController.channel?.name ?? "love"
+        titleView.title = "Thread Reply"
+        titleView.subtitle = "with \(channelName)"
+    }
+    
+    // TODO: Documentation
+    open func addHeaderMessage() {
+        if let message = messageController.message {
+            let messageView = _MessageContentView<ExtraData>().withoutAutoresizingMaskConstraints
+            let layoutOptions = cellLayoutOptionsForMessage(
+                at: IndexPath(item: 0, section: 0),
+                messages: AnyRandomAccessCollection([message])
+            )
+            
+            messageView.setUpLayoutIfNeeded(options: layoutOptions)
+            collectionView.addSubview(messageView)
+            messageView.content = message
+
+            let messageViewSize = messageView.systemLayoutSizeFitting(
+                CGSize(
+                    width: UIScreen.main.bounds.size.width,
+                    height: UIView.layoutFittingCompressedSize.height
+                ),
+                withHorizontalFittingPriority: .required,
+                verticalFittingPriority: .defaultLow
+            )
+            let topInset = messageViewSize.height + messageListLayout.spacing
+            collectionView.contentInset = UIEdgeInsets(top: topInset, left: 0, bottom: 0, right: 0)
+
+            messageView.topAnchor.pin(equalTo: collectionView.topAnchor, constant: -topInset).isActive = true
+            messageView.pin(anchors: [.leading, .trailing], to: collectionView.safeAreaLayoutGuide)
+        }
+    }
+    
+    /// Handles long press action on collection view.
+    ///
+    /// Default implementation will convert the gesture location to collection view's `indexPath`
+    /// and then call selection action on the selected cell.
+    @objc open func didLongPress(_ gesture: UILongPressGestureRecognizer) {
+        let location = gesture.location(in: collectionView)
+
+        guard
+            gesture.state == .began,
+            let ip = collectionView.indexPathForItem(at: location)
+        else { return }
+        
+        didSelectMessageCell(at: ip)
+    }
+
+    /// Updates the collection view data with given `changes`.
+    open func updateMessages(with changes: [ListChange<_ChatMessage<ExtraData>>], completion: ((Bool) -> Void)? = nil) {
+        collectionView.updateMessages(with: changes, completion: completion)
+    }
+
+    /// Presents custom actions controller with all possible actions with the selected message.
+    open func didSelectMessageCell(at indexPath: IndexPath) {
+        let message = messageController.replies[indexPath.item]
+        
+        guard
+            let cell = collectionView.cellForItem(at: indexPath) as? MessageCell<ExtraData>,
+            message.isInteractionEnabled
+        else { return }
+        
+        let messageController = channelController.client.messageController(
+            cid: channelController.cid!,
+            messageId: message.id
+        )
+        
+        presentActionsForMessage(message, cell: cell, messageController: messageController)
+    }
+    
+    /// Presents custom actions controller with all possible actions with the selected message.
+    open func presentActionsForMessage(
+        _ message: _ChatMessage<ExtraData>,
+        cell: MessageCell<ExtraData>,
+        messageController: _ChatMessageController<ExtraData>
+    ) {
+        let actionsController = _ChatMessageActionsVC<ExtraData>()
+        actionsController.messageController = messageController
+        actionsController.delegate = .init(delegate: self)
+
+        var reactionsController: _ChatMessageReactionsVC<ExtraData>? {
+            guard message.localState == nil else { return nil }
+
+            let controller = _ChatMessageReactionsVC<ExtraData>()
+            controller.messageController = messageController
+            return controller
+        }
+        
+        popupPresenter.present(
+            targetView: cell.messageContentView,
+            message: message,
+            actionsController: actionsController,
+            reactionsController: reactionsController
+        )
+    }
+
+    /// Restarts upload of given `attachment` in case of failure
+    open func restartUploading(for attachment: ChatMessageDefaultAttachment) {
+        guard let id = attachment.id else {
+            assertionFailure("Uploading cannot be restarted for attachment without `id`")
+            return
+        }
+
+        channelController.client
+            .messageController(cid: id.cid, messageId: id.messageId)
+            .restartFailedAttachmentUploading(with: id)
+    }
+    
+    // MARK: Cell action handlers
+
+    /// Handles the tap on an attachment.
+    ///
+    /// Default implementation tries to restart the upload in case of failure.
+    /// If the attachment is correctly uploaded and displayed
+    /// then for image or file it shows the preview.
+    /// For link it tries to open it.
+    // TODO: Not implemented
+    open func handleTapOnAttachment(_ attachment: ChatMessageAttachment, forCellAt indexPath: IndexPath) {
+        guard let attachment = attachment as? ChatMessageDefaultAttachment else {
+            return
+        }
+
+        guard attachment.localState != .uploadingFailed else {
+            restartUploading(for: attachment)
+            return
+        }
+
+        switch attachment.type {
+        case .image, .file:
+            router.showPreview(for: attachment)
+        case .link:
+            router.openLink(attachment)
+        default:
+            break
+        }
+    }
+
+    /// Executes the provided action on the message
+    // TODO: Not implemented
+    open func handleTapOnAttachmentAction(
+        _ action: AttachmentAction,
+        for attachment: ChatMessageAttachment,
+        forCellAt indexPath: IndexPath
+    ) {
+        // Can we have a helper on `ChannelController` returning a `messageController` for the provided message id?
+        channelController.client
+            .messageController(
+                cid: channelController.cid!,
+                messageId: messageController.replies[indexPath.item].id
+            )
+            .dispatchEphemeralMessageAction(action)
+    }
+}
+
+extension MessageThreadVC: _ChatMessageComposerViewControllerDelegate {
+    open func messageComposerViewControllerDidSendMessage(_ vc: _ChatMessageComposerVC<ExtraData>) {
+        setNeedsScrollToMostRecentMessage()
+    }
+}
+
+extension MessageThreadVC: _ChatChannelControllerDelegate {
+    open func channelController(
+        _ channelController: _ChatChannelController<ExtraData>,
+        didUpdateChannel channel: EntityChange<_ChatChannel<ExtraData>>
+    ) {
+        updateNavigationTitle()
+    }
+}
+
+extension MessageThreadVC: _ChatMessageControllerDelegate {
+    open func messageController(
+        _ controller: _ChatMessageController<ExtraData>,
+        didChangeReplies changes: [ListChange<_ChatMessage<ExtraData>>]
+    ) {
+        updateMessages(with: changes)
+    }
+}
+
+extension MessageThreadVC: _ChatMessageActionsVCDelegate {
+    open func chatMessageActionsVC(
+        _ vc: _ChatMessageActionsVC<ExtraData>,
+        message: _ChatMessage<ExtraData>,
+        didTapOnActionItem actionItem: ChatMessageActionItem
+    ) {
+        switch actionItem {
+        case is EditActionItem:
+            dismiss(animated: true) { [weak self] in
+                self?.messageComposerViewController.state = .edit(message)
+            }
+        case is InlineReplyActionItem:
+            dismiss(animated: true) { [weak self] in
+                self?.messageComposerViewController.state = .quote(message)
+            }
+        default:
+            return
+        }
+    }
+
+    open func chatMessageActionsVCDidFinish(
+        _ vc: _ChatMessageActionsVC<ExtraData>
+    ) {
+        dismiss(animated: true)
+    }
+}
+
+extension MessageThreadVC: MessageContentViewDelegate {
+    public func messageContentViewDidTapOnErrorIndicator(_ indexPath: IndexPath?) {
+        guard let indexPath = indexPath else { assertionFailure("IndexPath is not available"); return }
+        didSelectMessageCell(at: indexPath)
+    }
+    
+    public func messageContentViewDidTapOnThread(_ indexPath: IndexPath?) {
+        guard let indexPath = indexPath else { assertionFailure("IndexPath is not available"); return }
+        guard let channel = channelController.channel else { return }
+        
+        let controller = MessageThreadVC<ExtraData>()
+        controller.channelController = channelController
+        controller.messageController = channelController.client.messageController(
+            cid: channel.cid,
+            messageId: messageController.replies[indexPath.item].id
+        )
+        navigationController?.show(controller, sender: self)
+    }
+    
+    // TODO: Currently not supported
+    public func messageContentViewDidTapOnQuotedMessage(_ indexPath: IndexPath?) {
+        print(#function, indexPath)
+    }
+}

--- a/Sources/StreamChatUI/ChatMessageList/RETHINK/PopUpPresenter.swift
+++ b/Sources/StreamChatUI/ChatMessageList/RETHINK/PopUpPresenter.swift
@@ -1,0 +1,77 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+open class PopupPresenter {
+    /// Feedback generator used when presenting actions controller on selected message
+    open var impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
+    
+    public let rootViewController: UIViewController
+    
+    public init(rootViewController: UIViewController) {
+        self.rootViewController = rootViewController
+    }
+    
+    open func present<ExtraData>(
+        targetView: UIView,
+        message: _ChatMessage<ExtraData>,
+        actionsController: _ChatMessageActionsVC<ExtraData>,
+        reactionsController: _ChatMessageReactionsVC<ExtraData>?
+    ) {
+        // TODO: for PR: This should be doable via:
+        // 1. options: [.autoreverse, .repeat] and
+        // 2. `UIView.setAnimationRepeatCount(0)` inside the animation block...
+        //
+        // and then just set completion to the animation to transform this back. aka `cell.messageView.transform = .identity`
+        // however, this doesn't work as after the animation is done, it clips back to the value set in animation block
+        // and then on completion goes back to `.identity`... This is really strange, but I was fighting it for some time
+        // and couldn't find proper solution...
+        // Also there are some limitations to the current solution ->
+        // According to my debug view hiearchy, the content inside `messageView.messageBubbleView` is not constrainted to the
+        // bubble view itself, meaning right now if we want to scale the view of incoming message, we scale the avatarView
+        // of the sender as well...
+        UIView.animate(
+            withDuration: 0.2,
+            delay: 0,
+            options: [.curveEaseIn],
+            animations: {
+                targetView.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
+            },
+            completion: { _ in
+                self.impactFeedbackGenerator.impactOccurred()
+
+                UIView.animate(
+                    withDuration: 0.1,
+                    delay: 0,
+                    options: [.curveEaseOut],
+                    animations: {
+                        targetView.transform = .identity
+                    }
+                )
+                
+                let popup = _ChatMessagePopupVC<ExtraData>()
+                // only `message` is used but I don't want to break current implementation
+                popup.message = _ChatMessageGroupPart(
+                    message: message,
+                    quotedMessage: nil,
+                    isFirstInGroup: true,
+                    isLastInGroup: true,
+                    didTapOnAttachment: nil,
+                    didTapOnAttachmentAction: nil
+                )
+                // TODO: Whole PopupVC has to be updated for the new MessageCell
+                popup.messageContentViewClass = _ChatMessageContentView<ExtraData>.self
+                popup.messageViewFrame = targetView.superview!.convert(targetView.frame, to: nil)
+                popup.actionsController = actionsController
+                popup.reactionsController = reactionsController
+                popup.modalPresentationStyle = .overFullScreen
+                popup.modalTransitionStyle = .crossDissolve
+
+                self.rootViewController.present(popup, animated: false)
+            }
+        )
+    }
+}

--- a/Sources/StreamChatUI/Components+MessageList.swift
+++ b/Sources/StreamChatUI/Components+MessageList.swift
@@ -8,7 +8,6 @@ import UIKit.UIImage
 public extension _Components {
     struct MessageListUI {
         public var messageListVC: _ChatMessageListVC<ExtraData>.Type = _ChatMessageListVC<ExtraData>.self
-//        public var messageListVC: MessageListVC<ExtraData>.Type = MessageListVC<ExtraData>.self
 
         public var defaultMessageCell: _СhatMessageCollectionViewCell<ExtraData>.Type =
             _СhatMessageCollectionViewCell<ExtraData>.self

--- a/Sources/StreamChatUI/Components+MessageList.swift
+++ b/Sources/StreamChatUI/Components+MessageList.swift
@@ -8,6 +8,7 @@ import UIKit.UIImage
 public extension _Components {
     struct MessageListUI {
         public var messageListVC: _ChatMessageListVC<ExtraData>.Type = _ChatMessageListVC<ExtraData>.self
+//        public var messageListVC: MessageListVC<ExtraData>.Type = MessageListVC<ExtraData>.self
 
         public var defaultMessageCell: _СhatMessageCollectionViewCell<ExtraData>.Type =
             _СhatMessageCollectionViewCell<ExtraData>.self
@@ -16,6 +17,7 @@ public extension _Components {
         public var channelNamer: ChatChannelNamer<ExtraData> = DefaultChatChannelNamer()
         public var messageContentSubviews = MessageContentViewSubviews()
         public var messageReactions = MessageReactions()
+        public var layoutOptionsResolver: MessageLayoutOptionsResolver<ExtraData> = DefaultMessageLayoutOptionsResolver()
     }
 
     struct MessageReactions {

--- a/Sources/StreamChatUI/Generated/L10n.swift
+++ b/Sources/StreamChatUI/Generated/L10n.swift
@@ -119,6 +119,20 @@ internal enum L10n {
       /// Thread Reply
       internal static let reply = L10n.tr("Localizable", "message.threads.reply")
     }
+    internal enum Title {
+      /// %d members, %d online
+      internal static func group(_ p1: Int, _ p2: Int) -> String {
+        return L10n.tr("Localizable", "message.title.group", p1, p2)
+      }
+      /// Offline
+      internal static let offline = L10n.tr("Localizable", "message.title.offline")
+      /// Online
+      internal static let online = L10n.tr("Localizable", "message.title.online")
+      /// Seen %@ ago
+      internal static func seeMinutesAgo(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "message.title.see-minutes-ago", String(describing: p1))
+      }
+    }
   }
 
   internal enum MessageList {

--- a/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
@@ -45,3 +45,8 @@
 
 "composer.suggestions.commands.header" = "Instant Commands";
 "message.sending.attachment-uploading-failed" = "UPLOADING FAILED";
+
+"message.title.online" = "Online";
+"message.title.see-minutes-ago" = "Seen %@ ago";
+"message.title.offline" = "Offline";
+"message.title.group" = "%d members, %d online";

--- a/Sources/StreamChatUI/Utils/DateFormatter+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/DateFormatter+Extensions.swift
@@ -13,3 +13,12 @@ extension DateFormatter {
         return formatter
     }
 }
+
+extension DateComponentsFormatter {
+    static var minutes: DateComponentsFormatter = {
+        let df = DateComponentsFormatter()
+        df.allowedUnits = [.minute]
+        df.unitsStyle = .full
+        return df
+    }()
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -687,6 +687,13 @@
 		8AE8950D24D8660800E852EC /* PingPongEmojiFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */; };
 		A35757C72613081B00DC914C /* ChatMessageListKeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35757C62613081B00DC914C /* ChatMessageListKeyboardObserver.swift */; };
 		A35757D12613082B00DC914C /* ChatMessageListTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35757D02613082B00DC914C /* ChatMessageListTitleView.swift */; };
+		A39A8A9B26380E14003453D9 /* MessageListVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39A8A9A26380E14003453D9 /* MessageListVC.swift */; };
+		A39A8AA526380E3E003453D9 /* MessageListKeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39A8AA426380E3E003453D9 /* MessageListKeyboardObserver.swift */; };
+		A39A8ABF26380F9F003453D9 /* MessageCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39A8ABE26380F9F003453D9 /* MessageCollectionView.swift */; };
+		A39A8AC926380FC3003453D9 /* PopUpPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39A8AC826380FC3003453D9 /* PopUpPresenter.swift */; };
+		A39A8AD326381035003453D9 /* MessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39A8AD226381035003453D9 /* MessageCell.swift */; };
+		A39A8ADD26381072003453D9 /* MessageThreadVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39A8ADC26381072003453D9 /* MessageThreadVC.swift */; };
+		A39A8AE7263825F4003453D9 /* MessageLayoutOptionsResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39A8AE6263825F4003453D9 /* MessageLayoutOptionsResolver.swift */; };
 		A3BB3FFF261DA74D00365496 /* ContainerStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BB3FFE261DA74D00365496 /* ContainerStackView.swift */; };
 		A3C0D774261CA25700A8A1A2 /* ContainerStackView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C0D773261CA25700A8A1A2 /* ContainerStackView_Tests.swift */; };
 		AD0169CB25CAEDC0009EBAD2 /* yoda.jpg in Resources */ = {isa = PBXBuildFile; fileRef = AD0169CA25CAEDC0009EBAD2 /* yoda.jpg */; };
@@ -1863,6 +1870,13 @@
 		8AE8950B24D85FF200E852EC /* PingPongEmojiFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingPongEmojiFormatter.swift; sourceTree = "<group>"; };
 		A35757C62613081B00DC914C /* ChatMessageListKeyboardObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageListKeyboardObserver.swift; sourceTree = "<group>"; };
 		A35757D02613082B00DC914C /* ChatMessageListTitleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatMessageListTitleView.swift; sourceTree = "<group>"; };
+		A39A8A9A26380E14003453D9 /* MessageListVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListVC.swift; sourceTree = "<group>"; };
+		A39A8AA426380E3E003453D9 /* MessageListKeyboardObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListKeyboardObserver.swift; sourceTree = "<group>"; };
+		A39A8ABE26380F9F003453D9 /* MessageCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCollectionView.swift; sourceTree = "<group>"; };
+		A39A8AC826380FC3003453D9 /* PopUpPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpPresenter.swift; sourceTree = "<group>"; };
+		A39A8AD226381035003453D9 /* MessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCell.swift; sourceTree = "<group>"; };
+		A39A8ADC26381072003453D9 /* MessageThreadVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageThreadVC.swift; sourceTree = "<group>"; };
+		A39A8AE6263825F4003453D9 /* MessageLayoutOptionsResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageLayoutOptionsResolver.swift; sourceTree = "<group>"; };
 		A3BB3FFE261DA74D00365496 /* ContainerStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerStackView.swift; sourceTree = "<group>"; };
 		A3C0D773261CA25700A8A1A2 /* ContainerStackView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerStackView_Tests.swift; sourceTree = "<group>"; };
 		AD0169CA25CAEDC0009EBAD2 /* yoda.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = yoda.jpg; sourceTree = "<group>"; };
@@ -3600,6 +3614,12 @@
 			isa = PBXGroup;
 			children = (
 				8830513D263031C40069D731 /* MessageLayoutOptions.swift */,
+				A39A8A9A26380E14003453D9 /* MessageListVC.swift */,
+				A39A8AE6263825F4003453D9 /* MessageLayoutOptionsResolver.swift */,
+				A39A8ADC26381072003453D9 /* MessageThreadVC.swift */,
+				A39A8AC826380FC3003453D9 /* PopUpPresenter.swift */,
+				A39A8ABE26380F9F003453D9 /* MessageCollectionView.swift */,
+				A39A8AA426380E3E003453D9 /* MessageListKeyboardObserver.swift */,
 				88305157263035D30069D731 /* MessageContentView.swift */,
 				8830520126306B4F0069D731 /* MessageContentView_Tests.swift */,
 				883051612630363A0069D731 /* MessageBubbleView.swift */,
@@ -3895,6 +3915,7 @@
 		8AD5EC8522E9A3E8005CFAC9 = {
 			isa = PBXGroup;
 			children = (
+				A39A8AD226381035003453D9 /* MessageCell.swift */,
 				79AF43922631692D00E75CDA /* StreamChat.playground */,
 				792E3D6A25C97D920040B0C2 /* Package.swift */,
 				799C9415247D2F38001F1104 /* Sources */,
@@ -4935,7 +4956,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A39A8A9B26380E14003453D9 /* MessageListVC.swift in Sources */,
 				883051622630363A0069D731 /* MessageBubbleView.swift in Sources */,
+				A39A8ABF26380F9F003453D9 /* MessageCollectionView.swift in Sources */,
+				E7166CDA25BED62D00B03B07 /* UIConfig+Navigation.swift in Sources */,
 				228190EB256733420048D7C6 /* UIFont+Extensions.swift in Sources */,
 				ADB4167526208F2000E623E3 /* ImageAttachmentPreview.swift in Sources */,
 				888123D2255D430B00070D5A /* UIView+Extensions.swift in Sources */,
@@ -4971,6 +4995,7 @@
 				DBC8A5762581476E00B20A82 /* ChatMessageListVC.swift in Sources */,
 				8800A28C258A1924006D64C4 /* ChatMessageFileAttachmentListView.swift in Sources */,
 				88A8CF16256E7BDA004EA4C7 /* ChatMessageContentView.swift in Sources */,
+				A39A8AA526380E3E003453D9 /* MessageListKeyboardObserver.swift in Sources */,
 				E79AC10A25831A1500C3CE5D /* ChatMessageComposerMentionCollectionViewCell.swift in Sources */,
 				226C438D25802AAD008B3648 /* ChatInputTextView.swift in Sources */,
 				224165A825910A2C00ED7F78 /* ChatMessageComposerCheckmarkControl.swift in Sources */,
@@ -4981,6 +5006,7 @@
 				888ABA072594FDE30015937E /* ChatMessageInteractiveAttachmentView.swift in Sources */,
 				BDDD1E9E2632C4C900BA007B /* Components+ChannelList.swift in Sources */,
 				88BD82B02549D18F00369074 /* ChatChannelListItemView.swift in Sources */,
+				A39A8AE7263825F4003453D9 /* MessageLayoutOptionsResolver.swift in Sources */,
 				8825334C258CE82500B77352 /* ChatMessageActionsRouter.swift in Sources */,
 				BDDD1EA02632C4C900BA007B /* Components+CurrentUser.swift in Sources */,
 				DB9A3D662582783F00555D36 /* ChatVC.swift in Sources */,
@@ -5009,6 +5035,7 @@
 				DBC8A564258113F700B20A82 /* ChatThreadVC.swift in Sources */,
 				DB8230F2259B8DBF00E7D7FE /* ChatMessageGiphyView.swift in Sources */,
 				22086B38259509350007F8C0 /* ChatMessageComposerDocumentAttachmentCollectionViewCell.swift in Sources */,
+				A39A8AC926380FC3003453D9 /* PopUpPresenter.swift in Sources */,
 				22086B40259509450007F8C0 /* ChatMessageComposerDocumentAttachmentView.swift in Sources */,
 				E768AAFB2627691600328E6E /* TypingAnimationView.swift in Sources */,
 				ADB4166C26208F1C00E623E3 /* AttachmentPreview.swift in Sources */,
@@ -5037,6 +5064,7 @@
 				BDDD1E9D2632C4C900BA007B /* Components+Navigation.swift in Sources */,
 				BDDD1EA62632C6D600BA007B /* AppearanceProvider.swift in Sources */,
 				A35757C72613081B00DC914C /* ChatMessageListKeyboardObserver.swift in Sources */,
+				A39A8ADD26381072003453D9 /* MessageThreadVC.swift in Sources */,
 				7943383326208D5A0094471F /* ChatMessageConfirmEditButton.swift in Sources */,
 				BDDD1E9B2632C4C900BA007B /* Components+MessageList.swift in Sources */,
 				BDDD1EA12632C4C900BA007B /* Components+MessageComposer.swift in Sources */,
@@ -5058,6 +5086,8 @@
 				AD43F90926153BAD00F2D4BB /* ChatMessageQuoteView.swift in Sources */,
 				885B3D7725642B3D003E6BDF /* CurrentChatUserAvatarView.swift in Sources */,
 				DBC8A4C6257E696900B20A82 /* ChatMessageThreadInfoView.swift in Sources */,
+				A39A8AD326381035003453D9 /* MessageCell.swift in Sources */,
+				7844B16825EFB44600B87E89 /* UIConfig+SwiftUI.swift in Sources */,
 				224FF6912562F58F00725DD1 /* UIColor+Extensions.swift in Sources */,
 				22C2359A259CA87B00DC805A /* Animation.swift in Sources */,
 				79088339254876F200896F03 /* ChatMessageListCollectionView.swift in Sources */,


### PR DESCRIPTION
# Description

Implementation of two new VCs. Both controllers use the new `MessageContentView`. Since `MessageContentView` is not completely done this PR only adds the classes and doesn't connect them to the current flow.

Parts of the logic that were same for both view controllers were extracted to the custom components. These components are not final and may be refactored in the future, e.g. `PopUpPresenter` could be replaced with custom view controller presentation.