### PR TITLE
Update ChatMessageImageGallery.swift

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery.swift
@@ -30,7 +30,6 @@ open class _ChatMessageImageGallery<ExtraData: ExtraDataTypes>: _View, ThemeProv
         label.textAlignment = .center
         return label
             .withoutAutoresizingMaskConstraints
-            .withBidirectionalLanguagesSupport
     }()
 
     private var layouts: [[NSLayoutConstraint]] = []


### PR DESCRIPTION
The count of additional attachments isn't localized, hence does not need bidirectional support.
The "+1" looks left-aligned if the label is enabled with bidirectional support.
Removing the bidirectional support so that the label is centered.

# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested

## Description of the pull request

Removed natural(left) alignment of the chat message image gallery so that the additional attachments
count looks better.

![before](https://user-images.githubusercontent.com/11807135/116803334-17bf6380-ab34-11eb-9e8b-6649003a3018.png)  ![after](https://user-images.githubusercontent.com/11807135/116803335-1a21bd80-ab34-11eb-9bc9-cc33a2f200e5.png)


