### PR TITLE
Fix hiding issue when view switches container + Composer View Layout Polish

### DIFF
--- a/Sources/StreamChatUI/Appearance+Images.swift
+++ b/Sources/StreamChatUI/Appearance+Images.swift
@@ -168,8 +168,6 @@ public extension Appearance {
         public var messageComposerAlsoSendToChannelCheck: UIImage = UIImage(named: "threadCheckmark", in: .streamChatUI)!
         public var messageComposerDiscardAttachment: UIImage = UIImage(named: "discardAttachment", in: .streamChatUI)!
         public var messageComposerShrinkInput: UIImage = UIImage(named: "shrinkInputArrow", in: .streamChatUI)!
-        public var messageComposerReplyButton: UIImage = UIImage(named: "replyArrow", in: .streamChatUI)!
-        public var messageComposerEditMessage: UIImage = UIImage(named: "editPencil", in: .streamChatUI)!
         public var messageComposerSendMessage: UIImage = UIImage(named: "sendMessageArrow", in: .streamChatUI)!
         public var messageComposerSendEditedMessage: UIImage = UIImage(named: "editMessageCheckmark", in: .streamChatUI)!
         public var messageComposerDownloadAndOpen: UIImage = UIImage(named: "download_and_open", in: .streamChatUI)!

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
@@ -117,7 +117,7 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
                 self.composerView.sendButton.isHidden = false
                 self.composerView.editButton.isHidden = true
                 self.composerView.messageQuoteView.isHidden = true
-                self.composerView.topContainer.isHidden = true
+                self.composerView.headerView.isHidden = true
             }
             composerView.messageInputView.setSlashCommandViews(hidden: true)
         case let .slashCommand(command):
@@ -129,7 +129,7 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
         case let .quote(messageToQuote):
             composerView.titleLabel.text = L10n.Composer.Title.reply
             Animate {
-                self.composerView.topContainer.isHidden = false
+                self.composerView.headerView.isHidden = false
                 self.composerView.messageQuoteView.isHidden = false
                 self.composerView.messageInputView.commandLabel.isHidden = true
             }
@@ -139,7 +139,7 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
             Animate {
                 self.composerView.editButton.isHidden = false
                 self.composerView.sendButton.isHidden = true
-                self.composerView.topContainer.isHidden = false
+                self.composerView.headerView.isHidden = false
                 self.composerView.messageInputView.commandLabel.isHidden = true
             }
             inputTextView.text = message.text

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
@@ -128,9 +128,6 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
             dismissSuggestionsViewController()
         case let .quote(messageToQuote):
             composerView.titleLabel.text = L10n.Composer.Title.reply
