### PR TITLE
Do not send typing events unless they are enabled for this channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- Add `areTypingEventsEnabled`, `areReactionsEnabled`, `areRepliesEnabled`, `areReadEventsEnabled`, `areUploadsEnabled` to `ChatChannelListController` [#1085](https://github.com/GetStream/stream-chat-swift/pull/1085)
+
 ### 🐞 Fixed
 - Fix background color of message list in dark mode [#1109](https://github.com/GetStream/stream-chat-swift/pull/1109)
 - Fix inconsistent dismissal of popup actions [#1109](https://github.com/GetStream/stream-chat-swift/pull/1109)

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -433,6 +433,25 @@ public class _ChatChannelController<ExtraData: ExtraDataTypes>: DataController, 
     }
 }
 
+// MARK: - Channel features
+
+public extension _ChatChannelController {
+    /// `true` if the channel has typing events enabled. Defaults to `false` if the channel doesn't exist yet.
+    var areTypingEventsEnabled: Bool { channel?.config.typingEventsEnabled == true }
+    
+    /// `true` if the channel has reactions enabled. Defaults to `false` if the channel doesn't exist yet.
+    var areReactionsEnabled: Bool { channel?.config.reactionsEnabled == true }
+    
+    /// `true` if the channel has replies enabled. Defaults to `false` if the channel doesn't exist yet.
+    var areRepliesEnabled: Bool { channel?.config.repliesEnabled == true }
+    
+    /// `true` if the channel has read events enabled. Defaults to `false` if the channel doesn't exist yet.
+    var areReadEventsEnabled: Bool { channel?.config.readEventsEnabled == true }
+    
+    /// `true` if the channel supports uploading files/images. Defaults to `false` if the channel doesn't exist yet.
+    var areUploadsEnabled: Bool { channel?.config.uploadsEnabled == true }
+}
+
 // MARK: - Channel actions
 
 public extension _ChatChannelController {
@@ -659,7 +678,7 @@ public extension _ChatChannelController {
             self.callback { completion?(error) }
         })
     }
-    
+     
     /// Sends the start typing event and schedule a timer to send the stop typing event.
     ///
     /// This method is meant to be called every time the user presses a key. The method will manage requests and timer as needed.
