### PR TITLE
[CIS-829] Make the visibility of deleted messages configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - Support for pasting images into the composer [#1258](https://github.com/GetStream/stream-chat-swift/pull/1258)
+- The visibility of deleted messages is now configurable using `ChatClientConfig.deletedMessagesVisibility`. You can choose from the following options [#1269](https://github.com/GetStream/stream-chat-swift/pull/1269):
+```swift
+/// All deleted messages are always hidden.
+case alwaysHidden
+
+/// Deleted message by current user are visible, other deleted messages are hidden.
+case visibleForCurrentUser
+
+/// Deleted messages are always visible.
+case alwaysVisible
+``` 
 
 ### 🐞 Fixed
 - Fix crash when scrolling to bottom after sending the first message [#1262](https://github.com/GetStream/stream-chat-swift/pull/1262)

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -173,7 +173,8 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
                     .onDisk(databaseFileURL: dbFileURL),
                     config.shouldFlushLocalStorageOnStart,
                     config.isClientInActiveMode, // Only reset Ephemeral values in active mode
-                    config.localCaching
+                    config.localCaching,
+                    config.deletedMessagesVisibility
                 )
             }
             
@@ -189,7 +190,8 @@ public class _ChatClient<ExtraData: ExtraDataTypes> {
                 .inMemory,
                 config.shouldFlushLocalStorageOnStart,
                 config.isClientInActiveMode, // Only reset Ephemeral values in active mode
-                config.localCaching
+                config.localCaching,
+                config.deletedMessagesVisibility
             )
         } catch {
             fatalError("Failed to initialize the in-memory storage with error: \(error). This is a non-recoverable error.")
@@ -499,9 +501,16 @@ extension _ChatClient {
             _ kind: DatabaseContainer.Kind,
             _ shouldFlushOnStart: Bool,
             _ shouldResetEphemeralValuesOnStart: Bool,
-            _ localCachingSettings: ChatClientConfig.LocalCaching?
+            _ localCachingSettings: ChatClientConfig.LocalCaching?,
+            _ deletedMessageVisibility: ChatClientConfig.DeletedMessageVisibility?
         ) throws -> DatabaseContainer = {
-            try DatabaseContainer(kind: $0, shouldFlushOnStart: $1, shouldResetEphemeralValuesOnStart: $2, localCachingSettings: $3)
+            try DatabaseContainer(
+                kind: $0,
+                shouldFlushOnStart: $1,
+                shouldResetEphemeralValuesOnStart: $2,
+                localCachingSettings: $3,
+                deletedMessagesVisibility: $4
+            )
         }
         
         var requestEncoderBuilder: (_ baseURL: URL, _ apiKey: APIKey) -> RequestEncoder = DefaultRequestEncoder.init

--- a/Sources/StreamChat/ChatClient_Mock.swift
+++ b/Sources/StreamChat/ChatClient_Mock.swift
@@ -142,7 +142,8 @@ extension _ChatClient.Environment {
                         kind: .onDisk(databaseFileURL: .newTemporaryFileURL()),
                         shouldFlushOnStart: $1,
                         shouldResetEphemeralValuesOnStart: $2,
-                        localCachingSettings: $3
+                        localCachingSettings: $3,
+                        deletedMessagesVisibility: $4
                     )
                 } catch {
                     XCTFail("Unable to initialize DatabaseContainerMock \(error)")

--- a/Sources/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources/StreamChat/Config/ChatClientConfig.swift
@@ -106,7 +106,20 @@ public struct ChatClientConfig {
             return StreamCDNClient.maxAttachmentSize
         }
     }
