### PR TITLE
[CIS-994] Fix the issue with receiving .didBecomeActive before connecting the client for the first time

### DIFF
--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -299,11 +299,6 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         self.eventWorkerBuilders = eventWorkerBuilders
 
         currentUserId = fetchCurrentUserIdFromDatabase()
-        
-        backgroundTaskScheduler?.startListeningForAppStateUpdates(
-            onEnteringBackground: { [weak self] in self?.handleAppDidEnterBackground() },
-            onEnteringForeground: { [weak self] in self?.handleAppDidBecomeActive() }
-        )
     }
     
     deinit {
@@ -363,6 +358,11 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
     /// are received.
     public func disconnect() {
         clientUpdater.disconnect()
+        
+        backgroundTaskScheduler?.startListeningForAppStateUpdates(
+            onEnteringBackground: {},
+            onEnteringForeground: {}
+        )
     }
 
     func fetchCurrentUserIdFromDatabase() -> UserId? {
@@ -413,6 +413,11 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
             userConnectionProvider: userConnectionProvider,
             completion: completion
         )
+        
+        backgroundTaskScheduler?.startListeningForAppStateUpdates(
+            onEnteringBackground: { [weak self] in self?.handleAppDidEnterBackground() },
+            onEnteringForeground: { [weak self] in self?.handleAppDidBecomeActive() }
+        )
     }
     
     private func handleAppDidEnterBackground() {
@@ -441,6 +446,11 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
     private func handleAppDidBecomeActive() {
         cancelBackgroundTaskIfNeeded()
 
+        guard userConnectionProvider != nil else {
+            // The client has not been connected yet during this session
+            return
+        }
+        
         guard connectionStatus != .connected && connectionStatus != .connecting else {
             // We are connected or connecting anyway
             return

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -407,14 +407,16 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
         self.userConnectionProvider = userConnectionProvider
         clientUpdater.reloadUserIfNeeded(
             userInfo: userInfo,
-            userConnectionProvider: userConnectionProvider,
-            completion: completion
-        )
-        
-        backgroundTaskScheduler?.startListeningForAppStateUpdates(
-            onEnteringBackground: { [weak self] in self?.handleAppDidEnterBackground() },
-            onEnteringForeground: { [weak self] in self?.handleAppDidBecomeActive() }
-        )
+            userConnectionProvider: userConnectionProvider
+        ) { [backgroundTaskScheduler, weak self] error in
+            if error == nil {
+                backgroundTaskScheduler?.startListeningForAppStateUpdates(
+                    onEnteringBackground: { self?.handleAppDidEnterBackground() },
+                    onEnteringForeground: { self?.handleAppDidBecomeActive() }
+                )
+            }
+            completion?(error)
+        }
     }
     
     private func handleAppDidEnterBackground() {

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -358,11 +358,8 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
     /// are received.
     public func disconnect() {
         clientUpdater.disconnect()
-        
-        backgroundTaskScheduler?.startListeningForAppStateUpdates(
-            onEnteringBackground: {},
-            onEnteringForeground: {}
-        )
+        userConnectionProvider = nil
+        backgroundTaskScheduler?.stopListeningForAppStateUpdates()
     }
 
     func fetchCurrentUserIdFromDatabase() -> UserId? {

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -746,6 +746,7 @@ class ChatClient_Tests: StressTestCase {
             eventWorkerBuilders: [],
             environment: testEnv.environment
         )
+        client.connectAnonymousUser()
         
         // Assert that config allows background task
         assert(client.config.staysConnectedInBackground)
@@ -777,6 +778,7 @@ class ChatClient_Tests: StressTestCase {
             eventWorkerBuilders: [],
             environment: testEnv.environment
         )
+        client.connectAnonymousUser()
         
         // Simulate access to `webSocketClient` so it is initialized
         _ = client.webSocketClient
@@ -806,6 +808,7 @@ class ChatClient_Tests: StressTestCase {
             eventWorkerBuilders: [],
             environment: testEnv.environment
         )
+        client.connectAnonymousUser()
         
         // Simulate access to `webSocketClient` so it is initialized
         _ = client.webSocketClient
@@ -829,6 +832,7 @@ class ChatClient_Tests: StressTestCase {
             eventWorkerBuilders: [],
             environment: testEnv.environment
         )
+        client.connectAnonymousUser()
         
         // Simulate access to `webSocketClient` so it is initialized
         _ = client.webSocketClient
@@ -858,6 +862,7 @@ class ChatClient_Tests: StressTestCase {
             eventWorkerBuilders: [],
             environment: testEnv.environment
         )
+        client.connectAnonymousUser()
         
         // Simulate access to `webSocketClient` so it is initialized
         _ = client.webSocketClient
@@ -924,7 +929,7 @@ class ChatClient_Tests: StressTestCase {
     
     // App wakes from background
     
-    func test_onOpenFromBackground_connectCalled_ifConfigAllows() {
+    func test_didBecomeActiveNotification_connectUserWasCalled_callsConnect() {
         // Create a new chat client
         let client = ChatClient(
             config: inMemoryStorageConfig,
@@ -944,6 +949,77 @@ class ChatClient_Tests: StressTestCase {
         testEnv.backgroundTaskScheduler?.startListeningForAppStateUpdates_onForeground?()
         
         // Assert that `connect` is called
+        XCTAssertEqual(testEnv.clientUpdater?.connect_called, true)
+    }
+    
+    func test_didBecomeActiveNotification_connectUserWasNotCalled_doesNotCallConnect() {
+        // Create a new chat client
+        let client = ChatClient(
+            config: inMemoryStorageConfig,
+            workerBuilders: workerBuilders,
+            eventWorkerBuilders: [],
+            environment: testEnv.environment
+        )
+        
+        // Simulate access to `webSocketClient` so it is initialized
+        _ = client.webSocketClient
+        _ = client.clientUpdater
+        
+        // Assert that `connect` is not called yet
+        XCTAssertEqual(testEnv.clientUpdater?.connect_called, false)
+        
+        // Simulate waking from background
+        testEnv.backgroundTaskScheduler?.startListeningForAppStateUpdates_onForeground?()
+        
+        // Assert that `connect` is called
+        XCTAssertEqual(testEnv.clientUpdater?.connect_called, false)
+    }
+    
+    func test_didBecomeActiveNotification_connectedAndDiconnectedUser_shouldNotConnect() {
+        // Create a new chat client
+        let client = ChatClient(
+            config: inMemoryStorageConfig,
+            workerBuilders: workerBuilders,
+            eventWorkerBuilders: [],
+            environment: testEnv.environment
+        )
+        client.connectAnonymousUser()
+        client.disconnect()
+        
+        // Simulate access to `webSocketClient` so it is initialized
+        _ = client.webSocketClient
+        
+        // Assert that `connect` is not called yet
+        XCTAssertEqual(testEnv.clientUpdater?.connect_called, false)
+        
+        // Simulate waking from background
+        testEnv.backgroundTaskScheduler?.startListeningForAppStateUpdates_onForeground?()
+        
+        // Assert that `connect` is called
+        XCTAssertEqual(testEnv.clientUpdater?.connect_called, false)
+    }
+    
+    func test_didBecomeActiveNotification_connectedUserDiconnectedAndConnectedBack_shouldConnect() {
+        // Create a new chat client
+        let client = ChatClient(
+            config: inMemoryStorageConfig,
+            workerBuilders: workerBuilders,
+            eventWorkerBuilders: [],
+            environment: testEnv.environment
+        )
+        client.connectAnonymousUser()
+        
+        // Simulate access to `webSocketClient` so it is initialized
+        _ = client.webSocketClient
+        
+        XCTAssertEqual(testEnv.clientUpdater?.connect_called, false)
+
+        client.disconnect()
+        testEnv.backgroundTaskScheduler?.startListeningForAppStateUpdates_onForeground?()
+        XCTAssertEqual(testEnv.clientUpdater?.connect_called, false)
+
+        client.connectAnonymousUser()
+        testEnv.backgroundTaskScheduler?.startListeningForAppStateUpdates_onForeground?()
         XCTAssertEqual(testEnv.clientUpdater?.connect_called, true)
     }
 }

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -747,6 +747,7 @@ class ChatClient_Tests: StressTestCase {
             environment: testEnv.environment
         )
         client.connectAnonymousUser()
+        testEnv.clientUpdater?.reloadUserIfNeeded_completion?(nil)
         
         // Assert that config allows background task
         assert(client.config.staysConnectedInBackground)
@@ -779,6 +780,7 @@ class ChatClient_Tests: StressTestCase {
             environment: testEnv.environment
         )
         client.connectAnonymousUser()
+        testEnv.clientUpdater?.reloadUserIfNeeded_completion?(nil)
         
         // Simulate access to `webSocketClient` so it is initialized
         _ = client.webSocketClient
@@ -833,6 +835,7 @@ class ChatClient_Tests: StressTestCase {
             environment: testEnv.environment
         )
         client.connectAnonymousUser()
+        testEnv.clientUpdater?.reloadUserIfNeeded_completion?(nil)
         
         // Simulate access to `webSocketClient` so it is initialized
         _ = client.webSocketClient
@@ -863,6 +866,7 @@ class ChatClient_Tests: StressTestCase {
             environment: testEnv.environment
         )
         client.connectAnonymousUser()
+        testEnv.clientUpdater?.reloadUserIfNeeded_completion?(nil)
         
         // Simulate access to `webSocketClient` so it is initialized
         _ = client.webSocketClient
@@ -899,6 +903,7 @@ class ChatClient_Tests: StressTestCase {
             environment: testEnv.environment
         )
         client.connectAnonymousUser()
+        testEnv.clientUpdater?.reloadUserIfNeeded_completion?(nil)
         
         // Simulate access to `webSocketClient` so it is initialized
         _ = client.webSocketClient
@@ -938,6 +943,7 @@ class ChatClient_Tests: StressTestCase {
             environment: testEnv.environment
         )
         client.connectAnonymousUser()
+        testEnv.clientUpdater?.reloadUserIfNeeded_completion?(nil)
         
         // Simulate access to `webSocketClient` so it is initialized
         _ = client.webSocketClient
@@ -1010,6 +1016,7 @@ class ChatClient_Tests: StressTestCase {
             environment: testEnv.environment
         )
         client.connectAnonymousUser()
+        testEnv.clientUpdater?.reloadUserIfNeeded_completion?(nil)
         
         // Simulate access to `webSocketClient` so it is initialized
         _ = client.webSocketClient

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -986,6 +986,8 @@ class ChatClient_Tests: StressTestCase {
         client.connectAnonymousUser()
         client.disconnect()
         
+        XCTAssertEqual(testEnv.backgroundTaskScheduler?.stopListeningForAppStateUpdates_called, true)
+
         // Simulate access to `webSocketClient` so it is initialized
         _ = client.webSocketClient
         
@@ -1013,8 +1015,11 @@ class ChatClient_Tests: StressTestCase {
         _ = client.webSocketClient
         
         XCTAssertEqual(testEnv.clientUpdater?.connect_called, false)
-
+        XCTAssertEqual(testEnv.backgroundTaskScheduler?.stopListeningForAppStateUpdates_called, false)
+        
         client.disconnect()
+        XCTAssertEqual(testEnv.backgroundTaskScheduler?.stopListeningForAppStateUpdates_called, true)
+        
         testEnv.backgroundTaskScheduler?.startListeningForAppStateUpdates_onForeground?()
         XCTAssertEqual(testEnv.clientUpdater?.connect_called, false)
 

--- a/Sources/StreamChat/WebSocketClient/BackgroundTaskScheduler.swift
+++ b/Sources/StreamChat/WebSocketClient/BackgroundTaskScheduler.swift
@@ -15,6 +15,7 @@ protocol BackgroundTaskScheduler {
         onEnteringBackground: @escaping () -> Void,
         onEnteringForeground: @escaping () -> Void
     )
+    func stopListeningForAppStateUpdates()
 }
 
 #if os(iOS)
@@ -65,6 +66,23 @@ class IOSBackgroundTaskScheduler: BackgroundTaskScheduler {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleAppDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+    
+    func stopListeningForAppStateUpdates() {
+        onEnteringForeground = {}
+        onEnteringBackground = {}
+        
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        
+        NotificationCenter.default.removeObserver(
+            self,
             name: UIApplication.didBecomeActiveNotification,
             object: nil
         )

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
@@ -608,6 +608,11 @@ class MockBackgroundTaskScheduler: BackgroundTaskScheduler {
         startListeningForAppStateUpdates_onBackground = onEnteringBackground
         startListeningForAppStateUpdates_onForeground = onEnteringForeground
     }
+    
+    var stopListeningForAppStateUpdates_called: Bool = false
+    func stopListeningForAppStateUpdates() {
+        stopListeningForAppStateUpdates_called = true
+    }
 }
 
 class WebSocketPingControllerMock: WebSocketPingController {


### PR DESCRIPTION
We spotted one additional case when it's possible for `ChatClientUpdater.connect` to be called before obtaining credentials:
https://github.com/GetStream/stream-chat-swift/issues/1218

It happens because we subscribe for notifications in `ChatClient`'s init
Two fixes to prevent this:
1) Do not call `ChatClientUpdater.connect` if one of  `connect` methods has not been called on `ChatClient`
2) Only listen to app state notifications in connected state, i.e. only subscribe when we connect and unsubscribe on disconnect