### PR TITLE
Introduce `SwiftUIViewControllerRepresentable` and conformances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - Add `staysConnectedInBackground` flag to `ChatClientConfig` (#1170)[https://github.com/GetStream/stream-chat-swift/pull/1170] 
+- Add `asView` helper for getting SwiftUI views from StreamChatUI UIViewControllers (#1174)[https://github.com/GetStream/stream-chat-swift/pull/1174] 
 
 ### 🔄 Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ⛔️ Deprecated
+- `_ChatChannelListVC.View` is now deprecated. Please use `asView` instead (#1174)[https://github.com/GetStream/stream-chat-swift/pull/1174]
+
 ### ✅ Added
 - Add `staysConnectedInBackground` flag to `ChatClientConfig` (#1170)[https://github.com/GetStream/stream-chat-swift/pull/1170] 
 - Add `asView` helper for getting SwiftUI views from StreamChatUI UIViewControllers (#1174)[https://github.com/GetStream/stream-chat-swift/pull/1174] 

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC+SwiftUI.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC+SwiftUI.swift
@@ -30,3 +30,14 @@ extension _ChatChannelListVC {
         public func updateUIViewController(_ chatChannelListVC: _ChatChannelListVC<ExtraData>, context: Context) {}
     }
 }
+
+extension _ChatChannelListVC: SwiftUIRepresentable {
+    public var content: _ChatChannelListController<ExtraData> {
+        get {
+            controller
+        }
+        set {
+            controller = newValue
+        }
+    }
+}

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC+SwiftUI.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC+SwiftUI.swift
@@ -7,27 +7,25 @@ import SwiftUI
 
 @available(iOS 13.0, *)
 /// A `UIViewControllerRepresentable` subclass which wraps `ChatChannelListVC` and shows list of channels.
-public typealias ChatChannelList = _ChatChannelListVC<NoExtraData>.View
+public typealias ChatChannelList = SwiftUIViewControllerRepresentable<_ChatChannelListVC<NoExtraData>>
+
+@available(iOS 13.0, *)
+public extension SwiftUIViewControllerRepresentable where ViewController: _ChatChannelListVC<NoExtraData> {
+    @available(*, deprecated, renamed: "asView")
+    init(controller: _ChatChannelListController<NoExtraData>) {
+        self.init(
+            viewController: ViewController.self,
+            content: controller
+        )
+    }
+}
 
 @available(iOS 13.0, *)
 extension _ChatChannelListVC {
-    /// A `UIViewControllerRepresentable` subclass which wraps `ChatChannelListVC` and shows list of channels.
-    public struct View: UIViewControllerRepresentable {
-        /// The `ChatChannelListController` instance that provides channels data.
-        let controller: _ChatChannelListController<ExtraData>
-
-        public init(controller: _ChatChannelListController<ExtraData>) {
-            self.controller = controller
-        }
-
-        public func makeUIViewController(context: Context) -> _ChatChannelListVC<ExtraData> {
-            let vc = _ChatChannelListVC<ExtraData>()
-            vc.controller = controller
-            
-            return vc
-        }
-
-        public func updateUIViewController(_ chatChannelListVC: _ChatChannelListVC<ExtraData>, context: Context) {}
+    /// A SwiftUI View that wraps `_ChatChannelListVC` and shows list of messages.
+    @available(*, deprecated, renamed: "asView")
+    static func View(controller: _ChatChannelListController<ExtraData>) -> some View {
+        asView(controller)
     }
 }
 

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC+SwiftUI_Tests.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC+SwiftUI_Tests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 @available(iOS 13.0, *)
 class ChatChannelListView_Tests: iOS13TestCase {
-    var chatChannelList: ChatChannelList!
+    var chatChannelList: SwiftUIViewControllerRepresentable<ChatChannelListVC>!
     var mockedChannelListController: ChatChannelListController_Mock<NoExtraData>!
 
     var channels: [ChatChannel] = []
@@ -18,7 +18,7 @@ class ChatChannelListView_Tests: iOS13TestCase {
     override func setUp() {
         super.setUp()
         mockedChannelListController = ChatChannelListController_Mock.mock()
-        chatChannelList = ChatChannelListVC.View(controller: mockedChannelListController)
+        chatChannelList = ChatChannelListVC.asView(mockedChannelListController)
 
         channels = .dummy()
     }
@@ -48,7 +48,7 @@ class ChatChannelListView_Tests: iOS13TestCase {
 
             var body: some View {
                 NavigationView {
-                    ChatChannelListVC.View(controller: mockedChannelListController)
+                    ChatChannelListVC.asView(mockedChannelListController)
                         .navigationBarTitle("Custom title", displayMode: .inline)
                         .navigationBarItems(
                             leading:

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC+SwiftUI.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC+SwiftUI.swift
@@ -29,3 +29,14 @@ extension _ChatMessageListVC {
         public func updateUIViewController(_ chatChannelListVC: _ChatMessageListVC<ExtraData>, context: Context) {}
     }
 }
+
+extension _ChatMessageListVC: SwiftUIRepresentable {
+    public var content: _ChatChannelController<ExtraData> {
+        get {
+            channelController
+        }
+        set {
+            channelController = newValue
+        }
+    }
+}

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC+SwiftUI.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC+SwiftUI.swift
@@ -5,31 +5,6 @@
 import StreamChat
 import SwiftUI
 
-@available(iOS 13.0, *)
-/// A SwiftUI View that wraps `ChatMessageListVC` and shows list of messages.
-public typealias ChatMessageListView = _ChatMessageListVC<NoExtraData>.View
-
-@available(iOS 13.0, *)
-extension _ChatMessageListVC {
-    /// A SwiftUI View that wraps `ChatMessageListVC` and shows list of messages.
-    public struct View: UIViewControllerRepresentable {
-        /// The `_ChatChannelController` instance that provides channel data.
-        let controller: _ChatChannelController<ExtraData>
-
-        public init(controller: _ChatChannelController<ExtraData>) {
-            self.controller = controller
-        }
-
-        public func makeUIViewController(context: Context) -> _ChatMessageListVC<ExtraData> {
-            let vc = _ChatMessageListVC<ExtraData>()
-            vc.channelController = controller
-            return vc
-        }
-
-        public func updateUIViewController(_ chatChannelListVC: _ChatMessageListVC<ExtraData>, context: Context) {}
-    }
-}
-
 extension _ChatMessageListVC: SwiftUIRepresentable {
     public var content: _ChatChannelController<ExtraData> {
         get {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC+SwiftUI_Tests.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC+SwiftUI_Tests.swift
@@ -10,13 +10,13 @@ import XCTest
 
 @available(iOS 13.0, *)
 class ChatMessageListView_Tests: iOS13TestCase {
-    var chatMessageList: ChatMessageListView!
+    var chatMessageList: SwiftUIViewControllerRepresentable<ChatMessageListVC>!
     var mockedChannelController: ChatChannelController_Mock<NoExtraData>!
 
     override func setUp() {
         super.setUp()
         mockedChannelController = ChatChannelController_Mock.mock()
-        chatMessageList = ChatMessageListVC.View(controller: mockedChannelController)
+        chatMessageList = ChatMessageListVC.asView(mockedChannelController)
     }
 
     func test_chatMessageList_isPopulated() {
@@ -54,7 +54,7 @@ class ChatMessageListView_Tests: iOS13TestCase {
 
             var body: some View {
                 NavigationView {
-                    ChatMessageListVC.View(controller: mockedChannelController)
+                    ChatMessageListVC.asView(mockedChannelController)
                         .navigationBarTitle("Custom title", displayMode: .inline)
                         .navigationBarItems(
                             leading:

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -466,3 +466,18 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
         messageController.replies[indexPath.item]
     }
 }
+
+extension ChatThreadVC: SwiftUIRepresentable {
+    public var content: (
+        channelController: _ChatChannelController<ExtraData>,
+        messageController: _ChatMessageController<ExtraData>
+    ) {
+        get {
+            (channelController, messageController)
+        }
+        set {
+            channelController = newValue.channelController
+            messageController = newValue.messageController
+        }
+    }
+}

--- a/Sources/StreamChatUI/CommonViews/SwiftUIViewRepresentable.swift
+++ b/Sources/StreamChatUI/CommonViews/SwiftUIViewRepresentable.swift
@@ -26,6 +26,19 @@ public extension SwiftUIRepresentable where Self: UIView {
 }
 
 @available(iOS 13.0, *)
+public extension SwiftUIRepresentable where Self: UIViewController {
+    /// Creates `SwiftUIViewControllerRepresentable` instance wrapping the current type that can be used in your SwiftUI view
+    /// - Parameters:
+    ///     - content: Content of the view controller. Its value is automatically updated when it's changed
+    static func asView(_ content: ViewContent) -> SwiftUIViewControllerRepresentable<Self> {
+        SwiftUIViewControllerRepresentable(
+            viewController: self,
+            content: content
+        )
+    }
+}
+
+@available(iOS 13.0, *)
 /// A concrete type that wraps a view conforming to `SwiftUIRepresentable` and enables using it in SwiftUI via `UIViewRepresentable`
 public struct SwiftUIViewRepresentable<View: UIView & SwiftUIRepresentable>: UIViewRepresentable {
     private let view: View.Type
@@ -46,4 +59,30 @@ public struct SwiftUIViewRepresentable<View: UIView & SwiftUIRepresentable>: UIV
     public func updateUIView(_ uiView: View, context: Context) {
         uiView.content = content
     }
+}
+
+@available(iOS 13.0, *)
+/// A concrete type that wraps a view conforming to `SwiftUIRepresentable` and enables using it in SwiftUI via `UIViewControllerRepresentable`
+public struct SwiftUIViewControllerRepresentable<
+    ViewController: UIViewController &
+        SwiftUIRepresentable
+>: UIViewControllerRepresentable {
+    private let viewController: ViewController.Type
+    private let content: ViewController.ViewContent
+    
+    init(
+        viewController: ViewController.Type,
+        content: ViewController.ViewContent
+    ) {
+        self.viewController = viewController
+        self.content = content
+    }
+    
+    public func makeUIViewController(context: Context) -> ViewController {
+        let controller = ViewController()
+        controller.content = content
+        return controller
+    }
+    
+    public func updateUIViewController(_ uiViewController: ViewController, context: Context) {}
 }


### PR DESCRIPTION
Now, when you subclass our VCs, you can create SwiftUI views from them. For example, for you our `CustomChatMessageListVC`:
```swift
var body: some View {
        CustomChatMessageListVC.asView(channelController)
}
```