### PR TITLE
Fix link in Getting Started section

### DIFF
--- a/docusaurus/docs/iOS/basics/getting-started.md
+++ b/docusaurus/docs/iOS/basics/getting-started.md
@@ -2,7 +2,7 @@
 title: Getting Started
 ---
 
-To get started with StreamChat, we suggest you register and acquire an API token [on our website](getstream.io). Please enable developer tokens for your app before moving on with the guide, since we'll use them for prototyping.
+To get started with StreamChat, we suggest you register and acquire an API token [on our website](https://getstream.io/). Please enable developer tokens for your app before moving on with the guide, since we'll use them for prototyping.
 
 On the [Dashboard](https://getstream.io/dashboard/):
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] ~Code changes are tested (add some information if not applicable)~

## Description of the pull request

Fixes a link that was previously going to getstream.io/chat/docs/sdk/ios/basics/getting-started/getstream.io/ when clicked.