### PR TITLE
[CIS-843] Fallback to `unknown` if attachment type is missing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -140,6 +140,7 @@ var streamChatSourcesExcluded: [String] { [
     "Models/ChannelId_Tests.swift",
     "Models/Attachments/AttachmentTypes_Tests.swift",
     "Models/Attachments/AttachmentId_Tests.swift",
+    "Models/Attachments/ChatMessageAttachment_Tests.swift",
     "Models/ChatMessage_Tests.swift",
     "Workers/Background/NewChannelQueryUpdater_Tests.swift",
     "Workers/Background/AttachmentUploader_Tests.swift",

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessageAttachmentPayload_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessageAttachmentPayload_Tests.swift
@@ -43,4 +43,10 @@ final class MessageAttachmentPayload_Tests: XCTestCase {
         XCTAssertEqual(payload.type, "party_invite")
         XCTAssertEqual(payload.payload, expectedRawJSON)
     }
+
+    func test_unknownIsUsed_ifTypeIsMissing() throws {
+        let json = XCTestCase.mockData(fromFile: "AttachmentPayload+NoType", extension: "json")
+        let payload = try JSONDecoder.default.decode(MessageAttachmentPayload.self, from: json)
+        XCTAssertEqual(payload.type, .unknown)
+    }
 }

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
@@ -65,7 +65,7 @@ class MessagePayload_Tests: XCTestCase {
         XCTAssertEqual(payload.isSilent, true)
         XCTAssertEqual(payload.channel?.cid.rawValue, "messaging:channel-ex7-63")
         XCTAssertEqual(payload.quotedMessage?.id, "4C0CC2DA-8AB5-421F-808E-50DC7E40653D")
-        XCTAssertEqual(payload.attachments.count, 1)
+        XCTAssertEqual(payload.attachments.count, 2)
         XCTAssertEqual(payload.pinned, true)
         XCTAssertEqual(payload.pinnedAt, "2021-04-15T06:43:08.776911Z".toDate())
         XCTAssertEqual(payload.pinExpires, "2021-05-15T06:43:08.776911Z".toDate())

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON.swift
@@ -10,6 +10,7 @@ import Foundation
 indirect enum RawJSON: Codable, Hashable {
     case double(Double)
     case string(String)
+    case integer(Int)
     case bool(Bool)
     case dictionary([String: RawJSON])
     case array([RawJSON])
@@ -22,6 +23,9 @@ indirect enum RawJSON: Codable, Hashable {
             return
         } else if let value = try? singleValueContainer.decode(String.self) {
             self = .string(value)
+            return
+        } else if let value = try? singleValueContainer.decode(Int.self) {
+            self = .integer(value)
             return
         } else if let value = try? singleValueContainer.decode(Double.self) {
             self = .double(value)
@@ -47,6 +51,7 @@ indirect enum RawJSON: Codable, Hashable {
         var container = encoder.singleValueContainer()
         
         switch self {
+        case let .integer(value): try container.encode(value)
         case let .double(value): try container.encode(value)
         case let .bool(value): try container.encode(value)
         case let .string(value): try container.encode(value)

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -328,14 +328,3 @@ extension ClientError {
 
     class AttachmentDecoding: ClientError {}
 }
-
-extension _ChatMessageAttachment {
-    var asAnyAttachment: AnyChatMessageAttachment {
-        .init(
-            id: id,
-            type: type,
-            payload: payload as Any,
-            uploadingState: uploadingState
-        )
-    }
-}

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -299,12 +299,6 @@ extension LocalAttachmentState {
 }
 
 extension ClientError {
-    class MissingAttachmentType: ClientError {
-        init(id: AttachmentId) {
-            super.init("Attachment type is missing for attachment with id: \(id).")
-        }
-    }
-    
     class AttachmentDoesNotExist: ClientError {
         init(id: AttachmentId) {
             super.init("There is no `AttachmentDTO` instance in the DB matching id: \(id).")
@@ -314,15 +308,6 @@ extension ClientError {
     class AttachmentEditing: ClientError {
         init(id: AttachmentId, reason: String) {
             super.init("`AttachmentDTO` with id: \(id) can't be edited (\(reason))")
-        }
-    }
-    
-    class AttachmentSeedUploading: ClientError {
-        init(id: AttachmentId) {
-            super.init(
-                "Uploading only supported for attachments of type `.image` and `.file`."
-                    + "Failed to upload attachment with id: \(id)"
-            )
         }
     }
 

--- a/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
+++ b/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
@@ -106,6 +106,8 @@ public extension AttachmentType {
 
     /// Application custom types.
     static let linkPreview = Self(rawValue: "linkPreview")
+    /// Is used when attachment with missing `type` comes.
+    static let unknown = Self(rawValue: "unknown")
 }
 
 /// An attachment file description.

--- a/Sources/StreamChat/Models/Attachments/ChatMessageAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageAttachment.swift
@@ -26,11 +26,13 @@ public struct _ChatMessageAttachment<Payload> {
 
 extension _ChatMessageAttachment: Equatable where Payload: Equatable {}
 
-extension _ChatMessageAttachment {
+// MARK: - Type erasure/recovery
+
+extension AnyChatMessageAttachment {
     func attachment<Payload: AttachmentPayload>(
         payloadType: Payload.Type
     ) -> _ChatMessageAttachment<Payload>? {
-        guard Payload.type == type else { return nil }
+        guard Payload.type == type || type == .unknown else { return nil }
 
         let concretePayload: Payload
         switch payload {
@@ -50,6 +52,17 @@ extension _ChatMessageAttachment {
             id: id,
             type: type,
             payload: concretePayload,
+            uploadingState: uploadingState
+        )
+    }
+}
+
+extension _ChatMessageAttachment {
+    var asAnyAttachment: AnyChatMessageAttachment {
+        .init(
+            id: id,
+            type: type,
+            payload: payload as Any,
             uploadingState: uploadingState
         )
     }

--- a/Sources/StreamChat/Models/Attachments/ChatMessageAttachment_Tests.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageAttachment_Tests.swift
@@ -1,0 +1,105 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class ChatMessageAttachment_Tests: XCTestCase {
+    func test_payloadMemberLookUp() throws {
+        // Create file attachment with the given payload.
+        let attachment: ChatMessageFileAttachment = .mock(id: .unique)
+
+        // Assert payload fields are accessed correctly.
+        XCTAssertEqual(attachment.title, attachment.payload.title)
+        XCTAssertEqual(attachment.assetURL, attachment.payload.assetURL)
+        XCTAssertEqual(attachment.file, attachment.payload.file)
+    }
+
+    func test_asAnyAttachment() throws {
+        // Create file attachment.
+        let fileAttachment: ChatMessageFileAttachment = .mock(
+            id: .unique,
+            localState: .pendingUpload
+        )
+
+        // Erase attachment type.
+        let typeErasedAttachment = fileAttachment.asAnyAttachment
+
+        // Assert type-erased attachment has correct values.
+        XCTAssertEqual(typeErasedAttachment.id, fileAttachment.id)
+        XCTAssertEqual(typeErasedAttachment.type, fileAttachment.type)
+        XCTAssertEqual(typeErasedAttachment.payload as! FileAttachmentPayload, fileAttachment.payload)
+        XCTAssertEqual(typeErasedAttachment.uploadingState, fileAttachment.uploadingState)
+    }
+
+    func test_anyAttachment_withKnownType_asConcreteAttachment() throws {
+        // Create file attachment with known `file` type.
+        let originalAttachment = ChatMessageFileAttachment.mock(id: .unique)
+
+        // Erase attachment type.
+        let typeErasedAttachment = originalAttachment.asAnyAttachment
+
+        // Assert the attempt to treat attachment as `file` attachment succeeds
+        let fileAttachment = typeErasedAttachment.attachment(payloadType: FileAttachmentPayload.self)
+        XCTAssertEqual(fileAttachment, originalAttachment)
+
+        // Assert the attempt to treat attachment as some other attachment fails
+        XCTAssertNil(typeErasedAttachment.attachment(payloadType: ImageAttachmentPayload.self))
+        XCTAssertNil(typeErasedAttachment.attachment(payloadType: LinkAttachmentPayload.self))
+        XCTAssertNil(typeErasedAttachment.attachment(payloadType: GiphyAttachmentPayload.self))
+    }
+
+    func test_anyAttachment_withUnknownType_asConcreteAttachment() throws {
+        // Create file attachment payload.
+        let fileAttachmentPayload = FileAttachmentPayload(
+            title: .unique,
+            assetURL: .unique(),
+            file: .init(type: .csv, size: 256, mimeType: .unique)
+        )
+
+        // Create attachment with file payload but `unknown` type.
+        let fileAttachmentWithUnknownType = ChatMessageFileAttachment(
+            id: .unique,
+            type: .unknown,
+            payload: fileAttachmentPayload,
+            uploadingState: nil
+        )
+
+        // Erase attachment type.
+        let typeErasedAttachment = fileAttachmentWithUnknownType.asAnyAttachment
+
+        // Assert the attempt to treat attachment as `file` attachment succeeds even though the type doesn't match
+        let fileAttachment = typeErasedAttachment.attachment(payloadType: FileAttachmentPayload.self)
+        XCTAssertEqual(fileAttachment, fileAttachmentWithUnknownType)
+    }
+
+    func test_anyRawAttachment_withUnknownType_asConcreteAttachment() throws {
+        // Declare custom attachment payload.
+        struct Joke: AttachmentPayload, Equatable {
+            static let type = AttachmentType(rawValue: "joke")
+
+            let joke: String
+        }
+
+        // Create a joke.
+        let joke = Joke(joke: .unique)
+
+        // Create attachment with raw joke data and `unknown` type.
+        let typeErasedAttachment = _ChatMessageAttachment(
+            id: .unique,
+            type: .unknown,
+            payload: try JSONEncoder().encode(joke),
+            uploadingState: try .mock()
+        ).asAnyAttachment
+
+        // Assert we are able to decode joke attachment in the given conditions.
+        let jokeAttachment: _ChatMessageAttachment<Joke> = .init(
+            id: typeErasedAttachment.id,
+            type: typeErasedAttachment.type,
+            payload: joke,
+            uploadingState: typeErasedAttachment.uploadingState
+        )
+        XCTAssertEqual(typeErasedAttachment.attachment(payloadType: Joke.self), jokeAttachment)
+    }
+}

--- a/Sources/StreamChatTestTools/DummyData/MessageAttachmentPayload.swift
+++ b/Sources/StreamChatTestTools/DummyData/MessageAttachmentPayload.swift
@@ -33,9 +33,91 @@ extension MessageAttachmentPayload {
         let data = try! JSONEncoder.stream.encode(payload)
         return try? JSONDecoder.stream.decode(ImageAttachmentPayload.self, from: data)
     }
+
+    var decodedFilePayload: FileAttachmentPayload? {
+        let data = try! JSONEncoder.stream.encode(payload)
+        return try? JSONDecoder.stream.decode(FileAttachmentPayload.self, from: data)
+    }
     
     var decodedGiphyPayload: GiphyAttachmentPayload? {
         let data = try! JSONEncoder.stream.encode(payload)
         return try? JSONDecoder.stream.decode(GiphyAttachmentPayload.self, from: data)
+    }
+
+    var decodedLinkPayload: LinkAttachmentPayload? {
+        let data = try! JSONEncoder.stream.encode(payload)
+        return try? JSONDecoder.stream.decode(LinkAttachmentPayload.self, from: data)
+    }
+
+    static func image(
+        title: String = .unique,
+        imageURL: URL = URL(string: "https://getstream.io/some.jpg")!,
+        imagePreviewURL: URL = URL(string: "https://getstream.io/some_preview.jpg")!
+    ) -> Self {
+        .init(
+            type: .image,
+            payload: .dictionary([
+                "title": .string(title),
+                "image_url": .string(imageURL.absoluteString),
+                "thumb_url": .string(imagePreviewURL.absoluteString)
+            ])
+        )
+    }
+
+    static func file(
+        title: String = .unique,
+        assetURL: URL = URL(string: "https://getstream.io/some.pdf")!,
+        file: AttachmentFile = .init(type: .pdf, size: 1024, mimeType: "application/pdf")
+    ) -> Self {
+        .init(
+            type: .file,
+            payload: .dictionary([
+                "title": .string(title),
+                "asset_url": .string(assetURL.absoluteString),
+                "mime_type": .string(file.mimeType!),
+                "file_size": .string("\(file.size)")
+            ])
+        )
+    }
+
+    static func giphy(
+        title: String = .unique,
+        previewURL: URL = URL(string: "https://getstream.io/some.gif")!,
+        actions: [AttachmentAction] = []
+    ) -> Self {
+        let actionsData = try! JSONEncoder.default.encode(actions)
+        let actionsJSON = try! JSONDecoder.default.decode(RawJSON.self, from: actionsData)
+
+        return .init(
+            type: .giphy,
+            payload: .dictionary([
+                "title": .string(title),
+                "thumb_url": .string(previewURL.absoluteString),
+                "actions": actionsJSON
+            ])
+        )
+    }
+
+    static func link(
+        title: String = .unique,
+        text: String = .unique,
+        author: String = .unique,
+        ogURL: URL = URL(string: "https://getstream.io/some.pdf")!,
+        imageURL: URL = URL(string: "https://getstream.io/some.pdf")!,
+        previewURL: URL = URL(string: "https://getstream.io/some_preview.pdf")!,
+        titleURL: URL = URL(string: "https://getstream.io/page")!
+    ) -> Self {
+        .init(
+            type: .linkPreview,
+            payload: .dictionary([
+                "title": .string(title),
+                "text": .string(text),
+                "author_name": .string(author),
+                "og_scrape_url": .string(ogURL.absoluteString),
+                "image_url": .string(imageURL.absoluteString),
+                "thumb_url": .string(previewURL.absoluteString),
+                "title_link": .string(titleURL.absoluteString)
+            ])
+        )
     }
 }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -479,6 +479,7 @@
 		8806570D259A51C200E31D23 /* ChatMessageInteractiveAttachmentView+ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8806570C259A51C200E31D23 /* ChatMessageInteractiveAttachmentView+ActionButton.swift */; };
 		880899C426527FA6007D3493 /* ChatMessageFileAttachment_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880899C326527FA6007D3493 /* ChatMessageFileAttachment_Mock.swift */; };
 		880899CE2652817F007D3493 /* AttachmentUploadingState_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880899CD2652817F007D3493 /* AttachmentUploadingState_Mock.swift */; };
+		880899F0265299CD007D3493 /* AttachmentPayload+NoType.json in Resources */ = {isa = PBXBuildFile; fileRef = 880899EF265299CD007D3493 /* AttachmentPayload+NoType.json */; };
 		881506EC258212BF0013935B /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881506EB258212BF0013935B /* MultipartFormData.swift */; };
 		8819DFCF2525F3C600FD1A50 /* UserUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFCE2525F3C600FD1A50 /* UserUpdater.swift */; };
 		8819DFD52525F49D00FD1A50 /* UserController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFD42525F49D00FD1A50 /* UserController.swift */; };
@@ -1659,6 +1660,7 @@
 		8806570C259A51C200E31D23 /* ChatMessageInteractiveAttachmentView+ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatMessageInteractiveAttachmentView+ActionButton.swift"; sourceTree = "<group>"; };
 		880899C326527FA6007D3493 /* ChatMessageFileAttachment_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageFileAttachment_Mock.swift; sourceTree = "<group>"; };
 		880899CD2652817F007D3493 /* AttachmentUploadingState_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentUploadingState_Mock.swift; sourceTree = "<group>"; };
+		880899EF265299CD007D3493 /* AttachmentPayload+NoType.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "AttachmentPayload+NoType.json"; sourceTree = "<group>"; };
 		881506EB258212BF0013935B /* MultipartFormData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		8819DFCE2525F3C600FD1A50 /* UserUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater.swift; sourceTree = "<group>"; };
 		8819DFD42525F49D00FD1A50 /* UserController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserController.swift; sourceTree = "<group>"; };
@@ -4279,6 +4281,7 @@
 			isa = PBXGroup;
 			children = (
 				2289852625CC0331007F2C26 /* AttachmentPayloadCustom.json */,
+				880899EF265299CD007D3493 /* AttachmentPayload+NoType.json */,
 				E73BD9E7264C015200E208B7 /* AttachmentPayloadGiphyWithActions.json */,
 				E73BD9E8264C016400E208B7 /* AttachmentPayloadGiphyWithoutActions.json */,
 				2289852725CC0332007F2C26 /* AttachmentPayloadImage.json */,
@@ -5069,6 +5072,7 @@
 				8A0C3BC524C0AEDB00CAFD19 /* UserStartWatching.json in Resources */,
 				798779FC2498E47700015F8B /* Channel.json in Resources */,
 				88DA58042631E8F100FA8C53 /* MutedChannelPayload.json in Resources */,
+				880899F0265299CD007D3493 /* AttachmentPayload+NoType.json in Resources */,
 				8A0C3BD224C1CD1C00CAFD19 /* ChannelHidden+HistoryCleared.json in Resources */,
 				E7DB9F2E26329F440090D9C7 /* HealthCheck.json in Resources */,
 				E7DB9F402632B6C40090D9C7 /* ChannelVisible.json in Resources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -480,6 +480,7 @@
 		880899C426527FA6007D3493 /* ChatMessageFileAttachment_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880899C326527FA6007D3493 /* ChatMessageFileAttachment_Mock.swift */; };
 		880899CE2652817F007D3493 /* AttachmentUploadingState_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880899CD2652817F007D3493 /* AttachmentUploadingState_Mock.swift */; };
 		880899F0265299CD007D3493 /* AttachmentPayload+NoType.json in Resources */ = {isa = PBXBuildFile; fileRef = 880899EF265299CD007D3493 /* AttachmentPayload+NoType.json */; };
+		88089A0226529FD1007D3493 /* ChatMessageAttachment_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88089A0126529FD1007D3493 /* ChatMessageAttachment_Tests.swift */; };
 		881506EC258212BF0013935B /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881506EB258212BF0013935B /* MultipartFormData.swift */; };
 		8819DFCF2525F3C600FD1A50 /* UserUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFCE2525F3C600FD1A50 /* UserUpdater.swift */; };
 		8819DFD52525F49D00FD1A50 /* UserController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8819DFD42525F49D00FD1A50 /* UserController.swift */; };
@@ -1661,6 +1662,7 @@
 		880899C326527FA6007D3493 /* ChatMessageFileAttachment_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageFileAttachment_Mock.swift; sourceTree = "<group>"; };
 		880899CD2652817F007D3493 /* AttachmentUploadingState_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentUploadingState_Mock.swift; sourceTree = "<group>"; };
 		880899EF265299CD007D3493 /* AttachmentPayload+NoType.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "AttachmentPayload+NoType.json"; sourceTree = "<group>"; };
+		88089A0126529FD1007D3493 /* ChatMessageAttachment_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageAttachment_Tests.swift; sourceTree = "<group>"; };
 		881506EB258212BF0013935B /* MultipartFormData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		8819DFCE2525F3C600FD1A50 /* UserUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdater.swift; sourceTree = "<group>"; };
 		8819DFD42525F49D00FD1A50 /* UserController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserController.swift; sourceTree = "<group>"; };
@@ -2301,6 +2303,7 @@
 				225D7FE125D191400094E555 /* ChatMessageImageAttachment.swift */,
 				F6C0020926414E4D0055D110 /* ChatMessageAttachmentEnvelope.swift */,
 				88BDCA892642B02D0099AD74 /* ChatMessageAttachment.swift */,
+				88089A0126529FD1007D3493 /* ChatMessageAttachment_Tests.swift */,
 			);
 			path = Attachments;
 			sourceTree = "<group>";
