### PR TITLE
[CIS-928] Scroll to bottom button enahncements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `GalleryContentViewDelegate` methods updated to have optional index path
 - `FileActionContentViewDelegate` methods updated to have optional index path
 - `LinkPreviewViewDelegate` methods updated to have optional index path
+- `scrollToLatestMessageButton` type changed from `UIButton` to `_ScrollToLatestMessageButton<ExtraData>`
 
 ### ✅ Added
 - `mentionText(for:)` function added to `ComposerVC` for customizing the text displayed for mentions [#1188](https://github.com/GetStream/stream-chat-swift/issues/1188) [#1000](https://github.com/GetStream/stream-chat-swift/issues/1000)
 - `score` to `ChatMessageReactionData` so a slack-like reaction view is achievable. This would be used as content in `ChatMessageReactionsView` [#1200](https://github.com/GetStream/stream-chat-swift/issues/1200)
+
+### 🔄 Changed
+- `scrollToLatestMessageButton` is now visible every time the last message is not visible. Not only when there is unread message. [#1208](https://github.com/GetStream/stream-chat-swift/pull/1208) 
 
 ### 🐞 Fixed 
 - Fix sorting Member List by `createdAt` causing an issue [#1185](https://github.com/GetStream/stream-chat-swift/issues/1185)

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListCollectionView.swift
@@ -294,8 +294,10 @@ open class ChatMessageListCollectionView<ExtraData: ExtraDataTypes>: UICollectio
         if numberOfItems(inSection: 0) == 0 { return true }
         let lastIndexPath = IndexPath(item: 0, section: 0)
 
-        guard let attributes = collectionViewLayout.layoutAttributesForItem(at: lastIndexPath) else { return false }
-        return bounds.contains(attributes.frame)
+        guard let frame = collectionViewLayout.layoutAttributesForItem(at: lastIndexPath)?.frame else { return false }
+        // Fix frame height to return true after scrollToMostRecentMessage animation finishes.
+        let fixedFrame = CGRect(origin: frame.origin, size: CGSize(width: frame.width, height: frame.height - 1))
+        return bounds.contains(fixedFrame)
     }
 
     /// A Boolean that returns true if the last cell is visible, but can be just partially visible.

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListUnreadCountView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListUnreadCountView.swift
@@ -1,0 +1,18 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+/// A view that shows a number of unread messages on the Scroll-To-Latest-Message button in the Message List.
+public typealias ChatMessageListUnreadCountView = _ChatMessageListUnreadCountView<NoExtraData>
+
+/// A view that shows a number of unread messages on the Scroll-To-Latest-Message button in the Message List.
+open class _ChatMessageListUnreadCountView<ExtraData: ExtraDataTypes>: _ChatChannelUnreadCountView<ExtraData> {
+    override open func setUpAppearance() {
+        super.setUpAppearance()
+        
+        backgroundColor = tintColor
+    }
+}

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -271,10 +271,11 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
     open func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if collectionView.isLastCellFullyVisible, channelController.channel?.isUnread == true {
             channelController.markRead()
-            
-            // Hide the button immediately. Temporary solution until CIS-881 is implemented.
-            setScrollToLatestMessageButton(visible: false)
+
+            // Hide the badge immediately. Temporary solution until CIS-881 is implemented.
+            scrollToLatestMessageButton.content = .noUnread
         }
+        setScrollToLatestMessageButton(visible: !collectionView.isLastCellFullyVisible)
     }
     
     /// Scrolls to most recent message

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -89,7 +89,7 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
     /// A button to scroll the collection view to the bottom.
     ///
     /// Visible when there is unread message and the collection view is not at the bottom already.
-    open private(set) lazy var scrollToLatestMessageButton: UIButton = components
+    open private(set) lazy var scrollToLatestMessageButton: _ScrollToLatestMessageButton<ExtraData> = components
         .scrollToLatestMessageButton
         .init()
         .withoutAutoresizingMaskConstraints
@@ -283,10 +283,9 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
         collectionView.scrollToMostRecentMessage(animated: animated)
     }
     
-    /// Update the visibility of `scrollToLatestMessageButton` based on unread messages and visible messages.
+    /// Update the `scrollToLatestMessageButton` based on unread messages.
     open func updateScrollToLatestMessageButton() {
-        let visible = channelController.channel?.isUnread == true && !collectionView.isLastCellFullyVisible
-        setScrollToLatestMessageButton(visible: visible)
+        scrollToLatestMessageButton.content = channelController.channel?.unreadCount ?? .noUnread
     }
     
     /// Set the visibility of `scrollToLatestMessageButton`.

--- a/Sources/StreamChatUI/ChatMessageList/ScrollToLatestMessageButton.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ScrollToLatestMessageButton.swift
@@ -2,10 +2,27 @@
 // Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
+import StreamChat
 import UIKit
 
 /// A Button that is used to indicate unread messages in the Message list.
-open class ScrollToLatestMessageButton: _Button, AppearanceProvider {
+public typealias ScrollToLatestMessageButton = _ScrollToLatestMessageButton<NoExtraData>
+
+/// A Button that is used to indicate unread messages in the Message list.
+open class _ScrollToLatestMessageButton<ExtraData: ExtraDataTypes>: _Button, ThemeProvider {
+    /// The unread count that will be shown on the button as a badge icon.
+    var content: ChannelUnreadCount = .noUnread {
+        didSet {
+            updateContentIfNeeded()
+        }
+    }
+    
+    /// The view showing number of unread messages in channel if any.
+    open private(set) lazy var unreadCountView: _ChatMessageListUnreadCountView<ExtraData> = components
+        .messageListUnreadCountView
+        .init()
+        .withoutAutoresizingMaskConstraints
+    
     override open func layoutSubviews() {
         super.layoutSubviews()
         
@@ -20,6 +37,18 @@ open class ScrollToLatestMessageButton: _Button, AppearanceProvider {
         layer.addShadow(color: appearance.colorPalette.shadow)
     }
     
+    override open func setUpLayout() {
+        super.setUpLayout()
         
+        addSubview(unreadCountView)
+        unreadCountView.centerXAnchor.pin(equalTo: centerXAnchor).isActive = true
+        unreadCountView.centerYAnchor.pin(equalTo: topAnchor).isActive = true
+    }
+    
+    override open func updateContent() {
+        super.updateContent()
+        
+        unreadCountView.content = content
+        unreadCountView.invalidateIntrinsicContentSize()
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ScrollToLatestMessageButton.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ScrollToLatestMessageButton.swift
@@ -6,6 +6,12 @@ import UIKit
 
 /// A Button that is used to indicate unread messages in the Message list.
 open class ScrollToLatestMessageButton: _Button, AppearanceProvider {
+    override open func layoutSubviews() {
+        super.layoutSubviews()
+        
+        layer.cornerRadius = bounds.height / 2
+    }
+
     override open func setUpAppearance() {
         super.setUpAppearance()
         
@@ -14,9 +20,6 @@ open class ScrollToLatestMessageButton: _Button, AppearanceProvider {
         layer.addShadow(color: appearance.colorPalette.shadow)
     }
     
-    override open func layoutSubviews() {
-        super.layoutSubviews()
         
-        layer.cornerRadius = bounds.height / 2
     }
 }

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -180,8 +180,13 @@ public struct _Components<ExtraData: ExtraDataTypes> {
     public var giphyBadgeView: _ChatMessageGiphyView<ExtraData>.GiphyBadge.Type = _ChatMessageGiphyView<ExtraData>.GiphyBadge.self
     
     /// The button that indicates unread messages at the bottom of the message list and scroll to the latest message on tap.
-    public var scrollToLatestMessageButton: UIButton.Type = ScrollToLatestMessageButton.self
+    public var scrollToLatestMessageButton: _ScrollToLatestMessageButton<ExtraData>.Type =
+        _ScrollToLatestMessageButton<ExtraData>.self
 
+    /// The view that shows a number of unread messages on the Scroll-To-Latest-Message button in the Message List.
+    public var messageListUnreadCountView: _ChatMessageListUnreadCountView<ExtraData>.Type =
+        _ChatMessageListUnreadCountView<ExtraData>.self
+    
     // MARK: - Channel list components
 
     /// The logic to generate a name for the given channel.

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -783,6 +783,7 @@
 		BDDD1EAA2632CE3C00BA007B /* Appearance+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDD1EA92632CE3C00BA007B /* Appearance+SwiftUI.swift */; };
 		BDDD1EAC2632E32000BA007B /* AppearanceProvider_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDD1EAB2632E32000BA007B /* AppearanceProvider_Tests.swift */; };
 		BDDD1EAE2632E6C200BA007B /* Appearance+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDD1EAD2632E6C200BA007B /* Appearance+SwiftUI_Tests.swift */; };
+		BDEB9417268211EC00928AF1 /* ChatMessageListUnreadCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEB9416268211EC00928AF1 /* ChatMessageListUnreadCountView.swift */; };
 		DA0BB1612513B5F200CAEFBD /* StringInterpolation+Extenstions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0BB1602513B5F200CAEFBD /* StringInterpolation+Extenstions.swift */; };
 		DA15A20424DF257500BE2423 /* ChannelQuery_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA15A20224DF256F00BE2423 /* ChannelQuery_Tests.swift */; };
 		DA49714E2549C28000AC68C2 /* AttachmentDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA49714D2549C28000AC68C2 /* AttachmentDTO_Tests.swift */; };
