### PR TITLE
Use `usEast` as the default base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix crash when opening attachments on iPad [#1060](https://github.com/GetStream/stream-chat-swift/pull/1060) [#997](https://github.com/GetStream/stream-chat-swift/pull/977)
 
 ### 🔄 Changed
+- ⚠️ The default `BaseURL` was changed from `.dublin` to `.usEast` to match other SDKs [#1078](https://github.com/GetStream/stream-chat-swift/pull/1078)
 - Split `UIConfig` into `Appearance` and `Components` to improve clarity [#1014](https://github.com/GetStream/stream-chat-swift/pull/1014)
 - Change log level for `ChannelRead` when it doesn't exist in channel from `error` to `info` [#1043](https://github.com/GetStream/stream-chat-swift/pull/1043) 
 - Newly joined members' `markRead` events will cause a read object creation for them [#1068](https://github.com/GetStream/stream-chat-swift/pull/1068)

--- a/Sources/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources/StreamChat/Config/ChatClientConfig.swift
@@ -16,7 +16,7 @@ import Foundation
 public struct ChatClientConfig {
     /// The `APIKey` unique for your chat app.
     ///
-    /// The API key can be obtained by registering on [our website](https://getstream.io/chat/trial/).
+    /// The API key can be obtained by registering on [our website](https://getstream.io/chat/\).
     ///
     public let apiKey: APIKey
     
@@ -27,7 +27,7 @@ public struct ChatClientConfig {
     }()
     
     /// The datacenter `ChatClient` uses for connecting.
-    public var baseURL: BaseURL = .dublin
+    public var baseURL: BaseURL = .usEast
     
     /// Determines whether `ChatClient` caches the data locally. This makes it possible to browse the existing chat data also
     /// when the internet connection is not available.
@@ -103,7 +103,7 @@ extension ChatClientConfig {
 
 /// A struct representing an API key of the chat app.
 ///
-/// An API key can be obtained by registering on [our website](https://getstream.io/chat/trial/).
+/// An API key can be obtained by registering on [our website](https://getstream.io/chat/trial/\).
 ///
 public struct APIKey: Equatable {
     /// The string representation of the API key


### PR DESCRIPTION
make sure to connect to us-east by default, this needs to be added clearly to the changelog 