### PR TITLE
Fix invisible images in the message composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix background color of message list in dark mode [#1109](https://github.com/GetStream/stream-chat-swift/pull/1109)
 - Fix inconsistent dismissal of popup actions [#1109](https://github.com/GetStream/stream-chat-swift/pull/1109)
-- Fix message list animation glitches when keyboard appears [#1140](https://github.com/GetStream/stream-chat-swift/pull/1140)
+- Fix message list animation glitches when keyboard appears [#1139](https://github.com/GetStream/stream-chat-swift/pull/1139)
+- Fix issue where images might not render in the message composer in some cases [#1140](https://github.com/GetStream/stream-chat-swift/pull/1140)
 
 ### 🔄 Changed
 - `swipeableViewWillShowActionViews(for:)` and `swipeableViewActionViews(for:)` are `open` now [#1122](https://github.com/GetStream/stream-chat-swift/issues/1122)

--- a/Sources/StreamChatUI/Utils/UIImageView+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/UIImageView+Extensions.swift
@@ -107,7 +107,6 @@ extension ImageProcessors {
                 size: size,
                 unit: .points,
                 contentMode: .aspectFill,
-                crop: true,
                 upscale: false
             ).process(image)
         }


### PR DESCRIPTION
Not sure why, but Nuke sometimes fail to crop the image resulting in a full black square instead of a resized image.
I removed the `crop: true` parameter (default is `false`) and it seems to work. 
