### PR TITLE
[CIS-808] Fixing WS Events

### DIFF
--- a/Sources/StreamChat/Utils/InternetConnection/InternetConnection.swift
+++ b/Sources/StreamChat/Utils/InternetConnection/InternetConnection.swift
@@ -90,7 +90,7 @@ extension InternetConnection {
 // MARK: - Internet Connection Monitors
 
 /// A delegate to receive Internet connection events.
-protocol InternetConnectionDelegate: class {
+protocol InternetConnectionDelegate: AnyObject {
     /// Calls when the Internet connection status did change.
     /// - Parameter status: an Internet connection status.
     func internetConnectionStatusDidChange(status: InternetConnection.Status)

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/MessageReactionsMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/MessageReactionsMiddleware.swift
@@ -8,7 +8,7 @@ import Foundation
 struct MessageReactionsMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
     func handle(event: Event, session: DatabaseSession) -> Event? {
         guard
-            let reactionEvent = event as? EventWithReactionPayload,
+            let reactionEvent = event as? ReactionEvent,
             let payload = reactionEvent.payload as? EventPayload<ExtraData>,
             let reaction = payload.reaction
         else {

--- a/Sources/StreamChat/WebSocketClient/Events/ChannelEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/ChannelEvents.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct ChannelUpdatedEvent: EventWithChannelId, EventWithPayload {
+public struct ChannelUpdatedEvent: ChannelEvent {
     public let cid: ChannelId
     public let userId: UserId?
     public let messageId: MessageId?
@@ -36,7 +36,7 @@ public struct ChannelUpdatedEvent: EventWithChannelId, EventWithPayload {
     }
 }
 
-public struct ChannelDeletedEvent: EventWithChannelId, EventWithPayload {
+public struct ChannelDeletedEvent: ChannelEvent {
     public let cid: ChannelId
     public let deletedAt: Date
     
@@ -49,7 +49,8 @@ public struct ChannelDeletedEvent: EventWithChannelId, EventWithPayload {
     }
 }
 
-public struct ChannelTruncatedEvent: EventWithUserPayload, EventWithChannelId {
+// TODO: Figure out what to do with those Events which need both Channel and User...
+public struct ChannelTruncatedEvent: UserEvent, ChannelEvent {
     public let userId: UserId
     public let cid: ChannelId
     let payload: Any
@@ -61,7 +62,7 @@ public struct ChannelTruncatedEvent: EventWithUserPayload, EventWithChannelId {
     }
 }
 
-public struct ChannelVisibleEvent: EventWithChannelId, EventWithPayload {
+public struct ChannelVisibleEvent: ChannelEvent {
     public let cid: ChannelId
     let payload: Any
 
@@ -71,7 +72,7 @@ public struct ChannelVisibleEvent: EventWithChannelId, EventWithPayload {
     }
 }
 
-public struct ChannelHiddenEvent: EventWithChannelId, EventWithPayload {
+public struct ChannelHiddenEvent: ChannelEvent {
     public let cid: ChannelId
     public let hiddenAt: Date
     public let isHistoryCleared: Bool

--- a/Sources/StreamChat/WebSocketClient/Events/Event.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/Event.swift
@@ -19,6 +19,10 @@ protocol UserEvent: EventWithPayload {
     var userId: UserId { get }
 }
 
+protocol ChannelEvent: EventWithPayload {
+    var cid: ChannelId { get }
+}
+
 /// A protocol for any `MessageEvent` where it has a `user` payload and `channel` payload.
 protocol MessageEvent: EventWithPayload {
     var userId: UserId { get }
@@ -33,11 +37,34 @@ protocol ReactionEvent: EventWithPayload {
     var reactionScore: Int { get }
 }
 
-/// A protocol for user `Event` where it has a user payload.
-@available(*, deprecated, message: "Delete this and use/create channel specific Event protocols")
-protocol EventWithUserPayload: EventWithPayload {
+// TODO: Probably be a better namer :D
+protocol UserTypingEvent: EventWithPayload {
+    var userId: UserId { get }
+    var cid: ChannelId { get }
+    var isTyping: Bool { get }
+}
+
+protocol UserNotificationEvent: EventWithPayload {
     var userId: UserId { get }
 }
+
+protocol CurrentUserNotificationEvent: EventWithPayload {
+    var currentUserId: UserId { get }
+}
+
+// TODO: Does it make sense to have separate `ChannelNotificationEvent` x `ChannelEvent`??
+// We can change it easily...
+protocol ChannelNotificationEvent: EventWithPayload {
+    var cid: ChannelId { get }
+}
+
+// TODO: Better naming?
+protocol InviteRelatedNotificationEvent: EventWithPayload {
+    var cid: ChannelId { get }
+    var userId: UserId { get }
+}
+
+// -------------------------------------------------------
 
 /// A protocol for a current user `Event` where it has `me` payload.
 @available(*, deprecated, message: "Delete this and use/create channel specific Event protocols")

--- a/Sources/StreamChat/WebSocketClient/Events/Event.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/Event.swift
@@ -32,6 +32,7 @@ protocol ChannelEvent: EventWithPayload {
 protocol MessageEvent: EventWithPayload {
     var userId: UserId { get }
     var cid: ChannelId { get }
+    var messageId: MessageId { get }
 }
 
 /// A protocol for any  `ReactionEvent` where it has reaction with message payload, cid and userId.

--- a/Sources/StreamChat/WebSocketClient/Events/Event.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/Event.swift
@@ -19,6 +19,11 @@ protocol UserEvent: EventWithPayload {
     var userId: UserId { get }
 }
 
+/// A protocol for any `UserEvent` where it has a `user` payload and is associated with Channel.
+protocol UserChannelSpecificEvent: UserEvent {
+    var cid: ChannelId { get }
+}
+
 protocol ChannelEvent: EventWithPayload {
     var cid: ChannelId { get }
 }
@@ -61,6 +66,14 @@ protocol ChannelNotificationEvent: EventWithPayload {
 // TODO: Better naming?
 protocol InviteRelatedNotificationEvent: EventWithPayload {
     var cid: ChannelId { get }
+    var userId: UserId { get }
+}
+
+protocol NotificationMarkReadEventProtocol: NotificationMarkReadAllEventProtocol {
+    var cid: ChannelId { get }
+}
+
+protocol NotificationMarkReadAllEventProtocol: EventWithPayload {
     var userId: UserId { get }
 }
 

--- a/Sources/StreamChat/WebSocketClient/Events/Event.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/Event.swift
@@ -24,18 +24,25 @@ protocol UserChannelSpecificEvent: UserEvent {
     var cid: ChannelId { get }
 }
 
+/// A protocol for any `ChannelEvent` where it has a  `channel` payload.
 protocol ChannelEvent: EventWithPayload {
     var cid: ChannelId { get }
 }
 
-/// A protocol for any `MessageEvent` where it has a `user` payload and `channel` payload.
+/// A protocol for any `MemberEvent` where it has a `member`, and `channel` payload.
+public protocol MemberEvent: Event {
+    var memberUserId: UserId { get }
+    var cid: ChannelId { get }
+}
+
+/// A protocol for any `MessageEvent` where it has a `user`, `channel` and `message` payloads.
 protocol MessageEvent: EventWithPayload {
     var userId: UserId { get }
     var cid: ChannelId { get }
     var messageId: MessageId { get }
 }
 
-/// A protocol for any  `ReactionEvent` where it has reaction with message payload, cid and userId.
+/// A protocol for any  `ReactionEvent` where it has reaction with `message`, `channel`, `user` and `reaction` payload.
 protocol ReactionEvent: EventWithPayload {
     var userId: UserId { get }
     var cid: ChannelId { get }
@@ -43,7 +50,7 @@ protocol ReactionEvent: EventWithPayload {
     var reactionScore: Int { get }
 }
 
-// TODO: Probably be a better namer :D
+/// A protocol for `TypingEvent` which contains `user`, `channel` payloads. Also differs whether it's start or stop by `isTyping` property.
 protocol UserTypingEvent: EventWithPayload {
     var userId: UserId { get }
     var cid: ChannelId { get }
@@ -54,29 +61,37 @@ protocol UserNotificationEvent: EventWithPayload {
     var userId: UserId { get }
 }
 
+/// A protocol for `NotificationMutesUpdatedEvent` which contains `me` AKA `currentUser` payload.
 protocol CurrentUserNotificationEvent: EventWithPayload {
     var currentUserId: UserId { get }
 }
 
-// TODO: Does it make sense to have separate `ChannelNotificationEvent` x `ChannelEvent`??
-// We can change it easily...
+// TODO: Does it make sense to have separate `ChannelNotificationEvent` x
+// `ChannelEvent` and `MessageNotificationEvent` x `MessageEvent` ??
+
+/// A protocol for Channel-related `NotificationEvents` which contain `channel` payload
 protocol ChannelNotificationEvent: EventWithPayload {
     var cid: ChannelId { get }
 }
 
-// TODO: Better naming?
+/// A protocol for recognizing invitation related events (invitation accepted, rejected, added, removed)
+/// Contains `user` and `channel` payload
 protocol InviteRelatedNotificationEvent: EventWithPayload {
+    var userId: UserId { get }
     var cid: ChannelId { get }
+}
+
+/// A protocol for `NotificationMarkAllReadEvent`, contains only `user` payload.
+protocol NotificationMarkReadAllEventProtocol: EventWithPayload {
     var userId: UserId { get }
 }
 
+/// A protocol for `NotificationMarkReadEvent`, contains `user`and `channel` payload.
 protocol NotificationMarkReadEventProtocol: NotificationMarkReadAllEventProtocol {
     var cid: ChannelId { get }
 }
 
-protocol NotificationMarkReadAllEventProtocol: EventWithPayload {
-    var userId: UserId { get }
-}
+protocol NotificationMessageEvent: MessageEvent {}
 
 // -------------------------------------------------------
 

--- a/Sources/StreamChat/WebSocketClient/Events/Event.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/Event.swift
@@ -14,29 +14,39 @@ protocol EventWithPayload: Event {
     var payload: Any { get }
 }
 
+/// A protocol for any `UserEvent` where it has a `user` payload.
+protocol UserEvent: EventWithPayload {
+    var userId: UserId { get }
+}
+
+/// A protocol for any `MessageEvent` where it has a `user` payload and `channel` payload.
+protocol MessageEvent: EventWithPayload {
+    var userId: UserId { get }
+    var cid: ChannelId { get }
+}
+
 /// A protocol for user `Event` where it has a user payload.
+@available(*, deprecated, message: "Delete this and use/create channel specific Event protocols")
 protocol EventWithUserPayload: EventWithPayload {
     var userId: UserId { get }
 }
 
 /// A protocol for a current user `Event` where it has `me` payload.
+@available(*, deprecated, message: "Delete this and use/create channel specific Event protocols")
 protocol EventWithCurrentUserPayload: EventWithPayload {
     var currentUserId: UserId { get }
 }
 
-/// A protocol for an owner `Event`. Event has 2 users where the owner of the event does something with another user, e.g. ban.
-protocol EventWithOwnerPayload: EventWithPayload {
-    var ownerId: UserId { get }
-}
-
 /// A protocol for channel `Event` where it has `cid` at least.
 /// The combination of `EventWithChannelId` and `EventWithPayload` events required a `channel` object inside payload.
-protocol EventWithChannelId: Event {
+@available(*, deprecated, message: "Delete this and use/create channel specific Event protocols")
+protocol EventWithChannelId: EventWithPayload {
     var cid: ChannelId { get }
 }
 
 /// A protocol for message `Event` where it has a message payload.
-protocol EventWithMessagePayload: EventWithUserPayload, EventWithChannelId {
+@available(*, deprecated, message: "Delete this and use/create channel specific Event protocols")
+protocol EventWithMessagePayload: EventWithChannelId {
     var messageId: MessageId { get }
 }
 

--- a/Sources/StreamChat/WebSocketClient/Events/Event.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/Event.swift
@@ -25,6 +25,14 @@ protocol MessageEvent: EventWithPayload {
     var cid: ChannelId { get }
 }
 
+/// A protocol for any  `ReactionEvent` where it has reaction with message payload, cid and userId.
+protocol ReactionEvent: EventWithPayload {
+    var userId: UserId { get }
+    var cid: ChannelId { get }
+    var reactionType: MessageReactionType { get }
+    var reactionScore: Int { get }
+}
+
 /// A protocol for user `Event` where it has a user payload.
 @available(*, deprecated, message: "Delete this and use/create channel specific Event protocols")
 protocol EventWithUserPayload: EventWithPayload {
@@ -53,10 +61,4 @@ protocol EventWithMessagePayload: EventWithChannelId {
 /// A protocol for member `Event` where it has a member object and user object.
 protocol EventWithMemberPayload: EventWithPayload {
     var memberUserId: UserId { get }
-}
-
-/// A protocol for reaction `Event` where it has reacction with message payload.
-protocol EventWithReactionPayload: EventWithMessagePayload {
-    var reactionType: MessageReactionType { get }
-    var reactionScore: Int { get }
 }

--- a/Sources/StreamChat/WebSocketClient/Events/MemberEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/MemberEvents.swift
@@ -4,12 +4,7 @@
 
 import Foundation
 
-public protocol MemberEvent: Event {
-    var memberUserId: UserId { get }
-    var cid: ChannelId { get }
-}
-
-public struct MemberAddedEvent: EventWithMemberPayload, EventWithChannelId, MemberEvent {
+public struct MemberAddedEvent: MemberEvent {
     public let memberUserId: UserId
     public let cid: ChannelId
     
@@ -22,7 +17,7 @@ public struct MemberAddedEvent: EventWithMemberPayload, EventWithChannelId, Memb
     }
 }
 
-public struct MemberUpdatedEvent: EventWithMemberPayload, EventWithChannelId, MemberEvent {
+public struct MemberUpdatedEvent: MemberEvent {
     public let memberUserId: UserId
     public let cid: ChannelId
     
@@ -35,7 +30,7 @@ public struct MemberUpdatedEvent: EventWithMemberPayload, EventWithChannelId, Me
     }
 }
 
-public struct MemberRemovedEvent: MemberEvent, EventWithChannelId {
+public struct MemberRemovedEvent: MemberEvent {
     public var memberUserId: UserId
     public let cid: ChannelId
     

--- a/Sources/StreamChat/WebSocketClient/Events/MessageEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/MessageEvents.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct MessageNewEvent: UserEvent, EventWithMessagePayload {
+public struct MessageNewEvent: MessageEvent {
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
@@ -25,7 +25,7 @@ public struct MessageNewEvent: UserEvent, EventWithMessagePayload {
     }
 }
 
-public struct MessageUpdatedEvent: MessageEvent, EventWithMessagePayload {
+public struct MessageUpdatedEvent: MessageEvent {
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
@@ -42,7 +42,7 @@ public struct MessageUpdatedEvent: MessageEvent, EventWithMessagePayload {
     }
 }
 
-public struct MessageDeletedEvent: MessageEvent, EventWithMessagePayload {
+public struct MessageDeletedEvent: MessageEvent {
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
@@ -59,7 +59,8 @@ public struct MessageDeletedEvent: MessageEvent, EventWithMessagePayload {
     }
 }
 
-public struct MessageReadEvent: MessageEvent, EventWithChannelId {
+// TODO: MessageReadEvent doesn't have message Id????
+public struct MessageReadEvent: EventWithChannelId {
     public let userId: UserId
     public let cid: ChannelId
     public let readAt: Date

--- a/Sources/StreamChat/WebSocketClient/Events/MessageEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/MessageEvents.swift
@@ -59,8 +59,11 @@ public struct MessageDeletedEvent: MessageEvent {
     }
 }
 
-// TODO: MessageReadEvent doesn't have message Id????
-public struct MessageReadEvent: EventWithChannelId {
+/// `ChannelReadEvent`, this event tells that User has mark read all messages in channel.
+public typealias ChannelReadEvent = MessageReadEvent
+
+/// `ChannelReadEvent`, this event tells that User has mark read all messages in channel.
+public struct MessageReadEvent: ChannelEvent {
     public let userId: UserId
     public let cid: ChannelId
     public let readAt: Date

--- a/Sources/StreamChat/WebSocketClient/Events/MessageEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/MessageEvents.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct MessageNewEvent: EventWithUserPayload, EventWithMessagePayload {
+public struct MessageNewEvent: UserEvent, EventWithMessagePayload {
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
@@ -25,7 +25,7 @@ public struct MessageNewEvent: EventWithUserPayload, EventWithMessagePayload {
     }
 }
 
-public struct MessageUpdatedEvent: EventWithUserPayload, EventWithMessagePayload {
+public struct MessageUpdatedEvent: MessageEvent, EventWithMessagePayload {
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
@@ -42,7 +42,7 @@ public struct MessageUpdatedEvent: EventWithUserPayload, EventWithMessagePayload
     }
 }
 
-public struct MessageDeletedEvent: EventWithUserPayload, EventWithMessagePayload {
+public struct MessageDeletedEvent: MessageEvent, EventWithMessagePayload {
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
@@ -59,7 +59,7 @@ public struct MessageDeletedEvent: EventWithUserPayload, EventWithMessagePayload
     }
 }
 
-public struct MessageReadEvent: EventWithUserPayload, EventWithChannelId {
+public struct MessageReadEvent: MessageEvent, EventWithChannelId {
     public let userId: UserId
     public let cid: ChannelId
     public let readAt: Date

--- a/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct NotificationMessageNewEvent: EventWithMessagePayload, EventWithChannelId {
+public struct NotificationMessageNewEvent: NotificationMessageEvent {
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
@@ -71,7 +71,6 @@ public struct NotificationAddedToChannelEvent: ChannelNotificationEvent {
 }
 
 public struct NotificationRemovedFromChannelEvent: InviteRelatedNotificationEvent {
-    // TODO: Figure out if it's needed, according to events table it is.
     public let userId: UserId
     public let cid: ChannelId
 

--- a/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
@@ -22,7 +22,7 @@ public struct NotificationMessageNewEvent: EventWithMessagePayload, EventWithCha
     }
 }
 
-public struct NotificationMarkAllReadEvent: UserEvent {
+public struct NotificationMarkAllReadEvent: UserNotificationEvent {
     public let userId: UserId
     public let readAt: Date
     let payload: Any
@@ -50,7 +50,7 @@ public struct NotificationMarkReadEvent: UserEvent, EventWithChannelId {
     }
 }
 
-public struct NotificationMutesUpdatedEvent<ExtraData: ExtraDataTypes>: EventWithCurrentUserPayload {
+public struct NotificationMutesUpdatedEvent<ExtraData: ExtraDataTypes>: CurrentUserNotificationEvent {
     public let currentUserId: UserId
     let payload: Any
     
@@ -60,7 +60,7 @@ public struct NotificationMutesUpdatedEvent<ExtraData: ExtraDataTypes>: EventWit
     }
 }
 
-public struct NotificationAddedToChannelEvent: EventWithChannelId, EventWithPayload {
+public struct NotificationAddedToChannelEvent: ChannelNotificationEvent {
     public let cid: ChannelId
     let payload: Any
     
@@ -70,18 +70,21 @@ public struct NotificationAddedToChannelEvent: EventWithChannelId, EventWithPayl
     }
 }
 
-public struct NotificationRemovedFromChannelEvent: EventWithChannelId {
+public struct NotificationRemovedFromChannelEvent: InviteRelatedNotificationEvent {
+    // TODO: Figure out if it's needed, according to events table it is.
+    public let userId: UserId
     public let cid: ChannelId
 
     let payload: Any
     
     init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
         cid = try response.value(at: \.cid)
+        userId = try response.value(at: \.user?.id)
         payload = response
     }
 }
 
-public struct NotificationInvitedEvent<ExtraData: ExtraDataTypes>: EventWithUserPayload, EventWithChannelId {
+public struct NotificationInvitedEvent<ExtraData: ExtraDataTypes>: InviteRelatedNotificationEvent {
     public let cid: ChannelId
     public let userId: UserId
     public let memberRole: MemberRole
@@ -99,7 +102,7 @@ public struct NotificationInvitedEvent<ExtraData: ExtraDataTypes>: EventWithUser
     }
 }
 
-public struct NotificationInviteAcceptedEvent<ExtraData: ExtraDataTypes>: EventWithUserPayload, EventWithChannelId {
+public struct NotificationInviteAcceptedEvent<ExtraData: ExtraDataTypes>: InviteRelatedNotificationEvent {
     public let cid: ChannelId
     public let userId: UserId
     public let memberRole: MemberRole
@@ -119,7 +122,7 @@ public struct NotificationInviteAcceptedEvent<ExtraData: ExtraDataTypes>: EventW
     }
 }
 
-public struct NotificationInviteRejectedEvent<ExtraData: ExtraDataTypes>: EventWithUserPayload, EventWithChannelId {
+public struct NotificationInviteRejectedEvent<ExtraData: ExtraDataTypes>: InviteRelatedNotificationEvent {
     public let cid: ChannelId
     public let userId: UserId
     public let memberRole: MemberRole
@@ -139,7 +142,7 @@ public struct NotificationInviteRejectedEvent<ExtraData: ExtraDataTypes>: EventW
     }
 }
 
-public struct NotificationChannelMutesUpdatedEvent: EventWithUserPayload {
+public struct NotificationChannelMutesUpdatedEvent: UserNotificationEvent {
     public let userId: UserId
     let payload: Any
     

--- a/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
@@ -22,7 +22,7 @@ public struct NotificationMessageNewEvent: EventWithMessagePayload, EventWithCha
     }
 }
 
-public struct NotificationMarkAllReadEvent: EventWithUserPayload {
+public struct NotificationMarkAllReadEvent: UserEvent {
     public let userId: UserId
     public let readAt: Date
     let payload: Any
@@ -34,7 +34,7 @@ public struct NotificationMarkAllReadEvent: EventWithUserPayload {
     }
 }
 
-public struct NotificationMarkReadEvent: EventWithUserPayload, EventWithChannelId {
+public struct NotificationMarkReadEvent: UserEvent, EventWithChannelId {
     public let userId: UserId
     public let cid: ChannelId
     public let readAt: Date

--- a/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
@@ -22,7 +22,7 @@ public struct NotificationMessageNewEvent: EventWithMessagePayload, EventWithCha
     }
 }
 
-public struct NotificationMarkAllReadEvent: UserNotificationEvent {
+public struct NotificationMarkAllReadEvent: NotificationMarkReadAllEventProtocol {
     public let userId: UserId
     public let readAt: Date
     let payload: Any
@@ -34,7 +34,7 @@ public struct NotificationMarkAllReadEvent: UserNotificationEvent {
     }
 }
 
-public struct NotificationMarkReadEvent: UserEvent, EventWithChannelId {
+public struct NotificationMarkReadEvent: NotificationMarkReadEventProtocol {
     public let userId: UserId
     public let cid: ChannelId
     public let readAt: Date

--- a/Sources/StreamChat/WebSocketClient/Events/ReactionEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/ReactionEvents.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct ReactionNewEvent: EventWithReactionPayload {
+public struct ReactionNewEvent: ReactionEvent {
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
@@ -25,7 +25,7 @@ public struct ReactionNewEvent: EventWithReactionPayload {
     }
 }
 
-public struct ReactionUpdatedEvent: EventWithReactionPayload {
+public struct ReactionUpdatedEvent: ReactionEvent {
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId
@@ -46,7 +46,7 @@ public struct ReactionUpdatedEvent: EventWithReactionPayload {
     }
 }
 
-public struct ReactionDeletedEvent: EventWithReactionPayload {
+public struct ReactionDeletedEvent: ReactionEvent {
     public let userId: UserId
     public let cid: ChannelId
     public let messageId: MessageId

--- a/Sources/StreamChat/WebSocketClient/Events/TypingEvent.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/TypingEvent.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct TypingEvent: EventWithUserPayload, EventWithChannelId {
+public struct TypingEvent: UserTypingEvent {
     public let isTyping: Bool
     public let cid: ChannelId
     public let userId: UserId

--- a/Sources/StreamChat/WebSocketClient/Events/UserEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/UserEvents.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct UserPresenceChangedEvent<ExtraData: ExtraDataTypes>: EventWithUserPayload {
+public struct UserPresenceChangedEvent<ExtraData: ExtraDataTypes>: UserEvent {
     public let userId: UserId
     public let createdAt: Date?
     
@@ -17,7 +17,7 @@ public struct UserPresenceChangedEvent<ExtraData: ExtraDataTypes>: EventWithUser
     }
 }
 
-public struct UserUpdatedEvent<ExtraData: ExtraDataTypes>: EventWithUserPayload, EventWithChannelId {
+public struct UserUpdatedEvent<ExtraData: ExtraDataTypes>: UserEvent, EventWithChannelId {
     public let cid: ChannelId
     public let userId: UserId
     public let createdAt: Date?
@@ -34,7 +34,7 @@ public struct UserUpdatedEvent<ExtraData: ExtraDataTypes>: EventWithUserPayload,
 
 // MARK: - User Watching
 
-public struct UserWatchingEvent: EventWithUserPayload, EventWithChannelId {
+public struct UserWatchingEvent: UserEvent, EventWithChannelId {
     public let cid: ChannelId
     public let userId: UserId
     public let createdAt: Date
@@ -55,7 +55,19 @@ public struct UserWatchingEvent: EventWithUserPayload, EventWithChannelId {
 
 // MARK: - User Ban
 
-public struct UserBannedEvent: EventWithUserPayload, EventWithOwnerPayload, EventWithChannelId {
+public struct UserGloballyBannedEvent: UserEvent {
+    var userId: UserId
+    var createdAt: Date?
+    var payload: Any
+    
+    init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
+        userId = try response.value(at: \.user?.id)
+        createdAt = response.createdAt
+        payload = response
+    }
+}
+
+public struct UserBannedEvent: UserEvent, EventWithChannelId {
     public let cid: ChannelId
     public let userId: UserId
     public let ownerId: UserId
@@ -76,7 +88,19 @@ public struct UserBannedEvent: EventWithUserPayload, EventWithOwnerPayload, Even
     }
 }
 
-public struct UserUnbannedEvent: EventWithUserPayload, EventWithChannelId {
+public struct UserGloballyUnbannedEvent: UserEvent {
+    var userId: UserId
+    var createdAt: Date?
+    var payload: Any
+    
+    init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
+        userId = try response.value(at: \.user?.id)
+        createdAt = response.createdAt
+        payload = response
+    }
+}
+
+public struct UserUnbannedEvent: UserEvent, EventWithChannelId {
     public let cid: ChannelId
     public let userId: UserId
     public let createdAt: Date?

--- a/Sources/StreamChat/WebSocketClient/Events/UserEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/UserEvents.swift
@@ -17,7 +17,7 @@ public struct UserPresenceChangedEvent<ExtraData: ExtraDataTypes>: UserEvent {
     }
 }
 
-public struct UserUpdatedEvent<ExtraData: ExtraDataTypes>: UserEvent, EventWithChannelId {
+public struct UserUpdatedEvent<ExtraData: ExtraDataTypes>: UserChannelSpecificEvent {
     public let cid: ChannelId
     public let userId: UserId
     public let createdAt: Date?
@@ -34,7 +34,7 @@ public struct UserUpdatedEvent<ExtraData: ExtraDataTypes>: UserEvent, EventWithC
 
 // MARK: - User Watching
 
-public struct UserWatchingEvent: UserEvent, EventWithChannelId {
+public struct UserWatchingEvent: UserChannelSpecificEvent {
     public let cid: ChannelId
     public let userId: UserId
     public let createdAt: Date
@@ -67,7 +67,7 @@ public struct UserGloballyBannedEvent: UserEvent {
     }
 }
 
-public struct UserBannedEvent: UserEvent, EventWithChannelId {
+public struct UserBannedEvent: UserChannelSpecificEvent {
     public let cid: ChannelId
     public let userId: UserId
     public let ownerId: UserId
@@ -100,7 +100,7 @@ public struct UserGloballyUnbannedEvent: UserEvent {
     }
 }
 
-public struct UserUnbannedEvent: UserEvent, EventWithChannelId {
+public struct UserUnbannedEvent: UserChannelSpecificEvent {
     public let cid: ChannelId
     public let userId: UserId
     public let createdAt: Date?


### PR DESCRIPTION
This draft PR makes more specific protocols for handling event types, ideally it should give us an idea of required fields in some event types. What needs to be done is deleting `EventWithChannelId` and other `deprecated` protocols and fix tests. Also there are some inconsistencies in some events so I had to create some protocols like `UserChannelSpecificEvent` which indicates there is Event for user for given channel. Also we probably want to delete duplicate protocols of `NotificationMessageEvent` vs `MessageEvent`. 