@@ -2036,6 +2037,7 @@
 		BDDD1EA92632CE3C00BA007B /* Appearance+SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Appearance+SwiftUI.swift"; sourceTree = "<group>"; };
 		BDDD1EAB2632E32000BA007B /* AppearanceProvider_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppearanceProvider_Tests.swift; sourceTree = "<group>"; };
 		BDDD1EAD2632E6C200BA007B /* Appearance+SwiftUI_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Appearance+SwiftUI_Tests.swift"; sourceTree = "<group>"; };
+		BDEB9416268211EC00928AF1 /* ChatMessageListUnreadCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListUnreadCountView.swift; sourceTree = "<group>"; };
 		DA0BB1602513B5F200CAEFBD /* StringInterpolation+Extenstions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StringInterpolation+Extenstions.swift"; sourceTree = "<group>"; };
 		DA15A20224DF256F00BE2423 /* ChannelQuery_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelQuery_Tests.swift; sourceTree = "<group>"; };
 		DA49714D2549C28000AC68C2 /* AttachmentDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentDTO_Tests.swift; sourceTree = "<group>"; };
@@ -2530,6 +2532,7 @@
 				A35757C62613081B00DC914C /* ChatMessageListKeyboardObserver.swift */,
 				E768AA882625C18D00328E6E /* TypingIndicatorView.swift */,
 				BD69F5D42669392E00E9E3FA /* ScrollToLatestMessageButton.swift */,
