### PR TITLE
Fix Firebase build compilation

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -6917,6 +6917,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				"EXCLUDED_ARCHS[sdk=iphoneos*]" = "armv7 armv7s";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/StreamChat/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;


### PR DESCRIPTION
We need to exclude these architectures because of these warnings:
[09:08:55]: ▸ warning: The armv7 architecture is deprecated for your deployment target (iOS 11.0). You should update your ARCHS build setting to remove the armv7 architecture. (in target 'StreamChat' from project 'StreamChat')
636
[09:08:55]: ▸ warning: The armv7s architecture is deprecated for your deployment target (iOS 11.0). You should update your ARCHS build setting to remove the armv7s architecture. (in target 'StreamChat' from project 'StreamChat')

I ran Firebase distribution locally and it works, here I run the job to build it on CI, let's see if that works
https://github.com/GetStream/stream-chat-swift/actions/runs/907053373