### PR TITLE
Fix `image/file/link/giphy` actions not being handled in threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ⚠️ Breaking Changes from `4.0-beta.3`
 - `ChatOnlineIndicatorView` renamed to `OnlineIndicatorView`
+- `GalleryContentViewDelegate` methods updated to have optional index path
+- `FileActionContentViewDelegate` methods updated to have optional index path
+- `LinkPreviewViewDelegate` methods updated to have optional index path
 
 ### ✅ Added
 - `mentionText(for:)` function added to `ComposerVC` for customizing the text displayed for mentions [#1188](https://github.com/GetStream/stream-chat-swift/issues/1188) [#1000](https://github.com/GetStream/stream-chat-swift/issues/1000)
@@ -17,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix ComposerView not respecting `ChannelConfig.maxMessageLength [#1190](https://github.com/GetStream/stream-chat-swift/issues/1190)
 - Fix mentions not being parsed correctly [#1188](https://github.com/GetStream/stream-chat-swift/issues/1188)
 - Fix layout feedback loop for Quoted Message without bubble view [#1203](https://github.com/GetStream/stream-chat-swift/issues/1203)
+- Fix image/file/link/giphy actions not being handled in `ChatThreadVC` [#1207](https://github.com/GetStream/stream-chat-swift/pull/1207)
+- Fix `ChatMessageLinkPreviewView` not being taken from `Components` [#1207](https://github.com/GetStream/stream-chat-swift/pull/1207)
 
 # [4.0.0-beta.3](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.3)
 _June 11, 2021_

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/FileAttachmentViewInjector.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/FileAttachmentViewInjector.swift
@@ -8,7 +8,7 @@ import UIKit
 /// The delegate used `GiphyAttachmentViewInjector` to communicate user interactions.
 public protocol FileActionContentViewDelegate: ChatMessageContentViewDelegate {
     /// Called when the user taps on attachment action
-    func didTapOnAttachment(_ attachment: ChatMessageFileAttachment, at indexPath: IndexPath)
+    func didTapOnAttachment(_ attachment: ChatMessageFileAttachment, at indexPath: IndexPath?)
 }
 
 public typealias FilesAttachmentViewInjector = _FilesAttachmentViewInjector<NoExtraData>
@@ -21,11 +21,10 @@ public class _FilesAttachmentViewInjector<ExtraData: ExtraDataTypes>: _Attachmen
             .init()
         
         attachmentListView.didTapOnAttachment = { [weak self] attachment in
-            guard let delegate = self?.contentView.delegate as? FileActionContentViewDelegate,
-                  let indexPath = self?.contentView.indexPath?()
+            guard
+                let delegate = self?.contentView.delegate as? FileActionContentViewDelegate
             else { return }
-            
-            delegate.didTapOnAttachment(attachment, at: indexPath)
+            delegate.didTapOnAttachment(attachment, at: self?.contentView.indexPath?())
         }
         
         return attachmentListView.withoutAutoresizingMaskConstraints

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/GalleryAttachmentViewInjector.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/GalleryAttachmentViewInjector.swift
@@ -11,7 +11,7 @@ public protocol GalleryContentViewDelegate: ChatMessageContentViewDelegate {
     func didTapOnImageAttachment(
         _ attachment: ChatMessageImageAttachment,
         previews: [ImagePreviewable],
-        at indexPath: IndexPath
+        at indexPath: IndexPath?
     )
 }
 
@@ -41,13 +41,10 @@ open class _GalleryAttachmentViewInjector<ExtraData: ExtraDataTypes>: _Attachmen
     }
 
     open func handleTapOnAttachment(_ attachment: ChatMessageImageAttachment) {
-        guard
-            let indexPath = contentView.indexPath?()
-        else { return }
         (contentView.delegate as? GalleryContentViewDelegate)?.didTapOnImageAttachment(
             attachment,
             previews: galleryView.previews,
-            at: indexPath
+            at: contentView.indexPath?()
         )
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/LinkAttachmentViewInjector.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/LinkAttachmentViewInjector.swift
@@ -10,7 +10,7 @@ public protocol LinkPreviewViewDelegate: ChatMessageContentViewDelegate {
     /// Called when the user taps the link preview.
     func didTapOnLinkAttachment(
         _ attachment: ChatMessageLinkAttachment,
-        at indexPath: IndexPath
+        at indexPath: IndexPath?
     )
 }
 
@@ -38,13 +38,12 @@ open class _LinkAttachmentViewInjector<ExtraData: ExtraDataTypes>: _AttachmentVi
     @objc
     open func handleTapOnAttachment() {
         guard
-            let attachment = linkPreviewView.content,
-            let indexPath = contentView.indexPath?()
+            let attachment = linkPreviewView.content
         else { return }
         (contentView.delegate as? LinkPreviewViewDelegate)?
             .didTapOnLinkAttachment(
                 attachment,
-                at: indexPath
+                at: contentView.indexPath?()
             )
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/LinkAttachmentViewInjector.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/LinkAttachmentViewInjector.swift
@@ -19,7 +19,10 @@ public typealias LinkAttachmentViewInjector = _LinkAttachmentViewInjector<NoExtr
 
 /// View injector for showing link attachments.
 open class _LinkAttachmentViewInjector<ExtraData: ExtraDataTypes>: _AttachmentViewInjector<ExtraData> {
-    open private(set) lazy var linkPreviewView = _ChatMessageLinkPreviewView<ExtraData>()
+    open private(set) lazy var linkPreviewView = contentView
+        .components
+        .linkPreviewView
+        .init()
         .withoutAutoresizingMaskConstraints
     
     override open func contentViewDidLayout(options: ChatMessageLayoutOptions) {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -408,14 +408,12 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
     open func didTapOnImageAttachment(
         _ attachment: ChatMessageImageAttachment,
         previews: [ImagePreviewable],
-        at indexPath: IndexPath
+        at indexPath: IndexPath?
     ) {
-        guard
-            let cell = collectionView.cellForItem(at: indexPath) as? _ChatMessageCollectionViewCell<ExtraData>,
-            let message = cell.messageContentView?.content
-        else { return }
+        guard let indexPath = indexPath else { return log.error("IndexPath is not available") }
+        
         router.showImageGallery(
-            message: message,
+            message: messageForIndexPath(indexPath),
             initialAttachment: attachment,
             previews: previews
         )

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -404,8 +404,8 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
     }
 
     // MARK: - Cell action handlers
-
-    public func didTapOnImageAttachment(
+    
+    open func didTapOnImageAttachment(
         _ attachment: ChatMessageImageAttachment,
         previews: [ImagePreviewable],
         at indexPath: IndexPath
@@ -428,7 +428,10 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
         router.showLinkPreview(link: attachment.originalURL)
     }
 
-    public func didTapOnAttachment(_ attachment: ChatMessageFileAttachment, at indexPath: IndexPath) {
+    open func didTapOnAttachment(
+        _ attachment: ChatMessageFileAttachment,
+        at indexPath: IndexPath
+    ) {
         router.showFilePreview(fileURL: attachment.payload.assetURL)
     }
     

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -428,9 +428,9 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
 
     open func didTapOnAttachment(
         _ attachment: ChatMessageFileAttachment,
-        at indexPath: IndexPath
+        at indexPath: IndexPath?
     ) {
-        router.showFilePreview(fileURL: attachment.payload.assetURL)
+        router.showFilePreview(fileURL: attachment.assetURL)
     }
     
     /// Executes the provided action on the message

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -421,7 +421,7 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
     
     open func didTapOnLinkAttachment(
         _ attachment: ChatMessageLinkAttachment,
-        at indexPath: IndexPath
+        at indexPath: IndexPath?
     ) {
         router.showLinkPreview(link: attachment.originalURL)
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -17,6 +17,7 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
     _ChatMessageControllerDelegate,
     _ChatMessageActionsVCDelegate,
     ChatMessageContentViewDelegate,
+    GiphyActionContentViewDelegate,
     UICollectionViewDelegate,
     UICollectionViewDataSource {
     /// Controller for observing data changes within the channel

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -17,7 +17,10 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
     _ChatMessageControllerDelegate,
     _ChatMessageActionsVCDelegate,
     ChatMessageContentViewDelegate,
+    GalleryContentViewDelegate,
     GiphyActionContentViewDelegate,
+    LinkPreviewViewDelegate,
+    FileActionContentViewDelegate,
     UICollectionViewDelegate,
     UICollectionViewDataSource {
     /// Controller for observing data changes within the channel
@@ -375,6 +378,32 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
                 messageId: messageController.replies[indexPath.item].id
             )
             .dispatchEphemeralMessageAction(action)
+    }
+    
+    open func didTapOnImageAttachment(
+        _ attachment: ChatMessageImageAttachment,
+        previews: [ImagePreviewable],
+        at indexPath: IndexPath
+    ) {
+        router.showImageGallery(
+            message: messageForIndexPath(indexPath),
+            initialAttachment: attachment,
+            previews: previews
+        )
+    }
+    
+    open func didTapOnLinkAttachment(
+        _ attachment: ChatMessageLinkAttachment,
+        at indexPath: IndexPath
+    ) {
+        router.showLinkPreview(link: attachment.originalURL)
+    }
+
+    open func didTapOnAttachment(
+        _ attachment: ChatMessageFileAttachment,
+        at indexPath: IndexPath
+    ) {
+        router.showFilePreview(fileURL: attachment.payload.assetURL)
     }
 
     // MARK: - _ComposerVCDelegate

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -399,7 +399,7 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
     
     open func didTapOnLinkAttachment(
         _ attachment: ChatMessageLinkAttachment,
-        at indexPath: IndexPath
+        at indexPath: IndexPath?
     ) {
         router.showLinkPreview(link: attachment.originalURL)
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -406,9 +406,9 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
 
     open func didTapOnAttachment(
         _ attachment: ChatMessageFileAttachment,
-        at indexPath: IndexPath
+        at indexPath: IndexPath?
     ) {
-        router.showFilePreview(fileURL: attachment.payload.assetURL)
+        router.showFilePreview(fileURL: attachment.assetURL)
     }
 
     // MARK: - _ComposerVCDelegate

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -261,6 +261,7 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
             )
             collectionView.addSubview(messageView)
             messageView.content = message
+            messageView.delegate = self
 
             let messageViewSize = messageView.systemLayoutSizeFitting(
                 CGSize(
@@ -383,10 +384,14 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
     open func didTapOnImageAttachment(
         _ attachment: ChatMessageImageAttachment,
         previews: [ImagePreviewable],
-        at indexPath: IndexPath
+        at indexPath: IndexPath?
     ) {
+        guard let message = indexPath.map(messageForIndexPath) ?? messageController.message else {
+            return log.error("Failed to get the message")
+        }
+        
         router.showImageGallery(
-            message: messageForIndexPath(indexPath),
+            message: message,
             initialAttachment: attachment,
             previews: previews
         )

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -155,6 +155,10 @@ public struct _Components<ExtraData: ExtraDataTypes> {
     /// The view that shows message's image attachments.
     public var imageGalleryView: _ChatMessageImageGallery<ExtraData>.Type =
         _ChatMessageImageGallery<ExtraData>.self
+    
+    /// The view that shows a link preview in message cell.
+    public var linkPreviewView: _ChatMessageLinkPreviewView<ExtraData>.Type =
+        _ChatMessageLinkPreviewView<ExtraData>.self
 
     /// The view that shows an overlay with uploading progress for image attachment that is being uploaded.
     public var imageUploadingOverlay: _ChatMessageImageGallery<ExtraData>.UploadingOverlay.Type =


### PR DESCRIPTION
**This PR**:
- fixes missing handling of attachment actions in `ChatThreadVC`
- updates `GalleryContentViewDelegate` to have option index path so it work for thread root messages


https://user-images.githubusercontent.com/12818985/122929243-64286200-d373-11eb-8771-fd87901a53ba.mp4


