### PR TITLE
Fix previous message bubble appearance on message deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix inconsistent dismissal of popup actions [#1109](https://github.com/GetStream/stream-chat-swift/pull/1109)
 - Fix message list animation glitches when keyboard appears [#1139](https://github.com/GetStream/stream-chat-swift/pull/1139)
 - Fix issue where images might not render in the message composer in some cases [#1140](https://github.com/GetStream/stream-chat-swift/pull/1140)
+- Fix issue with message bubbles not being updated properly when a message withing the same group is sent/deleted [#1141](https://github.com/GetStream/stream-chat-swift/pull/1141), [#1149](https://github.com/GetStream/stream-chat-swift/pull/1149)
 
 ### 🔄 Changed
 - `swipeableViewWillShowActionViews(for:)` and `swipeableViewActionViews(for:)` are `open` now [#1122](https://github.com/GetStream/stream-chat-swift/issues/1122)

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionView.swift
@@ -212,13 +212,22 @@ open class ChatMessageListCollectionView<ExtraData: ExtraDataTypes>: UICollectio
         with changes: [ListChange<_ChatMessage<ExtraData>>]
     ) -> [IndexPath] {
         changes.compactMap {
+            switch $0 {
             // Check if the latest message was inserted
-            guard case .insert(_, IndexPath(item: 0, section: 0)) = $0,
-                  numberOfItems(inSection: 0) > 1
-            else { return nil }
-
-            // Reload the second-to latests message
-            return IndexPath(item: 1, section: 0)
+            case .insert(_, IndexPath(row: 0, section: 0)):
+                guard numberOfItems(inSection: 0) > 1 else { return nil }
+                
+                // Reload the second-to latests message
+                return .init(item: 1, section: 0)
+            // Check if the message was deleted
+            case let .remove(_, indexPath):
+                guard numberOfItems(inSection: 0) > indexPath.item else { return nil }
+                
+                // Reload the previous message which is now at deleted message positon
+                return indexPath
+            default:
+                return nil
+            }
         }
     }
     


### PR DESCRIPTION
**This PR** fixes the issue when the previous message bubble is not updated when the following message is deleted


https://user-images.githubusercontent.com/12818985/120696660-7a9a7680-c4b5-11eb-82c0-0de8692bdfa7.mp4

