### PR TITLE
[CIS-969] Date overlay jumps when loading more messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,10 +41,13 @@ _June 23, 2021_
 - Ability to send silent messages. Silent messages are normal messages with an additional `isSilent` value set to `true`. Silent messages don’t trigger push notification for the recipient.[#1211](https://github.com/GetStream/stream-chat-swift/pull/1211)
 - Expose `cid` on `Message` [#1215](https://github.com/GetStream/stream-chat-swift/issues/1215)
 - `showMediaPicker`/`showFilePicker`/`attachmentsPickerActions` functions added to `ComposerVC` so it's possible to customize media/document pickers and add extend action sheet with actions for custom attachment types [#1194](https://github.com/GetStream/stream-chat-swift/pull/1194)
+- Make `ChatThreadVC` show overlay with timestamp of currently visible messages when scrolling [#1235](https://github.com/GetStream/stream-chat-swift/pull/1235)
 
 ### 🔄 Changed
 - `scrollToLatestMessageButton` is now visible every time the last message is not visible. Not only when there is unread message. [#1208](https://github.com/GetStream/stream-chat-swift/pull/1208) 
 - `mediaPickerVC` in `ComposerVC` updated to show both photos and videos [#1194](https://github.com/GetStream/stream-chat-swift/pull/1194)
+- `ChatMessageListScrollOverlayView` moved outside the `ChatMessageListView`. Now it's managed by `ChatMessageListVC` and `ChatThreadVC` explicitly [#1235](https://github.com/GetStream/stream-chat-swift/pull/1235)
+- Date formatter for scroll overlay used in `ChatMessageListVC` is now exposed as `DateFormatter.messageListDateOverlay` [#1235](https://github.com/GetStream/stream-chat-swift/pull/1235)
 
 ### 🐞 Fixed 
 - Fix sorting Member List by `createdAt` causing an issue [#1185](https://github.com/GetStream/stream-chat-swift/issues/1185)
@@ -59,6 +62,7 @@ _June 23, 2021_
 - Fix deadlock in Controllers when `synchronize` is called in a delegate callback [#1214](https://github.com/GetStream/stream-chat-swift/issues/1214)
 - Fix restart uploading action not being propagated [#1194](https://github.com/GetStream/stream-chat-swift/pull/1194)
 - Fix uploading progress not visible on image uploading overlay [#1194](https://github.com/GetStream/stream-chat-swift/pull/1194)
+- Fix timestamp overlay jumping when more messages are loaded [#1235](https://github.com/GetStream/stream-chat-swift/pull/1235)
 
 # [4.0.0-beta.3](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.3)
 _June 11, 2021_

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListScrollOverlayView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListScrollOverlayView.swift
@@ -4,17 +4,74 @@
 
 import UIKit
 
+/// A protocol for `ChatMessageListScrollOverlayView` data source.
+public protocol ChatMessageListScrollOverlayDataSource: AnyObject {
+    /// Get date for item at given index path
+    /// - Parameters:
+    ///   - overlay: A view requesting date
+    ///   - indexPath: An index path that should be used to get the date
+    func scrollOverlay(_ overlay: ChatMessageListScrollOverlayView, textForItemAt indexPath: IndexPath) -> String?
+}
+
 /// View that is displayed as top overlay when message list is scrolling
 open class ChatMessageListScrollOverlayView: _View, AppearanceProvider {
+    /// The displayed content.
     open var content: String? {
         didSet { updateContentIfNeeded() }
     }
     
-    open lazy var textLabel: UILabel = {
-        let textLabel = UILabel()
-        textLabel.adjustsFontForContentSizeCategory = true
-        return textLabel.withoutAutoresizingMaskConstraints
-    }()
+    /// The view used to display the content.
+    open private(set) lazy var textLabel: UILabel = UILabel()
+        .withBidirectionalLanguagesSupport
+        .withAdjustingFontForContentSizeCategory
+        .withoutAutoresizingMaskConstraints
+            
+    /// The data source used to get the content to display.
+    public weak var dataSource: ChatMessageListScrollOverlayDataSource?
+    
+    /// The list view that is listened for being scrolled.
+    public weak var listView: UITableView? {
+        didSet {
+            contentOffsetObservation = listView?.observe(\.contentOffset) { [weak self] tb, _ in
+                guard let self = self else { return }
+                
+                // To display correct date we use bottom edge of scroll overlay
+                let refPoint = CGPoint(
+                    x: self.center.x,
+                    y: self.frame.maxY
+                )
+                
+                // If we cannot find any indexPath for `cell` we try to use max visible indexPath (we have bottom to top) layout
+                guard
+                    let refPointInListView = self.superview?.convert(refPoint, to: tb),
+                    let indexPath = tb.indexPathForRow(at: refPointInListView) ?? tb.indexPathsForVisibleRows?.max()
+                else { return }
+                
+                let overlayText = self.dataSource?.scrollOverlay(self, textForItemAt: indexPath)
+                
+                // If we have no date we have no reason to display `dateView`
+                self.isHidden = (overlayText ?? "").isEmpty
+                self.content = overlayText
+                
+                // Apple's naming is quite weird as actually this property should rather be named `isScrolling`
+                // as it stays true when user stops dragging and scrollView is decelerating and becomes false
+                // when scrollView stops decelerating
+                //
+                // But this case doesn't cover situation when user drags scrollView to a certain `contentOffset`
+                // leaves the finger there for a while and then just lifts it, it doesn't change `contentOffset`
+                // so this handler is not called, this is handled by `scrollStateChanged`
+                // that reacts on `panGestureRecognizer` states and can handle this case properly
+                if !tb.isDragging {
+                    self.setAlpha(0)
+                }
+            }
+            
+            oldValue?.panGestureRecognizer.removeTarget(self, action: #selector(scrollStateChanged))
+            listView?.panGestureRecognizer.addTarget(self, action: #selector(scrollStateChanged))
+        }
+    }
+    
+    private var contentOffsetObservation: NSKeyValueObservation?
     
     override open func setUpLayout() {
         super.setUpLayout()
@@ -24,9 +81,7 @@ open class ChatMessageListScrollOverlayView: _View, AppearanceProvider {
     
     override open func setUpAppearance() {
         super.setUpAppearance()
-        
-        layer.cornerRadius = bounds.height / 2
-        
+                
         backgroundColor = appearance.colorPalette.background7
         
         textLabel.font = appearance.fonts.footnote
@@ -41,6 +96,31 @@ open class ChatMessageListScrollOverlayView: _View, AppearanceProvider {
     
     override open func layoutSubviews() {
         super.layoutSubviews()
+        
         layer.cornerRadius = bounds.height / 2
+    }
+    
+    /// Is invoked when a pan gesture state is changed.
+    @objc
+    open func scrollStateChanged(_ sender: UIPanGestureRecognizer) {
+        switch sender.state {
+        case .began:
+            setAlpha(1)
+        case .ended, .cancelled, .failed:
+            // This case handles situation when user pans to certain `contentOffset`, leaves the finger there
+            // and then lifts it without `contentOffset` change, so `scrollView` will not decelerate, if it does,
+            // it is handled by `contentOffset` observation
+            if listView?.isDecelerating == false {
+                setAlpha(0)
+            }
+        default: break
+        }
+    }
+    
+    /// Updates the alpha of the overlay.
+    open func setAlpha(_ alpha: CGFloat) {
+        Animate(isAnimated: true) {
+            self.alpha = alpha
+        }
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -244,7 +244,9 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
         _ overlay: ChatMessageListScrollOverlayView,
         textForItemAt indexPath: IndexPath
     ) -> String? {
-        overlayDateFormatter.string(from: channelController.messages[indexPath.item].createdAt)
+        DateFormatter
+            .messageListDateOverlay
+            .string(from: channelController.messages[indexPath.item].createdAt)
     }
 
     open func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -573,14 +575,6 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
         guard let indexPath = indexPath else { return log.error("IndexPath is not available") }
         print(#function, indexPath)
     }
-    
-    /// Formatter that is used to format date for scrolling overlay that should display day when message below were sent
-    open var overlayDateFormatter: DateFormatter = {
-        let df = DateFormatter()
-        df.setLocalizedDateFormatFromTemplate("MMMdd")
-        df.locale = .autoupdatingCurrent
-        return df
-    }()
     
     open func numberOfSections(in tableView: UITableView) -> Int {
         1

--- a/Sources/StreamChatUI/Utils/DateFormatter+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/DateFormatter+Extensions.swift
@@ -12,6 +12,15 @@ extension DateFormatter {
         formatter.locale = Locale.autoupdatingCurrent
         return formatter
     }
+    
+    /// Formatter that is used to format date for scrolling overlay that should display
+    /// day when message below was sent
+    public static let messageListDateOverlay: DateFormatter = {
+        let df = DateFormatter()
+        df.setLocalizedDateFormatFromTemplate("MMMdd")
+        df.locale = .autoupdatingCurrent
+        return df
+    }()
 }
 
 extension DateComponentsFormatter {


### PR DESCRIPTION
**This PR** fixed the issue when date overlay jumps when loading more but moving an overlay outside the list view.

Tried the following first:
- `preserveSuperviewLayoutMargins = true` and keep pinning to `self.layoutMargins`
- pin to `superview.layoutMargins` directly
- create a top constraint with a constant calculated based on `contentOffset.y`

and none of it works 🚫. It seems `layoutMargins` follow the content size of table view when it changes and only after margins are updated to fit visible content area. Trying to follow the `contentOffset.y` would also involve following the `contentSize.height` which makes the logic of calculating the constraint too complicated.



https://user-images.githubusercontent.com/12818985/123954615-48dfd700-d9b1-11eb-9ac5-efd625ccee70.mp4