### PR TITLE
[CIS-243] Implement silent messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - `mentionText(for:)` function added to `ComposerVC` for customizing the text displayed for mentions [#1188](https://github.com/GetStream/stream-chat-swift/issues/1188) [#1000](https://github.com/GetStream/stream-chat-swift/issues/1000)
 - `score` to `ChatMessageReactionData` so a slack-like reaction view is achievable. This would be used as content in `ChatMessageReactionsView` [#1200](https://github.com/GetStream/stream-chat-swift/issues/1200)
+- Ability to send silent messages. Silent messages are normal messages with an additional `isSilent` value set to `true`. Silent messages don’t trigger push notification for the recipient.[#1211](https://github.com/GetStream/stream-chat-swift/pull/1211)
 
 ### 🔄 Changed
 - `scrollToLatestMessageButton` is now visible every time the last message is not visible. Not only when there is unread message. [#1208](https://github.com/GetStream/stream-chat-swift/pull/1208) 

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
@@ -183,6 +183,7 @@ struct MessageRequestBody<ExtraData: ExtraDataTypes>: Encodable {
     let args: String?
     let parentId: String?
     let showReplyInChannel: Bool
+    let isSilent: Bool
     let quotedMessageId: String?
     let attachments: [MessageAttachmentPayload]
     let mentionedUserIds: [UserId]
@@ -198,6 +199,7 @@ struct MessageRequestBody<ExtraData: ExtraDataTypes>: Encodable {
         args: String? = nil,
         parentId: String? = nil,
         showReplyInChannel: Bool = false,
+        isSilent: Bool = false,
         quotedMessageId: String? = nil,
         attachments: [MessageAttachmentPayload] = [],
         mentionedUserIds: [UserId] = [],
@@ -212,6 +214,7 @@ struct MessageRequestBody<ExtraData: ExtraDataTypes>: Encodable {
         self.args = args
         self.parentId = parentId
         self.showReplyInChannel = showReplyInChannel
+        self.isSilent = isSilent
         self.quotedMessageId = quotedMessageId
         self.attachments = attachments
         self.mentionedUserIds = mentionedUserIds
@@ -231,6 +234,7 @@ struct MessageRequestBody<ExtraData: ExtraDataTypes>: Encodable {
         try container.encodeIfPresent(quotedMessageId, forKey: .quotedMessageId)
         try container.encode(pinned, forKey: .pinned)
         try container.encodeIfPresent(pinExpires, forKey: .pinExpires)
+        try container.encode(isSilent, forKey: .isSilent)
 
         if !attachments.isEmpty {
             try container.encode(attachments, forKey: .attachments)

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
@@ -114,6 +114,7 @@ class MessageRequestBody_Tests: XCTestCase {
             args: .unique,
             parentId: .unique,
             showReplyInChannel: true,
+            isSilent: true,
             quotedMessageId: "quoted-message-id",
             mentionedUserIds: [.unique],
             pinned: true,
@@ -127,6 +128,44 @@ class MessageRequestBody_Tests: XCTestCase {
             "text": payload.text,
             "parent_id": payload.parentId!,
             "show_in_channel": true,
+            "silent": true,
+            "args": payload.args!,
+            "quoted_message_id": "quoted-message-id",
+            "mentioned_users": payload.mentionedUserIds,
+            "secret_note": "Anakin is Vader ;-)",
+            "command": payload.command!,
+            "pinned": true,
+            "pin_expires": "2021-05-15T06:43:08.776Z"
+        ]
+        let expectedJSON = try JSONSerialization.data(withJSONObject: expected, options: [])
+        
+        AssertJSONEqual(serializedJSON, expectedJSON)
+    }
+    
+    /// Check whether the message body is serialized when `isSilent` is not provided in `init`
+    func test_isSerializedWithoutSilent() throws {
+        let payload: MessageRequestBody<CustomData> = .init(
+            id: .unique,
+            user: .dummy(userId: .unique),
+            text: .unique,
+            command: .unique,
+            args: .unique,
+            parentId: .unique,
+            showReplyInChannel: true,
+            quotedMessageId: "quoted-message-id",
+            mentionedUserIds: [.unique],
+            pinned: true,
+            pinExpires: "2021-05-15T06:43:08.776Z".toDate(),
+            extraData: .init(secretNote: "Anakin is Vader ;-)")
+        )
+        
+        let serializedJSON = try JSONEncoder.stream.encode(payload)
+        let expected: [String: Any] = [
+            "id": payload.id,
+            "text": payload.text,
+            "parent_id": payload.parentId!,
+            "show_in_channel": true,
+            "silent": false,
             "args": payload.args!,
             "quoted_message_id": "quoted-message-id",
             "mentioned_users": payload.mentionedUserIds,

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -756,6 +756,7 @@ public extension _ChatChannelController {
     /// - Parameters:
     ///   - text: Text of the message.
     ///   - pinning: Pins the new message. `nil` if should not be pinned.
+    ///   - isSilent: A flag indicating whether the message is a silent message. Silent messages are special messages that don't increase the unread messages count nor mark a channel as unread.
     ///   - attachments: An array of the attachments for the message.
     ///     `Note`: can be built-in types, custom attachment types conforming to `AttachmentEnvelope` protocol
     ///     and `ChatMessageAttachmentSeed`s.
@@ -768,6 +769,7 @@ public extension _ChatChannelController {
         pinning: MessagePinning? = nil,
 //        command: String? = nil,
 //        arguments: String? = nil,
+        isSilent: Bool = false,
         attachments: [AnyAttachmentPayload] = [],
         mentionedUserIds: [UserId] = [],
         quotedMessageId: MessageId? = nil,
@@ -789,6 +791,7 @@ public extension _ChatChannelController {
             in: cid,
             text: text,
             pinning: pinning,
+            isSilent: isSilent,
             command: nil,
             arguments: nil,
             attachments: attachments,

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
@@ -108,6 +108,7 @@ class ChannelController_Tests: StressTestCase {
             text: "Message",
             pinning: nil,
             quotedMessageId: nil,
+            isSilent: false,
             attachments: [
                 .mockImage,
                 .mockFile,

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -226,6 +226,7 @@ public extension _ChatMessageController {
         attachments: [AnyAttachmentPayload] = [],
         mentionedUserIds: [UserId] = [],
         showReplyInChannel: Bool = false,
+        isSilent: Bool = false,
         quotedMessageId: MessageId? = nil,
         extraData: ExtraData.Message = .defaultValue,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
@@ -240,6 +241,7 @@ public extension _ChatMessageController {
             attachments: attachments,
             mentionedUserIds: mentionedUserIds,
             showReplyInChannel: showReplyInChannel,
+            isSilent: isSilent,
             quotedMessageId: quotedMessageId,
             extraData: extraData
         ) { result in

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
@@ -289,6 +289,7 @@ class AttachmentDTO_Tests: XCTestCase {
                 text: "Message pending send",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 attachments: [.init(payload: TestAttachmentPayload.unique)],
                 extraData: NoExtraData.Message.defaultValue
             )

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -260,6 +260,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         attachments: [AnyAttachmentPayload],
         mentionedUserIds: [UserId],
         showReplyInChannel: Bool,
+        isSilent: Bool,
         quotedMessageId: MessageId?,
         extraData: ExtraData
     ) throws -> MessageDTO {
@@ -288,7 +289,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         message.args = arguments
         message.parentMessageId = parentMessageId
         message.extraData = try JSONEncoder.default.encode(extraData)
-        message.isSilent = false
+        message.isSilent = isSilent
         message.reactionScores = [:]
 
         message.attachments = Set(
@@ -478,6 +479,7 @@ extension MessageDTO {
             args: args,
             parentId: parentMessageId,
             showReplyInChannel: showReplyInChannel,
+            isSilent: isSilent,
             quotedMessageId: quotedMessage?.id,
             attachments: attachments
                 .sorted { $0.attachmentID.index < $1.attachmentID.index }

--- a/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
@@ -504,6 +504,7 @@ class MessageDTO_Tests: XCTestCase {
         ]
         let mentionedUserIds: [UserId] = [currentUserId]
         let messageShowReplyInChannel = true
+        let messageIsSilent = true
         let messageExtraData: NoExtraData = .defaultValue
 
         // Create message with attachments in the database.
@@ -517,7 +518,8 @@ class MessageDTO_Tests: XCTestCase {
                 parentMessageId: parentMessageId,
                 attachments: attachments,
                 mentionedUserIds: mentionedUserIds,
-                showReplyInChannel: true,
+                showReplyInChannel: messageShowReplyInChannel,
+                isSilent: messageIsSilent,
                 quotedMessageId: nil,
                 extraData: messageExtraData
             ).id
@@ -536,6 +538,7 @@ class MessageDTO_Tests: XCTestCase {
         XCTAssertEqual(requestBody.args, messageArguments)
         XCTAssertEqual(requestBody.parentId, parentMessageId)
         XCTAssertEqual(requestBody.showReplyInChannel, messageShowReplyInChannel)
+        XCTAssertEqual(requestBody.isSilent, messageIsSilent)
         XCTAssertEqual(requestBody.extraData, messageExtraData)
         XCTAssertEqual(requestBody.pinned, true)
         XCTAssertEqual(requestBody.pinExpires, messagePinning!.expirationDate)
@@ -623,6 +626,7 @@ class MessageDTO_Tests: XCTestCase {
                     attachments: [],
                     mentionedUserIds: [],
                     showReplyInChannel: false,
+                    isSilent: false,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
                 )
@@ -640,6 +644,7 @@ class MessageDTO_Tests: XCTestCase {
                     attachments: [],
                     mentionedUserIds: [],
                     showReplyInChannel: false,
+                    isSilent: false,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
                 )
@@ -738,6 +743,7 @@ class MessageDTO_Tests: XCTestCase {
                     attachments: newMessageAttachments,
                     mentionedUserIds: newMentionedUserIds,
                     showReplyInChannel: true,
+                    isSilent: false,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
                 )
@@ -781,6 +787,7 @@ class MessageDTO_Tests: XCTestCase {
                     attachments: [],
                     mentionedUserIds: [.unique],
                     showReplyInChannel: true,
+                    isSilent: false,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
                 )
@@ -817,6 +824,7 @@ class MessageDTO_Tests: XCTestCase {
                     attachments: [],
                     mentionedUserIds: [.unique],
                     showReplyInChannel: true,
+                    isSilent: false,
                     quotedMessageId: nil,
                     extraData: NoExtraData.defaultValue
                 )
@@ -853,6 +861,7 @@ class MessageDTO_Tests: XCTestCase {
                 text: newMessageText,
                 pinning: MessagePinning(expirationDate: .unique),
                 quotedMessageId: nil,
+                isSilent: false,
                 extraData: NoExtraData.defaultValue
             )
             newMessageId = messageDTO.id
@@ -891,6 +900,7 @@ class MessageDTO_Tests: XCTestCase {
                 attachments: [],
                 mentionedUserIds: [],
                 showReplyInChannel: false,
+                isSilent: false,
                 quotedMessageId: nil,
                 extraData: NoExtraData.defaultValue
             )

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -64,6 +64,7 @@ protocol MessageDatabaseSession {
         attachments: [AnyAttachmentPayload],
         mentionedUserIds: [UserId],
         showReplyInChannel: Bool,
+        isSilent: Bool,
         quotedMessageId: MessageId?,
         extraData: ExtraData
     ) throws -> MessageDTO
@@ -117,6 +118,7 @@ extension MessageDatabaseSession {
         text: String,
         pinning: MessagePinning?,
         quotedMessageId: MessageId?,
+        isSilent: Bool = false,
         attachments: [AnyAttachmentPayload] = [],
         mentionedUserIds: [UserId] = [],
         extraData: ExtraData = .defaultValue
@@ -131,6 +133,7 @@ extension MessageDatabaseSession {
             attachments: attachments,
             mentionedUserIds: mentionedUserIds,
             showReplyInChannel: false,
+            isSilent: isSilent,
             quotedMessageId: quotedMessageId,
             extraData: extraData
         )

--- a/Sources/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Mock.swift
@@ -80,6 +80,7 @@ extension DatabaseSessionMock {
         attachments: [AnyAttachmentPayload],
         mentionedUserIds: [UserId],
         showReplyInChannel: Bool,
+        isSilent: Bool,
         quotedMessageId: MessageId?,
         extraData: ExtraData
     ) throws -> MessageDTO where ExtraData: MessageExtraData {
@@ -95,6 +96,7 @@ extension DatabaseSessionMock {
             attachments: attachments,
             mentionedUserIds: mentionedUserIds,
             showReplyInChannel: showReplyInChannel,
+            isSilent: isSilent,
             quotedMessageId: quotedMessageId,
             extraData: extraData
         )

--- a/Sources/StreamChat/Workers/Background/MessageSender_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/MessageSender_Tests.swift
@@ -60,6 +60,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Message pending send without attachments",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 extraData: ExtraData.Message.defaultValue
             )
             message1.localMessageState = .pendingSend
@@ -70,6 +71,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Message pending send with attachments",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 attachments: [
                     .mockFile,
                     .mockImage,
@@ -85,6 +87,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Message without local state",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 attachments: [],
                 extraData: ExtraData.Message.defaultValue
             )
@@ -150,6 +153,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Message pending send",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 attachments: [
                     .init(payload: TestAttachmentPayload.unique),
                     .init(payload: TestAttachmentPayload.unique)
@@ -178,6 +182,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Message pending send",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 attachments: [
                     .mockImage,
                     .init(payload: TestAttachmentPayload.unique)
@@ -218,6 +223,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Message pending send",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 extraData: ExtraData.Message.defaultValue
             )
             message1.localMessageState = .pendingSend
@@ -248,6 +254,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Message pending send",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 extraData: ExtraData.Message.defaultValue
             )
             message1.localMessageState = .pendingSend
@@ -277,6 +284,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Message pending send 1",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 extraData: ExtraData.Message.defaultValue
             )
             message1.localMessageState = .pendingSend
@@ -287,6 +295,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Message pending send 2",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 extraData: ExtraData.Message.defaultValue
             )
             message2.localMessageState = .pendingSend
@@ -297,6 +306,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Message pending send 3",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 extraData: ExtraData.Message.defaultValue
             )
             message3.localMessageState = .pendingSend
@@ -364,6 +374,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Channel A message 1",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 extraData: ExtraData.Message.defaultValue
             )
             messageA1.localMessageState = .pendingSend
@@ -374,6 +385,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Channel A message 2",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 extraData: ExtraData.Message.defaultValue
             )
             messageA2.localMessageState = .pendingSend
@@ -384,6 +396,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Channel B message 1",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 extraData: ExtraData.Message.defaultValue
             )
             messageB1.localMessageState = .pendingSend
@@ -394,6 +407,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Channel B message 2",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 extraData: ExtraData.Message.defaultValue
             )
             messageB2.localMessageState = .pendingSend
@@ -457,6 +471,7 @@ class MessageSender_Tests: StressTestCase {
                 text: "Message pending send",
                 pinning: nil,
                 quotedMessageId: nil,
+                isSilent: false,
                 extraData: ExtraData.Message.defaultValue
             )
             message.localMessageState = .pendingSend

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -102,6 +102,7 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
     ///   - cid: The cid of the channel the message is create in.
     ///   - text: Text of the message.
     ///   - pinning: Pins the new message. Nil if should not be pinned.
+    ///   - isSilent: A flag indicating whether the message is a silent message. Silent messages are special messages that don't increase the unread messages count nor mark a channel as unread.
     ///   - attachments: An array of the attachments for the message.
     ///   - quotedMessageId: An id of the message new message quotes. (inline reply)
     ///   - extraData: Additional extra data of the message object.
@@ -111,6 +112,7 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
         in cid: ChannelId,
         text: String,
         pinning: MessagePinning? = nil,
+        isSilent: Bool,
         command: String?,
         arguments: String?,
         attachments: [AnyAttachmentPayload] = [],
@@ -131,6 +133,7 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
                 attachments: attachments,
                 mentionedUserIds: mentionedUserIds,
                 showReplyInChannel: false,
+                isSilent: isSilent,
                 quotedMessageId: quotedMessageId,
                 extraData: extraData
             )

--- a/Sources/StreamChat/Workers/ChannelUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Mock.swift
@@ -41,6 +41,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
 
     @Atomic var createNewMessage_cid: ChannelId?
     @Atomic var createNewMessage_text: String?
+    @Atomic var createNewMessage_isSilent: Bool?
     @Atomic var createNewMessage_command: String?
     @Atomic var createNewMessage_arguments: String?
     @Atomic var createNewMessage_attachments: [AnyAttachmentPayload]?
@@ -106,6 +107,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         
         createNewMessage_cid = nil
         createNewMessage_text = nil
+        createNewMessage_isSilent = nil
         createNewMessage_command = nil
         createNewMessage_arguments = nil
         createNewMessage_attachments = nil
@@ -180,6 +182,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         in cid: ChannelId,
         text: String,
         pinning: MessagePinning?,
+        isSilent: Bool,
         command: String?,
         arguments: String?,
         attachments: [AnyAttachmentPayload],
@@ -190,6 +193,7 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
     ) {
         createNewMessage_cid = cid
         createNewMessage_text = text
+        createNewMessage_isSilent = isSilent
         createNewMessage_command = command
         createNewMessage_arguments = arguments
         createNewMessage_attachments = attachments

--- a/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
@@ -153,6 +153,7 @@ class ChannelUpdater_Tests: StressTestCase {
                 in: cid,
                 text: text,
                 pinning: MessagePinning(expirationDate: .unique),
+                isSilent: false,
                 command: command,
                 arguments: arguments,
                 attachments: attachmentEnvelopes,
@@ -190,6 +191,7 @@ class ChannelUpdater_Tests: StressTestCase {
         XCTAssertEqual(message.extraData, extraData)
         XCTAssertEqual(message.localState, .pendingSend)
         XCTAssertEqual(message.isPinned, true)
+        XCTAssertEqual(message.isSilent, false)
         XCTAssertEqual(message.mentionedUsers.map(\.id), [currentUserId])
     }
     
@@ -221,6 +223,7 @@ class ChannelUpdater_Tests: StressTestCase {
             channelUpdater.createNewMessage(
                 in: .unique,
                 text: .unique,
+                isSilent: false,
                 command: .unique,
                 arguments: .unique,
                 mentionedUserIds: [.unique],

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -132,6 +132,7 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
         attachments: [AnyAttachmentPayload],
         mentionedUserIds: [UserId],
         showReplyInChannel: Bool,
+        isSilent: Bool,
         quotedMessageId: MessageId?,
         extraData: ExtraData.Message,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
@@ -148,6 +149,7 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
                 attachments: attachments,
                 mentionedUserIds: mentionedUserIds,
                 showReplyInChannel: showReplyInChannel,
+                isSilent: isSilent,
                 quotedMessageId: quotedMessageId,
                 extraData: extraData
             )

--- a/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -26,6 +26,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
     @Atomic var createNewReply_attachments: [AnyAttachmentPayload]?
     @Atomic var createNewReply_mentionedUserIds: [UserId]?
     @Atomic var createNewReply_showReplyInChannel: Bool?
+    @Atomic var createNewReply_isSilent: Bool?
     @Atomic var createNewReply_quotedMessageId: MessageId?
     @Atomic var createNewReply_pinning: MessagePinning?
     @Atomic var createNewReply_extraData: ExtraData.Message?
@@ -91,6 +92,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         createNewReply_attachments = nil
         createNewReply_mentionedUserIds = nil
         createNewReply_showReplyInChannel = nil
+        createNewReply_isSilent = nil
         createNewReply_extraData = nil
         createNewReply_completion = nil
         
@@ -165,6 +167,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         attachments: [AnyAttachmentPayload],
         mentionedUserIds: [UserId],
         showReplyInChannel: Bool,
+        isSilent: Bool,
         quotedMessageId: MessageId?,
         extraData: ExtraData.Message,
         completion: ((Result<MessageId, Error>) -> Void)? = nil
@@ -177,6 +180,7 @@ final class MessageUpdaterMock<ExtraData: ExtraDataTypes>: MessageUpdater<ExtraD
         createNewReply_attachments = attachments
         createNewReply_mentionedUserIds = mentionedUserIds
         createNewReply_showReplyInChannel = showReplyInChannel
+        createNewReply_isSilent = isSilent
         createNewReply_quotedMessageId = quotedMessageId
         createNewReply_pinning = pinning
         createNewReply_extraData = extraData

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -393,6 +393,7 @@ final class MessageUpdater_Tests: StressTestCase {
         let text: String = .unique
         let parentMessageId: MessageId = .unique
         let showReplyInChannel = true
+        let isSilent = false
         let command: String = .unique
         let arguments: String = .unique
         let extraData: NoExtraData = .defaultValue
@@ -419,6 +420,7 @@ final class MessageUpdater_Tests: StressTestCase {
                 attachments: attachmentEnvelopes,
                 mentionedUserIds: mentionedUserIds,
                 showReplyInChannel: showReplyInChannel,
+                isSilent: isSilent,
                 quotedMessageId: nil,
                 extraData: extraData
             ) { result in
@@ -451,6 +453,7 @@ final class MessageUpdater_Tests: StressTestCase {
         XCTAssertEqual(message.extraData, extraData)
         XCTAssertEqual(message.localState, .pendingSend)
         XCTAssertTrue(message.isPinned)
+        XCTAssertEqual(message.isSilent, isSilent)
         XCTAssertEqual(message.mentionedUsers.map(\.id), mentionedUserIds)
     }
     
@@ -477,6 +480,7 @@ final class MessageUpdater_Tests: StressTestCase {
                 attachments: [],
                 mentionedUserIds: [.unique],
                 showReplyInChannel: false,
+                isSilent: false,
                 quotedMessageId: nil,
                 extraData: .defaultValue
             ) { completion($0) }


### PR DESCRIPTION
## What does this PR do
With this PR, sending silent messages is possible.
More about silent messages can be read here: https://getstream.io/chat/docs/react/silent_messages/?language=swift

## Changes
- Add `isSilent` flag to `MessageRequestBody`
- Make changes to public APIs in `ChannelController` and `MessageController` to accept this flag
- Propagate this flag to lower levels and make relevant changes to the tests.