### PR TITLE
Add IDs To generated referenceDocs

### DIFF
--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/APIClient/Array.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/APIClient/Array.md
@@ -1,3 +1,7 @@
+---
+id: array 
+title: Array
+--- 
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/APIClient/CDNClient.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/APIClient/CDNClient.md
@@ -1,3 +1,7 @@
+---
+id: cdnclient 
+title: CDNClient
+--- 
 
 API client that handles working with content (e.g. uploading attachments)
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/APIClient/Endpoints/EmptyResponse.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/APIClient/Endpoints/EmptyResponse.md
@@ -1,3 +1,7 @@
+---
+id: emptyresponse 
+title: EmptyResponse
+--- 
 
 A type representing empty response of an Endpoint.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/APIClient/Endpoints/Payloads/ChannelCodingKeys.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/APIClient/Endpoints/Payloads/ChannelCodingKeys.md
@@ -1,3 +1,7 @@
+---
+id: channelcodingkeys 
+title: ChannelCodingKeys
+--- 
 
 Coding keys channel related payloads.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/APIClient/Endpoints/Payloads/ChannelConfig.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/APIClient/Endpoints/Payloads/ChannelConfig.md
@@ -1,3 +1,7 @@
+---
+id: channelconfig 
+title: ChannelConfig
+--- 
 
 A channel config.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/APIClient/Endpoints/Payloads/Command.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/APIClient/Endpoints/Payloads/Command.md
@@ -1,3 +1,7 @@
+---
+id: command 
+title: Command
+--- 
 
 A command in a message, e.g. /giphy.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/ChatClient.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/ChatClient.md
@@ -1,3 +1,7 @@
+---
+id: chatclient 
+title: ChatClient
+--- 
 
 The root object representing a Stream Chat.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/ClientError.ClientIsNotInActiveMode.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/ClientError.ClientIsNotInActiveMode.md
@@ -1,3 +1,7 @@
+---
+id: clienterror.clientisnotinactivemode 
+title: ClientError.ClientIsNotInActiveMode
+--- 
 
 ``` swift
 public class ClientIsNotInActiveMode: ClientError 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/ClientError.ConnectionNotSuccessful.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/ClientError.ConnectionNotSuccessful.md
@@ -1,3 +1,7 @@
+---
+id: clienterror.connectionnotsuccessful 
+title: ClientError.ConnectionNotSuccessful
+--- 
 
 ``` swift
 public class ConnectionNotSuccessful: ClientError 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/ClientError.MissingLocalStorageURL.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/ClientError.MissingLocalStorageURL.md
@@ -1,3 +1,7 @@
+---
+id: clienterror.missinglocalstorageurl 
+title: ClientError.MissingLocalStorageURL
+--- 
 
 ``` swift
 public class MissingLocalStorageURL: ClientError 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/ClientError.MissingToken.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/ClientError.MissingToken.md
@@ -1,3 +1,7 @@
+---
+id: clienterror.missingtoken 
+title: ClientError.MissingToken
+--- 
 
 ``` swift
 public class MissingToken: ClientError 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/APIKey.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/APIKey.md
@@ -1,3 +1,7 @@
+---
+id: apikey 
+title: APIKey
+--- 
 
 A struct representing an API key of the chat app.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/BaseURL.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/BaseURL.md
@@ -1,3 +1,7 @@
+---
+id: baseurl 
+title: BaseURL
+--- 
 
 A struct representing base URL for `ChatClient`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/ChatClientConfig.ChatChannel.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/ChatClientConfig.ChatChannel.md
@@ -1,3 +1,7 @@
+---
+id: chatclientconfig.chatchannel 
+title: ChatClientConfig.ChatChannel
+--- 
 
 `ChatChannel` specific local caching and model serialization settings.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/ChatClientConfig.LocalCaching.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/ChatClientConfig.LocalCaching.md
@@ -1,3 +1,7 @@
+---
+id: chatclientconfig.localcaching 
+title: ChatClientConfig.LocalCaching
+--- 
 
 Advanced settings for the local caching and model serialization.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/ChatClientConfig.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/ChatClientConfig.md
@@ -1,3 +1,7 @@
+---
+id: chatclientconfig 
+title: ChatClientConfig
+--- 
 
 A configuration object used to configure a `ChatClient` instance.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/ClientError.InvalidToken.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/ClientError.InvalidToken.md
@@ -1,3 +1,7 @@
+---
+id: clienterror.invalidtoken 
+title: ClientError.InvalidToken
+--- 
 
 ``` swift
 public class InvalidToken: ClientError 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/Token.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/Token.md
@@ -1,3 +1,7 @@
+---
+id: token 
+title: Token
+--- 
 
 The type is designed to store the JWT and the user it is related to.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/TokenProvider.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Config/TokenProvider.md
@@ -1,3 +1,7 @@
+---
+id: tokenprovider 
+title: TokenProvider
+--- 
 
 The type designed to provider a `Token` to the `ChatClient` when it asks for it.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/ChatChannelController.ObservableObject.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/ChatChannelController.ObservableObject.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelcontroller.observableobject 
+title: ChatChannelController.ObservableObject
+--- 
 
 A wrapper object for `ChannelListController` type which makes it possible to use the controller comfortably in SwiftUI.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/ChatChannelController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/ChatChannelController.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelcontroller 
+title: ChatChannelController
+--- 
 
 `ChatChannelController` is a controller class which allows mutating and observing changes of a specific chat channel.
 
@@ -370,7 +374,7 @@ method and call it every time the user presses a key. The controller will manage
 
   - completion: a completion block with an error if the request was failed.
 
-### `createNewMessage(text:pinning:attachments:quotedMessageId:extraData:completion:)`
+### `createNewMessage(text:pinning:attachments:mentionedUserIds:quotedMessageId:extraData:completion:)`
 
 Creates a new message locally and schedules it for send.
 
@@ -381,6 +385,7 @@ func createNewMessage(
 //        command: String? = nil,
 //        arguments: String? = nil,
         attachments: [AnyAttachmentPayload] = [],
+        mentionedUserIds: [UserId] = [],
         quotedMessageId: MessageId? = nil,
         extraData: ExtraData.Message = .defaultValue,
         completion: ((Result<MessageId, Error>) -> Void)? = nil

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/ChatChannelControllerDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/ChatChannelControllerDelegate.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelcontrollerdelegate 
+title: ChatChannelControllerDelegate
+--- 
 
 `ChatChannelController` uses this protocol to communicate changes to its delegate.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/ListOrdering.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/ListOrdering.md
@@ -1,3 +1,7 @@
+---
+id: listordering 
+title: ListOrdering
+--- 
 
 Describes the flow of the items in the list
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/ChatChannelListController.ObservableObject.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/ChatChannelListController.ObservableObject.md
@@ -1,3 +1,7 @@
+---
+id: chatchannellistcontroller.observableobject 
+title: ChatChannelListController.ObservableObject
+--- 
 
 A wrapper object for `ChannelListController` type which makes it possible to use the controller comfortably in SwiftUI.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/ChatChannelListController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/ChatChannelListController.md
@@ -1,3 +1,7 @@
+---
+id: chatchannellistcontroller 
+title: ChatChannelListController
+--- 
 
 `_ChatChannelListController` is a controller class which allows observing a list of chat channels based on the provided query.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/ChatChannelListControllerDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/ChatChannelListControllerDelegate.md
@@ -1,3 +1,7 @@
+---
+id: chatchannellistcontrollerdelegate 
+title: ChatChannelListControllerDelegate
+--- 
 
 `ChatChannelListController` uses this protocol to communicate changes to its delegate.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/ClientError.FetchFailed.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/ClientError.FetchFailed.md
@@ -1,3 +1,7 @@
+---
+id: clienterror.fetchfailed 
+title: ClientError.FetchFailed
+--- 
 
 ``` swift
 public class FetchFailed: Error 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.ObservableObject.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.ObservableObject.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelwatcherlistcontroller.observableobject 
+title: ChatChannelWatcherListController.ObservableObject
+--- 
 
 A wrapper object for `_ChatChannelWatcherListController` type which makes it possible to use the controller
 comfortably in SwiftUI.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelwatcherlistcontroller 
+title: ChatChannelWatcherListController
+--- 
 
 `_ChatChannelWatcherListController` is a controller class which allows observing
 a list of chat watchers based on the provided query.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListControllerDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListControllerDelegate.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelwatcherlistcontrollerdelegate 
+title: ChatChannelWatcherListControllerDelegate
+--- 
 
 ``` swift
 public protocol _ChatChannelWatcherListControllerDelegate: DataControllerStateDelegate 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ConnectionController/ChatConnectionController.ObservableObject.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ConnectionController/ChatConnectionController.ObservableObject.md
@@ -1,3 +1,7 @@
+---
+id: chatconnectioncontroller.observableobject 
+title: ChatConnectionController.ObservableObject
+--- 
 
 A wrapper object for `CurrentUserController` type which makes it possible to use the controller comfortably in SwiftUI.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ConnectionController/ChatConnectionController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ConnectionController/ChatConnectionController.md
@@ -1,3 +1,7 @@
+---
+id: chatconnectioncontroller 
+title: ChatConnectionController
+--- 
 
 `ChatConnectionController` is a controller class which allows to explicitly
 connect/disconnect the `ChatClient` and observe connection events.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ConnectionController/ChatConnectionControllerDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ConnectionController/ChatConnectionControllerDelegate.md
@@ -1,3 +1,7 @@
+---
+id: chatconnectioncontrollerdelegate 
+title: ChatConnectionControllerDelegate
+--- 
 
 `ChatConnectionController` uses this protocol to communicate changes to its delegate.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/Controller.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/Controller.md
@@ -1,3 +1,7 @@
+---
+id: controller 
+title: Controller
+--- 
 
 A protocol to which all controllers conform to.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/CurrentUserController/CurrentChatUserController.ObservableObject.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/CurrentUserController/CurrentChatUserController.ObservableObject.md
@@ -1,3 +1,7 @@
+---
+id: currentchatusercontroller.observableobject 
+title: CurrentChatUserController.ObservableObject
+--- 
 
 A wrapper object for `CurrentUserController` type which makes it possible to use the controller comfortably in SwiftUI.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/CurrentUserController/CurrentChatUserController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/CurrentUserController/CurrentChatUserController.md
@@ -1,3 +1,7 @@
+---
+id: currentchatusercontroller 
+title: CurrentChatUserController
+--- 
 
 `CurrentChatUserController` is a controller class which allows observing and mutating the currently logged-in
 user of `ChatClient`.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/CurrentUserController/CurrentChatUserControllerDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/CurrentUserController/CurrentChatUserControllerDelegate.md
@@ -1,3 +1,7 @@
+---
+id: currentchatusercontrollerdelegate 
+title: CurrentChatUserControllerDelegate
+--- 
 
 `CurrentChatUserController` uses this protocol to communicate changes to its delegate.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/DataController.State.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/DataController.State.md
@@ -1,3 +1,7 @@
+---
+id: datacontroller.state 
+title: DataController.State
+--- 
 
 Describes the possible states of `DataController`
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/DataController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/DataController.md
@@ -1,3 +1,7 @@
+---
+id: datacontroller 
+title: DataController
+--- 
 
 The base class for controllers which represent and control a data entity. Not meant to be used directly.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/DataControllerStateDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/DataControllerStateDelegate.md
@@ -1,3 +1,7 @@
+---
+id: datacontrollerstatedelegate 
+title: DataControllerStateDelegate
+--- 
 
 A delegate protocol some Controllers use to propagate the information about controller `state` changes. You can use it to let
 users know a certain activity is happening in the background, i.e. using a non-blocking activity indicator.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/EntityChange.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/EntityChange.md
@@ -1,3 +1,7 @@
+---
+id: entitychange 
+title: EntityChange
+--- 
 
 This enum describes the changes to a certain item when observing it.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ListChange.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/ListChange.md
@@ -1,3 +1,7 @@
+---
+id: listchange 
+title: ListChange
+--- 
 
 This enum describes the changes of the given collections of items.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MemberController/ChatChannelMemberController.ObservableObject.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MemberController/ChatChannelMemberController.ObservableObject.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelmembercontroller.observableobject 
+title: ChatChannelMemberController.ObservableObject
+--- 
 
 A wrapper object for `_ChatChannelMemberController` type which makes it possible to use the controller
 comfortably in SwiftUI.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MemberController/ChatChannelMemberController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MemberController/ChatChannelMemberController.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelmembercontroller 
+title: ChatChannelMemberController
+--- 
 
 `_ChatChannelMemberController` is a controller class which allows mutating and observing changes of a specific chat member.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MemberController/ChatChannelMemberControllerDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MemberController/ChatChannelMemberControllerDelegate.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelmembercontrollerdelegate 
+title: ChatChannelMemberControllerDelegate
+--- 
 
 `_ChatChannelMemberController` uses this protocol to communicate changes to its delegate.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MemberListController/ChatChannelMemberListController.ObservableObject.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MemberListController/ChatChannelMemberListController.ObservableObject.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelmemberlistcontroller.observableobject 
+title: ChatChannelMemberListController.ObservableObject
+--- 
 
 A wrapper object for `_ChatChannelMemberListController` type which makes it possible to use the controller
 comfortably in SwiftUI.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MemberListController/ChatChannelMemberListController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MemberListController/ChatChannelMemberListController.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelmemberlistcontroller 
+title: ChatChannelMemberListController
+--- 
 
 `_ChatChannelMemberListController` is a controller class which allows observing
 a list of chat users based on the provided query.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MemberListController/ChatChannelMemberListControllerDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MemberListController/ChatChannelMemberListControllerDelegate.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelmemberlistcontrollerdelegate 
+title: ChatChannelMemberListControllerDelegate
+--- 
 
 `_ChatChannelMemberListController` uses this protocol to communicate changes to its delegate.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MessageController/ChatMessageController.ObservableObject.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MessageController/ChatMessageController.ObservableObject.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagecontroller.observableobject 
+title: ChatMessageController.ObservableObject
+--- 
 
 A wrapper object for `CurrentUserController` type which makes it possible to use the controller comfortably in SwiftUI.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MessageController/ChatMessageController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MessageController/ChatMessageController.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagecontroller 
+title: ChatMessageController
+--- 
 
 `ChatMessageController` is a controller class which allows observing and mutating a chat message entity.
 
@@ -138,7 +142,7 @@ func deleteMessage(completion: ((Error?) -> Void)? = nil)
 
   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished. If request fails, the completion will be called with an error.
 
-### `createNewReply(text:pinning:attachments:showReplyInChannel:quotedMessageId:extraData:completion:)`
+### `createNewReply(text:pinning:attachments:mentionedUserIds:showReplyInChannel:quotedMessageId:extraData:completion:)`
 
 Creates a new reply message locally and schedules it for send.
 
@@ -149,6 +153,7 @@ func createNewReply(
 //        command: String? = nil,
 //        arguments: String? = nil,
         attachments: [AnyAttachmentPayload] = [],
+        mentionedUserIds: [UserId] = [],
         showReplyInChannel: Bool = false,
         quotedMessageId: MessageId? = nil,
         extraData: ExtraData.Message = .defaultValue,

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MessageController/ChatMessageControllerDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/MessageController/ChatMessageControllerDelegate.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagecontrollerdelegate 
+title: ChatMessageControllerDelegate
+--- 
 
 `_ChatMessageControllerDelegate` uses this protocol to communicate changes to its delegate.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/SearchControllers/ChatUserSearchController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/SearchControllers/ChatUserSearchController.md
@@ -1,3 +1,7 @@
+---
+id: chatusersearchcontroller 
+title: ChatUserSearchController
+--- 
 
 `_ChatUserSearchController` is a controller class which allows observing a list of chat users based on the provided query.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/SearchControllers/ChatUserSearchControllerDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/SearchControllers/ChatUserSearchControllerDelegate.md
@@ -1,3 +1,7 @@
+---
+id: chatusersearchcontrollerdelegate 
+title: ChatUserSearchControllerDelegate
+--- 
 
 `ChatUserSearchController` uses this protocol to communicate changes to its delegate.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/UserController/ChatUserController.ObservableObject.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/UserController/ChatUserController.ObservableObject.md
@@ -1,3 +1,7 @@
+---
+id: chatusercontroller.observableobject 
+title: ChatUserController.ObservableObject
+--- 
 
 A wrapper object for `ChatUserController` type which makes it possible to use the controller comfortably in SwiftUI.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/UserController/ChatUserController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/UserController/ChatUserController.md
@@ -1,3 +1,7 @@
+---
+id: chatusercontroller 
+title: ChatUserController
+--- 
 
 `_ChatUserController` is a controller class which allows mutating and observing changes of a specific chat user.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/UserController/ChatUserControllerDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/UserController/ChatUserControllerDelegate.md
@@ -1,3 +1,7 @@
+---
+id: chatusercontrollerdelegate 
+title: ChatUserControllerDelegate
+--- 
 
 `ChatChannelController` uses this protocol to communicate changes to its delegate.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/UserListController/ChatUserListController.ObservableObject.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/UserListController/ChatUserListController.ObservableObject.md
@@ -1,3 +1,7 @@
+---
+id: chatuserlistcontroller.observableobject 
+title: ChatUserListController.ObservableObject
+--- 
 
 A wrapper object for `UserListController` type which makes it possible to use the controller comfortably in SwiftUI.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/UserListController/ChatUserListController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/UserListController/ChatUserListController.md
@@ -1,3 +1,7 @@
+---
+id: chatuserlistcontroller 
+title: ChatUserListController
+--- 
 
 `_ChatUserListController` is a controller class which allows observing a list of chat users based on the provided query.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/UserListController/ChatUserListControllerDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Controllers/UserListController/ChatUserListControllerDelegate.md
@@ -1,3 +1,7 @@
+---
+id: chatuserlistcontrollerdelegate 
+title: ChatUserListControllerDelegate
+--- 
 
 `ChatUserListController` uses this protocol to communicate changes to its delegate.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Database/DataStore.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Database/DataStore.md
@@ -1,3 +1,7 @@
+---
+id: datastore 
+title: DataStore
+--- 
 
 `DataStore` provide access to all locally available model objects based on their id.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Database/DataStoreProvider.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Database/DataStoreProvider.md
@@ -1,3 +1,7 @@
+---
+id: datastoreprovider 
+title: DataStoreProvider
+--- 
 
 Types conforming to this protocol automatically exposes public `dataStore` variable.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Errors/ClientError.Location.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Errors/ClientError.Location.md
@@ -1,3 +1,7 @@
+---
+id: clienterror.location 
+title: ClientError.Location
+--- 
 
 ``` swift
 public struct Location: Equatable 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Errors/ClientError.Unexpected.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Errors/ClientError.Unexpected.md
