### PR TITLE
[CIS-911] Regenerate Links to other reference docs in files

### DIFF
--- a/docusaurus/docs/iOS/basics/getting-started.md
+++ b/docusaurus/docs/iOS/basics/getting-started.md
@@ -44,9 +44,9 @@ In the snippet above, we've:
 
 User Tokens are JWT tokens containing a User ID and used to authenticate a user. In this guide, we use development tokens, since they're the easiest to start with, and are great for prototyping an application before implementing a backend handling for tokens.
 
-For more information regarding user tokens, please check [Working with User guide](../guides/working-with-user#user-ids--tokens).
+For more information regarding user tokens, please check [Working with User guide](../../guides/working-with-user#user-ids--tokens).
 
-### [`ChatClientConfig`](../ReferenceDocs/Sources/StreamChat/Config/ChatClientConfig)
+### [`ChatClientConfig`](../../reference-docs/sources/stream-chat/config/chat-client-config)
 
 The `ChatClientConfig` object holds properties that the chat client will use to determine certain behaviors. For example, the `apiKey`, which tells the chat client which chat server to communicate with. It also has the `baseURL` property which tells the chat client which region of the world your server is at, which can be useful to reduce overall latency.
 
@@ -64,14 +64,14 @@ let chatClient = ChatClient(config: config, tokenProvider: tokenProvider)
 ```
 
 For more information regarding available regions, please check [Multi-region Support](https://getstream.io/chat/docs/ios-swift/multi_region/?language=swift)
-For more information regarding the configuration options, please check [ChatClientConfig Reference doc](../ReferenceDocs/Sources/StreamChat/Config/ChatClientConfig).
+For more information regarding the configuration options, please check [ChatClientConfig Reference doc](../../reference-docs/sources/stream-chat/config/chat-client-config).
 
-### [`ChatClient`](../ReferenceDocs/Sources/StreamChat/ChatClient)
+### [`ChatClient`](../../reference-docs/sources/stream-chat/config/chat-client)
 
 `ChatClient` is the main interaction point with our SDK. From it, you ask a certain Controller and use the controller to interact with StreamChat platform.
 
-For the list of possible controllers you can get from `ChatClient`, please check [Controllers Overview](../controllers/controllers-overview)
+For the list of possible controllers you can get from `ChatClient`, please check [Controllers Overview](../../controllers/controllers-overview)
 
-### [`ChatChannelListVC`](../ReferenceDocs/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC)
+### [`ChatChannelListVC`](../../reference-docs/sources/stream-chat-ui/chat-channel-list/chat-channel-list-vc)
 
 This `UIViewController` subclass is the UI component to display a list of Channels. You can configure its behaviour by subclassing and overriding functions.

--- a/docusaurus/docs/iOS/guides/working-with-user.md
+++ b/docusaurus/docs/iOS/guides/working-with-user.md
@@ -137,11 +137,11 @@ chatClient.currentUserController().reloadUserIfNeeded()
 
 You can get 2 types of controllers from `ChatClient`: `CurrentUserController` vs `UserController`
 
-### [`CurrentUserController`](../ReferenceDocs/Sources/StreamChat/Controllers/CurrentUserController/CurrentChatUserController)
+### [`CurrentUserController`](../../reference-docs/sources/stream-chat/controllers/current-user-controller/current-chat-user-controller)
 
 `CurrentUser` is a wrapper for the currently logged-in user's `User` object. `CurrentUser` includes information about the logged-in user, such as registered devices, muted users, flagged users, and unread count. You interact with your current user via `CurrentUserController`
 
-For all functions available on this controller, please check [CurrentUserController docs](../ReferenceDocs/Sources/StreamChat/Controllers/CurrentUserController/CurrentChatUserController).
+For all functions available on this controller, please check [CurrentUserController docs](.../../reference-docs/sources/stream-chat/controllers/current-user-controller/current-chat-user-controller).
 
 #### Observing Unread Count for Current User
 
@@ -178,8 +178,8 @@ currentUserController
     .store(in: &cancellables)
 ```
 
-### [`UserController`](../ReferenceDocs/Sources/StreamChat/Controllers/UserController/ChatUserController)
+### [`UserController`](../../reference-docs/sources/stream-chat/controllers/user-controller/chat-user-controller)
 
 For any user other than your current user in the platform, you use `UserController` to interact.
 
-To see available functions on UserController, please check [UserController guide](../ReferenceDocs/Sources/StreamChat/Controllers/UserController/ChatUserController).
+To see available functions on UserController, please check [UserController guide](../../reference-docs/sources/stream-chat/controllers/user-controller/chat-user-controller).

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/cell-action-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/cell-action-view.md
@@ -10,7 +10,7 @@ public class CellActionView: _View
 
 ## Inheritance
 
-[`_View`](../common-views/_view)
+[`_View`](../../common-views/_view)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/chat-channel-list-collection-view-cell.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/chat-channel-list-collection-view-cell.md
@@ -11,7 +11,7 @@ open class _ChatChannelListCollectionViewCell<ExtraData: ExtraDataTypes>: _Colle
 
 ## Inheritance
 
-[`_CollectionViewCell`](../common-views/_collection-view-cell), [`ThemeProvider`](../utils/theme-provider)
+[`_CollectionViewCell`](../../common-views/_collection-view-cell), [`ThemeProvider`](../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/chat-channel-list-item-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/chat-channel-list-item-view.md
@@ -11,7 +11,7 @@ open class _ChatChannelListItemView<ExtraData: ExtraDataTypes>: _View, ThemeProv
 
 ## Inheritance
 
-[`_View`](../common-views/_view), [`SwiftUIRepresentable`](../common-views/swift-ui-representable), [`ThemeProvider`](../utils/theme-provider)
+[`_View`](../../common-views/_view), [`SwiftUIRepresentable`](../../common-views/swift-ui-representable), [`ThemeProvider`](../../utils/theme-provider)
 
 ## Nested Type Aliases
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/chat-channel-list-vc.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/chat-channel-list-vc.md
@@ -16,7 +16,7 @@ open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
 
 ## Inheritance
 
-[`_ViewController`](../common-views/_view-controller), `DataControllerStateDelegate`, [`SwipeableViewDelegate`](swipeable-view-delegate), [`SwiftUIRepresentable`](../common-views/swift-ui-representable), [`ThemeProvider`](../utils/theme-provider), `UICollectionViewDataSource`, `UICollectionViewDelegate`, `_ChatChannelListControllerDelegate`
+[`_ViewController`](../../common-views/_view-controller), `DataControllerStateDelegate`, [`SwipeableViewDelegate`](../swipeable-view-delegate), [`SwiftUIRepresentable`](../../common-views/swift-ui-representable), [`ThemeProvider`](../../utils/theme-provider), `UICollectionViewDataSource`, `UICollectionViewDelegate`, `_ChatChannelListControllerDelegate`
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/chat-channel-read-status-checkmark-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/chat-channel-read-status-checkmark-view.md
@@ -10,7 +10,7 @@ open class ChatChannelReadStatusCheckmarkView: _View, AppearanceProvider, SwiftU
 
 ## Inheritance
 
-[`_View`](../common-views/_view), [`SwiftUIRepresentable`](../common-views/swift-ui-representable), [`AppearanceProvider`](../utils/appearance-provider)
+[`_View`](../../common-views/_view), [`SwiftUIRepresentable`](../../common-views/swift-ui-representable), [`AppearanceProvider`](../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/chat-channel-read-status-checkmark-view.status.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/chat-channel-read-status-checkmark-view.status.md
@@ -11,12 +11,6 @@ public enum Status
 
 ## Enumeration Cases
 
-### `empty`
-
-``` swift
-case read, unread, empty
-```
-
 ### `read`
 
 ``` swift
@@ -24,6 +18,12 @@ case read, unread, empty
 ```
 
 ### `unread`
+
+``` swift
+case read, unread, empty
+```
+
+### `empty`
 
 ``` swift
 case read, unread, empty

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/chat-channel-unread-count-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/chat-channel-unread-count-view.md
@@ -10,7 +10,7 @@ open class _ChatChannelUnreadCountView<ExtraData: ExtraDataTypes>: _View, ThemeP
 
 ## Inheritance
 
-[`_View`](../common-views/_view), [`SwiftUIRepresentable`](../common-views/swift-ui-representable), [`ThemeProvider`](../utils/theme-provider)
+[`_View`](../../common-views/_view), [`SwiftUIRepresentable`](../../common-views/swift-ui-representable), [`ThemeProvider`](../../utils/theme-provider)
 
 ## Nested Type Aliases
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/swipeable-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-channel-list/swipeable-view.md
@@ -10,7 +10,7 @@ open class _SwipeableView<ExtraData: ExtraDataTypes>: _View, ComponentsProvider,
 
 ## Inheritance
 
-[`_View`](../common-views/_view), [`ComponentsProvider`](../utils/components-provider), `UIGestureRecognizerDelegate`
+[`_View`](../../common-views/_view), [`ComponentsProvider`](../../utils/components-provider), `UIGestureRecognizerDelegate`
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-attachment-preview-vc.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-attachment-preview-vc.md
@@ -8,7 +8,7 @@ open class ChatMessageAttachmentPreviewVC: _ViewController, WKNavigationDelegate
 
 ## Inheritance
 
-[`_ViewController`](../../common-views/_view-controller), [`AppearanceProvider`](../../utils/appearance-provider), `WKNavigationDelegate`
+[`_ViewController`](../../../common-views/_view-controller), [`AppearanceProvider`](../../../utils/appearance-provider), `WKNavigationDelegate`
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-file-attachment-list-view.item-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-file-attachment-list-view.item-view.md
@@ -8,7 +8,7 @@ open class ItemView: _View, ThemeProvider
 
 ## Inheritance
 
-[`_View`](../../common-views/_view), [`ThemeProvider`](../../utils/theme-provider)
+[`_View`](../../../common-views/_view), [`ThemeProvider`](../../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-file-attachment-list-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-file-attachment-list-view.md
@@ -10,7 +10,7 @@ open class _ChatMessageFileAttachmentListView<ExtraData: ExtraDataTypes>: _View,
 
 ## Inheritance
 
-[`_View`](../../common-views/_view), [`ComponentsProvider`](../../utils/components-provider)
+[`_View`](../../../common-views/_view), [`ComponentsProvider`](../../../utils/components-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-giphy-view.giphy-badge.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-giphy-view.giphy-badge.md
@@ -8,7 +8,7 @@ open class GiphyBadge: _View, AppearanceProvider
 
 ## Inheritance
 
-[`_View`](../../common-views/_view), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_View`](../../../common-views/_view), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-giphy-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-giphy-view.md
@@ -8,7 +8,7 @@ open class _ChatMessageGiphyView<ExtraData: ExtraDataTypes>: _View, ComponentsPr
 
 ## Inheritance
 
-[`_View`](../../common-views/_view), [`ComponentsProvider`](../../utils/components-provider)
+[`_View`](../../../common-views/_view), [`ComponentsProvider`](../../../utils/components-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-image-gallery.image-preview.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-image-gallery.image-preview.md
@@ -8,7 +8,7 @@ open class ImagePreview: _View, ThemeProvider, ImagePreviewable
 
 ## Inheritance
 
-[`_View`](../../common-views/_view), [`ImagePreviewable`](image-previewable), [`ThemeProvider`](../../utils/theme-provider)
+[`_View`](../../../common-views/_view), [`ImagePreviewable`](../image-previewable), [`ThemeProvider`](../../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-image-gallery.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-image-gallery.md
@@ -10,7 +10,7 @@ open class _ChatMessageImageGallery<ExtraData: ExtraDataTypes>: _View, ThemeProv
 
 ## Inheritance
 
-[`_View`](../../common-views/_view), [`ThemeProvider`](../../utils/theme-provider)
+[`_View`](../../../common-views/_view), [`ThemeProvider`](../../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-image-gallery.uploading-overlay.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-image-gallery.uploading-overlay.md
@@ -8,7 +8,7 @@ open class UploadingOverlay: _View, ThemeProvider
 
 ## Inheritance
 
-[`_View`](../../common-views/_view), [`ThemeProvider`](../../utils/theme-provider)
+[`_View`](../../../common-views/_view), [`ThemeProvider`](../../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-interactive-attachment-view.action-button.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-interactive-attachment-view.action-button.md
@@ -8,7 +8,7 @@ open class ActionButton: _Button, AppearanceProvider
 
 ## Inheritance
 
-[`_Button`](../../common-views/_button), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_Button`](../../../common-views/_button), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-interactive-attachment-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-interactive-attachment-view.md
@@ -8,7 +8,7 @@ open class _ChatMessageInteractiveAttachmentView<ExtraData: ExtraDataTypes>: _Vi
 
 ## Inheritance
 
-[`_View`](../../common-views/_view), [`ThemeProvider`](../../utils/theme-provider)
+[`_View`](../../../common-views/_view), [`ThemeProvider`](../../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-link-preview-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/chat-message-link-preview-view.md
@@ -8,7 +8,7 @@ open class _ChatMessageLinkPreviewView<ExtraData: ExtraDataTypes>: _Control, The
 
 ## Inheritance
 
-[`_Control`](../../common-views/_control), [`ThemeProvider`](../../utils/theme-provider)
+[`_Control`](../../../common-views/_control), [`ThemeProvider`](../../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/file-action-content-view-delegate.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/file-action-content-view-delegate.md
@@ -10,7 +10,7 @@ public protocol FileActionContentViewDelegate: ChatMessageContentViewDelegate
 
 ## Inheritance
 
-[`ChatMessageContentViewDelegate`](../chat-message/chat-message-content-view-delegate)
+[`ChatMessageContentViewDelegate`](../../chat-message/chat-message-content-view-delegate)
 
 ## Requirements
 
@@ -19,5 +19,5 @@ public protocol FileActionContentViewDelegate: ChatMessageContentViewDelegate
 Called when the user taps on attachment action
 
 ``` swift
-func didTapOnAttachment(_ attachment: ChatMessageFileAttachment, at indexPath: IndexPath)
+func didTapOnAttachment(_ attachment: ChatMessageFileAttachment, at indexPath: IndexPath?)
 ```

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/gallery-content-view-delegate.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/gallery-content-view-delegate.md
@@ -10,7 +10,7 @@ public protocol GalleryContentViewDelegate: ChatMessageContentViewDelegate
 
 ## Inheritance
 
-[`ChatMessageContentViewDelegate`](../chat-message/chat-message-content-view-delegate)
+[`ChatMessageContentViewDelegate`](../../chat-message/chat-message-content-view-delegate)
 
 ## Requirements
 
@@ -22,6 +22,6 @@ Called when the user taps on one of the image attachments.
 func didTapOnImageAttachment(
         _ attachment: ChatMessageImageAttachment,
         previews: [ImagePreviewable],
-        at indexPath: IndexPath
+        at indexPath: IndexPath?
     )
 ```

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/giphy-action-content-view-delegate.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/giphy-action-content-view-delegate.md
@@ -10,7 +10,7 @@ public protocol GiphyActionContentViewDelegate: ChatMessageContentViewDelegate
 
 ## Inheritance
 
-[`ChatMessageContentViewDelegate`](../chat-message/chat-message-content-view-delegate)
+[`ChatMessageContentViewDelegate`](../../chat-message/chat-message-content-view-delegate)
 
 ## Requirements
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/link-attachment-view-injector.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/link-attachment-view-injector.md
@@ -17,7 +17,10 @@ open class _LinkAttachmentViewInjector<ExtraData: ExtraDataTypes>: _AttachmentVi
 ### `linkPreviewView`
 
 ``` swift
-open private(set) lazy var linkPreviewView = _ChatMessageLinkPreviewView<ExtraData>()
+open private(set) lazy var linkPreviewView = contentView
+        .components
+        .linkPreviewView
+        .init()
         .withoutAutoresizingMaskConstraints
 ```
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/link-preview-view-delegate.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/attachments/link-preview-view-delegate.md
@@ -10,7 +10,7 @@ public protocol LinkPreviewViewDelegate: ChatMessageContentViewDelegate
 
 ## Inheritance
 
-[`ChatMessageContentViewDelegate`](../chat-message/chat-message-content-view-delegate)
+[`ChatMessageContentViewDelegate`](../../chat-message/chat-message-content-view-delegate)
 
 ## Requirements
 
@@ -21,6 +21,6 @@ Called when the user taps the link preview.
 ``` swift
 func didTapOnLinkAttachment(
         _ attachment: ChatMessageLinkAttachment,
-        at indexPath: IndexPath
+        at indexPath: IndexPath?
     )
 ```

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message-list-collection-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message-list-collection-view.md
@@ -11,7 +11,7 @@ open class ChatMessageListCollectionView<ExtraData: ExtraDataTypes>: UICollectio
 
 ## Inheritance
 
-[`Customizable`](../common-views/customizable), [`ComponentsProvider`](../utils/components-provider), `UICollectionView`
+[`Customizable`](../../common-views/customizable), [`ComponentsProvider`](../../utils/components-provider), `UICollectionView`
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message-list-scroll-overlay-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message-list-scroll-overlay-view.md
@@ -10,7 +10,7 @@ open class ChatMessageListScrollOverlayView: _View, AppearanceProvider
 
 ## Inheritance
 
-[`_View`](../common-views/_view), [`AppearanceProvider`](../utils/appearance-provider)
+[`_View`](../../common-views/_view), [`AppearanceProvider`](../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message-list-unread-count-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message-list-unread-count-view.md
@@ -1,0 +1,21 @@
+---
+title: ChatMessageListUnreadCountView
+---
+
+A view that shows a number of unread messages on the Scroll-To-Latest-Message button in the Message List.
+
+``` swift
+open class _ChatMessageListUnreadCountView<ExtraData: ExtraDataTypes>: _ChatChannelUnreadCountView<ExtraData> 
+```
+
+## Inheritance
+
+`_ChatChannelUnreadCountView<ExtraData>`
+
+## Methods
+
+### `setUpAppearance()`
+
+``` swift
+override open func setUpAppearance() 
+```

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message-list-vc.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message-list-vc.md
@@ -22,7 +22,7 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
 
 ## Inheritance
 
-[`_ViewController`](../common-views/_view-controller), [`FileActionContentViewDelegate`](attachments/file-action-content-view-delegate), [`GalleryContentViewDelegate`](attachments/gallery-content-view-delegate), [`GiphyActionContentViewDelegate`](attachments/giphy-action-content-view-delegate), [`LinkPreviewViewDelegate`](attachments/link-preview-view-delegate), [`ChatMessageContentViewDelegate`](chat-message/chat-message-content-view-delegate), [`ChatMessageListCollectionViewDataSource`](chat-message-list-collection-view-data-source), [`SwiftUIRepresentable`](../common-views/swift-ui-representable), [`ComposerVCDelegate`](../composer/composer-vc-delegate), `UICollectionViewDelegate`, `_ChatChannelControllerDelegate`, [`_ChatMessageActionsVCDelegate`](../message-actions-popup/chat-message-actions-vc-delegate), [`ThemeProvider`](../utils/theme-provider)
+[`_ViewController`](../../common-views/_view-controller), [`FileActionContentViewDelegate`](../attachments/file-action-content-view-delegate), [`GalleryContentViewDelegate`](../attachments/gallery-content-view-delegate), [`GiphyActionContentViewDelegate`](../attachments/giphy-action-content-view-delegate), [`LinkPreviewViewDelegate`](../attachments/link-preview-view-delegate), [`ChatMessageContentViewDelegate`](../chat-message/chat-message-content-view-delegate), [`ChatMessageListCollectionViewDataSource`](../chat-message-list-collection-view-data-source), [`SwiftUIRepresentable`](../../common-views/swift-ui-representable), [`ComposerVCDelegate`](../../composer/composer-vc-delegate), `_ChatChannelControllerDelegate`, [`_ChatMessageActionsVCDelegate`](../../message-actions-popup/chat-message-actions-vc-delegate), [`ThemeProvider`](../../utils/theme-provider), `UICollectionViewDelegate`
 
 ## Properties
 
@@ -117,7 +117,7 @@ open private(set) lazy var typingIndicatorView: _TypingIndicatorView<ExtraData> 
 A button to scroll the collection view to the bottom.
 
 ``` swift
-open private(set) lazy var scrollToLatestMessageButton: UIButton = components
+open private(set) lazy var scrollToLatestMessageButton: _ScrollToLatestMessageButton<ExtraData> = components
         .scrollToLatestMessageButton
         .init()
         .withoutAutoresizingMaskConstraints
@@ -266,7 +266,7 @@ open func scrollToMostRecentMessage(animated: Bool = true)
 
 ### `updateScrollToLatestMessageButton()`
 
-Update the visibility of `scrollToLatestMessageButton` based on unread messages and visible messages.
+Update the `scrollToLatestMessageButton` based on unread messages.
 
 ``` swift
 open func updateScrollToLatestMessageButton() 
@@ -342,10 +342,10 @@ open func restartUploading(for attachmentId: AttachmentId)
 ### `didTapOnImageAttachment(_:previews:at:)`
 
 ``` swift
-public func didTapOnImageAttachment(
+open func didTapOnImageAttachment(
         _ attachment: ChatMessageImageAttachment,
         previews: [ImagePreviewable],
-        at indexPath: IndexPath
+        at indexPath: IndexPath?
     ) 
 ```
 
@@ -354,14 +354,17 @@ public func didTapOnImageAttachment(
 ``` swift
 open func didTapOnLinkAttachment(
         _ attachment: ChatMessageLinkAttachment,
-        at indexPath: IndexPath
+        at indexPath: IndexPath?
     ) 
 ```
 
 ### `didTapOnAttachment(_:at:)`
 
 ``` swift
-public func didTapOnAttachment(_ attachment: ChatMessageFileAttachment, at indexPath: IndexPath) 
+open func didTapOnAttachment(
+        _ attachment: ChatMessageFileAttachment,
+        at indexPath: IndexPath?
+    ) 
 ```
 
 ### `didTapOnAttachmentAction(_:at:)`

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message/chat-message-bubble-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message/chat-message-bubble-view.md
@@ -10,7 +10,7 @@ open class _ChatMessageBubbleView<ExtraData: ExtraDataTypes>: _View, AppearanceP
 
 ## Inheritance
 
-[`_View`](../../common-views/_view), [`SwiftUIRepresentable`](../../common-views/swift-ui-representable), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_View`](../../../common-views/_view), [`SwiftUIRepresentable`](../../../common-views/swift-ui-representable), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message/chat-message-collection-view-cell.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message/chat-message-collection-view-cell.md
@@ -12,7 +12,7 @@ public final class _ChatMessageCollectionViewCell<ExtraData: ExtraDataTypes>: _C
 
 ## Inheritance
 
-[`_CollectionViewCell`](../../common-views/_collection-view-cell)
+[`_CollectionViewCell`](../../../common-views/_collection-view-cell)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message/chat-message-content-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message/chat-message-content-view.md
@@ -10,7 +10,7 @@ open class _ChatMessageContentView<ExtraData: ExtraDataTypes>: _View, ThemeProvi
 
 ## Inheritance
 
-[`_View`](../../common-views/_view), [`ThemeProvider`](../../utils/theme-provider)
+[`_View`](../../../common-views/_view), [`ThemeProvider`](../../../utils/theme-provider)
 
 ## Nested Type Aliases
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message/chat-message-error-indicator.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message/chat-message-error-indicator.md
@@ -10,7 +10,7 @@ open class ChatMessageErrorIndicator: _Button, AppearanceProvider
 
 ## Inheritance
 
-[`_Button`](../../common-views/_button), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_Button`](../../../common-views/_button), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message/chat-reactions-bubble-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message/chat-reactions-bubble-view.md
@@ -8,7 +8,7 @@ open class ChatReactionsBubbleView: _View, AppearanceProvider
 
 ## Inheritance
 
-[`_View`](../../common-views/_view), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_View`](../../../common-views/_view), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message/chat-thread-arrow-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-message/chat-thread-arrow-view.md
@@ -8,7 +8,7 @@ open class ChatThreadArrowView: _View, AppearanceProvider
 
 ## Inheritance
 
-[`_View`](../../common-views/_view), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_View`](../../../common-views/_view), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-thread-vc.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/chat-thread-vc.md
@@ -13,13 +13,17 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
     _ChatMessageControllerDelegate,
     _ChatMessageActionsVCDelegate,
     ChatMessageContentViewDelegate,
+    GalleryContentViewDelegate,
+    GiphyActionContentViewDelegate,
+    LinkPreviewViewDelegate,
+    FileActionContentViewDelegate,
     UICollectionViewDelegate,
     UICollectionViewDataSource 
 ```
 
 ## Inheritance
 
-[`_ViewController`](../common-views/_view-controller), [`ChatMessageContentViewDelegate`](chat-message/chat-message-content-view-delegate), [`ComposerVCDelegate`](../composer/composer-vc-delegate), `UICollectionViewDataSource`, `UICollectionViewDelegate`, `_ChatChannelControllerDelegate`, [`_ChatMessageActionsVCDelegate`](../message-actions-popup/chat-message-actions-vc-delegate), [`ThemeProvider`](../utils/theme-provider), `_ChatMessageControllerDelegate`
+[`_ViewController`](../../common-views/_view-controller), [`FileActionContentViewDelegate`](../attachments/file-action-content-view-delegate), [`GalleryContentViewDelegate`](../attachments/gallery-content-view-delegate), [`GiphyActionContentViewDelegate`](../attachments/giphy-action-content-view-delegate), [`LinkPreviewViewDelegate`](../attachments/link-preview-view-delegate), [`ChatMessageContentViewDelegate`](../chat-message/chat-message-content-view-delegate), [`ComposerVCDelegate`](../../composer/composer-vc-delegate), [`ThemeProvider`](../../utils/theme-provider), `UICollectionViewDataSource`, `UICollectionViewDelegate`, `_ChatChannelControllerDelegate`, [`_ChatMessageActionsVCDelegate`](../../message-actions-popup/chat-message-actions-vc-delegate), `_ChatMessageControllerDelegate`
 
 ## Properties
 
@@ -299,6 +303,34 @@ Executes the provided action on the message
 open func didTapOnAttachmentAction(
         _ action: AttachmentAction,
         at indexPath: IndexPath
+    ) 
+```
+
+### `didTapOnImageAttachment(_:previews:at:)`
+
+``` swift
+open func didTapOnImageAttachment(
+        _ attachment: ChatMessageImageAttachment,
+        previews: [ImagePreviewable],
+        at indexPath: IndexPath?
+    ) 
+```
+
+### `didTapOnLinkAttachment(_:at:)`
+
+``` swift
+open func didTapOnLinkAttachment(
+        _ attachment: ChatMessageLinkAttachment,
+        at indexPath: IndexPath?
+    ) 
+```
+
+### `didTapOnAttachment(_:at:)`
+
+``` swift
+open func didTapOnAttachment(
+        _ attachment: ChatMessageFileAttachment,
+        at indexPath: IndexPath?
     ) 
 ```
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/reactions/chat-message-default-reactions-bubble-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/reactions/chat-message-default-reactions-bubble-view.md
@@ -12,6 +12,24 @@ open class _ChatMessageDefaultReactionsBubbleView<ExtraData: ExtraDataTypes>: _C
 
 ## Properties
 
+### `contentViewBackground`
+
+``` swift
+public let contentViewBackground = UIView().withoutAutoresizingMaskConstraints
+```
+
+### `tailBehind`
+
+``` swift
+public let tailBehind = UIImageView().withoutAutoresizingMaskConstraints
+```
+
+### `tailInFront`
+
+``` swift
+public let tailInFront = UIImageView().withoutAutoresizingMaskConstraints
+```
+
 ### `tailLeadingAnchor`
 
 ``` swift

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/reactions/chat-message-reaction-appearance.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/reactions/chat-message-reaction-appearance.md
@@ -11,7 +11,7 @@ public struct ChatMessageReactionAppearance: ChatMessageReactionAppearanceType
 
 ## Inheritance
 
-[`ChatMessageReactionAppearanceType`](chat-message-reaction-appearance-type)
+[`ChatMessageReactionAppearanceType`](../chat-message-reaction-appearance-type)
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/reactions/chat-message-reaction-data.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/reactions/chat-message-reaction-data.md
@@ -6,6 +6,14 @@ title: ChatMessageReactionData
 public struct ChatMessageReactionData 
 ```
 
+## Initializers
+
+### `init(type:score:isChosenByCurrentUser:)`
+
+``` swift
+public init(type: MessageReactionType, score: Int, isChosenByCurrentUser: Bool) 
+```
+
 ## Properties
 
 ### `type`

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/reactions/chat-message-reactions-bubble-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/reactions/chat-message-reactions-bubble-view.md
@@ -8,7 +8,7 @@ open class _ChatMessageReactionsBubbleView<ExtraData: ExtraDataTypes>: _View, Th
 
 ## Inheritance
 
-[`_View`](../../common-views/_view), [`ThemeProvider`](../../utils/theme-provider)
+[`_View`](../../../common-views/_view), [`ThemeProvider`](../../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/reactions/chat-message-reactions-vc.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/reactions/chat-message-reactions-vc.md
@@ -8,7 +8,7 @@ open class _ChatMessageReactionsVC<ExtraData: ExtraDataTypes>: _ViewController, 
 
 ## Inheritance
 
-[`_ViewController`](../../common-views/_view-controller), [`ThemeProvider`](../../utils/theme-provider), `_ChatMessageControllerDelegate`
+[`_ViewController`](../../../common-views/_view-controller), [`ThemeProvider`](../../../utils/theme-provider), `_ChatMessageControllerDelegate`
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/reactions/chat-message-reactions-view.item-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/reactions/chat-message-reactions-view.item-view.md
@@ -8,7 +8,7 @@ open class ItemView: _Button, AppearanceProvider
 
 ## Inheritance
 
-[`_Button`](../../common-views/_button), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_Button`](../../../common-views/_button), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/reactions/chat-message-reactions-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/reactions/chat-message-reactions-view.md
@@ -8,7 +8,7 @@ open class _ChatMessageReactionsView<ExtraData: ExtraDataTypes>: _View, ThemePro
 
 ## Inheritance
 
-[`_View`](../../common-views/_view), [`ThemeProvider`](../../utils/theme-provider)
+[`_View`](../../../common-views/_view), [`ThemeProvider`](../../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/scroll-to-latest-message-button.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/scroll-to-latest-message-button.md
@@ -5,14 +5,33 @@ title: ScrollToLatestMessageButton
 A Button that is used to indicate unread messages in the Message list.
 
 ``` swift
-open class ScrollToLatestMessageButton: _Button, AppearanceProvider 
+open class _ScrollToLatestMessageButton<ExtraData: ExtraDataTypes>: _Button, ThemeProvider 
 ```
 
 ## Inheritance
 
-[`_Button`](../common-views/_button), [`AppearanceProvider`](../utils/appearance-provider)
+[`_Button`](../../common-views/_button), [`ThemeProvider`](../../utils/theme-provider)
+
+## Properties
+
+### `unreadCountView`
+
+The view showing number of unread messages in channel if any.
+
+``` swift
+open private(set) lazy var unreadCountView: _ChatMessageListUnreadCountView<ExtraData> = components
+        .messageListUnreadCountView
+        .init()
+        .withoutAutoresizingMaskConstraints
+```
 
 ## Methods
+
+### `layoutSubviews()`
+
+``` swift
+override open func layoutSubviews() 
+```
 
 ### `setUpAppearance()`
 
@@ -20,8 +39,14 @@ open class ScrollToLatestMessageButton: _Button, AppearanceProvider
 override open func setUpAppearance() 
 ```
 
-### `layoutSubviews()`
+### `setUpLayout()`
 
 ``` swift
-override open func layoutSubviews() 
+override open func setUpLayout() 
+```
+
+### `updateContent()`
+
+``` swift
+override open func updateContent() 
 ```

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/title-container-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/title-container-view.md
@@ -11,7 +11,7 @@ open class TitleContainerView: _View, AppearanceProvider, SwiftUIRepresentable
 
 ## Inheritance
 
-[`_View`](../common-views/_view), [`SwiftUIRepresentable`](../common-views/swift-ui-representable), [`AppearanceProvider`](../utils/appearance-provider)
+[`_View`](../../common-views/_view), [`SwiftUIRepresentable`](../../common-views/swift-ui-representable), [`AppearanceProvider`](../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/typing-animation-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/typing-animation-view.md
@@ -10,7 +10,7 @@ open class TypingAnimationView: _View, AppearanceProvider
 
 ## Inheritance
 
-[`_View`](../common-views/_view), [`AppearanceProvider`](../utils/appearance-provider)
+[`_View`](../../common-views/_view), [`AppearanceProvider`](../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/typing-indicator-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/chat-message-list/typing-indicator-view.md
@@ -10,7 +10,7 @@ open class _TypingIndicatorView<ExtraData: ExtraDataTypes>: _View, ThemeProvider
 
 ## Inheritance
 
-[`_View`](../common-views/_view), [`ThemeProvider`](../utils/theme-provider)
+[`_View`](../../common-views/_view), [`ThemeProvider`](../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/attachment-button/attachment-button.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/attachment-button/attachment-button.md
@@ -11,7 +11,7 @@ open class AttachmentButton: _Button, AppearanceProvider
 
 ## Inheritance
 
-[`_Button`](../_button), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_Button`](../../_button), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/attachments/attachment-placeholder-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/attachments/attachment-placeholder-view.md
@@ -11,7 +11,7 @@ open class AttachmentPlaceholderView: _View, AppearanceProvider
 
 ## Inheritance
 
-[`_View`](../_view), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_View`](../../_view), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/attachments/attachment-preview-container.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/attachments/attachment-preview-container.md
@@ -10,7 +10,7 @@ open class AttachmentPreviewContainer: _View, AppearanceProvider
 
 ## Inheritance
 
-[`_View`](../_view), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_View`](../../_view), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/attachments/attachment-views/file-attachment-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/attachments/attachment-views/file-attachment-view.md
@@ -10,7 +10,7 @@ open class FileAttachmentView: _View, AppearanceProvider
 
 ## Inheritance
 
-[`_View`](../../_view), [`AppearanceProvider`](../../../utils/appearance-provider)
+[`_View`](../../../_view), [`AppearanceProvider`](../../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/attachments/attachment-views/image-attachment-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/attachments/attachment-views/image-attachment-view.md
@@ -10,7 +10,7 @@ open class _ImageAttachmentView<ExtraData: ExtraDataTypes>: _View, ThemeProvider
 
 ## Inheritance
 
-[`_View`](../../_view), [`ThemeProvider`](../../../utils/theme-provider)
+[`_View`](../../../_view), [`ThemeProvider`](../../../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/attachments/attachments-preview-vc.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/attachments/attachments-preview-vc.md
@@ -8,7 +8,7 @@ open class _AttachmentsPreviewVC<ExtraData: ExtraDataTypes>: _ViewController, Co
 
 ## Inheritance
 
-[`_ViewController`](../_view-controller), [`ComponentsProvider`](../../utils/components-provider)
+[`_ViewController`](../../_view-controller), [`ComponentsProvider`](../../../utils/components-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/attachments/default-attachment-preview-provider.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/attachments/default-attachment-preview-provider.md
@@ -11,7 +11,7 @@ public struct DefaultAttachmentPreviewProvider: AttachmentPreviewProvider
 
 ## Inheritance
 
-[`AttachmentPreviewProvider`](attachment-preview-provider)
+[`AttachmentPreviewProvider`](../attachment-preview-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/avatar-view/chat-avatar-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/avatar-view/chat-avatar-view.md
@@ -11,7 +11,7 @@ open class ChatAvatarView: _View
 
 ## Inheritance
 
-[`_View`](../_view)
+[`_View`](../../_view)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/avatar-view/chat-channel-avatar-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/avatar-view/chat-channel-avatar-view.md
@@ -10,7 +10,7 @@ open class _ChatChannelAvatarView<ExtraData: ExtraDataTypes>: _View, ThemeProvid
 
 ## Inheritance
 
-[`_View`](../_view), [`SwiftUIRepresentable`](../swift-ui-representable), [`ThemeProvider`](../../utils/theme-provider)
+[`_View`](../../_view), [`SwiftUIRepresentable`](../../swift-ui-representable), [`ThemeProvider`](../../../utils/theme-provider)
 
 ## Nested Type Aliases
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/avatar-view/chat-presence-avatar-view/chat-presence-avatar-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/avatar-view/chat-presence-avatar-view/chat-presence-avatar-view.md
@@ -10,7 +10,7 @@ open class _ChatPresenceAvatarView<ExtraData: ExtraDataTypes>: _View, Components
 
 ## Inheritance
 
-[`_View`](../../_view), [`ComponentsProvider`](../../../utils/components-provider)
+[`_View`](../../../_view), [`ComponentsProvider`](../../../../utils/components-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/avatar-view/chat-presence-avatar-view/online-indicator-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/avatar-view/chat-presence-avatar-view/online-indicator-view.md
@@ -11,7 +11,7 @@ open class OnlineIndicatorView: _View, AppearanceProvider, MaskProviding
 
 ## Inheritance
 
-[`_View`](../../_view), [`MaskProviding`](mask-providing), [`AppearanceProvider`](../../../utils/appearance-provider)
+[`_View`](../../../_view), [`MaskProviding`](../mask-providing), [`AppearanceProvider`](../../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/avatar-view/chat-user-avatar-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/avatar-view/chat-user-avatar-view.md
@@ -10,7 +10,7 @@ open class _ChatUserAvatarView<ExtraData: ExtraDataTypes>: _View, ThemeProvider
 
 ## Inheritance
 
-[`_View`](../_view), [`ThemeProvider`](../../utils/theme-provider)
+[`_View`](../../_view), [`ThemeProvider`](../../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/avatar-view/current-chat-user-avatar-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/avatar-view/current-chat-user-avatar-view.md
@@ -13,7 +13,7 @@ on the currently logged-in user.
 
 ## Inheritance
 
-[`_Control`](../_control), [`ThemeProvider`](../../utils/theme-provider), `_CurrentChatUserControllerDelegate`
+[`_Control`](../../_control), [`ThemeProvider`](../../../utils/theme-provider), `_CurrentChatUserControllerDelegate`
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/button.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/button.md
@@ -11,7 +11,7 @@ open class _Button: UIButton, Customizable
 
 ## Inheritance
 
-[`Customizable`](customizable), `UIButton`
+[`Customizable`](../customizable), `UIButton`
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/chat-loading-indicator.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/chat-loading-indicator.md
@@ -8,7 +8,7 @@ open class ChatLoadingIndicator: _View, AppearanceProvider
 
 ## Inheritance
 
-[`_View`](_view), [`AppearanceProvider`](../utils/appearance-provider)
+[`_View`](../_view), [`AppearanceProvider`](../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/chat-navigation-bar.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/chat-navigation-bar.md
@@ -8,7 +8,7 @@ open class ChatNavigationBar: _NavigationBar, AppearanceProvider
 
 ## Inheritance
 
-[`_NavigationBar`](_navigation-bar), [`AppearanceProvider`](../utils/appearance-provider)
+[`_NavigationBar`](../_navigation-bar), [`AppearanceProvider`](../../utils/appearance-provider)
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/checkbox-control/checkbox-control.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/checkbox-control/checkbox-control.md
@@ -10,7 +10,7 @@ open class CheckboxControl: _Control, AppearanceProvider
 
 ## Inheritance
 
-[`_Control`](../_control), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_Control`](../../_control), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/circular-close-button/circular-close-button.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/circular-close-button/circular-close-button.md
@@ -10,7 +10,7 @@ open class CircularCloseButton: _Button, AppearanceProvider
 
 ## Inheritance
 
-[`_Button`](../_button), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_Button`](../../_button), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/close-button.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/close-button.md
@@ -10,7 +10,7 @@ open class CloseButton: _Button, AppearanceProvider
 
 ## Inheritance
 
-[`_Button`](_button), [`AppearanceProvider`](../utils/appearance-provider)
+[`_Button`](../_button), [`AppearanceProvider`](../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/collection-reusable-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/collection-reusable-view.md
@@ -11,7 +11,7 @@ open class _CollectionReusableView: UICollectionReusableView, Customizable
 
 ## Inheritance
 
-[`Customizable`](customizable), `UICollectionReusableView`
+[`Customizable`](../customizable), `UICollectionReusableView`
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/collection-view-cell.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/collection-view-cell.md
@@ -11,7 +11,7 @@ open class _CollectionViewCell: UICollectionViewCell, Customizable
 
 ## Inheritance
 
-[`Customizable`](customizable), `UICollectionViewCell`
+[`Customizable`](../customizable), `UICollectionViewCell`
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/command-button/command-button.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/command-button/command-button.md
@@ -11,7 +11,7 @@ open class CommandButton: _Button, AppearanceProvider
 
 ## Inheritance
 
-[`_Button`](../_button), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_Button`](../../_button), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/command-label-view/command-label-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/command-label-view/command-label-view.md
@@ -11,7 +11,7 @@ open class CommandLabelView: _View, AppearanceProvider, SwiftUIRepresentable
 
 ## Inheritance
 
-[`_View`](../_view), [`SwiftUIRepresentable`](../swift-ui-representable), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_View`](../../_view), [`SwiftUIRepresentable`](../../swift-ui-representable), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/confirm-button/confirm-button.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/confirm-button/confirm-button.md
@@ -12,7 +12,7 @@ open class ConfirmButton: _Button, AppearanceProvider
 
 ## Inheritance
 
-[`_Button`](../_button), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_Button`](../../_button), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/control.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/control.md
@@ -11,7 +11,7 @@ open class _Control: UIControl, Customizable
 
 ## Inheritance
 
-[`Customizable`](customizable), `UIControl`
+[`Customizable`](../customizable), `UIControl`
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/create-chat-channel-button/create-chat-channel-button.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/create-chat-channel-button/create-chat-channel-button.md
@@ -11,7 +11,7 @@ open class CreateChatChannelButton: _Button, AppearanceProvider
 
 ## Inheritance
 
-[`_Button`](../_button), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_Button`](../../_button), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/input-chat-message-view/input-chat-message-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/input-chat-message-view/input-chat-message-view.md
@@ -10,7 +10,7 @@ open class _InputChatMessageView<ExtraData: ExtraDataTypes>: _View, ComponentsPr
 
 ## Inheritance
 
-[`_View`](../_view), [`AppearanceProvider`](../../utils/appearance-provider), [`ComponentsProvider`](../../utils/components-provider)
+[`_View`](../../_view), [`AppearanceProvider`](../../../utils/appearance-provider), [`ComponentsProvider`](../../../utils/components-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/input-text-view/input-text-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/input-text-view/input-text-view.md
@@ -11,7 +11,7 @@ open class InputTextView: UITextView, AppearanceProvider
 
 ## Inheritance
 
-[`AppearanceProvider`](../../utils/appearance-provider), `UITextView`
+[`AppearanceProvider`](../../../utils/appearance-provider), `UITextView`
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/list-collection-view-layout/cell-separator-reusable-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/list-collection-view-layout/cell-separator-reusable-view.md
@@ -10,7 +10,7 @@ open class CellSeparatorReusableView: _CollectionReusableView, AppearanceProvide
 
 ## Inheritance
 
-[`_CollectionReusableView`](../_collection-reusable-view), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_CollectionReusableView`](../../_collection-reusable-view), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/navigation-bar.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/navigation-bar.md
@@ -11,7 +11,7 @@ open class _NavigationBar: UINavigationBar, Customizable
 
 ## Inheritance
 
-[`Customizable`](customizable), `UINavigationBar`
+[`Customizable`](../customizable), `UINavigationBar`
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/quoted-chat-message-view/quoted-chat-message-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/quoted-chat-message-view/quoted-chat-message-view.md
@@ -10,7 +10,7 @@ open class _QuotedChatMessageView<ExtraData: ExtraDataTypes>: _View, ThemeProvid
 
 ## Inheritance
 
-[`_View`](../_view), [`SwiftUIRepresentable`](../swift-ui-representable), [`ThemeProvider`](../../utils/theme-provider)
+[`_View`](../../_view), [`SwiftUIRepresentable`](../../swift-ui-representable), [`ThemeProvider`](../../../utils/theme-provider)
 
 ## Nested Type Aliases
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/send-button/send-button.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/send-button/send-button.md
@@ -12,7 +12,7 @@ open class SendButton: _Button, AppearanceProvider
 
 ## Inheritance
 
-[`_Button`](../_button), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_Button`](../../_button), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/share-button.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/share-button.md
@@ -10,7 +10,7 @@ open class ShareButton: _Button, AppearanceProvider
 
 ## Inheritance
 
-[`_Button`](_button), [`AppearanceProvider`](../utils/appearance-provider)
+[`_Button`](../_button), [`AppearanceProvider`](../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/shrink-input-button/shrink-input-button.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/shrink-input-button/shrink-input-button.md
@@ -11,7 +11,7 @@ open class ShrinkInputButton: _Button, AppearanceProvider
 
 ## Inheritance
 
-[`_Button`](../_button), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_Button`](../../_button), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-command-suggestion-view/chat-command-suggestion-collection-view-cell.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-command-suggestion-view/chat-command-suggestion-collection-view-cell.md
@@ -10,7 +10,7 @@ open class _ChatCommandSuggestionCollectionViewCell<ExtraData: ExtraDataTypes>: 
 
 ## Inheritance
 
-[`_CollectionViewCell`](../../_collection-view-cell), [`ComponentsProvider`](../../../utils/components-provider)
+[`_CollectionViewCell`](../../../_collection-view-cell), [`ComponentsProvider`](../../../../utils/components-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-command-suggestion-view/chat-command-suggestion-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-command-suggestion-view/chat-command-suggestion-view.md
@@ -10,7 +10,7 @@ open class ChatCommandSuggestionView: _View, AppearanceProvider
 
 ## Inheritance
 
-[`_View`](../../_view), [`AppearanceProvider`](../../../utils/appearance-provider)
+[`_View`](../../../_view), [`AppearanceProvider`](../../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-mention-suggestion-view/chat-mention-suggestion-collection-view-cell.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-mention-suggestion-view/chat-mention-suggestion-collection-view-cell.md
@@ -10,7 +10,7 @@ open class _ChatMentionSuggestionCollectionViewCell<ExtraData: ExtraDataTypes>: 
 
 ## Inheritance
 
-[`_CollectionViewCell`](../../_collection-view-cell), [`ComponentsProvider`](../../../utils/components-provider)
+[`_CollectionViewCell`](../../../_collection-view-cell), [`ComponentsProvider`](../../../../utils/components-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-mention-suggestion-view/chat-mention-suggestion-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-mention-suggestion-view/chat-mention-suggestion-view.md
@@ -10,7 +10,7 @@ open class _ChatMentionSuggestionView<ExtraData: ExtraDataTypes>: _View, ThemePr
 
 ## Inheritance
 
-[`_View`](../../_view), [`ThemeProvider`](../../../utils/theme-provider)
+[`_View`](../../../_view), [`ThemeProvider`](../../../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-suggestions-collection-reusable-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-suggestions-collection-reusable-view.md
@@ -11,7 +11,7 @@ open class _ChatSuggestionsCollectionReusableView<ExtraData: ExtraDataTypes>: UI
 
 ## Inheritance
 
-[`ComponentsProvider`](../../utils/components-provider), `UICollectionReusableView`
+[`ComponentsProvider`](../../../utils/components-provider), `UICollectionReusableView`
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-suggestions-collection-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-suggestions-collection-view.md
@@ -12,7 +12,7 @@ open class _ChatSuggestionsCollectionView<ExtraData: ExtraDataTypes>: UICollecti
 
 ## Inheritance
 
-[`Customizable`](../customizable), [`ThemeProvider`](../../utils/theme-provider), `UICollectionView`
+[`Customizable`](../../customizable), [`ThemeProvider`](../../../utils/theme-provider), `UICollectionView`
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-suggestions-header-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-suggestions-header-view.md
@@ -10,7 +10,7 @@ open class ChatSuggestionsHeaderView: _View, AppearanceProvider
 
 ## Inheritance
 
-[`_View`](../_view), [`AppearanceProvider`](../../utils/appearance-provider)
+[`_View`](../../_view), [`AppearanceProvider`](../../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-suggestions-view-controller.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/suggestions/chat-suggestions-view-controller.md
@@ -12,7 +12,7 @@ open class _ChatSuggestionsViewController<ExtraData: ExtraDataTypes>: _ViewContr
 
 ## Inheritance
 
-[`_ViewController`](../_view-controller), [`ThemeProvider`](../../utils/theme-provider), `UICollectionViewDelegate`
+[`_ViewController`](../../_view-controller), [`ThemeProvider`](../../../utils/theme-provider), `UICollectionViewDelegate`
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/view-controller.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/view-controller.md
@@ -8,7 +8,7 @@ open class _ViewController: UIViewController, Customizable
 
 ## Inheritance
 
-[`Customizable`](customizable), `UIViewController`
+[`Customizable`](../customizable), `UIViewController`
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/common-views/view.md
@@ -11,7 +11,7 @@ open class _View: UIView, Customizable
 
 ## Inheritance
 
-[`Customizable`](customizable), `UIView`
+[`Customizable`](../customizable), `UIView`
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/components.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/components.md
@@ -400,6 +400,15 @@ public var imageGalleryView: _ChatMessageImageGallery<ExtraData>.Type =
         _ChatMessageImageGallery<ExtraData>.self
 ```
 
+### `linkPreviewView`
+
+The view that shows a link preview in message cell.
+
+``` swift
+public var linkPreviewView: _ChatMessageLinkPreviewView<ExtraData>.Type =
+        _ChatMessageLinkPreviewView<ExtraData>.self
+```
+
 ### `imageUploadingOverlay`
 
 The view that shows an overlay with uploading progress for image attachment that is being uploaded.
@@ -449,7 +458,17 @@ public var giphyBadgeView: _ChatMessageGiphyView<ExtraData>.GiphyBadge.Type = _C
 The button that indicates unread messages at the bottom of the message list and scroll to the latest message on tap.
 
 ``` swift
-public var scrollToLatestMessageButton: UIButton.Type = ScrollToLatestMessageButton.self
+public var scrollToLatestMessageButton: _ScrollToLatestMessageButton<ExtraData>.Type =
+        _ScrollToLatestMessageButton<ExtraData>.self
+```
+
+### `messageListUnreadCountView`
+
+The view that shows a number of unread messages on the Scroll-To-Latest-Message button in the Message List.
+
+``` swift
+public var messageListUnreadCountView: _ChatMessageListUnreadCountView<ExtraData>.Type =
+        _ChatMessageListUnreadCountView<ExtraData>.self
 ```
 
 ### `channelNamer`

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/composer/composer-vc.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/composer/composer-vc.md
@@ -15,7 +15,7 @@ open class _ComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
 
 ## Inheritance
 
-[`_ViewController`](../common-views/_view-controller), [`ThemeProvider`](../utils/theme-provider), `UIDocumentPickerDelegate`, `UIImagePickerControllerDelegate`, `UINavigationControllerDelegate`, `UITextViewDelegate`
+[`_ViewController`](../../common-views/_view-controller), [`ThemeProvider`](../../utils/theme-provider), `UIDocumentPickerDelegate`, `UIImagePickerControllerDelegate`, `UINavigationControllerDelegate`, `UITextViewDelegate`
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/composer/composer-view.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/composer/composer-view.md
@@ -22,7 +22,7 @@ High level overview of the composer layout:
 
 ## Inheritance
 
-[`_View`](../common-views/_view), [`ThemeProvider`](../utils/theme-provider)
+[`_View`](../../common-views/_view), [`ThemeProvider`](../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/image-gallery/image-collection-view-cell.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/image-gallery/image-collection-view-cell.md
@@ -10,7 +10,7 @@ open class _ImageCollectionViewCell<ExtraData: ExtraDataTypes>: _CollectionViewC
 
 ## Inheritance
 
-[`_CollectionViewCell`](../common-views/_collection-view-cell), [`ComponentsProvider`](../utils/components-provider), `UIScrollViewDelegate`
+[`_CollectionViewCell`](../../common-views/_collection-view-cell), [`ComponentsProvider`](../../utils/components-provider), `UIScrollViewDelegate`
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/image-gallery/image-gallery-vc.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/image-gallery/image-gallery-vc.md
@@ -16,7 +16,7 @@ open class _ImageGalleryVC<ExtraData: ExtraDataTypes>:
 
 ## Inheritance
 
-[`_ViewController`](../common-views/_view-controller), [`AppearanceProvider`](../utils/appearance-provider), `UICollectionViewDataSource`, `UICollectionViewDelegate`, `UICollectionViewDelegateFlowLayout`, `UIGestureRecognizerDelegate`
+[`_ViewController`](../../common-views/_view-controller), [`AppearanceProvider`](../../utils/appearance-provider), `UICollectionViewDataSource`, `UICollectionViewDelegate`, `UICollectionViewDelegateFlowLayout`, `UIGestureRecognizerDelegate`
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/block-user-action-item.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/block-user-action-item.md
@@ -10,7 +10,7 @@ public struct BlockUserActionItem: ChatMessageActionItem
 
 ## Inheritance
 
-[`ChatMessageActionItem`](chat-message-action-item)
+[`ChatMessageActionItem`](../chat-message-action-item)
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/chat-message-action-control.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/chat-message-action-control.md
@@ -10,7 +10,7 @@ open class ChatMessageActionControl: _Control, AppearanceProvider
 
 ## Inheritance
 
-[`_Control`](../common-views/_control), [`AppearanceProvider`](../utils/appearance-provider)
+[`_Control`](../../common-views/_control), [`AppearanceProvider`](../../utils/appearance-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/chat-message-actions-vc.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/chat-message-actions-vc.md
@@ -10,7 +10,7 @@ open class _ChatMessageActionsVC<ExtraData: ExtraDataTypes>: _ViewController, Th
 
 ## Inheritance
 
-[`_ViewController`](../common-views/_view-controller), [`ThemeProvider`](../utils/theme-provider)
+[`_ViewController`](../../common-views/_view-controller), [`ThemeProvider`](../../utils/theme-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/chat-message-popup-vc.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/chat-message-popup-vc.md
@@ -12,7 +12,7 @@ open class _ChatMessagePopupVC<ExtraData: ExtraDataTypes>: _ViewController, Comp
 
 ## Inheritance
 
-[`_ViewController`](../common-views/_view-controller), [`ComponentsProvider`](../utils/components-provider)
+[`_ViewController`](../../common-views/_view-controller), [`ComponentsProvider`](../../utils/components-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/copy-action-item.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/copy-action-item.md
@@ -10,7 +10,7 @@ public struct CopyActionItem: ChatMessageActionItem
 
 ## Inheritance
 
-[`ChatMessageActionItem`](chat-message-action-item)
+[`ChatMessageActionItem`](../chat-message-action-item)
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/delete-action-item.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/delete-action-item.md
@@ -10,7 +10,7 @@ public struct DeleteActionItem: ChatMessageActionItem
 
 ## Inheritance
 
-[`ChatMessageActionItem`](chat-message-action-item)
+[`ChatMessageActionItem`](../chat-message-action-item)
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/edit-action-item.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/edit-action-item.md
@@ -10,7 +10,7 @@ public struct EditActionItem: ChatMessageActionItem
 
 ## Inheritance
 
-[`ChatMessageActionItem`](chat-message-action-item)
+[`ChatMessageActionItem`](../chat-message-action-item)
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/inline-reply-action-item.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/inline-reply-action-item.md
@@ -10,7 +10,7 @@ public struct InlineReplyActionItem: ChatMessageActionItem
 
 ## Inheritance
 
-[`ChatMessageActionItem`](chat-message-action-item)
+[`ChatMessageActionItem`](../chat-message-action-item)
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/mute-user-action-item.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/mute-user-action-item.md
@@ -10,7 +10,7 @@ public struct MuteUserActionItem: ChatMessageActionItem
 
 ## Inheritance
 
-[`ChatMessageActionItem`](chat-message-action-item)
+[`ChatMessageActionItem`](../chat-message-action-item)
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/resend-action-item.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/resend-action-item.md
@@ -10,7 +10,7 @@ public struct ResendActionItem: ChatMessageActionItem
 
 ## Inheritance
 
-[`ChatMessageActionItem`](chat-message-action-item)
+[`ChatMessageActionItem`](../chat-message-action-item)
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/thread-reply-action-item.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/thread-reply-action-item.md
@@ -10,7 +10,7 @@ public struct ThreadReplyActionItem: ChatMessageActionItem
 
 ## Inheritance
 
-[`ChatMessageActionItem`](chat-message-action-item)
+[`ChatMessageActionItem`](../chat-message-action-item)
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/unblock-user-action-item.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/unblock-user-action-item.md
@@ -10,7 +10,7 @@ public struct UnblockUserActionItem: ChatMessageActionItem
 
 ## Inheritance
 
-[`ChatMessageActionItem`](chat-message-action-item)
+[`ChatMessageActionItem`](../chat-message-action-item)
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/unmute-user-action-item.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/message-actions-popup/unmute-user-action-item.md
@@ -10,7 +10,7 @@ public struct UnmuteUserActionItem: ChatMessageActionItem
 
 ## Inheritance
 
-[`ChatMessageActionItem`](chat-message-action-item)
+[`ChatMessageActionItem`](../chat-message-action-item)
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/navigation/chat-channel-list-router.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/navigation/chat-channel-list-router.md
@@ -12,7 +12,7 @@ open class _ChatChannelListRouter<ExtraData: ExtraDataTypes>:
 
 ## Inheritance
 
-[`ComponentsProvider`](../utils/components-provider), `NavigationRouter<_ChatChannelListVC<ExtraData>>`
+[`ComponentsProvider`](../../utils/components-provider), `NavigationRouter<_ChatChannelListVC<ExtraData>>`
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/navigation/chat-message-list-router.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/navigation/chat-message-list-router.md
@@ -15,7 +15,7 @@ open class _ChatMessageListRouter<ExtraData: ExtraDataTypes>:
 
 ## Inheritance
 
-`// We use UIViewController here because the router is used for both // the channel and thread message lists. NavigationRouter<UIViewController>`, [`ComponentsProvider`](../utils/components-provider), `UIViewControllerTransitioningDelegate`
+`// We use UIViewController here because the router is used for both // the channel and thread message lists. NavigationRouter<UIViewController>`, [`ComponentsProvider`](../../utils/components-provider), `UIViewControllerTransitioningDelegate`
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/utils/components-provider.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/utils/components-provider.md
@@ -8,7 +8,7 @@ public protocol ComponentsProvider: GenericComponentsProvider
 
 ## Inheritance
 
-[`GenericComponentsProvider`](generic-components-provider)
+[`GenericComponentsProvider`](../generic-components-provider)
 
 ## Default Implementations
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/utils/stream-image-cdn.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/utils/stream-image-cdn.md
@@ -8,7 +8,7 @@ public struct StreamImageCDN: ImageCDN
 
 ## Inheritance
 
-[`ImageCDN`](image-cdn)
+[`ImageCDN`](../image-cdn)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/utils/theme-provider.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat-ui/utils/theme-provider.md
@@ -8,7 +8,7 @@ public protocol ThemeProvider: ComponentsProvider, AppearanceProvider
 
 ## Inheritance
 
-[`AppearanceProvider`](appearance-provider), [`ComponentsProvider`](components-provider)
+[`AppearanceProvider`](../appearance-provider), [`ComponentsProvider`](../components-provider)
 
 ## Default Implementations
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/chat-client.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/chat-client.md
@@ -15,7 +15,7 @@ case requires it (i.e. more than one window with different workspaces in a Slack
 
 ## Inheritance
 
-[`ConnectionDetailsProviderDelegate`](api-client/connection-details-provider-delegate), [`ConnectionStateDelegate`](web-socket-client/connection-state-delegate)
+[`ConnectionDetailsProviderDelegate`](../api-client/connection-details-provider-delegate), [`ConnectionStateDelegate`](../web-socket-client/connection-state-delegate)
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/client-error.client-is-not-in-active-mode.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/client-error.client-is-not-in-active-mode.md
@@ -8,7 +8,7 @@ public class ClientIsNotInActiveMode: ClientError
 
 ## Inheritance
 
-[`ClientError`](errors/client-error)
+[`ClientError`](../errors/client-error)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/client-error.connection-not-successful.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/client-error.connection-not-successful.md
@@ -8,7 +8,7 @@ public class ConnectionNotSuccessful: ClientError
 
 ## Inheritance
 
-[`ClientError`](errors/client-error)
+[`ClientError`](../errors/client-error)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/client-error.missing-local-storage-url.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/client-error.missing-local-storage-url.md
@@ -8,7 +8,7 @@ public class MissingLocalStorageURL: ClientError
 
 ## Inheritance
 
-[`ClientError`](errors/client-error)
+[`ClientError`](../errors/client-error)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/client-error.missing-token.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/client-error.missing-token.md
@@ -8,4 +8,4 @@ public class MissingToken: ClientError
 
 ## Inheritance
 
-[`ClientError`](errors/client-error)
+[`ClientError`](../errors/client-error)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/config/client-error.invalid-token.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/config/client-error.invalid-token.md
@@ -8,4 +8,4 @@ public class InvalidToken: ClientError
 
 ## Inheritance
 
-[`ClientError`](../errors/client-error)
+[`ClientError`](../../errors/client-error)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-controller/chat-channel-controller-delegate.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-controller/chat-channel-controller-delegate.md
@@ -13,7 +13,7 @@ named `ChatChannelControllerDelegate`, which hides the generic types, and make t
 
 ## Inheritance
 
-[`DataControllerStateDelegate`](../data-controller-state-delegate)
+[`DataControllerStateDelegate`](../../data-controller-state-delegate)
 
 ## Default Implementations
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-controller/chat-channel-controller.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-controller/chat-channel-controller.md
@@ -19,7 +19,7 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`DataController`](../data-controller), [`DelegateCallable`](../delegate-callable), [`DataStoreProvider`](../../database/data-store-provider)
+[`DataController`](../../data-controller), [`DelegateCallable`](../../delegate-callable), [`DataStoreProvider`](../../../database/data-store-provider)
 
 ## Properties
 
@@ -373,7 +373,7 @@ method and call it every time the user presses a key. The controller will manage
 
   - completion: a completion block with an error if the request was failed.
 
-### `createNewMessage(text:pinning:attachments:mentionedUserIds:quotedMessageId:extraData:completion:)`
+### `createNewMessage(text:pinning:isSilent:attachments:mentionedUserIds:quotedMessageId:extraData:completion:)`
 
 Creates a new message locally and schedules it for send.
 
@@ -383,6 +383,7 @@ func createNewMessage(
         pinning: MessagePinning? = nil,
 //        command: String? = nil,
 //        arguments: String? = nil,
+        isSilent: Bool = false,
         attachments: [AnyAttachmentPayload] = [],
         mentionedUserIds: [UserId] = [],
         quotedMessageId: MessageId? = nil,
@@ -395,6 +396,7 @@ func createNewMessage(
 
   - text: Text of the message.
   - pinning: Pins the new message. `nil` if should not be pinned.
+  - isSilent: A flag indicating whether the message is a silent message. Silent messages are special messages that don't increase the unread messages count nor mark a channel as unread.
   - attachments: An array of the attachments for the message. `Note`: can be built-in types, custom attachment types conforming to `AttachmentEnvelope` protocol and `ChatMessageAttachmentSeed`s.
   - quotedMessageId: An id of the message new message quotes. (inline reply)
   - extraData: Additional extra data of the message object.

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-controller/chat-channel-controller.observable-object.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-controller/chat-channel-controller.observable-object.md
@@ -10,7 +10,7 @@ public class ObservableObject: SwiftUI.ObservableObject
 
 ## Inheritance
 
-`SwiftUI.ObservableObject`, [`_ChatChannelControllerDelegate`](chat-channel-controller-delegate)
+`SwiftUI.ObservableObject`, [`_ChatChannelControllerDelegate`](../chat-channel-controller-delegate)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-list-controller/chat-channel-list-controller-delegate.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-list-controller/chat-channel-list-controller-delegate.md
@@ -13,7 +13,7 @@ named `ChatChannelListControllerDelegate`, which hides the generic types, and ma
 
 ## Inheritance
 
-[`DataControllerStateDelegate`](../data-controller-state-delegate)
+[`DataControllerStateDelegate`](../../data-controller-state-delegate)
 
 ## Default Implementations
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-list-controller/chat-channel-list-controller.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-list-controller/chat-channel-list-controller.md
@@ -16,7 +16,7 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`DataController`](../data-controller), [`DelegateCallable`](../delegate-callable), [`DataStoreProvider`](../../database/data-store-provider)
+[`DataController`](../../data-controller), [`DelegateCallable`](../../delegate-callable), [`DataStoreProvider`](../../../database/data-store-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-list-controller/chat-channel-list-controller.observable-object.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-list-controller/chat-channel-list-controller.observable-object.md
@@ -10,7 +10,7 @@ public class ObservableObject: SwiftUI.ObservableObject
 
 ## Inheritance
 
-`SwiftUI.ObservableObject`, [`_ChatChannelListControllerDelegate`](chat-channel-list-controller-delegate)
+`SwiftUI.ObservableObject`, [`_ChatChannelListControllerDelegate`](../chat-channel-list-controller-delegate)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-watcher-list-controller/chat-channel-watcher-list-controller-delegate.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-watcher-list-controller/chat-channel-watcher-list-controller-delegate.md
@@ -8,7 +8,7 @@ public protocol _ChatChannelWatcherListControllerDelegate: DataControllerStateDe
 
 ## Inheritance
 
-[`DataControllerStateDelegate`](../data-controller-state-delegate)
+[`DataControllerStateDelegate`](../../data-controller-state-delegate)
 
 ## Requirements
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-watcher-list-controller/chat-channel-watcher-list-controller.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-watcher-list-controller/chat-channel-watcher-list-controller.md
@@ -17,7 +17,7 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`DataController`](../data-controller), [`DelegateCallable`](../delegate-callable), [`DataStoreProvider`](../../database/data-store-provider)
+[`DataController`](../../data-controller), [`DelegateCallable`](../../delegate-callable), [`DataStoreProvider`](../../../database/data-store-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-watcher-list-controller/chat-channel-watcher-list-controller.observable-object.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/channel-watcher-list-controller/chat-channel-watcher-list-controller.observable-object.md
@@ -11,7 +11,7 @@ public class ObservableObject: SwiftUI.ObservableObject
 
 ## Inheritance
 
-`SwiftUI.ObservableObject`, [`_ChatChannelWatcherListControllerDelegate`](chat-channel-watcher-list-controller-delegate)
+`SwiftUI.ObservableObject`, [`_ChatChannelWatcherListControllerDelegate`](../chat-channel-watcher-list-controller-delegate)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/connection-controller/chat-connection-controller.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/connection-controller/chat-connection-controller.md
@@ -17,7 +17,7 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`Controller`](../controller), [`DelegateCallable`](../delegate-callable), [`DataStoreProvider`](../../database/data-store-provider)
+[`Controller`](../../controller), [`DelegateCallable`](../../delegate-callable), [`DataStoreProvider`](../../../database/data-store-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/connection-controller/chat-connection-controller.observable-object.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/connection-controller/chat-connection-controller.observable-object.md
@@ -10,7 +10,7 @@ public class ObservableObject: SwiftUI.ObservableObject
 
 ## Inheritance
 
-`SwiftUI.ObservableObject`, [`_ChatConnectionControllerDelegate`](chat-connection-controller-delegate)
+`SwiftUI.ObservableObject`, [`_ChatConnectionControllerDelegate`](../chat-connection-controller-delegate)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/current-user-controller/current-chat-user-controller.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/current-user-controller/current-chat-user-controller.md
@@ -17,7 +17,7 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`DataController`](../data-controller), [`DelegateCallable`](../delegate-callable), [`DataStoreProvider`](../../database/data-store-provider)
+[`DataController`](../../data-controller), [`DelegateCallable`](../../delegate-callable), [`DataStoreProvider`](../../../database/data-store-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/current-user-controller/current-chat-user-controller.observable-object.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/current-user-controller/current-chat-user-controller.observable-object.md
@@ -10,7 +10,7 @@ public class ObservableObject: SwiftUI.ObservableObject
 
 ## Inheritance
 
-`SwiftUI.ObservableObject`, [`_CurrentChatUserControllerDelegate`](current-chat-user-controller-delegate)
+`SwiftUI.ObservableObject`, [`_CurrentChatUserControllerDelegate`](../current-chat-user-controller-delegate)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/data-controller.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/data-controller.md
@@ -10,7 +10,7 @@ public class DataController: Controller
 
 ## Inheritance
 
-[`Controller`](controller)
+[`Controller`](../controller)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/member-controller/chat-channel-member-controller-delegate.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/member-controller/chat-channel-member-controller-delegate.md
@@ -13,7 +13,7 @@ named `ChatChannelMemberControllerDelegate`, which hides the generic types, and 
 
 ## Inheritance
 
-[`DataControllerStateDelegate`](../data-controller-state-delegate)
+[`DataControllerStateDelegate`](../../data-controller-state-delegate)
 
 ## Default Implementations
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/member-controller/chat-channel-member-controller.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/member-controller/chat-channel-member-controller.md
@@ -17,7 +17,7 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`DataController`](../data-controller), [`DelegateCallable`](../delegate-callable), [`DataStoreProvider`](../../database/data-store-provider)
+[`DataController`](../../data-controller), [`DelegateCallable`](../../delegate-callable), [`DataStoreProvider`](../../../database/data-store-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/member-controller/chat-channel-member-controller.observable-object.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/member-controller/chat-channel-member-controller.observable-object.md
@@ -11,7 +11,7 @@ public class ObservableObject: SwiftUI.ObservableObject
 
 ## Inheritance
 
-`SwiftUI.ObservableObject`, [`_ChatChannelMemberControllerDelegate`](chat-channel-member-controller-delegate)
+`SwiftUI.ObservableObject`, [`_ChatChannelMemberControllerDelegate`](../chat-channel-member-controller-delegate)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/member-list-controller/chat-channel-member-list-controller-delegate.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/member-list-controller/chat-channel-member-list-controller-delegate.md
@@ -13,7 +13,7 @@ named `ChatChannelMemberListControllerDelegate`, which hides the generic types, 
 
 ## Inheritance
 
-[`DataControllerStateDelegate`](../data-controller-state-delegate)
+[`DataControllerStateDelegate`](../../data-controller-state-delegate)
 
 ## Default Implementations
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/member-list-controller/chat-channel-member-list-controller.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/member-list-controller/chat-channel-member-list-controller.md
@@ -17,7 +17,7 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`DataController`](../data-controller), [`DelegateCallable`](../delegate-callable), [`DataStoreProvider`](../../database/data-store-provider)
+[`DataController`](../../data-controller), [`DelegateCallable`](../../delegate-callable), [`DataStoreProvider`](../../../database/data-store-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/member-list-controller/chat-channel-member-list-controller.observable-object.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/member-list-controller/chat-channel-member-list-controller.observable-object.md
@@ -11,7 +11,7 @@ public class ObservableObject: SwiftUI.ObservableObject
 
 ## Inheritance
 
-`SwiftUI.ObservableObject`, [`_ChatChannelMemberListControllerDelegate`](chat-channel-member-list-controller-delegate)
+`SwiftUI.ObservableObject`, [`_ChatChannelMemberListControllerDelegate`](../chat-channel-member-list-controller-delegate)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/message-controller/chat-message-controller-delegate.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/message-controller/chat-message-controller-delegate.md
@@ -13,7 +13,7 @@ named `ChatMessageControllerDelegate`, which hides the generic types, and make t
 
 ## Inheritance
 
-[`DataControllerStateDelegate`](../data-controller-state-delegate)
+[`DataControllerStateDelegate`](../../data-controller-state-delegate)
 
 ## Default Implementations
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/message-controller/chat-message-controller.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/message-controller/chat-message-controller.md
@@ -16,7 +16,7 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`DataController`](../data-controller), [`DelegateCallable`](../delegate-callable), [`DataStoreProvider`](../../database/data-store-provider)
+[`DataController`](../../data-controller), [`DelegateCallable`](../../delegate-callable), [`DataStoreProvider`](../../../database/data-store-provider)
 
 ## Properties
 
@@ -141,7 +141,7 @@ func deleteMessage(completion: ((Error?) -> Void)? = nil)
 
   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished. If request fails, the completion will be called with an error.
 
-### `createNewReply(text:pinning:attachments:mentionedUserIds:showReplyInChannel:quotedMessageId:extraData:completion:)`
+### `createNewReply(text:pinning:attachments:mentionedUserIds:showReplyInChannel:isSilent:quotedMessageId:extraData:completion:)`
 
 Creates a new reply message locally and schedules it for send.
 
@@ -154,6 +154,7 @@ func createNewReply(
         attachments: [AnyAttachmentPayload] = [],
         mentionedUserIds: [UserId] = [],
         showReplyInChannel: Bool = false,
+        isSilent: Bool = false,
         quotedMessageId: MessageId? = nil,
         extraData: ExtraData.Message = .defaultValue,
         completion: ((Result<MessageId, Error>) -> Void)? = nil

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/message-controller/chat-message-controller.observable-object.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/message-controller/chat-message-controller.observable-object.md
@@ -10,7 +10,7 @@ public class ObservableObject: SwiftUI.ObservableObject
 
 ## Inheritance
 
-`SwiftUI.ObservableObject`, [`_ChatMessageControllerDelegate`](chat-message-controller-delegate)
+`SwiftUI.ObservableObject`, [`_ChatMessageControllerDelegate`](../chat-message-controller-delegate)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/search-controllers/chat-user-search-controller-delegate.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/search-controllers/chat-user-search-controller-delegate.md
@@ -13,7 +13,7 @@ named `ChatUserSearchControllerDelegate`, which hides the generic types, and mak
 
 ## Inheritance
 
-[`DataControllerStateDelegate`](../data-controller-state-delegate)
+[`DataControllerStateDelegate`](../../data-controller-state-delegate)
 
 ## Default Implementations
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/search-controllers/chat-user-search-controller.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/search-controllers/chat-user-search-controller.md
@@ -14,7 +14,7 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`DataController`](../data-controller), [`DelegateCallable`](../delegate-callable), [`DataStoreProvider`](../../database/data-store-provider)
+[`DataController`](../../data-controller), [`DelegateCallable`](../../delegate-callable), [`DataStoreProvider`](../../../database/data-store-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/user-controller/chat-user-controller-delegate.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/user-controller/chat-user-controller-delegate.md
@@ -13,7 +13,7 @@ named `ChatChannelControllerDelegate`, which hides the generic types, and make t
 
 ## Inheritance
 
-[`DataControllerStateDelegate`](../data-controller-state-delegate)
+[`DataControllerStateDelegate`](../../data-controller-state-delegate)
 
 ## Requirements
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/user-controller/chat-user-controller.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/user-controller/chat-user-controller.md
@@ -17,7 +17,7 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`DataController`](../data-controller), [`DelegateCallable`](../delegate-callable), [`DataStoreProvider`](../../database/data-store-provider)
+[`DataController`](../../data-controller), [`DelegateCallable`](../../delegate-callable), [`DataStoreProvider`](../../../database/data-store-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/user-controller/chat-user-controller.observable-object.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/user-controller/chat-user-controller.observable-object.md
@@ -10,7 +10,7 @@ public class ObservableObject: SwiftUI.ObservableObject
 
 ## Inheritance
 
-`SwiftUI.ObservableObject`, [`_ChatUserControllerDelegate`](chat-user-controller-delegate)
+`SwiftUI.ObservableObject`, [`_ChatUserControllerDelegate`](../chat-user-controller-delegate)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/user-list-controller/chat-user-list-controller-delegate.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/user-list-controller/chat-user-list-controller-delegate.md
@@ -13,7 +13,7 @@ named `ChatUserListControllerDelegate`, which hides the generic types, and make 
 
 ## Inheritance
 
-[`DataControllerStateDelegate`](../data-controller-state-delegate)
+[`DataControllerStateDelegate`](../../data-controller-state-delegate)
 
 ## Default Implementations
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/user-list-controller/chat-user-list-controller.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/user-list-controller/chat-user-list-controller.md
@@ -16,7 +16,7 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`DataController`](../data-controller), [`DelegateCallable`](../delegate-callable), [`DataStoreProvider`](../../database/data-store-provider)
+[`DataController`](../../data-controller), [`DelegateCallable`](../../delegate-callable), [`DataStoreProvider`](../../../database/data-store-provider)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/user-list-controller/chat-user-list-controller.observable-object.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/controllers/user-list-controller/chat-user-list-controller.observable-object.md
@@ -10,7 +10,7 @@ public class ObservableObject: SwiftUI.ObservableObject
 
 ## Inheritance
 
-`SwiftUI.ObservableObject`, [`_ChatUserListControllerDelegate`](chat-user-list-controller-delegate)
+`SwiftUI.ObservableObject`, [`_ChatUserListControllerDelegate`](../chat-user-list-controller-delegate)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/errors/client-error.unexpected.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/errors/client-error.unexpected.md
@@ -10,4 +10,4 @@ public class Unexpected: ClientError
 
 ## Inheritance
 
-[`ClientError`](client-error)
+[`ClientError`](../client-error)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/errors/client-error.unknown.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/errors/client-error.unknown.md
@@ -10,4 +10,4 @@ public class Unknown: ClientError
 
 ## Inheritance
 
-[`ClientError`](client-error)
+[`ClientError`](../client-error)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/attachments/attachment-file-type.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/attachments/attachment-file-type.md
@@ -40,39 +40,7 @@ public init(ext: String)
 
 ## Enumeration Cases
 
-### `pdf`
-
-A file attachment type.
-
-``` swift
-case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
-```
-
-### `tar`
-
-A file attachment type.
-
-``` swift
-case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
-```
-
-### `jpeg`
-
-A file attachment type.
-
-``` swift
-case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
-```
-
-### `mp4`
-
-A file attachment type.
-
-``` swift
-case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
-```
-
-### `zip`
+### `png`
 
 A file attachment type.
 
@@ -88,7 +56,15 @@ A file attachment type.
 case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
 ```
 
-### `ppt`
+### `pdf`
+
+A file attachment type.
+
+``` swift
+case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
+```
+
+### `doc`
 
 A file attachment type.
 
@@ -97,6 +73,46 @@ case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
 ```
 
 ### `csv`
+
+A file attachment type.
+
+``` swift
+case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
+```
+
+### `ppt`
+
+A file attachment type.
+
+``` swift
+case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
+```
+
+### `zip`
+
+A file attachment type.
+
+``` swift
+case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
+```
+
+### `mov`
+
+A file attachment type.
+
+``` swift
+case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
+```
+
+### `mp4`
+
+A file attachment type.
+
+``` swift
+case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
+```
+
+### `tar`
 
 A file attachment type.
 
@@ -120,14 +136,6 @@ A file attachment type.
 case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
 ```
 
-### `png`
-
-A file attachment type.
-
-``` swift
-case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
-```
-
 ### `mp3`
 
 A file attachment type.
@@ -136,15 +144,7 @@ A file attachment type.
 case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
 ```
 
-### `mov`
-
-A file attachment type.
-
-``` swift
-case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
-```
-
-### `doc`
+### `jpeg`
 
 A file attachment type.
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/attachments/file-attachment-payload.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/attachments/file-attachment-payload.md
@@ -10,7 +10,7 @@ public struct FileAttachmentPayload: AttachmentPayload
 
 ## Inheritance
 
-[`AttachmentPayload`](attachment-payload), `Decodable`, `Encodable`
+[`AttachmentPayload`](../attachment-payload), `Decodable`, `Encodable`
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/attachments/giphy-attachment-payload.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/attachments/giphy-attachment-payload.md
@@ -10,7 +10,7 @@ public struct GiphyAttachmentPayload: AttachmentPayload
 
 ## Inheritance
 
-[`AttachmentPayload`](attachment-payload), `Decodable`, `Encodable`
+[`AttachmentPayload`](../attachment-payload), `Decodable`, `Encodable`
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/attachments/image-attachment-payload.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/attachments/image-attachment-payload.md
@@ -10,7 +10,7 @@ public struct ImageAttachmentPayload: AttachmentPayload
 
 ## Inheritance
 
-[`AttachmentPayload`](attachment-payload), `Decodable`, `Encodable`
+[`AttachmentPayload`](../attachment-payload), `Decodable`, `Encodable`
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/attachments/link-attachment-payload.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/attachments/link-attachment-payload.md
@@ -10,7 +10,7 @@ public struct LinkAttachmentPayload: AttachmentPayload
 
 ## Inheritance
 
-[`AttachmentPayload`](attachment-payload), `Decodable`, `Encodable`
+[`AttachmentPayload`](../attachment-payload), `Decodable`, `Encodable`
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/channel-extra-data.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/channel-extra-data.md
@@ -10,4 +10,4 @@ public protocol ChannelExtraData: ExtraData
 
 ## Inheritance
 
-[`ExtraData`](extra-data)
+[`ExtraData`](../extra-data)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/channel-id.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/channel-id.md
@@ -12,7 +12,7 @@ It reflects channel's type and a unique id.
 
 ## Inheritance
 
-[`APIPathConvertible`](../api-client/api-path-convertible), `Codable`, `CustomStringConvertible`, `Hashable`
+[`APIPathConvertible`](../../api-client/api-path-convertible), `Codable`, `CustomStringConvertible`, `Hashable`
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/client-error.invalid-channel-id.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/client-error.invalid-channel-id.md
@@ -8,4 +8,4 @@ public class InvalidChannelId: ClientError
 
 ## Inheritance
 
-[`ClientError`](../errors/client-error)
+[`ClientError`](../../errors/client-error)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/message-extra-data.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/message-extra-data.md
@@ -13,4 +13,4 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`ExtraData`](extra-data)
+[`ExtraData`](../extra-data)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/message-reaction-extra-data.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/message-reaction-extra-data.md
@@ -13,4 +13,4 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`ExtraData`](extra-data)
+[`ExtraData`](../extra-data)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/no-extra-data.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/no-extra-data.md
@@ -16,7 +16,7 @@ public struct NoExtraData: Codable,
 
 ## Inheritance
 
-[`ExtraDataTypes`](../extra-data-types), [`ChannelExtraData`](channel-extra-data), `Codable`, `Hashable`, [`MessageExtraData`](message-extra-data), [`MessageReactionExtraData`](message-reaction-extra-data), [`UserExtraData`](user-extra-data)
+[`ChannelExtraData`](../channel-extra-data), `Codable`, [`ExtraDataTypes`](../../extra-data-types), `Hashable`, [`MessageExtraData`](../message-extra-data), [`MessageReactionExtraData`](../message-reaction-extra-data), [`UserExtraData`](../user-extra-data)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/user-extra-data.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/models/user-extra-data.md
@@ -13,4 +13,4 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`ExtraData`](extra-data)
+[`ExtraData`](../extra-data)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/any-member-list-filter-scope.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/any-member-list-filter-scope.md
@@ -11,4 +11,4 @@ public protocol AnyMemberListFilterScope: AnyUserListFilterScope
 
 ## Inheritance
 
-[`AnyUserListFilterScope`](any-user-list-filter-scope)
+[`AnyUserListFilterScope`](../any-user-list-filter-scope)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/channel-list-filter-scope.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/channel-list-filter-scope.md
@@ -14,4 +14,4 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`AnyChannelListFilterScope`](any-channel-list-filter-scope), [`FilterScope`](filter-scope)
+[`AnyChannelListFilterScope`](../any-channel-list-filter-scope), [`FilterScope`](../filter-scope)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/channel-query.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/channel-query.md
@@ -14,7 +14,7 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`APIPathConvertible`](../api-client/api-path-convertible), `Encodable`
+[`APIPathConvertible`](../../api-client/api-path-convertible), `Encodable`
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/member-list-filter-scope.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/member-list-filter-scope.md
@@ -14,4 +14,4 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`AnyMemberListFilterScope`](any-member-list-filter-scope), `_UserListFilterScope<ExtraData>`
+[`AnyMemberListFilterScope`](../any-member-list-filter-scope), `_UserListFilterScope<ExtraData>`

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/sorting/channel-list-sorting-key.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/sorting/channel-list-sorting-key.md
@@ -10,7 +10,7 @@ public enum ChannelListSortingKey: String, SortingKey
 
 ## Inheritance
 
-[`SortingKey`](sorting-key), `String`
+[`SortingKey`](../sorting-key), `String`
 
 ## Enumeration Cases
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/sorting/channel-member-list-sorting-key.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/sorting/channel-member-list-sorting-key.md
@@ -10,7 +10,7 @@ public enum ChannelMemberListSortingKey: String, SortingKey
 
 ## Inheritance
 
-[`SortingKey`](sorting-key), `String`
+[`SortingKey`](../sorting-key), `String`
 
 ## Enumeration Cases
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/sorting/user-list-sorting-key.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/sorting/user-list-sorting-key.md
@@ -10,7 +10,7 @@ public enum UserListSortingKey: String, SortingKey
 
 ## Inheritance
 
-[`SortingKey`](sorting-key), `String`
+[`SortingKey`](../sorting-key), `String`
 
 ## Enumeration Cases
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/user-list-filter-scope.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/query/user-list-filter-scope.md
@@ -14,4 +14,4 @@ Learn more about using custom extra data in our [cheat sheet](https://github.com
 
 ## Inheritance
 
-[`FilterScope`](filter-scope), [`AnyUserListFilterScope`](any-user-list-filter-scope)
+[`FilterScope`](../filter-scope), [`AnyUserListFilterScope`](../any-user-list-filter-scope)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/utils/logger/destination/base-log-destination.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/utils/logger/destination/base-log-destination.md
@@ -11,7 +11,7 @@ open class BaseLogDestination: LogDestination
 
 ## Inheritance
 
-[`LogDestination`](log-destination)
+[`LogDestination`](../log-destination)
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/utils/logger/destination/console-log-destination.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/utils/logger/destination/console-log-destination.md
@@ -10,7 +10,7 @@ public class ConsoleLogDestination: BaseLogDestination
 
 ## Inheritance
 
-[`BaseLogDestination`](base-log-destination)
+[`BaseLogDestination`](../base-log-destination)
 
 ## Methods
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/utils/logger/formatter/prefix-log-formatter.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/utils/logger/formatter/prefix-log-formatter.md
@@ -12,7 +12,7 @@ public class PrefixLogFormatter: LogFormatter
 
 ## Inheritance
 
-[`LogFormatter`](log-formatter)
+[`LogFormatter`](../log-formatter)
 
 ## Initializers
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/client-error.web-socket.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/client-error.web-socket.md
@@ -8,4 +8,4 @@ public class WebSocket: ClientError
 
 ## Inheritance
 
-[`ClientError`](../errors/client-error)
+[`ClientError`](../../errors/client-error)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/channel-deleted-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/channel-deleted-event.md
@@ -8,7 +8,7 @@ public struct ChannelDeletedEvent: ChannelSpecificEvent
 
 ## Inheritance
 
-[`ChannelSpecificEvent`](channel-specific-event)
+[`ChannelSpecificEvent`](../channel-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/channel-hidden-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/channel-hidden-event.md
@@ -8,7 +8,7 @@ public struct ChannelHiddenEvent: ChannelSpecificEvent
 
 ## Inheritance
 
-[`ChannelSpecificEvent`](channel-specific-event)
+[`ChannelSpecificEvent`](../channel-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/channel-truncated-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/channel-truncated-event.md
@@ -8,7 +8,7 @@ public struct ChannelTruncatedEvent: ChannelSpecificEvent
 
 ## Inheritance
 
-[`ChannelSpecificEvent`](channel-specific-event)
+[`ChannelSpecificEvent`](../channel-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/channel-updated-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/channel-updated-event.md
@@ -8,7 +8,7 @@ public struct ChannelUpdatedEvent: ChannelSpecificEvent
 
 ## Inheritance
 
-[`ChannelSpecificEvent`](channel-specific-event)
+[`ChannelSpecificEvent`](../channel-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/channel-visible-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/channel-visible-event.md
@@ -8,7 +8,7 @@ public struct ChannelVisibleEvent: ChannelSpecificEvent
 
 ## Inheritance
 
-[`ChannelSpecificEvent`](channel-specific-event)
+[`ChannelSpecificEvent`](../channel-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/clean-up-typing-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/clean-up-typing-event.md
@@ -12,7 +12,7 @@ public struct CleanUpTypingEvent: Event
 
 ## Inheritance
 
-`Equatable`, [`Event`](event)
+`Equatable`, [`Event`](../event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/client-error.event-decoding.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/client-error.event-decoding.md
@@ -8,4 +8,4 @@ public class EventDecoding: ClientError
 
 ## Inheritance
 
-[`ClientError`](../../errors/client-error)
+[`ClientError`](../../../errors/client-error)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/client-error.unsupported-event-type.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/client-error.unsupported-event-type.md
@@ -8,7 +8,7 @@ public class UnsupportedEventType: ClientError
 
 ## Inheritance
 
-[`ClientError`](../../errors/client-error)
+[`ClientError`](../../../errors/client-error)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/connection-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/connection-event.md
@@ -8,7 +8,7 @@ public protocol ConnectionEvent: Event
 
 ## Inheritance
 
-[`Event`](event)
+[`Event`](../event)
 
 ## Requirements
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/connection-status-updated.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/connection-status-updated.md
@@ -11,7 +11,7 @@ public struct ConnectionStatusUpdated: Event
 
 ## Inheritance
 
-[`Event`](event)
+[`Event`](../event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/health-check-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/health-check-event.md
@@ -8,7 +8,7 @@ public struct HealthCheckEvent: ConnectionEvent, EventWithPayload
 
 ## Inheritance
 
-[`ConnectionEvent`](connection-event), [`EventWithPayload`](event-with-payload)
+[`ConnectionEvent`](../connection-event), [`EventWithPayload`](../event-with-payload)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/member-added-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/member-added-event.md
@@ -8,7 +8,7 @@ public struct MemberAddedEvent: MemberEvent, ChannelSpecificEvent, EventWithPayl
 
 ## Inheritance
 
-[`EventWithPayload`](event-with-payload), [`ChannelSpecificEvent`](channel-specific-event), [`MemberEvent`](member-event)
+[`EventWithPayload`](../event-with-payload), [`ChannelSpecificEvent`](../channel-specific-event), [`MemberEvent`](../member-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/member-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/member-event.md
@@ -10,7 +10,7 @@ public protocol MemberEvent: Event
 
 ## Inheritance
 
-[`Event`](event)
+[`Event`](../event)
 
 ## Requirements
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/member-removed-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/member-removed-event.md
@@ -8,7 +8,7 @@ public struct MemberRemovedEvent: MemberEvent, ChannelSpecificEvent, EventWithPa
 
 ## Inheritance
 
-[`EventWithPayload`](event-with-payload), [`ChannelSpecificEvent`](channel-specific-event), [`MemberEvent`](member-event)
+[`EventWithPayload`](../event-with-payload), [`ChannelSpecificEvent`](../channel-specific-event), [`MemberEvent`](../member-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/member-updated-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/member-updated-event.md
@@ -8,7 +8,7 @@ public struct MemberUpdatedEvent: MemberEvent, ChannelSpecificEvent, EventWithPa
 
 ## Inheritance
 
-[`EventWithPayload`](event-with-payload), [`ChannelSpecificEvent`](channel-specific-event), [`MemberEvent`](member-event)
+[`EventWithPayload`](../event-with-payload), [`ChannelSpecificEvent`](../channel-specific-event), [`MemberEvent`](../member-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/message-deleted-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/message-deleted-event.md
@@ -8,7 +8,7 @@ public struct MessageDeletedEvent: MessageSpecificEvent
 
 ## Inheritance
 
-[`MessageSpecificEvent`](message-specific-event)
+[`MessageSpecificEvent`](../message-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/message-new-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/message-new-event.md
@@ -8,7 +8,7 @@ public struct MessageNewEvent: MessageSpecificEvent
 
 ## Inheritance
 
-[`MessageSpecificEvent`](message-specific-event)
+[`MessageSpecificEvent`](../message-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/message-read-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/message-read-event.md
@@ -10,7 +10,7 @@ public struct MessageReadEvent: UserSpecificEvent, ChannelSpecificEvent
 
 ## Inheritance
 
-[`UserSpecificEvent`](user-specific-event), [`ChannelSpecificEvent`](channel-specific-event)
+[`UserSpecificEvent`](../user-specific-event), [`ChannelSpecificEvent`](../channel-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/message-updated-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/message-updated-event.md
@@ -8,7 +8,7 @@ public struct MessageUpdatedEvent: MessageSpecificEvent
 
 ## Inheritance
 
-[`MessageSpecificEvent`](message-specific-event)
+[`MessageSpecificEvent`](../message-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/notification-added-to-channel-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/notification-added-to-channel-event.md
@@ -8,7 +8,7 @@ public struct NotificationAddedToChannelEvent: ChannelSpecificEvent
 
 ## Inheritance
 
-[`ChannelSpecificEvent`](channel-specific-event)
+[`ChannelSpecificEvent`](../channel-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/notification-channel-mutes-updated-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/notification-channel-mutes-updated-event.md
@@ -8,7 +8,7 @@ public struct NotificationChannelMutesUpdatedEvent: UserSpecificEvent
 
 ## Inheritance
 
-[`UserSpecificEvent`](user-specific-event)
+[`UserSpecificEvent`](../user-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/notification-mark-all-read-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/notification-mark-all-read-event.md
@@ -8,7 +8,7 @@ public struct NotificationMarkAllReadEvent: UserSpecificEvent
 
 ## Inheritance
 
-[`UserSpecificEvent`](user-specific-event)
+[`UserSpecificEvent`](../user-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/notification-mark-read-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/notification-mark-read-event.md
@@ -8,7 +8,7 @@ public struct NotificationMarkReadEvent: UserSpecificEvent, ChannelSpecificEvent
 
 ## Inheritance
 
-[`UserSpecificEvent`](user-specific-event), [`ChannelSpecificEvent`](channel-specific-event)
+[`UserSpecificEvent`](../user-specific-event), [`ChannelSpecificEvent`](../channel-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/notification-message-new-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/notification-message-new-event.md
@@ -8,7 +8,7 @@ public struct NotificationMessageNewEvent: MessageSpecificEvent
 
 ## Inheritance
 
-[`MessageSpecificEvent`](message-specific-event)
+[`MessageSpecificEvent`](../message-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/notification-mutes-updated-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/notification-mutes-updated-event.md
@@ -8,7 +8,7 @@ public struct NotificationMutesUpdatedEvent<ExtraData: ExtraDataTypes>: CurrentU
 
 ## Inheritance
 
-[`CurrentUserEvent`](current-user-event)
+[`CurrentUserEvent`](../current-user-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/notification-removed-from-channel-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/notification-removed-from-channel-event.md
@@ -8,7 +8,7 @@ public struct NotificationRemovedFromChannelEvent: CurrentUserEvent, ChannelSpec
 
 ## Inheritance
 
-[`ChannelSpecificEvent`](channel-specific-event), [`CurrentUserEvent`](current-user-event)
+[`ChannelSpecificEvent`](../channel-specific-event), [`CurrentUserEvent`](../current-user-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/reaction-deleted-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/reaction-deleted-event.md
@@ -8,7 +8,7 @@ public struct ReactionDeletedEvent: ReactionEvent
 
 ## Inheritance
 
-[`ReactionEvent`](reaction-event)
+[`ReactionEvent`](../reaction-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/reaction-new-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/reaction-new-event.md
@@ -8,7 +8,7 @@ public struct ReactionNewEvent: ReactionEvent
 
 ## Inheritance
 
-[`ReactionEvent`](reaction-event)
+[`ReactionEvent`](../reaction-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/reaction-updated-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/reaction-updated-event.md
@@ -8,7 +8,7 @@ public struct ReactionUpdatedEvent: ReactionEvent
 
 ## Inheritance
 
-[`ReactionEvent`](reaction-event)
+[`ReactionEvent`](../reaction-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/typing-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/typing-event.md
@@ -8,7 +8,7 @@ public struct TypingEvent: UserSpecificEvent, ChannelSpecificEvent
 
 ## Inheritance
 
-[`UserSpecificEvent`](user-specific-event), [`ChannelSpecificEvent`](channel-specific-event), `Equatable`
+[`ChannelSpecificEvent`](../channel-specific-event), `Equatable`, [`UserSpecificEvent`](../user-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/user-banned-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/user-banned-event.md
@@ -8,7 +8,7 @@ public struct UserBannedEvent: UserSpecificEvent, ChannelSpecificEvent
 
 ## Inheritance
 
-[`UserSpecificEvent`](user-specific-event), [`ChannelSpecificEvent`](channel-specific-event)
+[`UserSpecificEvent`](../user-specific-event), [`ChannelSpecificEvent`](../channel-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/user-globally-banned-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/user-globally-banned-event.md
@@ -8,4 +8,4 @@ public struct UserGloballyBannedEvent: UserSpecificEvent
 
 ## Inheritance
 
-[`UserSpecificEvent`](user-specific-event)
+[`UserSpecificEvent`](../user-specific-event)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/user-globally-unbanned-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/user-globally-unbanned-event.md
@@ -8,4 +8,4 @@ public struct UserGloballyUnbannedEvent: UserSpecificEvent
 
 ## Inheritance
 
-[`UserSpecificEvent`](user-specific-event)
+[`UserSpecificEvent`](../user-specific-event)

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/user-presence-changed-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/user-presence-changed-event.md
@@ -8,7 +8,7 @@ public struct UserPresenceChangedEvent: UserSpecificEvent
 
 ## Inheritance
 
-[`UserSpecificEvent`](user-specific-event)
+[`UserSpecificEvent`](../user-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/user-unbanned-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/user-unbanned-event.md
@@ -8,7 +8,7 @@ public struct UserUnbannedEvent: UserSpecificEvent, ChannelSpecificEvent
 
 ## Inheritance
 
-[`UserSpecificEvent`](user-specific-event), [`ChannelSpecificEvent`](channel-specific-event)
+[`UserSpecificEvent`](../user-specific-event), [`ChannelSpecificEvent`](../channel-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/user-updated-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/user-updated-event.md
@@ -8,7 +8,7 @@ public struct UserUpdatedEvent: UserSpecificEvent
 
 ## Inheritance
 
-[`UserSpecificEvent`](user-specific-event)
+[`UserSpecificEvent`](../user-specific-event)
 
 ## Properties
 

--- a/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/user-watching-event.md
+++ b/docusaurus/docs/iOS/reference-docs/sources/stream-chat/web-socket-client/events/user-watching-event.md
@@ -8,7 +8,7 @@ public struct UserWatchingEvent: UserSpecificEvent, ChannelSpecificEvent
 
 ## Inheritance
 
-[`UserSpecificEvent`](user-specific-event), [`ChannelSpecificEvent`](channel-specific-event)
+[`UserSpecificEvent`](../user-specific-event), [`ChannelSpecificEvent`](../channel-specific-event)
 
 ## Properties
 


### PR DESCRIPTION
 Your tunnel: https://stream-composer-links-fixed.loca.lt

# What this PR do:
- Fixes links to other files in reference docs so they are accessible. This was done by modifying swift-doc to add one more `../` path component to all paths due to nature of Docusaurus not handling this case.
# How to test it
- If you want to test this locally, checkout `staging` branch in `stream-chat-docusaurus-cli` repository and then run docusaurus on this branch. Links should be fixed. If you want to make sure, check out main and try to run docusaurus from the `staging` branch to see that links to other files in referenceDocs are broken.