-    
+
+    /// Specifies the visibility of deleted messages.
+    public enum DeletedMessageVisibility {
+        /// All deleted messages are always hidden.
+        case alwaysHidden
+        /// Deleted message by current user are visible, other deleted messages are hidden.
+        case visibleForCurrentUser
+        /// Deleted messages are always visible.
+        case alwaysVisible
+    }
+
+    /// Specifies the visibility of deleted messages.
+    public var deletedMessagesVisibility: DeletedMessageVisibility = .visibleForCurrentUser
+
     public init(apiKey: APIKey) {
         self.apiKey = apiKey
         isClientInActiveMode = !Bundle.main.isAppExtension

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -309,9 +309,16 @@ public class _ChatChannelController<ExtraData: ExtraDataTypes>: DataController, 
         _messagesObserver.computeValue = { [unowned self] in
             guard let cid = self.cid else { return nil }
             let sortAscending = self.listOrdering == .topToBottom ? false : true
+            let deletedMessageVisibility = self.client.databaseContainer.viewContext
+                .deletedMessagesVisibility ?? .visibleForCurrentUser
+
             let observer = ListDatabaseObserver(
                 context: self.client.databaseContainer.viewContext,
-                fetchRequest: MessageDTO.messagesFetchRequest(for: cid, sortAscending: sortAscending),
+                fetchRequest: MessageDTO.messagesFetchRequest(
+                    for: cid,
+                    sortAscending: sortAscending,
+                    deletedMessagesVisibility: deletedMessageVisibility
+                ),
                 itemCreator: { $0.asModel() as _ChatMessage<ExtraData> }
             )
             observer.onChange = { changes in

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -469,9 +469,16 @@ private extension _ChatMessageController {
     func setRepliesObserver() {
         _repliesObserver.computeValue = { [unowned self] in
             let sortAscending = self.listOrdering == .topToBottom ? false : true
+            let deletedMessageVisibility = self.client.databaseContainer.viewContext
+                .deletedMessagesVisibility ?? .visibleForCurrentUser
+
             let observer = ListDatabaseObserver(
                 context: self.client.databaseContainer.viewContext,
-                fetchRequest: MessageDTO.repliesFetchRequest(for: self.messageId, sortAscending: sortAscending),
+                fetchRequest: MessageDTO.repliesFetchRequest(
+                    for: self.messageId,
+                    sortAscending: sortAscending,
+                    deletedMessagesVisibility: deletedMessageVisibility
+                ),
                 itemCreator: { $0.asModel() as _ChatMessage<ExtraData> }
             )
             observer.onChange = { changes in

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -305,7 +305,10 @@ extension _ChatChannel {
             // (this is not 100% accurate but it's the best we have)
             let metionedUnreadMessagesRequest = NSFetchRequest<MessageDTO>(entityName: MessageDTO.entityName)
             metionedUnreadMessagesRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-                MessageDTO.channelMessagesPredicate(for: dto.cid),
+                MessageDTO.channelMessagesPredicate(
+                    for: dto.cid,
+                    deletedMessagesVisibility: context.deletedMessagesVisibility ?? .visibleForCurrentUser
+                ),
                 NSPredicate(format: "createdAt > %@", currentUserRead?.lastReadAt as NSDate? ?? NSDate(timeIntervalSince1970: 0)),
                 NSPredicate(format: "%@ IN mentionedUsers", currentUser.user)
             ])

--- a/Sources/StreamChat/Database/DatabaseContainer_Tests.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer_Tests.swift
@@ -229,6 +229,22 @@ class DatabaseContainer_Tests: StressTestCase {
             XCTAssertEqual(database.backgroundReadOnlyContext.localCachingSettings, cachingSettings)
         }
     }
+
+    func test_deletedMessagesVisibility_isStoredInAllContexts() throws {
+        let visibility = ChatClientConfig.DeletedMessageVisibility.alwaysVisible
+
+        let database = try DatabaseContainerMock(kind: .inMemory, deletedMessagesVisibility: visibility)
+
+        XCTAssertEqual(database.viewContext.deletedMessagesVisibility, visibility)
+
+        database.writableContext.performAndWait {
+            XCTAssertEqual(database.writableContext.deletedMessagesVisibility, visibility)
+        }
+
+        database.backgroundReadOnlyContext.performAndWait {
+            XCTAssertEqual(database.backgroundReadOnlyContext.deletedMessagesVisibility, visibility)
+        }
+    }
 }
 
 extension TestManagedObject: EphemeralValuesContainer {

--- a/Sources/StreamChat/Utils/Database/NSManagedObjectContext+Extensions.swift
+++ b/Sources/StreamChat/Utils/Database/NSManagedObjectContext+Extensions.swift
@@ -12,4 +12,12 @@ extension NSManagedObjectContext {
         get { userInfo[Self.localCachingKey] as? ChatClientConfig.LocalCaching }
         set { userInfo[Self.localCachingKey] = newValue }
     }
+
+    private static let deletedMessagesVisibilityKey = "io.getStream.StreamChat.deletedMessagesVisibility_key"
+
+    /// Provides the info about deleted messages behavior
+    var deletedMessagesVisibility: ChatClientConfig.DeletedMessageVisibility? {
+        get { userInfo[Self.deletedMessagesVisibilityKey] as? ChatClientConfig.DeletedMessageVisibility }
+        set { userInfo[Self.deletedMessagesVisibilityKey] = newValue }
+    }
 }

--- a/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
@@ -31,7 +31,8 @@ class DatabaseContainerMock: DatabaseContainer {
         shouldResetEphemeralValuesOnStart: Bool = true,
         modelName: String = "StreamChatModel",
         bundle: Bundle? = nil,
-        localCachingSettings: ChatClientConfig.LocalCaching? = nil
+        localCachingSettings: ChatClientConfig.LocalCaching? = nil,
+        deletedMessagesVisibility: ChatClientConfig.DeletedMessageVisibility? = nil
     ) throws {
         init_kind = kind
         try super.init(
@@ -40,7 +41,8 @@ class DatabaseContainerMock: DatabaseContainer {
             shouldResetEphemeralValuesOnStart: shouldResetEphemeralValuesOnStart,
             modelName: modelName,
             bundle: bundle,
-            localCachingSettings: localCachingSettings
+            localCachingSettings: localCachingSettings,
+            deletedMessagesVisibility: deletedMessagesVisibility
         )
     }
     


### PR DESCRIPTION
This PR adds an option to configure the visibility of deleted messages. This applies both to the channel messages, and to threads. 

We currently expose the following options:

```swift
/// All deleted messages are always hidden.
case alwaysHidden

/// Deleted message by current user are visible, other deleted messages are hidden.
case visibleForCurrentUser

/// Deleted messages are always visible.
case alwaysVisible
```