### PR TITLE
Fix sorting MemberList by createdAt causing crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed 
+- Fix sorting Member List by `createdAt` causing an issue [#1185](https://github.com/GetStream/stream-chat-swift/issues/1185)
 
 # [4.0.0-beta.3](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.3)
 _June 11, 2021_

--- a/Package.swift
+++ b/Package.swift
@@ -181,6 +181,7 @@ var streamChatSourcesExcluded: [String] { [
     "Query/ChannelListQuery_Tests.swift",
     "Query/ChannelWatcherListQuery_Tests.swift",
     "Query/Pagination_Tests.swift",
+    "Query/Sorting/ChannelMemberListSortingKey_Tests.swift",
     "Query/Sorting/Sorting_Tests.swift",
     "Query/Filter_Tests.swift",
     "Query/ChannelQuery_Tests.swift",

--- a/Sources/StreamChat/Query/Sorting/ChannelMemberListSortingKey.swift
+++ b/Sources/StreamChat/Query/Sorting/ChannelMemberListSortingKey.swift
@@ -6,7 +6,7 @@ import Foundation
 
 /// `ChannelMemberListSortingKey` describes the keys by which you can get sorted channel members after query.
 public enum ChannelMemberListSortingKey: String, SortingKey {
-    case createdAt
+    case createdAt = "memberCreatedAt"
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
@@ -32,7 +32,7 @@ extension ChannelMemberListSortingKey {
         return .init(keyPath: dateKeyPath, ascending: false)
     }()
     
-    func sortDescriptor(isAscending: Bool) -> NSSortDescriptor? {
+    func sortDescriptor(isAscending: Bool) -> NSSortDescriptor {
         .init(key: rawValue, ascending: isAscending)
     }
 }

--- a/Sources/StreamChat/Query/Sorting/ChannelMemberListSortingKey_Tests.swift
+++ b/Sources/StreamChat/Query/Sorting/ChannelMemberListSortingKey_Tests.swift
@@ -1,0 +1,25 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class ChannelMemberListSortingKey_Tests: XCTestCase {
+    func test_sortDescriptor_keyPaths_areValid() throws {
+        // Put all `ChannelMemberListSortingKey`s in an array
+        // We don't use `CaseIterable` since we only need this for tests
+        let sortingKeys = [ChannelMemberListSortingKey.createdAt]
+        
+        // Iterate over keys...
+        for key in sortingKeys {
+            switch key {
+            case .createdAt:
+                // ... and make sure all keys correspond to a valid KeyPath
+                XCTAssertEqual(key.rawValue, NSExpression(forKeyPath: \MemberDTO.memberCreatedAt).keyPath)
+            }
+        }
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		79177A2D248A6A2600F053A2 /* AssertAsync+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79177A2C248A6A2600F053A2 /* AssertAsync+Events.swift */; };
 		791C0B6324EEBDF40013CA2F /* MessageSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */; };
 		791C0B6524EFBD260013CA2F /* UnwrapAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */; };
+		791D3D9026776BE400E3A0F9 /* ChannelMemberListSortingKey_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791D3D8F26776BE400E3A0F9 /* ChannelMemberListSortingKey_Tests.swift */; };
 		79200D42250118A1002F4EB1 /* iOS13TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79200D41250118A1002F4EB1 /* iOS13TestCase.swift */; };
 		79200D46250140BB002F4EB1 /* StreamChat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 799C941B247D2F80001F1104 /* StreamChat.framework */; };
 		79200D47250140BB002F4EB1 /* StreamChat.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 799C941B247D2F80001F1104 /* StreamChat.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -1331,6 +1332,7 @@
 		79177A2C248A6A2600F053A2 /* AssertAsync+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AssertAsync+Events.swift"; sourceTree = "<group>"; };
 		791C0B6224EEBDF40013CA2F /* MessageSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSender_Tests.swift; sourceTree = "<group>"; };
 		791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnwrapAsync.swift; sourceTree = "<group>"; };
+		791D3D8F26776BE400E3A0F9 /* ChannelMemberListSortingKey_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberListSortingKey_Tests.swift; sourceTree = "<group>"; };
 		79200D41250118A1002F4EB1 /* iOS13TestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOS13TestCase.swift; sourceTree = "<group>"; };
 		79200D4B25025B81002F4EB1 /* Error+InternetNotAvailable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+InternetNotAvailable.swift"; sourceTree = "<group>"; };
 		7922F30524DACEF100C364BC /* TestDataModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TestDataModel.xcdatamodel; sourceTree = "<group>"; };
@@ -4366,6 +4368,7 @@
 				DA640FBA2535CF8500D32944 /* ChannelListSortingKey.swift */,
 				DA640FBD2535CF9200D32944 /* UserListSortingKey.swift */,
 				DA640FC02535CFA100D32944 /* ChannelMemberListSortingKey.swift */,
+				791D3D8F26776BE400E3A0F9 /* ChannelMemberListSortingKey_Tests.swift */,
 			);
 			path = Sorting;
 			sourceTree = "<group>";
@@ -5894,6 +5897,7 @@
 				DA8407302526002D005A0F62 /* UserListUpdater_Mock.swift in Sources */,
 				F69C4BC624F66CC200A3D740 /* EventLogger.swift in Sources */,
 				888E8C51252B4BAB00195E03 /* ChannelMemberBanRequestPayload_Tests.swift in Sources */,
+				791D3D9026776BE400E3A0F9 /* ChannelMemberListSortingKey_Tests.swift in Sources */,
 				882C5766252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift in Sources */,
 				8836133C25275170003CB958 /* MutedUserPayload.swift in Sources */,
 				88FD711F25B98B61003CEEE4 /* EventPayload_Tests.swift in Sources */,


### PR DESCRIPTION
The keyPath `createdAt` didn't exist on MemberDTO and it led to a crash
