### PR TITLE
[CIS-971] Make `Message.cid` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed 
 - `ConnectionController` fires its `controllerDidChangeConnectionStatus` method only when the connection status actually changes [#1207](https://github.com/GetStream/stream-chat-swift/issues/1207)
 - Fix cancelled ephemeral (giphy) messages and deleted messages are visible in threads [#1238](https://github.com/GetStream/stream-chat-swift/issues/1238)
+- Fix crash on missing `cid` value of `Message` during local cache invalidation [#1245](https://github.com/GetStream/stream-chat-swift/issues/1245)
 
 
 # [4.0.0-beta.4](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.4)

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -27,7 +27,7 @@ class MessageDTO: NSManagedObject {
     @NSManaged var user: UserDTO
     @NSManaged var mentionedUsers: Set<UserDTO>
     @NSManaged var threadParticipants: Set<UserDTO>
-    @NSManaged var channel: ChannelDTO
+    @NSManaged var channel: ChannelDTO?
     @NSManaged var replies: Set<MessageDTO>
     @NSManaged var flaggedBy: CurrentUserDTO?
     @NSManaged var reactions: Set<MessageReactionDTO>
@@ -514,7 +514,7 @@ private extension _ChatMessage {
         let context = dto.managedObjectContext!
         
         id = dto.id
-        cid = try! ChannelId(cid: dto.channel.cid)
+        cid = dto.channel.map { try! ChannelId(cid: $0.cid) }
         text = dto.text
         type = MessageType(rawValue: dto.type) ?? .regular
         command = dto.command

--- a/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
@@ -879,8 +879,8 @@ class MessageDTO_Tests: XCTestCase {
             database.viewContext.message(id: newMessageId)
         )
         
-        XCTAssertEqual(loadedMessage.channel.lastMessageAt, loadedMessage.createdAt)
-        XCTAssertEqual(loadedMessage.channel.defaultSortingAt, loadedMessage.createdAt)
+        XCTAssertEqual(loadedMessage.channel!.lastMessageAt, loadedMessage.createdAt)
+        XCTAssertEqual(loadedMessage.channel!.defaultSortingAt, loadedMessage.createdAt)
     }
     
     func test_replies_linkedToParentMessage_onCreatingNewMessage() throws {

--- a/Sources/StreamChat/Models/Message.swift
+++ b/Sources/StreamChat/Models/Message.swift
@@ -29,8 +29,9 @@ public struct _ChatMessage<ExtraData: ExtraDataTypes> {
     /// A unique identifier of the message.
     public let id: MessageId
     
-    /// The ChannelId this message belongs to.
-    public let cid: ChannelId
+    /// The ChannelId this message belongs to. This value can be temporarily `nil` for messages that are being removed from
+    /// the local cache, or when the local cache is in the process of invalidating.
+    public let cid: ChannelId?
     
     /// The text of the message.
     public let text: String


### PR DESCRIPTION
During the local cache invalidation process, the `channelDTO` value of the message can become `nil`. This PR fixes this edge case.