### PR TITLE
Fix app auto-reconnect on background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- Add `staysConnectedInBackground` flag to `ChatClientConfig` (#1170)[https://github.com/GetStream/stream-chat-swift/pull/1170] 
+
 ### 🔄 Changed
 
 ### 🐞 Fixed 
 -  `ChatChannelListItemView` now doesn't enable swipe context actions when there are no `swipeableViews` for the cell. (#1161)[https://github.com/GetStream/stream-chat-swift/pull/1161] 
+- Fix websocket connection automatically restored in background (#1170)[https://github.com/GetStream/stream-chat-swift/pull/1170] 
 
 # [4.0.0-beta.2](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.2)
 _June 04, 2021_

--- a/Dangerfile
+++ b/Dangerfile
@@ -6,11 +6,8 @@ if skip_danger_check
 end
 
 # Make it more obvious that a PR is a work in progress and shouldn't be merged yet.
-has_wip_label = github.pr_labels.any? { |label| label.include? "WIP" }
-has_wip_title = github.pr_title.include? "[WIP]"
-
-if has_wip_label || has_wip_title
-    message("Skipping Danger since PR is classed as Work in Progress")
+if github.pr_json["mergeable_state"] == "draft"
+    message("Skipping Danger since PR is classed as Draft")
     return
 end
 
@@ -23,7 +20,7 @@ if github.pr_body.length < 3 && git.lines_of_code > 50
 end
 
 ## Let's check if there are any changes in the project folder
-has_app_changes = !git.modified_files.grep('/Sources/StreamChat/').empty?
+has_app_changes = !git.modified_files.grep(/Sources/).empty?
 
 ## Then, we should check if tests are updated
 # has_test_changes = !git.modified_files.grep(/StreamChatCoreTests/).empty?
@@ -33,10 +30,11 @@ has_app_changes = !git.modified_files.grep('/Sources/StreamChat/').empty?
 # end
 
 has_meta_label = github.pr_labels.any? { |label| label.include? "meta" }
+has_demo_label = github.pr_labels.any? { |label| label.include? "demo" }
 has_no_changelog_tag = github.pr_body.include? "#no_changelog"
 has_skip_changelog_tag = github.pr_body.include? "#skip_changelog"
 
-has_changelog_escape = has_meta_label || has_no_changelog_tag || has_skip_changelog_tag
+has_changelog_escape = has_meta_label || has_demo_label || has_no_changelog_tag || has_skip_changelog_tag
 
 # Add a CHANGELOG entry for app changes
 if !has_changelog_escape && !git.modified_files.include?("CHANGELOG.md") && has_app_changes

--- a/Sources/StreamChat/APIClient/APIClient_Tests.swift
+++ b/Sources/StreamChat/APIClient/APIClient_Tests.swift
@@ -344,8 +344,8 @@ extension URLSessionConfiguration {
         return commonEquatability
             && multipathServiceType == otherConfiguration.multipathServiceType
             && sessionSendsLaunchEvents == otherConfiguration.sessionSendsLaunchEvents
-        #endif
-        
+        #else
         return commonEquatability
+        #endif
     }
 }

--- a/Sources/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources/StreamChat/Config/ChatClientConfig.swift
@@ -66,6 +66,23 @@ public struct ChatClientConfig {
     /// Is `true` by default.
     public var shouldConnectAutomatically = true
     
+    /// If set to `true`, the `ChatClient` will try to stay connected while app is backgrounded.
+    /// If set to `false`, websocket disconnects immediately when app is backgrounded.
+    ///
+    /// This flag aims to reduce unnecessary reconnections while quick app switches,
+    /// like when a user just checks a notification or another app.
+    /// `ChatClient` starts a background task to keep the connection alive,
+    /// and disconnects when background task expires.
+    /// `ChatClient` tries to stay connected while in background up to 5 minutes.
+    /// Usually, disconnection occurs around 2-3 minutes.
+    ///
+    /// - Important: If you're using manual connection flow (`shouldConnectAutomatically` set to `false`), this flag is ineffective.
+    /// You should handle connection manually when sending app to background
+    /// or opening app from background.
+    ///
+    /// Default value is `true`
+    public var staysConnectedInBackground = true
+    
     /// Creates a new instance of `ChatClientConfig`.
     ///
     /// - Parameter apiKey: The API key of the chat app the `ChatClient` connects to.

--- a/Sources/StreamChat/WebSocketClient/Engine/URLSessionWebSocketEngine.swift
+++ b/Sources/StreamChat/WebSocketClient/Engine/URLSessionWebSocketEngine.swift
@@ -92,6 +92,11 @@ class URLSessionWebSocketEngine: NSObject, WebSocketEngine, URLSessionDataDelega
     }
     
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        // If we received this callback because we closed the WS connection
+        // intentionally, `error` param will be `nil`.
+        // Delegate is already informed with `didCloseWith` callback,
+        // so we don't need to call delegate again.
+        guard let error = error else { return }
         delegate?.webSocketDidDisconnect(error: WebSocketEngineError(error: error))
     }
 }

--- a/Sources/StreamChat/Workers/ChatClientUpdater.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater.swift
@@ -137,7 +137,7 @@ class ChatClientUpdater<ExtraData: ExtraDataTypes> {
 
     /// Disconnects the chat client the controller represents from the chat servers. No further updates from the servers
     /// are received.
-    func disconnect() {
+    func disconnect(source: WebSocketConnectionState.DisconnectionSource = .userInitiated) {
         // Disconnecting is not possible in connectionless mode (duh)
         guard client.config.isClientInActiveMode else {
             log.error(ClientError.ClientIsNotInActiveMode().localizedDescription)
@@ -150,7 +150,7 @@ class ChatClientUpdater<ExtraData: ExtraDataTypes> {
         }
 
         // Disconnect the web socket
-        client.webSocketClient?.disconnect(source: .userInitiated)
+        client.webSocketClient?.disconnect(source: source)
 
         // Reset `connectionId`. This would happen asynchronously by the callback from WebSocketClient anyway, but it's
         // safer to do it here synchronously to immediately stop all API calls.

--- a/Sources/StreamChatTestTools/ChatClientUpdater_Mock.swift
+++ b/Sources/StreamChatTestTools/ChatClientUpdater_Mock.swift
@@ -23,6 +23,7 @@ class ChatClientUpdaterMock<ExtraData: ExtraDataTypes>: ChatClientUpdater<ExtraD
     @Atomic var connect_completion: ((Error?) -> Void)?
 
     @Atomic var disconnect_called = false
+    @Atomic var disconnect_source: WebSocketConnectionState.DisconnectionSource?
 
     // MARK: - Overrides
 
@@ -43,8 +44,9 @@ class ChatClientUpdaterMock<ExtraData: ExtraDataTypes>: ChatClientUpdater<ExtraD
         connect_completion = completion
     }
 
-    override func disconnect() {
+    override func disconnect(source: WebSocketConnectionState.DisconnectionSource = .userInitiated) {
         disconnect_called = true
+        disconnect_source = source
     }
 
     // MARK: - Clean Up


### PR DESCRIPTION
Also moves the handling logic from WSClient to ChatClient.

Basically, when we disconnected, we automatically set a timer for reconnection, and reconnected while in background.