-            let image = appearance.images.messageComposerReplyButton
-                .tinted(with: appearance.colorPalette.inactiveTint)
-            composerView.stateIcon.image = image
             Animate {
                 self.composerView.topContainer.isHidden = false
                 self.composerView.messageQuoteView.isHidden = false
@@ -139,9 +136,6 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
             composerView.messageQuoteView.content = .init(message: messageToQuote, avatarAlignment: .left)
         case let .edit(message):
             composerView.titleLabel.text = L10n.Composer.Title.edit
-            let image = appearance.images.messageComposerEditMessage
-                .tinted(with: appearance.colorPalette.inactiveTint)
-            composerView.stateIcon.image = image
             Animate {
                 self.composerView.editButton.isHidden = false
                 self.composerView.sendButton.isHidden = true

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
@@ -97,6 +97,12 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
         setupInputView()
     }
 
+    override open func setUpLayout() {
+        super.setUpLayout()
+
+        view.embed(composerView)
+    }
+
     override open func updateContent() {
         super.updateContent()
         switch state {
@@ -165,8 +171,6 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
     }
     
     func setupInputView() {
-        view.embed(composerView)
-
         composerView.messageInputView.inputTextView.delegate = self
         
         composerView.attachmentButton.addTarget(self, action: #selector(showAttachmentsPicker), for: .touchUpInside)

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerView.swift
@@ -72,13 +72,6 @@ open class _ChatMessageComposerView<ExtraData: ExtraDataTypes>: _View, ThemeProv
         .composerButton.init()
         .withoutAutoresizingMaskConstraints
     
-    public private(set) lazy var stateIcon: UIImageView = {
-        let imageView = UIImageView().withoutAutoresizingMaskConstraints
-        imageView.contentMode = .center
-        imageView.widthAnchor.pin(equalTo: imageView.heightAnchor, multiplier: 1).isActive = true
-        return imageView
-    }()
-    
     public private(set) lazy var dismissButton: UIButton = components
         .messageComposer
         .composerButton.init()
@@ -147,7 +140,6 @@ open class _ChatMessageComposerView<ExtraData: ExtraDataTypes>: _View, ThemeProv
         topContainer.addArrangedSubview(stateIcon)
         topContainer.addArrangedSubview(titleLabel)
         topContainer.addArrangedSubview(dismissButton)
-        stateIcon.heightAnchor.pin(equalToConstant: 40).isActive = true
 
         centerContainer.axis = .horizontal
         centerContainer.alignment = .fill

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerView.swift
@@ -92,22 +92,7 @@ open class _ChatMessageComposerView<ExtraData: ExtraDataTypes>: _View, ThemeProv
         .messageComposer
         .checkmarkControl.init()
         .withoutAutoresizingMaskConstraints
-    
-    // MARK: - Overrides
-    
-    override open func didMoveToSuperview() {
-        super.didMoveToSuperview()
-        guard superview != nil else { return }
-        
-        setUp()
-        setUpLayout()
-        
-        setUpAppearance()
-        updateContent()
-    }
-    
-    // MARK: - Public
-    
+
     override open func setUpAppearance() {
         super.setUpAppearance()
         

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerView.swift
@@ -11,7 +11,7 @@ open class _ChatMessageComposerView<ExtraData: ExtraDataTypes>: _View, ThemeProv
     public private(set) lazy var container = ContainerStackView()
         .withoutAutoresizingMaskConstraints
 
-    public private(set) lazy var topContainer = ContainerStackView()
+    public private(set) lazy var headerView = UIView()
         .withoutAutoresizingMaskConstraints
 
     public private(set) lazy var bottomContainer = ContainerStackView()
@@ -92,7 +92,7 @@ open class _ChatMessageComposerView<ExtraData: ExtraDataTypes>: _View, ThemeProv
         backgroundColor = appearance.colorPalette.popoverBackground
         
         centerContentContainer.clipsToBounds = true
-        centerContentContainer.layer.cornerRadius = 25
+        centerContentContainer.layer.cornerRadius = 20
         centerContentContainer.layer.borderWidth = 1
         centerContentContainer.layer.borderColor = appearance.colorPalette.border.cgColor
         
@@ -125,21 +125,18 @@ open class _ChatMessageComposerView<ExtraData: ExtraDataTypes>: _View, ThemeProv
         embed(container)
 
         container.isLayoutMarginsRelativeArrangement = true
-        container.spacing = 0
         container.axis = .vertical
         container.alignment = .fill
-        container.addArrangedSubview(topContainer)
+        container.addArrangedSubview(headerView)
         container.addArrangedSubview(centerContainer)
         container.addArrangedSubview(bottomContainer)
         bottomContainer.isHidden = true
-        topContainer.isHidden = true
+        headerView.isHidden = true
 
         bottomContainer.addArrangedSubview(checkmarkControl)
 
-        topContainer.alignment = .fill
-        topContainer.addArrangedSubview(stateIcon)
-        topContainer.addArrangedSubview(titleLabel)
-        topContainer.addArrangedSubview(dismissButton)
+        headerView.addSubview(titleLabel)
+        headerView.addSubview(dismissButton)
 
         centerContainer.axis = .horizontal
         centerContainer.alignment = .fill
@@ -159,7 +156,6 @@ open class _ChatMessageComposerView<ExtraData: ExtraDataTypes>: _View, ThemeProv
         messageQuoteView.isHidden = true
         imageAttachmentsView.isHidden = true
         documentAttachmentsView.isHidden = true
-        imageAttachmentsView.heightAnchor.pin(equalToConstant: 120).isActive = true
 
         centerRightContainer.alignment = .center
         centerRightContainer.spacing = .auto
@@ -173,8 +169,16 @@ open class _ChatMessageComposerView<ExtraData: ExtraDataTypes>: _View, ThemeProv
         centerLeftContainer.addArrangedSubview(attachmentButton)
         centerLeftContainer.addArrangedSubview(commandsButton)
         centerLeftContainer.addArrangedSubview(shrinkInputButton)
+
+        dismissButton.widthAnchor.pin(equalToConstant: 24).isActive = true
+        dismissButton.heightAnchor.pin(equalToConstant: 24).isActive = true
+        dismissButton.trailingAnchor.pin(equalTo: centerRightContainer.trailingAnchor).isActive = true
+        titleLabel.centerXAnchor.pin(equalTo: centerXAnchor).isActive = true
+        titleLabel.pin(anchors: [.top, .bottom], to: headerView)
+        imageAttachmentsView.heightAnchor.pin(equalToConstant: 120).isActive = true
+        messageInputView.inputTextView.preservesSuperviewLayoutMargins = false
         
-        [shrinkInputButton, attachmentButton, commandsButton, sendButton, editButton, dismissButton]
+        [shrinkInputButton, attachmentButton, commandsButton, sendButton, editButton]
             .forEach { button in
                 button.pin(anchors: [.width], to: 20)
                 button.pin(anchors: [.height], to: 20)

--- a/Sources/StreamChatUI/CommonViews/ChatInputView/ChatCommandLabel.swift
+++ b/Sources/StreamChatUI/CommonViews/ChatInputView/ChatCommandLabel.swift
@@ -61,8 +61,9 @@ open class _ChatCommandLabel<ExtraData: ExtraDataTypes>: _View, AppearanceProvid
         super.setUpLayout()
 
         embed(container)
-        container.preservesSuperviewLayoutMargins = true
         container.isLayoutMarginsRelativeArrangement = true
+        container.layoutMargins.top = 4
+        container.layoutMargins.bottom = 4
 
         container.addArrangedSubview(iconView)
         container.addArrangedSubview(commandLabel)
@@ -70,7 +71,6 @@ open class _ChatCommandLabel<ExtraData: ExtraDataTypes>: _View, AppearanceProvid
         commandLabel.isHidden = false
         
         iconView.contentMode = .scaleAspectFit
-        layer.cornerRadius = bounds.height / 2
     }
     
     override open func updateContent() {

--- a/Sources/StreamChatUI/CommonViews/ChatInputView/ChatInputTextView.swift
+++ b/Sources/StreamChatUI/CommonViews/ChatInputView/ChatInputTextView.swift
@@ -46,7 +46,7 @@ open class ChatInputTextView: UITextView, AppearanceProvider {
     
     open func setUpAppearance() {
         backgroundColor = .clear
-        textContainer.lineFragmentPadding = 10
+        textContainer.lineFragmentPadding = 8
         font = appearance.fonts.body
         textColor = appearance.colorPalette.text
         

--- a/Sources/StreamChatUI/CommonViews/ChatInputView/ChatMessageInputView.swift
+++ b/Sources/StreamChatUI/CommonViews/ChatInputView/ChatMessageInputView.swift
@@ -36,10 +36,14 @@ open class _ChatMessageInputView<ExtraData: ExtraDataTypes>: _View, ComponentsPr
     }
     
     override open func setUpLayout() {
-        embed(container)
+        addSubview(container)
+        container.pin(to: layoutMarginsGuide)
+        directionalLayoutMargins.leading = 8
+        directionalLayoutMargins.top = 1
+        directionalLayoutMargins.trailing = 8
+        directionalLayoutMargins.bottom = 1
 
-        container.preservesSuperviewLayoutMargins = true
-        container.isLayoutMarginsRelativeArrangement = true
+        container.preservesSuperviewLayoutMargins = false
         container.alignment = .center
         container.spacing = 4
 
@@ -51,7 +55,7 @@ open class _ChatMessageInputView<ExtraData: ExtraDataTypes>: _View, ComponentsPr
         inputTextView.setContentCompressionResistancePriority(.streamLow, for: .horizontal)
 
         NSLayoutConstraint.activate([
-            cleanButton.heightAnchor.pin(equalToConstant: 30),
+            cleanButton.heightAnchor.pin(equalToConstant: 24),
             cleanButton.widthAnchor.pin(equalTo: cleanButton.heightAnchor, multiplier: 1)
         ])
     }

--- a/Sources/StreamChatUI/CommonViews/ContainerStackView.swift
+++ b/Sources/StreamChatUI/CommonViews/ContainerStackView.swift
@@ -203,6 +203,14 @@ public class ContainerStackView: UIView {
         assert(subviews.contains(subview))
         subview.removeFromSuperview()
 
+        // Reset hiding state from the removed view. This important especially if the view
+        // is added to another container, since the view will have the size to 0 and the other
+        // container won't be able to hide the view because it thinks it is already hidden.
+        subview.alpha = 1.0
+        hideConstraintsByView[subview]?.isActive = false
+        hideConstraintsByView[subview] = nil
+
+        // Remove the hiding observer from the removed view
         hidingObserversByView[subview] = nil
 
         invalidateConstraints()


### PR DESCRIPTION
# In this PR

- Fixes issue when a view that was already hidden would switch container, and remain with the size 0 and alpha = 0. This would cause a problem because the view would always have the size 0 and it wouldn't be possible to hide it again, because it already had alpha = 0.
- Fixes an issue on composer view that was causing the composer to layout twice
- Removes the state icon and polishes the composer layout according to Figma

With this PR, now the iMessage clone works as expected ✅