### PR TITLE
[CIS-828] Investigate reconnection strategy tests failure

### DIFF
--- a/Sources/StreamChat/APIClient/APIClient_Mock.swift
+++ b/Sources/StreamChat/APIClient/APIClient_Mock.swift
@@ -70,7 +70,7 @@ class APIClientMock: APIClient {
 extension APIClientMock {
     convenience init() {
         self.init(
-            sessionConfiguration: .default,
+            sessionConfiguration: .ephemeral,
             requestEncoder: DefaultRequestEncoder(baseURL: .unique(), apiKey: .init(.unique)),
             requestDecoder: DefaultRequestDecoder()
         )

--- a/Sources/StreamChat/APIClient/APIClient_Tests.swift
+++ b/Sources/StreamChat/APIClient/APIClient_Tests.swift
@@ -24,7 +24,7 @@ class APIClient_Tests: StressTestCase {
         baseURL = .unique()
         
         // Prepare the URL protocol test environment
-        sessionConfiguration = URLSessionConfiguration.default
+        sessionConfiguration = .ephemeral
         RequestRecorderURLProtocol.startTestSession(with: &sessionConfiguration)
         MockNetworkURLProtocol.startTestSession(with: &sessionConfiguration)
         sessionConfiguration.httpMaximumConnectionsPerHost = Int.max

--- a/Sources/StreamChat/WebSocketClient/Engine/WebSocketEngine_Mock.swift
+++ b/Sources/StreamChat/WebSocketClient/Engine/WebSocketEngine_Mock.swift
@@ -22,7 +22,7 @@ class WebSocketEngineMock: WebSocketEngine {
     @Atomic var sendPing_calledCount = 0
     
     convenience init() {
-        self.init(request: .init(url: URL(string: "test_url")!), sessionConfiguration: .default, callbackQueue: .main)
+        self.init(request: .init(url: URL(string: "test_url")!), sessionConfiguration: .ephemeral, callbackQueue: .main)
     }
     
     required init(request: URLRequest, sessionConfiguration: URLSessionConfiguration, callbackQueue: DispatchQueue) {

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient_Mock.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient_Mock.swift
@@ -59,7 +59,7 @@ class WebSocketClientMock: WebSocketClient {
 extension WebSocketClientMock {
     convenience init() {
         self.init(
-            sessionConfiguration: .default,
+            sessionConfiguration: .ephemeral,
             requestEncoder: DefaultRequestEncoder(baseURL: .unique(), apiKey: .init(.unique)),
             eventDecoder: EventDecoder<NoExtraData>(),
             eventNotificationCenter: EventNotificationCenterMock(database: DatabaseContainerMock()),

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
@@ -65,7 +65,7 @@ class WebSocketClient_Tests: StressTestCase {
         environment.backgroundTaskScheduler = backgroundTaskScheduler
         
         webSocketClient = WebSocketClient(
-            sessionConfiguration: .default,
+            sessionConfiguration: .ephemeral,
             requestEncoder: requestEncoder,
             eventDecoder: decoder,
             eventNotificationCenter: eventNotificationCenter,


### PR DESCRIPTION
# What this PR do:
- FIxes `WebSocketClient_Tests` which failed on CI due to possibly bad configuration policy (using `default`, not `ehemeral`
# How to test it
- Check if the tests for this PR are green, if yes, this solution works

# Explanation of the fix:

The `WebSocketClient` was initialized in tests with `default` `URLSessionConfiguration`, which stores all the caches and other session-related data on the disk. It is possible that due to unknown nature of the CI machine where github actions run tests those cached data were still persistent through all tests during the Test run. What I did is basically change the configuration to `ephemeral` which doesn't cache and any of the related data to disk and should resolve the problem.  

You can read more about the `URLSessionConfiguration` in here:
https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1410529-ephemeral 