### PR TITLE
[CIS-588] Add support for pasting images in the composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ⚠️ Breaking Changes from `4.0-beta.6`
 - The `ChatSuggestionsViewController` was renamed to `ChatSuggestionsVC` to follow the same pattern across the codebase. [#1195](https://github.com/GetStream/stream-chat-swift/pull/1195)
 
+### ✅ Added
+- Support for pasting images into the composer [#1258](https://github.com/GetStream/stream-chat-swift/pull/1258)
+
 ### 🐞 Fixed
 - Fix crash when scrolling to bottom after sending the first message [#1262](https://github.com/GetStream/stream-chat-swift/pull/1262)
 - Fix crash when thread root message is not loaded when thread is opened [#1263](https://github.com/GetStream/stream-chat-swift/pull/1263)

--- a/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
+++ b/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
@@ -2,12 +2,11 @@
 // Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
-import MobileCoreServices
 import StreamChat
 import UIKit
 
-/// The delegate of the `InputTextView` that notifies when an `UIImage` is pasted.
-public protocol InputTextViewImagePasteDelegate: AnyObject {
+/// The delegate of the `InputTextView` that notifies when an attachment is pasted in the text view.
+public protocol InputTextViewClipboardAttachmentDelegate: AnyObject {
     /// Notifies that an `UIImage` has been pasted into the text view
     /// - Parameters:
     ///   - inputTextView: The `InputTextView` in which the image was pasted
@@ -18,8 +17,8 @@ public protocol InputTextViewImagePasteDelegate: AnyObject {
 /// A view for inputting text with placeholder support. Since it is a subclass
 /// of `UITextView`, the `UITextViewDelegate` can be used to observe text changes.
 open class InputTextView: UITextView, AppearanceProvider {
-    /// The delegate which gets notified when an image is pasted into the text view
-    open weak var imagePasteDelegate: InputTextViewImagePasteDelegate?
+    /// The delegate which gets notified when an attachment is pasted into the text view
+    open var clipboardAttachmentDelegate: InputTextViewClipboardAttachmentDelegate?
     
     /// Whether this text view should allow images to be pasted
     open var allowsPastingImages: Bool = true
@@ -121,7 +120,7 @@ open class InputTextView: UITextView, AppearanceProvider {
 
     override open func paste(_ sender: Any?) {
         if let pasteboardImage = UIPasteboard.general.image {
-            imagePasteDelegate?.inputTextView(self, didPasteImage: pasteboardImage)
+            clipboardAttachmentDelegate?.inputTextView(self, didPasteImage: pasteboardImage)
         } else {
             super.paste(sender)
         }

--- a/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
+++ b/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
@@ -18,10 +18,10 @@ public protocol InputTextViewClipboardAttachmentDelegate: AnyObject {
 /// of `UITextView`, the `UITextViewDelegate` can be used to observe text changes.
 open class InputTextView: UITextView, AppearanceProvider {
     /// The delegate which gets notified when an attachment is pasted into the text view
-    open var clipboardAttachmentDelegate: InputTextViewClipboardAttachmentDelegate?
+    open weak var clipboardAttachmentDelegate: InputTextViewClipboardAttachmentDelegate?
     
     /// Whether this text view should allow images to be pasted
-    open var allowsPastingImages: Bool = true
+    open var isPastingImagesEnabled: Bool = true
     
     /// Label used as placeholder for textView when it's empty.
     open private(set) lazy var placeholderLabel: UILabel = UILabel()
@@ -111,7 +111,7 @@ open class InputTextView: UITextView, AppearanceProvider {
     
     override open func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         // If action is paste and the pasteboard has an image, we allow it
-        if action == #selector(paste(_:)) && allowsPastingImages && UIPasteboard.general.hasImages {
+        if action == #selector(paste(_:)) && isPastingImagesEnabled && UIPasteboard.general.hasImages {
             return true
         }
 

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -35,7 +35,7 @@ open class _ComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
     UIImagePickerControllerDelegate,
     UIDocumentPickerDelegate,
     UINavigationControllerDelegate,
-    InputTextViewImagePasteDelegate {
+    InputTextViewClipboardAttachmentDelegate {
     /// The content of the composer.
     public struct Content {
         /// The text of the input text view.
@@ -240,7 +240,7 @@ open class _ComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
         composerView.inputMessageView.textView.delegate = self
         
         // Set the delegate for handling the pasting of UIImages in the text view
-        composerView.inputMessageView.textView.imagePasteDelegate = self
+        composerView.inputMessageView.textView.clipboardAttachmentDelegate = self
 
         composerView.attachmentButton.addTarget(self, action: #selector(showAttachmentsPicker), for: .touchUpInside)
         composerView.sendButton.addTarget(self, action: #selector(publishMessage), for: .touchUpInside)
@@ -773,7 +773,7 @@ open class _ComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
         present(alert, animated: true)
     }
     
-    // MARK: - InputTextViewImagePasteDelegate
+    // MARK: - InputTextViewClipboardAttachmentDelegate
     
     open func inputTextView(_ inputTextView: InputTextView, didPasteImage image: UIImage) {
         do {


### PR DESCRIPTION
### What does this PR do?

- This PR allows the user to copy images from anywhere and paste them into the composer.
- This support is limited to images currently, as the pasteboard readily provides us the copied image

https://user-images.githubusercontent.com/11807135/124904280-76a4cb80-e002-11eb-98d4-cdce8322c9d1.mp4

