### PR TITLE
Change response type of getMessage endpoint

### DIFF
--- a/Sources/StreamChat/APIClient/Endpoints/MessageEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/MessageEndpoints.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 extension Endpoint {
-    static func getMessage<ExtraData: ExtraDataTypes>(messageId: MessageId) -> Endpoint<MessagePayload<ExtraData>> {
+    static func getMessage<ExtraData: ExtraDataTypes>(messageId: MessageId) -> Endpoint<MessagePayload<ExtraData>.Boxed> {
         .init(
             path: messageId.path,
             method: .get,

--- a/Sources/StreamChat/APIClient/Endpoints/MessageEndpoints_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/MessageEndpoints_Tests.swift
@@ -9,7 +9,7 @@ final class MessageEndpoints_Tests: XCTestCase {
     func test_getMessage_buildsCorrectly() {
         let messageId: MessageId = .unique
         
-        let expectedEndpoint = Endpoint<MessagePayload<NoExtraData>>(
+        let expectedEndpoint = Endpoint<MessagePayload<NoExtraData>.Boxed>(
             path: "messages/\(messageId)",
             method: .get,
             queryItems: nil,
@@ -18,7 +18,7 @@ final class MessageEndpoints_Tests: XCTestCase {
         )
         
         // Build endpoint
-        let endpoint: Endpoint<MessagePayload<NoExtraData>> = .getMessage(messageId: messageId)
+        let endpoint: Endpoint<MessagePayload<NoExtraData>.Boxed> = .getMessage(messageId: messageId)
         
         // Assert endpoint is built correctly
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -13,12 +13,12 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
     ///   - messageId: The message identifier.
     ///   - completion: The completion. Will be called with an error if smth goes wrong, otherwise - will be called with `nil`.
     func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Error?) -> Void)? = nil) {
-        let endpoint: Endpoint<MessagePayload<ExtraData>> = .getMessage(messageId: messageId)
+        let endpoint: Endpoint<MessagePayload<ExtraData>.Boxed> = .getMessage(messageId: messageId)
         apiClient.request(endpoint: endpoint) {
             switch $0 {
-            case let .success(message):
+            case let .success(boxed):
                 self.database.write({ session in
-                    try session.saveMessage(payload: message, for: cid)
+                    try session.saveMessage(payload: boxed.message, for: cid)
                 }, completion: { error in
                     completion?(error)
                 })

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -304,7 +304,7 @@ final class MessageUpdater_Tests: StressTestCase {
         messageUpdater.getMessage(cid: cid, messageId: messageId)
                 
         // Assert correct endpoint is called
-        let expectedEndpoint: Endpoint<MessagePayload<ExtraData>> = .getMessage(messageId: messageId)
+        let expectedEndpoint: Endpoint<MessagePayload<ExtraData>.Boxed> = .getMessage(messageId: messageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
     }
     
@@ -317,14 +317,16 @@ final class MessageUpdater_Tests: StressTestCase {
         
         // Simulate API response with failure
         let error = TestError()
-        apiClient.test_simulateResponse(Result<MessagePayload<ExtraData>, Error>.failure(error))
+        apiClient.test_simulateResponse(Result<MessagePayload<ExtraData>.Boxed, Error>.failure(error))
                 
         // Assert the completion is called with the error
         AssertAsync.willBeEqual(completionCalledError as? TestError, error)
     }
     
     func test_getMessage_propogatesDatabaseError() throws {
-        let messagePayload: MessagePayload<ExtraData> = .dummy(messageId: .unique, authorUserId: .unique)
+        let messagePayload: MessagePayload<ExtraData>.Boxed = .init(
+            message: .dummy(messageId: .unique, authorUserId: .unique)
+        )
         let channelId = ChannelId.unique
 
         // Create channel in the database
@@ -336,12 +338,12 @@ final class MessageUpdater_Tests: StressTestCase {
         
         // Simulate `getMessage(cid:, messageId:)` call
         var completionCalledError: Error?
-        messageUpdater.getMessage(cid: channelId, messageId: messagePayload.id) {
+        messageUpdater.getMessage(cid: channelId, messageId: messagePayload.message.id) {
             completionCalledError = $0
         }
         
         // Simulate API response with success
-        apiClient.test_simulateResponse(Result<MessagePayload<ExtraData>, Error>.success(messagePayload))
+        apiClient.test_simulateResponse(Result<MessagePayload<ExtraData>.Boxed, Error>.success(messagePayload))
                 
         // Assert database error is propogated
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
@@ -365,8 +367,10 @@ final class MessageUpdater_Tests: StressTestCase {
         }
         
         // Simulate API response with success
-        let messagePayload: MessagePayload<ExtraData> = .dummy(messageId: messageId, authorUserId: currentUserId)
-        apiClient.test_simulateResponse(Result<MessagePayload<ExtraData>, Error>.success(messagePayload))
+        let messagePayload: MessagePayload<ExtraData>.Boxed = .init(
+            message: .dummy(messageId: messageId, authorUserId: currentUserId)
+        )
+        apiClient.test_simulateResponse(Result<MessagePayload<ExtraData>.Boxed, Error>.success(messagePayload))
         
         // Assert completion is called
         AssertAsync.willBeTrue(completionCalled)
@@ -587,11 +591,13 @@ final class MessageUpdater_Tests: StressTestCase {
         }
         
         // Assert message endpoint is called.
-        let messageEndpoint: Endpoint<MessagePayload<ExtraData>> = .getMessage(messageId: messageId)
+        let messageEndpoint: Endpoint<MessagePayload<ExtraData>.Boxed> = .getMessage(messageId: messageId)
         AssertAsync.willBeEqual(apiClient.request_endpoint, AnyEndpoint(messageEndpoint))
         
         // Simulate message response with success.
-        let messagePayload: MessagePayload<ExtraData> = .dummy(messageId: messageId, authorUserId: currentUserId)
+        let messagePayload: MessagePayload<ExtraData>.Boxed = .init(
+            message: .dummy(messageId: messageId, authorUserId: currentUserId)
+        )
         apiClient.test_simulateResponse(.success(messagePayload))
         
         // Assert flag endpoint is called.
@@ -654,12 +660,12 @@ final class MessageUpdater_Tests: StressTestCase {
         }
         
         // Assert message endpoint is called.
-        let messageEndpoint: Endpoint<MessagePayload<ExtraData>> = .getMessage(messageId: messageId)
+        let messageEndpoint: Endpoint<MessagePayload<ExtraData>.Boxed> = .getMessage(messageId: messageId)
         AssertAsync.willBeEqual(apiClient.request_endpoint, AnyEndpoint(messageEndpoint))
         
         // Simulate message response with failure.
         let networkError = TestError()
-        apiClient.test_simulateResponse(Result<MessagePayload<ExtraData>, Error>.failure(networkError))
+        apiClient.test_simulateResponse(Result<MessagePayload<ExtraData>.Boxed, Error>.failure(networkError))
         
         // Assert the message network error is propogated.
         AssertAsync.willBeEqual(completionCalledError as? TestError, networkError)
@@ -684,11 +690,13 @@ final class MessageUpdater_Tests: StressTestCase {
         }
         
         // Assert message endpoint is called.
-        let messageEndpoint: Endpoint<MessagePayload<ExtraData>> = .getMessage(messageId: messageId)
+        let messageEndpoint: Endpoint<MessagePayload<ExtraData>.Boxed> = .getMessage(messageId: messageId)
         AssertAsync.willBeEqual(apiClient.request_endpoint, AnyEndpoint(messageEndpoint))
         
         // Simulate message response with success.
-        let messagePayload: MessagePayload<ExtraData> = .dummy(messageId: messageId, authorUserId: currentUserId)
+        let messagePayload: MessagePayload<ExtraData>.Boxed = .init(
+            message: .dummy(messageId: messageId, authorUserId: currentUserId)
+        )
         apiClient.test_simulateResponse(.success(messagePayload))
         
         // Assert the message database error is propogated.


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

`ChatMessageController.synchronize` fails. the followings are error logs.
```
2021-04-29 10:48:01.643 [ERROR] [com.apple.NSURLSession-delegate] [RequestDecoder.swift:71]
[decodeRequestResponse(data:response:error:)] > keyNotFound(MessagePayloadsCodingKeys(stringValue: "id", intValue: nil), Swift.DecodingError.Context(codingPath: [], debugDescription: "No value associated with key MessagePayloadsCodingKeys(stringValue: \"id\", intValue: nil) (\"id\").", underlyingError: nil))
```

In the `synchronize` implementation, `messageUpdater.getMessage` request fails because response type of `getMessage` endpoint should be `MessagePayload<ExtraData>.Boxed`, not `MessagePayload<ExtraData>`

[REST API](https://getstream.io/chat/docs/rest/#messages-getmanymessages) says successful response of `GET /messages/{id}` contains `message` field, which type is `Message`