+				BDEB9416268211EC00928AF1 /* ChatMessageListUnreadCountView.swift */,
 				E74DB0102655473300508D22 /* TypingIndicatorView_Tests.swift */,
 				E768AAFA2627691600328E6E /* TypingAnimationView.swift */,
 				DBC8A563258113F700B20A82 /* ChatThreadVC.swift */,
@@ -5351,6 +5354,7 @@
 				DBC8A5762581476E00B20A82 /* ChatMessageListVC.swift in Sources */,
 				8800A28C258A1924006D64C4 /* ChatMessageFileAttachmentListView.swift in Sources */,
 				88A8CF16256E7BDA004EA4C7 /* ChatMessageContentView.swift in Sources */,
+				BDEB9417268211EC00928AF1 /* ChatMessageListUnreadCountView.swift in Sources */,
 				226C438D25802AAD008B3648 /* InputTextView.swift in Sources */,
 				AD87D097263C7783008B466C /* CommandButton.swift in Sources */,
 				224165A825910A2C00ED7F78 /* CheckboxControl.swift in Sources */,


### PR DESCRIPTION
## This PR
- changes the behaviour of the `scrollToLatestMessageButton`. The button is now visible every time the last message is not visible. 
- adding badge icon to the button. Needed to create a new class with tint colour instead of alert colour on the background. 
- fixes issue where the `isLastCellFullyVisible` is `false` after calling `scrollToMostRecentMessage`

Badge preview:
![Badge button](https://user-images.githubusercontent.com/7560049/122955617-8c6a8d80-d380-11eb-96d8-4c906522b399.png)

Scrolling behaviour:

https://user-images.githubusercontent.com/7560049/122955624-8e345100-d380-11eb-8116-d3e9f410a5c0.mov



## Links
https://stream-io.atlassian.net/browse/CIS-928