### PR TITLE
[CIS-834] Hotfix: Layout feedback loop when longtapping message

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListRouter.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListRouter.swift
@@ -22,6 +22,7 @@ open class _ChatMessageListRouter<ExtraData: ExtraDataTypes>: ChatRouter<_ChatMe
         popup.modalPresentationStyle = .overFullScreen
         popup.modalTransitionStyle = .crossDissolve
 
+        navigationController?.view.endEditing(true)
         rootViewController.present(popup, animated: false)
     }
     


### PR DESCRIPTION
**Important note: The branch to merge is `release/beta`, we need to pick this commit into other release branches as well...** 

# What this PR do:
- Hotfixes crash that occured while longpressing message with active keyboard for composer
# How to test it
 Follow steps in the ticket:

- Open any chat and make keyboard appear by tapping in composer input on real device or show keyboard on simulator
- Long tap on message any message cell to pupup context menu
- Expect app not to crash on layout feedback loop, because keyboard should be already hidden... 

This is hotfix, the proper fix should come with composer audit where the layout feedback loop is properly resolved