### PR TITLE
Fix image picker crash in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _April 23, 2021_
 
 ### 🐞 Fixed
 - All channel events are correctly propagated to the UI.
+- Crash where unavailable media types were passed to media pickers. 
 
 # [3.1.7](https://github.com/GetStream/stream-chat-swift/releases/tag/3.1.7)
 _April 23, 2021_

--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerVC.swift
@@ -77,14 +77,14 @@ open class _ChatMessageComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
     
     internal private(set) lazy var imagePicker: UIImagePickerController = {
         let picker = UIImagePickerController()
-        picker.mediaTypes = ["internal.image"]
+        picker.mediaTypes = ["public.image"]
         picker.sourceType = .photoLibrary
         picker.delegate = self
         return picker
     }()
     
     internal private(set) lazy var documentPicker: UIDocumentPickerViewController = {
-        let picker = UIDocumentPickerViewController(documentTypes: ["internal.item"], in: .import)
+        let picker = UIDocumentPickerViewController(documentTypes: ["public.item"], in: .import)
         picker.delegate = self
         picker.allowsMultipleSelection = true
         return picker


### PR DESCRIPTION
# Description

In production code we had a typo in string constant that determines which media types are available for the user to pick from.