### PR TITLE
Open `ChatMessage` extensions, add missing tests

### DIFF
--- a/Sample/Samples/CombineSimpleChat/CombineSimpleChatViewController.swift
+++ b/Sample/Samples/CombineSimpleChat/CombineSimpleChatViewController.swift
@@ -240,7 +240,7 @@ final class CombineSimpleChatViewController: UITableViewController, UITextViewDe
     /// The editing is allowed for non-deleted messages
     ///
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        channelController.messages[indexPath.row].deletedAt == nil
+        channelController.messages[indexPath.row].isDeleted == false
     }
     
     ///

--- a/Sample/Samples/SimpleChat/SimpleChatViewController.swift
+++ b/Sample/Samples/SimpleChat/SimpleChatViewController.swift
@@ -193,7 +193,7 @@ final class SimpleChatViewController: UITableViewController, ChatChannelControll
     /// The editing is allowed for non-deleted messages
     ///
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        channelController.messages[indexPath.row].deletedAt == nil
+        channelController.messages[indexPath.row].isDeleted == false
     }
     
     ///

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
@@ -382,7 +382,7 @@ open class _ChatMessageContentView<ExtraData: ExtraDataTypes>: _View, ThemeProvi
         }
 
         // Metadata
-        onlyVisibleForYouContainer?.isVisible = content?.onlyVisibleForCurrentUser ?? false
+        onlyVisibleForYouContainer?.isVisible = content?.isOnlyVisibleForCurrentUser == true
 
         authorNameLabel?.isVisible = layoutOptions?.contains(.authorName) == true
         authorNameLabel?.text = content?.author.name

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView_Tests.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView_Tests.swift
@@ -301,7 +301,7 @@ extension _ChatMessage {
             options.insert(.text)
         }
 