@@ -1,3 +1,7 @@
+---
+id: clienterror.unexpected 
+title: ClientError.Unexpected
+--- 
 
 An unexpected error.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Errors/ClientError.Unknown.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Errors/ClientError.Unknown.md
@@ -1,3 +1,7 @@
+---
+id: clienterror.unknown 
+title: ClientError.Unknown
+--- 
 
 An unknown error.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Errors/ClientError.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Errors/ClientError.md
@@ -1,3 +1,7 @@
+---
+id: clienterror 
+title: ClientError
+--- 
 
 A Client error.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Errors/ErrorPayload.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Errors/ErrorPayload.md
@@ -1,3 +1,7 @@
+---
+id: errorpayload 
+title: ErrorPayload
+--- 
 
 A parsed server response error.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/ExtraDataTypes.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/ExtraDataTypes.md
@@ -1,3 +1,7 @@
+---
+id: extradatatypes 
+title: ExtraDataTypes
+--- 
 
 A protocol defining extra data types used by `ChatClient`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/AnyChannel.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/AnyChannel.md
@@ -1,3 +1,7 @@
+---
+id: anychannel 
+title: AnyChannel
+--- 
 
 A type-erased version of `ChannelModel<CustomData>`. Not intended to be used directly.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload.md
@@ -1,3 +1,7 @@
+---
+id: anyattachmentpayload 
+title: AnyAttachmentPayload
+--- 
 
 A type-erased type that wraps either a local file URL that has to be uploaded
 and attached to the message OR a custom payload which the message attachment

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AnyChatMessageAttachment.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AnyChatMessageAttachment.md
@@ -1,3 +1,7 @@
+---
+id: anychatmessageattachment 
+title: AnyChatMessageAttachment
+--- 
 
 ## Methods
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentAction.ActionStyle.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentAction.ActionStyle.md
@@ -1,3 +1,7 @@
+---
+id: attachmentaction.actionstyle 
+title: AttachmentAction.ActionStyle
+--- 
 
 An attachment action style, e.g. primary button.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentAction.ActionType.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentAction.ActionType.md
@@ -1,3 +1,7 @@
+---
+id: attachmentaction.actiontype 
+title: AttachmentAction.ActionType
+--- 
 
 An attachment action type, e.g. button.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentAction.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentAction.md
@@ -1,3 +1,7 @@
+---
+id: attachmentaction 
+title: AttachmentAction
+--- 
 
 An attachment action, e.g. send, shuffle.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentFile.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentFile.md
@@ -1,3 +1,7 @@
+---
+id: attachmentfile 
+title: AttachmentFile
+--- 
 
 An attachment file description.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentFileType.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentFileType.md
@@ -1,3 +1,7 @@
+---
+id: attachmentfiletype 
+title: AttachmentFileType
+--- 
 
 An attachment file type.
 
@@ -37,7 +41,7 @@ public init(ext: String)
 
 ## Enumeration Cases
 
-### `csv`
+### `mov`
 
 A file attachment type.
 
@@ -45,7 +49,7 @@ A file attachment type.
 case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
 ```
 
-### `doc`
+### `png`
 
 A file attachment type.
 
@@ -53,15 +57,7 @@ A file attachment type.
 case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
 ```
 
-### `xls`
-
-A file attachment type.
-
-``` swift
-case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
-```
-
-### `zip`
+### `mp3`
 
 A file attachment type.
 
@@ -85,47 +81,7 @@ A file attachment type.
 case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
 ```
 
-### `mov`
-
-A file attachment type.
-
-``` swift
-case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
-```
-
 ### `gif`
-
-A file attachment type.
-
-``` swift
-case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
-```
-
-### `mp4`
-
-A file attachment type.
-
-``` swift
-case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
-```
-
-### `ppt`
-
-A file attachment type.
-
-``` swift
-case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
-```
-
-### `png`
-
-A file attachment type.
-
-``` swift
-case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
-```
-
-### `generic`
 
 A file attachment type.
 
@@ -141,7 +97,55 @@ A file attachment type.
 case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
 ```
 
-### `mp3`
+### `xls`
+
+A file attachment type.
+
+``` swift
+case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
+```
+
+### `csv`
+
+A file attachment type.
+
+``` swift
+case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
+```
+
+### `doc`
+
+A file attachment type.
+
+``` swift
+case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
+```
+
+### `zip`
+
+A file attachment type.
+
+``` swift
+case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
+```
+
+### `generic`
+
+A file attachment type.
+
+``` swift
+case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
+```
+
+### `ppt`
+
+A file attachment type.
+
+``` swift
+case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
+```
+
+### `mp4`
 
 A file attachment type.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentId.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentId.md
@@ -1,3 +1,7 @@
+---
+id: attachmentid 
+title: AttachmentId
+--- 
 
 An object that uniquely identifies a message attachment.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentPayload.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentPayload.md
@@ -1,3 +1,7 @@
+---
+id: attachmentpayload 
+title: AttachmentPayload
+--- 
 
 A protocol an attachment payload type has to conform in order it can be
 attached to/exposed on the message.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentType.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentType.md
@@ -1,3 +1,7 @@
+---
+id: attachmenttype 
+title: AttachmentType
+--- 
 
 An attachment type.
 There are some predefined types on backend but any type can be introduced and sent to backend.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentUploadingState.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/AttachmentUploadingState.md
@@ -1,3 +1,7 @@
+---
+id: attachmentuploadingstate 
+title: AttachmentUploadingState
+--- 
 
 A type representing the uploading state for attachments that require prior uploading.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/ChatMessageAttachment.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/ChatMessageAttachment.md
@@ -1,3 +1,7 @@
+---
+id: chatmessageattachment 
+title: ChatMessageAttachment
+--- 
 
 A type representing a chat message attachment.
 `_ChatMessageAttachment<Payload>` is an immutable snapshot of message attachment at the given time.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/ChatMessageFileAttachment.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/ChatMessageFileAttachment.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagefileattachment 
+title: ChatMessageFileAttachment
+--- 
 
 A type alias for attachment with `FileAttachmentPayload` payload type.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/ChatMessageGiphyAttachment.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/ChatMessageGiphyAttachment.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagegiphyattachment 
+title: ChatMessageGiphyAttachment
+--- 
 
 A type alias for attachment with `GiphyAttachmentPayload` payload type.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/ChatMessageImageAttachment.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/ChatMessageImageAttachment.md
@@ -1,3 +1,7 @@
+---
+id: chatmessageimageattachment 
+title: ChatMessageImageAttachment
+--- 
 
 A type alias for attachment with `ImageAttachmentPayload` payload type.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/ChatMessageLinkAttachment.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/ChatMessageLinkAttachment.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagelinkattachment 
+title: ChatMessageLinkAttachment
+--- 
 
 A type alias for attachment with `LinkAttachmentPayload` payload type.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/FileAttachmentPayload.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/FileAttachmentPayload.md
@@ -1,3 +1,7 @@
+---
+id: fileattachmentpayload 
+title: FileAttachmentPayload
+--- 
 
 Represents a payload for attachments with `.file` type.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/GiphyAttachmentPayload.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/GiphyAttachmentPayload.md
@@ -1,3 +1,7 @@
+---
+id: giphyattachmentpayload 
+title: GiphyAttachmentPayload
+--- 
 
 Represents a payload for attachments with `.giphy` type.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/ImageAttachmentPayload.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/ImageAttachmentPayload.md
@@ -1,3 +1,7 @@
+---
+id: imageattachmentpayload 
+title: ImageAttachmentPayload
+--- 
 
 Represents a payload for attachments with `.image` type.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/LinkAttachmentPayload.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/LinkAttachmentPayload.md
@@ -1,3 +1,7 @@
+---
+id: linkattachmentpayload 
+title: LinkAttachmentPayload
+--- 
 
 Represents a payload for attachments with `.linkPreview` type.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/LocalAttachmentState.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Attachments/LocalAttachmentState.md
@@ -1,3 +1,7 @@
+---
+id: localattachmentstate 
+title: LocalAttachmentState
+--- 
 
 A local state of the attachment. Applies only for attachments linked to the new messages sent from current device.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/BanEnabling.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/BanEnabling.md
@@ -1,3 +1,7 @@
+---
+id: banenabling 
+title: BanEnabling
+--- 
 
 An option to enable ban users.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChannelExtraData.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChannelExtraData.md
@@ -1,3 +1,7 @@
+---
+id: channelextradata 
+title: ChannelExtraData
+--- 
 
 Additional data fields `ChannelModel` can be extended with. You can use it to store your custom data related to a channel.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChannelId.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChannelId.md
@@ -1,3 +1,7 @@
+---
+id: channelid 
+title: ChannelId
+--- 
 
 A type representing a unique identifier of a `ChatChannel`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChannelType.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChannelType.md
@@ -1,3 +1,7 @@
+---
+id: channeltype 
+title: ChannelType
+--- 
 
 An enum describing possible types of a channel.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChannelUnreadCount.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChannelUnreadCount.md
@@ -1,3 +1,7 @@
+---
+id: channelunreadcount 
+title: ChannelUnreadCount
+--- 
 
 A struct describing unread counts for a channel.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChatChannel.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChatChannel.md
@@ -1,3 +1,7 @@
+---
+id: chatchannel 
+title: ChatChannel
+--- 
 
 A type representing a chat channel. `_ChatChannel` is an immutable snapshot of a channel entity at the given time.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChatChannelMember.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChatChannelMember.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelmember 
+title: ChatChannelMember
+--- 
 
 A type representing a chat channel member. `_ChatChannelMember` is an immutable snapshot of a channel entity at the given time.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChatChannelRead.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChatChannelRead.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelread 
+title: ChatChannelRead
+--- 
 
 A type representing a user's last read action on a channel.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChatMessage.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChatMessage.md
@@ -1,3 +1,7 @@
+---
+id: chatmessage 
+title: ChatMessage
+--- 
 
 A type representing a chat message. `_ChatMessage` is an immutable snapshot of a chat message entity at the given time.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChatMessageReaction.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChatMessageReaction.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagereaction 
+title: ChatMessageReaction
+--- 
 
 A type representing a message reaction. `_ChatMessageReaction` is an immutable snapshot
 of a message reaction entity at the given time.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChatUser.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ChatUser.md
@@ -1,3 +1,7 @@
+---
+id: chatuser 
+title: ChatUser
+--- 
 
 A type representing a chat user. `ChatUser` is an immutable snapshot of a chat user entity at the given time.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ClientError.InvalidChannelId.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ClientError.InvalidChannelId.md
@@ -1,3 +1,7 @@
+---
+id: clienterror.invalidchannelid 
+title: ClientError.InvalidChannelId
+--- 
 
 ``` swift
 public class InvalidChannelId: ClientError 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/CurrentChatUser.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/CurrentChatUser.md
@@ -1,3 +1,7 @@
+---
+id: currentchatuser 
+title: CurrentChatUser
+--- 
 
 A type representing the currently logged-in user. `_CurrentChatUser` is an immutable snapshot of a current user entity at
 the given time.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Device.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/Device.md
@@ -1,3 +1,7 @@
+---
+id: device 
+title: Device
+--- 
 
 An object representing a device which can receive push notifications.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/DeviceId.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/DeviceId.md
@@ -1,3 +1,7 @@
+---
+id: deviceid 
+title: DeviceId
+--- 
 
 A unique identifier of a device.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ExtraData.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/ExtraData.md
@@ -1,3 +1,7 @@
+---
+id: extradata 
+title: ExtraData
+--- 
 
 A parent protocol for all extra data protocols. Not meant to be adopted directly.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/LocalMessageState.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/LocalMessageState.md
@@ -1,3 +1,7 @@
+---
+id: localmessagestate 
+title: LocalMessageState
+--- 
 
 A possible additional local state of the message. Applies only for the messages of the current user.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MemberRole.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MemberRole.md
@@ -1,3 +1,7 @@
+---
+id: memberrole 
+title: MemberRole
+--- 
 
 An enum describing possible roles of a member in a channel.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MessageExtraData.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MessageExtraData.md
@@ -1,3 +1,7 @@
+---
+id: messageextradata 
+title: MessageExtraData
+--- 
 
 You need to make your custom type conforming to this protocol if you want to use it for extending `ChatMessage` entity with
 your custom additional data.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MessageId.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MessageId.md
@@ -1,3 +1,7 @@
+---
+id: messageid 
+title: MessageId
+--- 
 
 A unique identifier of a message.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MessagePinDetails.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MessagePinDetails.md
@@ -1,3 +1,7 @@
+---
+id: messagepindetails 
+title: MessagePinDetails
+--- 
 
 ``` swift
 public struct _MessagePinDetails<ExtraData: ExtraDataTypes> 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MessagePinning.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MessagePinning.md
@@ -1,3 +1,7 @@
+---
+id: messagepinning 
+title: MessagePinning
+--- 
 
 Describes the pinning expiration
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MessageReactionExtraData.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MessageReactionExtraData.md
@@ -1,3 +1,7 @@
+---
+id: messagereactionextradata 
+title: MessageReactionExtraData
+--- 
 
 You need to make your custom type conforming to this protocol if you want to use it for extending `ChatMessageReaction` entity
 with your custom additional data.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MessageReactionType.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MessageReactionType.md
@@ -1,3 +1,7 @@
+---
+id: messagereactiontype 
+title: MessageReactionType
+--- 
 
 The type that describes a message reaction type.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MessageType.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MessageType.md
@@ -1,3 +1,7 @@
+---
+id: messagetype 
+title: MessageType
+--- 
 
 A type of the message.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MuteDetails.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/MuteDetails.md
@@ -1,3 +1,7 @@
+---
+id: mutedetails 
+title: MuteDetails
+--- 
 
 Describes user/channel mute details.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/NoExtraData.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/NoExtraData.md
@@ -1,3 +1,7 @@
+---
+id: noextradata 
+title: NoExtraData
+--- 
 
 A type representing no extra data for the given model object.
 
@@ -13,7 +17,7 @@ public struct NoExtraData: Codable,
 
 ## Inheritance
 
-`Codable`, [`ExtraDataTypes`](../ExtraDataTypes), [`ChannelExtraData`](ChannelExtraData), `Hashable`, [`MessageExtraData`](MessageExtraData), [`MessageReactionExtraData`](MessageReactionExtraData), [`UserExtraData`](UserExtraData)
+[`ExtraDataTypes`](../ExtraDataTypes), [`ChannelExtraData`](ChannelExtraData), `Codable`, `Hashable`, [`MessageExtraData`](MessageExtraData), [`MessageReactionExtraData`](MessageReactionExtraData), [`UserExtraData`](UserExtraData)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/TeamId.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/TeamId.md
@@ -1,3 +1,7 @@
+---
+id: teamid 
+title: TeamId
+--- 
 
 A unique identifier of team.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/UnreadCount.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/UnreadCount.md
@@ -1,3 +1,7 @@
+---
+id: unreadcount 
+title: UnreadCount
+--- 
 
 A struct containing information about unread counts of channels and messages.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/UserExtraData.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/UserExtraData.md
@@ -1,3 +1,7 @@
+---
+id: userextradata 
+title: UserExtraData
+--- 
 
 You need to make your custom type conforming to this protocol if you want to use it for extending `ChatUser` entity with your
 custom additional data.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/UserId.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/UserId.md
@@ -1,3 +1,7 @@
+---
+id: userid 
+title: UserId
+--- 
 
 A unique identifier of a user.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/UserRole.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Models/UserRole.md
