### PR TITLE
[CIS-880] Fix a flaky test

### DIFF
--- a/Sources/StreamChat/Workers/Background/MissingEventsPublisher_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/MissingEventsPublisher_Tests.swift
@@ -162,12 +162,6 @@ final class MissingEventsPublisher_Tests: StressTestCase {
 
         AssertAsync.willBeEqual(apiClient.request_allRecordedCalls.count, 1)
 
-        apiClient.test_simulateResponse(
-            Result<MissingEventsPayload<ExtraData>, Error>.failure(
-                ClientError(with: ErrorPayload(code: 0, message: "", statusCode: 400))
-            )
-        )
-
         var refetchCalled = false
         channelDatabaseCleanupUpdater.refetchExistingChannelListQueries_body = {
             refetchCalled = true
@@ -179,6 +173,12 @@ final class MissingEventsPublisher_Tests: StressTestCase {
             // Check refetch wasn't called yet
             XCTAssertFalse(refetchCalled)
         }
+        
+        apiClient.test_simulateResponse(
+            Result<MissingEventsPayload<ExtraData>, Error>.failure(
+                ClientError(with: ErrorPayload(code: 0, message: "", statusCode: 400))
+            )
+        )
 
         AssertAsync {
             Assert.willBeTrue(refetchCalled)


### PR DESCRIPTION
It was reported a couple of times that the test is flaky, I wasn't able to make it fail, but I think the reason is that we subscribe for things after we simulate the response. Probably it worked because usually we get to subscribe before the code we test actually execute, and in some rare cases it's faster than we get to subscribe.
So let's place response simulation below subscriptions