### PR TITLE
Update `ChatMessageAttachment` to have non-optional payload

### DIFF
--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
@@ -90,9 +90,9 @@ class AttachmentDTO_Tests: XCTestCase {
             fileAttachment.uploadingState,
             attachmentEnvelope.localFileURL.map { .init(localFileURL: $0, state: .pendingUpload) }
         )
-        XCTAssertEqual(fileAttachment.payload.title, attachmentEnvelope.localFileURL?.lastPathComponent)
-        XCTAssertEqual(fileAttachment.payload.file, attachmentEnvelope.localFileURL?.attachmentFile)
-        XCTAssertEqual(fileAttachment.payload.assetURL, attachmentEnvelope.localFileURL)
+        XCTAssertEqual(fileAttachment.title, attachmentEnvelope.localFileURL?.lastPathComponent)
+        XCTAssertEqual(fileAttachment.file, attachmentEnvelope.localFileURL?.attachmentFile)
+        XCTAssertEqual(fileAttachment.assetURL, attachmentEnvelope.localFileURL)
     }
 
     func test_attachmentEnvelope_isStoredAndLoadedFromDB() throws {

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
@@ -90,9 +90,9 @@ class AttachmentDTO_Tests: XCTestCase {
             fileAttachment.uploadingState,
             attachmentEnvelope.localFileURL.map { .init(localFileURL: $0, state: .pendingUpload) }
         )
-        XCTAssertEqual(fileAttachment.payload?.title, attachmentEnvelope.localFileURL?.lastPathComponent)
-        XCTAssertEqual(fileAttachment.payload?.file, attachmentEnvelope.localFileURL?.attachmentFile)
-        XCTAssertEqual(fileAttachment.payload?.assetURL, attachmentEnvelope.localFileURL)
+        XCTAssertEqual(fileAttachment.payload.title, attachmentEnvelope.localFileURL?.lastPathComponent)
+        XCTAssertEqual(fileAttachment.payload.file, attachmentEnvelope.localFileURL?.attachmentFile)
+        XCTAssertEqual(fileAttachment.payload.assetURL, attachmentEnvelope.localFileURL)
     }
 
     func test_attachmentEnvelope_isStoredAndLoadedFromDB() throws {

--- a/Sources/StreamChat/Models/Attachments/ChatMessageAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageAttachment.swift
@@ -11,11 +11,16 @@ public struct AttachmentUploadingState: Equatable {
     public let state: LocalAttachmentState
 }
 
+@dynamicMemberLookup
 public struct _ChatMessageAttachment<Payload> {
     public let id: AttachmentId
     public let type: AttachmentType
     public let payload: Payload
     public let uploadingState: AttachmentUploadingState?
+
+    public subscript<T>(dynamicMember keyPath: KeyPath<Payload, T>) -> T {
+        payload[keyPath: keyPath]
+    }
 }
 
 extension _ChatMessageAttachment: Equatable where Payload: Equatable {}

--- a/Sources/StreamChat/Models/Attachments/ChatMessageAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageAttachment.swift
@@ -14,7 +14,7 @@ public struct AttachmentUploadingState: Equatable {
 public struct _ChatMessageAttachment<Payload> {
     public let id: AttachmentId
     public let type: AttachmentType
-    public let payload: Payload?
+    public let payload: Payload
     public let uploadingState: AttachmentUploadingState?
 }
 
@@ -26,14 +26,18 @@ extension _ChatMessageAttachment {
     ) -> _ChatMessageAttachment<Payload>? {
         guard Payload.type == type else { return nil }
 
-        let concretePayload: Payload?
+        let concretePayload: Payload
         switch payload {
         case let payload as Payload:
             concretePayload = payload
         case let data as Data:
-            concretePayload = try? JSONDecoder.stream.decode(Payload.self, from: data)
+            guard
+                let decodedPayload = try? JSONDecoder.stream.decode(Payload.self, from: data)
+            else { return nil }
+
+            concretePayload = decodedPayload
         default:
-            concretePayload = nil
+            return nil
         }
 
         return .init(

--- a/Sources/StreamChat/Workers/Background/AttachmentUploader_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/AttachmentUploader_Tests.swift
@@ -93,7 +93,7 @@ final class AttachmentUploader_Tests: StressTestCase {
                     // Assert attachment state eventually becomes `.uploaded`.
                     Assert.willBeEqual(imageModel?.uploadingState?.state, .uploaded)
                     // Assert `attachment.imageURL` is set.
-                    Assert.willBeEqual(originalURLString(imageModel?.payload.imageURL), payload.file.absoluteString)
+                    Assert.willBeEqual(originalURLString(imageModel?.imageURL), payload.file.absoluteString)
                 }
             case .file:
                 var fileModel: ChatMessageFileAttachment? {
@@ -103,7 +103,7 @@ final class AttachmentUploader_Tests: StressTestCase {
                     // Assert attachment state eventually becomes `.uploaded`.
                     Assert.willBeEqual(fileModel?.uploadingState?.state, .uploaded)
                     // Assert `attachment.assetURL` is set.
-                    Assert.willBeEqual(originalURLString(fileModel?.payload.assetURL), payload.file.absoluteString)
+                    Assert.willBeEqual(originalURLString(fileModel?.assetURL), payload.file.absoluteString)
                 }
             default: throw TestError()
             }

--- a/Sources/StreamChat/Workers/Background/AttachmentUploader_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/AttachmentUploader_Tests.swift
@@ -93,7 +93,7 @@ final class AttachmentUploader_Tests: StressTestCase {
                     // Assert attachment state eventually becomes `.uploaded`.
                     Assert.willBeEqual(imageModel?.uploadingState?.state, .uploaded)
                     // Assert `attachment.imageURL` is set.
-                    Assert.willBeEqual(originalURLString(imageModel?.payload?.imageURL), payload.file.absoluteString)
+                    Assert.willBeEqual(originalURLString(imageModel?.payload.imageURL), payload.file.absoluteString)
                 }
             case .file:
                 var fileModel: ChatMessageFileAttachment? {
@@ -103,7 +103,7 @@ final class AttachmentUploader_Tests: StressTestCase {
                     // Assert attachment state eventually becomes `.uploaded`.
                     Assert.willBeEqual(fileModel?.uploadingState?.state, .uploaded)
                     // Assert `attachment.assetURL` is set.
-                    Assert.willBeEqual(originalURLString(fileModel?.payload?.assetURL), payload.file.absoluteString)
+                    Assert.willBeEqual(originalURLString(fileModel?.payload.assetURL), payload.file.absoluteString)
                 }
             default: throw TestError()
             }

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatFileAttachmentListView+ItemView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatFileAttachmentListView+ItemView.swift
@@ -144,7 +144,7 @@ extension _ChatMessageFileAttachmentListView {
         // MARK: - Private
 
         private var fileIcon: UIImage? {
-            guard let file = content?.payload?.file else { return nil }
+            guard let file = content?.file else { return nil }
 
             return appearance.images.fileIcons[file.type] ?? appearance.images.fileFallback
         }

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageGiphyView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageGiphyView.swift
@@ -12,7 +12,7 @@ public typealias ChatMessageGiphyView = _ChatMessageGiphyView<NoExtraData>
 open class _ChatMessageGiphyView<ExtraData: ExtraDataTypes>: _View, ComponentsProvider {
     public var content: ChatMessageGiphyAttachment? {
         didSet {
-            let isDifferentImage = oldValue?.payload?.previewURL != content?.payload?.previewURL
+            let isDifferentImage = oldValue?.previewURL != content?.previewURL
             guard hasFailed || isDifferentImage else { return }
             updateContentIfNeeded()
         }
@@ -75,7 +75,7 @@ open class _ChatMessageGiphyView<ExtraData: ExtraDataTypes>: _View, ComponentsPr
         imageTask = nil
         imageView.clear()
 
-        if let url = content?.payload?.previewURL {
+        if let url = content?.previewURL {
             imageTask = ImagePipeline.shared.loadData(with: url) { [weak self] result in
                 guard case let .success((rawGif, _)) = result else {
                     self?.hasFailed = true

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery+ImagePreview.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery+ImagePreview.swift
@@ -80,7 +80,7 @@ extension _ChatMessageImageGallery {
             loadingIndicator.isVisible = true
             imageView.layoutIfNeeded()
             imageTask = imageView
-                .loadImage(from: attachment?.payload?.imagePreviewURL, resizeAutomatically: false) { [weak self] _ in
+                .loadImage(from: attachment?.payload.imagePreviewURL, resizeAutomatically: false) { [weak self] _ in
                     self?.loadingIndicator.isVisible = false
                     self?.imageTask = nil
                 }

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView.swift
@@ -88,11 +88,11 @@ open class _ChatMessageInteractiveAttachmentView<ExtraData: ExtraDataTypes>: _Vi
     override open func updateContent() {
         preview.content = content
 
-        titleLabel.text = "\"" + (content?.payload?.title ?? "") + "\""
+        titleLabel.text = "\"" + (content?.title ?? "") + "\""
 
         actionsStackView.removeAllArrangedSubviews()
         
-        (content?.payload?.actions ?? [])
+        (content?.actions ?? [])
             .map(createActionButton)
             .forEach(actionsStackView.addArrangedSubview)
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.swift
@@ -44,7 +44,7 @@ open class ChatMessageListCollectionViewLayout: UICollectionViewLayout {
     /// With better approximation you are getting better performance
     open var estimatedItemHeight: CGFloat = 200
     /// Vertical spacing between items
-    open var spacing: CGFloat = 4
+    open var spacing: CGFloat = 2
 
     /// Items that have been added to collectionview during currently running batch updates
     open var appearingItems: Set<IndexPath> = []

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -98,6 +98,7 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
 
         messageController.setDelegate(self)
         messageController.synchronize()
+        messageController.loadPreviousReplies()
 
         updateNavigationTitle()
     }

--- a/Sources/StreamChatUI/ImageGallery/ImageCollectionViewCell.swift
+++ b/Sources/StreamChatUI/ImageGallery/ImageCollectionViewCell.swift
@@ -67,7 +67,7 @@ open class ImageCollectionViewCell: _CollectionViewCell, UIScrollViewDelegate {
     override open func updateContent() {
         super.updateContent()
 
-        imageView.loadImage(from: content.payload?.imageURL, resizeAutomatically: false)
+        imageView.loadImage(from: content.payload.imageURL, resizeAutomatically: false)
     }
     
     open func viewForZooming(in scrollView: UIScrollView) -> UIView? {

--- a/Sources/StreamChatUI/ImageGallery/ImageGalleryVC.swift
+++ b/Sources/StreamChatUI/ImageGallery/ImageGalleryVC.swift
@@ -245,7 +245,7 @@ open class _ImageGalleryVC<ExtraData: ExtraDataTypes>:
     /// Called when `shareButton` is tapped.
     @objc
     open func shareButtonTapped() {
-        guard let imageURL = images[currentPage].payload?.imageURL else { return }
+        let imageURL = images[currentPage].payload.imageURL
         let activityViewController = UIActivityViewController(
             activityItems: [imageURL],
             applicationActivities: nil


### PR DESCRIPTION
**This PR**:
- makes `ChatMessageAttachment.payload` non-optional
- adds dynamic payload lookup to `ChatMessageAttachment`