### PR TITLE
[CIS-885] Fix context menu for messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed 
 - `ConnectionController` fires its `controllerDidChangeConnectionStatus` method only when the connection status actually changes [#1207](https://github.com/GetStream/stream-chat-swift/issues/1207)
 - Fix cancelled ephemeral (giphy) messages and deleted messages are visible in threads [#1238](https://github.com/GetStream/stream-chat-swift/issues/1238)
-
+- Fix long-tap on message with long text not showing action menu [#1160](https://github.com/GetStream/stream-chat-swift/issues/1128)
 
 # [4.0.0-beta.4](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.4)
 _June 23, 2021_

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.swift
@@ -100,14 +100,15 @@ open class _ChatMessagePopupVC<ExtraData: ExtraDataTypes>: _ViewController, Comp
             }
         }
         
-        constraints.append(
-            actionsController.view.widthAnchor.pin(equalTo: view.widthAnchor, multiplier: 0.7)
-        )
+        constraints += [
+            actionsController.view.widthAnchor.pin(equalTo: view.widthAnchor, multiplier: 0.7),
+            actionsController.view.bottomAnchor.pin(lessThanOrEqualTo: view.bottomAnchor).almostRequired
+        ]
 
         messageContainerStackView.addArrangedSubview(messageContentContainerView)
         constraints += [
             messageContentContainerView.widthAnchor.pin(equalToConstant: messageViewFrame.width),
-            messageContentContainerView.heightAnchor.pin(equalToConstant: messageViewFrame.height)
+            messageContentContainerView.heightAnchor.pin(lessThanOrEqualToConstant: messageViewFrame.height)
         ]
 
         let actionsContainerStackView = ContainerStackView()


### PR DESCRIPTION
# What this PR do:
- Fixes issue where longtap on a message in messageList would not be seen because the message is too long and there is no scrollViewAnymore
# How to test it
- Go to any messagelist and type down message which has bigger height than the device, then long-tap it and expect the message to be truncated and all items from contextMenu available. 


# Known issues: 
This fixes the issue, however introduces some strange UI behavior, this is probably work for @skorepak aka UI Polisher :) 


https://user-images.githubusercontent.com/17381941/124087990-d32c4780-da52-11eb-8273-65fc759f98a9.mov

