### PR TITLE
Mentions refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ⚠️ Breaking Changes from `4.0-beta.3`
 - `ChatOnlineIndicatorView` renamed to `OnlineIndicatorView`
 
+### ✅ Added
+- `mentionText(for:)` function added to `ComposerVC` for customizing the text displayed for mentions [#1188](https://github.com/GetStream/stream-chat-swift/issues/1188) [#1000](https://github.com/GetStream/stream-chat-swift/issues/1000)
+
 ### 🐞 Fixed 
 - Fix sorting Member List by `createdAt` causing an issue [#1185](https://github.com/GetStream/stream-chat-swift/issues/1185)
 - Fix ComposerView not respecting `ChannelConfig.maxMessageLength [#1190](https://github.com/GetStream/stream-chat-swift/issues/1190)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed 
 - Fix sorting Member List by `createdAt` causing an issue [#1185](https://github.com/GetStream/stream-chat-swift/issues/1185)
 - Fix ComposerView not respecting `ChannelConfig.maxMessageLength [#1190](https://github.com/GetStream/stream-chat-swift/issues/1190)
+- Fix mentions not being parsed correctly [#1188](https://github.com/GetStream/stream-chat-swift/issues/1188)
 
 # [4.0.0-beta.3](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.3)
 _June 11, 2021_

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
@@ -185,6 +185,7 @@ struct MessageRequestBody<ExtraData: ExtraDataTypes>: Encodable {
     let showReplyInChannel: Bool
     let quotedMessageId: String?
     let attachments: [MessageAttachmentPayload]
+    let mentionedUserIds: [UserId]
     var pinned: Bool
     var pinExpires: Date?
     let extraData: ExtraData.Message
@@ -199,6 +200,7 @@ struct MessageRequestBody<ExtraData: ExtraDataTypes>: Encodable {
         showReplyInChannel: Bool = false,
         quotedMessageId: String? = nil,
         attachments: [MessageAttachmentPayload] = [],
+        mentionedUserIds: [UserId] = [],
         pinned: Bool = false,
         pinExpires: Date? = nil,
         extraData: ExtraData.Message
@@ -212,6 +214,7 @@ struct MessageRequestBody<ExtraData: ExtraDataTypes>: Encodable {
         self.showReplyInChannel = showReplyInChannel
         self.quotedMessageId = quotedMessageId
         self.attachments = attachments
+        self.mentionedUserIds = mentionedUserIds
         self.pinned = pinned
         self.pinExpires = pinExpires
         self.extraData = extraData
@@ -231,6 +234,10 @@ struct MessageRequestBody<ExtraData: ExtraDataTypes>: Encodable {
 
         if !attachments.isEmpty {
             try container.encode(attachments, forKey: .attachments)
+        }
+        
+        if !mentionedUserIds.isEmpty {
+            try container.encode(mentionedUserIds, forKey: .mentionedUsers)
         }
         
         try extraData.encode(to: encoder)

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
@@ -115,12 +115,13 @@ class MessageRequestBody_Tests: XCTestCase {
             parentId: .unique,
             showReplyInChannel: true,
             quotedMessageId: "quoted-message-id",
+            mentionedUserIds: [.unique],
             pinned: true,
             pinExpires: "2021-05-15T06:43:08.776Z".toDate(),
             extraData: .init(secretNote: "Anakin is Vader ;-)")
         )
         
-        let serialized = try JSONEncoder.stream.encode(payload)
+        let serializedJSON = try JSONEncoder.stream.encode(payload)
         let expected: [String: Any] = [
             "id": payload.id,
             "text": payload.text,
@@ -128,13 +129,15 @@ class MessageRequestBody_Tests: XCTestCase {
             "show_in_channel": true,
             "args": payload.args!,
             "quoted_message_id": "quoted-message-id",
+            "mentioned_users": payload.mentionedUserIds,
             "secret_note": "Anakin is Vader ;-)",
             "command": payload.command!,
             "pinned": true,
             "pin_expires": "2021-05-15T06:43:08.776Z"
         ]
+        let expectedJSON = try JSONSerialization.data(withJSONObject: expected, options: [])
         
-        AssertJSONEqual(serialized, expected)
+        AssertJSONEqual(serializedJSON, expectedJSON)
     }
 }
 

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -769,6 +769,7 @@ public extension _ChatChannelController {
 //        command: String? = nil,
 //        arguments: String? = nil,
         attachments: [AnyAttachmentPayload] = [],
+        mentionedUserIds: [UserId] = [],
         quotedMessageId: MessageId? = nil,
         extraData: ExtraData.Message = .defaultValue,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
@@ -791,6 +792,7 @@ public extension _ChatChannelController {
             command: nil,
             arguments: nil,
             attachments: attachments,
+            mentionedUserIds: mentionedUserIds,
             quotedMessageId: quotedMessageId,
             extraData: extraData
         ) { result in

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -224,6 +224,7 @@ public extension _ChatMessageController {
 //        command: String? = nil,
 //        arguments: String? = nil,
         attachments: [AnyAttachmentPayload] = [],
+        mentionedUserIds: [UserId] = [],
         showReplyInChannel: Bool = false,
         quotedMessageId: MessageId? = nil,
         extraData: ExtraData.Message = .defaultValue,
@@ -237,6 +238,7 @@ public extension _ChatMessageController {
             arguments: nil,
             parentMessageId: messageId,
             attachments: attachments,
+            mentionedUserIds: mentionedUserIds,
             showReplyInChannel: showReplyInChannel,
             quotedMessageId: quotedMessageId,
             extraData: extraData

--- a/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
@@ -502,6 +502,7 @@ class MessageDTO_Tests: XCTestCase {
             .mockFile,
             .mockImage
         ]
+        let mentionedUserIds: [UserId] = [currentUserId]
         let messageShowReplyInChannel = true
         let messageExtraData: NoExtraData = .defaultValue
 
@@ -515,6 +516,7 @@ class MessageDTO_Tests: XCTestCase {
                 arguments: messageArguments,
                 parentMessageId: parentMessageId,
                 attachments: attachments,
+                mentionedUserIds: mentionedUserIds,
                 showReplyInChannel: true,
                 quotedMessageId: nil,
                 extraData: messageExtraData
@@ -538,6 +540,7 @@ class MessageDTO_Tests: XCTestCase {
         XCTAssertEqual(requestBody.pinned, true)
         XCTAssertEqual(requestBody.pinExpires, messagePinning!.expirationDate)
         XCTAssertEqual(requestBody.attachments.map(\.type), attachments.map(\.type))
+        XCTAssertEqual(requestBody.mentionedUserIds, mentionedUserIds)
     }
     
     func test_additionalLocalState_isStored() {
@@ -618,6 +621,7 @@ class MessageDTO_Tests: XCTestCase {
                     arguments: nil,
                     parentMessageId: nil,
                     attachments: [],
+                    mentionedUserIds: [],
                     showReplyInChannel: false,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
@@ -634,6 +638,7 @@ class MessageDTO_Tests: XCTestCase {
                     arguments: nil,
                     parentMessageId: nil,
                     attachments: [],
+                    mentionedUserIds: [],
                     showReplyInChannel: false,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
@@ -719,6 +724,7 @@ class MessageDTO_Tests: XCTestCase {
             .mockImage
         ]
         let newMessagePinning: MessagePinning? = MessagePinning(expirationDate: .unique)
+        let newMentionedUserIds: [UserId] = [.unique]
                 
         _ = try waitFor { completion in
             database.write({
@@ -730,6 +736,7 @@ class MessageDTO_Tests: XCTestCase {
                     arguments: newMessageArguments,
                     parentMessageId: newMessageParentMessageId,
                     attachments: newMessageAttachments,
+                    mentionedUserIds: newMentionedUserIds,
                     showReplyInChannel: true,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
@@ -772,6 +779,7 @@ class MessageDTO_Tests: XCTestCase {
                     arguments: .unique,
                     parentMessageId: .unique,
                     attachments: [],
+                    mentionedUserIds: [.unique],
                     showReplyInChannel: true,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
@@ -807,6 +815,7 @@ class MessageDTO_Tests: XCTestCase {
                     arguments: .unique,
                     parentMessageId: .unique,
                     attachments: [],
+                    mentionedUserIds: [.unique],
                     showReplyInChannel: true,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
@@ -880,6 +889,7 @@ class MessageDTO_Tests: XCTestCase {
                 arguments: nil,
                 parentMessageId: messageId,
                 attachments: [],
+                mentionedUserIds: [],
                 showReplyInChannel: false,
                 quotedMessageId: nil,
                 extraData: NoExtraData.defaultValue

--- a/Sources/StreamChat/Database/DTOs/UserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/UserDTO.swift
@@ -67,7 +67,7 @@ extension UserDTO {
     ///   - id: The id of the user to fetch
     ///   - context: The context used to fetch `UserDTO`
     ///
-    fileprivate static func load(id: String, context: NSManagedObjectContext) -> UserDTO? {
+    static func load(id: String, context: NSManagedObjectContext) -> UserDTO? {
         let request = NSFetchRequest<UserDTO>(entityName: UserDTO.entityName)
         request.predicate = NSPredicate(format: "id == %@", id)
         return try? context.fetch(request).first

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -62,6 +62,7 @@ protocol MessageDatabaseSession {
         arguments: String?,
         parentMessageId: MessageId?,
         attachments: [AnyAttachmentPayload],
+        mentionedUserIds: [UserId],
         showReplyInChannel: Bool,
         quotedMessageId: MessageId?,
         extraData: ExtraData
@@ -117,6 +118,7 @@ extension MessageDatabaseSession {
         pinning: MessagePinning?,
         quotedMessageId: MessageId?,
         attachments: [AnyAttachmentPayload] = [],
+        mentionedUserIds: [UserId] = [],
         extraData: ExtraData = .defaultValue
     ) throws -> MessageDTO {
         try createNewMessage(
@@ -127,6 +129,7 @@ extension MessageDatabaseSession {
             arguments: nil,
             parentMessageId: nil,
             attachments: attachments,
+            mentionedUserIds: mentionedUserIds,
             showReplyInChannel: false,
             quotedMessageId: quotedMessageId,
             extraData: extraData

--- a/Sources/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Mock.swift
@@ -78,6 +78,7 @@ extension DatabaseSessionMock {
         arguments: String?,
         parentMessageId: MessageId?,
         attachments: [AnyAttachmentPayload],
+        mentionedUserIds: [UserId],
         showReplyInChannel: Bool,
         quotedMessageId: MessageId?,
         extraData: ExtraData
@@ -92,6 +93,7 @@ extension DatabaseSessionMock {
             arguments: arguments,
             parentMessageId: parentMessageId,
             attachments: attachments,
+            mentionedUserIds: mentionedUserIds,
             showReplyInChannel: showReplyInChannel,
             quotedMessageId: quotedMessageId,
             extraData: extraData

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -114,6 +114,7 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
         command: String?,
         arguments: String?,
         attachments: [AnyAttachmentPayload] = [],
+        mentionedUserIds: [UserId],
         quotedMessageId: MessageId?,
         extraData: ExtraData.Message,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
@@ -128,6 +129,7 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
                 arguments: arguments,
                 parentMessageId: nil,
                 attachments: attachments,
+                mentionedUserIds: mentionedUserIds,
                 showReplyInChannel: false,
                 quotedMessageId: quotedMessageId,
                 extraData: extraData

--- a/Sources/StreamChat/Workers/ChannelUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Mock.swift
@@ -44,6 +44,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
     @Atomic var createNewMessage_command: String?
     @Atomic var createNewMessage_arguments: String?
     @Atomic var createNewMessage_attachments: [AnyAttachmentPayload]?
+    @Atomic var createNewMessage_mentionedUserIds: [UserId]?
     @Atomic var createNewMessage_quotedMessageId: MessageId?
     @Atomic var createNewMessage_pinning: MessagePinning?
     @Atomic var createNewMessage_extraData: ExtraData.Message?
@@ -108,6 +109,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         createNewMessage_command = nil
         createNewMessage_arguments = nil
         createNewMessage_attachments = nil
+        createNewMessage_mentionedUserIds = nil
         createNewMessage_extraData = nil
         createNewMessage_completion = nil
         
@@ -181,6 +183,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         command: String?,
         arguments: String?,
         attachments: [AnyAttachmentPayload],
+        mentionedUserIds: [UserId],
         quotedMessageId: MessageId?,
         extraData: ExtraData.Message,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
@@ -190,6 +193,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         createNewMessage_command = command
         createNewMessage_arguments = arguments
         createNewMessage_attachments = attachments
+        createNewMessage_mentionedUserIds = mentionedUserIds
         createNewMessage_quotedMessageId = quotedMessageId
         createNewMessage_pinning = pinning
         createNewMessage_extraData = extraData

--- a/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
@@ -156,13 +156,15 @@ class ChannelUpdater_Tests: StressTestCase {
                 command: command,
                 arguments: arguments,
                 attachments: attachmentEnvelopes,
+                mentionedUserIds: [currentUserId],
                 quotedMessageId: nil,
                 extraData: extraData
             ) { result in
-                if let newMessageId = try? result.get() {
+                do {
+                    let newMessageId = try result.get()
                     completion(newMessageId)
-                } else {
-                    XCTFail("Saving the message failed.")
+                } catch {
+                    XCTFail("Saving the message failed. \(error)")
                 }
             }
         }
@@ -188,6 +190,7 @@ class ChannelUpdater_Tests: StressTestCase {
         XCTAssertEqual(message.extraData, extraData)
         XCTAssertEqual(message.localState, .pendingSend)
         XCTAssertEqual(message.isPinned, true)
+        XCTAssertEqual(message.mentionedUsers.map(\.id), [currentUserId])
     }
     
     func test_createNewMessage_propagatesErrorWhenSavingFails() throws {
@@ -220,6 +223,7 @@ class ChannelUpdater_Tests: StressTestCase {
                 text: .unique,
                 command: .unique,
                 arguments: .unique,
+                mentionedUserIds: [.unique],
                 quotedMessageId: nil,
                 extraData: .defaultValue
             ) { completion($0) }

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -130,6 +130,7 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
         arguments: String?,
         parentMessageId: MessageId,
         attachments: [AnyAttachmentPayload],
+        mentionedUserIds: [UserId],
         showReplyInChannel: Bool,
         quotedMessageId: MessageId?,
         extraData: ExtraData.Message,
@@ -145,6 +146,7 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
                 arguments: arguments,
                 parentMessageId: parentMessageId,
                 attachments: attachments,
+                mentionedUserIds: mentionedUserIds,
                 showReplyInChannel: showReplyInChannel,
                 quotedMessageId: quotedMessageId,
                 extraData: extraData

--- a/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -24,6 +24,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
     @Atomic var createNewReply_arguments: String?
     @Atomic var createNewReply_parentMessageId: MessageId?
     @Atomic var createNewReply_attachments: [AnyAttachmentPayload]?
+    @Atomic var createNewReply_mentionedUserIds: [UserId]?
     @Atomic var createNewReply_showReplyInChannel: Bool?
     @Atomic var createNewReply_quotedMessageId: MessageId?
     @Atomic var createNewReply_pinning: MessagePinning?
@@ -88,6 +89,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         createNewReply_arguments = nil
         createNewReply_parentMessageId = nil
         createNewReply_attachments = nil
+        createNewReply_mentionedUserIds = nil
         createNewReply_showReplyInChannel = nil
         createNewReply_extraData = nil
         createNewReply_completion = nil
@@ -161,6 +163,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         arguments: String?,
         parentMessageId: MessageId?,
         attachments: [AnyAttachmentPayload],
+        mentionedUserIds: [UserId],
         showReplyInChannel: Bool,
         quotedMessageId: MessageId?,
         extraData: ExtraData.Message,
@@ -172,6 +175,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         createNewReply_arguments = arguments
         createNewReply_parentMessageId = parentMessageId
         createNewReply_attachments = attachments
+        createNewReply_mentionedUserIds = mentionedUserIds
         createNewReply_showReplyInChannel = showReplyInChannel
         createNewReply_quotedMessageId = quotedMessageId
         createNewReply_pinning = pinning

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -405,6 +405,7 @@ final class MessageUpdater_Tests: StressTestCase {
             fileAttachmentEnvelope,
             customAttachmentEnvelope
         ]
+        let mentionedUserIds: [UserId] = [currentUserId]
 
         // Create new reply message
         let newMessageId: MessageId = try waitFor { completion in
@@ -416,6 +417,7 @@ final class MessageUpdater_Tests: StressTestCase {
                 arguments: arguments,
                 parentMessageId: parentMessageId,
                 attachments: attachmentEnvelopes,
+                mentionedUserIds: mentionedUserIds,
                 showReplyInChannel: showReplyInChannel,
                 quotedMessageId: nil,
                 extraData: extraData
@@ -449,6 +451,7 @@ final class MessageUpdater_Tests: StressTestCase {
         XCTAssertEqual(message.extraData, extraData)
         XCTAssertEqual(message.localState, .pendingSend)
         XCTAssertTrue(message.isPinned)
+        XCTAssertEqual(message.mentionedUsers.map(\.id), mentionedUserIds)
     }
     
     func test_createNewMessage_propagatesErrorWhenSavingFails() throws {
@@ -472,6 +475,7 @@ final class MessageUpdater_Tests: StressTestCase {
                 arguments: .unique,
                 parentMessageId: .unique,
                 attachments: [],
+                mentionedUserIds: [.unique],
                 showReplyInChannel: false,
                 quotedMessageId: nil,
                 extraData: .defaultValue

--- a/Tests/Shared/CustomAssertions/AssertJSONEqual.swift
+++ b/Tests/Shared/CustomAssertions/AssertJSONEqual.swift
@@ -118,10 +118,21 @@ func CompareJSONEqual(
                         JSONSerialization.data(withJSONObject: nestedDict2)
                     )
                 } else {
-                    throw error(domain: "CompareJSONEqual", message: "Values for key \(key) do not match")
+                    throw error(
+                        domain: "CompareJSONEqual",
+                        message: "Nested values for key \(key) do not match. "
+                            + "Expression 1 value: \(value), Expression 2 value: \(value2)"
+                    )
                 }
             } else if String(describing: value) != String(describing: value2) {
-                throw error(domain: "CompareJSONEqual", message: "Values for key \(key) do not match")
+                // If you get a failure here because your values are arrays, you should
+                // change how you encode the [String: Any] dictionary. Please see
+                // `test_channelEditDetailPayload_encodedCorrectly` for more info
+                throw error(
+                    domain: "CompareJSONEqual",
+                    message: "Values for key \(key) do not match. "
+                        + "Expression 1 value: \(value), Expression 2 value: \(value2)"
+                )
             }
         }
     } catch {


### PR DESCRIPTION
1. We had some un-overridable functions in ChatChannelListVC, reported by users. First commits `open`s them
1. `mentionedUsers` was not being sent to backend, now that is fixed
1. `ComposerVC` now correctly handles mentions, and it's also possible to customize what's displayed as mention text. 

Only missing feature is editing mentions, currently not possible.