### PR TITLE
Add header support to `ChatMessageListCVLayout`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -258,6 +258,7 @@ var streamChatUIFilesExcluded: [String] { [
     "ChatMessageList/ChatMessage/__Snapshots__/ChatMessageContentView_Tests/test_appearance.default-light-bubble-continuousBubble-avatarSizePadding-text-quotedMessage-threadInfo-reactions.png",
     "ChatMessageList/ChatMessage/__Snapshots__/ChatMessageContentView_Tests/test_appearance.default-light-bubble-avatar-metadata-text-reactions.png",
     "ChatMessageList/ChatMessage/__Snapshots__/ChatMessageContentView_Tests/test_appearanceCustomization_usingSubclassing.default-light.png",
+    "ChatMessageList/ChatThreadVC_Tests.swift",
     "ChatMessageList/TitleContainerView_Tests.swift",
     "ChatMessageList/Attachments/ChatMessageFileAttachmentListView_Tests.swift",
     "ChatMessageList/Attachments/ChatMessageImageGallery_Tests.swift",

--- a/Sources/StreamChatTestTools/Controllers/ChatMessageController_Mock.swift
+++ b/Sources/StreamChatTestTools/Controllers/ChatMessageController_Mock.swift
@@ -6,6 +6,34 @@ import Foundation
 @testable import StreamChat
 
 public class ChatMessageController_Mock<ExtraData: ExtraDataTypes>: _ChatMessageController<ExtraData> {
+    public private(set) var loadNextReplies_called = false
+    override public func loadNextReplies(
+        after messageId: MessageId? = nil,
+        limit: Int = 25,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        loadNextReplies_called = true
+        super.loadNextReplies(
+            after: messageId,
+            limit: limit,
+            completion: completion
+        )
+    }
+    
+    public private(set) var loadPreviousReplies_called = false
+    override public func loadPreviousReplies(
+        before messageId: MessageId? = nil,
+        limit: Int = 25,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        loadPreviousReplies_called = true
+        super.loadPreviousReplies(
+            before: messageId,
+            limit: limit,
+            completion: completion
+        )
+    }
+    
     /// Creates a new mock instance of `ChatMessageController`.
     public static func mock() -> ChatMessageController_Mock<ExtraData> {
         .init(client: .mock(), cid: try! .init(cid: "mock:channel"), messageId: "MockMessage")

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC_Tests.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC_Tests.swift
@@ -1,0 +1,40 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+@testable import StreamChatTestTools
+import StreamChatUI
+import XCTest
+
+final class ChatThreadVC_Tests: XCTestCase {
+    private var subject: ChatThreadVC!
+    private var channelController: ChatChannelController_Mock<NoExtraData>!
+    private var messageController: ChatMessageController_Mock<NoExtraData>!
+    
+    // MARK: - Setup
+    
+    override func setUp() {
+        super.setUp()
+        
+        channelController = .mock()
+        messageController = .mock()
+        
+        subject = .init()
+        subject.channelController = channelController
+        subject.messageController = messageController
+    }
+    
+    // MARK: - Tests
+    
+    func test_threadVC_loadsInitialReplies() {
+        // we need `viewDidLoad` to be called as replies are loaded there
+        subject.loadViewIfNeeded()
+        
+        XCTAssertTrue(messageController.loadPreviousReplies_called)
+    }
+    
+    func test_threadVC_hasStickyHeader() {
+        XCTAssertTrue(subject.messageListLayout.estimatedHeaderHeight > 0)
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		64DA56BB26412EED00DCBF82 /* ChannelDatabaseCleanupUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64DA56BA26412EED00DCBF82 /* ChannelDatabaseCleanupUpdater.swift */; };
 		64DA56BD2641587D00DCBF82 /* ChannelListCleanupUpdater_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64DA56BC2641587D00DCBF82 /* ChannelListCleanupUpdater_Tests.swift */; };
 		64F70D4B26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F70D4A26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift */; };
+		6902F7A02645619000F89AA5 /* ChatThreadVC_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6902F79F2645619000F89AA5 /* ChatThreadVC_Tests.swift */; };
 		6971257E260CA503003C7B47 /* NSManagedObjectContext+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6971256C260CA4CB003C7B47 /* NSManagedObjectContext+Extensions.swift */; };
 		69736BF226413E5D00090B67 /* ChatMessageListScrollOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69736BF126413E5D00090B67 /* ChatMessageListScrollOverlayView.swift */; };
 		697C6F90260CFA37000E9023 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69712522260BC9B4003C7B47 /* Deprecations.swift */; };
@@ -1232,6 +1233,7 @@
 		64DA56BA26412EED00DCBF82 /* ChannelDatabaseCleanupUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelDatabaseCleanupUpdater.swift; sourceTree = "<group>"; };
 		64DA56BC2641587D00DCBF82 /* ChannelListCleanupUpdater_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListCleanupUpdater_Tests.swift; sourceTree = "<group>"; };
 		64F70D4A26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+InternetNotAvailable_Tests.swift"; sourceTree = "<group>"; };
+		6902F79F2645619000F89AA5 /* ChatThreadVC_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThreadVC_Tests.swift; sourceTree = "<group>"; };
 		69712522260BC9B4003C7B47 /* Deprecations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecations.swift; sourceTree = "<group>"; };
 		6971256C260CA4CB003C7B47 /* NSManagedObjectContext+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Extensions.swift"; sourceTree = "<group>"; };
 		69736BF126413E5D00090B67 /* ChatMessageListScrollOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListScrollOverlayView.swift; sourceTree = "<group>"; };
@@ -2433,6 +2435,7 @@
 				69736BF126413E5D00090B67 /* ChatMessageListScrollOverlayView.swift */,
 				A396B752260CCE7400D8D15B /* TitleContainerView_Tests.swift */,
 				A30DEC98260B47DE0066E8CE /* TitleContainerView.swift */,
+				6902F79F2645619000F89AA5 /* ChatThreadVC_Tests.swift */,
 			);
 			path = ChatMessageList;
 			sourceTree = "<group>";
@@ -5291,6 +5294,8 @@
 				79B4F14325D3F0F70063FFB5 /* ChannelId.swift in Sources */,
 				A3C0D774261CA25700A8A1A2 /* ContainerStackView_Tests.swift in Sources */,
 				AD71130225F138BA00932AEE /* ChatChannelAvatarView_Tests.swift in Sources */,
+				ADEA7F10261D28A400CA2289 /* ChatImageAttachmentsCollectionView_Tests.swift in Sources */,
+				6902F7A02645619000F89AA5 /* ChatThreadVC_Tests.swift in Sources */,
 				BDDD1EA42632C66200BA007B /* Components+SwiftUI_Tests.swift in Sources */,
 				7849AF6725F243C8007817D4 /* ChatChannelListItemView+SwiftUI_Tests.swift in Sources */,
 				F86C887725FA5C020000BCA9 /* ChatChannelAvatarView+SwiftUI_Tests.swift in Sources */,


### PR DESCRIPTION
- load replies in `ChatThreadVC`
- add header support to `ChatMessageListCollectionViewLayout`
- show `messageController.message` as header in `ChatThreadVC`
- add some tests to `ChatThreadVC`