### PR TITLE
Update Nuke to v10 for SwiftUI support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.0"),
         
         // StreamChatUI
-        .package(url: "https://github.com/kean/Nuke.git", from: "9.0.0"),
+        .package(url: "https://github.com/kean/Nuke.git", from: "10.0.0"),
         .package(url: "https://github.com/kirualex/SwiftyGif.git", from: "5.3.0")
     ],
     targets: [

--- a/Sources/StreamChatUI/Utils/UIImageView+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/UIImageView+Extensions.swift
@@ -23,7 +23,7 @@ extension UIImageView {
         resize: Bool = true,
         preferredSize: CGSize? = nil,
         components: _Components<ExtraData>,
-        completion: ImageTask.Completion? = nil
+        completion: ((_ result: Result<ImageResponse, ImagePipeline.Error>) -> Void)? = nil
     ) -> ImageTask? {
         guard !SystemEnvironment.isTests else {
             // When running tests, we load the images synchronously
@@ -63,7 +63,7 @@ extension UIImageView {
         }
         
         let imageKey = components.imageCDN.cachingKey(forImage: url)
-        let request = ImageRequest(url: url, processors: preprocessors, options: ImageRequestOptions(filteredURL: imageKey))
+        let request = ImageRequest(url: url, processors: preprocessors, userInfo: [.imageIdKey: imageKey])
         let options = ImageLoadingOptions(placeholder: placeholder)
 
         currentImageLoadingTask = Nuke.loadImage(with: request, options: options, into: self, completion: completion)

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -7717,7 +7717,7 @@
 			repositoryURL = "https://github.com/kean/Nuke";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.1.2;
+				minimumVersion = 10.0.0;
 			};
 		};
 		79A4AE0F2536EE5500C32A74 /* XCRemoteSwiftPackageReference "Starscream" */ = {

--- a/StreamChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StreamChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/kean/Nuke",
         "state": {
           "branch": null,
-          "revision": "7f73ceaeacd5df75a7994cd82e165ad9ff1815db",
-          "version": "9.6.1"
+          "revision": "5a8d11b4b8fd631f2937d2e41910ae329aed31b7",
+          "version": "10.0.0"
         }
       },
       {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Nuke v10 comes with SwiftUI support. The issue is I'm already using Nuke in my SwiftUI project, but since Stream is also. using it but on a different Nuke version, SPM cannot reconcile the differences. This PR bumps Nuke version so it's forward compatible with SwiftUI and any projects already using the latest Nuke version.