### PR TITLE
Fix `ChatMessageListCollectionViewLayout_Tests` in Xcode 12.5

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
@@ -174,7 +174,7 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
 
     // MARK: - Animation updates
 
-    override open func prepare(forCollectionViewUpdates updateItems: [UICollectionViewUpdateItem]) {
+    open func _prepare(forCollectionViewUpdates updateItems: [UICollectionViewUpdateItem]) {
         previousItems = currentItems
         
         // used to determine what contentOffset should be restored after batch updates
@@ -237,6 +237,14 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
         }
 
         preBatchUpdatesCall = false
+    }
+    
+    /// Only public by design, if you need to override this method override `_prepare(forCollectionViewUpdates:)`
+    override public func prepare(forCollectionViewUpdates updateItems: [UICollectionViewUpdateItem]) {
+        // In Xcode 12.5 it is impossible to use own `updateItems` - our solution with `UICollectionViewUpdateItem` subclass stopped working
+        // (Apple is probably checking some private API and our customized getters are not called),
+        // so instead of testing `prepare(forCollectionViewUpdates:)` we will test our custom function
+        _prepare(forCollectionViewUpdates: updateItems)
         super.prepare(forCollectionViewUpdates: updateItems)
     }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout_Tests.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout_Tests.swift
@@ -68,13 +68,13 @@ final class ChatMessageListCollectionViewLayout_Tests: XCTestCase {
         
         let updateItems = indices.map(TestUpdateItem.init(deleteIndex:))
         
-        subject.prepare(forCollectionViewUpdates: updateItems)
+        subject._prepare(forCollectionViewUpdates: updateItems)
         
         XCTAssertTrue(subject.currentItems.isEmpty)
     }
     
     func testLayoutInsertions() throws {
-        subject.prepare(forCollectionViewUpdates: [TestUpdateItem(insertIndex: 0)])
+        subject._prepare(forCollectionViewUpdates: [TestUpdateItem(insertIndex: 0)])
         
         // As `UUID` in `LayoutItem.id` is "random" adding `Equatable` conformance and direct comparison
         // wouldn't make sense as we have one "random" property


### PR DESCRIPTION
In Xcode 12.5 started failing some tests - we can now fix `ChatMessageListCollectionViewLayout_Tests`. 

Cause of those tests failing is that original `prepare(forCollectionViewUpdates:)` on `UICollectionViewLayout` started to check some private API so are customized getters in `TestUpdateItem` are not called. This means that both tests in suite fail with this error:
```
*** -[NSMutableIndexSet addIndexesInRange:]: Range {9223372036854775807, 1} exceeds maximum index value of NSNotFound - 1
```
In Xcode 12.4 everything works fine.

By extracting all code that was originally in `prepare(forCollectionViewUpdates:)` to our customized method we can ensure that all work that we expect to be done is really done and also prevent calling `super.prepare(forCollectionViewUpdates:)` in tests.

Also some snapshot tests started to fail in 12.5, snapshots look correct to the human eye so I think that it will be necessary to rerecord expected images.