### PR TITLE
Use separate `channelsCount` for `ChatChannelListVC`

### DIFF
--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -58,11 +58,15 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
     
     /// Reuse identifier of `collectionViewCell`
     open var collectionViewCellReuseIdentifier: String { "Cell" }
+    
+    /// We use private property for channels count so we can update it inside `performBatchUpdates` as [documented](https://developer.apple.com/documentation/uikit/uicollectionview/1618045-performbatchupdates#discussion)
+    private var channelsCount = 0
 
     override open func setUp() {
         super.setUp()
         controller.setDelegate(self)
         controller.synchronize()
+        channelsCount = controller.channels.count
         
         collectionView.register(
             components.channelList.collectionViewCell.self,
@@ -111,7 +115,7 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
     }
 
     open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        controller.channels.count
+        channelsCount
     }
     
     open func collectionView(
@@ -226,7 +230,7 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
 
 extension _ChatChannelListVC: _ChatChannelListControllerDelegate {
     public func controllerWillChangeChannels(_ controller: _ChatChannelListController<ExtraData>) {
-        // We can't call `performBatchUpdates` unless collection view is properly laid out.
+        channelsCount = controller.channels.count
         collectionView.layoutIfNeeded()
     }
 
@@ -234,6 +238,7 @@ extension _ChatChannelListVC: _ChatChannelListControllerDelegate {
         _ controller: _ChatChannelListController<ExtraData>,
         didChangeChannels changes: [ListChange<_ChatChannel<ExtraData>>]
     ) {
+        let newChannelsCount = controller.channels.count
         var movedItems: [IndexPath] = []
         
         collectionView.performBatchUpdates(
@@ -251,6 +256,8 @@ extension _ChatChannelListVC: _ChatChannelListControllerDelegate {
                         collectionView.reloadItems(at: [index])
                     }
                 }
+                
+                channelsCount = newChannelsCount
             },
             completion: { _ in
                 // Move changes from NSFetchController also can mean an update of the content.


### PR DESCRIPTION
Use separate `channelsCount` for channels in `ChatChannelListVC` so it can be updated inside `performBatchUpdates` as documented.