### PR TITLE
Fix swift warnings

### DIFF
--- a/DemoApp/Info.plist
+++ b/DemoApp/Info.plist
@@ -18,6 +18,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/Sources/StreamChat/APIClient/APIClient_Tests.swift
+++ b/Sources/StreamChat/APIClient/APIClient_Tests.swift
@@ -78,7 +78,7 @@ class APIClient_Tests: StressTestCase {
         let testEndpoint = Endpoint<Data>.mock()
         
         // Create a request and assert the result is failure
-        let result = try await { apiClient.request(endpoint: testEndpoint, completion: $0) }
+        let result = try waitFor { apiClient.request(endpoint: testEndpoint, completion: $0) }
         AssertResultFailure(result, testError)
     }
 
@@ -110,7 +110,7 @@ class APIClient_Tests: StressTestCase {
         let testEndpoint: Endpoint<FileUploadPayload> = .uploadAttachment(with: .unique, type: .image)
 
         // Create a request and assert the result is failure
-        let result = try await {
+        let result = try waitFor {
             apiClient.uploadFile(
                 endpoint: testEndpoint,
                 multipartFormData: .init(Data(), fileName: .unique),
@@ -206,7 +206,7 @@ class APIClient_Tests: StressTestCase {
         let testEndpoint = Endpoint<TestUser>.mock()
         
         // Create a request and wait for the completion block
-        let result = try await { apiClient.request(endpoint: testEndpoint, completion: $0) }
+        let result = try waitFor { apiClient.request(endpoint: testEndpoint, completion: $0) }
         
         // Check the incoming data to the encoder is the URLResponse and data from the network
         XCTAssertEqual(decoder.decodeRequestResponse_data, try! JSONEncoder.stream.encode(TestUser(name: "Leia!")))
@@ -235,7 +235,7 @@ class APIClient_Tests: StressTestCase {
         let testEndpoint: Endpoint<FileUploadPayload> = .uploadAttachment(with: .unique, type: .image)
 
         // Create a request and wait for the completion block
-        let result = try await {
+        let result = try waitFor {
             apiClient.uploadFile(
                 endpoint: testEndpoint,
                 multipartFormData: .init(Data(), fileName: .unique),
@@ -270,7 +270,7 @@ class APIClient_Tests: StressTestCase {
         let testEndpoint = Endpoint<TestUser>.mock()
         
         // Create a request and wait for the completion block
-        let result = try await { apiClient.request(endpoint: testEndpoint, completion: $0) }
+        let result = try waitFor { apiClient.request(endpoint: testEndpoint, completion: $0) }
         
         // Check the incoming error to the encoder is the error from the response
         assert(decoder.decodeRequestResponse_error != nil)
@@ -302,7 +302,7 @@ class APIClient_Tests: StressTestCase {
         let testEndpoint: Endpoint<FileUploadPayload> = .uploadAttachment(with: .unique, type: .image)
 
         // Create a request and wait for the completion block
-        let result = try await {
+        let result = try waitFor {
             apiClient.uploadFile(
                 endpoint: testEndpoint,
                 multipartFormData: .init(Data(), fileName: .unique),

--- a/Sources/StreamChat/APIClient/RequestEncoder_Tests.swift
+++ b/Sources/StreamChat/APIClient/RequestEncoder_Tests.swift
@@ -34,7 +34,7 @@ class RequestEncoder_Tests: XCTestCase {
         )
         
         // Encode the request and wait for the result
-        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        let request = try waitFor { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
         
         // Check the required query item values are present
         let urlComponents = try XCTUnwrap(URLComponents(url: request.url!, resolvingAgainstBaseURL: false))
@@ -55,7 +55,7 @@ class RequestEncoder_Tests: XCTestCase {
         connectionDetailsProvider.token = token
 
         // Encode the request and wait for the result
-        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        let request = try waitFor { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
 
         // Check the auth headers are present
         XCTAssertEqual(request.allHTTPHeaderFields?["Stream-Auth-Type"], "jwt")
@@ -75,7 +75,7 @@ class RequestEncoder_Tests: XCTestCase {
         connectionDetailsProvider.token = .anonymous
 
         // Encode the request and wait for the result.
-        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        let request = try waitFor { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
 
         // Check the anonymous auth header is set.
         XCTAssertEqual(request.allHTTPHeaderFields?["Stream-Auth-Type"], "anonymous")
@@ -120,7 +120,7 @@ class RequestEncoder_Tests: XCTestCase {
         connectionDetailsProvider.connectionId = connectionId
         
         // Encode the request and wait for the result
-        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        let request = try waitFor { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
         
         // Check the connection id is set
         let urlComponents = try XCTUnwrap(URLComponents(url: request.url!, resolvingAgainstBaseURL: false))
@@ -172,7 +172,7 @@ class RequestEncoder_Tests: XCTestCase {
         connectionDetailsProvider.token = token
 
         // Encode the request and wait for the result
-        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        let request = try waitFor { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
 
         // Check the connection id is set
         let urlComponents = try XCTUnwrap(URLComponents(url: request.url!, resolvingAgainstBaseURL: false))
@@ -196,7 +196,7 @@ class RequestEncoder_Tests: XCTestCase {
         )
         
         // Encode the request and wait for the result
-        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        let request = try waitFor { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
         
         // Check the URL is set up correctly
         XCTAssertEqual(request.httpMethod, endpoint.method.rawValue)
@@ -221,7 +221,7 @@ class RequestEncoder_Tests: XCTestCase {
         )
         
         // Encode the request and wait for the result
-        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        let request = try waitFor { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
         
         // Check the body is present
         let body = try XCTUnwrap(request.httpBody)
@@ -245,7 +245,7 @@ class RequestEncoder_Tests: XCTestCase {
         )
         
         // Encode the request and wait for the result
-        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        let request = try waitFor { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
         
         // Check the body is present (and empty)
         let body = try XCTUnwrap(request.httpBody)
@@ -266,7 +266,7 @@ class RequestEncoder_Tests: XCTestCase {
         )
         
         // Encode the request and wait for the result
-        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        let request = try waitFor { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
         
         // Check the body is present
         let body = try XCTUnwrap(request.httpBody)
@@ -287,7 +287,7 @@ class RequestEncoder_Tests: XCTestCase {
         )
         
         // Encode the request and wait for the result
-        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        let request = try waitFor { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
         
         // Check the body is present (and empty)
         let body = try XCTUnwrap(request.httpBody)
@@ -312,7 +312,7 @@ class RequestEncoder_Tests: XCTestCase {
         )
         
         // Encode the request and wait for the result
-        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        let request = try waitFor { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
         
         // Check both JSONs are present in the query items
         let urlComponents = try XCTUnwrap(URLComponents(url: request.url!, resolvingAgainstBaseURL: false))
@@ -342,7 +342,7 @@ class RequestEncoder_Tests: XCTestCase {
         )
         
         // Encode the request and wait for the result
-        let request = try await { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
+        let request = try waitFor { encoder.encodeRequest(for: endpoint, completion: $0) }.get()
         
         let urlComponents = try XCTUnwrap(URLComponents(url: request.url!, resolvingAgainstBaseURL: false))
         

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -344,7 +344,7 @@ class ChatClient_Tests: StressTestCase {
             .webSocketClient(testEnv.webSocketClient!, didUpdateConectionState: .connected(connectionId: connectionId))
         
         AssertAsync.willBeEqual(providedConnectionId, connectionId)
-        XCTAssertEqual(try await { client.provideConnectionId(completion: $0) }, connectionId)
+        XCTAssertEqual(try waitFor { client.provideConnectionId(completion: $0) }, connectionId)
         
         // Simulate WebSocketConnection disconnecting and assert connectionId is reset
         testEnv.webSocketClient?.connectionStateDelegate?
@@ -483,7 +483,7 @@ class ChatClient_Tests: StressTestCase {
         
         // Take main then background queue.
         for queue in [DispatchQueue.main, DispatchQueue.global()] {
-            let error: Error? = try await { completion in
+            let error: Error? = try waitFor { completion in
                 // Dispatch creating a chat-client to specific queue.
                 queue.async {
                     // Create a `ChatClient` instance with the same config

--- a/Sources/StreamChat/Config/TokenProvider_Tests.swift
+++ b/Sources/StreamChat/Config/TokenProvider_Tests.swift
@@ -9,7 +9,7 @@ import XCTest
 final class TokenProvider_Tests: StressTestCase {
     func test_anonymousProvider_propagatesToken() throws {
         // Get token from `anonymous` provider.
-        let token = try await { TokenProvider.anonymous.getToken(.mock, $0) }.get()
+        let token = try waitFor { TokenProvider.anonymous.getToken(.mock, $0) }.get()
 
         // Assert token is correct.
         XCTAssertEqual(token.rawValue, "")
@@ -21,7 +21,7 @@ final class TokenProvider_Tests: StressTestCase {
         let userId: UserId = .unique
 
         // Get a token from `development` token provider.
-        let token = try await {
+        let token = try waitFor {
             TokenProvider.development(userId: userId).getToken(.mock, $0)
         }.get()
 
@@ -37,7 +37,7 @@ final class TokenProvider_Tests: StressTestCase {
         let token = Token.unique(userId: .unique)
 
         // Get a token from `static` token provider.
-        let receivedToken = try await {
+        let receivedToken = try waitFor {
             TokenProvider.static(token).getToken(.mock, $0)
         }.get()
 
@@ -50,7 +50,7 @@ final class TokenProvider_Tests: StressTestCase {
         let token = Token.unique()
 
         // Get a token from `closure` token provider.
-        let receivedToken = try await {
+        let receivedToken = try waitFor {
             TokenProvider
                 .closure { $1(.success(token)) }
                 .getToken(.mock, $0)
@@ -65,7 +65,7 @@ final class TokenProvider_Tests: StressTestCase {
         let error = TestError()
 
         // Get a token from `closure` token provider.
-        let receivedError = try await {
+        let receivedError = try waitFor {
             TokenProvider
                 .closure { $1(.failure(error)) }
                 .getToken(.mock, $0)

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
@@ -526,7 +526,7 @@ class ChannelController_Tests: StressTestCase {
     
     func test_channelChanges_arePropagated() throws {
         // Simulate changes in the DB:
-        _ = try await {
+        _ = try waitFor {
             client.databaseContainer.write({ session in
                 try session.saveChannel(payload: self.dummyPayload(with: self.channelId), query: nil)
             }, completion: $0)
@@ -537,7 +537,7 @@ class ChannelController_Tests: StressTestCase {
         AssertAsync.willBeTrue(controller.channel?.isFrozen)
         
         // Simulate channel changes
-        _ = try await {
+        _ = try waitFor {
             client.databaseContainer.write({ session in
                 let context = (session as! NSManagedObjectContext)
                 let channelDTO = try! context.fetch(ChannelDTO.fetchRequest(for: self.channelId)).first!
@@ -552,7 +552,7 @@ class ChannelController_Tests: StressTestCase {
         let payload = dummyPayload(with: channelId)
         
         // Simulate changes in the DB:
-        _ = try await {
+        _ = try waitFor {
             client.databaseContainer.write({ session in
                 try session.saveChannel(payload: payload)
             }, completion: $0)
@@ -568,7 +568,7 @@ class ChannelController_Tests: StressTestCase {
             authorUserId: .unique,
             createdAt: Date()
         )
-        _ = try await {
+        _ = try waitFor {
             client.databaseContainer.write({ session in
                 try session.saveMessage(payload: newMessagePayload, for: self.channelId)
             }, completion: $0)
@@ -770,7 +770,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback!(channelId)
 
         // Simulate DB update
-        var error = try await {
+        var error = try waitFor {
             client.databaseContainer.write({ session in
                 try session.saveChannel(payload: self.dummyPayload(with: self.channelId), query: nil)
             }, completion: $0)
@@ -792,7 +792,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(newCid)
 
         // Simulate DB update
-        error = try await {
+        error = try waitFor {
             client.databaseContainer.write({ session in
                 try session.saveChannel(payload: self.dummyPayload(with: newCid), query: nil)
             }, completion: $0)
@@ -913,7 +913,7 @@ class ChannelController_Tests: StressTestCase {
         controller.synchronize()
         
         // Simulate DB update
-        let error = try await {
+        let error = try waitFor {
             client.databaseContainer.write({ session in
                 try session.saveChannel(payload: self.dummyPayload(with: self.channelId), query: nil)
             }, completion: $0)
@@ -989,7 +989,7 @@ class ChannelController_Tests: StressTestCase {
         )
         
         // Simulate DB update
-        var error = try await {
+        var error = try waitFor {
             client.databaseContainer.write({ session in
                 try session.saveChannel(payload: payload, query: nil)
             }, completion: $0)
@@ -1005,7 +1005,7 @@ class ChannelController_Tests: StressTestCase {
         
         // Simulate DB update with the same payload
         // except `extraData` is changed now
-        error = try await {
+        error = try waitFor {
             client.databaseContainer.write({ session in
                 let newPayload: ChannelPayload<CustomExtraData> = .init(
                     channel: .init(
@@ -1051,7 +1051,7 @@ class ChannelController_Tests: StressTestCase {
         controller.synchronize()
         
         // Simulate DB update
-        _ = try await {
+        _ = try waitFor {
             client.databaseContainer.write({ session in
                 try session.saveChannel(payload: self.dummyPayload(with: self.channelId), query: nil)
             }, completion: $0)
@@ -1262,7 +1262,7 @@ class ChannelController_Tests: StressTestCase {
         setupControllerForNewChannel(query: query)
 
         // Simulate `updateChannel` call and assert the error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.updateChannel(name: .unique, imageURL: .unique(), team: nil, extraData: .init()) { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1274,7 +1274,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
 
         // Simulate `updateChannel` call and assert no error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.updateChannel(name: .unique, imageURL: .unique(), team: nil, extraData: .init()) { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1338,7 +1338,7 @@ class ChannelController_Tests: StressTestCase {
         setupControllerForNewChannel(query: query)
 
         // Simulate `muteChannel` call and assert error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.muteChannel { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1350,7 +1350,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
 
         // Simulate `muteChannel` call and assert no error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.muteChannel { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1417,7 +1417,7 @@ class ChannelController_Tests: StressTestCase {
         setupControllerForNewChannel(query: query)
 
         // Simulate `unmuteChannel` call and assert error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.muteChannel { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1429,7 +1429,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
 
         // Simulate `unmuteChannel` call and assert no error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.unmuteChannel { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1496,7 +1496,7 @@ class ChannelController_Tests: StressTestCase {
         setupControllerForNewChannel(query: query)
 
         // Simulate `deleteChannel` call and assert error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.deleteChannel { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1508,7 +1508,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
 
         // Simulate `deleteChannel` call and assert no error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.deleteChannel { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1574,7 +1574,7 @@ class ChannelController_Tests: StressTestCase {
         setupControllerForNewChannel(query: query)
 
         // Simulate `truncateChannel` call and assert error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.truncateChannel { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1586,7 +1586,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
 
         // Simulate `truncateChannel` call and assert no error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.truncateChannel { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1652,7 +1652,7 @@ class ChannelController_Tests: StressTestCase {
         setupControllerForNewChannel(query: query)
 
         // Simulate `hideChannel` call and assert error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.hideChannel { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1664,7 +1664,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
 
         // Simulate `hideChannel` call and assert no error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.hideChannel { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1731,7 +1731,7 @@ class ChannelController_Tests: StressTestCase {
         setupControllerForNewChannel(query: query)
 
         // Simulate `showChannel` call and assert error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.showChannel { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1743,7 +1743,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
 
         // Simulate `showChannel` call and assert no error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.showChannel { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1808,7 +1808,7 @@ class ChannelController_Tests: StressTestCase {
         var messageId: MessageId?
         
         // Create new channel with message in DB
-        error = try await {
+        error = try waitFor {
             client.databaseContainer.write({ session in
                 messageId = try self.setupChannelWithMessage(session)
             }, completion: $0)
@@ -1851,7 +1851,7 @@ class ChannelController_Tests: StressTestCase {
     
     func test_loadPreviousMessages_throwsError_on_emptyMessages() throws {
         // Simulate `loadPreviousMessages` call and assert error is returned
-        let error: Error? = try await { [callbackQueueID] completion in
+        let error: Error? = try waitFor { [callbackQueueID] completion in
             controller.loadPreviousMessages { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1865,7 +1865,7 @@ class ChannelController_Tests: StressTestCase {
         var messageId: MessageId?
         
         // Create new channel with message in DB
-        error = try await {
+        error = try waitFor {
             client.databaseContainer.write({ session in
                 messageId = try self.setupChannelWithMessage(session)
             }, completion: $0)
@@ -1895,7 +1895,7 @@ class ChannelController_Tests: StressTestCase {
         var messageId: MessageId?
         
         // Create new channel with message in DB
-        error = try await {
+        error = try waitFor {
             client.databaseContainer.write({ session in
                 messageId = try self.setupChannelWithMessage(session)
             }, completion: $0)
@@ -1938,7 +1938,7 @@ class ChannelController_Tests: StressTestCase {
     
     func test_loadNextMessages_throwsError_on_emptyMessages() throws {
         // Simulate `loadNextMessages` call and assert error is returned
-        let error: Error? = try await { [callbackQueueID] completion in
+        let error: Error? = try waitFor { [callbackQueueID] completion in
             controller.loadNextMessages { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -1952,7 +1952,7 @@ class ChannelController_Tests: StressTestCase {
         var messageId: MessageId?
         
         // Create new channel with message in DB
-        error = try await {
+        error = try waitFor {
             client.databaseContainer.write({ session in
                 messageId = try self.setupChannelWithMessage(session)
             }, completion: $0)
@@ -2139,7 +2139,7 @@ class ChannelController_Tests: StressTestCase {
         setupControllerForNewChannel(query: query)
         
         // Simulate `createNewMessage` call and assert error is returned
-        let result: Result<MessageId, Error> = try await { [callbackQueueID] completion in
+        let result: Result<MessageId, Error> = try waitFor { [callbackQueueID] completion in
             controller.createNewMessage(
                 text: .unique,
 //                command: .unique,
@@ -2167,7 +2167,7 @@ class ChannelController_Tests: StressTestCase {
         let members: Set<UserId> = [.unique]
 
         // Simulate `addMembers` call and assert error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.addMembers(userIds: members) { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2179,7 +2179,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
 
         // Simulate `addMembers` call and assert no error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.addMembers(userIds: members) { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2251,7 +2251,7 @@ class ChannelController_Tests: StressTestCase {
         let members: Set<UserId> = [.unique]
 
         // Simulate `removeMembers` call and assert error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.removeMembers(userIds: members) { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2263,7 +2263,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
 
         // Simulate `removeMembers` call and assert no error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.removeMembers(userIds: members) { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2334,7 +2334,7 @@ class ChannelController_Tests: StressTestCase {
         setupControllerForNewChannel(query: query)
         
         // Simulate `markRead` call and assert error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.markRead { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2346,7 +2346,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
         
         // Simulate `markRead` call and assert no error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.markRead { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2412,7 +2412,7 @@ class ChannelController_Tests: StressTestCase {
         setupControllerForNewChannel(query: query)
         
         // Simulate `enableSlowMode` call and assert error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.enableSlowMode(cooldownDuration: .random(in: 1...120)) { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2424,7 +2424,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
         
         // Simulate `enableSlowMode` call and assert no error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.enableSlowMode(cooldownDuration: .random(in: 1...120)) { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2444,7 +2444,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
         
         // Simulate `enableSlowMode` call with invalid cooldown and assert error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.enableSlowMode(cooldownDuration: .random(in: 130...250)) { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2453,7 +2453,7 @@ class ChannelController_Tests: StressTestCase {
         XCTAssert(error is ClientError.InvalidCooldownDuration)
         
         // Simulate `enableSlowMode` call with another invalid cooldown and assert error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.enableSlowMode(cooldownDuration: .random(in: -100...0)) { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2517,7 +2517,7 @@ class ChannelController_Tests: StressTestCase {
         setupControllerForNewChannel(query: query)
         
         // Simulate `disableSlowMode` call and assert error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.disableSlowMode { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2529,7 +2529,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
         
         // Simulate `disableSlowMode` call and assert no error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.disableSlowMode { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2597,7 +2597,7 @@ class ChannelController_Tests: StressTestCase {
         setupControllerForNewChannel(query: query)
         
         // Simulate `startWatching` call and assert error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.startWatching { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2609,7 +2609,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
         
         // Simulate `startWatching` call and assert no error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.startWatching { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2677,7 +2677,7 @@ class ChannelController_Tests: StressTestCase {
         setupControllerForNewChannel(query: query)
         
         // Simulate `stopWatching` call and assert error is returned
-        var error: Error? = try await { [callbackQueueID] completion in
+        var error: Error? = try waitFor { [callbackQueueID] completion in
             controller.stopWatching { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)
@@ -2689,7 +2689,7 @@ class ChannelController_Tests: StressTestCase {
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
         
         // Simulate `stopWatching` call and assert no error is returned
-        error = try await { [callbackQueueID] completion in
+        error = try waitFor { [callbackQueueID] completion in
             controller.stopWatching { error in
                 AssertTestQueue(withId: callbackQueueID)
                 completion(error)

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -206,7 +206,7 @@ class ChannelListController_Tests: StressTestCase {
         // Simulate changes in the DB:
         // 1. Add the channel to the DB
         let cid: ChannelId = .unique
-        _ = try await {
+        _ = try waitFor {
             client.databaseContainer.write({ session in
                 try session.saveChannel(payload: self.dummyPayload(with: cid), query: self.query)
             }, completion: $0)

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -354,7 +354,7 @@ final class CurrentUserController_Tests: StressTestCase {
     }
     
     func test_updateUser_whenCurrentUserDoesNotExist_shouldError() throws {
-        let error = try await {
+        let error = try waitFor {
             controller.updateUserData(
                 name: .unique,
                 imageURL: nil,
@@ -405,7 +405,7 @@ final class CurrentUserController_Tests: StressTestCase {
     }
 
     func test_synchronizeDevices__whenCurrentUserDoesNotExist_propagatesError() throws {
-        let error = try await {
+        let error = try waitFor {
             controller.synchronizeDevices(completion: $0)
         }
 
@@ -477,7 +477,7 @@ final class CurrentUserController_Tests: StressTestCase {
     }
     
     func test_addDevice_whenCurrentUserDoesNotExist_shouldError() throws {
-        let error = try await {
+        let error = try waitFor {
             controller.addDevice(token: "test".data(using: .utf8)!, completion: $0)
         }
         
@@ -553,7 +553,7 @@ final class CurrentUserController_Tests: StressTestCase {
     }
     
     func test_removeDevice_whenCurrentUserDoesNotExist_shouldError() throws {
-        let error = try await {
+        let error = try waitFor {
             controller.removeDevice(id: .unique, completion: $0)
         }
         

--- a/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
@@ -757,7 +757,7 @@ final class MessageController_Tests: StressTestCase {
     
     func test_loadNextReplies_failsOnEmptyReplies() throws {
         // Simulate `loadNextReplies` call and catch the completion error.
-        let completionError = try await {
+        let completionError = try waitFor {
             controller.loadNextReplies(completion: $0)
         }
         

--- a/Sources/StreamChat/Controllers/UserListController/UserListController_Tests.swift
+++ b/Sources/StreamChat/Controllers/UserListController/UserListController_Tests.swift
@@ -202,7 +202,7 @@ class UserListController_Tests: StressTestCase {
         // Simulate changes in the DB:
         // 1. Add the user to the DB
         let id: UserId = .unique
-        _ = try await {
+        _ = try waitFor {
             client.databaseContainer.write({ session in
                 try session.saveUser(payload: self.dummyUser(id: id), query: self.query)
             }, completion: $0)

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
@@ -142,7 +142,7 @@ class AttachmentDTO_Tests: XCTestCase {
         let payload: AttachmentPayload = .dummy()
         
         // Try to save an attachment and catch an error
-        let error = try await {
+        let error = try waitFor {
             database.write({ session in
                 let id = AttachmentId(cid: .unique, messageId: messageId, index: 0)
                 try session.saveAttachment(payload: payload, id: id)
@@ -161,7 +161,7 @@ class AttachmentDTO_Tests: XCTestCase {
         let payload: AttachmentPayload = .dummy()
         
         // Try to save an attachment and catch an error
-        let error = try await {
+        let error = try waitFor {
             database.write({ session in
                 let id = AttachmentId(cid: cid, messageId: .unique, index: 0)
                 try session.saveAttachment(payload: payload, id: id)

--- a/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
@@ -262,7 +262,7 @@ class MessageDTO_Tests: XCTestCase {
             pinned: true
         )
 
-        let (channelDTO, messageDTO): (ChannelDTO, MessageDTO) = try await { completion in
+        let (channelDTO, messageDTO): (ChannelDTO, MessageDTO) = try waitFor { completion in
             var channelDTO: ChannelDTO!
             var messageDTO: MessageDTO!
             
@@ -294,7 +294,7 @@ class MessageDTO_Tests: XCTestCase {
             pinned: false
         )
 
-        let (channelDTO, messageDTO): (ChannelDTO, MessageDTO) = try await { completion in
+        let (channelDTO, messageDTO): (ChannelDTO, MessageDTO) = try waitFor { completion in
             // Asynchronously save the payload to the db
             database.write { session in
                 // Create the channel first
@@ -548,7 +548,7 @@ class MessageDTO_Tests: XCTestCase {
         let cid: ChannelId = .unique
         let currentUserId: UserId = .unique
         
-        _ = try await { completion in
+        _ = try waitFor { completion in
             database.write({ (session) in
                 let currentUserPayload: CurrentUserPayload<NoExtraData> = .dummy(
                     userId: currentUserId,
@@ -568,7 +568,7 @@ class MessageDTO_Tests: XCTestCase {
         var message1Id: MessageId!
         var message2Id: MessageId!
 
-        _ = try await { completion in
+        _ = try waitFor { completion in
             database.write({ session in
                 let message1DTO = try session.createNewMessage(
                     in: cid,
@@ -651,7 +651,7 @@ class MessageDTO_Tests: XCTestCase {
         let cid: ChannelId = .unique
         let currentUserId: UserId = .unique
         
-        _ = try await { completion in
+        _ = try waitFor { completion in
             database.write({ (session) in
                 let currentUserPayload: CurrentUserPayload<NoExtraData> = .dummy(
                     userId: currentUserId,
@@ -680,7 +680,7 @@ class MessageDTO_Tests: XCTestCase {
         ]
         let newMessagePinning: MessagePinning? = MessagePinning(expirationDate: .unique)
                 
-        _ = try await { completion in
+        _ = try waitFor { completion in
             database.write({
                 let messageDTO = try $0.createNewMessage(
                     in: cid,
@@ -722,7 +722,7 @@ class MessageDTO_Tests: XCTestCase {
     }
     
     func test_creatingNewMessage_withoutExistingCurrentUser_throwsError() throws {
-        let result = try await { completion in
+        let result = try waitFor { completion in
             database.write({ (session) in
                 try session.createNewMessage(
                     in: .unique,
@@ -744,7 +744,7 @@ class MessageDTO_Tests: XCTestCase {
     
     func test_creatingNewMessage_withoutExistingChannel_throwsError() throws {
         // Save current user first
-        _ = try await {
+        _ = try waitFor {
             database.write({
                 let currentUserPayload: CurrentUserPayload<NoExtraData> = .dummy(
                     userId: .unique,
@@ -757,7 +757,7 @@ class MessageDTO_Tests: XCTestCase {
         }
                 
         // Try to create a new message
-        let result = try await { completion in
+        let result = try waitFor { completion in
             database.write({ (session) in
                 try session.createNewMessage(
                     in: .unique,

--- a/Sources/StreamChat/Database/DatabaseContainer_Tests.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer_Tests.swift
@@ -27,7 +27,7 @@ class DatabaseContainer_Tests: StressTestCase {
         let container = try DatabaseContainer(kind: .inMemory)
         
         // Write a valid entity to DB and wait for the completion block to be called
-        let successCompletion = try await { container.write({ session in
+        let successCompletion = try waitFor { container.write({ session in
             let context = session as! NSManagedObjectContext
             let teamDTO = NSEntityDescription.insertNewObject(forEntityName: "TeamDTO", into: context) as! TeamDTO
             teamDTO.id = .unique
@@ -37,7 +37,7 @@ class DatabaseContainer_Tests: StressTestCase {
         XCTAssertNil(successCompletion)
         
         // Write an invalid entity to DB and wait for the completion block to be called with error
-        let errorCompletion = try await { container.write({ session in
+        let errorCompletion = try waitFor { container.write({ session in
             let context = session as! NSManagedObjectContext
             NSEntityDescription.insertNewObject(forEntityName: "TeamDTO", into: context)
             // Team id is not set, this should produce an error

--- a/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
@@ -116,7 +116,7 @@ class ChannelUpdater_Tests: StressTestCase {
         let cid: ChannelId = .unique
         let currentUserId: UserId = .unique
         
-        _ = try await { completion in
+        _ = try waitFor { completion in
             database.write({ (session) in
                 let currentUserPayload: CurrentUserPayload<NoExtraData> = .dummy(
                     userId: currentUserId,
@@ -148,7 +148,7 @@ class ChannelUpdater_Tests: StressTestCase {
         ]
 
         // Create new message
-        let newMessageId: MessageId = try await { completion in
+        let newMessageId: MessageId = try waitFor { completion in
             channelUpdater.createNewMessage(
                 in: cid,
                 text: text,
@@ -195,7 +195,7 @@ class ChannelUpdater_Tests: StressTestCase {
         let cid: ChannelId = .unique
         let currentUserId: UserId = .unique
         
-        _ = try await { completion in
+        _ = try waitFor { completion in
             database.write({ (session) in
                 let currentUserPayload: CurrentUserPayload<NoExtraData> = .dummy(
                     userId: currentUserId,
@@ -214,7 +214,7 @@ class ChannelUpdater_Tests: StressTestCase {
         let testError = TestError()
         database.write_errorResponse = testError
         
-        let result: Result<MessageId, Error> = try await { completion in
+        let result: Result<MessageId, Error> = try waitFor { completion in
             channelUpdater.createNewMessage(
                 in: .unique,
                 text: .unique,

--- a/Sources/StreamChat/Workers/ChatClientUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater_Tests.swift
@@ -74,7 +74,7 @@ final class ChatClientUpdater_Tests_Tests: StressTestCase {
         let updater = ChatClientUpdater<ExtraData>(client: client)
 
         // Simulate `connect` call.
-        let error = try await(updater.connect)
+        let error = try waitFor(updater.connect)
 
         // Assert `ClientError.ClientIsNotInActiveMode` is propagated
         XCTAssertTrue(error is ClientError.ClientIsNotInActiveMode)
@@ -88,7 +88,7 @@ final class ChatClientUpdater_Tests_Tests: StressTestCase {
         let updater = ChatClientUpdater<ExtraData>(client: client)
 
         // Simulate `connect` call.
-        let error = try await(updater.connect)
+        let error = try waitFor(updater.connect)
 
         // Assert `connect` completion is called without any error.
         XCTAssertNil(error)
@@ -228,7 +228,7 @@ final class ChatClientUpdater_Tests_Tests: StressTestCase {
 
         // Call `reloadUserIfNeeded` without changing a token provider
         // and synchronously get the result since no job should be done.
-        let error = try await(updater.reloadUserIfNeeded)
+        let error = try waitFor(updater.reloadUserIfNeeded)
 
         // Assert error is nil.
         XCTAssertNil(error)
@@ -387,7 +387,7 @@ final class ChatClientUpdater_Tests_Tests: StressTestCase {
         let updater = ChatClientUpdater<ExtraData>(client: client)
 
         // Simulate `reloadUserIfNeeded` call and catch the result.
-        let error = try await(updater.reloadUserIfNeeded)
+        let error = try waitFor(updater.reloadUserIfNeeded)
 
         // Assert error from token provider is propagated.
         XCTAssertEqual(error as? TestError, tokenProviderError)
@@ -411,7 +411,7 @@ final class ChatClientUpdater_Tests_Tests: StressTestCase {
         let updater = ChatClientUpdater<ExtraData>(client: client)
 
         // Simulate `reloadUserIfNeeded` call and catch the result.
-        let error = try await(updater.reloadUserIfNeeded)
+        let error = try waitFor(updater.reloadUserIfNeeded)
 
         // Assert `ClientError.ClientIsNotInActiveMode` is propagated.
         XCTAssertTrue(error is ClientError.ClientIsNotInActiveMode)
@@ -435,7 +435,7 @@ final class ChatClientUpdater_Tests_Tests: StressTestCase {
         client.mockDatabaseContainer.removeAllData_errorResponse = databaseFlushError
 
         // Simulate `reloadUserIfNeeded` call and catch the result.
-        let error = try await(updater.reloadUserIfNeeded)
+        let error = try waitFor(updater.reloadUserIfNeeded)
 
         // Assert database error is propagated.
         XCTAssertEqual(error as? TestError, databaseFlushError)

--- a/Sources/StreamChat/Workers/CurrentUserUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/CurrentUserUpdater_Tests.swift
@@ -169,7 +169,7 @@ final class CurrentUserUpdater_Tests: StressTestCase {
             try $0.saveCurrentUser(payload: userPayload)
         }
         
-        let error = try await {
+        let error = try waitFor {
             currentUserUpdater.updateUserData(
                 currentUserId: .unique,
                 name: nil,

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -43,7 +43,7 @@ final class MessageUpdater_Tests: StressTestCase {
     
     func test_editMessage_propogates_CurrentUserDoesNotExist_Error() throws {
         // Simulate `editMessage(messageId:, text:)` call
-        let completionError = try await {
+        let completionError = try waitFor {
             messageUpdater.editMessage(messageId: .unique, text: .unique, completion: $0)
         }
         
@@ -56,7 +56,7 @@ final class MessageUpdater_Tests: StressTestCase {
         try database.createCurrentUser()
         
         // Simulate `editMessage(messageId:, text:)` call
-        let completionError = try await {
+        let completionError = try waitFor {
             messageUpdater.editMessage(messageId: .unique, text: .unique, completion: $0)
         }
         
@@ -86,7 +86,7 @@ final class MessageUpdater_Tests: StressTestCase {
             try database.createMessage(id: messageId, authorId: currentUserId, localState: initialState)
             
             // Edit created message with new text
-            let completionError = try await {
+            let completionError = try waitFor {
                 messageUpdater.editMessage(messageId: messageId, text: updatedText, completion: $0)
             }
             
@@ -125,7 +125,7 @@ final class MessageUpdater_Tests: StressTestCase {
             try database.createMessage(id: messageId, authorId: currentUserId, text: initialText, localState: state)
             
             // Edit created message with new text
-            let completionError = try await {
+            let completionError = try waitFor {
                 messageUpdater.editMessage(messageId: messageId, text: updatedText, completion: $0)
             }
             
@@ -187,7 +187,7 @@ final class MessageUpdater_Tests: StressTestCase {
         database.write_errorResponse = databaseError
         
         // Simulate `deleteMessage(messageId:)` call
-        let completionError = try await {
+        let completionError = try waitFor {
             messageUpdater.deleteMessage(messageId: .unique, completion: $0)
         }
         
@@ -407,7 +407,7 @@ final class MessageUpdater_Tests: StressTestCase {
         ]
 
         // Create new reply message
-        let newMessageId: MessageId = try await { completion in
+        let newMessageId: MessageId = try waitFor { completion in
             messageUpdater.createNewReply(
                 in: cid,
                 text: text,
@@ -463,7 +463,7 @@ final class MessageUpdater_Tests: StressTestCase {
         let testError = TestError()
         database.write_errorResponse = testError
         
-        let result: Result<MessageId, Error> = try await { completion in
+        let result: Result<MessageId, Error> = try waitFor { completion in
             messageUpdater.createNewReply(
                 in: .unique,
                 text: .unique,
@@ -923,7 +923,7 @@ final class MessageUpdater_Tests: StressTestCase {
     func test_pinMessage_propogates_MessageDoesNotExist_Error() throws {
         try database.createCurrentUser()
 
-        let completionError = try await {
+        let completionError = try waitFor {
             messageUpdater.pinMessage(messageId: .unique, pinning: .expirationDate(.unique), completion: $0)
         }
 
@@ -951,7 +951,7 @@ final class MessageUpdater_Tests: StressTestCase {
             // Create a new message in the database
             try database.createMessage(id: messageId, authorId: currentUserId, localState: initialState)
 
-            let completionError = try await {
+            let completionError = try waitFor {
                 messageUpdater.pinMessage(messageId: messageId, pinning: pin, completion: $0)
             }
 
@@ -988,7 +988,7 @@ final class MessageUpdater_Tests: StressTestCase {
             // Create a new message in the database
             try database.createMessage(id: messageId, authorId: currentUserId, text: initialText, localState: state)
 
-            let completionError = try await {
+            let completionError = try waitFor {
                 messageUpdater.pinMessage(messageId: messageId, pinning: MessagePinning(expirationDate: .unique), completion: $0)
             }
 
@@ -1008,7 +1008,7 @@ final class MessageUpdater_Tests: StressTestCase {
     func test_unpinMessage_propogates_MessageDoesNotExist_Error() throws {
         try database.createCurrentUser()
 
-        let completionError = try await {
+        let completionError = try waitFor {
             messageUpdater.unpinMessage(messageId: .unique, completion: $0)
         }
 
@@ -1043,7 +1043,7 @@ final class MessageUpdater_Tests: StressTestCase {
                 localState: initialState
             )
 
-            let completionError = try await {
+            let completionError = try waitFor {
                 messageUpdater.unpinMessage(messageId: messageId, completion: $0)
             }
 
@@ -1088,7 +1088,7 @@ final class MessageUpdater_Tests: StressTestCase {
             )
 
             // Edit created message with new text
-            let completionError = try await {
+            let completionError = try waitFor {
                 messageUpdater.unpinMessage(messageId: messageId, completion: $0)
             }
 
@@ -1107,7 +1107,7 @@ final class MessageUpdater_Tests: StressTestCase {
     // MARK: - Restart failed attachment uploading
     
     func test_restartFailedAttachmentUploading_propagatesAttachmentDoesNotExistError() throws {
-        let error = try await {
+        let error = try waitFor {
             messageUpdater.restartFailedAttachmentUploading(with: .unique, completion: $0)
         }
 
@@ -1147,7 +1147,7 @@ final class MessageUpdater_Tests: StressTestCase {
             }
 
             // Try to restart uploading and catch the error.
-            let error = try await {
+            let error = try waitFor {
                 messageUpdater.restartFailedAttachmentUploading(with: attachmentId, completion: $0)
             }
 
@@ -1179,7 +1179,7 @@ final class MessageUpdater_Tests: StressTestCase {
         database.write_errorResponse = databaseError
 
         // Try to restart uploading and catch the error.
-        let error = try await {
+        let error = try waitFor {
             messageUpdater.restartFailedAttachmentUploading(with: attachmentId, completion: $0)
         }
 
@@ -1206,7 +1206,7 @@ final class MessageUpdater_Tests: StressTestCase {
         }
 
         // Try to restart uploading and catch the error.
-        let error = try await {
+        let error = try waitFor {
             messageUpdater.restartFailedAttachmentUploading(with: attachmentId, completion: $0)
         }
 
@@ -1218,7 +1218,7 @@ final class MessageUpdater_Tests: StressTestCase {
 
     func test_resendMessage_propagatesCurrentUserDoesNotExist_Error() throws {
         // Simulate `resendMessage` call
-        let completionError = try await {
+        let completionError = try waitFor {
             messageUpdater.resendMessage(with: .unique, completion: $0)
         }
 
@@ -1231,7 +1231,7 @@ final class MessageUpdater_Tests: StressTestCase {
         try database.createCurrentUser()
 
         // Simulate `resendMessage` call
-        let completionError = try await {
+        let completionError = try waitFor {
             messageUpdater.resendMessage(with: .unique, completion: $0)
         }
 
@@ -1262,7 +1262,7 @@ final class MessageUpdater_Tests: StressTestCase {
             try database.createMessage(id: messageId, authorId: currentUserId, localState: state)
             
             // Try to resend the message
-            let completionError = try await {
+            let completionError = try waitFor {
                 messageUpdater.resendMessage(with: messageId, completion: $0)
             }
             
@@ -1285,7 +1285,7 @@ final class MessageUpdater_Tests: StressTestCase {
         database.write_errorResponse = databaseError
 
         // Try to resend the message
-        let completionError = try await {
+        let completionError = try waitFor {
             messageUpdater.resendMessage(with: messageId, completion: $0)
         }
 
@@ -1304,7 +1304,7 @@ final class MessageUpdater_Tests: StressTestCase {
         try database.createMessage(id: messageId, authorId: currentUserId, localState: .sendingFailed)
 
         // Resend failed message
-        let completionError = try await {
+        let completionError = try waitFor {
             messageUpdater.resendMessage(with: messageId, completion: $0)
         }
 
@@ -1340,7 +1340,7 @@ final class MessageUpdater_Tests: StressTestCase {
         )
 
         // Simulate `dispatchEphemeralMessageAction`
-        let completionError = try await {
+        let completionError = try waitFor {
             messageUpdater.dispatchEphemeralMessageAction(
                 cid: cid,
                 messageId: messageId,
@@ -1479,7 +1479,7 @@ final class MessageUpdater_Tests: StressTestCase {
 
     func test_dispatchEphemeralMessageAction_propagatesCurrentUserDoesNotExist_Error() throws {
         // Simulate `dispatchEphemeralMessageAction` call
-        let completionError = try await {
+        let completionError = try waitFor {
             messageUpdater.dispatchEphemeralMessageAction(
                 cid: .unique,
                 messageId: .unique,
@@ -1497,7 +1497,7 @@ final class MessageUpdater_Tests: StressTestCase {
         try database.createCurrentUser()
 
         // Simulate `dispatchEphemeralMessageAction` call
-        let completionError = try await {
+        let completionError = try waitFor {
             messageUpdater.dispatchEphemeralMessageAction(
                 cid: .unique,
                 messageId: .unique,
@@ -1535,7 +1535,7 @@ final class MessageUpdater_Tests: StressTestCase {
             try database.createMessage(id: messageId, authorId: currentUserId, type: type)
 
             // Simulate `dispatchEphemeralMessageAction` call
-            let completionError = try await {
+            let completionError = try waitFor {
                 messageUpdater.dispatchEphemeralMessageAction(
                     cid: cid,
                     messageId: messageId,
@@ -1555,7 +1555,7 @@ final class MessageUpdater_Tests: StressTestCase {
         database.write_errorResponse = databaseError
 
         // Simulate `dispatchEphemeralMessageAction` call
-        let completionError = try await {
+        let completionError = try waitFor {
             messageUpdater.dispatchEphemeralMessageAction(
                 cid: .unique,
                 messageId: .unique,

--- a/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
@@ -106,7 +106,7 @@ class DatabaseContainerMock: DatabaseContainer {
 extension DatabaseContainer {
     /// Writes changes to the DB synchronously. Only for test purposes!
     func writeSynchronously(_ actions: @escaping (DatabaseSession) throws -> Void) throws {
-        let error = try await { completion in
+        let error = try waitFor { completion in
             self.write(actions, completion: completion)
         }
         if let error = error {

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC+SwiftUI.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC+SwiftUI.swift
@@ -9,6 +9,7 @@ import SwiftUI
 /// A `UIViewControllerRepresentable` subclass which wraps `ChatChannelListVC` and shows list of channels.
 public typealias ChatChannelList = _ChatChannelListVC<NoExtraData>.View
 
+@available(iOS 13.0, *)
 extension _ChatChannelListVC {
     /// A `UIViewControllerRepresentable` subclass which wraps `ChatChannelListVC` and shows list of channels.
     public struct View: UIViewControllerRepresentable {

--- a/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/ListCollectionViewLayout.swift
+++ b/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/ListCollectionViewLayout.swift
@@ -6,7 +6,7 @@ import StreamChat
 import UIKit
 
 /// The `ListCollectionViewLayout` delegate to control how to display the list.
-public protocol ListCollectionViewLayoutDelegate: class, UICollectionViewDelegate {
+public protocol ListCollectionViewLayoutDelegate: UICollectionViewDelegate {
     /// Implement this method to have detailed control over the visibility of the cell separators.
     func collectionView(
         _ collectionView: UICollectionView,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -276,7 +276,7 @@
 		799C945C247D59D8001F1104 /* ChatClient_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C942F247D2FB9001F1104 /* ChatClient_Tests.swift */; };
 		799C945E247D7283001F1104 /* DatabaseContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C945D247D7283001F1104 /* DatabaseContainer.swift */; };
 		799C9460247D77D6001F1104 /* DatabaseContainer_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C945F247D77D6001F1104 /* DatabaseContainer_Tests.swift */; };
-		799C9462247D78E2001F1104 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C9461247D78E2001F1104 /* Await.swift */; };
+		799C9462247D78E2001F1104 /* WaitFor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C9461247D78E2001F1104 /* WaitFor.swift */; };
 		799C9468247D791A001F1104 /* AssertJSONEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C9464247D7919001F1104 /* AssertJSONEqual.swift */; };
 		799C9469247D791A001F1104 /* AssertResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C9465247D7919001F1104 /* AssertResult.swift */; };
 		799C946A247D791A001F1104 /* AssertAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C9466247D7919001F1104 /* AssertAsync.swift */; };
@@ -918,7 +918,7 @@
 		F8788EDB261D9B99006019DD /* TemporaryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C9474247D7D41001F1104 /* TemporaryData.swift */; };
 		F8788EE5261D9BF0006019DD /* ChatClientUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8788EE4261D9BF0006019DD /* ChatClientUpdater_Mock.swift */; };
 		F8788EEE261D9CC2006019DD /* ChannelId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A71E22578EF650082498D /* ChannelId.swift */; };
-		F8788EF7261D9D18006019DD /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C9461247D78E2001F1104 /* Await.swift */; };
+		F8788EF7261D9D18006019DD /* WaitFor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799C9461247D78E2001F1104 /* WaitFor.swift */; };
 		F8788F00261D9D53006019DD /* UserPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790B9E3124DC221A005455AA /* UserPayload.swift */; };
 		F8788F09261D9D81006019DD /* CurrentUserPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0D649224E5794C0017A3C0 /* CurrentUserPayload.swift */; };
 		F8788F12261D9D92006019DD /* UnreadCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67415BF24F0129800C3222F /* UnreadCount.swift */; };
@@ -1442,7 +1442,7 @@
 		799C9451247D59B1001F1104 /* StreamChatTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StreamChatTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		799C945D247D7283001F1104 /* DatabaseContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseContainer.swift; sourceTree = "<group>"; };
 		799C945F247D77D6001F1104 /* DatabaseContainer_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseContainer_Tests.swift; sourceTree = "<group>"; };
-		799C9461247D78E2001F1104 /* Await.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Await.swift; sourceTree = "<group>"; };
+		799C9461247D78E2001F1104 /* WaitFor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WaitFor.swift; sourceTree = "<group>"; };
 		799C9464247D7919001F1104 /* AssertJSONEqual.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertJSONEqual.swift; sourceTree = "<group>"; };
 		799C9465247D7919001F1104 /* AssertResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertResult.swift; sourceTree = "<group>"; };
 		799C9466247D7919001F1104 /* AssertAsync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertAsync.swift; sourceTree = "<group>"; };
@@ -2598,7 +2598,7 @@
 			children = (
 				799C9463247D7919001F1104 /* CustomAssertions */,
 				792A71E22578EF650082498D /* ChannelId.swift */,
-				799C9461247D78E2001F1104 /* Await.swift */,
+				799C9461247D78E2001F1104 /* WaitFor.swift */,
 				791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */,
 				7988F6B624D15F100004219B /* StressTestCase.swift */,
 				799C9474247D7D41001F1104 /* TemporaryData.swift */,
@@ -5334,7 +5334,7 @@
 				F8788F36261DA083006019DD /* AttachmentPayload.swift in Sources */,
 				793061722577BB48005CF846 /* ChatMessageController_Mock.swift in Sources */,
 				7930614E2577A1AF005CF846 /* ChatUser_Mock.swift in Sources */,
-				F8788EF7261D9D18006019DD /* Await.swift in Sources */,
+				F8788EF7261D9D18006019DD /* WaitFor.swift in Sources */,
 				AD0169E625CAF235009EBAD2 /* CurrentChatUserController_Mock.swift in Sources */,
 				F8788F12261D9D92006019DD /* UnreadCount.swift in Sources */,
 				ADFCCD0825C9B8D70024505D /* ChannelUnreadCount_Mock.swift in Sources */,
@@ -5702,7 +5702,7 @@
 				796CBC6525FBAD12003299B0 /* Member_Tests.swift in Sources */,
 				79DDF812249CD5AC002F4412 /* APIClient_Tests.swift in Sources */,
 				DA7229E424E140600074503A /* ChannelEditDetailPayload_Tests.swift in Sources */,
-				799C9462247D78E2001F1104 /* Await.swift in Sources */,
+				799C9462247D78E2001F1104 /* WaitFor.swift in Sources */,
 				88DA57EA2631E82B00FA8C53 /* MutedChannelPayload_Tests.swift in Sources */,
 				88AA92882547332000BFA0C3 /* MessageReactionPayload.swift in Sources */,
 				8A0D64A924E57A560017A3C0 /* GuestUserTokenRequestPayload_Tests.swift in Sources */,

--- a/Tests/Shared/WaitFor.swift
+++ b/Tests/Shared/WaitFor.swift
@@ -8,29 +8,29 @@ enum WaiterError: Error {
     case waitingForResultTimedOut
 }
 
-/// The maximum time `await` waits for the wrapped function to complete. When running stress tests, this value
+/// The maximum time `waitFor` waits for the wrapped function to complete. When running stress tests, this value
 /// is much higher because the system might be under very heavy load.
-private let awaitTimeout: TimeInterval = TestRunnerEnvironment.isStressTest || TestRunnerEnvironment.isCI ? 10 : 1
+private let waitForTimeout: TimeInterval = TestRunnerEnvironment.isStressTest || TestRunnerEnvironment.isCI ? 10 : 1
 
 /// Allows calling an asynchronous function in the synchronous way in tests.
 ///
 /// Example usage:
 /// ```
 ///   func asyncFunction(completion: (T) -> Void) { }
-///   let result: T = try await { asyncFunction(completion: $0) }
+///   let result: T = try waitFor { asyncFunction(completion: $0) }
 /// ```
 ///
 /// - Parameters:
 ///   - timeout: The maximum time this function waits for `action` to complete.
 ///   - action: The asynchronous action this function wrapps.
 ///   - done: `action` is required to call this closure when finished. The value then becomes the return value of
-///     the whole `await` function.
+///     the whole `waitFor` function.
 ///
 /// - Throws: `WaiterError.waitingForResultTimedOut` if `action` doesn't call the completion closure within the `timeout` period.
 ///
 /// - Returns: The result of `action`.
-func await<T>(
-    timeout: TimeInterval = awaitTimeout,
+func waitFor<T>(
+    timeout: TimeInterval = waitForTimeout,
     file: StaticString = #file,
     line: UInt = #line,
     _ action: (_ done: @escaping (T) -> Void) -> Void


### PR DESCRIPTION
With the new `async/await` that'll eventually be introduced to Swift, our own `await` stuff was causing a lot of warnings, now that's resolved, alongside other minor warnings.