### PR TITLE
Fix composer mention suggestions for missing edge case

### DIFF
--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -506,6 +506,12 @@ open class _ComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
         guard firstMentionSymbolBeforeCaret.location != NSNotFound else {
             return nil
         }
+
+        let charIndexBeforeMentionSymbol = firstMentionSymbolBeforeCaret.lowerBound - 1
+        let charRangeBeforeMentionSymbol = NSRange(location: charIndexBeforeMentionSymbol, length: 1)
+        if charIndexBeforeMentionSymbol >= 0, text.substring(with: charRangeBeforeMentionSymbol) != " " {
+            return nil
+        }
         
         let mentionStart = firstMentionSymbolBeforeCaret.upperBound
         let mentionEnd = caretLocation


### PR DESCRIPTION
## Description of the pull request
The mention suggestions would still catch when a "@" was close to text, example: "sdsasd@email.com"