@@ -667,6 +686,14 @@ public extension _ChatChannelController {
     /// - Parameter completion: a completion block with an error if the request was failed.
     ///
     func sendKeystrokeEvent(completion: ((Error?) -> Void)? = nil) {
+        /// Ignore if typing events are not enabled
+        guard areTypingEventsEnabled else {
+            callback {
+                completion?(nil)
+            }
+            return
+        }
+
         /// Perform action only if channel is already created on backend side and have a valid `cid`.
         guard let cid = cid, isChannelAlreadyCreated else {
             channelModificationFailed { completion?($0) }
@@ -685,6 +712,12 @@ public extension _ChatChannelController {
     /// - Parameter completion: a completion block with an error if the request was failed.
     ///
     func sendStartTypingEvent(completion: ((Error?) -> Void)? = nil) {
+        /// Ignore if typing events are not enabled
+        guard areTypingEventsEnabled else {
+            channelFeatureDisabled(feature: "typing events", completion: completion)
+            return
+        }
+
         /// Perform action only if channel is already created on backend side and have a valid `cid`.
         guard let cid = cid, isChannelAlreadyCreated else {
             channelModificationFailed { completion?($0) }
@@ -703,6 +736,12 @@ public extension _ChatChannelController {
     /// - Parameter completion: a completion block with an error if the request was failed.
     ///
     func sendStopTypingEvent(completion: ((Error?) -> Void)? = nil) {
+        /// Ignore if typing events are not enabled
+        guard areTypingEventsEnabled else {
+            channelFeatureDisabled(feature: "typing events", completion: completion)
+            return
+        }
+
         /// Perform action only if channel is already created on backend side and have a valid `cid`.
         guard let cid = cid, isChannelAlreadyCreated else {
             channelModificationFailed { completion?($0) }
@@ -758,6 +797,16 @@ public extension _ChatChannelController {
             self.callback {
                 completion?(result)
             }
+        }
+    }
+
+    /// A convenience method that invokes the completion? with a ChannelFeatureDisabled error
+    /// ie. VCs should use the `are{FEATURE_NAME}Enabled` props (ie. `areReadEventsEnabled`) before using any feature
+    private func channelFeatureDisabled(feature: String, completion: ((Error?) -> Void)?) {
+        let error = ClientError.ChannelFeatureDisabled("Channel feature: \(feature) is disabled for this channel.")
+        log.error(error.localizedDescription)
+        callback {
+            completion?(error)
         }
     }
 
@@ -824,6 +873,20 @@ public extension _ChatChannelController {
             channelModificationFailed(completion)
             return
         }
+
+        /// Read events are not enabled for this channel
+        guard areReadEventsEnabled else {
+            channelFeatureDisabled(feature: "read events", completion: completion)
+            return
+        }
+        
+        if channel?.isUnread != true {
+            callback {
+                completion?(nil)
+            }
+            return
+        }
+
         updater.markRead(cid: cid) { error in
             self.callback {
                 completion?(error)
@@ -1257,4 +1320,8 @@ extension ClientError {
             "You can't specify a value outside the range 1-120 for cooldown duration."
         }
     }
+}
+
+extension ClientError {
+    class ChannelFeatureDisabled: ClientError {}
 }

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
@@ -143,6 +143,96 @@ class ChannelController_Tests: StressTestCase {
         XCTAssertEqual(Set(controller.messages.map(\.id)), Set(payload.messages.map(\.id)))
     }
 
+    // MARK: - Channel config feature tests
+       
+    func test_readFeatures_onNilChannel_returnsFalse() {
+        XCTAssertFalse(controller.areReactionsEnabled)
+        XCTAssertFalse(controller.areRepliesEnabled)
+        XCTAssertFalse(controller.areUploadsEnabled)
+        XCTAssertFalse(controller.areTypingEventsEnabled)
+        XCTAssertFalse(controller.areReadEventsEnabled)
+    }
+
+    func test_readAreReadEventsEnabled_whenTrue_returnsTrue() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(readEventsEnabled: true))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+        XCTAssertTrue(controller.areReadEventsEnabled)
+    }
+    
+    func test_readAreReadEventsEnabled_whenFalse_returnsFalse() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(readEventsEnabled: false))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+        XCTAssertFalse(controller.areReadEventsEnabled)
+    }
+    
+    func test_readAreTypingEventsEnabled_whenTrue_returnsTrue() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(typingEventsEnabled: true))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+        XCTAssertTrue(controller.areTypingEventsEnabled)
+    }
+    
+    func test_readAreTypingEventsEnabled_whenFalse_returnsFalse() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(typingEventsEnabled: false))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+        XCTAssertFalse(controller.areTypingEventsEnabled)
+    }
+    
+    func test_readAreReactionsEnabled_whenTrue_returnsTrue() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(reactionsEnabled: true))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+        XCTAssertTrue(controller.areReactionsEnabled)
+    }
+    
+    func test_readAreReactionsEnabled_whenFalse_returnsFalse() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(reactionsEnabled: false))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+        XCTAssertFalse(controller.areReactionsEnabled)
+    }
+    
+    func test_readAreRepliesEnabled_whenTrue_returnsTrue() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(repliesEnabled: true))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+        XCTAssertTrue(controller.areRepliesEnabled)
+    }
+    
+    func test_readAreRepliesEnabled_whenFalse_returnsFalse() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(repliesEnabled: false))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+        XCTAssertFalse(controller.areRepliesEnabled)
+    }
+    
+    func test_readAreUploadsEnabled_whenTrue_returnsTrue() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(uploadsEnabled: true))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+        XCTAssertTrue(controller.areUploadsEnabled)
+    }
+    
+    func test_readAreUploadsEnabled_whenFalse_returnsFalse() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(uploadsEnabled: false))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+        XCTAssertFalse(controller.areUploadsEnabled)
+    }
+    
     // MARK: - Synchronize tests
     
     func test_synchronize_changesControllerState() {
@@ -1977,7 +2067,12 @@ class ChannelController_Tests: StressTestCase {
     
     // MARK: - Keystroke
     
-    func test_keystroke() {
+    func test_keystroke() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(typingEventsEnabled: true))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+
         controller.sendKeystrokeEvent {
             XCTAssertNil($0)
         }
@@ -2008,7 +2103,12 @@ class ChannelController_Tests: StressTestCase {
         AssertAsync.canBeReleased(&weakController)
     }
     
-    func test_startTyping() {
+    func test_startTyping() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(typingEventsEnabled: true))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+
         controller.sendStartTypingEvent {
             XCTAssertNil($0)
         }
@@ -2039,7 +2139,12 @@ class ChannelController_Tests: StressTestCase {
         AssertAsync.canBeReleased(&weakController)
     }
     
-    func test_stopTyping() {
+    func test_stopTyping() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(typingEventsEnabled: true))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+
         controller.sendStopTypingEvent {
             XCTAssertNil($0)
         }
@@ -2068,6 +2173,77 @@ class ChannelController_Tests: StressTestCase {
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
         // `weakController` should be deallocated too
         AssertAsync.canBeReleased(&weakController)
+    }
+    
+    func test_sendKeystrokeEvent_whenTypingEventsAreDisabled_doesNothing() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(typingEventsEnabled: false))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+
+        var completionCalled = false
+
+        let error: Error? = try waitFor { completion in
+            controller.sendKeystrokeEvent {
+                completionCalled = true
+                completion($0)
+            }
+        }
+        
+        XCTAssertTrue(completionCalled)
+        XCTAssertNil(error)
+    }
+    
+    func test_sendStartTypingEvent_whenTypingEventsAreDisabled_errors() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(typingEventsEnabled: false))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+
+        var completionCalled = false
+
+        let error: Error? = try waitFor { completion in
+            controller.sendStartTypingEvent {
+                completionCalled = true
+                completion($0)
+            }
+        }
+        
+        XCTAssertTrue(completionCalled)
+        XCTAssertNotNil(error)
+        
+        guard let channelFeatureError = error as? ClientError.ChannelFeatureDisabled else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertEqual(channelFeatureError.localizedDescription, "Channel feature: typing events is disabled for this channel.")
+    }
+    
+    func test_sendStopTypingEvent_whenTypingEventsAreDisabled_errors() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(typingEventsEnabled: false))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+
+        var completionCalled = false
+
+        let error: Error? = try waitFor { completion in
+            controller.sendStopTypingEvent {
+                completionCalled = true
+                completion($0)
+            }
+        }
+        
+        XCTAssertTrue(completionCalled)
+        XCTAssertNotNil(error)
+        
+        guard let channelFeatureError = error as? ClientError.ChannelFeatureDisabled else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertEqual(channelFeatureError.localizedDescription, "Channel feature: typing events is disabled for this channel.")
     }
     
     // MARK: - Message sending
