### PR TITLE
Fix docs location for `attachment(payloadType:)`

### DIFF
--- a/Sources/StreamChat/Models/Attachments/ChatMessageAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageAttachment.swift
@@ -54,14 +54,14 @@ public struct AttachmentUploadingState: Equatable {
 
 public typealias AnyChatMessageAttachment = _ChatMessageAttachment<Any>
 
-/// Converts type-erased attachment to the attachment with the concrete payload.
-///
-/// Attachment with the requested payload type will be returned if the type-erased payload
-/// has a `Payload` instance under the hood OR if it’s a `Data` that can be decoded as a `Payload`.
-///
-/// - Parameter payloadType: The payload type the current type-erased attachment payload should be treated as.
-/// - Returns: The attachment with the requested payload type or `nil`.
 public extension AnyChatMessageAttachment {
+    /// Converts type-erased attachment to the attachment with the concrete payload.
+    ///
+    /// Attachment with the requested payload type will be returned if the type-erased payload
+    /// has a `Payload` instance under the hood OR if it’s a `Data` that can be decoded as a `Payload`.
+    ///
+    /// - Parameter payloadType: The payload type the current type-erased attachment payload should be treated as.
+    /// - Returns: The attachment with the requested payload type or `nil`.
     func attachment<Payload: AttachmentPayload>(
         payloadType: Payload.Type
     ) -> _ChatMessageAttachment<Payload>? {


### PR DESCRIPTION
**This PR** moves documentation to the correct place