@@ -1,3 +1,7 @@
+---
+id: userrole 
+title: UserRole
+--- 
 
 ``` swift
 public enum UserRole: String, Codable, Hashable 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/AnyChannelListFilterScope.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/AnyChannelListFilterScope.md
@@ -1,3 +1,7 @@
+---
+id: anychannellistfilterscope 
+title: AnyChannelListFilterScope
+--- 
 
 A namespace for the `FilterKey`s suitable to be used for `ChannelListQuery`. This scope is not aware of any extra data types.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/AnyMemberListFilterScope.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/AnyMemberListFilterScope.md
@@ -1,3 +1,7 @@
+---
+id: anymemberlistfilterscope 
+title: AnyMemberListFilterScope
+--- 
 
 A namespace for the `FilterKey`s suitable to be used for `ChannelMemberListQuery`. This scope is not aware of any
 extra data types.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/AnyUserListFilterScope.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/AnyUserListFilterScope.md
@@ -1,3 +1,7 @@
+---
+id: anyuserlistfilterscope 
+title: AnyUserListFilterScope
+--- 
 
 A namespace for the `FilterKey`s suitable to be used for `UserListQuery`. This scope is not aware of any extra data types.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/ChannelListFilterScope.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/ChannelListFilterScope.md
@@ -1,3 +1,7 @@
+---
+id: channellistfilterscope 
+title: ChannelListFilterScope
+--- 
 
 An extra-data-specific namespace for the `FilterKey`s suitable to be used for `_ChannelListQuery`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/ChannelListQuery.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/ChannelListQuery.md
@@ -1,3 +1,7 @@
+---
+id: channellistquery 
+title: ChannelListQuery
+--- 
 
 A query is used for querying specific channels from backend.
 You can specify filter, sorting, pagination, limit for fetched messages in channel and other options.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/ChannelMemberListQuery.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/ChannelMemberListQuery.md
@@ -1,3 +1,7 @@
+---
+id: channelmemberlistquery 
+title: ChannelMemberListQuery
+--- 
 
 A query type used for fetching channel members from the backend.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/ChannelQuery.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/ChannelQuery.md
@@ -1,3 +1,7 @@
+---
+id: channelquery 
+title: ChannelQuery
+--- 
 
 A channel query.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/ChannelWatcherListQuery.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/ChannelWatcherListQuery.md
@@ -1,3 +1,7 @@
+---
+id: channelwatcherlistquery 
+title: ChannelWatcherListQuery
+--- 
 
 A query type used for fetching a channel's watchers from the backend.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Filter.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Filter.md
@@ -1,3 +1,7 @@
+---
+id: filter 
+title: Filter
+--- 
 
 Filter is used to specify the details about which elements should be returned from a specific query.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/FilterKey.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/FilterKey.md
@@ -1,3 +1,7 @@
+---
+id: filterkey 
+title: FilterKey
+--- 
 
 A helper struct that represents a key of a filter.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/FilterOperator.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/FilterOperator.md
@@ -1,3 +1,7 @@
+---
+id: filteroperator 
+title: FilterOperator
+--- 
 
 An enum with possible operators to use in filters.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/FilterScope.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/FilterScope.md
@@ -1,3 +1,7 @@
+---
+id: filterscope 
+title: FilterScope
+--- 
 
 A phantom protocol used to limit the scope of `Filter`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/FilterValue.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/FilterValue.md
@@ -1,3 +1,7 @@
+---
+id: filtervalue 
+title: FilterValue
+--- 
 
 A protocol to which all values that can be used as `Filter` values conform.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Int.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Int.md
@@ -1,3 +1,7 @@
+---
+id: int 
+title: Int
+--- 
 
 ## Properties
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/MemberListFilterScope.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/MemberListFilterScope.md
@@ -1,3 +1,7 @@
+---
+id: memberlistfilterscope 
+title: MemberListFilterScope
+--- 
 
 An extra-data-specific namespace for the `FilterKey`s suitable to be used for `_ChannelMemberListQuery`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/MessagesPagination.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/MessagesPagination.md
@@ -1,3 +1,7 @@
+---
+id: messagespagination 
+title: MessagesPagination
+--- 
 
 ``` swift
 public struct MessagesPagination: Encodable, Equatable 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Pagination.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Pagination.md
@@ -1,3 +1,7 @@
+---
+id: pagination 
+title: Pagination
+--- 
 
 Basic pagination with `pageSize` and `offset`.
 Used everywhere except `ChannelQuery`. (See `MessagesPagination`)

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/PaginationParameter.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/PaginationParameter.md
@@ -1,3 +1,7 @@
+---
+id: paginationparameter 
+title: PaginationParameter
+--- 
 
 Pagination parameters
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.md
@@ -1,3 +1,7 @@
+---
+id: channellistsortingkey 
+title: ChannelListSortingKey
+--- 
 
 `ChannelListSortingKey` is keys by which you can get sorted channels after query.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Sorting/ChannelMemberListSortingKey.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Sorting/ChannelMemberListSortingKey.md
@@ -1,3 +1,7 @@
+---
+id: channelmemberlistsortingkey 
+title: ChannelMemberListSortingKey
+--- 
 
 `ChannelMemberListSortingKey` describes the keys by which you can get sorted channel members after query.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Sorting/Sorting.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Sorting/Sorting.md
@@ -1,3 +1,7 @@
+---
+id: sorting 
+title: Sorting
+--- 
 
 Sorting options.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Sorting/SortingKey.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Sorting/SortingKey.md
@@ -1,3 +1,7 @@
+---
+id: sortingkey 
+title: SortingKey
+--- 
 
 A sorting key protocol.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Sorting/UserListSortingKey.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/Sorting/UserListSortingKey.md
@@ -1,3 +1,7 @@
+---
+id: userlistsortingkey 
+title: UserListSortingKey
+--- 
 
 `UserListSortingKey` is keys by which you can get sorted users after query.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/UserListFilterScope.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/UserListFilterScope.md
@@ -1,3 +1,7 @@
+---
+id: userlistfilterscope 
+title: UserListFilterScope
+--- 
 
 An extra-data-specific namespace for the `FilterKey`s suitable to be used for `_UserListQuery`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/UserListQuery.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Query/UserListQuery.md
@@ -1,3 +1,7 @@
+---
+id: userlistquery 
+title: UserListQuery
+--- 
 
 A query is used for querying specific users from backend.
 You can specify filter, sorting and pagination.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Atomic.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Atomic.md
@@ -1,3 +1,7 @@
+---
+id: atomic 
+title: Atomic
+--- 
 
 A mutable thread safe variable.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/LazyCachedMapCollection.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/LazyCachedMapCollection.md
@@ -1,3 +1,7 @@
+---
+id: lazycachedmapcollection 
+title: LazyCachedMapCollection
+--- 
 
 Read-only collection that applies transformation to element on first access.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Destination/BaseLogDestination.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Destination/BaseLogDestination.md
@@ -1,3 +1,7 @@
+---
+id: baselogdestination 
+title: BaseLogDestination
+--- 
 
 Base class for log destinations. Already implements basic functionaly to allow easy destination implementation.
 Extending this class, instead of implementing `LogDestination` is easier (and recommended) for creating new destinations.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Destination/ConsoleLogDestination.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Destination/ConsoleLogDestination.md
@@ -1,3 +1,7 @@
+---
+id: consolelogdestination 
+title: ConsoleLogDestination
+--- 
 
 Basic destination for outputting messages to console.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Destination/LogDestination.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Destination/LogDestination.md
@@ -1,3 +1,7 @@
+---
+id: logdestination 
+title: LogDestination
+--- 
 
 ``` swift
 public protocol LogDestination 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Destination/LogDetails.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Destination/LogDetails.md
@@ -1,3 +1,7 @@
+---
+id: logdetails 
+title: LogDetails
+--- 
 
 Encapsulates the components of a log message.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Destination/LogLevel.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Destination/LogLevel.md
@@ -1,3 +1,7 @@
+---
+id: loglevel 
+title: LogLevel
+--- 
 
 Log level for any messages to be logged.
 Please check [this Apple Logging Article](https:​//developer.apple.com/documentation/os/logging/generating_log_messages_from_your_code) to understand different logging levels.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Formatter/LogFormatter.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Formatter/LogFormatter.md
@@ -1,3 +1,7 @@
+---
+id: logformatter 
+title: LogFormatter
+--- 
 
 ``` swift
 public protocol LogFormatter 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Formatter/PrefixLogFormatter.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Formatter/PrefixLogFormatter.md
@@ -1,3 +1,7 @@
+---
+id: prefixlogformatter 
+title: PrefixLogFormatter
+--- 
 
 Formats the given log message with the given prefixes by log level.
 Useful for emphasizing different leveled messages on console, when used as:​

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/LogConfig.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/LogConfig.md
@@ -1,3 +1,7 @@
+---
+id: logconfig 
+title: LogConfig
+--- 
 
 ``` swift
 public enum LogConfig 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Logger.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/Logger.md
@@ -1,3 +1,7 @@
+---
+id: logger 
+title: Logger
+--- 
 
 Entitiy used for loggin messages.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/log.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/Logger/log.md
@@ -1,3 +1,7 @@
+---
+id: log 
+title: log
+--- 
 
 ``` swift
 public var log: Logger 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/RandomAccessCollection.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/Utils/RandomAccessCollection.md
@@ -1,3 +1,7 @@
+---
+id: randomaccesscollection 
+title: RandomAccessCollection
+--- 
 
 ## Methods
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/ClientError.WebSocket.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/ClientError.WebSocket.md
@@ -1,3 +1,7 @@
+---
+id: clienterror.websocket 
+title: ClientError.WebSocket
+--- 
 
 ``` swift
 public class WebSocket: ClientError 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/ConnectionStatus.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/ConnectionStatus.md
@@ -1,3 +1,7 @@
+---
+id: connectionstatus 
+title: ConnectionStatus
+--- 
 
 Describes the possible states of the client connection to the servers.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ChannelDeletedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ChannelDeletedEvent.md
@@ -1,3 +1,7 @@
+---
+id: channeldeletedevent 
+title: ChannelDeletedEvent
+--- 
 
 ``` swift
 public struct ChannelDeletedEvent: ChannelSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ChannelHiddenEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ChannelHiddenEvent.md
@@ -1,3 +1,7 @@
+---
+id: channelhiddenevent 
+title: ChannelHiddenEvent
+--- 
 
 ``` swift
 public struct ChannelHiddenEvent: ChannelSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ChannelReadEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ChannelReadEvent.md
@@ -1,3 +1,7 @@
+---
+id: channelreadevent 
+title: ChannelReadEvent
+--- 
 
 `ChannelReadEvent`, this event tells that User has mark read all messages in channel.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ChannelTruncatedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ChannelTruncatedEvent.md
@@ -1,3 +1,7 @@
+---
+id: channeltruncatedevent 
+title: ChannelTruncatedEvent
+--- 
 
 ``` swift
 public struct ChannelTruncatedEvent: ChannelSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ChannelUpdatedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ChannelUpdatedEvent.md
@@ -1,3 +1,7 @@
+---
+id: channelupdatedevent 
+title: ChannelUpdatedEvent
+--- 
 
 ``` swift
 public struct ChannelUpdatedEvent: ChannelSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ChannelVisibleEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ChannelVisibleEvent.md
@@ -1,3 +1,7 @@
+---
+id: channelvisibleevent 
+title: ChannelVisibleEvent
+--- 
 
 ``` swift
 public struct ChannelVisibleEvent: ChannelSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/CleanUpTypingEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/CleanUpTypingEvent.md
@@ -1,3 +1,7 @@
+---
+id: cleanuptypingevent 
+title: CleanUpTypingEvent
+--- 
 
 A special event type which is only emitted by the SDK and never the backend.
 This event is emitted by `TypingStartCleanupMiddleware` to signal that a typing event

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ClientError.EventDecoding.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ClientError.EventDecoding.md
@@ -1,3 +1,7 @@
+---
+id: clienterror.eventdecoding 
+title: ClientError.EventDecoding
+--- 
 
 ``` swift
 public class EventDecoding: ClientError 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ClientError.UnsupportedEventType.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ClientError.UnsupportedEventType.md
@@ -1,3 +1,7 @@
+---
+id: clienterror.unsupportedeventtype 
+title: ClientError.UnsupportedEventType
+--- 
 
 ``` swift
 public class UnsupportedEventType: ClientError 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ConnectionEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ConnectionEvent.md
@@ -1,3 +1,7 @@
+---
+id: connectionevent 
+title: ConnectionEvent
+--- 
 
 ``` swift
 public protocol ConnectionEvent: Event 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ConnectionStatusUpdated.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ConnectionStatusUpdated.md
@@ -1,3 +1,7 @@
+---
+id: connectionstatusupdated 
+title: ConnectionStatusUpdated
+--- 
 
 Emitted when `Client` changes it's connection status. You can listen to this event and indicate the different connection
 states in the UI (banners like "Offline", "Reconnecting"", etc.).

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/Event.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/Event.md
@@ -1,3 +1,7 @@
+---
+id: event 
+title: Event
+--- 
 
 An `Event` object representing an event in the chat system.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/HealthCheckEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/HealthCheckEvent.md
@@ -1,3 +1,7 @@
+---
+id: healthcheckevent 
+title: HealthCheckEvent
+--- 
 
 ``` swift
 public struct HealthCheckEvent: ConnectionEvent, EventWithPayload 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MemberAddedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MemberAddedEvent.md
@@ -1,3 +1,7 @@
+---
+id: memberaddedevent 
+title: MemberAddedEvent
+--- 
 
 ``` swift
 public struct MemberAddedEvent: MemberEvent, ChannelSpecificEvent, EventWithPayload 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MemberEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MemberEvent.md
@@ -1,3 +1,7 @@
+---
+id: memberevent 
+title: MemberEvent
+--- 
 
 A protocol for any `MemberEvent` where it has a `member`, and `channel` payload.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MemberRemovedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MemberRemovedEvent.md
@@ -1,3 +1,7 @@
+---
+id: memberremovedevent 
+title: MemberRemovedEvent
+--- 
 
 ``` swift
 public struct MemberRemovedEvent: MemberEvent, ChannelSpecificEvent, EventWithPayload 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MemberUpdatedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MemberUpdatedEvent.md
@@ -1,3 +1,7 @@
+---
+id: memberupdatedevent 
+title: MemberUpdatedEvent
+--- 
 
 ``` swift
 public struct MemberUpdatedEvent: MemberEvent, ChannelSpecificEvent, EventWithPayload 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MessageDeletedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MessageDeletedEvent.md
@@ -1,3 +1,7 @@
+---
+id: messagedeletedevent 
+title: MessageDeletedEvent
+--- 
 
 ``` swift
 public struct MessageDeletedEvent: MessageSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MessageNewEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MessageNewEvent.md
@@ -1,3 +1,7 @@
+---
+id: messagenewevent 
+title: MessageNewEvent
+--- 
 
 ``` swift
 public struct MessageNewEvent: MessageSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MessageReadEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MessageReadEvent.md
@@ -1,3 +1,7 @@
+---
+id: messagereadevent 
+title: MessageReadEvent
+--- 
 
 `ChannelReadEvent`, this event tells that User has mark read all messages in channel.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MessageUpdatedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/MessageUpdatedEvent.md
@@ -1,3 +1,7 @@
+---
+id: messageupdatedevent 
+title: MessageUpdatedEvent
+--- 
 
 ``` swift
 public struct MessageUpdatedEvent: MessageSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/NotificationAddedToChannelEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/NotificationAddedToChannelEvent.md
@@ -1,3 +1,7 @@
+---
+id: notificationaddedtochannelevent 
+title: NotificationAddedToChannelEvent
+--- 
 
 ``` swift
 public struct NotificationAddedToChannelEvent: ChannelSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/NotificationChannelMutesUpdatedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/NotificationChannelMutesUpdatedEvent.md
@@ -1,3 +1,7 @@
+---
+id: notificationchannelmutesupdatedevent 
+title: NotificationChannelMutesUpdatedEvent
+--- 
 
 ``` swift
 public struct NotificationChannelMutesUpdatedEvent: UserSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/NotificationMarkAllReadEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/NotificationMarkAllReadEvent.md
@@ -1,3 +1,7 @@
+---
+id: notificationmarkallreadevent 
+title: NotificationMarkAllReadEvent
+--- 
 
 ``` swift
 public struct NotificationMarkAllReadEvent: UserSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/NotificationMarkReadEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/NotificationMarkReadEvent.md
@@ -1,3 +1,7 @@
+---
+id: notificationmarkreadevent 
+title: NotificationMarkReadEvent
+--- 
 
 ``` swift
 public struct NotificationMarkReadEvent: UserSpecificEvent, ChannelSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/NotificationMessageNewEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/NotificationMessageNewEvent.md
@@ -1,3 +1,7 @@
+---
+id: notificationmessagenewevent 
+title: NotificationMessageNewEvent
+--- 
 
 ``` swift
 public struct NotificationMessageNewEvent: MessageSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/NotificationMutesUpdatedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/NotificationMutesUpdatedEvent.md
@@ -1,3 +1,7 @@
+---
+id: notificationmutesupdatedevent 
+title: NotificationMutesUpdatedEvent
+--- 
 
 ``` swift
 public struct NotificationMutesUpdatedEvent<ExtraData: ExtraDataTypes>: CurrentUserEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/NotificationRemovedFromChannelEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/NotificationRemovedFromChannelEvent.md
@@ -1,3 +1,7 @@
+---
+id: notificationremovedfromchannelevent 
+title: NotificationRemovedFromChannelEvent
+--- 
 
 ``` swift
 public struct NotificationRemovedFromChannelEvent: CurrentUserEvent, ChannelSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ReactionDeletedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ReactionDeletedEvent.md
@@ -1,3 +1,7 @@
+---
+id: reactiondeletedevent 
+title: ReactionDeletedEvent
+--- 
 
 ``` swift
 public struct ReactionDeletedEvent: ReactionEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ReactionNewEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ReactionNewEvent.md
@@ -1,3 +1,7 @@
+---
+id: reactionnewevent 
+title: ReactionNewEvent
+--- 
 
 ``` swift
 public struct ReactionNewEvent: ReactionEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ReactionUpdatedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/ReactionUpdatedEvent.md
@@ -1,3 +1,7 @@
+---
+id: reactionupdatedevent 
+title: ReactionUpdatedEvent
+--- 
 
 ``` swift
 public struct ReactionUpdatedEvent: ReactionEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/TypingEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/TypingEvent.md
@@ -1,3 +1,7 @@
+---
+id: typingevent 
+title: TypingEvent
+--- 
 
 ``` swift
 public struct TypingEvent: UserSpecificEvent, ChannelSpecificEvent 
@@ -5,7 +9,7 @@ public struct TypingEvent: UserSpecificEvent, ChannelSpecificEvent
 
 ## Inheritance
 
-[`ChannelSpecificEvent`](ChannelSpecificEvent), `Equatable`, [`UserSpecificEvent`](UserSpecificEvent)
+[`UserSpecificEvent`](UserSpecificEvent), [`ChannelSpecificEvent`](ChannelSpecificEvent), `Equatable`
 
 ## Properties
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/UserBannedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/UserBannedEvent.md
@@ -1,3 +1,7 @@
+---
+id: userbannedevent 
+title: UserBannedEvent
+--- 
 
 ``` swift
 public struct UserBannedEvent: UserSpecificEvent, ChannelSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/UserGloballyBannedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/UserGloballyBannedEvent.md