@@ -2327,7 +2503,41 @@ class ChannelController_Tests: StressTestCase {
     }
     
     // MARK: - Mark read
+
+    func test_markRead_whenReadEventsAreDisabled_errors() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(readEventsEnabled: false))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+
+        let error: Error? = try waitFor { completion in
+            controller.markRead { error in
+                completion(error)
+            }
+        }
+        
+        guard let channelFeatureError = error as? ClientError.ChannelFeatureDisabled else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertEqual(channelFeatureError.localizedDescription, "Channel feature: read events is disabled for this channel.")
+    }
     
+    func test_markRead_whenTheChannelIsRead_doesNothing() throws {
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: self.dummyPayload(with: self.channelId))
+        }
+
+        let error: Error? = try waitFor { completion in
+            controller.markRead { error in
+                completion(error)
+            }
+        }
+        
+        XCTAssertNil(error)
+    }
+
     func test_markRead_failsForNewChannels() throws {
         //  Create `ChannelController` for new channel
         let query = _ChannelQuery(channelPayload: .unique)
@@ -2341,8 +2551,11 @@ class ChannelController_Tests: StressTestCase {
             }
         }
         XCTAssert(error is ClientError.ChannelNotCreatedYet)
-        
+
         // Simulate successful backend channel creation
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: self.dummyPayload(with: query.cid!))
+        }
         env.channelUpdater!.update_channelCreatedCallback?(query.cid!)
         
         // Simulate `markRead` call and assert no error is returned
