### PR TITLE
[CIS-621] Fix quoting a quoted message bug

### DIFF
--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
@@ -57,6 +57,7 @@ class MessagePayload<ExtraData: ExtraDataTypes>: Decodable {
     let parentId: String?
     let showReplyInChannel: Bool
     let quotedMessage: MessagePayload<ExtraData>?
+    let quotedMessageId: MessageId?
     let mentionedUsers: [UserPayload<ExtraData.User>]
     let threadParticipants: [UserPayload<ExtraData.User>]
     let replyCount: Int
@@ -114,6 +115,7 @@ class MessagePayload<ExtraData: ExtraDataTypes>: Decodable {
         pinnedBy = try container.decodeIfPresent(UserPayload<ExtraData.User>.self, forKey: .pinnedBy)
         pinnedAt = try container.decodeIfPresent(Date.self, forKey: .pinnedAt)
         pinExpires = try container.decodeIfPresent(Date.self, forKey: .pinExpires)
+        quotedMessageId = try container.decodeIfPresent(MessageId.self, forKey: .quotedMessageId)
     }
     
     init(
@@ -171,6 +173,7 @@ class MessagePayload<ExtraData: ExtraDataTypes>: Decodable {
         self.pinnedBy = pinnedBy
         self.pinnedAt = pinnedAt
         self.pinExpires = pinExpires
+        self.quotedMessageId = quotedMessageId
     }
 }
 

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
@@ -38,6 +38,7 @@ class MessagePayload_Tests: XCTestCase {
         XCTAssertEqual(payload.pinnedAt, "2021-04-15T06:43:08.776911Z".toDate())
         XCTAssertEqual(payload.pinExpires, "2021-05-15T06:43:08.776911Z".toDate())
         XCTAssertEqual(payload.pinnedBy?.id, "broken-waterfall-5")
+        XCTAssertEqual(payload.quotedMessageId, "4C0CC2DA-8AB5-421F-808E-50DC7E40653D")
     }
 
     func test_messagePayload_isSerialized_withDefaultExtraData_withBrokenAttachmentPayload() throws {
@@ -70,6 +71,7 @@ class MessagePayload_Tests: XCTestCase {
         XCTAssertEqual(payload.pinnedAt, "2021-04-15T06:43:08.776911Z".toDate())
         XCTAssertEqual(payload.pinExpires, "2021-05-15T06:43:08.776911Z".toDate())
         XCTAssertEqual(payload.pinnedBy?.id, "broken-waterfall-5")
+        XCTAssertEqual(payload.quotedMessageId, "4C0CC2DA-8AB5-421F-808E-50DC7E40653D")
     }
     
     func test_messagePayload_isSerialized_withCustomExtraData() throws {
@@ -101,6 +103,7 @@ class MessagePayload_Tests: XCTestCase {
         XCTAssertEqual(payload.pinnedAt, "2021-04-15T06:43:08.776911Z".toDate())
         XCTAssertEqual(payload.pinExpires, "2021-05-15T06:43:08.776911Z".toDate())
         XCTAssertEqual(payload.pinnedBy?.id, "broken-waterfall-5")
+        XCTAssertEqual(payload.quotedMessageId, "4C0CC2DA-8AB5-421F-808E-50DC7E40653D")
     }
 }
 

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -383,7 +383,15 @@ extension NSManagedObjectContext: MessageDatabaseSession {
             dto.pinnedBy = try saveUser(payload: pinnedByUser)
         }
 
-        dto.quotedMessage = try payload.quotedMessage.flatMap { try saveMessage(payload: $0, for: cid) }
+        if let quotedMessage = payload.quotedMessage {
+            dto.quotedMessage = try saveMessage(payload: quotedMessage, for: cid)
+        } else if let quotedMessageId = payload.quotedMessageId {
+            // In case we do not have a fully formed quoted message in the payload,
+            // we check for quotedMessageId. This can happen in the case of nested quoted messages.
+            dto.quotedMessage = message(id: quotedMessageId)
+        } else {
+            dto.quotedMessage = nil
+        }
 
         let user = try saveUser(payload: payload.user)
         dto.user = user


### PR DESCRIPTION
### What does this PR do
- Fixes a bug where quoting a message which already quotes some message shows the already quoted message as non-quoted

**Example**
- There's message "A"
- A user creates an inline reply (quotes) "B" that quotes message "A"
- A user creates an inline reply (quotes) "C" that quotes message "B"

Result (earlier) -> message "B" no longer has the quoted message visible.
Result (now)  -> message "B" correctly displays the quoted message.