### PR TITLE
[CIS-224] Implement token refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- Refresh authorization token when WebSocket connection disconnects because the token has expired [#1069](https://github.com/GetStream/stream-chat-swift/pull/1069)
+
 ### 🐞 Fixed
 - Fix crash when opening attachments on iPad [#1060](https://github.com/GetStream/stream-chat-swift/pull/1060) [#997](https://github.com/GetStream/stream-chat-swift/pull/977)
 

--- a/Sources/StreamChatTestTools/ChatClientUpdater_Mock.swift
+++ b/Sources/StreamChatTestTools/ChatClientUpdater_Mock.swift
@@ -9,7 +9,13 @@ class ChatClientUpdaterMock<ExtraData: ExtraDataTypes>: ChatClientUpdater<ExtraD
     @Atomic var prepareEnvironment_newToken: Token?
     var prepareEnvironment_called: Bool { prepareEnvironment_newToken != nil }
 
-    @Atomic var reloadUserIfNeeded_called = false
+    @Atomic var reloadUserIfNeeded_called = false {
+        didSet {
+            reloadUserIfNeeded_callsCount += 1
+        }
+    }
+
+    var reloadUserIfNeeded_callsCount = 0
     @Atomic var reloadUserIfNeeded_completion: ((Error?) -> Void)?
     @Atomic var reloadUserIfNeeded_callSuper: (() -> Void)?
 
@@ -47,6 +53,7 @@ class ChatClientUpdaterMock<ExtraData: ExtraDataTypes>: ChatClientUpdater<ExtraD
         prepareEnvironment_newToken = nil
 
         reloadUserIfNeeded_called = false
+        reloadUserIfNeeded_callsCount = 0
         reloadUserIfNeeded_completion = nil
         reloadUserIfNeeded_callSuper = nil
 


### PR DESCRIPTION
When websocket disconnects with token expiration error we should call `reloadUserIfNeeded` to reacquire it 