@@ -2357,9 +2570,22 @@ class ChannelController_Tests: StressTestCase {
         XCTAssertNil(error)
     }
     
-    func test_markRead_callsChannelUpdater() {
+    func test_markRead_callsChannelUpdater() throws {
+        // setup data for this test
+        let payload = dummyPayload(with: channelId)
+        let dummyUserPayload: CurrentUserPayload<NoExtraData> = .dummy(userId: payload.channelReads.first!.user.id, role: .user)
+
+        // Save two channels to DB (only one matching the query) and wait for completion
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveCurrentUser(payload: dummyUserPayload)
+
+            // Channel with the id matching the query
+            try session.saveChannel(payload: payload)
+        }
+ 
         // Simulate `markRead` call and catch the completion
         var completionCalled = false
+
         controller.markRead { [callbackQueueID] error in
             AssertTestQueue(withId: callbackQueueID)
             XCTAssertNil(error)
@@ -2388,7 +2614,15 @@ class ChannelController_Tests: StressTestCase {
         AssertAsync.canBeReleased(&weakController)
     }
     
-    func test_markRead_propagatesErrorFromUpdater() {
+    func test_markRead_propagatesErrorFromUpdater() throws {
+        let payload = dummyPayload(with: channelId)
+        let dummyUserPayload: CurrentUserPayload<NoExtraData> = .dummy(userId: payload.channelReads.first!.user.id, role: .user)
+        
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveCurrentUser(payload: dummyUserPayload)
+            try session.saveChannel(payload: payload)
+        }
+
         // Simulate `markRead` call and catch the completion
         var completionCalledError: Error?
         controller.markRead { [callbackQueueID] in

--- a/Sources/StreamChat/WebSocketClient/Events/EventPayload.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/EventPayload.swift
@@ -24,6 +24,7 @@ struct EventPayload<ExtraData: ExtraDataTypes>: Decodable {
         case isChannelHistoryCleared = "clear_history"
         case banReason = "reason"
         case banExpiredAt = "expiration"
+        case parentId = "parent_id"
     }
     
     let eventType: EventType
@@ -42,7 +43,8 @@ struct EventPayload<ExtraData: ExtraDataTypes>: Decodable {
     let isChannelHistoryCleared: Bool?
     let banReason: String?
     let banExpiredAt: Date?
-    
+    let parentId: MessageId?
+
     init(
         eventType: EventType,
         connectionId: String? = nil,
@@ -59,7 +61,8 @@ struct EventPayload<ExtraData: ExtraDataTypes>: Decodable {
         createdAt: Date? = nil,
         isChannelHistoryCleared: Bool? = nil,
         banReason: String? = nil,
-        banExpiredAt: Date? = nil
+        banExpiredAt: Date? = nil,
+        parentId: MessageId? = nil
     ) {
         self.eventType = eventType
         self.connectionId = connectionId
@@ -77,6 +80,7 @@ struct EventPayload<ExtraData: ExtraDataTypes>: Decodable {
         self.isChannelHistoryCleared = isChannelHistoryCleared
         self.banReason = banReason
         self.banExpiredAt = banExpiredAt
+        self.parentId = parentId
     }
     
     init(from decoder: Decoder) throws {
@@ -99,6 +103,7 @@ struct EventPayload<ExtraData: ExtraDataTypes>: Decodable {
         isChannelHistoryCleared = try container.decodeIfPresent(Bool.self, forKey: .isChannelHistoryCleared)
         banReason = try container.decodeIfPresent(String.self, forKey: .banReason)
         banExpiredAt = try container.decodeIfPresent(Date.self, forKey: .banExpiredAt)
+        parentId = try container.decodeIfPresent(MessageId.self, forKey: .parentId)
     }
     
     func event() throws -> Event {

--- a/Sources/StreamChat/WebSocketClient/Events/TypingEvent.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/TypingEvent.swift
@@ -8,7 +8,9 @@ public struct TypingEvent: UserSpecificEvent, ChannelSpecificEvent {
     public let isTyping: Bool
     public let cid: ChannelId
     public let userId: UserId
-    
+    public let parentId: MessageId?
+    public let isThread: Bool
+
     let payload: Any
     
     init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
@@ -16,6 +18,8 @@ public struct TypingEvent: UserSpecificEvent, ChannelSpecificEvent {
         userId = try response.value(at: \.user?.id)
         isTyping = response.eventType == .userStartTyping
         payload = response
+        parentId = try? response.value(at: \.parentId)
+        isThread = parentId != nil
     }
 }
 

--- a/Sources/StreamChat/WebSocketClient/Events/TypingEvent_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/TypingEvent_Tests.swift
@@ -7,24 +7,60 @@
 import XCTest
 
 class TypingEvent_Tests: XCTestCase {
-    func test_Typing() throws {
-        let eventDecoder = EventDecoder<NoExtraData>()
-        let cid = ChannelId(type: .messaging, id: "general")
-        let userId = "luke_skywalker"
-        
-        // User Started Typing Event.
-        var json = XCTestCase.mockData(fromFile: "UserStartTyping")
-        var event = try eventDecoder.decode(from: json) as? TypingEvent
-        XCTAssertTrue(event?.isTyping ?? false)
-        XCTAssertEqual(event?.cid, cid)
-        XCTAssertEqual(event?.userId, userId)
-        
-        // User Stopped Typing Event.
-        json = XCTestCase.mockData(fromFile: "UserStopTyping")
-        event = try eventDecoder.decode(from: json) as? TypingEvent
-        XCTAssertFalse(event?.isTyping ?? true)
-        XCTAssertEqual(event?.cid, cid)
-        XCTAssertEqual(event?.userId, userId)
+    var eventDecoder: EventDecoder<NoExtraData>!
+    var cid: ChannelId = ChannelId(type: .messaging, id: "general")
+    var userId = "luke_skywalker"
+
+    override func setUp() {
+        super.setUp()
+        eventDecoder = EventDecoder<NoExtraData>()
+    }
+
+    func test_parseTypingStartEvent() throws {
+        let json = XCTestCase.mockData(fromFile: "UserStartTyping")
+        guard let event = try eventDecoder.decode(from: json) as? TypingEvent else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertTrue(event.isTyping)
+        XCTAssertEqual(event.cid, cid)
+        XCTAssertEqual(event.userId, userId)
+    }
+    
+    func test_parseTypingStoptEvent() throws {
+        let json = XCTestCase.mockData(fromFile: "UserStopTyping")
+        guard let event = try eventDecoder.decode(from: json) as? TypingEvent else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertFalse(event.isTyping)
+        XCTAssertEqual(event.cid, cid)
+        XCTAssertEqual(event.userId, userId)
+        XCTAssertFalse(event.isThread)
+    }
+
+    func test_parseTypingStartEventInThread() throws {
+        let json = XCTestCase.mockData(fromFile: "UserStartTypingThread")
+        guard let event = try eventDecoder.decode(from: json) as? TypingEvent else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertTrue(event.isTyping)
+        XCTAssertTrue(event.isThread)
+    }
+    
+    func test_parseTypingStoptEventInThread() throws {
+        let json = XCTestCase.mockData(fromFile: "UserStopTypingThread")
+        guard let event = try eventDecoder.decode(from: json) as? TypingEvent else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertFalse(event.isTyping)
+        XCTAssertTrue(event.isThread)
     }
 }
 

--- a/Sources/StreamChatTestTools/DummyData/XCTestCase+Dummy.swift
+++ b/Sources/StreamChatTestTools/DummyData/XCTestCase+Dummy.swift
@@ -111,7 +111,30 @@ extension XCTestCase {
         watchers: [UserPayload<NoExtraData>]? = nil,
         includeMembership: Bool = true,
         messages: [MessagePayload<NoExtraData>]? = nil,
-        pinnedMessages: [MessagePayload<NoExtraData>] = []
+        pinnedMessages: [MessagePayload<NoExtraData>] = [],
+        channelConfig: ChannelConfig = .init(
+            reactionsEnabled: true,
+            typingEventsEnabled: true,
+            readEventsEnabled: true,
+            connectEventsEnabled: true,
+            uploadsEnabled: true,
+            repliesEnabled: true,
+            searchEnabled: true,
+            mutesEnabled: true,
+            urlEnrichmentEnabled: true,
+            messageRetention: "1000",
+            maxMessageLength: 100,
+            commands: [
+                .init(
+                    name: "test",
+                    description: "test commant",
+                    set: "test",
+                    args: "test"
+                )
+            ],
+            createdAt: XCTestCase.channelCreatedDate,
+            updatedAt: .unique
+        )
     ) -> ChannelPayload<NoExtraData> {
         var payloadMessages: [MessagePayload<NoExtraData>] = []
         if let messages = messages {
@@ -137,29 +160,7 @@ extension XCTestCase {
                     deletedAt: nil,
                     updatedAt: .unique,
                     createdBy: dummyUser,
-                    config: .init(
-                        reactionsEnabled: true,
-                        typingEventsEnabled: true,
-                        readEventsEnabled: true,
-                        connectEventsEnabled: true,
-                        uploadsEnabled: true,
-                        repliesEnabled: true,
-                        searchEnabled: true,
-                        mutesEnabled: true,
-                        urlEnrichmentEnabled: true,
-                        messageRetention: "1000",
-                        maxMessageLength: 100,
-                        commands: [
-                            .init(
-                                name: "test",
-                                description: "test commant",
-                                set: "test",
-                                args: "test"
-                            )
-                        ],
-                        createdAt: XCTestCase.channelCreatedDate,
-                        updatedAt: .unique
-                    ),
+                    config: channelConfig,
                     isFrozen: true,
                     memberCount: 100,
                     team: .unique,

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -131,7 +131,7 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
         messageComposerBottomConstraint = messageComposerVC.view.bottomAnchor.pin(equalTo: view.bottomAnchor)
         messageComposerBottomConstraint?.isActive = true
         
-        if channelController.channel?.config.typingEventsEnabled == true {
+        if channelController.areTypingEventsEnabled {
             let typingIndicatorViewHeight: CGFloat = 22
             
             view.addSubview(typingIndicatorView)

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		22C2359A259CA87B00DC805A /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C23599259CA87B00DC805A /* Animation.swift */; };
 		22CAFA7625CAE278005935D9 /* RawJSON_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */; };
 		22FF4365256E943F00133910 /* ChatSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FF4364256E943F00133910 /* ChatSuggestionsViewController.swift */; };
+		43BAAD492664F59600323D8E /* UserStopTypingThread.json in Resources */ = {isa = PBXBuildFile; fileRef = 43BAAD472664F59600323D8E /* UserStopTypingThread.json */; };
+		43BAAD4A2664F59600323D8E /* UserStartTypingThread.json in Resources */ = {isa = PBXBuildFile; fileRef = 43BAAD482664F59600323D8E /* UserStartTypingThread.json */; };
 		640A36C72642827900E2B032 /* DatabaseCleanupUpdater_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640A36C62642827900E2B032 /* DatabaseCleanupUpdater_Mock.swift */; };
 		6428DD5526201DCC0065DA1D /* BannerShowingConnectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */; };
 		647F66D5261E22C200111B19 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F66D4261E22C200111B19 /* BannerView.swift */; };
@@ -1253,6 +1255,8 @@
 		22C23599259CA87B00DC805A /* Animation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
 		22CAFA7525CAE278005935D9 /* RawJSON_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawJSON_Tests.swift; sourceTree = "<group>"; };
 		22FF4364256E943F00133910 /* ChatSuggestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSuggestionsViewController.swift; sourceTree = "<group>"; };
+		43BAAD472664F59600323D8E /* UserStopTypingThread.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UserStopTypingThread.json; sourceTree = "<group>"; };
+		43BAAD482664F59600323D8E /* UserStartTypingThread.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UserStartTypingThread.json; sourceTree = "<group>"; };
 		640A36C62642827900E2B032 /* DatabaseCleanupUpdater_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseCleanupUpdater_Mock.swift; sourceTree = "<group>"; };
 		6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerShowingConnectionDelegate.swift; sourceTree = "<group>"; };
 		647F66D4261E22C200111B19 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
@@ -3905,6 +3909,8 @@
 		8A0C3BC124C0AD6E00CAFD19 /* User */ = {
 			isa = PBXGroup;
 			children = (
+				43BAAD482664F59600323D8E /* UserStartTypingThread.json */,
+				43BAAD472664F59600323D8E /* UserStopTypingThread.json */,
 				8A0C3BBD24C0AC6400CAFD19 /* UserPresence.json */,
 				8A0C3BC324C0ADD400CAFD19 /* UserStartWatching.json */,
 				E732A921263B075F003BD781 /* UserUpdated.json */,
@@ -5083,6 +5089,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A0CC9F724C608C500705CF9 /* ReactionUpdated.json in Resources */,
+				43BAAD492664F59600323D8E /* UserStopTypingThread.json in Resources */,
+				43BAAD4A2664F59600323D8E /* UserStartTypingThread.json in Resources */,
 				8A62706524BE403C0040BFD6 /* UserStopTyping.json in Resources */,
 				794927F3249E3F77009D7EB7 /* NotificationAddedToChannel.json in Resources */,
 				8836FFD5254082FF009FDF73 /* FlagUserPayload+NoExtraData.json in Resources */,

--- a/Tests/StreamChatTests/MockEnpointResponses/Events/User/UserStartTypingThread.json
+++ b/Tests/StreamChatTests/MockEnpointResponses/Events/User/UserStartTypingThread.json
@@ -1,0 +1,19 @@
+{
+   "type":"typing.start",
+   "cid":"messaging:default-channel-5",
+   "channel_id":"default-channel-5",
+   "channel_type":"messaging",
+   "user":{
+      "id":"han_solo",
+      "role":"user",
+      "created_at":"2020-12-07T11:37:34.230369Z",
+      "updated_at":"2021-04-15T11:58:11.078864Z",
+      "last_active":"2021-05-28T14:50:54.888046052Z",
+      "banned":false,
+      "online":true,
+      "image":"https://vignette.wikia.nocookie.net/starwars/images/e/e2/TFAHanSolo.png",
+      "name":"Han Solo"
+   },
+   "parent_id":"27DF5474-B283-4174-95EA-640B0AE3D888",
+   "created_at":"2021-05-28T14:51:06.190007509Z"
+}

--- a/Tests/StreamChatTests/MockEnpointResponses/Events/User/UserStopTypingThread.json
+++ b/Tests/StreamChatTests/MockEnpointResponses/Events/User/UserStopTypingThread.json
@@ -1,0 +1,19 @@
+{
+   "type":"typing.stop",
+   "cid":"messaging:default-channel-5",
+   "channel_id":"default-channel-5",
+   "channel_type":"messaging",
+   "user":{
+      "id":"han_solo",
+      "role":"user",
+      "created_at":"2020-12-07T11:37:34.230369Z",
+      "updated_at":"2021-04-15T11:58:11.078864Z",
+      "last_active":"2021-05-28T17:56:50.174964411Z",
+      "banned":false,
+      "online":true,
+      "image":"https://vignette.wikia.nocookie.net/starwars/images/e/e2/TFAHanSolo.png",
+      "name":"Han Solo"
+   },
+   "parent_id":"27DF5474-B283-4174-95EA-640B0AE3D888",
+   "created_at":"2021-05-28T17:57:02.132607158Z"
+}


### PR DESCRIPTION
Add convenient helpers to check which features are enabled for a channel:

- Typing events
- Read events
- Uploads
- Replies
- Reactions

Channel Controller changes:

- `sendKeystrokeEvent` does not do anything if typing events are disabled
- `sendStartTypingEvent` and `sendStopTypingEvent` error when called on a channel with typing events disabled
- `markRead` returns an error if read events are disabled