@@ -5815,6 +5818,7 @@
 				790A4C58252F2AF2001F4A23 /* DeviceDTO_Tests.swift in Sources */,
 				8A0D64AB24E57BF20017A3C0 /* ChannelListPayload_Tests.swift in Sources */,
 				799C9468247D791A001F1104 /* AssertJSONEqual.swift in Sources */,
+				88089A0226529FD1007D3493 /* ChatMessageAttachment_Tests.swift in Sources */,
 				DA84072A2525EB2F005A0F62 /* UserListQuery_Tests.swift in Sources */,
 				79158CFC25F1341300186102 /* ChannelTruncatedEventMiddleware_Tests.swift in Sources */,
 				799C9460247D77D6001F1104 /* DatabaseContainer_Tests.swift in Sources */,

--- a/Tests/StreamChatTests/MockEnpointResponses/Attachment/AttachmentPayload+NoType.json
+++ b/Tests/StreamChatTests/MockEnpointResponses/Attachment/AttachmentPayload+NoType.json
@@ -1,0 +1,5 @@
+{
+  "place" : "DeathStar",
+  "name" : "New Year Eve Party",
+  "guest_list" : "https:\/\/docs.google.com\/document\/guest_list_death_star",
+}


### PR DESCRIPTION
**This PR**:
- introduces an `unknown` attachment type and makes use of it when `type` field is missing in attachment JSON
- adds missing tests for attachment type erasure/recovery
- removes unused error types