### PR TITLE
Send `typingStop` event when message editing finished

### DIFF
--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -356,6 +356,10 @@ open class _ComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
 
         if let editingMessage = content.editingMessage {
             editMessage(withId: editingMessage.id, newText: text)
+            
+            // This is just a temporary solution. This will be handled on the LLC level
+            // in CIS-883
+            channelController?.sendStopTypingEvent()
         } else {
             createNewMessage(text: text)
         }


### PR DESCRIPTION
Implementing this on the LLC level requires some refactoring around `TypingEventSender` (CIS-883). This is just a temporary fix until the feature is implemented on the LLC level.

(spotted on the video by @evsaev here https://github.com/GetStream/stream-chat-swift/pull/1148#issue-661089889 :) )