### PR TITLE
Fix shrink button is visible when it shouldn't be

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `didLongPress` -> `handleLongPress`
   - `textDidChange` -> `handleTextChange`
   If you've subclassed UI components and overridden these functions, you should rename your overrides.
-  For more information, see (#1177)[https://github.com/GetStream/stream-chat-swift/pull/1177] and [#1178](https://github.com/GetStream/stream-chat-swift/issues/1178)
+  For more information, see [#1177](https://github.com/GetStream/stream-chat-swift/pull/1177) and [#1178](https://github.com/GetStream/stream-chat-swift/issues/1178)
 
 ### ⛔️ Deprecated
-- `_ChatChannelListVC.View` is now deprecated. Please use `asView` instead (#1174)[https://github.com/GetStream/stream-chat-swift/pull/1174]
+- `_ChatChannelListVC.View` is now deprecated. Please use `asView` instead [#1174](https://github.com/GetStream/stream-chat-swift/pull/1174)
 
 ### ✅ Added
-- Add `staysConnectedInBackground` flag to `ChatClientConfig` (#1170)[https://github.com/GetStream/stream-chat-swift/pull/1170] 
-- Add `asView` helper for getting SwiftUI views from StreamChatUI UIViewControllers (#1174)[https://github.com/GetStream/stream-chat-swift/pull/1174] 
+- Add `staysConnectedInBackground` flag to `ChatClientConfig` [#1170](https://github.com/GetStream/stream-chat-swift/pull/1170)
+- Add `asView` helper for getting SwiftUI views from StreamChatUI UIViewControllers [#1174](https://github.com/GetStream/stream-chat-swift/pull/1174)
 
 ### 🔄 Changed
+- Logic for displaying suggestions (commands or mentions) were not compatible with SwiftUI, so it's changed to AutoLayout [#1171](https://github.com/GetStream/stream-chat-swift/pull/1171)
 
 ### 🐞 Fixed 
--  `ChatChannelListItemView` now doesn't enable swipe context actions when there are no `swipeableViews` for the cell. (#1161)[https://github.com/GetStream/stream-chat-swift/pull/1161] 
-- Fix websocket connection automatically restored in background (#1170)[https://github.com/GetStream/stream-chat-swift/pull/1170] 
+-  `ChatChannelListItemView` now doesn't enable swipe context actions when there are no `swipeableViews` for the cell. [#1161](https://github.com/GetStream/stream-chat-swift/pull/1161)
+- Fix websocket connection automatically restored in background [#1170](https://github.com/GetStream/stream-chat-swift/pull/1170)
+- Commands view in composer is no longer displayed when there are no commands [#1171](https://github.com/GetStream/stream-chat-swift/pull/1171) [#1178](https://github.com/GetStream/stream-chat-swift/issues/1178)
 
 # [4.0.0-beta.2](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.2)
 _June 04, 2021_

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -288,7 +288,7 @@ open class _ComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
 
         let isAttachmentButtonHidden = !content.isEmpty || channelConfig?.uploadsEnabled == false
         let isCommandsButtonHidden = !content.isEmpty || channelConfig?.commands?.isEmpty == true
-        let isShrinkInputButtonHidden = content.isEmpty
+        let isShrinkInputButtonHidden = content.isEmpty || (isAttachmentButtonHidden && isCommandsButtonHidden)
         
         Animate {
             self.composerView.attachmentButton.isHidden = isAttachmentButtonHidden

--- a/Sources/StreamChatUI/Utils/UIImageView+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/UIImageView+Extensions.swift
@@ -23,7 +23,7 @@ extension UIImageView {
         resize: Bool = true,
         preferredSize: CGSize? = nil,
         components: _Components<ExtraData>,
-        completion: ImageTask.Completion? = nil
+        completion: ((_ result: Result<ImageResponse, ImagePipeline.Error>) -> Void)? = nil
     ) -> ImageTask? {
         guard !SystemEnvironment.isTests else {
             // When running tests, we load the images synchronously


### PR DESCRIPTION
If the channel type doesn't support attachments or commands, shrink button shouldn't be displayed.

The change in UIImageView+Extension was to silence the Nuke deprecation warning

Also add CHANGELOG entry for #1171 