@@ -1,3 +1,7 @@
+---
+id: usergloballybannedevent 
+title: UserGloballyBannedEvent
+--- 
 
 ``` swift
 public struct UserGloballyBannedEvent: UserSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/UserGloballyUnbannedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/UserGloballyUnbannedEvent.md
@@ -1,3 +1,7 @@
+---
+id: usergloballyunbannedevent 
+title: UserGloballyUnbannedEvent
+--- 
 
 ``` swift
 public struct UserGloballyUnbannedEvent: UserSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/UserPresenceChangedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/UserPresenceChangedEvent.md
@@ -1,3 +1,7 @@
+---
+id: userpresencechangedevent 
+title: UserPresenceChangedEvent
+--- 
 
 ``` swift
 public struct UserPresenceChangedEvent: UserSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/UserUnbannedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/UserUnbannedEvent.md
@@ -1,3 +1,7 @@
+---
+id: userunbannedevent 
+title: UserUnbannedEvent
+--- 
 
 ``` swift
 public struct UserUnbannedEvent: UserSpecificEvent, ChannelSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/UserUpdatedEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/UserUpdatedEvent.md
@@ -1,3 +1,7 @@
+---
+id: userupdatedevent 
+title: UserUpdatedEvent
+--- 
 
 ``` swift
 public struct UserUpdatedEvent: UserSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/UserWatchingEvent.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChat/WebSocketClient/Events/UserWatchingEvent.md
@@ -1,3 +1,7 @@
+---
+id: userwatchingevent 
+title: UserWatchingEvent
+--- 
 
 ``` swift
 public struct UserWatchingEvent: UserSpecificEvent, ChannelSpecificEvent 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Appearance.ColorPalette.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Appearance.ColorPalette.md
@@ -1,3 +1,7 @@
+---
+id: appearance.colorpalette 
+title: Appearance.ColorPalette
+--- 
 
 ``` swift
 struct ColorPalette 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Appearance.Fonts.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Appearance.Fonts.md
@@ -1,3 +1,7 @@
+---
+id: appearance.fonts 
+title: Appearance.Fonts
+--- 
 
 ``` swift
 struct Fonts 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Appearance.Images.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Appearance.Images.md
@@ -1,3 +1,7 @@
+---
+id: appearance.images 
+title: Appearance.Images
+--- 
 
 ``` swift
 struct Images 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Appearance.ObservableObject.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Appearance.ObservableObject.md
@@ -1,3 +1,7 @@
+---
+id: appearance.observableobject 
+title: Appearance.ObservableObject
+--- 
 
 ``` swift
 @dynamicMemberLookup

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Appearance.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Appearance.md
@@ -1,3 +1,7 @@
+---
+id: appearance 
+title: Appearance
+--- 
 
 An object containing visual configuration for whole application.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/CellActionView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/CellActionView.md
@@ -1,3 +1,7 @@
+---
+id: cellactionview 
+title: CellActionView
+--- 
 
 View which wraps inside `SwipeActionButton` for leading layout
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelList.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelList.md
@@ -1,3 +1,7 @@
+---
+id: chatchannellist 
+title: ChatChannelList
+--- 
 
 ``` swift
 @available(iOS 13.0, *)

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListCollectionViewCell.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListCollectionViewCell.md
@@ -1,3 +1,7 @@
+---
+id: chatchannellistcollectionviewcell 
+title: ChatChannelListCollectionViewCell
+--- 
 
 A `UICollectionViewCell` subclass that shows channel information.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListCollectionViewDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListCollectionViewDelegate.md
@@ -1,3 +1,7 @@
+---
+id: chatchannellistcollectionviewdelegate 
+title: ChatChannelListCollectionViewDelegate
+--- 
 
 ``` swift
 open class ChatChannelListCollectionViewDelegate: NSObject, UICollectionViewDelegate 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.Content.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.Content.md
@@ -1,3 +1,7 @@
+---
+id: chatchannellistitemview.content 
+title: ChatChannelListItemView.Content
+--- 
 
 The content of this view.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.SwiftUIWrapper.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.SwiftUIWrapper.md
@@ -1,3 +1,7 @@
+---
+id: chatchannellistitemview.swiftuiwrapper 
+title: ChatChannelListItemView.SwiftUIWrapper
+--- 
 
 SwiftUI wrapper of `_ChatChannelListItemView`.
 Servers to wrap custom SwiftUI view as a UIKit view so it can be easily injected into `_Components`.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.md
@@ -1,3 +1,7 @@
+---
+id: chatchannellistitemview 
+title: ChatChannelListItemView
+--- 
 ![ChatChannelListItemView](../../../../assets/ChannelListItemView_documentation.default-light.png)
 
 An `UIView` subclass that shows summary and preview information about a given channel.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemViewSwiftUIView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemViewSwiftUIView.md
@@ -1,3 +1,7 @@
+---
+id: chatchannellistitemviewswiftuiview 
+title: ChatChannelListItemViewSwiftUIView
+--- 
 
 ``` swift
 @available(iOS 13.0, *)

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.md
@@ -1,3 +1,7 @@
+---
+id: chatchannellistvc 
+title: ChatChannelListVC
+--- 
 
 A `UIViewController` subclass  that shows list of channels.
 
@@ -5,6 +9,8 @@ A `UIViewController` subclass  that shows list of channels.
 open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
     UICollectionViewDataSource,
     UICollectionViewDelegate,
+    _ChatChannelListControllerDelegate,
+    DataControllerStateDelegate,
     ThemeProvider,
     SwipeableViewDelegate 
 ```
@@ -12,14 +18,6 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
 ## Inheritance
 
 [`_ViewController`](../CommonViews/_ViewController), `DataControllerStateDelegate`, [`SwipeableViewDelegate`](SwipeableViewDelegate), [`SwiftUIRepresentable`](../CommonViews/SwiftUIRepresentable), [`ThemeProvider`](../Utils/ThemeProvider), `UICollectionViewDataSource`, `UICollectionViewDelegate`, `_ChatChannelListControllerDelegate`
-
-## Nested Type Aliases
-
-### `ExtraData`
-
-``` swift
-public typealias ExtraData = ExtraData
-```
 
 ## Properties
 
