### PR TITLE
[CIS-254] Implement methods for working with invites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - `urlRequest(forImage url:)` added to `ImageCDN` protocol, this can be used to inject custom HTTP headers into image loading requests [#1291](https://github.com/GetStream/stream-chat-swift/issues/1291)
+- Functionality that allows [inviting](https://getstream.io/chat/docs/react/channel_invites/?language=swift) users to channels with subsequent acceptance or rejection on their part [#1276](https://github.com/GetStream/stream-chat-swift/pull/1276)
 
 ### 🐞 Fixed
 - Fix an issue where member role sent from backend was not recognized by the SDK [#1288](https://github.com/GetStream/stream-chat-swift/pull/1288)

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
@@ -118,6 +118,52 @@ extension Endpoint {
         )
     }
     
+    static func inviteMembers(
+        cid: ChannelId,
+        userIds: Set<UserId>
+    ) -> Endpoint<EmptyResponse> {
+        .init(
+            path: "channels/" + cid.apiPath,
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["invites": userIds]
+        )
+    }
+    
+    static func acceptInvite(
+        cid: ChannelId,
+        message: String?
+    ) -> Endpoint<EmptyResponse> {
+        .init(
+            path: "channels/" + cid.apiPath,
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ChannelInvitePayload(
+                channelId: cid,
+                accept: true,
+                reject: false,
+                message: .init(message: message)
+            )
+        )
+    }
+    
+    static func rejectInvite(cid: ChannelId) -> Endpoint<EmptyResponse> {
+        .init(
+            path: "channels/" + cid.apiPath,
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ChannelInvitePayload(
+                channelId: cid,
+                accept: false,
+                reject: true,
+                message: nil
+            )
+        )
+    }
+    
     static func markRead(cid: ChannelId) -> Endpoint<EmptyResponse> {
         .init(
             path: "channels/" + cid.apiPath + "/read",

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
@@ -141,7 +141,6 @@ extension Endpoint {
             queryItems: nil,
             requiresConnectionId: false,
             body: ChannelInvitePayload(
-                channelId: cid,
                 accept: true,
                 reject: false,
                 message: .init(message: message)
@@ -156,7 +155,6 @@ extension Endpoint {
             queryItems: nil,
             requiresConnectionId: false,
             body: ChannelInvitePayload(
-                channelId: cid,
                 accept: false,
                 reject: true,
                 message: nil

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -261,6 +261,63 @@ final class ChannelEndpoints_Tests: XCTestCase {
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
     }
     
+    func test_inviteMembers_buildsCorrectly() {
+        let cid = ChannelId.unique
+        let userIds: Set<UserId> = Set([UserId.unique, UserId.unique])
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: "channels/" + cid.apiPath,
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["invites": userIds]
+        )
+        
+        let endpoint: Endpoint<EmptyResponse> = .inviteMembers(cid: cid, userIds: userIds)
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
+    
+    func test_acceptInvite_buildsCorrectly() {
+        let cid = ChannelId.unique
+        let message = "Welcome"
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: "channels/" + cid.apiPath,
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ChannelInvitePayload(
+                channelId: cid,
+                accept: true,
+                reject: false,
+                message: .init(message: message)
+            )
+        )
+        
+        let endpoint: Endpoint<EmptyResponse> = .acceptInvite(cid: cid, message: message)
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
+    
+    func test_rejectInvite_buildsCorrectly() {
+        let cid = ChannelId.unique
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: "channels/" + cid.apiPath,
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ChannelInvitePayload(
+                channelId: cid,
+                accept: false,
+                reject: true,
+                message: nil
+            )
+        )
+        
+        let endpoint: Endpoint<EmptyResponse> = .rejectInvite(cid: cid)
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+    }
+    
     func test_markRead_buildsCorrectly() {
         let cid = ChannelId.unique
         

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -287,7 +287,6 @@ final class ChannelEndpoints_Tests: XCTestCase {
             queryItems: nil,
             requiresConnectionId: false,
             body: ChannelInvitePayload(
-                channelId: cid,
                 accept: true,
                 reject: false,
                 message: .init(message: message)
@@ -307,7 +306,6 @@ final class ChannelEndpoints_Tests: XCTestCase {
             queryItems: nil,
             requiresConnectionId: false,
             body: ChannelInvitePayload(
-                channelId: cid,
                 accept: false,
                 reject: true,
                 message: nil

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MemberPayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MemberPayload.swift
@@ -6,7 +6,7 @@ import Foundation
 
 struct MemberContainerPayload<ExtraData: UserExtraData>: Decodable {
     let member: MemberPayload<ExtraData>?
-    let invite: MemberInivePayload?
+    let invite: MemberInvitePayload?
     let memberRole: MemberRolePayload?
     
     init(from decoder: Decoder) throws {
@@ -17,7 +17,7 @@ struct MemberContainerPayload<ExtraData: UserExtraData>: Decodable {
     
     init(
         member: MemberPayload<ExtraData>?,
-        invite: MemberInivePayload?,
+        invite: MemberInvitePayload?,
         memberRole: MemberRolePayload?
     ) {
         self.member = member
@@ -86,7 +86,7 @@ struct MemberPayload<ExtraData: UserExtraData>: Decodable {
     }
 }
 
-struct MemberInivePayload: Decodable {
+struct MemberInvitePayload: Decodable {
     private enum CodingKeys: String, CodingKey {
         case role
         case isInvited = "invited"

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -888,6 +888,57 @@ public extension _ChatChannelController {
         }
     }
     
+    func inviteMembers(userIds: Set<UserId>, completion: ((Error?) -> Void)? = nil) {
+        /// Perform action only if channel is already created on backend side and have a valid `cid`.
+        guard let cid = cid, isChannelAlreadyCreated else {
+            channelModificationFailed(completion)
+            return
+        }
+        
+        updater.inviteMembers(cid: cid, userIds: userIds) { error in
+            self.callback {
+                completion?(error)
+            }
+        }
+    }
+    
+    /// Accept Request
+    /// - Parameters:
+    ///   - cid: The channel identifier.
+    ///   - userId: userId
+    ///   - message: message
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
+    func acceptInvite(message: String?, completion: ((Error?) -> Void)? = nil) {
+        /// Perform action only if channel is already created on backend side and have a valid `cid`.
+        guard let cid = cid, isChannelAlreadyCreated else {
+            channelModificationFailed(completion)
+            return
+        }
+        updater.acceptInvite(cid: cid, message: message) { error in
+            self.callback {
+                completion?(error)
+            }
+        }
+    }
+    
+    /// Reject Request
+    /// - Parameters:
+    ///   - cid: The channel identifier.
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
+    func rejectInvite(completion: ((Error?) -> Void)? = nil) {
+        /// Perform action only if channel is already created on backend side and have a valid `cid`.
+        guard let cid = cid, isChannelAlreadyCreated else {
+            channelModificationFailed(completion)
+            return
+        }
+        
+        updater.rejectInvite(cid: cid) { error in
+            self.callback {
+                completion?(error)
+            }
+        }
+    }
+    
     /// Marks the channel as read.
     ///
     /// - Parameter completion: The completion. Will be called on a **callbackQueue** when the network request is finished.

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -888,6 +888,10 @@ public extension _ChatChannelController {
         }
     }
     
+    /// Invite members to a channel. They can then accept or decline the invitation
+    /// - Parameters:
+    ///   - userIds: Set of ids of users to be invited to the channel
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     func inviteMembers(userIds: Set<UserId>, completion: ((Error?) -> Void)? = nil) {
         /// Perform action only if channel is already created on backend side and have a valid `cid`.
         guard let cid = cid, isChannelAlreadyCreated else {
@@ -908,7 +912,7 @@ public extension _ChatChannelController {
     ///   - userId: userId
     ///   - message: message
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
-    func acceptInvite(message: String?, completion: ((Error?) -> Void)? = nil) {
+    func acceptInvite(message: String? = nil, completion: ((Error?) -> Void)? = nil) {
         /// Perform action only if channel is already created on backend side and have a valid `cid`.
         guard let cid = cid, isChannelAlreadyCreated else {
             channelModificationFailed(completion)

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
@@ -2704,6 +2704,163 @@ class ChannelController_Tests: StressTestCase {
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
     }
     
+    // MARK: - Inviting members
+    
+    func test_inviteMembers_callsChannelUpdater() {
+        let members: Set<UserId> = [.unique, .unique]
+        
+        // Simulate `inviteMembers` call and catch the completion
+        var completionCalled = false
+        controller.inviteMembers(userIds: members) { [callbackQueueID] error in
+            AssertTestQueue(withId: callbackQueueID)
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+        
+        // Keep a weak ref so we can check if it's actually deallocated
+        weak var weakController = controller
+        
+        // (Try to) deallocate the controller
+        // by not keeping any references to it
+        controller = nil
+        
+        // Assert cid and members state are passed to `channelUpdater`, completion is not called yet
+        XCTAssertEqual(env.channelUpdater!.inviteMembers_cid, channelId)
+        XCTAssertEqual(env.channelUpdater!.inviteMembers_userIds, members)
+        XCTAssertFalse(completionCalled)
+        
+        // Simulate successful update
+        env.channelUpdater!.inviteMembers_completion?(nil)
+        // Release reference of completion so we can deallocate stuff
+        env.channelUpdater!.inviteMembers_completion = nil
+        
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+        // `weakController` should be deallocated too
+        AssertAsync.canBeReleased(&weakController)
+    }
+    
+    func test_inviteMembers_propagatesErrorFromUpdater() {
+        let members: Set<UserId> = [.unique, .unique]
+        
+        // Simulate `inviteMembers` call and catch the completion
+        var completionCalledError: Error?
+        controller.inviteMembers(userIds: members) { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionCalledError = $0
+        }
+        
+        // Simulate failed update
+        let testError = TestError()
+        env.channelUpdater!.inviteMembers_completion?(testError)
+        
+        // Completion should be called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
+        controller = nil
+    }
+    
+    // MARK: - Accepting invites
+    
+    func test_acceptInvite_callsChannelUpdater() {
+        // Simulate `acceptInvite` call and catch the completion
+        var completionCalled = false
+        let message = "Hooray"
+        controller.acceptInvite(message: message) { [callbackQueueID] error in
+            AssertTestQueue(withId: callbackQueueID)
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+        
+        // Keep a weak ref so we can check if it's actually deallocated
+        weak var weakController = controller
+        
+        // (Try to) deallocate the controller
+        // by not keeping any references to it
+        controller = nil
+        
+        // Assert cid and members state are passed to `channelUpdater`, completion is not called yet
+        XCTAssertEqual(env.channelUpdater!.acceptInvite_cid, channelId)
+        XCTAssertEqual(env.channelUpdater!.acceptInvite_message, message)
+        XCTAssertFalse(completionCalled)
+        
+        // Simulate successful update
+        env.channelUpdater!.acceptInvite_completion?(nil)
+        // Release reference of completion so we can deallocate stuff
+        env.channelUpdater!.acceptInvite_completion = nil
+        
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+        // `weakController` should be deallocated too
+        AssertAsync.canBeReleased(&weakController)
+    }
+    
+    func test_acceptInvite_propagatesErrorFromUpdater() {
+        // Simulate `inviteMembers` call and catch the completion
+        var completionCalledError: Error?
+        controller.acceptInvite(message: "Hooray") { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionCalledError = $0
+        }
+        
+        // Simulate failed update
+        let testError = TestError()
+        env.channelUpdater!.acceptInvite_completion?(testError)
+        
+        // Completion should be called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
+        controller = nil
+    }
+    
+    // MARK: - Accepting invites
+    
+    func test_rejectInvite_callsChannelUpdater() {
+        // Simulate `acceptInvite` call and catch the completion
+        var completionCalled = false
+        controller.rejectInvite { [callbackQueueID] error in
+            AssertTestQueue(withId: callbackQueueID)
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+        
+        // Keep a weak ref so we can check if it's actually deallocated
+        weak var weakController = controller
+        
+        // (Try to) deallocate the controller
+        // by not keeping any references to it
+        controller = nil
+        
+        // Assert cid and members state are passed to `channelUpdater`, completion is not called yet
+        XCTAssertEqual(env.channelUpdater!.rejectInvite_cid, channelId)
+        XCTAssertFalse(completionCalled)
+        
+        // Simulate successful update
+        env.channelUpdater!.rejectInvite_completion?(nil)
+        // Release reference of completion so we can deallocate stuff
+        env.channelUpdater!.rejectInvite_completion = nil
+        
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+        // `weakController` should be deallocated too
+        AssertAsync.canBeReleased(&weakController)
+    }
+    
+    func test_rejectInvite_propagatesErrorFromUpdater() {
+        // Simulate `inviteMembers` call and catch the completion
+        var completionCalledError: Error?
+        controller.rejectInvite { [callbackQueueID] in
+            AssertTestQueue(withId: callbackQueueID)
+            completionCalledError = $0
+        }
+        
+        // Simulate failed update
+        let testError = TestError()
+        env.channelUpdater!.rejectInvite_completion?(testError)
+        
+        // Completion should be called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
+        controller = nil
+    }
+    
     // MARK: - Removing members
     
     func test_removeMembers_failsForNewChannels() throws {

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -19,9 +19,9 @@ class MemberDTO: NSManagedObject {
     @NSManaged var isBanned: Bool
     @NSManaged var isShadowBanned: Bool
     
-    //  @NSManaged var invitedAcceptedAt: Date?
-    //  @NSManaged var invitedRejectedAt: Date?
-    //  @NSManaged var isInvited: Bool
+    @NSManaged var inviteAcceptedAt: Date?
+    @NSManaged var inviteRejectedAt: Date?
+    @NSManaged var isInvited: Bool
     
     // MARK: - Relationships
     
@@ -107,6 +107,9 @@ extension NSManagedObjectContext {
         dto.isBanned = payload.isBanned ?? false
         dto.isShadowBanned = payload.isShadowBanned ?? false
         dto.banExpiresAt = payload.banExpiresAt
+        dto.isInvited = payload.isInvited ?? false
+        dto.inviteAcceptedAt = payload.inviteAcceptedAt
+        dto.inviteRejectedAt = payload.inviteRejectedAt
         
         if let query = query {
             let queryDTO = try saveQuery(query)
@@ -160,9 +163,9 @@ extension _ChatChannelMember {
             memberRole: role,
             memberCreatedAt: dto.memberCreatedAt,
             memberUpdatedAt: dto.memberUpdatedAt,
-            isInvited: false,
-            inviteAcceptedAt: nil,
-            inviteRejectedAt: nil,
+            isInvited: dto.isInvited,
+            inviteAcceptedAt: dto.inviteAcceptedAt,
+            inviteRejectedAt: dto.inviteRejectedAt,
             isBannedFromChannel: dto.isBanned,
             banExpiresAt: dto.banExpiresAt,
             isShadowBannedFromChannel: dto.isShadowBanned

--- a/Sources/StreamChat/Query/ChannelQuery.swift
+++ b/Sources/StreamChat/Query/ChannelQuery.swift
@@ -119,8 +119,8 @@ extension _ChannelQuery: APIPathConvertible {
 }
 
 /// An answer for an invite to a channel.
-public struct ChannelInvitePayload: Encodable {
-    public struct Message: Encodable {
+struct ChannelInvitePayload: Encodable {
+    struct Message: Encodable {
         let message: String?
     }
     

--- a/Sources/StreamChat/Query/ChannelQuery.swift
+++ b/Sources/StreamChat/Query/ChannelQuery.swift
@@ -130,8 +130,6 @@ struct ChannelInvitePayload: Encodable {
         case message
     }
 
-    /// A channel id
-    let channelId: ChannelId
     /// Accept the invite.
     let accept: Bool?
     /// Reject the invite.

--- a/Sources/StreamChat/Query/ChannelQuery.swift
+++ b/Sources/StreamChat/Query/ChannelQuery.swift
@@ -118,23 +118,28 @@ extension _ChannelQuery: APIPathConvertible {
     var apiPath: String { cid?.apiPath ?? type.rawValue }
 }
 
-///// An answer for an invite to a channel.
-// public struct ChannelInviteAnswer: Encodable {
-//    private enum CodingKeys: String, CodingKey {
-//        case accept = "accept_invite"
-//        case reject = "reject_invite"
-//        case message
-//    }
-//
-//    /// A channel.
-//    let channel: Channel
-//    /// Accept the invite.
-//    let accept: Bool?
-//    /// Reject the invite.
-//    let reject: Bool?
-//    /// Additional message.
-//    let message: Message?
-// }
+/// An answer for an invite to a channel.
+public struct ChannelInvitePayload: Encodable {
+    public struct Message: Encodable {
+        let message: String?
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case accept = "accept_invite"
+        case reject = "reject_invite"
+        case message
+    }
+
+    /// A channel id
+    let channelId: ChannelId
+    /// Accept the invite.
+    let accept: Bool?
+    /// Reject the invite.
+    let reject: Bool?
+    /// Additional message.
+    let message: Message?
+}
+
 //
 ///// An answer for an invite to a channel.
 // public struct ChannelInviteResponse: Decodable {

--- a/Sources/StreamChat/WebSocketClient/Events/EventType.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/EventType.swift
@@ -78,8 +78,18 @@ enum EventType: String, Codable {
     /// When someone else from channel has muted someone.
     case notificationChannelMutesUpdated = "notification.channel_mutes_updated"
     
-    /// When the user accepts an invite.
+    /// When a user is added to a channel.
     case notificationAddedToChannel = "notification.added_to_channel"
+    
+    /// When a user is invited to a channel
+    case notificationInvited = "notification.invited"
+    
+    /// When a user accepted a channel invitation
+    case notificationInviteAccepted = "notification.invite_accepted"
+    
+    /// When a user rejected a channel invitation
+    case notificationInviteRejected = "notification.invite_rejected"
+
     /// When a user was removed from a channel.
     case notificationRemovedFromChannel = "notification.removed_from_channel"
         
@@ -124,6 +134,12 @@ enum EventType: String, Codable {
         case .notificationAddedToChannel: return try NotificationAddedToChannelEvent(from: response)
         case .notificationRemovedFromChannel: return try NotificationRemovedFromChannelEvent(from: response)
         case .notificationChannelMutesUpdated: return try NotificationChannelMutesUpdatedEvent(from: response)
+        case .notificationInvited:
+            return try NotificationInvitedEvent(from: response)
+        case .notificationInviteAccepted:
+            return try NotificationInviteAccepted(from: response)
+        case .notificationInviteRejected:
+            return try NotificationInviteRejected(from: response)
         }
     }
 }

--- a/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
@@ -92,3 +92,42 @@ public struct NotificationChannelMutesUpdatedEvent: UserSpecificEvent {
         payload = response
     }
 }
+
+public struct NotificationInvitedEvent: MemberEvent {
+    public let memberUserId: UserId
+    public let cid: ChannelId
+    
+    let payload: Any
+    
+    init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
+        cid = try response.value(at: \.cid)
+        memberUserId = try response.value(at: \.user?.id)
+        payload = response
+    }
+}
+
+public struct NotificationInviteAccepted: MemberEvent {
+    public let memberUserId: UserId
+    public let cid: ChannelId
+    
+    let payload: Any
+    
+    init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
+        cid = try response.value(at: \.cid)
+        memberUserId = try response.value(at: \.user?.id)
+        payload = response
+    }
+}
+
+public struct NotificationInviteRejected: MemberEvent {
+    public let memberUserId: UserId
+    public let cid: ChannelId
+    
+    let payload: Any
+    
+    init<ExtraData: ExtraDataTypes>(from response: EventPayload<ExtraData>) throws {
+        cid = try response.value(at: \.cid)
+        memberUserId = try response.value(at: \.user?.id)
+        payload = response
+    }
+}

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -192,11 +192,10 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
         }
     }
     
-    /// Accept Request
+    /// Accept invitation to a channel
     /// - Parameters:
-    ///   - cid: The channel identifier.
-    ///   - userId: userId
-    ///   - message: message
+    ///   - cid: A channel identifier of a channel a user was invited to.
+    ///   - message: A message for invitation acceptance
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     func acceptInvite(
         cid: ChannelId,
@@ -208,9 +207,9 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
         }
     }
 
-    /// Reject Request
+    /// Reject invitation to a channel
     /// - Parameters:
-    ///   - cid: The channel identifier.
+    ///   - cid: A channel identifier of a channel a user was invited to.
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     func rejectInvite(
         cid: ChannelId,

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -177,6 +177,11 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
         }
     }
     
+    /// Invite members to a channel. They can then accept or decline the invitation
+    /// - Parameters:
+    ///   - cid: The channel identifier
+    ///   - userIds: Set of ids of users to be invited to the channel
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     func inviteMembers(
         cid: ChannelId,
         userIds: Set<UserId>,
@@ -198,9 +203,7 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
         message: String?,
         completion: ((Error?) -> Void)? = nil
     ) {
-        apiClient.request(
-            endpoint: .acceptInvite(cid: cid, message: message)
-        ) {
+        apiClient.request(endpoint: .acceptInvite(cid: cid, message: message)) {
             completion?($0.error)
         }
     }

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -177,6 +177,47 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
         }
     }
     
+    func inviteMembers(
+        cid: ChannelId,
+        userIds: Set<UserId>,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        apiClient.request(endpoint: .inviteMembers(cid: cid, userIds: userIds)) {
+            completion?($0.error)
+        }
+    }
+    
+    /// Accept Request
+    /// - Parameters:
+    ///   - cid: The channel identifier.
+    ///   - userId: userId
+    ///   - message: message
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
+    func acceptInvite(
+        cid: ChannelId,
+        message: String?,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        apiClient.request(
+            endpoint: .acceptInvite(cid: cid, message: message)
+        ) {
+            completion?($0.error)
+        }
+    }
+
+    /// Reject Request
+    /// - Parameters:
+    ///   - cid: The channel identifier.
+    ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
+    func rejectInvite(
+        cid: ChannelId,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        apiClient.request(endpoint: .rejectInvite(cid: cid)) {
+            completion?($0.error)
+        }
+    }
+    
     /// Marks a channel as read
     /// - Parameters:
     ///   - cid: Channel id of the channel to be marked as read

--- a/Sources/StreamChat/Workers/ChannelUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Mock.swift
@@ -36,6 +36,17 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
     @Atomic var addMembers_userIds: Set<UserId>?
     @Atomic var addMembers_completion: ((Error?) -> Void)?
     
+    @Atomic var inviteMembers_cid: ChannelId?
+    @Atomic var inviteMembers_userIds: Set<UserId>?
+    @Atomic var inviteMembers_completion: ((Error?) -> Void)?
+    
+    @Atomic var acceptInvite_cid: ChannelId?
+    @Atomic var acceptInvite_message: String?
+    @Atomic var acceptInvite_completion: ((Error?) -> Void)?
+    
+    @Atomic var rejectInvite_cid: ChannelId?
+    @Atomic var rejectInvite_completion: ((Error?) -> Void)?
+    
     @Atomic var removeMembers_cid: ChannelId?
     @Atomic var removeMembers_userIds: Set<UserId>?
     @Atomic var removeMembers_completion: ((Error?) -> Void)?
@@ -101,6 +112,17 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         addMembers_cid = nil
         addMembers_userIds = nil
         addMembers_completion = nil
+        
+        inviteMembers_cid = nil
+        inviteMembers_userIds = nil
+        inviteMembers_completion = nil
+        
+        acceptInvite_cid = nil
+        acceptInvite_message = nil
+        acceptInvite_completion = nil
+        
+        rejectInvite_cid = nil
+        rejectInvite_completion = nil
         
         removeMembers_cid = nil
         removeMembers_userIds = nil
@@ -210,6 +232,34 @@ class ChannelUpdaterMock<ExtraData: ExtraDataTypes>: ChannelUpdater<ExtraData> {
         addMembers_cid = cid
         addMembers_userIds = userIds
         addMembers_completion = completion
+    }
+    
+    override func inviteMembers(
+        cid: ChannelId,
+        userIds: Set<UserId>,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        inviteMembers_cid = cid
+        inviteMembers_userIds = userIds
+        inviteMembers_completion = completion
+    }
+    
+    override func acceptInvite(
+        cid: ChannelId,
+        message: String? = nil,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        acceptInvite_cid = cid
+        acceptInvite_message = message
+        acceptInvite_completion = completion
+    }
+    
+    override func rejectInvite(
+        cid: ChannelId,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        rejectInvite_cid = cid
+        rejectInvite_completion = completion
     }
     
     override func removeMembers(cid: ChannelId, userIds: Set<UserId>, completion: ((Error?) -> Void)? = nil) {

--- a/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
@@ -552,6 +552,151 @@ class ChannelUpdater_Tests: StressTestCase {
         AssertAsync.willBeEqual(completionCalledError as? TestError, error)
     }
     
+    // MARK: - Invite members
+
+    func test_inviteMembers_makesCorrectAPICall() {
+        let channelID = ChannelId.unique
+        let userIds: Set<UserId> = Set([UserId.unique])
+
+        // Simulate `inviteMembers(cid:, mute:, userIds:)` call
+        channelUpdater.inviteMembers(cid: channelID, userIds: userIds)
+
+        // Assert correct endpoint is called
+        let referenceEndpoint: Endpoint<EmptyResponse> = .inviteMembers(cid: channelID, userIds: userIds)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
+    }
+
+    func test_inviteMembers_successfulResponse_isPropagatedToCompletion() {
+        let channelID = ChannelId.unique
+        let userIds: Set<UserId> = Set([UserId.unique])
+        
+        // Simulate `inviteMembers(cid:, mute:, userIds:)` call
+        var completionCalled = false
+        channelUpdater.inviteMembers(cid: channelID, userIds: userIds) { error in
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+
+        // Assert completion is not called yet
+        XCTAssertFalse(completionCalled)
+
+        // Simulate API response with success
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.success(.init()))
+
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+    }
+
+    func test_inviteMembers_errorResponse_isPropagatedToCompletion() {
+        let channelID = ChannelId.unique
+        let userIds: Set<UserId> = Set([UserId.unique])
+        
+        // Simulate `muteChannel(cid:, mute:, completion:)` call
+        var completionCalledError: Error?
+        channelUpdater.inviteMembers(cid: channelID, userIds: userIds) { completionCalledError = $0 }
+
+        // Simulate API response with failure
+        let error = TestError()
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(error))
+
+        // Assert the completion is called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, error)
+    }
+    
+    // MARK: - Accept invite
+
+    func test_acceptInvite_makesCorrectAPICall() {
+        let channelID = ChannelId.unique
+        let message = "Hooray"
+
+        channelUpdater.acceptInvite(cid: channelID, message: message)
+
+        // Assert correct endpoint is called
+        let referenceEndpoint: Endpoint<EmptyResponse> = .acceptInvite(cid: channelID, message: message)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
+    }
+
+    func test_acceptInvite_successfulResponse_isPropagatedToCompletion() {
+        let channelID = ChannelId.unique
+        let message = "Hooray"
+
+        // Simulate `acceptInvite(cid:, mute:, userIds:)` call
+        var completionCalled = false
+        channelUpdater.acceptInvite(cid: channelID, message: message) { error in
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+
+        // Assert completion is not called yet
+        XCTAssertFalse(completionCalled)
+
+        // Simulate API response with success
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.success(.init()))
+
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+    }
+
+    func test_acceptInvite_errorResponse_isPropagatedToCompletion() {
+        let channelID = ChannelId.unique
+        
+        var completionCalledError: Error?
+        channelUpdater.acceptInvite(cid: channelID, message: "Hooray") { completionCalledError = $0 }
+
+        // Simulate API response with failure
+        let error = TestError()
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(error))
+
+        // Assert the completion is called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, error)
+    }
+    
+    // MARK: - Reject invite
+
+    func test_rejectInvite_makesCorrectAPICall() {
+        let channelID = ChannelId.unique
+
+        channelUpdater.rejectInvite(cid: channelID)
+
+        // Assert correct endpoint is called
+        let referenceEndpoint: Endpoint<EmptyResponse> = .rejectInvite(cid: channelID)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
+    }
+
+    func test_rejectInvite_successfulResponse_isPropagatedToCompletion() {
+        let channelID = ChannelId.unique
+
+        // Simulate `rejectInvite(cid:, mute:, userIds:)` call
+        var completionCalled = false
+        channelUpdater.rejectInvite(cid: channelID) { error in
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+
+        // Assert completion is not called yet
+        XCTAssertFalse(completionCalled)
+
+        // Simulate API response with success
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.success(.init()))
+
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+    }
+
+    func test_rejectInvite_errorResponse_isPropagatedToCompletion() {
+        let channelID = ChannelId.unique
+        
+        var completionCalledError: Error?
+        channelUpdater.rejectInvite(cid: channelID) { completionCalledError = $0 }
+
+        // Simulate API response with failure
+        let error = TestError()
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(error))
+
+        // Assert the completion is called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, error)
+    }
+    
     // MARK: - Remove members
 
     func test_removeMembers_makesCorrectAPICall() {


### PR DESCRIPTION
Add methods for inviting a member, and for accepting/rejecting the invite.

```swift
channelController.inviteMembers(userIds: ["luke_skywalker", "leia_organa"]) { error in ... }
```
```swift
channelController.acceptInvite(message: "Hi everyone!") { error in ... }
```
```swift
channelController.rejectInvite() { error in ... }
```

After this change will have been merged, customers will be able to call invite/acceptInvite/rejectInvite endpoints, but they won't be able to react to events. For this to work we need changes from Pavel that introduce a mechanism for propagating events to customers' code