### PR TITLE
[CIS-827] Change log level for ChannelRead in `ChannelReadUpdaterMiddleware`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 - Split `UIConfig` into `Appearance` and `Components` to improve clarity [#1014](https://github.com/GetStream/stream-chat-swift/pull/1014)
+- Change log level for `ChannelRead` when it doesn't exist in channel from `error` to `info` [#1043](https://github.com/GetStream/stream-chat-swift/pull/1043) 
 
 # [3.1.9](https://github.com/GetStream/stream-chat-swift/releases/tag/3.1.9)
 _May 03, 2021_

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware.swift
@@ -53,7 +53,7 @@ struct ChannelReadUpdaterMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware 
             read.lastReadAt = lastReadAt
             read.unreadMessageCount = 0
         } else {
-            log.error("Failed to update channel read for cid \(cid) and userId \(userId).")
+            log.info("Failed to update channel read for cid \(cid) and userId \(userId).")
         }
     }
     
@@ -74,7 +74,7 @@ struct ChannelReadUpdaterMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware 
                 read.unreadMessageCount += 1
             }
         } else {
-            log.error(
+            log.info(
                 "Can't increase unread count for \(cid) because the `ChannelReadDTO` for " +
                     "the current user doesn't exist."
             )


### PR DESCRIPTION
# What this PR do:
- Changes log level for missing `ChannelReads` on `Channel` so they are logged as `info` rather than being `error`.