-        guard deletedAt == nil else {
+        guard isDeleted == false else {
             return options
         }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView_Tests.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView_Tests.swift
@@ -318,7 +318,7 @@ extension _ChatMessage {
         if !reactionScores.isEmpty {
             options.insert(.reactions)
         }
-        if lastActionFailed {
+        if isLastActionFailed {
             options.insert(.errorIndicator)
         }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView_Tests.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView_Tests.swift
@@ -294,7 +294,7 @@ extension _ChatMessage {
         if isLastInGroup {
             options.insert(.metadata)
         }
-        if isLastInGroup && onlyVisibleForCurrentUser {
+        if isLastInGroup && isOnlyVisibleForCurrentUser {
             options.insert(.onlyVisibleForYouIndicator)
         }
         if textContent?.isEmpty == false {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
@@ -61,7 +61,7 @@ open class _ChatMessageLayoutOptionsResolver<ExtraData: ExtraDataTypes> {
         if isLastInGroup {
             options.insert(.metadata)
         }
-        if message.onlyVisibleForCurrentUser {
+        if message.isOnlyVisibleForCurrentUser {
             options.insert(.onlyVisibleForYouIndicator)
         }
         if message.textContent?.isEmpty == false {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
@@ -68,7 +68,7 @@ open class _ChatMessageLayoutOptionsResolver<ExtraData: ExtraDataTypes> {
             options.insert(.text)
         }
 
-        guard message.deletedAt == nil else {
+        guard message.isDeleted == false else {
             return options
         }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
@@ -89,7 +89,7 @@ open class _ChatMessageLayoutOptionsResolver<ExtraData: ExtraDataTypes> {
         if !message.reactionScores.isEmpty && channel.config.reactionsEnabled {
             options.insert(.reactions)
         }
-        if message.lastActionFailed {
+        if message.isLastActionFailed {
             options.insert(.errorIndicator)
         }
 

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
@@ -81,7 +81,7 @@ open class _ChatMessageActionsVC<ExtraData: ExtraDataTypes>: _ViewController, Th
         guard
             let currentUser = messageController.dataStore.currentUser(),
             let message = message,
-            message.deletedAt == nil
+            message.isDeleted == false
         else { return [] }
 
         switch message.localState {

--- a/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
@@ -13,11 +13,11 @@ public extension _ChatMessage {
             isDeleted == false
         else { return false }
 
-        return localState == nil || lastActionFailed
+        return localState == nil || isLastActionFailed
     }
 
     /// A boolean value that checks if the last action (`send`, `edit` or `delete`) on the message failed.
-    var lastActionFailed: Bool {
+    var isLastActionFailed: Bool {
         guard isDeleted == false else { return false }
 
         switch localState {

--- a/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
@@ -28,10 +28,7 @@ extension _ChatMessage {
 
     /// A boolean value that checks if the message is the root of a thread.
     var isRootOfThread: Bool {
-        let isThreadStart = replyCount > 0
-        let isThreadReplyInChannel = showReplyInChannel
-
-        return isThreadStart || isThreadReplyInChannel
+        replyCount > 0
     }
 
     /// A boolean value that checks if the message is the part (child) of a thread.

--- a/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
@@ -48,7 +48,7 @@ public extension _ChatMessage {
     }
 
     /// A boolean value that checks if the message is visible for current user only.
-    var onlyVisibleForCurrentUser: Bool {
+    var isOnlyVisibleForCurrentUser: Bool {
         guard isSentByCurrentUser else {
             return false
         }

--- a/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
@@ -5,7 +5,7 @@
 import Foundation
 import StreamChat
 
-extension _ChatMessage {
+public extension _ChatMessage {
     /// A boolean value that checks if actions are available on the message (e.g. `edit`, `delete`, `resend`, etc.).
     var isInteractionEnabled: Bool {
         guard
@@ -33,7 +33,7 @@ extension _ChatMessage {
         replyCount > 0
     }
 
-    /// A boolean value that checks if the message is the part (child) of a thread.
+    /// A boolean value that checks if the message is part of a thread.
     var isPartOfThread: Bool {
         parentMessageId != nil
     }

--- a/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
@@ -10,7 +10,7 @@ extension _ChatMessage {
     var isInteractionEnabled: Bool {
         guard
             type != .ephemeral,
-            deletedAt == nil
+            isDeleted == false
         else { return false }
 
         return localState == nil || lastActionFailed
@@ -18,9 +18,11 @@ extension _ChatMessage {
 
     /// A boolean value that checks if the last action (`send`, `edit` or `delete`) on the message failed.
     var lastActionFailed: Bool {
+        guard isDeleted == false else { return false }
+
         switch localState {
         case .sendingFailed, .syncingFailed, .deletingFailed:
-            return deletedAt == nil
+            return true
         default:
             return false
         }
@@ -42,11 +44,7 @@ extension _ChatMessage {
             return nil
         }
 
-        guard deletedAt == nil else {
-            return L10n.Message.deletedMessagePlaceholder
-        }
-
-        return text
+        return isDeleted ? L10n.Message.deletedMessagePlaceholder : text
     }
 
     /// A boolean value that checks if the message is visible for current user only.
@@ -55,7 +53,7 @@ extension _ChatMessage {
             return false
         }
 
-        return deletedAt != nil || type == .ephemeral
+        return isDeleted || type == .ephemeral
     }
 
     /// Returns last active thread participant.
@@ -67,5 +65,10 @@ extension _ChatMessage {
         return threadParticipants
             .sorted(by: { sortingCriteriaDate($0) > sortingCriteriaDate($1) })
             .first
+    }
+
+    /// A boolean value that says if the message is deleted.
+    var isDeleted: Bool {
+        deletedAt != nil
     }
 }

--- a/Tests/StreamChatUITests/ChatMessage_Tests.swift
+++ b/Tests/StreamChatUITests/ChatMessage_Tests.swift
@@ -125,9 +125,9 @@ final class ChatMessage_Tests: XCTestCase {
         }
     }
 
-    // MARK: - lastActionFailed
+    // MARK: - isLastActionFailed
 
-    func test_lastActionFailed_returnsTrue_forNonDeletedMessageWithFailedLocalState() {
+    func test_isLastActionFailed_returnsTrue_forNonDeletedMessageWithFailedLocalState() {
         let failedLocalStates: [LocalMessageState] = [
             .deletingFailed,
             .sendingFailed,
@@ -143,11 +143,11 @@ final class ChatMessage_Tests: XCTestCase {
                 isSentByCurrentUser: true
             )
 
-            XCTAssertTrue(nonDeletedMessageWithFailedLocalState.lastActionFailed)
+            XCTAssertTrue(nonDeletedMessageWithFailedLocalState.isLastActionFailed)
         }
     }
 
-    func test_lastActionFailed_returnsFalse_forNonDeletedMessageWithNonFailedLocalState() {
+    func test_isLastActionFailed_returnsFalse_forNonDeletedMessageWithNonFailedLocalState() {
         let nonFailedLocalStates: [LocalMessageState?] = [
             nil,
             .sending,
@@ -166,11 +166,11 @@ final class ChatMessage_Tests: XCTestCase {
                 isSentByCurrentUser: true
             )
 
-            XCTAssertFalse(nonDeletedMessageWithNonFailedLocalState.lastActionFailed)
+            XCTAssertFalse(nonDeletedMessageWithNonFailedLocalState.isLastActionFailed)
         }
     }
 
-    func test_lastActionFailed_returnsFalse_forDeletedMessage_noMatterTheLocalStateIs() {
+    func test_isLastActionFailed_returnsFalse_forDeletedMessage_noMatterTheLocalStateIs() {
         for localState: LocalMessageState? in [
             nil,
             .pendingSync,
@@ -190,7 +190,7 @@ final class ChatMessage_Tests: XCTestCase {
                 localState: localState
             )
 
-            XCTAssertFalse(deletedMessage.lastActionFailed)
+            XCTAssertFalse(deletedMessage.isLastActionFailed)
         }
     }
 

--- a/Tests/StreamChatUITests/ChatMessage_Tests.swift
+++ b/Tests/StreamChatUITests/ChatMessage_Tests.swift
@@ -302,9 +302,9 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertEqual(nonDeletedNonEphemeralMessage.textContent, nonDeletedNonEphemeralMessage.text)
     }
 
-    // MARK: - onlyVisibleForCurrentUser
+    // MARK: - isOnlyVisibleForCurrentUser
 
-    func test_onlyVisibleForCurrentUser_returnsTrue_forEphemeralMessage_sentByCurrentUser() {
+    func test_isOnlyVisibleForCurrentUser_returnsTrue_forEphemeralMessage_sentByCurrentUser() {
         let ephemeralMessageFromCurrentUser: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -313,10 +313,10 @@ final class ChatMessage_Tests: XCTestCase {
             isSentByCurrentUser: true
         )
 
-        XCTAssertTrue(ephemeralMessageFromCurrentUser.onlyVisibleForCurrentUser)
+        XCTAssertTrue(ephemeralMessageFromCurrentUser.isOnlyVisibleForCurrentUser)
     }
 
-    func test_onlyVisibleForCurrentUser_returnsTrue_forDeletedMessage_sentByCurrentUser() {
+    func test_isOnlyVisibleForCurrentUser_returnsTrue_forDeletedMessage_sentByCurrentUser() {
         let deletedMessageFromCurrentUser: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -325,10 +325,10 @@ final class ChatMessage_Tests: XCTestCase {
             isSentByCurrentUser: true
         )
 
-        XCTAssertTrue(deletedMessageFromCurrentUser.onlyVisibleForCurrentUser)
+        XCTAssertTrue(deletedMessageFromCurrentUser.isOnlyVisibleForCurrentUser)
     }
 
-    func test_onlyVisibleForCurrentUser_returnsTrue_forDeletedEphemeralMessage_sentByCurrentUser() {
+    func test_isOnlyVisibleForCurrentUser_returnsTrue_forDeletedEphemeralMessage_sentByCurrentUser() {
         let deletedEphemeralMessageFromCurrentUser: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -338,10 +338,10 @@ final class ChatMessage_Tests: XCTestCase {
             isSentByCurrentUser: true
         )
 
-        XCTAssertTrue(deletedEphemeralMessageFromCurrentUser.onlyVisibleForCurrentUser)
+        XCTAssertTrue(deletedEphemeralMessageFromCurrentUser.isOnlyVisibleForCurrentUser)
     }
 
-    func test_onlyVisibleForCurrentUser_returnsFalse_forMessageSentNotByCurrentUser() {
+    func test_isOnlyVisibleForCurrentUser_returnsFalse_forMessageSentNotByCurrentUser() {
         let deletedEphemeralMessageFromAnotherUser: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -351,7 +351,7 @@ final class ChatMessage_Tests: XCTestCase {
             isSentByCurrentUser: false
         )
 
-        XCTAssertFalse(deletedEphemeralMessageFromAnotherUser.onlyVisibleForCurrentUser)
+        XCTAssertFalse(deletedEphemeralMessageFromAnotherUser.isOnlyVisibleForCurrentUser)
     }
 
     // MARK: - isDeleted

--- a/Tests/StreamChatUITests/ChatMessage_Tests.swift
+++ b/Tests/StreamChatUITests/ChatMessage_Tests.swift
@@ -9,7 +9,7 @@ import XCTest
 final class ChatMessage_Tests: XCTestCase {
     // MARK: - lastActiveThreadParticipant
 
-    func test_lastActiveThreadParticipantNoThreadParticipants() {
+    func test_lastActiveThreadParticipant_whenNoThreadParticipants_returnsNil() {
         let message = ChatMessage.mock(
             id: .anonymous,
             text: "Text",
@@ -20,7 +20,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertNil(message.lastActiveThreadParticipant)
     }
     
-    func test_lastActiveThreadParticipantReturnsLastActive() {
+    func test_lastActiveThreadParticipant_whenManyParticipants_returnsLastActive() {
         let message = ChatMessage.mock(
             id: .anonymous,
             text: "Text",
@@ -41,7 +41,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertEqual(message.lastActiveThreadParticipant?.name, "Second")
     }
     
-    func test_lastActiveThreadParticipantLastActiveIsNotPresentFallbacksToUserUpdatedAt() {
+    func test_lastActiveThreadParticipant_whenLastActiveIsNotPresent_sortsByUpdatedAt() {
         let message = ChatMessage.mock(
             id: .anonymous,
             text: "Text",
@@ -73,7 +73,7 @@ final class ChatMessage_Tests: XCTestCase {
 
     // MARK: - isInteractionEnabled
 
-    func test_isInteractionEnabled_returnsFalse_forEphemeralMessage() {
+    func test_isInteractionEnabled_whenMessageIsEphemeral_returnsFalse() {
         let ephemeralMessage: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -84,7 +84,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertFalse(ephemeralMessage.isInteractionEnabled)
     }
 
-    func test_isInteractionEnabled_returnsFalse_forDeletedMessage() {
+    func test_isInteractionEnabled_whenMessageIsDeleted_returnsFalse() {
         let deletedMessage: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -95,7 +95,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertFalse(deletedMessage.isInteractionEnabled)
     }
 
-    func test_isInteractionEnabled_returnsTrue_forMessageWithoutLocalState() {
+    func test_isInteractionEnabled_whenMessageWithoutLocalState_returnsTrue() {
         let nonDeletedNonEphemeralMessageWithoutLocalState: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -106,7 +106,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertTrue(nonDeletedNonEphemeralMessageWithoutLocalState.isInteractionEnabled)
     }
 
-    func test_isInteractionEnabled_returnsTrue_forMessageWithFailedLocalState() {
+    func test_isInteractionEnabled_whenMessageWithFailedLocalState_returnsTrue() {
         let failedLocalStates: [LocalMessageState] = [
             .deletingFailed,
             .sendingFailed,
@@ -127,7 +127,7 @@ final class ChatMessage_Tests: XCTestCase {
 
     // MARK: - isLastActionFailed
 
-    func test_isLastActionFailed_returnsTrue_forNonDeletedMessageWithFailedLocalState() {
+    func test_isLastActionFailed_whenNonDeletedMessageWithFailedLocalState_returnsTrue() {
         let failedLocalStates: [LocalMessageState] = [
             .deletingFailed,
             .sendingFailed,
@@ -147,7 +147,7 @@ final class ChatMessage_Tests: XCTestCase {
         }
     }
 
-    func test_isLastActionFailed_returnsFalse_forNonDeletedMessageWithNonFailedLocalState() {
+    func test_isLastActionFailed_whenNotDeletedMessageWithFailedLocalState_returnsFalse() {
         let nonFailedLocalStates: [LocalMessageState?] = [
             nil,
             .sending,
@@ -170,7 +170,7 @@ final class ChatMessage_Tests: XCTestCase {
         }
     }
 
-    func test_isLastActionFailed_returnsFalse_forDeletedMessage_noMatterTheLocalStateIs() {
+    func test_isLastActionFailed_whenMessageIsDeleted_returnsFalse() {
         for localState: LocalMessageState? in [
             nil,
             .pendingSync,
@@ -196,7 +196,7 @@ final class ChatMessage_Tests: XCTestCase {
 
     // MARK: - isRootOfThread
 
-    func test_isRootOfThread_returnsFalse_ifMessageIsThreadPart() {
+    func test_isRootOfThread_whenMessageIsPartOfThread_returnsFalse() {
         let threadPartMessage: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -207,7 +207,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertFalse(threadPartMessage.isRootOfThread)
     }
 
-    func test_isRootOfThread_returnsTrue_ifMessageIsThreadRoot() {
+    func test_isRootOfThread_whenMessageIsRootOfThread_returnsTrue() {
         let threadRootMessage: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -219,7 +219,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertTrue(threadRootMessage.isRootOfThread)
     }
 
-    func test_isRootOfThread_returnsFalse_ifMessageDoesNotBelongToThread() {
+    func test_isRootOfThread_whenMessageDoesNotBelongToThread_returnsFalse() {
         let nonThreadMessage: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -233,7 +233,7 @@ final class ChatMessage_Tests: XCTestCase {
 
     // MARK: - isPartOfThread
 
-    func test_isPartOfThread_returnsTrue_ifMessageIsThreadPart() {
+    func test_isPartOfThread_whenMessageIsPartOfThread_returnsTrue() {
         let threadPartMessage: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -244,7 +244,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertTrue(threadPartMessage.isPartOfThread)
     }
 
-    func test_isPartOfThread_returnsFalse_ifMessageIsThreadRoot() {
+    func test_isPartOfThread_whenMessageIsRootOfThread_returnsFalse() {
         let threadRootMessage: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -256,7 +256,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertFalse(threadRootMessage.isPartOfThread)
     }
 
-    func test_isPartOfThread_returnsFalse_ifMessageDoesNotBelongToThread() {
+    func test_isPartOfThread_whenMessageDoesNotBelongToThread_returnsFalse() {
         let nonThreadMessage: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -270,7 +270,7 @@ final class ChatMessage_Tests: XCTestCase {
 
     // MARK: - textContent
 
-    func test_textContent_returnsNil_forEphemeralMessage() {
+    func test_textContent_whenMessageIsEphemeral_returnsNil() {
         let ephemeralMessage: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -281,7 +281,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertNil(ephemeralMessage.textContent)
     }
 
-    func test_textContent_returnsPlaceholder_forNonEphemeralDeletedMessage() {
+    func test_textContent_whenMessageIsNotEphemeralButDeleted_returnsDeletedPlaceholder() {
         let deletedNonEphemeralMessage: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -292,7 +292,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertEqual(deletedNonEphemeralMessage.textContent, L10n.Message.deletedMessagePlaceholder)
     }
 
-    func test_textContent_returnsText_forNonEphemeralNonDeletedMessage() {
+    func test_textContent_whenMessageIsNorEphemeralNorDeleted_returnsText() {
         let nonDeletedNonEphemeralMessage: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -304,7 +304,7 @@ final class ChatMessage_Tests: XCTestCase {
 
     // MARK: - isOnlyVisibleForCurrentUser
 
-    func test_isOnlyVisibleForCurrentUser_returnsTrue_forEphemeralMessage_sentByCurrentUser() {
+    func test_isOnlyVisibleForCurrentUser_whenMessageIsEphemeralAndSentByCurrentUser_returnsTrue() {
         let ephemeralMessageFromCurrentUser: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -316,7 +316,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertTrue(ephemeralMessageFromCurrentUser.isOnlyVisibleForCurrentUser)
     }
 
-    func test_isOnlyVisibleForCurrentUser_returnsTrue_forDeletedMessage_sentByCurrentUser() {
+    func test_isOnlyVisibleForCurrentUser_whenMessageIsDeletedAndSentByCurrentUser_returnsTrue() {
         let deletedMessageFromCurrentUser: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -328,7 +328,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertTrue(deletedMessageFromCurrentUser.isOnlyVisibleForCurrentUser)
     }
 
-    func test_isOnlyVisibleForCurrentUser_returnsTrue_forDeletedEphemeralMessage_sentByCurrentUser() {
+    func test_isOnlyVisibleForCurrentUser_whenMessageIsDeletedEphemeralAndSentByCurrentUser_returnsTrue() {
         let deletedEphemeralMessageFromCurrentUser: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -341,7 +341,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertTrue(deletedEphemeralMessageFromCurrentUser.isOnlyVisibleForCurrentUser)
     }
 
-    func test_isOnlyVisibleForCurrentUser_returnsFalse_forMessageSentNotByCurrentUser() {
+    func test_isOnlyVisibleForCurrentUser_whenMessageIsSentNotByCurrentUser_returnsFalse() {
         let deletedEphemeralMessageFromAnotherUser: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -356,7 +356,7 @@ final class ChatMessage_Tests: XCTestCase {
 
     // MARK: - isDeleted
 
-    func test_isDeleted_returnsFalse_forNonDeletedMessage() {
+    func test_isDeleted_whenMessageIsNotDeleted_returnsFalse() {
         let nonDeletedMessage: ChatMessage = .mock(
             id: .unique,
             text: .unique,
@@ -367,7 +367,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertFalse(nonDeletedMessage.isDeleted)
     }
 
-    func test_isDeleted_returnsTrue_forDeletedMessage() {
+    func test_isDeleted_whenMessageIsDeleted_returnsTrue() {
         let deletedMessage: ChatMessage = .mock(
             id: .unique,
             text: .unique,

--- a/Tests/StreamChatUITests/ChatMessage_Tests.swift
+++ b/Tests/StreamChatUITests/ChatMessage_Tests.swift
@@ -7,6 +7,8 @@
 import XCTest
 
 final class ChatMessage_Tests: XCTestCase {
+    // MARK: - lastActiveThreadParticipant
+
     func test_lastActiveThreadParticipantNoThreadParticipants() {
         let message = ChatMessage.mock(
             id: .anonymous,
@@ -67,6 +69,289 @@ final class ChatMessage_Tests: XCTestCase {
         )
         
         XCTAssertEqual(message.lastActiveThreadParticipant?.name, "Second")
+    }
+
+    // MARK: - isInteractionEnabled
+
+    func test_isInteractionEnabled_returnsFalse_forEphemeralMessage() {
+        let ephemeralMessage: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            type: .ephemeral,
+            author: .mock(id: .unique)
+        )
+
+        XCTAssertFalse(ephemeralMessage.isInteractionEnabled)
+    }
+
+    func test_isInteractionEnabled_returnsFalse_forDeletedMessage() {
+        let deletedMessage: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            deletedAt: .unique
+        )
+
+        XCTAssertFalse(deletedMessage.isInteractionEnabled)
+    }
+
+    func test_isInteractionEnabled_returnsTrue_forMessageWithoutLocalState() {
+        let nonDeletedNonEphemeralMessageWithoutLocalState: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            localState: nil
+        )
+
+        XCTAssertTrue(nonDeletedNonEphemeralMessageWithoutLocalState.isInteractionEnabled)
+    }
+
+    func test_isInteractionEnabled_returnsTrue_forMessageWithFailedLocalState() {
+        let failedLocalStates: [LocalMessageState] = [
+            .deletingFailed,
+            .sendingFailed,
+            .syncingFailed
+        ]
+
+        for localState in failedLocalStates {
+            let nonDeletedNonEphemeralMessageWithFailedLocalState: ChatMessage = .mock(
+                id: .unique,
+                text: .unique,
+                author: .mock(id: .unique),
+                localState: localState
+            )
+
+            XCTAssertTrue(nonDeletedNonEphemeralMessageWithFailedLocalState.isInteractionEnabled)
+        }
+    }
+
+    // MARK: - lastActionFailed
+
+    func test_lastActionFailed_returnsTrue_forNonDeletedMessageWithFailedLocalState() {
+        let failedLocalStates: [LocalMessageState] = [
+            .deletingFailed,
+            .sendingFailed,
+            .syncingFailed
+        ]
+
+        for localState in failedLocalStates {
+            let nonDeletedMessageWithFailedLocalState: ChatMessage = .mock(
+                id: .unique,
+                text: .unique,
+                author: .mock(id: .unique),
+                localState: localState,
+                isSentByCurrentUser: true
+            )
+
+            XCTAssertTrue(nonDeletedMessageWithFailedLocalState.lastActionFailed)
+        }
+    }
+
+    func test_lastActionFailed_returnsFalse_forNonDeletedMessageWithNonFailedLocalState() {
+        let nonFailedLocalStates: [LocalMessageState?] = [
+            nil,
+            .sending,
+            .pendingSend,
+            .syncing,
+            .pendingSync,
+            .deleting
+        ]
+
+        for localState in nonFailedLocalStates {
+            let nonDeletedMessageWithNonFailedLocalState: ChatMessage = .mock(
+                id: .unique,
+                text: .unique,
+                author: .mock(id: .unique),
+                localState: localState,
+                isSentByCurrentUser: true
+            )
+
+            XCTAssertFalse(nonDeletedMessageWithNonFailedLocalState.lastActionFailed)
+        }
+    }
+
+    func test_lastActionFailed_returnsFalse_forDeletedMessage_noMatterTheLocalStateIs() {
+        for localState: LocalMessageState? in [
+            nil,
+            .pendingSync,
+            .syncing,
+            .syncingFailed,
+            .pendingSend,
+            .sending,
+            .sendingFailed,
+            .deleting,
+            .deletingFailed
+        ] {
+            let deletedMessage: ChatMessage = .mock(
+                id: .unique,
+                text: .unique,
+                author: .mock(id: .unique),
+                deletedAt: .unique,
+                localState: localState
+            )
+
+            XCTAssertFalse(deletedMessage.lastActionFailed)
+        }
+    }
+
+    // MARK: - isRootOfThread
+
+    func test_isRootOfThread_returnsFalse_ifMessageIsThreadPart() {
+        let threadPartMessage: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            parentMessageId: .unique
+        )
+
+        XCTAssertFalse(threadPartMessage.isRootOfThread)
+    }
+
+    func test_isRootOfThread_returnsTrue_ifMessageIsThreadRoot() {
+        let threadRootMessage: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            parentMessageId: nil,
+            replyCount: 10
+        )
+
+        XCTAssertTrue(threadRootMessage.isRootOfThread)
+    }
+
+    func test_isRootOfThread_returnsFalse_ifMessageDoesNotBelongToThread() {
+        let nonThreadMessage: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            parentMessageId: nil,
+            replyCount: 0
+        )
+
+        XCTAssertFalse(nonThreadMessage.isRootOfThread)
+    }
+
+    // MARK: - isPartOfThread
+
+    func test_isPartOfThread_returnsTrue_ifMessageIsThreadPart() {
+        let threadPartMessage: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            parentMessageId: .unique
+        )
+
+        XCTAssertTrue(threadPartMessage.isPartOfThread)
+    }
+
+    func test_isPartOfThread_returnsFalse_ifMessageIsThreadRoot() {
+        let threadRootMessage: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            parentMessageId: nil,
+            replyCount: 10
+        )
+
+        XCTAssertFalse(threadRootMessage.isPartOfThread)
+    }
+
+    func test_isPartOfThread_returnsFalse_ifMessageDoesNotBelongToThread() {
+        let nonThreadMessage: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            parentMessageId: nil,
+            replyCount: 0
+        )
+
+        XCTAssertFalse(nonThreadMessage.isPartOfThread)
+    }
+
+    // MARK: - textContent
+
+    func test_textContent_returnsNil_forEphemeralMessage() {
+        let ephemeralMessage: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            type: .ephemeral,
+            author: .mock(id: .unique)
+        )
+
+        XCTAssertNil(ephemeralMessage.textContent)
+    }
+
+    func test_textContent_returnsPlaceholder_forNonEphemeralDeletedMessage() {
+        let deletedNonEphemeralMessage: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            deletedAt: .unique
+        )
+
+        XCTAssertEqual(deletedNonEphemeralMessage.textContent, L10n.Message.deletedMessagePlaceholder)
+    }
+
+    func test_textContent_returnsText_forNonEphemeralNonDeletedMessage() {
+        let nonDeletedNonEphemeralMessage: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            author: .mock(id: .unique)
+        )
+
+        XCTAssertEqual(nonDeletedNonEphemeralMessage.textContent, nonDeletedNonEphemeralMessage.text)
+    }
+
+    // MARK: - onlyVisibleForCurrentUser
+
+    func test_onlyVisibleForCurrentUser_returnsTrue_forEphemeralMessage_sentByCurrentUser() {
+        let ephemeralMessageFromCurrentUser: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            type: .ephemeral,
+            author: .mock(id: .unique),
+            isSentByCurrentUser: true
+        )
+
+        XCTAssertTrue(ephemeralMessageFromCurrentUser.onlyVisibleForCurrentUser)
+    }
+
+    func test_onlyVisibleForCurrentUser_returnsTrue_forDeletedMessage_sentByCurrentUser() {
+        let deletedMessageFromCurrentUser: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            deletedAt: .unique,
+            isSentByCurrentUser: true
+        )
+
+        XCTAssertTrue(deletedMessageFromCurrentUser.onlyVisibleForCurrentUser)
+    }
+
+    func test_onlyVisibleForCurrentUser_returnsTrue_forDeletedEphemeralMessage_sentByCurrentUser() {
+        let deletedEphemeralMessageFromCurrentUser: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            type: .ephemeral,
+            author: .mock(id: .unique),
+            deletedAt: .unique,
+            isSentByCurrentUser: true
+        )
+
+        XCTAssertTrue(deletedEphemeralMessageFromCurrentUser.onlyVisibleForCurrentUser)
+    }
+
+    func test_onlyVisibleForCurrentUser_returnsFalse_forMessageSentNotByCurrentUser() {
+        let deletedEphemeralMessageFromAnotherUser: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            type: .ephemeral,
+            author: .mock(id: .unique),
+            deletedAt: .unique,
+            isSentByCurrentUser: false
+        )
+
+        XCTAssertFalse(deletedEphemeralMessageFromAnotherUser.onlyVisibleForCurrentUser)
     }
 
     // MARK: - isDeleted

--- a/Tests/StreamChatUITests/ChatMessage_Tests.swift
+++ b/Tests/StreamChatUITests/ChatMessage_Tests.swift
@@ -68,4 +68,28 @@ final class ChatMessage_Tests: XCTestCase {
         
         XCTAssertEqual(message.lastActiveThreadParticipant?.name, "Second")
     }
+
+    // MARK: - isDeleted
+
+    func test_isDeleted_returnsFalse_forNonDeletedMessage() {
+        let nonDeletedMessage: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            deletedAt: nil
+        )
+
+        XCTAssertFalse(nonDeletedMessage.isDeleted)
+    }
+
+    func test_isDeleted_returnsTrue_forDeletedMessage() {
+        let deletedMessage: ChatMessage = .mock(
+            id: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            deletedAt: .unique
+        )
+
+        XCTAssertTrue(deletedMessage.isDeleted)
+    }
 }


### PR DESCRIPTION
**This PR**:
- adds `ChatMessage.isDeleted` helper
- fixes `ChatMessage.isRootOfThread` helper
- adds missing tests for `ChatMessage` extensions
- renames fields to follow naming convention