### PR TITLE
[CIS-934] Fix deadlock when connectionId is requested in a nested manner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Subviews of `ChatMessageDefaultReactionsBubbleView` are now public [#1209](https://github.com/GetStream/stream-chat-swift/pull/1209)
 - Fix composer overlapping last message. This happened for channels with typing events disabled. [#1210](https://github.com/GetStream/stream-chat-swift/issues/1210)
 - Fix an issue where composer textView's caret jumps to the end of input [#1117](https://github.com/GetStream/stream-chat-swift/issues/1117)
+- Fix deadlock in Controllers when `synchronize` is called in a delegate callback [#1214](https://github.com/GetStream/stream-chat-swift/issues/1214)
 
 # [4.0.0-beta.3](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.3)
 _June 11, 2021_

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -529,14 +529,18 @@ extension _ChatClient: ConnectionStateDelegate {
         connectionId: String?,
         shouldNotifyWaiters: Bool
     ) {
+        var connectionIdWaiters: [(String?) -> Void]!
         _connectionId.mutate { mutableConnectionId in
-            _connectionIdWaiters.mutate { connectionIdWaiters in
-                mutableConnectionId = connectionId
+            mutableConnectionId = connectionId
+            _connectionIdWaiters.mutate { _connectionIdWaiters in
+                connectionIdWaiters = _connectionIdWaiters
                 if shouldNotifyWaiters {
-                    connectionIdWaiters.forEach { $0(connectionId) }
-                    connectionIdWaiters.removeAll()
+                    _connectionIdWaiters.removeAll()
                 }
             }
+        }
+        if shouldNotifyWaiters {
+            connectionIdWaiters.forEach { $0(connectionId) }
         }
     }
 }


### PR DESCRIPTION
This happened when a controller's `synchronize` was called when `CurrentChatUserController`'s `didChangeUser` callback happened. The reason was nested `provideConnectionId` calls. It doesn't make sense to provide connectionId to waiters while keeping a lock to the `connectionId` resource.
