### PR TITLE
[CIS-996] Fix unread count badge hiding logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+### 🐞 Fixed
+- Fix issue where badge with unread count could remain visible with 0 value [#1259](https://github.com/GetStream/stream-chat-swift/pull/1259)
+
 # [4.0.0-beta.5](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.5)
 _July 07, 2021_
 

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelUnreadCountView.swift
@@ -48,7 +48,7 @@ open class _ChatChannelUnreadCountView<ExtraData: ExtraDataTypes>: _View, ThemeP
     }
     
     override open func updateContent() {
-        isHidden = content.mentionedMessages == 0 && content.messages == 0
+        isHidden = content.messages == 0
         unreadCountLabel.text = String(content.messages)
     }
 }


### PR DESCRIPTION
## This PR
- fixes unread count badge logic allowing the badge to be shown with 0

## Links
https://stream-io.atlassian.net/browse/CIS-996