### PR TITLE
[CIS-913] Fix layout feedback loop in ChatMessageContentView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix sorting Member List by `createdAt` causing an issue [#1185](https://github.com/GetStream/stream-chat-swift/issues/1185)
 - Fix ComposerView not respecting `ChannelConfig.maxMessageLength [#1190](https://github.com/GetStream/stream-chat-swift/issues/1190)
 - Fix mentions not being parsed correctly [#1188](https://github.com/GetStream/stream-chat-swift/issues/1188)
+- Fix layout feedback loop for Quoted Message without bubble view [#1203](https://github.com/GetStream/stream-chat-swift/issues/1203)
 
 # [4.0.0-beta.3](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.3)
 _June 11, 2021_

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
@@ -298,7 +298,7 @@ open class _ChatMessageContentView<ExtraData: ExtraDataTypes>: _View, ThemeProvi
         // Quoted message
         if options.contains(.quotedMessage) {
             let quotedMessageView = createQuotedMessageView()
-            bubbleContentContainer.addArrangedSubview(quotedMessageView, respectsLayoutMargins: true)
+            bubbleContentContainer.addArrangedSubview(quotedMessageView)
         }
 
         // Text
@@ -545,7 +545,6 @@ open class _ChatMessageContentView<ExtraData: ExtraDataTypes>: _View, ThemeProvi
             textView?.adjustsFontForContentSizeCategory = true
             textView?.textContainerInset = .init(top: 0, left: 8, bottom: 0, right: 8)
             textView?.textContainer.lineFragmentPadding = 0
-            textView?.translatesAutoresizingMaskIntoConstraints = false
             textView?.font = appearance.fonts.body
         }
         return textView!

--- a/Sources/StreamChatUI/CommonViews/OnlyLinkTappableTextView.swift
+++ b/Sources/StreamChatUI/CommonViews/OnlyLinkTappableTextView.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-/// Text View that ignore all user interactions except touches on links
+/// Text View that ignores all user interactions except touches on links
 class OnlyLinkTappableTextView: UITextView {
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         if let range = characterRange(at: point),


### PR DESCRIPTION
I reproduced the issue @b-onc described and was able to fix it with this change.
I checked the resulting layouts before/after and they're identical.
I would really appreciate an opinion on how adequate the fix is, and if it's not, we still can figure out another solution based on the fact that this is still a root cause of the issue.