### PR TITLE
Disable cell swiping when there are no swipeable buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+### 🐞 Fixed 
+-  `ChatChannelListItemView` now doesn't enable swipe context actions when there are no `swipeableViews` for the cell. (#1161)[https://github.com/GetStream/stream-chat-swift/pull/1161] 
+
 # [4.0.0-beta.2](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.2)
 _June 04, 2021_
 

--- a/Sources/StreamChatUI/ChatChannelList/SwipeableView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/SwipeableView.swift
@@ -88,7 +88,10 @@ open class _SwipeableView<ExtraData: ExtraDataTypes>: _View, ComponentsProvider,
 
     @objc open func didPan(_ gesture: UIPanGestureRecognizer) {
         // If we don't have indexPath or any actionViews, we don't want to proceed with the swiping.
-        guard let indexPath = indexPath?(), let actionButtons = delegate?.swipeableViewActionViews(for: indexPath) else { return }
+        guard let indexPath = indexPath?(),
+              let actionButtons = delegate?.swipeableViewActionViews(for: indexPath),
+              actionButtons.isEmpty == false
+        else { return }
 
         var swipeVelocity = gesture.velocity(in: self)
         var swipePosition = gesture.translation(in: self)


### PR DESCRIPTION
# What this PR do:
- Fixes issue causing possibility of having swipe gesture recognizer on `ChatChannelListItemViewCell` to reveal the swipeable container even when there were no buttons 
# How to test it
- Go to `ChatChannelListVC` and go to `open func swipeableViewActionViews(for indexPath: IndexPath) -> [UIView]` from there return empty array. When you run the application, try to reveal the swipeable buttons by swiping if the swiping function is enabled.

Fixes #1159 