### PR TITLE
Make `ChannelConfig.commands` non-optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `didLongPress` -> `handleLongPress`
   - `textDidChange` -> `handleTextChange`
   If you've subclassed UI components and overridden these functions, you should rename your overrides.
-  For more information, see [#1177](https://github.com/GetStream/stream-chat-swift/pull/1177) and [#1178](https://github.com/GetStream/stream-chat-swift/issues/1178)
+  For more information, see (#1177)[https://github.com/GetStream/stream-chat-swift/pull/1177] and [#1178](https://github.com/GetStream/stream-chat-swift/issues/1178)
+- `ChannelConfig.commands` is no longer an optional [#1182](https://github.com/GetStream/stream-chat-swift/issues/1182)
 
 ### ⛔️ Deprecated
 - `_ChatChannelListVC.View` is now deprecated. Please use `asView` instead [#1174](https://github.com/GetStream/stream-chat-swift/pull/1174)

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/ChannelListPayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/ChannelListPayload.swift
@@ -249,14 +249,14 @@ public struct ChannelConfig: Codable {
     /// The max message length. 5000 by default.
     public let maxMessageLength: Int
     /// An array of commands, e.g. /giphy.
-    public let commands: [Command]?
+    public let commands: [Command]
     /// A channel created date.
     public let createdAt: Date
     /// A channel updated date.
     public let updatedAt: Date
     
     /// Determines if users are able to flag messages. Enabled by default.
-    public var flagsEnabled: Bool { commands?.map(\.name).contains("flag") ?? false }
+    public var flagsEnabled: Bool { commands.map(\.name).contains("flag") }
         
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -287,7 +287,7 @@ open class _ComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
         composerView.confirmButton.isEnabled = !content.isEmpty
 
         let isAttachmentButtonHidden = !content.isEmpty || channelConfig?.uploadsEnabled == false
-        let isCommandsButtonHidden = !content.isEmpty || channelConfig?.commands?.isEmpty == true
+        let isCommandsButtonHidden = !content.isEmpty || channelConfig?.commands.isEmpty == true
         let isShrinkInputButtonHidden = content.isEmpty || (isAttachmentButtonHidden && isCommandsButtonHidden)
         
         Animate {


### PR DESCRIPTION
Backend doesn't send `commands` when it's empty and we initialize it as empty when it's missing, it doesn't need to be optional