### PR TITLE
[CIS-841] Fix custom fonts breaking composer input resizing

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerInputTextView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/MessageComposer/ChatMessageComposerInputTextView.swift
@@ -12,10 +12,6 @@ internal class _ChatMessageComposerInputTextView<ExtraData: ExtraDataTypes>: UIT
     Customizable,
     UIConfigProvider
 {
-    // MARK: - Properties
-            
-    lazy var textViewHeightConstraint = heightAnchor.pin(equalToConstant: .zero)
-    
     // MARK: - Subviews
     
     internal lazy var placeholderLabel: UILabel = UILabel()
@@ -85,8 +81,6 @@ internal class _ChatMessageComposerInputTextView<ExtraData: ExtraDataTypes>: UIT
         placeholderLabel.pin(anchors: [.centerY], to: self)
         
         isScrollEnabled = false
-        
-        textViewHeightConstraint.isActive = true
     }
     
     internal func updateContent() {}
@@ -98,7 +92,5 @@ internal class _ChatMessageComposerInputTextView<ExtraData: ExtraDataTypes>: UIT
         
     @objc func textDidChange() {
         placeholderLabel.isHidden = !text.isEmpty
-        textViewHeightConstraint.constant = calculatedTextHeight() + textContainerInset.bottom + textContainerInset.top
-        layoutIfNeeded()
     }
 }


### PR DESCRIPTION
# In this PR
Removes the manual text view height calculation that causes UITextView layout glitches. (This is already on main)

**Before:** 

https://user-images.githubusercontent.com/12814114/118479894-788c9580-b709-11eb-957a-11302c777376.mov

**After:** 

https://user-images.githubusercontent.com/12814114/118479916-804c3a00-b709-11eb-99fa-082b4e973f94.mov




