### PR TITLE
[CIS-974] Messages maintain correct order of the local time is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `ConnectionController` fires its `controllerDidChangeConnectionStatus` method only when the connection status actually changes [#1207](https://github.com/GetStream/stream-chat-swift/issues/1207)
 - Fix cancelled ephemeral (giphy) messages and deleted messages are visible in threads [#1238](https://github.com/GetStream/stream-chat-swift/issues/1238)
 - Fix crash on missing `cid` value of `Message` during local cache invalidation [#1245](https://github.com/GetStream/stream-chat-swift/issues/1245)
-
+- Messages keep correct order if the local device time is different from the server time [#1246](https://github.com/GetStream/stream-chat-swift/issues/1246)
 
 # [4.0.0-beta.4](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.4)
 _June 23, 2021_

--- a/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
@@ -529,6 +529,7 @@ class MessageDTO_Tests: XCTestCase {
                 showReplyInChannel: messageShowReplyInChannel,
                 isSilent: messageIsSilent,
                 quotedMessageId: nil,
+                createdAt: nil,
                 extraData: messageExtraData
             ).id
         }
@@ -636,6 +637,7 @@ class MessageDTO_Tests: XCTestCase {
                     showReplyInChannel: false,
                     isSilent: false,
                     quotedMessageId: nil,
+                    createdAt: nil,
                     extraData: NoExtraData.defaultValue
                 )
                 message1Id = message1DTO.id
@@ -654,29 +656,24 @@ class MessageDTO_Tests: XCTestCase {
                     showReplyInChannel: false,
                     isSilent: false,
                     quotedMessageId: nil,
+                    createdAt: nil,
                     extraData: NoExtraData.defaultValue
                 )
+                // Reset the `locallyCreateAt` value of the second message to simulate the message was sent
+                message2DTO.locallyCreatedAt = nil
                 message2Id = message2DTO.id
             }, completion: completion)
         }
         
-        var message1: MessageDTO? {
-            database.viewContext.message(id: message1Id)
-        }
-        
-        var message2: MessageDTO? {
-            database.viewContext.message(id: message2Id)
-        }
-        
+        let message1: MessageDTO = try XCTUnwrap(database.viewContext.message(id: message1Id))
+        let message2: MessageDTO = try XCTUnwrap(database.viewContext.message(id: message2Id))
+
         AssertAsync {
-            Assert.willBeTrue(message1 != nil)
-            Assert.willBeTrue(message2 != nil)
-            
             // Message 1 should have `locallyCreatedAt` as `defaultSortingKey`
-            Assert.willBeEqual(message1?.defaultSortingKey, message1?.locallyCreatedAt)
+            Assert.willBeEqual(message1.defaultSortingKey, message1.locallyCreatedAt)
             
             // Message 2 should have `createdAt` as `defaultSortingKey`
-            Assert.willBeEqual(message2?.defaultSortingKey, message2?.createdAt)
+            Assert.willBeEqual(message2.defaultSortingKey, message2.createdAt)
         }
     }
 
@@ -753,6 +750,7 @@ class MessageDTO_Tests: XCTestCase {
                     showReplyInChannel: true,
                     isSilent: false,
                     quotedMessageId: nil,
+                    createdAt: nil,
                     extraData: NoExtraData.defaultValue
                 )
                 newMessageId = messageDTO.id
@@ -797,6 +795,7 @@ class MessageDTO_Tests: XCTestCase {
                     showReplyInChannel: true,
                     isSilent: false,
                     quotedMessageId: nil,
+                    createdAt: nil,
                     extraData: NoExtraData.defaultValue
                 )
             }, completion: completion)
@@ -834,6 +833,7 @@ class MessageDTO_Tests: XCTestCase {
                     showReplyInChannel: true,
                     isSilent: false,
                     quotedMessageId: nil,
+                    createdAt: nil,
                     extraData: NoExtraData.defaultValue
                 )
             }, completion: completion)
@@ -910,6 +910,7 @@ class MessageDTO_Tests: XCTestCase {
                 showReplyInChannel: false,
                 isSilent: false,
                 quotedMessageId: nil,
+                createdAt: nil,
                 extraData: NoExtraData.defaultValue
             )
             // Get reply messageId

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -66,6 +66,7 @@ protocol MessageDatabaseSession {
         showReplyInChannel: Bool,
         isSilent: Bool,
         quotedMessageId: MessageId?,
+        createdAt: Date?,
         extraData: ExtraData
     ) throws -> MessageDTO
     
@@ -135,6 +136,7 @@ extension MessageDatabaseSession {
             showReplyInChannel: false,
             isSilent: isSilent,
             quotedMessageId: quotedMessageId,
+            createdAt: nil,
             extraData: extraData
         )
     }

