### PR TITLE
Fix scrolling when new message is sent + Refactor Keyboard Observer

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionView.swift
@@ -182,6 +182,10 @@ open class ChatMessageListCollectionView<ExtraData: ExtraDataTypes>: UICollectio
         with changes: [ListChange<_ChatMessage<ExtraData>>],
         completion: ((Bool) -> Void)? = nil
     ) {
+        // Before committing the changes, we need to check if were scrolled
+        // to the bottom, if yes, we should stay scrolled to the bottom
+        let shouldScrollToBottom = isLastCellFullyVisible
+
         performBatchUpdates {
             for change in changes {
                 switch change {
@@ -196,11 +200,6 @@ open class ChatMessageListCollectionView<ExtraData: ExtraDataTypes>: UICollectio
                 }
             }
         } completion: { flag in
-
-            if shouldScrollToBottom {
-                self.scrollToMostRecentMessage()
-            }
-
             // If a new message was inserted, reload the previous message to give it chance to update
             // its appearance in case it's now part of a group.
             let indexPaths = self.indexPathsToMessagesBeforeInsertedAfterBatchUpdate(with: changes)
@@ -213,6 +212,10 @@ open class ChatMessageListCollectionView<ExtraData: ExtraDataTypes>: UICollectio
                 if self.isLastCellFullyVisible {
                     self.scrollToMostRecentMessage()
                 }
+            }
+
+            if shouldScrollToBottom {
+                self.scrollToMostRecentMessage()
             }
 
             completion?(flag)

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListKeyboardObserver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListKeyboardObserver.swift
@@ -58,6 +58,11 @@ open class ChatMessageListKeyboardObserver {
             delay: 0.0,
             options: UIView.AnimationOptions(rawValue: keyboardAnimationCurve),
             animations: { [weak self] in
+                
+                UIView.performWithoutAnimation {
+                    self?.collectionView.layoutIfNeeded()
+                }
+                
                 self?.containerView.layoutIfNeeded()
 
                 let isKeyboardShowing = intersectedKeyboardHeight > 0

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -280,16 +280,6 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
         }
     }
     
-    /// Will scroll to most recent message on next `updateMessages` call
-    open func setNeedsScrollToMostRecentMessage(animated: Bool = true) {
-        collectionView.setNeedsScrollToMostRecentMessage(animated: animated)
-    }
-
-    /// Force scroll to most recent message check without waiting for `updateMessages`
-    open func scrollToMostRecentMessageIfNeeded() {
-        collectionView.scrollToMostRecentMessageIfNeeded()
-    }
-
     /// Scrolls to most recent message
     open func scrollToMostRecentMessage(animated: Bool = true) {
         collectionView.scrollToMostRecentMessage(animated: animated)
@@ -472,7 +462,7 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
     // MARK: - _ComposerVCDelegate
 
     open func composerDidCreateNewMessage() {
-        setNeedsScrollToMostRecentMessage()
+        scrollToMostRecentMessage()
     }
 
     // MARK: - _ChatChannelControllerDelegate

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -174,7 +174,8 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
         view.backgroundColor = appearance.colorPalette.background
         
         collectionView.backgroundColor = appearance.colorPalette.background
-        
+        collectionView.contentInset.top += max(collectionView.layoutMargins.right, collectionView.layoutMargins.left)
+
         navigationItem.titleView = titleView
     }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -573,13 +573,3 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
         return df
     }()
 }
-
-private extension UICollectionView {
-    var isLastCellFullyVisible: Bool {
-        if numberOfItems(inSection: 0) == 0 { return true }
-        let lastIndexPath = IndexPath(item: 0, section: 0)
-
-        guard let attributes = collectionViewLayout.layoutAttributesForItem(at: lastIndexPath) else { return false }
-        return bounds.contains(attributes.frame)
-    }
-}

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -28,7 +28,7 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
     /// Observer responsible for setting the correct offset when keyboard frame is changed
     open lazy var keyboardObserver = ChatMessageListKeyboardObserver(
         containerView: view,
-        scrollView: collectionView,
+        collectionView: collectionView,
         composerBottomConstraint: messageComposerBottomConstraint,
         viewController: self
     )

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -28,7 +28,7 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
     /// Observer responsible for setting the correct offset when keyboard frame is changed
     open lazy var keyboardObserver = ChatMessageListKeyboardObserver(
         containerView: view,
-        scrollView: collectionView,
+        collectionView: collectionView,
         composerBottomConstraint: messageComposerBottomConstraint,
         viewController: self
     )

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -148,7 +148,7 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
         // Scroll to newest message when there are no replies
         // breaks the `contentOffset` set by parent message
         if !messageController.replies.isEmpty {
-            scrollToMostRecentMessageIfNeeded()
+            scrollToMostRecentMessage()
         }
     }
 
@@ -241,16 +241,6 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
         if indexPath.row + 1 >= collectionView.numberOfItems(inSection: 0) {
             messageController.loadPreviousReplies()
         }
-    }
-
-    /// Will scroll to most recent message on next `updateMessages` call
-    open func setNeedsScrollToMostRecentMessage(animated: Bool = true) {
-        collectionView.setNeedsScrollToMostRecentMessage(animated: animated)
-    }
-
-    /// Force scroll to most recent message check without waiting for `updateMessages`
-    open func scrollToMostRecentMessageIfNeeded() {
-        collectionView.scrollToMostRecentMessageIfNeeded()
     }
 
     /// Scrolls to most recent message
@@ -400,7 +390,7 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
     // MARK: - _ComposerVCDelegate
 
     open func composerDidCreateNewMessage() {
-        setNeedsScrollToMostRecentMessage()
+        scrollToMostRecentMessage()
     }
 
     // MARK: - _ChatChannelControllerDelegate

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -130,7 +130,8 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
         view.backgroundColor = appearance.colorPalette.background
 
         collectionView.backgroundColor = appearance.colorPalette.background
-
+        collectionView.contentInset.top += max(collectionView.layoutMargins.right, collectionView.layoutMargins.left)
+        
         navigationItem.titleView = titleView
     }
 

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -455,9 +455,6 @@ open class _ComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
     /// - Parameter text: The text content of the message.
     open func createNewMessage(text: String) {
         guard let cid = channelController?.cid else { return }
-        defer {
-            delegate?.composerDidCreateNewMessage()
-        }
 
         if let threadParentMessageId = content.threadMessage?.id {
             let messageController = channelController?.client.messageController(
@@ -471,7 +468,9 @@ open class _ComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
                 attachments: content.attachments,
                 showReplyInChannel: composerView.checkboxControl.isSelected,
                 quotedMessageId: content.quotingMessage?.id
-            )
+            ) { _ in
+                self.delegate?.composerDidCreateNewMessage()
+            }
             return
         }
 
@@ -480,7 +479,9 @@ open class _ComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
             pinning: nil,
             attachments: content.attachments,
             quotedMessageId: content.quotingMessage?.id
-        )
+        ) { _ in
+            self.delegate?.composerDidCreateNewMessage()
+        }
     }
 
     /// Updates an existing message.


### PR DESCRIPTION
## Description of the pull request
- Fixes list not scrolling when the current user sends a new message
- Removes "scrollToBottomIfNeeded" since it is not used anywhere, and is not useful
- Fixes when a new message is received, and the list is scrolled to the bottom, should remain scrolled to the bottom
- Content inset is now adjusted for typing indicator view when it appears.
- Refactors Keyboard Observer Implementation:
   - Uses Apple's recommended way to get the keyboard height, to support docked keyboards.
   - If the last message is hidden by the keyboard, just check if it is visible, and scroll to bottom.