### PR TITLE
[CIS-1023] Fix composer buttons not shown in first render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix deleted messages appearance [#1267](https://github.com/GetStream/stream-chat-swift/pull/1267)
+- Fix composer commands and attachment buttons not shown in first render when channel is not in cache [#1277](https://github.com/GetStream/stream-chat-swift/pull/1277)
 
 ### ⚠️ Breaking Changes from `4.0-beta.6`
 - The `ChatSuggestionsViewController` was renamed to `ChatSuggestionsVC` to follow the same pattern across the codebase. [#1195](https://github.com/GetStream/stream-chat-swift/pull/1195)

--- a/Sources/StreamChatTestTools/Controllers/ChatChannelController_Mock.swift
+++ b/Sources/StreamChatTestTools/Controllers/ChatChannelController_Mock.swift
@@ -26,6 +26,11 @@ public class ChatChannelController_Mock<ExtraData: ExtraDataTypes>: _ChatChannel
         get { state_mock ?? super.state }
         set { super.state = newValue }
     }
+
+    public private(set) var synchronize_completion: ((Error?) -> Void)?
+    override public func synchronize(_ completion: ((Error?) -> Void)? = nil) {
+        synchronize_completion = completion
+    }
 }
 
 public extension ChatChannelController_Mock {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -123,7 +123,9 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
         messageComposerVC.userSearchController = userSuggestionSearchController
         
         channelController.setDelegate(self)
-        channelController.synchronize()
+        channelController.synchronize { [weak self] _ in
+            self?.messageComposerVC.updateContent()
+        }
         
         if channelController.channel?.isDirectMessageChannel == true {
             timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC_Tests.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC_Tests.swift
@@ -96,4 +96,26 @@ final class ChatMessageListVC_Tests: XCTestCase {
             variants: [.defaultLight]
         )
     }
+
+    func test_setUp_whenChannelControllerSynchronizeCompletes_shouldUpdateComposer() {
+        class ComposerVC_Mock: ComposerVC {
+            var updateContentCallCount = 0
+
+            override func updateContent() {
+                updateContentCallCount += 1
+            }
+        }
+
+        var components = Components()
+        components.messageComposerVC = ComposerVC_Mock.self
+        vc.components = components
+
+        vc.setUp()
+
+        // When channel controller synchronize completes
+        channelControllerMock.synchronize_completion?(nil)
+
+        let composer = vc.messageComposerVC as! ComposerVC_Mock
+        XCTAssertEqual(composer.updateContentCallCount, 1)
+    }
 }


### PR DESCRIPTION
## Description of the pull request

### Problem
If the `ChatMessageListVC` was presented without the channel list, the `commandsButton` and `attachmentsButton` would not be shown in the first render of the composer (first `updateContent()`).  Because when presenting the channel list this way the channels are not cached and so the `channelConfig` will be `nil` on the first `updateContent()`, which means that the `commandsButton` and `attachmentsButton` will be hidden. 

### Solution
The solution is to call `composerVC.updateContent() ` when the `channelController.synchronize` finishes from the `MessageListVC`. With this, the composer is updated and will get the channel config properly and show the buttons.

### Demo
I've changed the demo app to present a message list without the channel list to replicate the problem. In this video we can see that after the loading of the channel the buttons are shown. Before they were not.

https://user-images.githubusercontent.com/12814114/125656137-2db3d53a-9578-43b3-94ec-cd089aafd6c7.mp4