@@ -143,7 +141,7 @@ open func collectionView(
 ### `collectionView(_:viewForSupplementaryElementOfKind:at:)`
 
 ``` swift
-public func collectionView(
+open func collectionView(
         _ collectionView: UICollectionView,
         viewForSupplementaryElementOfKind kind: String,
         at indexPath: IndexPath
@@ -219,7 +217,7 @@ open func moreButtonPressedForCell(at indexPath: IndexPath)
 ### `controllerWillChangeChannels(_:)`
 
 ``` swift
-public func controllerWillChangeChannels(_ controller: _ChatChannelListController<ExtraData>) 
+open func controllerWillChangeChannels(_ controller: _ChatChannelListController<ExtraData>) 
 ```
 
 ### `controller(_:didChangeChannels:)`
@@ -234,5 +232,5 @@ open func controller(
 ### `controller(_:didChangeState:)`
 
 ``` swift
-public func controller(_ controller: DataController, didChangeState state: DataController.State) 
+open func controller(_ controller: DataController, didChangeState state: DataController.State) 
 ```

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelReadStatusCheckmarkView.Status.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelReadStatusCheckmarkView.Status.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelreadstatuscheckmarkview.status 
+title: ChatChannelReadStatusCheckmarkView.Status
+--- 
 
 An underlying type for status in the view.
 Right now corresponding functionality in LLC is missing and it will likely be replaced with the type from LLC.
@@ -8,13 +12,13 @@ public enum Status
 
 ## Enumeration Cases
 
-### `unread`
+### `read`
 
 ``` swift
 case read, unread, empty
 ```
 
-### `read`
+### `unread`
 
 ``` swift
 case read, unread, empty

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelReadStatusCheckmarkView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelReadStatusCheckmarkView.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelreadstatuscheckmarkview 
+title: ChatChannelReadStatusCheckmarkView
+--- 
 
 A view that shows a read/unread status of the last message in channel.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountView.SwiftUIWrapper.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountView.SwiftUIWrapper.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelunreadcountview.swiftuiwrapper 
+title: ChatChannelUnreadCountView.SwiftUIWrapper
+--- 
 
 SwiftUI wrapper of `_ChatChannelUnreadCountView`.
 Servers to wrap custom SwiftUI view as a UIKit view so it can be easily injected into `_Components`.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountView.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelunreadcountview 
+title: ChatChannelUnreadCountView
+--- 
 
 A view that shows a number of unread messages in channel.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountViewSwiftUIView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountViewSwiftUIView.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelunreadcountviewswiftuiview 
+title: ChatChannelUnreadCountViewSwiftUIView
+--- 
 
 ``` swift
 @available(iOS 13.0, *)

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/SwipeableView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/SwipeableView.md
@@ -1,3 +1,7 @@
+---
+id: swipeableview 
+title: SwipeableView
+--- 
 
 A view with swipe functionality that is used as action buttons view for channel list item view.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/SwipeableViewDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatChannelList/SwipeableViewDelegate.md
@@ -1,3 +1,7 @@
+---
+id: swipeableviewdelegate 
+title: SwipeableViewDelegate
+--- 
 
 Delegate responsible for easily assigning swipe action buttons to collectionView cells.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/AttachmentViewInjector.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/AttachmentViewInjector.md
@@ -1,3 +1,7 @@
+---
+id: attachmentviewinjector 
+title: AttachmentViewInjector
+--- 
 
 An object used for injecting attachment views into `ChatMessageContentView`. The injector is also
 responsible for updating the content of the injected views.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageAttachmentPreviewVC.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageAttachmentPreviewVC.md
@@ -1,3 +1,7 @@
+---
+id: chatmessageattachmentpreviewvc 
+title: ChatMessageAttachmentPreviewVC
+--- 
 
 ``` swift
 open class ChatMessageAttachmentPreviewVC: _ViewController, WKNavigationDelegate, AppearanceProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageFileAttachmentListView.ItemView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageFileAttachmentListView.ItemView.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagefileattachmentlistview.itemview 
+title: ChatMessageFileAttachmentListView.ItemView
+--- 
 
 ``` swift
 open class ItemView: _View, ThemeProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageFileAttachmentListView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageFileAttachmentListView.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagefileattachmentlistview 
+title: ChatMessageFileAttachmentListView
+--- 
 
 View which holds one or more file attachment views in a message or composer attachment view
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageGiphyView.GiphyBadge.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageGiphyView.GiphyBadge.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagegiphyview.giphybadge 
+title: ChatMessageGiphyView.GiphyBadge
+--- 
 
 ``` swift
 open class GiphyBadge: _View, AppearanceProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageGiphyView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageGiphyView.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagegiphyview 
+title: ChatMessageGiphyView
+--- 
 
 ``` swift
 open class _ChatMessageGiphyView<ExtraData: ExtraDataTypes>: _View, ComponentsProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery.ImagePreview.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery.ImagePreview.md
@@ -1,3 +1,7 @@
+---
+id: chatmessageimagegallery.imagepreview 
+title: ChatMessageImageGallery.ImagePreview
+--- 
 
 ``` swift
 open class ImagePreview: _View, ThemeProvider, ImagePreviewable 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery.UploadingOverlay.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery.UploadingOverlay.md
@@ -1,3 +1,7 @@
+---
+id: chatmessageimagegallery.uploadingoverlay 
+title: ChatMessageImageGallery.UploadingOverlay
+--- 
 
 ``` swift
 open class UploadingOverlay: _View, ThemeProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery.md
@@ -1,3 +1,7 @@
+---
+id: chatmessageimagegallery 
+title: ChatMessageImageGallery
+--- 
 
 Gallery view that displays images.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView.ActionButton.Content.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView.ActionButton.Content.md
@@ -1,3 +1,7 @@
+---
+id: chatmessageinteractiveattachmentview.actionbutton.content 
+title: ChatMessageInteractiveAttachmentView.ActionButton.Content
+--- 
 
 ``` swift
 public struct Content 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView.ActionButton.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView.ActionButton.md
@@ -1,3 +1,7 @@
+---
+id: chatmessageinteractiveattachmentview.actionbutton 
+title: ChatMessageInteractiveAttachmentView.ActionButton
+--- 
 
 ``` swift
 open class ActionButton: _Button, AppearanceProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView.md
@@ -1,3 +1,7 @@
+---
+id: chatmessageinteractiveattachmentview 
+title: ChatMessageInteractiveAttachmentView
+--- 
 
 ``` swift
 open class _ChatMessageInteractiveAttachmentView<ExtraData: ExtraDataTypes>: _View, ThemeProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageLinkPreviewView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageLinkPreviewView.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagelinkpreviewview 
+title: ChatMessageLinkPreviewView
+--- 
 
 ``` swift
 open class _ChatMessageLinkPreviewView<ExtraData: ExtraDataTypes>: _Control, ThemeProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/FileActionContentViewDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/FileActionContentViewDelegate.md
@@ -1,3 +1,7 @@
+---
+id: fileactioncontentviewdelegate 
+title: FileActionContentViewDelegate
+--- 
 
 The delegate used `GiphyAttachmentViewInjector` to communicate user interactions.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/FilesAttachmentViewInjector.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/FilesAttachmentViewInjector.md
@@ -1,3 +1,7 @@
+---
+id: filesattachmentviewinjector 
+title: FilesAttachmentViewInjector
+--- 
 
 ``` swift
 public class _FilesAttachmentViewInjector<ExtraData: ExtraDataTypes>: _AttachmentViewInjector<ExtraData> 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/GalleryAttachmentViewInjector.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/GalleryAttachmentViewInjector.md
@@ -1,3 +1,7 @@
+---
+id: galleryattachmentviewinjector 
+title: GalleryAttachmentViewInjector
+--- 
 
 ``` swift
 open class _GalleryAttachmentViewInjector<ExtraData: ExtraDataTypes>: _AttachmentViewInjector<ExtraData> 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/GalleryContentViewDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/GalleryContentViewDelegate.md
@@ -1,3 +1,7 @@
+---
+id: gallerycontentviewdelegate 
+title: GalleryContentViewDelegate
+--- 
 
 The delegate used `GalleryAttachmentViewInjector` to communicate user interactions.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/GiphyActionContentViewDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/GiphyActionContentViewDelegate.md
@@ -1,3 +1,7 @@
+---
+id: giphyactioncontentviewdelegate 
+title: GiphyActionContentViewDelegate
+--- 
 
 The delegate used `GiphyAttachmentViewInjector` to communicate user interactions.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/GiphyAttachmentViewInjector.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/GiphyAttachmentViewInjector.md
@@ -1,3 +1,7 @@
+---
+id: giphyattachmentviewinjector 
+title: GiphyAttachmentViewInjector
+--- 
 
 ``` swift
 public class _GiphyAttachmentViewInjector<ExtraData: ExtraDataTypes>: _AttachmentViewInjector<ExtraData> 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ImagePreviewable.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ImagePreviewable.md
@@ -1,3 +1,7 @@
+---
+id: imagepreviewable 
+title: ImagePreviewable
+--- 
 
 Properties necessary for image to be previewed.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/LinkAttachmentViewInjector.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/LinkAttachmentViewInjector.md
@@ -1,3 +1,7 @@
+---
+id: linkattachmentviewinjector 
+title: LinkAttachmentViewInjector
+--- 
 
 View injector for showing link attachments.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/LinkPreviewViewDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/LinkPreviewViewDelegate.md
@@ -1,3 +1,7 @@
+---
+id: linkpreviewviewdelegate 
+title: LinkPreviewViewDelegate
+--- 
 
 The delegate used in `LinkAttachmentViewInjector` to communicate user interactions.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageBubbleView.Content.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageBubbleView.Content.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagebubbleview.content 
+title: ChatMessageBubbleView.Content
+--- 
 
 A type describing the content of this view.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageBubbleView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageBubbleView.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagebubbleview 
+title: ChatMessageBubbleView
+--- 
 
 A view that displays a bubble around a message.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagecollectionviewcell 
+title: ChatMessageCollectionViewCell
+--- 
 
 The cell that displays the message content of a dynamic type and layout.
 Once the cell is set up it is expected to be dequeued for messages with

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.SwiftUIWrapper.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.SwiftUIWrapper.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagecontentview.swiftuiwrapper 
+title: ChatMessageContentView.SwiftUIWrapper
+--- 
 
 SwiftUI wrapper of `_ChatMessageContentView`.
 Servers to wrap custom SwiftUI view as a UIKit view so it can be easily injected into `_Components`.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagecontentview 
+title: ChatMessageContentView
+--- 
 
 A view that displays the message content.
 
@@ -97,6 +101,15 @@ Exists if `layout(options:​ MessageLayoutOptions)` was invoked with the option
 public private(set) var authorAvatarView: ChatAvatarView?
 ```
 
+### `authorAvatarSpacer`
+
+Shows a spacer where the author avatar should be.
+Exists if `layout(options:​ MessageLayoutOptions)` was invoked with the options containing `.avatarSizePadding`.
+
+``` swift
+public private(set) var authorAvatarSpacer: UIView?
+```
+
 ### `textView`
 
 Shows message text content.
@@ -147,7 +160,7 @@ public private(set) var onlyVisibleForYouLabel: UILabel?
 ### `errorIndicatorView`
 
 Shows error indicator.
-Exists if `layout(options:​ MessageLayoutOptions)` was invoked with the options containing `.error`.
+Exists if `layout(options:​ MessageLayoutOptions)` was invoked with the options containing `.errorIndicator`.
 
 ``` swift
 public private(set) var errorIndicatorView: ChatMessageErrorIndicator?
@@ -269,6 +282,15 @@ The container which holds `onlyVisibleForYouIconImageView` and `onlyVisibleForYo
 public private(set) var onlyVisibleForYouContainer: ContainerStackView?
 ```
 
+### `errorIndicatorContainer`
+
+The container which holds `errorIndicatorView`
+Exists if `layout(options:​ MessageLayoutOptions)` was invoked with the options containing `.errorIndicator`.
+
+``` swift
+public private(set) var errorIndicatorContainer: UIView?
+```
+
 ### `bubbleToReactionsConstraint`
 
 Constraint between bubble and reactions.
@@ -366,6 +388,18 @@ open func createAvatarView() -> ChatAvatarView
 
 The `authorAvatarView` subview.
 
+### `createAvatarSpacer()`
+
+Instantiates, configures and assigns `createAvatarSpacer` when called for the first time.
+
+``` swift
+open func createAvatarSpacer() -> UIView 
+```
+
+#### Returns
+
+The `authorAvatarSpacer` subview.
+
 ### `createThreadAvatarView()`
 
 Instantiates, configures and assigns `threadAvatarView` when called for the first time.
@@ -449,6 +483,18 @@ open func createErrorIndicatorView() -> ChatMessageErrorIndicator
 #### Returns
 
 The `errorIndicatorView` subview.
+
+### `createErrorIndicatorContainer()`
+
+Instantiates, configures and assigns `errorIndicatorContainer` when called for the first time.
+
+``` swift
+open func createErrorIndicatorContainer() -> UIView 
+```
+
+#### Returns
+
+The `errorIndicatorContainer` subview.
 
 ### `createReactionsBubbleView()`
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentViewDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentViewDelegate.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagecontentviewdelegate 
+title: ChatMessageContentViewDelegate
+--- 
 
 A protocol for message content delegate responsible for action handling.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentViewSwiftUIView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentViewSwiftUIView.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagecontentviewswiftuiview 
+title: ChatMessageContentViewSwiftUIView
+--- 
 
 ``` swift
 @available(iOS 13.0, *)

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageErrorIndicator.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageErrorIndicator.md
@@ -1,3 +1,9 @@
+---
+id: chatmessageerrorindicator 
+title: ChatMessageErrorIndicator
+--- 
+
+A view that displays an error indicator inside the message content view.
 
 ``` swift
 open class ChatMessageErrorIndicator: _Button, AppearanceProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptions.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptions.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagelayoutoptions 
+title: ChatMessageLayoutOptions
+--- 
 
 Describes the layout of base message content view.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagelayoutoptionsresolver 
+title: ChatMessageLayoutOptionsResolver
+--- 
 
 Resolves layout options for the message at given `indexPath`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatReactionsBubbleView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatReactionsBubbleView.md
@@ -1,3 +1,7 @@
+---
+id: chatreactionsbubbleview 
+title: ChatReactionsBubbleView
+--- 
 
 ``` swift
 open class ChatReactionsBubbleView: _View, AppearanceProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatThreadArrowView.Direction.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatThreadArrowView.Direction.md
@@ -1,3 +1,7 @@
+---
+id: chatthreadarrowview.direction 
+title: ChatThreadArrowView.Direction
+--- 
 
 ``` swift
 public enum Direction 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatThreadArrowView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatThreadArrowView.md
@@ -1,3 +1,7 @@
+---
+id: chatthreadarrowview 
+title: ChatThreadArrowView
+--- 
 
 ``` swift
 open class ChatThreadArrowView: _View, AppearanceProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionView.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagelistcollectionview 
+title: ChatMessageListCollectionView
+--- 
 
 The collection view that provides convenient API for dequeuing `_ChatMessageCollectionViewCell` instances
 with the provided content view type and layout options.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewDataSource.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewDataSource.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagelistcollectionviewdatasource 
+title: ChatMessageListCollectionViewDataSource
+--- 
 
 Protocol that adds delegate methods specific for `ChatMessageListCollectionView`
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.LayoutItem.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.LayoutItem.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagelistcollectionviewlayout.layoutitem 
+title: ChatMessageListCollectionViewLayout.LayoutItem
+--- 
 
 ``` swift
 public struct LayoutItem 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagelistcollectionviewlayout 
+title: ChatMessageListCollectionViewLayout
+--- 
 
 Custom Table View like layout that position item at index path 0-0 on bottom of the list.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListKeyboardObserver.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListKeyboardObserver.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagelistkeyboardobserver 
+title: ChatMessageListKeyboardObserver
+--- 
 
 ``` swift
 open class ChatMessageListKeyboardObserver 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListScrollOverlayView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListScrollOverlayView.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagelistscrolloverlayview 
+title: ChatMessageListScrollOverlayView
+--- 
 
 View that is displayed as top overlay when message list is scrolling
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagelistvc 
+title: ChatMessageListVC
+--- 
 
 Controller that shows list of messages and composer together in the selected channel.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.md
@@ -1,3 +1,7 @@
+---
+id: chatthreadvc 
+title: ChatThreadVC
+--- 
 
 Controller responsible for displaying message thread.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageDefaultReactionsBubbleView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageDefaultReactionsBubbleView.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagedefaultreactionsbubbleview 
+title: ChatMessageDefaultReactionsBubbleView
+--- 
 
 ``` swift
 open class _ChatMessageDefaultReactionsBubbleView<ExtraData: ExtraDataTypes>: _ChatMessageReactionsBubbleView<ExtraData> 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionAppearance.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionAppearance.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagereactionappearance 
+title: ChatMessageReactionAppearance
+--- 
 
 The default `ReactionAppearanceType` implementation without any additional data
 which can be used to provide custom icons for message reaction.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionAppearanceType.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionAppearanceType.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagereactionappearancetype 
+title: ChatMessageReactionAppearanceType
+--- 
 
 The type describing message reaction appearance.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionData.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionData.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagereactiondata 
+title: ChatMessageReactionData
+--- 
 
 ``` swift
 public struct ChatMessageReactionData 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsBubbleStyle.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsBubbleStyle.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagereactionsbubblestyle 
+title: ChatMessageReactionsBubbleStyle
+--- 
 
 ``` swift
 public enum ChatMessageReactionsBubbleStyle 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsBubbleView.Content.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsBubbleView.Content.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagereactionsbubbleview.content 
+title: ChatMessageReactionsBubbleView.Content
+--- 
 
 ``` swift
 public struct Content 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsBubbleView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsBubbleView.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagereactionsbubbleview 
+title: ChatMessageReactionsBubbleView
+--- 
 
 ``` swift
 open class _ChatMessageReactionsBubbleView<ExtraData: ExtraDataTypes>: _View, ThemeProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsVC.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsVC.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagereactionsvc 
+title: ChatMessageReactionsVC
+--- 
 
 ``` swift
 open class _ChatMessageReactionsVC<ExtraData: ExtraDataTypes>: _ViewController, ThemeProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.Content.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.Content.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagereactionsview.content 
+title: ChatMessageReactionsView.Content
+--- 
 
 ``` swift
 public struct Content 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.ItemView.Content.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.ItemView.Content.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagereactionsview.itemview.content 
+title: ChatMessageReactionsView.ItemView.Content
+--- 
 
 ``` swift
 public struct Content 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.ItemView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.ItemView.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagereactionsview.itemview 
+title: ChatMessageReactionsView.ItemView
+--- 
 
 ``` swift
 open class ItemView: _Button, AppearanceProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagereactionsview 
+title: ChatMessageReactionsView
+--- 
 
 ``` swift
 open class _ChatMessageReactionsView<ExtraData: ExtraDataTypes>: _View, ThemeProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ScrollToLatestMessageButton.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ScrollToLatestMessageButton.md
@@ -1,3 +1,7 @@
+---
+id: scrolltolatestmessagebutton 
+title: ScrollToLatestMessageButton
+--- 
 
 A Button that is used to indicate unread messages in the Message list.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/TitleContainerView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/TitleContainerView.md
@@ -1,3 +1,7 @@
+---
+id: titlecontainerview 
+title: TitleContainerView
+--- 
 ![TitleContainerView](../../../../assets/TitleContainerView_documentation.default-light.png)
 
 A view that is used as a wrapper for status data in navigationItem's titleView.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/TypingAnimationView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/TypingAnimationView.md
@@ -1,3 +1,7 @@
+---
+id: typinganimationview 
+title: TypingAnimationView
+--- 
 
 A `UIView` subclass with 3 dots which can be animated with fading out effect.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/TypingIndicatorView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ChatMessageList/TypingIndicatorView.md
@@ -1,3 +1,7 @@
+---
+id: typingindicatorview 
+title: TypingIndicatorView
+--- 
 
 An `UIView` subclass indicating that user or multiple users are currently typing.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AttachmentButton/AttachmentButton.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AttachmentButton/AttachmentButton.md
@@ -1,3 +1,7 @@
+---
+id: attachmentbutton 
+title: AttachmentButton
+--- 
 ![AttachmentButton](../../../../../assets/AttachmentButton_documentation.default-light.png)
 
 Button for opening attachments.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentPlaceholderView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentPlaceholderView.md
@@ -1,3 +1,7 @@
+---
+id: attachmentplaceholderview 
+title: AttachmentPlaceholderView
+--- 
 ![AttachmentPlaceholderView](../../../../../assets/AttachmentPlaceholderView_documentation.default-light.png)
 
 Default attachment view to be used as a placeholder when attachment preview is not implemented for custom attachments.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentPreviewContainer.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentPreviewContainer.md
@@ -1,3 +1,7 @@
+---
+id: attachmentpreviewcontainer 
+title: AttachmentPreviewContainer
+--- 
 
 A view that wraps attachment preview and provides default controls (ie:​ remove button) for it.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentPreviewProvider.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentPreviewProvider.md
@@ -1,3 +1,7 @@
+---
+id: attachmentpreviewprovider 
+title: AttachmentPreviewProvider
+--- 
 
 ``` swift
 public protocol AttachmentPreviewProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/FileAttachmentView.Content.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/FileAttachmentView.Content.md
@@ -1,3 +1,7 @@
+---
+id: fileattachmentview.content 
+title: FileAttachmentView.Content
+--- 
 
 ``` swift
 public struct Content 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/FileAttachmentView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/FileAttachmentView.md
@@ -1,3 +1,7 @@
+---
+id: fileattachmentview 
+title: FileAttachmentView
+--- 
 
 A view that displays the file attachment.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/ImageAttachmentView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/ImageAttachmentView.md
@@ -1,3 +1,7 @@
+---
+id: imageattachmentview 
+title: ImageAttachmentView
+--- 
 
 A view that displays the image attachment.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentsPreviewVC.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentsPreviewVC.md
@@ -1,3 +1,7 @@
+---
+id: attachmentspreviewvc 
+title: AttachmentsPreviewVC
+--- 
 
 ``` swift
 open class _AttachmentsPreviewVC<ExtraData: ExtraDataTypes>: _ViewController, ComponentsProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/DefaultAttachmentPreviewProvider.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/DefaultAttachmentPreviewProvider.md
@@ -1,3 +1,7 @@
+---
+id: defaultattachmentpreviewprovider 
+title: DefaultAttachmentPreviewProvider
+--- 
 
 Default provider that is used when AttachmentPreviewProvider is not implemented for custom attachment payload. This
 provider always returns a new instance of `AttachmentPlaceholderView`.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/FileAttachmentPayload.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/FileAttachmentPayload.md
@@ -1,3 +1,7 @@
+---
+id: fileattachmentpayload 
+title: FileAttachmentPayload
+--- 
 
 ## Properties
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/ImageAttachmentPayload.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/ImageAttachmentPayload.md
@@ -1,3 +1,7 @@
+---
+id: imageattachmentpayload 
+title: ImageAttachmentPayload
+--- 
 
 ## Properties
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatAvatarView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatAvatarView.md
@@ -1,3 +1,7 @@
+---
+id: chatavatarview 
+title: ChatAvatarView
+--- 
 ![ChatAvatarView](../../../../../assets/ChatAvatarView_documentation.default-light.png)
 
 A view that displays the avatar image. By default a circular image.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.SwiftUIWrapper.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.SwiftUIWrapper.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelavatarview.swiftuiwrapper 
+title: ChatChannelAvatarView.SwiftUIWrapper
+--- 
 
 SwiftUI wrapper of `_ChatChannelAvatarView`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelavatarview 
+title: ChatChannelAvatarView
+--- 
 
 A view that shows a channel avatar including an online indicator if any user is online.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarViewSwiftUIView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarViewSwiftUIView.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelavatarviewswiftuiview 
+title: ChatChannelAvatarViewSwiftUIView
+--- 
 
 ``` swift
 @available(iOS 13.0, *)

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatPresenceAvatarView/ChatPresenceAvatarView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatPresenceAvatarView/ChatPresenceAvatarView.md
@@ -1,3 +1,7 @@
+---
+id: chatpresenceavatarview 
+title: ChatPresenceAvatarView
+--- 
 
 A view that shows a user avatar including an indicator of the user presence (online/offline).
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatPresenceAvatarView/MaskProviding.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatPresenceAvatarView/MaskProviding.md
@@ -1,3 +1,7 @@
+---
+id: maskproviding 
+title: MaskProviding
+--- 
 
 Protocol used to get path to make a cutout in a parent view.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatPresenceAvatarView/OnlineIndicatorView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatPresenceAvatarView/OnlineIndicatorView.md
@@ -1,3 +1,7 @@
+---
+id: onlineindicatorview 
+title: OnlineIndicatorView
+--- 
 ![OnlineIndicatorView](../../../../../../assets/OnlineIndicatorView_documentation.default-light.png)
 
 A view used to indicate the presence of a user.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatUserAvatarView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatUserAvatarView.md
@@ -1,3 +1,7 @@
+---
+id: chatuseravatarview 
+title: ChatUserAvatarView
+--- 
 
 A view that shows a user avatar including an indicator of the user presence (online/offline).
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/CurrentChatUserAvatarView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/CurrentChatUserAvatarView.md
@@ -1,3 +1,7 @@
+---
+id: currentchatuseravatarview 
+title: CurrentChatUserAvatarView
+--- 
 
 A UIControl subclass that is designed to show the avatar of the currently logged in user.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ChatLoadingIndicator.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ChatLoadingIndicator.md
@@ -1,3 +1,7 @@
+---
+id: chatloadingindicator 
+title: ChatLoadingIndicator
+--- 
 
 ``` swift
 open class ChatLoadingIndicator: _View, AppearanceProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ChatNavigationBar.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ChatNavigationBar.md
@@ -1,3 +1,7 @@
+---
+id: chatnavigationbar 
+title: ChatNavigationBar
+--- 
 
 ``` swift
 open class ChatNavigationBar: _NavigationBar, AppearanceProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/CheckboxControl/CheckboxControl.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/CheckboxControl/CheckboxControl.md
@@ -1,3 +1,7 @@
+---
+id: checkboxcontrol 
+title: CheckboxControl
+--- 
 
 A view to check/uncheck an option.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/CircularCloseButton/CircularCloseButton.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/CircularCloseButton/CircularCloseButton.md
@@ -1,3 +1,7 @@
+---
+id: circularclosebutton 
+title: CircularCloseButton
+--- 
 
 Button for closing, dismissing or clearing information.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/CloseButton.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/CloseButton.md
@@ -1,3 +1,7 @@
+---
+id: closebutton 
+title: CloseButton
+--- 
 
 A Button subclass that should be used for closing.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/CommandButton/CommandButton.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/CommandButton/CommandButton.md
@@ -1,3 +1,7 @@
+---
+id: commandbutton 
+title: CommandButton
+--- 
 ![CommandButton](../../../../../assets/CommandButton_documentation.default-light.png)
 
 Button for opening commands.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/CommandLabelView/CommandLabelView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/CommandLabelView/CommandLabelView.md
@@ -1,3 +1,7 @@
+---
+id: commandlabelview 
+title: CommandLabelView
+--- 
 ![CommandLabelView](../../../../../assets/CommandLabelView_documentation.default-light.png)
 
 A view that display the command name and icon.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ConfirmButton/ConfirmButton.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ConfirmButton/ConfirmButton.md
@@ -1,3 +1,7 @@
+---
+id: confirmbutton 
+title: ConfirmButton
+--- 
 ![ConfirmButton](../../../../../assets/ConfirmButton_documentation_disabled.default-light.png
 ConfirmButton_documentation_enabled.default-light.png)
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ContainerStackView.Alignment.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ContainerStackView.Alignment.md
@@ -1,3 +1,7 @@
+---
+id: containerstackview.alignment 
+title: ContainerStackView.Alignment
+--- 
 
 Describes the alignment of the arranged subviews in perpendicular to the container's axis.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ContainerStackView.Distribution.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ContainerStackView.Distribution.md
@@ -1,3 +1,7 @@
+---
+id: containerstackview.distribution 
+title: ContainerStackView.Distribution
+--- 
 
 Describes the size distribution of the arranged subviews in a container stack view.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ContainerStackView.Spacing.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ContainerStackView.Spacing.md
@@ -1,3 +1,7 @@
+---
+id: containerstackview.spacing 
+title: ContainerStackView.Spacing
+--- 
 
 Describes the Spacing between the arranged subviews.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ContainerStackView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ContainerStackView.md
@@ -1,3 +1,7 @@
+---
+id: containerstackview 
+title: ContainerStackView
+--- 
 
 A view that works similar to a `UIStackView` but in a more simpler and flexible way.
 The aim of this view is to make UI customizability easier in the SDK.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/CreateChatChannelButton/CreateChatChannelButton.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/CreateChatChannelButton/CreateChatChannelButton.md
@@ -1,3 +1,7 @@
+---
+id: createchatchannelbutton 
+title: CreateChatChannelButton
+--- 
 ![CreateChatChannelButton](../../../../../assets/CreateChatChannelButton_documentation.default-light.png)
 
 A Button subclass used for the create new channel action.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Customizable.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Customizable.md
@@ -1,3 +1,7 @@
+---
+id: customizable 
+title: Customizable
+--- 
 
 ``` swift
 public protocol Customizable 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/InputChatMessageView/InputChatMessageView.Content.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/InputChatMessageView/InputChatMessageView.Content.md
@@ -1,3 +1,7 @@
+---
+id: inputchatmessageview.content 
+title: InputChatMessageView.Content
+--- 
 
 The content of the view
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/InputChatMessageView/InputChatMessageView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/InputChatMessageView/InputChatMessageView.md
@@ -1,3 +1,7 @@
+---
+id: inputchatmessageview 
+title: InputChatMessageView
+--- 
 
 A view to input content of a message.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.md
@@ -1,3 +1,7 @@
+---
+id: inputtextview 
+title: InputTextView
+--- 
 
 A view for inputting text with placeholder support. Since it is a subclass
 of `UITextView`, the `UITextViewDelegate` can be used to observe text changes.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/CellSeparatorReusableView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/CellSeparatorReusableView.md
@@ -1,3 +1,7 @@
+---
+id: cellseparatorreusableview 
+title: CellSeparatorReusableView
+--- 
 
 The cell separator reusable view that acts as container of the visible part of the separator view.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/ListCollectionViewLayout.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/ListCollectionViewLayout.md
@@ -1,3 +1,7 @@
+---
+id: listcollectionviewlayout 
+title: ListCollectionViewLayout
+--- 
 
 An `UICollectionViewFlowLayout` implementation to make the collection view behave as a `UITableView`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/ListCollectionViewLayoutDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/ListCollectionViewLayoutDelegate.md
@@ -1,3 +1,7 @@
+---
+id: listcollectionviewlayoutdelegate 
+title: ListCollectionViewLayoutDelegate
+--- 
 
 The `ListCollectionViewLayout` delegate to control how to display the list.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedAvatarAlignment.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedAvatarAlignment.md
@@ -1,3 +1,7 @@
+---
+id: quotedavataralignment 
+title: QuotedAvatarAlignment
+--- 
 
 The quoted author's avatar position in relation with the text message.
 New custom alignments can be added with extensions and by overriding the `QuotedChatMessageView.setAvatarAlignment()`.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.Content.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.Content.md
@@ -1,3 +1,7 @@
+---
+id: quotedchatmessageview.content 
+title: QuotedChatMessageView.Content
+--- 
 
 The content of the view.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.SwiftUIWrapper.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.SwiftUIWrapper.md
@@ -1,3 +1,7 @@
+---
+id: quotedchatmessageview.swiftuiwrapper 
+title: QuotedChatMessageView.SwiftUIWrapper
+--- 
 
 SwiftUI wrapper of `QuotedChatMessageView`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.md
@@ -1,3 +1,7 @@
+---
+id: quotedchatmessageview 
+title: QuotedChatMessageView
+--- 
 
 A view that displays a quoted message.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageViewSwiftUIView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageViewSwiftUIView.md
@@ -1,3 +1,7 @@
+---
+id: quotedchatmessageviewswiftuiview 
+title: QuotedChatMessageViewSwiftUIView
+--- 
 
 ``` swift
 @available(iOS 13.0, *)

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/SendButton/SendButton.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/SendButton/SendButton.md
@@ -1,3 +1,7 @@
+---
+id: sendbutton 
+title: SendButton
+--- 
 ![SendButton](../../../../../assets/SendButton_documentation_disabled.default-light.png
 SendButton_documentation_enabled.default-light.png)
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ShareButton.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ShareButton.md
@@ -1,3 +1,7 @@
+---
+id: sharebutton 
+title: ShareButton
+--- 
 
 A Button subclass that should be used for sharing content.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ShrinkInputButton/ShrinkInputButton.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/ShrinkInputButton/ShrinkInputButton.md
@@ -1,3 +1,7 @@
+---
+id: shrinkinputbutton 
+title: ShrinkInputButton
+--- 
 ![ShrinkInputButton](../../../../../assets/ShrinkInputButton_documentation.default-light.png)
 
 Button for shrinking the input view to allow more space for other actions.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatCommandSuggestionView/ChatCommandSuggestionCollectionViewCell.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatCommandSuggestionView/ChatCommandSuggestionCollectionViewCell.md
@@ -1,3 +1,7 @@
+---
+id: chatcommandsuggestioncollectionviewcell 
+title: ChatCommandSuggestionCollectionViewCell
+--- 
 
 A view cell that displays a command.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatCommandSuggestionView/ChatCommandSuggestionView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatCommandSuggestionView/ChatCommandSuggestionView.md
@@ -1,3 +1,7 @@
+---
+id: chatcommandsuggestionview 
+title: ChatCommandSuggestionView
+--- 
 
 A view that displays the command name, image and arguments.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatMentionSuggestionView/ChatMentionSuggestionCollectionViewCell.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatMentionSuggestionView/ChatMentionSuggestionCollectionViewCell.md
@@ -1,3 +1,7 @@
+---
+id: chatmentionsuggestioncollectionviewcell 
+title: ChatMentionSuggestionCollectionViewCell
+--- 
 
 `UICollectionView` subclass which embeds inside `ChatMessageComposerMentionCellView`
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatMentionSuggestionView/ChatMentionSuggestionView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatMentionSuggestionView/ChatMentionSuggestionView.md
@@ -1,3 +1,7 @@
+---
+id: chatmentionsuggestionview 
+title: ChatMentionSuggestionView
+--- 
 
 A View that is embed inside `UICollectionViewCell`  which shows information about user which we want to tag in suggestions
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatMessageComposerSuggestionsCommandDataSource.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatMessageComposerSuggestionsCommandDataSource.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagecomposersuggestionscommanddatasource 
+title: ChatMessageComposerSuggestionsCommandDataSource
+--- 
 
 ``` swift
 open class _ChatMessageComposerSuggestionsCommandDataSource<ExtraData: ExtraDataTypes>: NSObject, UICollectionViewDataSource 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatMessageComposerSuggestionsMentionDataSource.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatMessageComposerSuggestionsMentionDataSource.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagecomposersuggestionsmentiondatasource 
+title: ChatMessageComposerSuggestionsMentionDataSource
+--- 
 
 ``` swift
 open class _ChatMessageComposerSuggestionsMentionDataSource<ExtraData: ExtraDataTypes>: NSObject,

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsCollectionReusableView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsCollectionReusableView.md
@@ -1,3 +1,7 @@
+---
+id: chatsuggestionscollectionreusableview 
+title: ChatSuggestionsCollectionReusableView
+--- 
 
 The header reusable view of the suggestion collection view.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsCollectionView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsCollectionView.md
@@ -1,3 +1,7 @@
+---
+id: chatsuggestionscollectionview 
+title: ChatSuggestionsCollectionView
+--- 
 
 The collection view of the suggestions view controller.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsCollectionViewLayout.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsCollectionViewLayout.md
@@ -1,3 +1,7 @@
+---
+id: chatsuggestionscollectionviewlayout 
+title: ChatSuggestionsCollectionViewLayout
+--- 
 
 The collection view layout of the suggestions collection view.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsHeaderView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsHeaderView.md
@@ -1,3 +1,7 @@
+---
+id: chatsuggestionsheaderview 
+title: ChatSuggestionsHeaderView
+--- 
 
 The header view of the suggestion collection view.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsViewController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsViewController.md
@@ -1,3 +1,7 @@
+---
+id: chatsuggestionsviewcontroller 
+title: ChatSuggestionsViewController
+--- 
 
 A view controller that shows suggestions of commands or mentions.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/SwiftUIRepresentable.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/SwiftUIRepresentable.md
@@ -1,3 +1,7 @@
+---
+id: swiftuirepresentable 
+title: SwiftUIRepresentable
+--- 
 
 Protocol with necessary properties to make `SwiftUIRepresentable` instance
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/SwiftUIViewControllerRepresentable.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/SwiftUIViewControllerRepresentable.md
@@ -1,3 +1,7 @@
+---
+id: swiftuiviewcontrollerrepresentable 
+title: SwiftUIViewControllerRepresentable
+--- 
 
 ``` swift
 @available(iOS 13.0, *)

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/SwiftUIViewRepresentable.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/SwiftUIViewRepresentable.md
@@ -1,3 +1,7 @@
+---
+id: swiftuiviewrepresentable 
+title: SwiftUIViewRepresentable
+--- 
 
 ``` swift
 @available(iOS 13.0, *)

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/_Button.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/_Button.md
@@ -1,3 +1,7 @@
+---
+id: _button 
+title: _Button
+--- 
 
 Base class for overridable views StreamChatUI provides.
 All conformers will have StreamChatUI appearance settings by default.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/_CollectionReusableView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/_CollectionReusableView.md
@@ -1,3 +1,7 @@
+---
+id: _collectionreusableview 
+title: _CollectionReusableView
+--- 
 
 Base class for overridable views StreamChatUI provides.
 All conformers will have StreamChatUI appearance settings by default.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/_CollectionViewCell.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/_CollectionViewCell.md
@@ -1,3 +1,7 @@
+---
+id: _collectionviewcell 
+title: _CollectionViewCell
+--- 
 
 Base class for overridable views StreamChatUI provides.
 All conformers will have StreamChatUI appearance settings by default.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/_Control.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/_Control.md
@@ -1,3 +1,7 @@
+---
+id: _control 
+title: _Control
+--- 
 
 Base class for overridable views StreamChatUI provides.
 All conformers will have StreamChatUI appearance settings by default.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/_NavigationBar.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/_NavigationBar.md
@@ -1,3 +1,7 @@
+---
+id: _navigationbar 
+title: _NavigationBar
+--- 
 
 Base class for overridable views StreamChatUI provides.
 All conformers will have StreamChatUI appearance settings by default.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/_View.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/_View.md
@@ -1,3 +1,7 @@
+---
+id: _view 
+title: _View
+--- 
 
 Base class for overridable views StreamChatUI provides.
 All conformers will have StreamChatUI appearance settings by default.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/_ViewController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/CommonViews/_ViewController.md
@@ -1,3 +1,7 @@
+---
+id: _viewcontroller 
+title: _ViewController
+--- 
 
 ``` swift
 open class _ViewController: UIViewController, Customizable 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Components.ObservableObject.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Components.ObservableObject.md
@@ -1,3 +1,7 @@
+---
+id: components.observableobject 
+title: Components.ObservableObject
+--- 
 
 ``` swift
 @dynamicMemberLookup

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Components.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Components.md
@@ -1,3 +1,7 @@
+---
+id: components 
+title: Components
+--- 
 
 An object containing types of UI Components that are used through the UI SDK.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Composer/ComposerState.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Composer/ComposerState.md
@@ -1,3 +1,7 @@
+---
+id: composerstate 
+title: ComposerState
+--- 
 
 The possible composer states. An Enum is not used so it does not cause
 future breaking changes and is possible to extend with new cases.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Composer/ComposerVC.Content.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Composer/ComposerVC.Content.md
@@ -1,3 +1,7 @@
+---
+id: composervc.content 
+title: ComposerVC.Content
+--- 
 
 The content of the composer.
 
@@ -7,7 +11,7 @@ public struct Content
 
 ## Initializers
 
-### `init(text:state:editingMessage:quotingMessage:threadMessage:attachments:command:)`
+### `init(text:state:editingMessage:quotingMessage:threadMessage:attachments:mentionedUsers:command:)`
 
 ``` swift
 public init(
@@ -17,6 +21,7 @@ public init(
             quotingMessage: _ChatMessage<ExtraData>?,
             threadMessage: _ChatMessage<ExtraData>?,
             attachments: [AnyAttachmentPayload],
+            mentionedUsers: Set<_ChatUser<ExtraData.User>>,
             command: Command?
         ) 
 ```
@@ -69,6 +74,14 @@ The attachments of the message.
 
 ``` swift
 public var attachments: [AnyAttachmentPayload]
+```
+
+### `mentionedUsers`
+
+The mentioned users in the message.
+
+``` swift
+public var mentionedUsers: Set<_ChatUser<ExtraData.User>>
 ```
 
 ### `command`

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Composer/ComposerVC.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Composer/ComposerVC.md
@@ -1,3 +1,7 @@
+---
+id: composervc 
+title: ComposerVC
+--- 
 
 A view controller that manages the composer view.
 
@@ -270,6 +274,14 @@ open func showMentionSuggestions(for typingMention: String, mentionRange: NSRang
   - typingMention: The potential user mention the current user is typing.
   - mentionRange: The position where the current user is typing a mention to it can be replaced with the suggestion.
 
+### `mentionText(for:)`
+
+Provides the mention text for composer text field, when the user selects a mention suggestion.
+
+``` swift
+open func mentionText(for user: _ChatUser<ExtraData.User>) -> String 
+```
+
 ### `showSuggestions()`
 
 Shows the suggestions view
@@ -290,6 +302,16 @@ open func dismissSuggestions()
 
 ``` swift
 open func textViewDidChange(_ textView: UITextView) 
+```
+
+### `textView(_:shouldChangeTextIn:replacementText:)`
+
+``` swift
+open func textView(
+        _ textView: UITextView,
+        shouldChangeTextIn range: NSRange,
+        replacementText text: String
+    ) -> Bool 
 ```
 
 ### `imagePickerController(_:didFinishPickingMediaWithInfo:)`

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Composer/ComposerVCDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Composer/ComposerVCDelegate.md
@@ -1,3 +1,7 @@
+---
+id: composervcdelegate 
+title: ComposerVCDelegate
+--- 
 
 The delegate of the ComposerVC that notifies composer events.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Composer/ComposerView.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Composer/ComposerView.md
@@ -1,3 +1,7 @@
+---
+id: composerview 
+title: ComposerView
+--- 
 
 /// The composer view that layouts all the components to create a new message.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ImageGallery/ImageCollectionViewCell.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ImageGallery/ImageCollectionViewCell.md
@@ -1,3 +1,7 @@
+---
+id: imagecollectionviewcell 
+title: ImageCollectionViewCell
+--- 
 
 `UICollectionViewCell` for a single image.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ImageGallery/ImageGalleryVC.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ImageGallery/ImageGalleryVC.md
@@ -1,3 +1,7 @@
+---
+id: imagegalleryvc 
+title: ImageGalleryVC
+--- 
 
 View controller to showcase and slide through multiple images.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ImageGallery/ZoomAnimator.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ImageGallery/ZoomAnimator.md
@@ -1,3 +1,7 @@
+---
+id: zoomanimator 
+title: ZoomAnimator
+--- 
 
 Object for animating transition of an image.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ImageGallery/ZoomDismissalInteractionController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ImageGallery/ZoomDismissalInteractionController.md
@@ -1,3 +1,7 @@
+---
+id: zoomdismissalinteractioncontroller 
+title: ZoomDismissalInteractionController
+--- 
 
 Controller for interactive dismissal.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ImageGallery/ZoomTransitionController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/ImageGallery/ZoomTransitionController.md
@@ -1,3 +1,7 @@
+---
+id: zoomtransitioncontroller 
+title: ZoomTransitionController
+--- 
 
 Object for controlling zoom transition.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/BlockUserActionItem.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/BlockUserActionItem.md
@@ -1,3 +1,7 @@
+---
+id: blockuseractionitem 
+title: BlockUserActionItem
+--- 
 
 Instance of `ChatMessageActionItem` for blocking user.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionControl.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionControl.md
@@ -1,3 +1,7 @@
+---
+id: chatmessageactioncontrol 
+title: ChatMessageActionControl
+--- 
 
 Button for action displayed in `_ChatMessageActionsView`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionItem.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionItem.md
@@ -1,3 +1,7 @@
+---
+id: chatmessageactionitem 
+title: ChatMessageActionItem
+--- 
 
 Protocol for action item.
 Action items are then showed in `_ChatMessageActionsView`.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.Delegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.Delegate.md
@@ -1,3 +1,7 @@
+---
+id: chatmessageactionsvc.delegate 
+title: ChatMessageActionsVC.Delegate
+--- 
 
 Delegate instance for `_ChatMessageActionsVC`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.md
@@ -1,3 +1,7 @@
+---
+id: chatmessageactionsvc 
+title: ChatMessageActionsVC
+--- 
 
 View controller to show message actions.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVCDelegate.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVCDelegate.md
@@ -1,3 +1,7 @@
+---
+id: chatmessageactionsvcdelegate 
+title: ChatMessageActionsVCDelegate
+--- 
 
 ``` swift
 public protocol _ChatMessageActionsVCDelegate: AnyObject 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagepopupvc 
+title: ChatMessagePopupVC
+--- 
 
 `_ChatMessagePopupVC` is shown when user long-presses a message.
 By default, it has a blurred background, reactions, and actions which are shown for a given message

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/CopyActionItem.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/CopyActionItem.md
@@ -1,3 +1,7 @@
+---
+id: copyactionitem 
+title: CopyActionItem
+--- 
 
 Instance of `ChatMessageActionItem` for copy message action.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/DeleteActionItem.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/DeleteActionItem.md
@@ -1,3 +1,7 @@
+---
+id: deleteactionitem 
+title: DeleteActionItem
+--- 
 
 Instance of `ChatMessageActionItem` for deleting message action.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/EditActionItem.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/EditActionItem.md
@@ -1,3 +1,7 @@
+---
+id: editactionitem 
+title: EditActionItem
+--- 
 
 Instance of `ChatMessageActionItem` for edit message action.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/InlineReplyActionItem.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/InlineReplyActionItem.md
@@ -1,3 +1,7 @@
+---
+id: inlinereplyactionitem 
+title: InlineReplyActionItem
+--- 
 
 Instance of `ChatMessageActionItem` for inline reply.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/MessageActionsTransitionController.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/MessageActionsTransitionController.md
@@ -1,3 +1,7 @@
+---
+id: messageactionstransitioncontroller 
+title: MessageActionsTransitionController
+--- 
 
 Transitions controller for `ChatMessagePopupVC`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/MuteUserActionItem.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/MuteUserActionItem.md
@@ -1,3 +1,7 @@
+---
+id: muteuseractionitem 
+title: MuteUserActionItem
+--- 
 
 Instance of `ChatMessageActionItem` for muting user.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ResendActionItem.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ResendActionItem.md
@@ -1,3 +1,7 @@
+---
+id: resendactionitem 
+title: ResendActionItem
+--- 
 
 Instance of `ChatMessageActionItem` for resending message action.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ThreadReplyActionItem.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ThreadReplyActionItem.md
@@ -1,3 +1,7 @@
+---
+id: threadreplyactionitem 
+title: ThreadReplyActionItem
+--- 
 
 Instance of `ChatMessageActionItem` for thread reply.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/UnblockUserActionItem.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/UnblockUserActionItem.md
@@ -1,3 +1,7 @@
+---
+id: unblockuseractionitem 
+title: UnblockUserActionItem
+--- 
 
 Instance of `ChatMessageActionItem` for unblocking user.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/UnmuteUserActionItem.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/UnmuteUserActionItem.md
@@ -1,3 +1,7 @@
+---
+id: unmuteuseractionitem 
+title: UnmuteUserActionItem
+--- 
 
 Instance of `ChatMessageActionItem` for unmuting user.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Navigation/AlertsRouter.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Navigation/AlertsRouter.md
@@ -1,3 +1,7 @@
+---
+id: alertsrouter 
+title: AlertsRouter
+--- 
 
 A `NavigationRouter` instance responsible for presenting alerts.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Navigation/ChatChannelListRouter.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Navigation/ChatChannelListRouter.md
@@ -1,3 +1,7 @@
+---
+id: chatchannellistrouter 
+title: ChatChannelListRouter
+--- 
 
 A `NavigationRouter` subclass that handles navigation actions of `ChatChannelListVC`.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Navigation/ChatMessageListRouter.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Navigation/ChatMessageListRouter.md
@@ -1,3 +1,7 @@
+---
+id: chatmessagelistrouter 
+title: ChatMessageListRouter
+--- 
 
 A `NavigationRouter` subclass used for navigating from message-list-based view controllers.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Navigation/NavigationRouter.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Navigation/NavigationRouter.md
@@ -1,3 +1,7 @@
+---
+id: navigationrouter 
+title: NavigationRouter
+--- 
 
 A root class for all routes in the SDK.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/UIConfig.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/UIConfig.md
@@ -1,3 +1,7 @@
+---
+id: uiconfig 
+title: UIConfig
+--- 
 
 ``` swift
 @available(*, deprecated, message: "UIConfig has split into Appearance and Components")

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/UIConfigProvider.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/UIConfigProvider.md
@@ -1,3 +1,7 @@
+---
+id: uiconfigprovider 
+title: UIConfigProvider
+--- 
 
 ``` swift
 @available(

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/AppearanceProvider.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/AppearanceProvider.md
@@ -1,3 +1,7 @@
+---
+id: appearanceprovider 
+title: AppearanceProvider
+--- 
 
 ``` swift
 public protocol AppearanceProvider: AnyObject 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/CGSize.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/CGSize.md
@@ -1,3 +1,7 @@
+---
+id: cgsize 
+title: CGSize
+--- 
 
 ## Properties
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/ChatChannelNamer.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/ChatChannelNamer.md
@@ -1,3 +1,7 @@
+---
+id: chatchannelnamer 
+title: ChatChannelNamer
+--- 
 
 Typealias for closure taking `_ChatChannel<ExtraData>` and `UserId` which returns
 the current name of the channel. Use this type when you create closure for naming a channel.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/ChatMessage.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/ChatMessage.md
@@ -1,3 +1,7 @@
+---
+id: chatmessage 
+title: ChatMessage
+--- 
 
 ## Properties
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/ComponentsProvider.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/ComponentsProvider.md
@@ -1,3 +1,7 @@
+---
+id: componentsprovider 
+title: ComponentsProvider
+--- 
 
 ``` swift
 public protocol ComponentsProvider: GenericComponentsProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/DefaultChatChannelNamer(maxMemberNames_separator_).md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/DefaultChatChannelNamer(maxMemberNames_separator_).md
@@ -1,3 +1,7 @@
+---
+id: defaultchatchannelnamer(maxmembernames_separator_) 
+title: DefaultChatChannelNamer(maxMemberNames_separator_)
+--- 
 
 Generates a name for the given channel, given the current user's id.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/GenericComponentsProvider.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/GenericComponentsProvider.md
@@ -1,3 +1,7 @@
+---
+id: genericcomponentsprovider 
+title: GenericComponentsProvider
+--- 
 
 ``` swift
 public protocol GenericComponentsProvider: AnyObject 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/ImageCDN.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/ImageCDN.md
@@ -1,3 +1,7 @@
+---
+id: imagecdn 
+title: ImageCDN
+--- 
 
 ImageCDN is providing set of functions to improve handling of images from CDN.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/ImageProcessors.LateResize.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/ImageProcessors.LateResize.md
@@ -1,3 +1,7 @@
+---
+id: imageprocessors.lateresize 
+title: ImageProcessors.LateResize
+--- 
 
 Scales an image to a specified size.
 The getting of the size is offloaded via closure after the image is loaded.

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/NavigationVC.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/NavigationVC.md
@@ -1,3 +1,7 @@
+---
+id: navigationvc 
+title: NavigationVC
+--- 
 
 The navigation controller with navigation bar of `ChatNavigationBar` type.
 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/StreamImageCDN.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/StreamImageCDN.md
@@ -1,3 +1,7 @@
+---
+id: streamimagecdn 
+title: StreamImageCDN
+--- 
 
 ``` swift
 public struct StreamImageCDN: ImageCDN 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/ThemeProvider.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/Utils/ThemeProvider.md
@@ -1,3 +1,7 @@
+---
+id: themeprovider 
+title: ThemeProvider
+--- 
 
 ``` swift
 public protocol ThemeProvider: ComponentsProvider, AppearanceProvider 

--- a/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/View.md
+++ b/docusaurus/docs/iOS/ReferenceDocs/Sources/StreamChatUI/View.md
@@ -1,3 +1,7 @@
+---
+id: view 
+title: View
+--- 
 
 ## Methods
 

--- a/docusaurus/sidebars-ios.json
+++ b/docusaurus/sidebars-ios.json
@@ -46,124 +46,124 @@
         "controllers/controllers-overview",
         {
           "ChannelController": [
-            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/ChatChannelController",
-            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/ChatChannelControllerDelegate",
-            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/ChatChannelController.ObservableObject",
-            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/ListOrdering"
+            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/chatchannelcontroller",
+            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/chatchannelcontrollerdelegate",
+            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/chatchannelcontroller.observableobject",
+            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelController/listordering"
           ]
         },
         {
           "ChannelListController": [
-            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/ChatChannelListController",
-            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/ChatChannelListControllerDelegate",
-            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/ChatChannelListController.ObservableObject",
-            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/ClientError.FetchFailed"
+            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/chatchannellistcontroller",
+            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/chatchannellistcontrollerdelegate",
+            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/chatchannellistcontroller.observableobject",
+            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelListController/clienterror.fetchfailed"
           ]
         },
         {
           "ChannelWatcherListController": [
-            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController",
-            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListControllerDelegate",
-            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.ObservableObject"
+            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelWatcherListController/chatchannelwatcherlistcontroller",
+            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelWatcherListController/chatchannelwatcherlistcontrollerdelegate",
+            "ReferenceDocs/Sources/StreamChat/Controllers/ChannelWatcherListController/chatchannelwatcherlistcontroller.observableobject"
           ]
         },
         {
           "ConnectionController": [
-            "ReferenceDocs/Sources/StreamChat/Controllers/ConnectionController/ChatConnectionController",
-            "ReferenceDocs/Sources/StreamChat/Controllers/ConnectionController/ChatConnectionControllerDelegate",
-            "ReferenceDocs/Sources/StreamChat/Controllers/ConnectionController/ChatConnectionController.ObservableObject"
+            "ReferenceDocs/Sources/StreamChat/Controllers/ConnectionController/chatconnectioncontroller",
+            "ReferenceDocs/Sources/StreamChat/Controllers/ConnectionController/chatconnectioncontrollerdelegate",
+            "ReferenceDocs/Sources/StreamChat/Controllers/ConnectionController/chatconnectioncontroller.observableobject"
           ]
         },
         {
           "CurrentUserController": [
-            "ReferenceDocs/Sources/StreamChat/Controllers/CurrentUserController/CurrentChatUserController",
-            "ReferenceDocs/Sources/StreamChat/Controllers/CurrentUserController/CurrentChatUserControllerDelegate",
-            "ReferenceDocs/Sources/StreamChat/Controllers/CurrentUserController/CurrentChatUserController.ObservableObject"
+            "ReferenceDocs/Sources/StreamChat/Controllers/CurrentUserController/currentchatusercontroller",
+            "ReferenceDocs/Sources/StreamChat/Controllers/CurrentUserController/currentchatusercontrollerdelegate",
+            "ReferenceDocs/Sources/StreamChat/Controllers/CurrentUserController/currentchatusercontroller.observableobject"
           ]
         },
         {
           "MemberController": [
-            "ReferenceDocs/Sources/StreamChat/Controllers/MemberController/ChatChannelMemberController",
-            "ReferenceDocs/Sources/StreamChat/Controllers/MemberController/ChatChannelMemberControllerDelegate",
-            "ReferenceDocs/Sources/StreamChat/Controllers/MemberController/ChatChannelMemberController.ObservableObject"
+            "ReferenceDocs/Sources/StreamChat/Controllers/MemberController/chatchannelmembercontroller",
+            "ReferenceDocs/Sources/StreamChat/Controllers/MemberController/chatchannelmembercontrollerdelegate",
+            "ReferenceDocs/Sources/StreamChat/Controllers/MemberController/chatchannelmembercontroller.observableobject"
           ]
         },
         {
           "MemberListController": [
-            "ReferenceDocs/Sources/StreamChat/Controllers/MemberListController/ChatChannelMemberListController",
-            "ReferenceDocs/Sources/StreamChat/Controllers/MemberListController/ChatChannelMemberListControllerDelegate",
-            "ReferenceDocs/Sources/StreamChat/Controllers/MemberListController/ChatChannelMemberListController.ObservableObject"
+            "ReferenceDocs/Sources/StreamChat/Controllers/MemberListController/chatchannelmemberlistcontroller",
+            "ReferenceDocs/Sources/StreamChat/Controllers/MemberListController/chatchannelmemberlistcontrollerdelegate",
+            "ReferenceDocs/Sources/StreamChat/Controllers/MemberListController/chatchannelmemberlistcontroller.observableobject"
           ]
         },
         {
           "MessageController": [
-            "ReferenceDocs/Sources/StreamChat/Controllers/MessageController/ChatMessageController",
-            "ReferenceDocs/Sources/StreamChat/Controllers/MessageController/ChatMessageControllerDelegate",
-            "ReferenceDocs/Sources/StreamChat/Controllers/MessageController/ChatMessageController.ObservableObject"
+            "ReferenceDocs/Sources/StreamChat/Controllers/MessageController/chatmessagecontroller",
+            "ReferenceDocs/Sources/StreamChat/Controllers/MessageController/chatmessagecontrollerdelegate",
+            "ReferenceDocs/Sources/StreamChat/Controllers/MessageController/chatmessagecontroller.observableobject"
           ]
         },
         {
           "SearchControllers": [
-            "ReferenceDocs/Sources/StreamChat/Controllers/SearchControllers/ChatUserSearchController",
-            "ReferenceDocs/Sources/StreamChat/Controllers/SearchControllers/ChatUserSearchControllerDelegate"
+            "ReferenceDocs/Sources/StreamChat/Controllers/SearchControllers/chatusersearchcontroller",
+            "ReferenceDocs/Sources/StreamChat/Controllers/SearchControllers/chatusersearchcontrollerdelegate"
           ]
         },
         {
           "UserController": [
-            "ReferenceDocs/Sources/StreamChat/Controllers/UserController/ChatUserController",
-            "ReferenceDocs/Sources/StreamChat/Controllers/UserController/ChatUserControllerDelegate",
-            "ReferenceDocs/Sources/StreamChat/Controllers/UserController/ChatUserController.ObservableObject"
+            "ReferenceDocs/Sources/StreamChat/Controllers/UserController/chatusercontroller",
+            "ReferenceDocs/Sources/StreamChat/Controllers/UserController/chatusercontrollerdelegate",
+            "ReferenceDocs/Sources/StreamChat/Controllers/UserController/chatusercontroller.observableobject"
           ]
         },
         {
           "UserListController": [
-            "ReferenceDocs/Sources/StreamChat/Controllers/UserListController/ChatUserListController",
-            "ReferenceDocs/Sources/StreamChat/Controllers/UserListController/ChatUserListControllerDelegate",
-            "ReferenceDocs/Sources/StreamChat/Controllers/UserListController/ChatUserListController.ObservableObject"
+            "ReferenceDocs/Sources/StreamChat/Controllers/UserListController/chatuserlistcontroller",
+            "ReferenceDocs/Sources/StreamChat/Controllers/UserListController/chatuserlistcontrollerdelegate",
+            "ReferenceDocs/Sources/StreamChat/Controllers/UserListController/chatuserlistcontroller.observableobject"
           ]
         },
         {
           "DataController": [
-            "ReferenceDocs/Sources/StreamChat/Controllers/DataController",
-            "ReferenceDocs/Sources/StreamChat/Controllers/DataController.State",
-            "ReferenceDocs/Sources/StreamChat/Controllers/DataControllerStateDelegate"
+            "ReferenceDocs/Sources/StreamChat/Controllers/datacontroller",
+            "ReferenceDocs/Sources/StreamChat/Controllers/datacontroller.state",
+            "ReferenceDocs/Sources/StreamChat/Controllers/datacontrollerstatedelegate"
           ]
         },
-        "ReferenceDocs/Sources/StreamChat/Controllers/Controller",
-        "ReferenceDocs/Sources/StreamChat/Controllers/EntityChange",
-        "ReferenceDocs/Sources/StreamChat/Controllers/ListChange"
+        "ReferenceDocs/Sources/StreamChat/Controllers/controller",
+        "ReferenceDocs/Sources/StreamChat/Controllers/entitychange",
+        "ReferenceDocs/Sources/StreamChat/Controllers/listchange"
       ]
     },
     {
       "UI Components": [
-        "ReferenceDocs/Sources/StreamChatUI/Components",
+        "ReferenceDocs/Sources/StreamChatUI/components",
         {
           "ChatChannelList": [
-            "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC",
+            "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/chatchannellistvc",
             {
               "ChatChannelListCollectionViewCell": [
-                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListCollectionViewCell",
-                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListCollectionViewDelegate",
-                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView",
-                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemViewSwiftUIView",
-                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.SwiftUIWrapper",
-                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.Content",
-                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/SwipeableView",
-                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/SwipeableViewDelegate",
-                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/CellActionView"
+                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/chatchannellistcollectionviewcell",
+                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/chatchannellistcollectionviewdelegate",
+                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/chatchannellistitemview",
+                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/chatchannellistitemviewswiftuiview",
+                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/chatchannellistitemview.swiftuiwrapper",
+                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/chatchannellistitemview.content",
+                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/swipeableview",
+                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/swipeableviewdelegate",
+                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/cellactionview"
               ]
             },
             {
               "ChatChannelReadStatus": [
-                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelReadStatusCheckmarkView",
-                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelReadStatusCheckmarkView.Status"
+                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/chatchannelreadstatuscheckmarkview",
+                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/chatchannelreadstatuscheckmarkview.status"
               ]
             },
             {
               "ChatChannelUnreadCountView": [
-                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountView",
-                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountView.SwiftUIWrapper",
-                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountViewSwiftUIView"
+                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/chatchannelunreadcountview",
+                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/chatchannelunreadcountview.swiftuiwrapper",
+                "ReferenceDocs/Sources/StreamChatUI/ChatChannelList/chatchannelunreadcountviewswiftuiview"
               ]
             }
           ]
@@ -172,262 +172,262 @@
           "ChatMessageList": [
             {
               "Attachments": [
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/AttachmentViewInjector",
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageAttachmentPreviewVC",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/attachmentviewinjector",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/chatmessageattachmentpreviewvc",
                 {
                   "Interactive Attachments": [
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView.ActionButton.Content",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView.ActionButton",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageInteractiveAttachmentView",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageGiphyView.GiphyBadge",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageGiphyView",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/GiphyActionContentViewDelegate",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/GiphyAttachmentViewInjector"
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/chatmessageinteractiveattachmentview.actionbutton.content",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/chatmessageinteractiveattachmentview.actionbutton",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/chatmessageinteractiveattachmentview",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/chatmessagegiphyview.giphybadge",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/chatmessagegiphyview",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/giphyactioncontentviewdelegate",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/giphyattachmentviewinjector"
                   ]
                 },
                 {
                   "ImageGallery Attachments": [
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ImagePreviewable",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery.ImagePreview",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery.UploadingOverlay",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/GalleryAttachmentViewInjector",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/GalleryContentViewDelegate"
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/imagepreviewable",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/chatmessageimagegallery.imagepreview",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/chatmessageimagegallery.uploadingoverlay",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/chatmessageimagegallery",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/galleryattachmentviewinjector",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/gallerycontentviewdelegate"
                   ]
                 },
                 {
                   "File Attachments": [
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageFileAttachmentListView.ItemView",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageFileAttachmentListView",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/FileActionContentViewDelegate",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/FilesAttachmentViewInjector"
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/chatmessagefileattachmentlistview.itemview",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/chatmessagefileattachmentlistview",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/fileactioncontentviewdelegate",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/filesattachmentviewinjector"
                   ]
                 },
                 {
                   "Link Attachments": [
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageLinkPreviewView",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/LinkAttachmentViewInjector",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/LinkPreviewViewDelegate"
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/chatmessagelinkpreviewview",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/linkattachmentviewinjector",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Attachments/linkpreviewviewdelegate"
                   ]
                 }
               ]
             },
             {
               "ChatMessage": [
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageBubbleView.Content",
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageBubbleView",
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCollectionViewCell",
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.SwiftUIWrapper",
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView",
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentViewDelegate",
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentViewSwiftUIView",
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageErrorIndicator",
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptions",
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver",
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatReactionsBubbleView",
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatThreadArrowView.Direction",
-                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatThreadArrowView",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/chatmessagebubbleview.content",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/chatmessagebubbleview",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/chatmessagecollectionviewcell",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/chatmessagecontentview.swiftuiwrapper",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/chatmessagecontentview",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/chatmessagecontentviewdelegate",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/chatmessagecontentviewswiftuiview",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/chatmessageerrorindicator",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/chatmessagelayoutoptions",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/chatmessagelayoutoptionsresolver",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/chatreactionsbubbleview",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/chatthreadarrowview.direction",
+                "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessage/chatthreadarrowview",
                 {
                   "Reactions": [
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageDefaultReactionsBubbleView",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionAppearance",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionAppearanceType",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionData",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsBubbleStyle",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsBubbleView.Content",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsBubbleView",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsVC",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.Content",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.ItemView.Content",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView.ItemView",
-                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsView"
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/chatmessagedefaultreactionsbubbleview",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/chatmessagereactionappearance",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/chatmessagereactionappearancetype",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/chatmessagereactiondata",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/chatmessagereactionsbubblestyle",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/chatmessagereactionsbubbleview.content",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/chatmessagereactionsbubbleview",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/chatmessagereactionsvc",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/chatmessagereactionsview.content",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/chatmessagereactionsview.itemview.content",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/chatmessagereactionsview.itemview",
+                    "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/Reactions/chatmessagereactionsview"
                   ]
                 }
               ]
             },
             {
               "MessageActionsPopup": [
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/BlockUserActionItem",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionControl",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionItem",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.Delegate",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVCDelegate",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/CopyActionItem",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/DeleteActionItem",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/EditActionItem",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/InlineReplyActionItem",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/MessageActionsTransitionController",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/MuteUserActionItem",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ResendActionItem",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/ThreadReplyActionItem",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/UnblockUserActionItem",
-                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/UnmuteUserActionItem"
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/blockuseractionitem",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/chatmessageactioncontrol",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/chatmessageactionitem",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/chatmessageactionsvc.delegate",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/chatmessageactionsvc",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/chatmessageactionsvcdelegate",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/chatmessagepopupvc",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/copyactionitem",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/deleteactionitem",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/editactionitem",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/inlinereplyactionitem",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/messageactionstransitioncontroller",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/muteuseractionitem",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/resendactionitem",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/threadreplyactionitem",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/unblockuseractionitem",
+                "ReferenceDocs/Sources/StreamChatUI/MessageActionsPopup/unmuteuseractionitem"
               ]
             },
-            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionView",
-            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewDataSource",
-            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout.LayoutItem",
-            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionViewLayout",
-            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListKeyboardObserver",
-            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListScrollOverlayView",
-            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC",
-            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ChatThreadVC",
-            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/ScrollToLatestMessageButton",
-            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/TitleContainerView",
-            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/TypingAnimationView",
-            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/TypingIndicatorView"
+            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/chatmessagelistcollectionview",
+            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/chatmessagelistcollectionviewdatasource",
+            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/chatmessagelistcollectionviewlayout.layoutitem",
+            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/chatmessagelistcollectionviewlayout",
+            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/chatmessagelistkeyboardobserver",
+            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/chatmessagelistscrolloverlayview",
+            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/chatmessagelistvc",
+            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/chatthreadvc",
+            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/scrolltolatestmessagebutton",
+            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/titlecontainerview",
+            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/typinganimationview",
+            "ReferenceDocs/Sources/StreamChatUI/ChatMessageList/typingindicatorview"
           ]
         },
         {
           "Composer": [
-            "ReferenceDocs/Sources/StreamChatUI/Composer/ComposerState",
-            "ReferenceDocs/Sources/StreamChatUI/Composer/ComposerVC.Content",
-            "ReferenceDocs/Sources/StreamChatUI/Composer/ComposerVC",
-            "ReferenceDocs/Sources/StreamChatUI/Composer/ComposerVCDelegate",
-            "ReferenceDocs/Sources/StreamChatUI/Composer/ComposerView"
+            "ReferenceDocs/Sources/StreamChatUI/Composer/composerstate",
+            "ReferenceDocs/Sources/StreamChatUI/Composer/composervc.content",
+            "ReferenceDocs/Sources/StreamChatUI/Composer/composervc",
+            "ReferenceDocs/Sources/StreamChatUI/Composer/composervcdelegate",
+            "ReferenceDocs/Sources/StreamChatUI/Composer/composerview"
           ]
         },
         {
           "ImageGallery": [
-            "ReferenceDocs/Sources/StreamChatUI/ImageGallery/ImageCollectionViewCell",
-            "ReferenceDocs/Sources/StreamChatUI/ImageGallery/ImageGalleryVC",
-            "ReferenceDocs/Sources/StreamChatUI/ImageGallery/ZoomAnimator",
-            "ReferenceDocs/Sources/StreamChatUI/ImageGallery/ZoomDismissalInteractionController",
-            "ReferenceDocs/Sources/StreamChatUI/ImageGallery/ZoomTransitionController"
+            "ReferenceDocs/Sources/StreamChatUI/ImageGallery/imagecollectionviewcell",
+            "ReferenceDocs/Sources/StreamChatUI/ImageGallery/imagegalleryvc",
+            "ReferenceDocs/Sources/StreamChatUI/ImageGallery/zoomanimator",
+            "ReferenceDocs/Sources/StreamChatUI/ImageGallery/zoomdismissalinteractioncontroller",
+            "ReferenceDocs/Sources/StreamChatUI/ImageGallery/zoomtransitioncontroller"
           ]
         },
         {
           "Navigation": [
-            "ReferenceDocs/Sources/StreamChatUI/Navigation/AlertsRouter",
-            "ReferenceDocs/Sources/StreamChatUI/Navigation/ChatChannelListRouter",
-            "ReferenceDocs/Sources/StreamChatUI/Navigation/ChatMessageListRouter",
-            "ReferenceDocs/Sources/StreamChatUI/Navigation/NavigationRouter"
+            "ReferenceDocs/Sources/StreamChatUI/Navigation/alertsrouter",
+            "ReferenceDocs/Sources/StreamChatUI/Navigation/chatchannellistrouter",
+            "ReferenceDocs/Sources/StreamChatUI/Navigation/chatmessagelistrouter",
+            "ReferenceDocs/Sources/StreamChatUI/Navigation/navigationrouter"
           ]
         },
         {
           "CommonViews": [
-            "ReferenceDocs/Sources/StreamChatUI/CommonViews/Customizable",
-            "ReferenceDocs/Sources/StreamChatUI/CommonViews/ChatLoadingIndicator",
-            "ReferenceDocs/Sources/StreamChatUI/CommonViews/ChatNavigationBar",
-            "ReferenceDocs/Sources/StreamChatUI/CommonViews/CheckboxControl/CheckboxControl",
-            "ReferenceDocs/Sources/StreamChatUI/CommonViews/CircularCloseButton/CircularCloseButton",
-            "ReferenceDocs/Sources/StreamChatUI/CommonViews/CommandButton/CommandButton",
-            "ReferenceDocs/Sources/StreamChatUI/CommonViews/CommandLabelView/CommandLabelView",
-            "ReferenceDocs/Sources/StreamChatUI/CommonViews/ConfirmButton/ConfirmButton",
-            "ReferenceDocs/Sources/StreamChatUI/CommonViews/CloseButton",
-            "ReferenceDocs/Sources/StreamChatUI/CommonViews/CreateChatChannelButton/CreateChatChannelButton",
-            "ReferenceDocs/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView",
-            "ReferenceDocs/Sources/StreamChatUI/CommonViews/SendButton/SendButton",
-            "ReferenceDocs/Sources/StreamChatUI/CommonViews/ShareButton",
-            "ReferenceDocs/Sources/StreamChatUI/CommonViews/ShrinkInputButton/ShrinkInputButton",
+            "ReferenceDocs/Sources/StreamChatUI/CommonViews/customizable",
+            "ReferenceDocs/Sources/StreamChatUI/CommonViews/chatloadingindicator",
+            "ReferenceDocs/Sources/StreamChatUI/CommonViews/chatnavigationbar",
+            "ReferenceDocs/Sources/StreamChatUI/CommonViews/CheckboxControl/checkboxcontrol",
+            "ReferenceDocs/Sources/StreamChatUI/CommonViews/CircularCloseButton/circularclosebutton",
+            "ReferenceDocs/Sources/StreamChatUI/CommonViews/CommandButton/commandbutton",
+            "ReferenceDocs/Sources/StreamChatUI/CommonViews/CommandLabelView/commandlabelview",
+            "ReferenceDocs/Sources/StreamChatUI/CommonViews/ConfirmButton/confirmbutton",
+            "ReferenceDocs/Sources/StreamChatUI/CommonViews/closebutton",
+            "ReferenceDocs/Sources/StreamChatUI/CommonViews/CreateChatChannelButton/createchatchannelbutton",
+            "ReferenceDocs/Sources/StreamChatUI/CommonViews/InputTextView/inputtextview",
+            "ReferenceDocs/Sources/StreamChatUI/CommonViews/SendButton/sendbutton",
+            "ReferenceDocs/Sources/StreamChatUI/CommonViews/sharebutton",
+            "ReferenceDocs/Sources/StreamChatUI/CommonViews/ShrinkInputButton/shrinkinputbutton",
             {
               "Attachments": [
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentsPreviewVC",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentPlaceholderView",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentPreviewContainer",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentPreviewProvider",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/DefaultAttachmentPreviewProvider",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/FileAttachmentPayload",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/ImageAttachmentPayload",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/AttachmentButton/AttachmentButton",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/attachmentspreviewvc",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/attachmentplaceholderview",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/attachmentpreviewcontainer",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/attachmentpreviewprovider",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/defaultattachmentpreviewprovider",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/fileattachmentpayload",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/imageattachmentpayload",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/AttachmentButton/attachmentbutton",
                 {
                   "AttachmentViews": [
-                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/FileAttachmentView.Content",
-                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/FileAttachmentView",
-                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/ImageAttachmentView"
+                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/fileattachmentview.content",
+                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/fileattachmentview",
+                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/Attachments/AttachmentViews/imageattachmentview"
                   ]
                 }
               ]
             },
             {
               "AvatarView": [
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatAvatarView",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.SwiftUIWrapper",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarViewSwiftUIView",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/chatavatarview",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/chatchannelavatarview.swiftuiwrapper",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/chatchannelavatarview",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/chatchannelavatarviewswiftuiview",
                 {
                   "ChatPresenceAvatarView": [
-                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatPresenceAvatarView/OnlineIndicatorView",
-                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatPresenceAvatarView/ChatPresenceAvatarView",
-                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatPresenceAvatarView/MaskProviding"
+                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatPresenceAvatarView/onlineindicatorview",
+                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatPresenceAvatarView/chatpresenceavatarview",
+                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatPresenceAvatarView/maskproviding"
                   ]
                 },
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/ChatUserAvatarView",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/CurrentChatUserAvatarView"
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/chatuseravatarview",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/AvatarView/currentchatuseravatarview"
               ]
             },
             {
-              "ContainerStackView": [
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/ContainerStackView.Alignment",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/ContainerStackView.Distribution",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/ContainerStackView.Spacing",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/ContainerStackView"
+              "containerstackview": [
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/containerstackview.alignment",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/containerstackview.distribution",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/containerstackview.spacing",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/containerstackview"
               ]
             },
             {
               "InputChatMessageView": [
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/InputChatMessageView/InputChatMessageView.Content",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/InputChatMessageView/InputChatMessageView"
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/InputChatMessageView/inputchatmessageview.content",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/InputChatMessageView/inputchatmessageview"
               ]
             },
             {
               "ListCollectionViewLayout": [
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/CellSeparatorReusableView",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/ListCollectionViewLayout",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/ListCollectionViewLayoutDelegate"
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/cellseparatorreusableview",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/listcollectionviewlayout",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/ListCollectionViewLayout/listcollectionviewlayoutdelegate"
               ]
             },
             {
               "QuotedChatMessageView": [
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedAvatarAlignment",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.Content",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.SwiftUIWrapper",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageViewSwiftUIView"
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/quotedavataralignment",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/quotedchatmessageview.content",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/quotedchatmessageview.swiftuiwrapper",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/quotedchatmessageview",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/quotedchatmessageviewswiftuiview"
               ]
             },
             {
               "Suggestions": [
                 {
                   "ChatCommandSuggestionView": [
-                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatCommandSuggestionView/ChatCommandSuggestionCollectionViewCell",
-                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatCommandSuggestionView/ChatCommandSuggestionView"
+                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatCommandSuggestionView/chatcommandsuggestioncollectionviewcell",
+                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatCommandSuggestionView/chatcommandsuggestionview"
                   ]
                 },
                 {
                   "ChatMentionSuggestionView": [
-                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatMentionSuggestionView/ChatMentionSuggestionCollectionViewCell",
-                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatMentionSuggestionView/ChatMentionSuggestionView"
+                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatMentionSuggestionView/chatmentionsuggestioncollectionviewcell",
+                    "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatMentionSuggestionView/chatmentionsuggestionview"
                   ]
                 },
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatMessageComposerSuggestionsCommandDataSource",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatMessageComposerSuggestionsMentionDataSource",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsCollectionReusableView",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsCollectionView",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsCollectionViewLayout",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsHeaderView",
-                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsViewController"
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/chatmessagecomposersuggestionscommanddatasource",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/chatmessagecomposersuggestionsmentiondatasource",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/chatsuggestionscollectionreusableview",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/chatsuggestionscollectionview",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/chatsuggestionscollectionviewlayout",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/chatsuggestionsheaderview",
+                "ReferenceDocs/Sources/StreamChatUI/CommonViews/Suggestions/chatsuggestionsviewcontroller"
               ]
             }
           ]
         },
         {
           "Utils": [
-            "ReferenceDocs/Sources/StreamChatUI/Utils/AppearanceProvider",
-            "ReferenceDocs/Sources/StreamChatUI/Utils/CGSize",
-            "ReferenceDocs/Sources/StreamChatUI/Utils/ChatChannelNamer",
-            "ReferenceDocs/Sources/StreamChatUI/Utils/ChatMessage",
-            "ReferenceDocs/Sources/StreamChatUI/Utils/ComponentsProvider",
-            "ReferenceDocs/Sources/StreamChatUI/Utils/DefaultChatChannelNamer(maxMemberNames_separator_)",
-            "ReferenceDocs/Sources/StreamChatUI/Utils/GenericComponentsProvider",
-            "ReferenceDocs/Sources/StreamChatUI/Utils/ImageCDN",
-            "ReferenceDocs/Sources/StreamChatUI/Utils/ImageProcessors.LateResize",
-            "ReferenceDocs/Sources/StreamChatUI/Utils/ImageProcessors",
-            "ReferenceDocs/Sources/StreamChatUI/Utils/NavigationVC",
-            "ReferenceDocs/Sources/StreamChatUI/Utils/StreamImageCDN",
-            "ReferenceDocs/Sources/StreamChatUI/Utils/ThemeProvider"
+            "ReferenceDocs/Sources/StreamChatUI/Utils/appearanceprovider",
+            "ReferenceDocs/Sources/StreamChatUI/Utils/cgsize",
+            "ReferenceDocs/Sources/StreamChatUI/Utils/chatchannelnamer",
+            "ReferenceDocs/Sources/StreamChatUI/Utils/chatmessage",
+            "ReferenceDocs/Sources/StreamChatUI/Utils/componentsprovider",
+          
+            "ReferenceDocs/Sources/StreamChatUI/Utils/genericcomponentsprovider",
+            "ReferenceDocs/Sources/StreamChatUI/Utils/imagecdn",
+            "ReferenceDocs/Sources/StreamChatUI/Utils/imageprocessors.lateresize",
+            
+            "ReferenceDocs/Sources/StreamChatUI/Utils/navigationvc",
+            "ReferenceDocs/Sources/StreamChatUI/Utils/streamimagecdn",
+            "ReferenceDocs/Sources/StreamChatUI/Utils/themeprovider"
           ]
         }
       ]


### PR DESCRIPTION
# Magic link
https://stream-ids-implementation.loca.lt/chat/docs/sdk/

# What this PR do:
- Adds IDS and TITLES to reference documentation so Docusaurus can find the pages
# How to test it
- Check the magic tunel link posted above -> Go to some component and try to refresh it in your browser, it should not throw 404 now
