### PR TITLE
[CIS-989] Expose extra data on built-in attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ⚠️ Breaking Changes from `4.0-beta.4`
 - The `CreateChatChannelButton` component was removed. The component acted only as a placeholder and the functionality should be always provided by the hosting app. For an example implementation see the [Demo app](https://github.com/GetStream/stream-chat-swift/blob/main/DemoApp/ChatPresenter.swift).
+- The payload of `AnyChatMessageAttachment` changed from `Any` to `Data` [#1248](https://github.com/GetStream/stream-chat-swift/pull/1248).
 
 ### ✅ Added
 - `search(query:)` function to `UserSearchController` to make a custom search with a query [#1206](https://github.com/GetStream/stream-chat-swift/issues/1206)
@@ -16,6 +17,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   -  `connectUser`
   -  `connectGuestUser`
   -  `connectAnonymousUser`
+- Extra data support for `.image/.video/.file` attachments [#1248](https://github.com/GetStream/stream-chat-swift/pull/1248):
+1. Declare custom extra data type conforming to `Codable`:
+```swift
+struct CommentPayload: Codable {
+    let comment: String
+}
+```
+2. Create an instance of extra data and provide it to an envelope for `.image/.video/.file` attachment:
+```swift
+let commentPayload = CommentPayload(comment: "Happy birthday! 🎉")
+let envelope = try AnyAttachmentEnvelope(localFileURL: *url*, attachmentType: .image, extraData: commentPayload)
+channelController.createNewMessage(..., attachments: [envelope])
+```
+3. Receive extra data back from attachment:
+```swift
+if let commentPayload = message.imageAttachments.first?.extraData(ofType: CommentPayload.self) {
+    print(commentPayload.comment") // Happy birthday! 🎉
+}
+```
 
 ### 🔄 Changed
 - `shouldConnectAutomatically` setting in `ChatConfig`, it now has no effect and all logic that used it now behaves like it was set to `true`.

--- a/Package.swift
+++ b/Package.swift
@@ -145,6 +145,7 @@ var streamChatSourcesExcluded: [String] { [
     "Models/Attachments/AttachmentTypes_Tests.swift",
     "Models/Attachments/AttachmentId_Tests.swift",
     "Models/Attachments/AnyAttachmentPayload_Tests.swift",
+    "Models/Attachments/FileAttachmentPayload_Tests.swift",
     "Models/Attachments/VideoAttachmentPayload_Tests.swift",
     "Models/Attachments/ChatMessageAttachment_Tests.swift",
     "Models/Attachments/ImageAttachmentPayload_Tests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -146,6 +146,7 @@ var streamChatSourcesExcluded: [String] { [
     "Models/Attachments/AttachmentId_Tests.swift",
     "Models/Attachments/AnyAttachmentPayload_Tests.swift",
     "Models/Attachments/ChatMessageAttachment_Tests.swift",
+    "Models/Attachments/ImageAttachmentPayload_Tests.swift",
     "Models/ChatMessage_Tests.swift",
     "Workers/Background/NewChannelQueryUpdater_Tests.swift",
     "Workers/Background/AttachmentUploader_Tests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -145,6 +145,7 @@ var streamChatSourcesExcluded: [String] { [
     "Models/Attachments/AttachmentTypes_Tests.swift",
     "Models/Attachments/AttachmentId_Tests.swift",
     "Models/Attachments/AnyAttachmentPayload_Tests.swift",
+    "Models/Attachments/VideoAttachmentPayload_Tests.swift",
     "Models/Attachments/ChatMessageAttachment_Tests.swift",
     "Models/Attachments/ImageAttachmentPayload_Tests.swift",
     "Models/ChatMessage_Tests.swift",

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -154,66 +154,17 @@ private extension AttachmentDTO {
             return nil
         }
     }
-
-    func asModel<T: Decodable>(payloadType: T.Type = T.self) -> _ChatMessageAttachment<T>? {
-        guard
-            let payload = payload(ofType: payloadType)
-        else { return nil }
-
-        return .init(
-            id: attachmentID,
-            type: attachmentType,
-            payload: payload,
-            uploadingState: uploadingState
-        )
-    }
-
-    /// Helper decoding method that logs error only if object exists.
-    /// Returns `nil` if `Data` for decoding is `nil`.
-    func payload<T: Decodable>(ofType type: T.Type = T.self) -> T? {
-        do {
-            return try JSONDecoder.default.decode(type, from: data)
-        } catch {
-            log.error(
-                "Failed to decode attachment of type:\(type) with hash: <\(id)>, "
-                    + "falling back to ChatMessageCustomAttachment."
-                    + "Error: \(error)"
-            )
-            return nil
-        }
-    }
 }
 
 extension AttachmentDTO {
     /// Snapshots the current state of `AttachmentDTO` and returns an immutable model object from it.
-    func asAnyModel() -> AnyChatMessageAttachment? {
-        let attachment: AnyChatMessageAttachment?
-
-        switch attachmentType {
-        case .image:
-            attachment = asModel(payloadType: ImageAttachmentPayload.self)?.asAnyAttachment
-        case .file:
-            attachment = asModel(payloadType: FileAttachmentPayload.self)?.asAnyAttachment
-        case .video:
-            attachment = asModel(payloadType: VideoAttachmentPayload.self)?.asAnyAttachment
-        case .giphy:
-            attachment = asModel(payloadType: GiphyAttachmentPayload.self)?.asAnyAttachment
-        case .linkPreview:
-            attachment = asModel(payloadType: LinkAttachmentPayload.self)?.asAnyAttachment
-        default:
-            attachment = .init(
-                id: attachmentID,
-                type: attachmentType,
-                payload: data,
-                uploadingState: uploadingState
-            )
-        }
-
-        if attachment == nil {
-            log.error("Failed to decode attachment of type: \(attachmentType)")
-        }
-
-        return attachment
+    func asAnyModel() -> AnyChatMessageAttachment {
+        .init(
+            id: attachmentID,
+            type: attachmentType,
+            payload: data,
+            uploadingState: uploadingState
+        )
     }
     
     /// Snapshots the current state of `AttachmentDTO` and returns its representation for used in API calls.
@@ -231,41 +182,34 @@ extension AttachmentDTO {
     }
 
     func update(uploadedFileURL: URL) {
+        let attachment = asAnyModel()
         let updatedPayload: AnyEncodable
-        switch attachmentType {
-        case .image:
-            guard var image: ImageAttachmentPayload = payload() else {
-                log.assertionFailure(
-                    "Image payload must be decoded to provide the `imageURL` before sending"
-                )
-                return
-            }
-            image.imageURL = uploadedFileURL
-            updatedPayload = image.asAnyEncodable
-        case .video:
-            guard var video: VideoAttachmentPayload = payload() else {
-                log.assertionFailure(
-                    "Video payload must be decoded to provide the `videoURL` before sending"
-                )
-                return
-            }
-            video.videoURL = uploadedFileURL
-            updatedPayload = video.asAnyEncodable
-        default:
-            guard var file: FileAttachmentPayload = payload() else {
-                log.assertionFailure(
-                    "File payload must be decoded to provide the `assetURL` before sending"
-                )
-                return
-            }
-            file.assetURL = uploadedFileURL
-            updatedPayload = file.asAnyEncodable
+        
+        if let image = attachment.attachment(payloadType: ImageAttachmentPayload.self) {
+            var payload = image.payload
+            payload.imageURL = uploadedFileURL
+            updatedPayload = payload.asAnyEncodable
+        } else if let video = attachment.attachment(payloadType: VideoAttachmentPayload.self) {
+            var payload = video.payload
+            payload.videoURL = uploadedFileURL
+            updatedPayload = payload.asAnyEncodable
+        } else if let file = attachment.attachment(payloadType: FileAttachmentPayload.self) {
+            var payload = file.payload
+            payload.assetURL = uploadedFileURL
+            updatedPayload = payload.asAnyEncodable
+        } else {
+            log.assertionFailure(
+                "Attachment of type \(attachment.type) is not supposed to be updated with uploaded file URL."
+            )
+            return
         }
         
         do {
             data = try JSONEncoder.stream.encode(updatedPayload)
         } catch {
-            log.assertionFailure("Failed to encode updated payload.")
+            log.assertionFailure(
+                "Failed to encode updated payload for attachment with id \(attachmentID) after uploading."
+            )
         }
     }
 }

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
@@ -45,7 +45,7 @@ class AttachmentDTO_Tests: XCTestCase {
         let imagePayload = attachment.decodedImagePayload
         let imageAttachmentModel = try XCTUnwrap(
             loadedAttachment
-                .asAnyModel()?
+                .asAnyModel()
                 .attachment(payloadType: ImageAttachmentPayload.self)
         )
 
@@ -80,7 +80,7 @@ class AttachmentDTO_Tests: XCTestCase {
         let giphyPayload = attachment.decodedGiphyPayload
         let giphyAttachmentWithActionsPayload = try XCTUnwrap(
             loadedAttachment
-                .asAnyModel()?
+                .asAnyModel()
                 .attachment(payloadType: GiphyAttachmentPayload.self)
         )
 
@@ -115,7 +115,7 @@ class AttachmentDTO_Tests: XCTestCase {
         let giphyPayload = attachment.decodedGiphyPayload
         let giphyAttachmentWithoutActionsPayload = try XCTUnwrap(
             loadedAttachment
-                .asAnyModel()?
+                .asAnyModel()
                 .attachment(payloadType: GiphyAttachmentPayload.self)
         )
 
@@ -150,7 +150,7 @@ class AttachmentDTO_Tests: XCTestCase {
 
         let fileAttachment = try XCTUnwrap(
             loadedAttachment
-                .asAnyModel()?
+                .asAnyModel()
                 .attachment(payloadType: FileAttachmentPayload.self)
         )
 
@@ -189,7 +189,7 @@ class AttachmentDTO_Tests: XCTestCase {
 
         let attachmentModel = try XCTUnwrap(
             loadedAttachment
-                .asAnyModel()?
+                .asAnyModel()
                 .attachment(payloadType: TestAttachmentPayload.self)
         )
 

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -585,7 +585,7 @@ private extension _ChatMessage {
         $_author = ({ dto.user.asModel() }, dto.managedObjectContext)
         $_attachments = ({
             dto.attachments
-                .compactMap { $0.asAnyModel() }
+                .map { $0.asAnyModel() }
                 .sorted { $0.id.index < $1.id.index }
         }, dto.managedObjectContext)
         

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="20C69" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
-        <attribute name="data" optional="YES" attributeType="Binary"/>
+        <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="localProgress" optional="YES" attributeType="Double" minValueString="0" maxValueString="1" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="localStateRaw" optional="YES" attributeType="String" defaultValueString=""/>

--- a/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload.swift
+++ b/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload.swift
@@ -19,7 +19,7 @@ public struct AnyAttachmentPayload {
     public let type: AttachmentType
 
     /// A payload that will exposed on attachment when the message is sent.
-    public let payload: Encodable?
+    public let payload: Encodable
 
     /// A URL referencing to the local file that should be uploaded.
     public let localFileURL: URL?

--- a/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload.swift
+++ b/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload.swift
@@ -52,13 +52,23 @@ public extension AnyAttachmentPayload {
     /// available on `ChatMessage` with the `uploadingState` reflecting the file uploading progress.
     ///
     /// - Important: Until the message is sent all URLs on exposed attachment will be equal to the given `localFileURL`.
+    /// - Important: A given extra data must have dictionary representation.
     ///
     /// - Parameters:
     ///   - localFileURL: The local URL referencing to the file.
     ///   - attachmentType: The type of resulting attachment exposed on the message.
-    /// - Throws: The error if `localFileURL` is not the file URL.
-    init(localFileURL: URL, attachmentType: AttachmentType) throws {
+    ///   - extraData: An extra data that should be added to attachment.
+    /// - Throws: The error if `localFileURL` is not the file URL or if `extraData` can not be represented as
+    /// a dictionary.
+    init(
+        localFileURL: URL,
+        attachmentType: AttachmentType,
+        extraData: Encodable? = nil
+    ) throws {
         let file = try AttachmentFile(url: localFileURL)
+        let extraData = try extraData
+            .flatMap { try JSONEncoder.stream.encode($0.asAnyEncodable) }
+            .flatMap { try JSONDecoder.stream.decode([String: RawJSON].self, from: $0) }
 
         let payload: AttachmentPayload
         switch attachmentType {
@@ -66,19 +76,22 @@ public extension AnyAttachmentPayload {
             payload = ImageAttachmentPayload(
                 title: localFileURL.lastPathComponent,
                 imageURL: localFileURL,
-                imagePreviewURL: localFileURL
+                imagePreviewURL: localFileURL,
+                extraData: extraData
             )
         case .video:
             payload = VideoAttachmentPayload(
                 title: localFileURL.lastPathComponent,
                 videoURL: localFileURL,
-                file: file
+                file: file,
+                extraData: extraData
             )
         case .file:
             payload = FileAttachmentPayload(
                 title: localFileURL.lastPathComponent,
                 assetURL: localFileURL,
-                file: file
+                file: file,
+                extraData: extraData
             )
         default:
             throw ClientError.UnsupportedUploadableAttachmentType(attachmentType)

--- a/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload.swift
+++ b/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload.swift
@@ -101,3 +101,19 @@ extension ClientError {
         }
     }
 }
+
+extension AttachmentPayload {
+    static func decodeExtraData(from decoder: Decoder) throws -> [String: RawJSON]? {
+        guard case let .dictionary(payload) = try RawJSON(from: decoder) else {
+            throw ClientError.AttachmentDecoding("Failed to decode extra data.")
+        }
+        
+        let customPayload = payload.removingValues(
+            forKeys:
+            AttachmentCodingKeys.allCases.map(\.rawValue) +
+                AttachmentFile.CodingKeys.allCases.map(\.rawValue)
+        )
+        
+        return customPayload.isEmpty ? nil : customPayload
+    }
+}

--- a/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload_Tests.swift
+++ b/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload_Tests.swift
@@ -11,62 +11,53 @@ final class AnyAttachmentPayload_Tests: XCTestCase {
         // Create any image payload.
         let url: URL = .localYodaImage
         let type: AttachmentType = .image
-        let anyPayload = try AnyAttachmentPayload(localFileURL: url, attachmentType: type)
+        let extraData = PhotoMetadata.random
+        let anyPayload = try AnyAttachmentPayload(localFileURL: url, attachmentType: type, extraData: extraData)
         
         // Assert any payload fields are correct.
+        let payload = try XCTUnwrap(anyPayload.payload as? ImageAttachmentPayload)
         XCTAssertEqual(anyPayload.type, type)
         XCTAssertEqual(anyPayload.localFileURL, url)
-        XCTAssertEqual(
-            anyPayload.payload as? ImageAttachmentPayload,
-            .init(
-                title: url.lastPathComponent,
-                imageURL: url,
-                imagePreviewURL: url,
-                extraData: [:]
-            )
-        )
+        XCTAssertEqual(payload.title, url.lastPathComponent)
+        XCTAssertEqual(payload.imageURL, url)
+        XCTAssertEqual(payload.imagePreviewURL, url)
+        XCTAssertEqual(payload.extraData(), extraData)
     }
     
     func test_whenInitWithVideoAttachmentType_payloadIsVideo() throws {
         // Create any video payload.
         let url: URL = .localYodaImage
         let type: AttachmentType = .video
-        let anyPayload = try AnyAttachmentPayload(localFileURL: url, attachmentType: type)
-        
+        let extraData = PhotoMetadata.random
+        let anyPayload = try AnyAttachmentPayload(localFileURL: url, attachmentType: type, extraData: extraData)
+
         // Assert any payload fields are correct.
+        let payload = try XCTUnwrap(anyPayload.payload as? VideoAttachmentPayload)
         XCTAssertEqual(anyPayload.type, type)
         XCTAssertEqual(anyPayload.localFileURL, url)
-        XCTAssertEqual(
-            anyPayload.payload as? VideoAttachmentPayload,
-            .init(
-                title: url.lastPathComponent,
-                videoURL: url,
-                file: try AttachmentFile(url: url),
-                extraData: [:]
-            )
-        )
+        XCTAssertEqual(payload.title, url.lastPathComponent)
+        XCTAssertEqual(payload.videoURL, url)
+        XCTAssertEqual(payload.file, try AttachmentFile(url: url))
+        XCTAssertEqual(payload.extraData(), extraData)
     }
-    
+
     func test_whenInitWithFileAttachmentType_payloadIsFile() throws {
         // Create any file payload.
         let url: URL = .localYodaQuote
         let type: AttachmentType = .file
-        let anyPayload = try AnyAttachmentPayload(localFileURL: url, attachmentType: type)
-        
+        let extraData = PhotoMetadata.random
+        let anyPayload = try AnyAttachmentPayload(localFileURL: url, attachmentType: type, extraData: extraData)
+
         // Assert any payload fields are correct.
+        let payload = try XCTUnwrap(anyPayload.payload as? FileAttachmentPayload)
         XCTAssertEqual(anyPayload.type, type)
         XCTAssertEqual(anyPayload.localFileURL, url)
-        XCTAssertEqual(
-            anyPayload.payload as? FileAttachmentPayload,
-            .init(
-                title: url.lastPathComponent,
-                assetURL: url,
-                file: try AttachmentFile(url: url),
-                extraData: [:]
-            )
-        )
+        XCTAssertEqual(payload.title, url.lastPathComponent)
+        XCTAssertEqual(payload.assetURL, url)
+        XCTAssertEqual(payload.file, try AttachmentFile(url: url))
+        XCTAssertEqual(payload.extraData(), extraData)
     }
-    
+
     func test_whenInitWithCustomAttachmentType_errorIsThrown() {
         XCTAssertThrowsError(
             // Try to create uploadable attachment with custom type
@@ -77,5 +68,38 @@ final class AnyAttachmentPayload_Tests: XCTestCase {
         ) { error in
             XCTAssertTrue(error is ClientError.UnsupportedUploadableAttachmentType)
         }
+    }
+
+    func test_whenInitWithNonDictionaryRepresentableExtraData_errorIsThrown() {
+        struct MyCustomExtraData {}
+
+        XCTAssertThrowsError(
+            // Try to create uploadable attachment with invalid extra data
+            try AnyAttachmentPayload(
+                localFileURL: .localYodaQuote,
+                attachmentType: .init(rawValue: .unique),
+                extraData: String.unique
+            )
+        )
+    }
+}
+
+private struct PhotoMetadata: Codable, Equatable {
+    struct Location: Codable, Equatable {
+        let longitude: Double
+        let latitude: Double
+    }
+    
+    let location: Location
+    let comment: String
+    
+    static var random: Self {
+        .init(
+            location: .init(
+                longitude: .random(in: 0...100),
+                latitude: .random(in: 0...100)
+            ),
+            comment: .unique
+        )
     }
 }

--- a/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload_Tests.swift
+++ b/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload_Tests.swift
@@ -21,7 +21,8 @@ final class AnyAttachmentPayload_Tests: XCTestCase {
             .init(
                 title: url.lastPathComponent,
                 imageURL: url,
-                imagePreviewURL: url
+                imagePreviewURL: url,
+                extraData: [:]
             )
         )
     }

--- a/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload_Tests.swift
+++ b/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload_Tests.swift
@@ -41,7 +41,8 @@ final class AnyAttachmentPayload_Tests: XCTestCase {
             .init(
                 title: url.lastPathComponent,
                 videoURL: url,
-                file: try AttachmentFile(url: url)
+                file: try AttachmentFile(url: url),
+                extraData: [:]
             )
         )
     }

--- a/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload_Tests.swift
+++ b/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload_Tests.swift
@@ -61,7 +61,8 @@ final class AnyAttachmentPayload_Tests: XCTestCase {
             .init(
                 title: url.lastPathComponent,
                 assetURL: url,
-                file: try AttachmentFile(url: url)
+                file: try AttachmentFile(url: url),
+                extraData: [:]
             )
         )
     }

--- a/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
+++ b/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
@@ -233,26 +233,6 @@ public enum AttachmentFileType: String, Codable, Equatable, CaseIterable {
     }
 }
 
-extension String {
-    var attachmentFixedURL: URL? {
-        if let url = URL(string: self), url.isFileURL {
-            return url
-        }
-
-        var urlString = self
-        
-        if urlString.hasPrefix("//") {
-            urlString = "https:\(urlString)"
-        }
-        
-        if !urlString.lowercased().hasPrefix("http") {
-            urlString = "https://\(urlString)"
-        }
-        
-        return URL(string: urlString)
-    }
-}
-
 extension ClientError {
     class InvalidAttachmentFileURL: ClientError {
         init(_ url: URL) {

--- a/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
+++ b/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
@@ -112,7 +112,7 @@ public extension AttachmentType {
 
 /// An attachment file description.
 public struct AttachmentFile: Codable, Hashable {
-    private enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey, CaseIterable {
         case mimeType = "mime_type"
         case size = "file_size"
     }

--- a/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
+++ b/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-enum AttachmentCodingKeys: String, CodingKey {
+enum AttachmentCodingKeys: String, CodingKey, CaseIterable {
     case title
     case type
     case image

--- a/Sources/StreamChat/Models/Attachments/ChatMessageAttachment_Tests.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageAttachment_Tests.swift
@@ -29,7 +29,11 @@ final class ChatMessageAttachment_Tests: XCTestCase {
         // Assert type-erased attachment has correct values.
         XCTAssertEqual(typeErasedAttachment.id, fileAttachment.id)
         XCTAssertEqual(typeErasedAttachment.type, fileAttachment.type)
-        XCTAssertEqual(typeErasedAttachment.payload as! FileAttachmentPayload, fileAttachment.payload)
+        XCTAssertEqual(
+            try JSONDecoder.stream
+                .decode(FileAttachmentPayload.self, from: typeErasedAttachment.payload),
+            fileAttachment.payload
+        )
         XCTAssertEqual(typeErasedAttachment.uploadingState, fileAttachment.uploadingState)
     }
 
@@ -55,7 +59,7 @@ final class ChatMessageAttachment_Tests: XCTestCase {
         let fileAttachmentPayload = FileAttachmentPayload(
             title: .unique,
             assetURL: .unique(),
-            file: .init(type: .csv, size: 256, mimeType: .unique)
+            file: .init(type: .csv, size: 256, mimeType: "text/csv")
         )
 
         // Create attachment with file payload but `unknown` type.
@@ -86,12 +90,12 @@ final class ChatMessageAttachment_Tests: XCTestCase {
         let joke = Joke(joke: .unique)
 
         // Create attachment with raw joke data and `unknown` type.
-        let typeErasedAttachment = _ChatMessageAttachment(
+        let typeErasedAttachment = AnyChatMessageAttachment(
             id: .unique,
             type: .unknown,
             payload: try JSONEncoder().encode(joke),
             uploadingState: try .mock()
-        ).asAnyAttachment
+        )
 
         // Assert we are able to decode joke attachment in the given conditions.
         let jokeAttachment: _ChatMessageAttachment<Joke> = .init(

--- a/Sources/StreamChat/Models/Attachments/ChatMessageAttachment_Tests.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageAttachment_Tests.swift
@@ -59,7 +59,8 @@ final class ChatMessageAttachment_Tests: XCTestCase {
         let fileAttachmentPayload = FileAttachmentPayload(
             title: .unique,
             assetURL: .unique(),
-            file: .init(type: .csv, size: 256, mimeType: "text/csv")
+            file: .init(type: .csv, size: 256, mimeType: "text/csv"),
+            extraData: nil
         )
 
         // Create attachment with file payload but `unknown` type.

--- a/Sources/StreamChat/Models/Attachments/ChatMessageFileAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageFileAttachment.swift
@@ -43,18 +43,10 @@ extension FileAttachmentPayload: Encodable {
 extension FileAttachmentPayload: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: AttachmentCodingKeys.self)
-
-        guard
-            let assetURL = try container
-            .decodeIfPresent(String.self, forKey: .assetURL)?
-            .attachmentFixedURL
-        else {
-            throw ClientError.AttachmentDecoding("File attachment must contain `assetURL`")
-        }
-
+        
         self.init(
             title: try container.decodeIfPresent(String.self, forKey: .title),
-            assetURL: assetURL,
+            assetURL: try container.decode(URL.self, forKey: .assetURL),
             file: try AttachmentFile(from: decoder)
         )
     }

--- a/Sources/StreamChat/Models/Attachments/ChatMessageFileAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageFileAttachment.swift
@@ -22,6 +22,17 @@ public struct FileAttachmentPayload: AttachmentPayload {
     public internal(set) var assetURL: URL
     /// The file itself.
     public let file: AttachmentFile
+    /// An extra data.
+    let extraData: [String: RawJSON]?
+    
+    /// Decodes extra data as an instance of the given type.
+    /// - Parameter ofType: The type an extra data should be decoded as.
+    /// - Returns: Extra data of the given type or `nil` if decoding fails.
+    public func extraData<T: Decodable>(ofType: T.Type = T.self) -> T? {
+        extraData
+            .flatMap { try? JSONEncoder.stream.encode($0) }
+            .flatMap { try? JSONDecoder.stream.decode(T.self, from: $0) }
+    }
 }
 
 extension FileAttachmentPayload: Equatable {}
@@ -30,11 +41,12 @@ extension FileAttachmentPayload: Equatable {}
 
 extension FileAttachmentPayload: Encodable {
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: AttachmentCodingKeys.self)
-
-        try container.encode(title, forKey: .title)
-        try container.encode(assetURL, forKey: .assetURL)
-        try file.encode(to: encoder)
+        var values = extraData ?? [:]
+        values[AttachmentCodingKeys.title.rawValue] = title.map { .string($0) }
+        values[AttachmentCodingKeys.assetURL.rawValue] = .string(assetURL.absoluteString)
+        values[AttachmentFile.CodingKeys.size.rawValue] = .integer(Int(file.size))
+        values[AttachmentFile.CodingKeys.mimeType.rawValue] = file.mimeType.map { .string($0) }
+        try values.encode(to: encoder)
     }
 }
 
@@ -47,7 +59,8 @@ extension FileAttachmentPayload: Decodable {
         self.init(
             title: try container.decodeIfPresent(String.self, forKey: .title),
             assetURL: try container.decode(URL.self, forKey: .assetURL),
-            file: try AttachmentFile(from: decoder)
+            file: try AttachmentFile(from: decoder),
+            extraData: try Self.decodeExtraData(from: decoder)
         )
     }
 }

--- a/Sources/StreamChat/Models/Attachments/ChatMessageGiphyAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageGiphyAttachment.swift
@@ -42,16 +42,10 @@ extension GiphyAttachmentPayload: Encodable {
 extension GiphyAttachmentPayload: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: AttachmentCodingKeys.self)
-
-        guard
-            let previewURL = try container
-            .decodeIfPresent(String.self, forKey: .thumbURL)?
-            .attachmentFixedURL
-        else { throw ClientError.AttachmentDecoding() }
-
+        
         self.init(
             title: try container.decode(String.self, forKey: .title),
-            previewURL: previewURL,
+            previewURL: try container.decode(URL.self, forKey: .thumbURL),
             actions: try container.decodeIfPresent([AttachmentAction].self, forKey: .actions) ?? []
         )
     }

--- a/Sources/StreamChat/Models/Attachments/ChatMessageImageAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageImageAttachment.swift
@@ -43,18 +43,11 @@ extension ImageAttachmentPayload: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: AttachmentCodingKeys.self)
 
-        guard
-            let imageURL = (
-                try container.decodeIfPresent(String.self, forKey: .image)
-                    ?? container.decodeIfPresent(String.self, forKey: .imageURL)
-                    ?? container.decodeIfPresent(String.self, forKey: .assetURL)
-            )?.attachmentFixedURL
-        else { throw ClientError.AttachmentDecoding() }
+        let imageURL = try
+            container.decodeIfPresent(URL.self, forKey: .image) ??
+            container.decodeIfPresent(URL.self, forKey: .imageURL) ??
+            container.decode(URL.self, forKey: .assetURL)
         
-        let imagePreviewURL = try container
-            .decodeIfPresent(String.self, forKey: .thumbURL)?
-            .attachmentFixedURL
-
         let title = (
             try container.decodeIfPresent(String.self, forKey: .title) ??
                 container.decodeIfPresent(String.self, forKey: .fallback) ??
@@ -64,7 +57,7 @@ extension ImageAttachmentPayload: Decodable {
         self.init(
             title: title,
             imageURL: imageURL,
-            imagePreviewURL: imagePreviewURL ?? imageURL
+            imagePreviewURL: try container.decodeIfPresent(URL.self, forKey: .thumbURL) ?? imageURL
         )
     }
 }

--- a/Sources/StreamChat/Models/Attachments/ChatMessageLinkAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageLinkAttachment.swift
@@ -56,36 +56,23 @@ extension LinkAttachmentPayload: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: AttachmentCodingKeys.self)
 
-        guard
-            let originalURL = try container
-            .decode(String.self, forKey: .ogURL)
-            .attachmentFixedURL,
-            let assetURL = (
-                try container.decodeIfPresent(String.self, forKey: .imageURL) ??
-                    container.decodeIfPresent(String.self, forKey: .image) ??
-                    container.decodeIfPresent(String.self, forKey: .assetURL)
-            )?.attachmentFixedURL
-        else {
-            throw ClientError.AttachmentDecoding("Link attachment must contain `originalURL` and `assetURL`")
-        }
+        let assetURL = try
+            container.decodeIfPresent(URL.self, forKey: .imageURL) ??
+            container.decodeIfPresent(URL.self, forKey: .image) ??
+            container.decode(URL.self, forKey: .assetURL)
 
         self.init(
-            originalURL: originalURL,
+            originalURL: try container.decode(URL.self, forKey: .ogURL),
             title: try container
                 .decodeIfPresent(String.self, forKey: .title)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
             text: try container
                 .decodeIfPresent(String.self, forKey: .text)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
-            author: try container
-                .decodeIfPresent(String.self, forKey: .author),
-            titleLink: try container
-                .decodeIfPresent(String.self, forKey: .titleLink)?
-                .attachmentFixedURL,
+            author: try container.decodeIfPresent(String.self, forKey: .author),
+            titleLink: try container.decodeIfPresent(URL.self, forKey: .titleLink),
             assetURL: assetURL,
-            previewURL: try container
-                .decodeIfPresent(String.self, forKey: .thumbURL)?
-                .attachmentFixedURL ?? assetURL
+            previewURL: try container.decodeIfPresent(URL.self, forKey: .thumbURL) ?? assetURL
         )
     }
 }

--- a/Sources/StreamChat/Models/Attachments/ChatMessageVideoAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageVideoAttachment.swift
@@ -22,6 +22,17 @@ public struct VideoAttachmentPayload: AttachmentPayload {
     public internal(set) var videoURL: URL
     /// The video itself.
     public let file: AttachmentFile
+    /// An extra data.
+    let extraData: [String: RawJSON]?
+    
+    /// Decodes extra data as an instance of the given type.
+    /// - Parameter ofType: The type an extra data should be decoded as.
+    /// - Returns: Extra data of the given type or `nil` if decoding fails.
+    public func extraData<T: Decodable>(ofType: T.Type = T.self) -> T? {
+        extraData
+            .flatMap { try? JSONEncoder.stream.encode($0) }
+            .flatMap { try? JSONDecoder.stream.decode(T.self, from: $0) }
+    }
 }
 
 extension VideoAttachmentPayload: Equatable {}
@@ -30,11 +41,12 @@ extension VideoAttachmentPayload: Equatable {}
 
 extension VideoAttachmentPayload: Encodable {
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: AttachmentCodingKeys.self)
-
-        try container.encode(title, forKey: .title)
-        try container.encode(videoURL, forKey: .assetURL)
-        try file.encode(to: encoder)
+        var values = extraData ?? [:]
+        values[AttachmentCodingKeys.title.rawValue] = title.map { .string($0) }
+        values[AttachmentCodingKeys.assetURL.rawValue] = .string(videoURL.absoluteString)
+        values[AttachmentFile.CodingKeys.size.rawValue] = .integer(Int(file.size))
+        values[AttachmentFile.CodingKeys.mimeType.rawValue] = file.mimeType.map { .string($0) }
+        try values.encode(to: encoder)
     }
 }
 
@@ -47,7 +59,8 @@ extension VideoAttachmentPayload: Decodable {
         self.init(
             title: try container.decodeIfPresent(String.self, forKey: .title),
             videoURL: try container.decode(URL.self, forKey: .assetURL),
-            file: try AttachmentFile(from: decoder)
+            file: try AttachmentFile(from: decoder),
+            extraData: try Self.decodeExtraData(from: decoder)
         )
     }
 }

--- a/Sources/StreamChat/Models/Attachments/ChatMessageVideoAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageVideoAttachment.swift
@@ -43,18 +43,10 @@ extension VideoAttachmentPayload: Encodable {
 extension VideoAttachmentPayload: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: AttachmentCodingKeys.self)
-
-        guard
-            let assetURL = try container
-            .decodeIfPresent(String.self, forKey: .assetURL)?
-            .attachmentFixedURL
-        else {
-            throw ClientError.AttachmentDecoding("Video attachment must contain `assetURL`")
-        }
-
+        
         self.init(
             title: try container.decodeIfPresent(String.self, forKey: .title),
-            videoURL: assetURL,
+            videoURL: try container.decode(URL.self, forKey: .assetURL),
             file: try AttachmentFile(from: decoder)
         )
     }

--- a/Sources/StreamChat/Models/Attachments/FileAttachmentPayload_Tests.swift
+++ b/Sources/StreamChat/Models/Attachments/FileAttachmentPayload_Tests.swift
@@ -1,0 +1,70 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import StreamChatTestTools
+import XCTest
+
+final class FileAttachmentPayload_Tests: XCTestCase {
+    func test_decodingDefaultValues() throws {
+        // Create attachment field values.
+        let title: String = .unique
+        let assetURL: URL = .localYodaImage
+        let file = AttachmentFile(type: .mp4, size: 10 * 1024 * 1024, mimeType: "video/mp4")
+        
+        // Create JSON with the given values.
+        let json = """
+        {
+            "title": "\(title)",
+            "asset_url": "\(assetURL.absoluteString)",
+            "file_size": \(file.size),
+            "mime_type": "\(file.mimeType!)"
+        }
+        """.data(using: .utf8)!
+        
+        // Decode attachment from JSON.
+        let payload = try JSONDecoder.stream.decode(FileAttachmentPayload.self, from: json)
+        
+        // Assert default values are decoded correctly.
+        XCTAssertEqual(payload.title, title)
+        XCTAssertEqual(payload.assetURL, assetURL)
+        XCTAssertEqual(payload.file, file)
+        XCTAssertEqual(payload.extraData, nil)
+    }
+    
+    func test_decodingExtraData() throws {
+        struct ExtraData: Codable {
+            let comment: String
+        }
+        
+        // Create attachment field values.
+        let title: String = .unique
+        let assetURL: URL = .localYodaImage
+        let file = AttachmentFile(type: .mp4, size: 10 * 1024 * 1024, mimeType: "video/mp4")
+        let comment: String = .unique
+        
+        // Create JSON with the given values.
+        let json = """
+        {
+            "title": "\(title)",
+            "asset_url": "\(assetURL.absoluteString)",
+            "file_size": \(file.size),
+            "mime_type": "\(file.mimeType!)",
+            "comment": "\(comment)"
+        }
+        """.data(using: .utf8)!
+        
+        // Decode attachment from JSON.
+        let payload = try JSONDecoder.stream.decode(FileAttachmentPayload.self, from: json)
+        
+        // Assert default values are decoded correctly.
+        XCTAssertEqual(payload.title, title)
+        XCTAssertEqual(payload.assetURL, assetURL)
+        XCTAssertEqual(payload.file, file)
+        
+        // Assert extra data can be decoded.
+        let extraData = try XCTUnwrap(payload.extraData(ofType: ExtraData.self))
+        XCTAssertEqual(extraData.comment, comment)
+    }
+}

--- a/Sources/StreamChat/Models/Attachments/ImageAttachmentPayload_Tests.swift
+++ b/Sources/StreamChat/Models/Attachments/ImageAttachmentPayload_Tests.swift
@@ -1,0 +1,68 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import StreamChatTestTools
+import XCTest
+
+final class ImageAttachmentPayload_Tests: XCTestCase {
+    func test_decodingDefaultValues() throws {
+        // Create attachment field values.
+        let title: String = .unique
+        let imageURL: URL = .unique()
+        let thumbURL: URL = .unique()
+        
+        // Create JSON with the given values.
+        let json = """
+        {
+            "title": "\(title)",
+            "image_url": "\(imageURL.absoluteString)",
+            "thumb_url": "\(thumbURL.absoluteString)"
+        }
+        """.data(using: .utf8)!
+        
+        // Decode attachment from JSON.
+        let payload = try JSONDecoder.stream.decode(ImageAttachmentPayload.self, from: json)
+        
+        // Assert values are decoded correctly.
+        XCTAssertEqual(payload.title, title)
+        XCTAssertEqual(payload.imageURL, imageURL)
+        XCTAssertEqual(payload.imagePreviewURL, thumbURL)
+        XCTAssertNil(payload.extraData)
+    }
+    
+    func test_decodingExtraData() throws {
+        struct ExtraData: Codable {
+            let comment: String
+        }
+        
+        // Create attachment field values.
+        let title: String = .unique
+        let imageURL: URL = .unique()
+        let thumbURL: URL = .unique()
+        let comment: String = .unique
+        
+        // Create JSON with the given values.
+        let json = """
+        {
+            "title": "\(title)",
+            "image_url": "\(imageURL.absoluteString)",
+            "thumb_url": "\(thumbURL.absoluteString)",
+            "comment": "\(comment)"
+        }
+        """.data(using: .utf8)!
+        
+        // Decode attachment from JSON.
+        let payload = try JSONDecoder.stream.decode(ImageAttachmentPayload.self, from: json)
+        
+        // Assert values are decoded correctly.
+        XCTAssertEqual(payload.title, title)
+        XCTAssertEqual(payload.imageURL, imageURL)
+        XCTAssertEqual(payload.imagePreviewURL, thumbURL)
+        
+        // Assert extra data can be decoded.
+        let extraData = try XCTUnwrap(payload.extraData(ofType: ExtraData.self))
+        XCTAssertEqual(extraData.comment, comment)
+    }
+}

--- a/Sources/StreamChat/Models/Attachments/VideoAttachmentPayload_Tests.swift
+++ b/Sources/StreamChat/Models/Attachments/VideoAttachmentPayload_Tests.swift
@@ -1,0 +1,70 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import StreamChatTestTools
+import XCTest
+
+final class VideoAttachmentPayload_Tests: XCTestCase {
+    func test_decodingDefaultValues() throws {
+        // Create attachment field values.
+        let title: String = .unique
+        let videoURL: URL = .localYodaImage
+        let file = AttachmentFile(type: .mp4, size: 10 * 1024 * 1024, mimeType: "video/mp4")
+        
+        // Create JSON with the given values.
+        let json = """
+        {
+            "title": "\(title)",
+            "asset_url": "\(videoURL.absoluteString)",
+            "file_size": \(file.size),
+            "mime_type": "\(file.mimeType!)"
+        }
+        """.data(using: .utf8)!
+        
+        // Decode attachment from JSON.
+        let payload = try JSONDecoder.stream.decode(VideoAttachmentPayload.self, from: json)
+        
+        // Assert default values are decoded correctly.
+        XCTAssertEqual(payload.title, title)
+        XCTAssertEqual(payload.videoURL, videoURL)
+        XCTAssertEqual(payload.file, file)
+        XCTAssertNil(payload.extraData)
+    }
+    
+    func test_decodingExtraData() throws {
+        struct ExtraData: Codable {
+            let comment: String
+        }
+        
+        // Create attachment field values.
+        let title: String = .unique
+        let videoURL: URL = .localYodaImage
+        let file = AttachmentFile(type: .mp4, size: 10 * 1024 * 1024, mimeType: "video/mp4")
+        let comment: String = .unique
+        
+        // Create JSON with the given values.
+        let json = """
+        {
+            "title": "\(title)",
+            "asset_url": "\(videoURL.absoluteString)",
+            "file_size": \(file.size),
+            "mime_type": "\(file.mimeType!)",
+            "comment": "\(comment)"
+        }
+        """.data(using: .utf8)!
+        
+        // Decode attachment from JSON.
+        let payload = try JSONDecoder.stream.decode(VideoAttachmentPayload.self, from: json)
+        
+        // Assert default values are decoded correctly.
+        XCTAssertEqual(payload.title, title)
+        XCTAssertEqual(payload.videoURL, videoURL)
+        XCTAssertEqual(payload.file, file)
+        
+        // Assert extra data can be decoded.
+        let extraData = try XCTUnwrap(payload.extraData(ofType: ExtraData.self))
+        XCTAssertEqual(extraData.comment, comment)
+    }
+}

--- a/Sources/StreamChat/Utils/Dictionary+Extensions.swift
+++ b/Sources/StreamChat/Utils/Dictionary+Extensions.swift
@@ -8,4 +8,15 @@ extension Dictionary {
     func mapKeys<TransformedKey: Hashable>(_ transform: (Key) -> TransformedKey) -> [TransformedKey: Value] {
         .init(uniqueKeysWithValues: map { (transform($0.key), $0.value) })
     }
+    
+    @discardableResult
+    mutating func removeValues(forKeys keys: [Key]) -> [Value?] {
+        keys.map { removeValue(forKey: $0) }
+    }
+    
+    func removingValues(forKeys keys: [Key]) -> Self {
+        var result = self
+        result.removeValues(forKeys: keys)
+        return result
+    }
 }

--- a/Sources/StreamChat/Workers/Background/AttachmentUploader_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/AttachmentUploader_Tests.swift
@@ -89,7 +89,7 @@ final class AttachmentUploader_Tests: StressTestCase {
             switch envelope.type {
             case .image:
                 var imageModel: ChatMessageImageAttachment? {
-                    attachment.asAnyModel()?.attachment(payloadType: ImageAttachmentPayload.self)
+                    attachment.asAnyModel().attachment(payloadType: ImageAttachmentPayload.self)
                 }
                 AssertAsync {
                     // Assert attachment state eventually becomes `.uploaded`.
@@ -99,7 +99,7 @@ final class AttachmentUploader_Tests: StressTestCase {
                 }
             case .file:
                 var fileModel: ChatMessageFileAttachment? {
-                    attachment.asAnyModel()?.attachment(payloadType: FileAttachmentPayload.self)
+                    attachment.asAnyModel().attachment(payloadType: FileAttachmentPayload.self)
                 }
                 AssertAsync {
                     // Assert attachment state eventually becomes `.uploaded`.
@@ -109,7 +109,7 @@ final class AttachmentUploader_Tests: StressTestCase {
                 }
             case .video:
                 var videoModel: ChatMessageVideoAttachment? {
-                    attachment.asAnyModel()?.attachment(payloadType: VideoAttachmentPayload.self)
+                    attachment.asAnyModel().attachment(payloadType: VideoAttachmentPayload.self)
                 }
                 AssertAsync {
                     // Assert attachment state eventually becomes `.uploaded`.

--- a/Sources/StreamChatTestTools/Models/Attachments/AnyAttachmentPayload_Mock.swift
+++ b/Sources/StreamChatTestTools/Models/Attachments/AnyAttachmentPayload_Mock.swift
@@ -42,11 +42,14 @@ public extension AnyAttachmentPayload {
 
 extension AnyAttachmentPayload: Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        let lhsData = try? JSONEncoder.default.encode(lhs.payload.asAnyEncodable)
-        let rhsData = try? JSONEncoder.default.encode(rhs.payload.asAnyEncodable)
+        let lhsData = try! JSONEncoder.default.encode(lhs.payload.asAnyEncodable)
+        let lhsJSON = try! JSONDecoder.default.decode(RawJSON.self, from: lhsData)
+
+        let rhsData = try! JSONEncoder.default.encode(rhs.payload.asAnyEncodable)
+        let rhsJSON = try! JSONDecoder.default.decode(RawJSON.self, from: rhsData)
 
         return lhs.type == rhs.type &&
             lhs.localFileURL == rhs.localFileURL &&
-            lhsData == rhsData
+            lhsJSON == rhsJSON
     }
 }

--- a/Sources/StreamChatTestTools/Models/Attachments/AnyAttachmentPayload_Mock.swift
+++ b/Sources/StreamChatTestTools/Models/Attachments/AnyAttachmentPayload_Mock.swift
@@ -42,8 +42,8 @@ public extension AnyAttachmentPayload {
 
 extension AnyAttachmentPayload: Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        let lhsData = try? JSONEncoder.default.encode(lhs.payload?.asAnyEncodable)
-        let rhsData = try? JSONEncoder.default.encode(rhs.payload?.asAnyEncodable)
+        let lhsData = try? JSONEncoder.default.encode(lhs.payload.asAnyEncodable)
+        let rhsData = try? JSONEncoder.default.encode(rhs.payload.asAnyEncodable)
 
         return lhs.type == rhs.type &&
             lhs.localFileURL == rhs.localFileURL &&

--- a/Sources/StreamChatTestTools/Models/Attachments/ChatMessageFileAttachment_Mock.swift
+++ b/Sources/StreamChatTestTools/Models/Attachments/ChatMessageFileAttachment_Mock.swift
@@ -10,7 +10,7 @@ public extension ChatMessageFileAttachment {
         id: AttachmentId,
         title: String = "Sample.pdf",
         assetURL: URL = URL(string: "http://asset.url")!,
-        file: AttachmentFile = AttachmentFile(type: .pdf, size: 120, mimeType: "pdf"),
+        file: AttachmentFile = AttachmentFile(type: .pdf, size: 120, mimeType: "application/pdf"),
         localState: LocalAttachmentState? = .uploaded
     ) -> Self {
         .init(

--- a/Sources/StreamChatTestTools/Models/Attachments/ChatMessageFileAttachment_Mock.swift
+++ b/Sources/StreamChatTestTools/Models/Attachments/ChatMessageFileAttachment_Mock.swift
@@ -11,7 +11,8 @@ public extension ChatMessageFileAttachment {
         title: String = "Sample.pdf",
         assetURL: URL = URL(string: "http://asset.url")!,
         file: AttachmentFile = AttachmentFile(type: .pdf, size: 120, mimeType: "application/pdf"),
-        localState: LocalAttachmentState? = .uploaded
+        localState: LocalAttachmentState? = .uploaded,
+        extraData: [String: RawJSON]? = nil
     ) -> Self {
         .init(
             id: id,
@@ -19,7 +20,8 @@ public extension ChatMessageFileAttachment {
             payload: .init(
                 title: title,
                 assetURL: assetURL,
-                file: file
+                file: file,
+                extraData: extraData
             ),
             uploadingState: localState.map {
                 .init(

--- a/Sources/StreamChatTestTools/Models/Attachments/ChatMessageImageAttachment_Mock.swift
+++ b/Sources/StreamChatTestTools/Models/Attachments/ChatMessageImageAttachment_Mock.swift
@@ -10,7 +10,8 @@ extension ChatMessageImageAttachment {
         id: AttachmentId,
         imageURL: URL = .localYodaImage,
         title: String = URL.localYodaImage.lastPathComponent,
-        localState: LocalAttachmentState? = nil
+        localState: LocalAttachmentState? = nil,
+        extraData: [String: RawJSON]? = nil
     ) -> Self {
         .init(
             id: id,
@@ -18,7 +19,8 @@ extension ChatMessageImageAttachment {
             payload: .init(
                 title: title,
                 imageURL: imageURL,
-                imagePreviewURL: imageURL
+                imagePreviewURL: imageURL,
+                extraData: extraData
             ),
             uploadingState: localState.map {
                 .init(

--- a/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView_Tests.swift
+++ b/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView_Tests.swift
@@ -55,7 +55,7 @@ class QuotedChatMessageView_Tests: XCTestCase {
             id: .unique,
             title: "Data.csv",
             assetURL: .unique(),
-            file: AttachmentFile(type: .csv, size: 0, mimeType: nil),
+            file: AttachmentFile(type: .csv, size: 0, mimeType: "text/csv"),
             localState: nil
         )
 

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -493,6 +493,7 @@
 		80C6026F2514281000A6B714 /* UITableViewController+Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */; };
 		80C6027B25157E4D00A6B714 /* View+AlertTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */; };
 		80D880432546553500908B7B /* ChatScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D880422546553500908B7B /* ChatScrollView.swift */; };
+		843C53AB269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843C53AA269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift */; };
 		843F0BC326775CDB00B342CB /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843F0BC226775CDB00B342CB /* Cache.swift */; };
 		843F0BC526775D2D00B342CB /* VideoPreviewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843F0BC426775D2D00B342CB /* VideoPreviewLoader.swift */; };
 		843F0BC72677640000B342CB /* VideoAttachmentGalleryPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843F0BC62677640000B342CB /* VideoAttachmentGalleryPreview.swift */; };
@@ -1776,6 +1777,7 @@
 		80C6026E2514281000A6B714 /* UITableViewController+Cells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewController+Cells.swift"; sourceTree = "<group>"; };
 		80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AlertTextField.swift"; sourceTree = "<group>"; };
 		80D880422546553500908B7B /* ChatScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScrollView.swift; sourceTree = "<group>"; };
+		843C53AA269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentPayload_Tests.swift; sourceTree = "<group>"; };
 		843F0BC226775CDB00B342CB /* Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
 		843F0BC426775D2D00B342CB /* VideoPreviewLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPreviewLoader.swift; sourceTree = "<group>"; };
 		843F0BC62677640000B342CB /* VideoAttachmentGalleryPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentGalleryPreview.swift; sourceTree = "<group>"; };
@@ -2477,6 +2479,7 @@
 				22692C9625D1841E007C41D0 /* ChatMessageFileAttachment.swift */,
 				79983C80266633C2000995F6 /* ChatMessageVideoAttachment.swift */,
 				225D7FE125D191400094E555 /* ChatMessageImageAttachment.swift */,
+				843C53AA269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift */,
 				F6C0020926414E4D0055D110 /* AnyAttachmentPayload.swift */,
 				84CC56EA267B3D5900DF2784 /* AnyAttachmentPayload_Tests.swift */,
 				88BDCA892642B02D0099AD74 /* ChatMessageAttachment.swift */,
@@ -6248,6 +6251,7 @@
 				79D6CE1725F7C02400BE2EEC /* ChannelWatcherListQuery_Tests.swift in Sources */,
 				88CD396625B584E000399F8E /* HTTPHeader_Tests.swift in Sources */,
 				DAEAF4B824DC026C0015FB28 /* ChannelEndpoints_Tests.swift in Sources */,
+				843C53AB269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift in Sources */,
 				792FCB4D24A3D56D000290C7 /* DatabaseSession_Tests.swift in Sources */,
 				F62BE7852506309B00D13B86 /* MissingEventsPayload_Tests.swift in Sources */,
 				7922F30824DACF1F00C364BC /* TestManagedObject.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -494,6 +494,7 @@
 		80C6027B25157E4D00A6B714 /* View+AlertTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */; };
 		80D880432546553500908B7B /* ChatScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D880422546553500908B7B /* ChatScrollView.swift */; };
 		843C53AB269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843C53AA269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift */; };
+		843C53AD269373EA00C7D8EA /* VideoAttachmentPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843C53AC269373EA00C7D8EA /* VideoAttachmentPayload_Tests.swift */; };
 		843F0BC326775CDB00B342CB /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843F0BC226775CDB00B342CB /* Cache.swift */; };
 		843F0BC526775D2D00B342CB /* VideoPreviewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843F0BC426775D2D00B342CB /* VideoPreviewLoader.swift */; };
 		843F0BC72677640000B342CB /* VideoAttachmentGalleryPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843F0BC62677640000B342CB /* VideoAttachmentGalleryPreview.swift */; };
@@ -1778,6 +1779,7 @@
 		80C6027A25157E4D00A6B714 /* View+AlertTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AlertTextField.swift"; sourceTree = "<group>"; };
 		80D880422546553500908B7B /* ChatScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScrollView.swift; sourceTree = "<group>"; };
 		843C53AA269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentPayload_Tests.swift; sourceTree = "<group>"; };
+		843C53AC269373EA00C7D8EA /* VideoAttachmentPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentPayload_Tests.swift; sourceTree = "<group>"; };
 		843F0BC226775CDB00B342CB /* Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
 		843F0BC426775D2D00B342CB /* VideoPreviewLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPreviewLoader.swift; sourceTree = "<group>"; };
 		843F0BC62677640000B342CB /* VideoAttachmentGalleryPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentGalleryPreview.swift; sourceTree = "<group>"; };
@@ -2478,6 +2480,7 @@
 				22692C8E25D18097007C41D0 /* ChatMessageGiphyAttachment.swift */,
 				22692C9625D1841E007C41D0 /* ChatMessageFileAttachment.swift */,
 				79983C80266633C2000995F6 /* ChatMessageVideoAttachment.swift */,
+				843C53AC269373EA00C7D8EA /* VideoAttachmentPayload_Tests.swift */,
 				225D7FE125D191400094E555 /* ChatMessageImageAttachment.swift */,
 				843C53AA269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift */,
 				F6C0020926414E4D0055D110 /* AnyAttachmentPayload.swift */,
@@ -6207,6 +6210,7 @@
 				799C9468247D791A001F1104 /* AssertJSONEqual.swift in Sources */,
 				88089A0226529FD1007D3493 /* ChatMessageAttachment_Tests.swift in Sources */,
 				DA84072A2525EB2F005A0F62 /* UserListQuery_Tests.swift in Sources */,
+				843C53AD269373EA00C7D8EA /* VideoAttachmentPayload_Tests.swift in Sources */,
 				79158CFC25F1341300186102 /* ChannelTruncatedEventMiddleware_Tests.swift in Sources */,
 				799C9460247D77D6001F1104 /* DatabaseContainer_Tests.swift in Sources */,
 				649968D9264E6A71000515AB /* CDNClient_Mock.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -495,6 +495,7 @@
 		80D880432546553500908B7B /* ChatScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D880422546553500908B7B /* ChatScrollView.swift */; };
 		843C53AB269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843C53AA269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift */; };
 		843C53AD269373EA00C7D8EA /* VideoAttachmentPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843C53AC269373EA00C7D8EA /* VideoAttachmentPayload_Tests.swift */; };
+		843C53AF2693759E00C7D8EA /* FileAttachmentPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843C53AE2693759E00C7D8EA /* FileAttachmentPayload_Tests.swift */; };
 		843F0BC326775CDB00B342CB /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843F0BC226775CDB00B342CB /* Cache.swift */; };
 		843F0BC526775D2D00B342CB /* VideoPreviewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843F0BC426775D2D00B342CB /* VideoPreviewLoader.swift */; };
 		843F0BC72677640000B342CB /* VideoAttachmentGalleryPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843F0BC62677640000B342CB /* VideoAttachmentGalleryPreview.swift */; };
@@ -1780,6 +1781,7 @@
 		80D880422546553500908B7B /* ChatScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScrollView.swift; sourceTree = "<group>"; };
 		843C53AA269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentPayload_Tests.swift; sourceTree = "<group>"; };
 		843C53AC269373EA00C7D8EA /* VideoAttachmentPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentPayload_Tests.swift; sourceTree = "<group>"; };
+		843C53AE2693759E00C7D8EA /* FileAttachmentPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileAttachmentPayload_Tests.swift; sourceTree = "<group>"; };
 		843F0BC226775CDB00B342CB /* Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
 		843F0BC426775D2D00B342CB /* VideoPreviewLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPreviewLoader.swift; sourceTree = "<group>"; };
 		843F0BC62677640000B342CB /* VideoAttachmentGalleryPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentGalleryPreview.swift; sourceTree = "<group>"; };
@@ -2479,6 +2481,7 @@
 				22692C8625D176F4007C41D0 /* ChatMessageLinkAttachment.swift */,
 				22692C8E25D18097007C41D0 /* ChatMessageGiphyAttachment.swift */,
 				22692C9625D1841E007C41D0 /* ChatMessageFileAttachment.swift */,
+				843C53AE2693759E00C7D8EA /* FileAttachmentPayload_Tests.swift */,
 				79983C80266633C2000995F6 /* ChatMessageVideoAttachment.swift */,
 				843C53AC269373EA00C7D8EA /* VideoAttachmentPayload_Tests.swift */,
 				225D7FE125D191400094E555 /* ChatMessageImageAttachment.swift */,
@@ -6224,6 +6227,7 @@
 				F61D7C3324FFA60600188A0E /* MessageUpdater_Mock.swift in Sources */,
 				79280F7D24891B1300CDEB89 /* WebSocketEngine_Mock.swift in Sources */,
 				8819DFE2252628CA00FD1A50 /* UserUpdater_Tests.swift in Sources */,
+				843C53AF2693759E00C7D8EA /* FileAttachmentPayload_Tests.swift in Sources */,
 				88D85DA0252F16B400AE1030 /* MemberController+Combine_Tests.swift in Sources */,
 				79B5517C24E6A1CA00CE9FEC /* MessagePayloads_Tests.swift in Sources */,
 				F6D61D9D2510B57F00EB0624 /* NSManagedObject_Tests.swift in Sources */,

--- a/Tests/StreamChatTests/DummyData/ChatMessageAttachment_Sample.swift
+++ b/Tests/StreamChatTests/DummyData/ChatMessageAttachment_Sample.swift
@@ -10,7 +10,7 @@ extension AnyChatMessageAttachment {
     static func sample(
         id: AttachmentId = .unique,
         type: AttachmentType = .image,
-        payload: Any = "payload",
+        payload: Data = "payload".data(using: .utf8)!,
         uploadingState: AttachmentUploadingState? = nil
     ) -> AnyChatMessageAttachment {
         AnyChatMessageAttachment(


### PR DESCRIPTION
**This PR** addresses https://github.com/GetStream/stream-chat-swift/issues/1234 and allows to send in-rich built-in attachments with custom fields and parse it back.

To extend an image attachment with a custom fields declare a `Codable` type first:
```swift
struct CommentPayload: Codable {
 let comment: String
}
```

To send an image attachment with custom payload do the following:
```swift
// 1. Create custom payload.
let commentPayload = CommentPayload(comment: "Happy birthday! 🎉")
// 2. Create an envelope for built-in attachment with custom payload.
let envelope = AnyAttachmentEnvelope(localFileURL: *url*, attachmentType: .image, extraData: commentPayload)
// 3. Send the message with attachment
channelController.createNewMessage(..., attachments: [envelope])
```

When message is sent an attachment JSON would looks like this:
```swift
{
 "type": "image",
 "title": "cake.png",
 "image_url": "https://getstream.io/attachments/cake.png",
 "thumb_url": "https://getstream.io/attachments/cake_thumb.png",
 "comment": "Happy birthday! 🎉"
}
```

Custom `comment` field can now be accessed as shown below :
```swift
// 1. Get an attachment from the message
let attachment = message.imageAttachments.first

// 2. Decode attachment extra data as your payload type.
let commentPayload = attachment?.extraData(ofType: CommentPayload.self)

// 3. Work with custom fields
print(commentPayload?.comment ?? "There's no comment :(") // Happy birthday! 🎉
```