--- a/Sources/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Mock.swift
@@ -82,6 +82,7 @@ extension DatabaseSessionMock {
         showReplyInChannel: Bool,
         isSilent: Bool,
         quotedMessageId: MessageId?,
+        createdAt: Date?,
         extraData: ExtraData
     ) throws -> MessageDTO where ExtraData: MessageExtraData {
         try throwErrorIfNeeded()
@@ -98,6 +99,7 @@ extension DatabaseSessionMock {
             showReplyInChannel: showReplyInChannel,
             isSilent: isSilent,
             quotedMessageId: quotedMessageId,
+            createdAt: createdAt,
             extraData: extraData
         )
     }

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="20C69" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20F71" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
@@ -191,6 +191,9 @@
         <fetchIndex name="id">
             <fetchIndexElement property="id" type="Binary" order="ascending"/>
         </fetchIndex>
+        <fetchIndex name="defaultSortingAt">
+            <fetchIndexElement property="defaultSortingKey" type="Binary" order="ascending"/>
+        </fetchIndex>
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="id"/>
@@ -276,18 +279,18 @@
     </entity>
     <elements>
         <element name="AttachmentDTO" positionX="9" positionY="153" width="128" height="164"/>
-        <element name="CurrentUserDTO" positionX="0" positionY="0" width="128" height="148"/>
-        <element name="DeviceDTO" positionX="9" positionY="153" width="128" height="88"/>
         <element name="ChannelDTO" positionX="0" positionY="0" width="128" height="493"/>
         <element name="ChannelListQueryDTO" positionX="0" positionY="0" width="128" height="88"/>
         <element name="ChannelMemberListQueryDTO" positionX="9" positionY="153" width="128" height="88"/>
+        <element name="ChannelMuteDTO" positionX="9" positionY="162" width="128" height="89"/>
         <element name="ChannelReadDTO" positionX="9" positionY="153" width="128" height="103"/>
+        <element name="CurrentUserDTO" positionX="0" positionY="0" width="128" height="148"/>
+        <element name="DeviceDTO" positionX="9" positionY="153" width="128" height="88"/>
         <element name="MemberDTO" positionX="0" positionY="0" width="128" height="254"/>
         <element name="MessageDTO" positionX="0" positionY="0" width="128" height="539"/>
         <element name="MessageReactionDTO" positionX="9" positionY="153" width="128" height="163"/>
         <element name="TeamDTO" positionX="0" positionY="0" width="128" height="88"/>
         <element name="UserDTO" positionX="0" positionY="0" width="128" height="389"/>
         <element name="UserListQueryDTO" positionX="9" positionY="153" width="128" height="103"/>
-        <element name="ChannelMuteDTO" positionX="9" positionY="162" width="128" height="89"/>
     </elements>
 </model>

--- a/Sources/StreamChat/Workers/Background/MessageSender.swift
+++ b/Sources/StreamChat/Workers/Background/MessageSender.swift
@@ -204,6 +204,7 @@ private class MessageSendingQueue<ExtraData: ExtraDataTypes> {
             let messageDTO = try $0.saveMessage(payload: message, for: cid)
             if messageDTO.localMessageState == .sending {
                 messageDTO.localMessageState = nil
+                messageDTO.locallyCreatedAt = nil
             }
         }, completion: {
             if let error = $0 {
@@ -221,7 +222,7 @@ private class MessageSendingQueue<ExtraData: ExtraDataTypes> {
             }
         }, completion: {
             if let error = $0 {
-                log.error("Error changin localMessageState message with id \(id) to `sendingFailed`: \(error)")
+                log.error("Error changing localMessageState message with id \(id) to `sendingFailed`: \(error)")
             }
             completion()
         })

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -135,6 +135,7 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
                 showReplyInChannel: false,
                 isSilent: isSilent,
                 quotedMessageId: quotedMessageId,
+                createdAt: nil,
                 extraData: extraData
             )
             

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -151,6 +151,7 @@ class MessageUpdater<ExtraData: ExtraDataTypes>: Worker {
                 showReplyInChannel: showReplyInChannel,
                 isSilent: isSilent,
                 quotedMessageId: quotedMessageId,
+                createdAt: nil,
                 extraData: extraData
             )
             

--- a/Tests/Shared/TemporaryData.swift
+++ b/Tests/Shared/TemporaryData.swift
@@ -63,8 +63,8 @@ extension Date {
     static var unique: Date { Date(timeIntervalSince1970: .random(in: 1_000_000...1_500_000_000)) }
 
     /// Returns a new random date before the provided date
-    static func unique(before date: Date) -> Date {
-        Date(timeIntervalSince1970: .random(in: Date.distantPast.timeIntervalSince1970..<date.timeIntervalSince1970 - 1))
+    static func unique(before date: Date, after: Date = Date.distantPast) -> Date {
+        Date(timeIntervalSince1970: .random(in: after.timeIntervalSince1970..<date.timeIntervalSince1970 - 1))
     }
 
     /// Returns a new random date after the provided date


### PR DESCRIPTION
[Fixes #1231]

We didn't reset `locallyCreatedAt` value after the message was sent which was causing the wrong ordering of the messages when the local time was different from the server time.

I also added an artificial time offset for the unsent messages sorting key such that the most recent message is always at the bottom of the list.
