### PR TITLE
[CIS-1035] Introduce `urlRequest(forImage)` to ImageCDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- `urlRequest(forImage url:)` added to `ImageCDN` protocol, this can be used to inject custom HTTP headers into image loading requests [#1291](https://github.com/GetStream/stream-chat-swift/issues/1291)
+
 ### 🐞 Fixed
 - Fix an issue where member role sent from backend was not recognized by the SDK [#1288](https://github.com/GetStream/stream-chat-swift/pull/1288)
 

--- a/Sources/StreamChatUI/Utils/ImageCDN.swift
+++ b/Sources/StreamChatUI/Utils/ImageCDN.swift
@@ -11,6 +11,10 @@ public protocol ImageCDN {
     /// - Returns: String to be used as an image cache key.
     func cachingKey(forImage url: URL) -> String
     
+    /// Prepare and return a `URLRequest` for the given image `URL`
+    /// This function can be used to inject custom headers for image loading request.
+    func urlRequest(forImage url: URL) -> URLRequest
+    
     /// Enhance image URL with size parameters to get thumbnail
     /// - Parameters:
     ///   - originalURL: URL of the image to get the thumbnail for.
@@ -20,10 +24,19 @@ public protocol ImageCDN {
     func thumbnailURL(originalURL: URL, preferredSize: CGSize) -> URL
 }
 
-public struct StreamImageCDN: ImageCDN {
+extension ImageCDN {
+    public func urlRequest(forImage url: URL) -> URLRequest {
+        URLRequest(url: url)
+    }
+}
+
+open class StreamImageCDN: ImageCDN {
     public static var streamCDNURL = "stream-io-cdn.com"
     
-    public func cachingKey(forImage url: URL) -> String {
+    // Initializer required for subclasses
+    public init() {}
+    
+    open func cachingKey(forImage url: URL) -> String {
         let key = url.absoluteString
         
         guard
@@ -40,7 +53,13 @@ public struct StreamImageCDN: ImageCDN {
         return components.string ?? key
     }
     
-    public func thumbnailURL(originalURL: URL, preferredSize: CGSize) -> URL {
+    // Although this is the same as the default impl, we still need it
+    // so subclasses can safely override it
+    open func urlRequest(forImage url: URL) -> URLRequest {
+        URLRequest(url: url)
+    }
+    
+    open func thumbnailURL(originalURL: URL, preferredSize: CGSize) -> URL {
         guard
             var components = URLComponents(url: originalURL, resolvingAgainstBaseURL: true),
             let host = components.host,

--- a/Sources/StreamChatUI/Utils/UIImageView+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/UIImageView+Extensions.swift
@@ -63,7 +63,12 @@ extension UIImageView {
         }
         
         let imageKey = components.imageCDN.cachingKey(forImage: url)
-        let request = ImageRequest(url: url, processors: preprocessors, options: ImageRequestOptions(filteredURL: imageKey))
+        let urlRequest = components.imageCDN.urlRequest(forImage: url)
+        let request = ImageRequest(
+            urlRequest: urlRequest,
+            processors: preprocessors,
+            options: ImageRequestOptions(filteredURL: imageKey)
+        )
         let options = ImageLoadingOptions(placeholder: placeholder)
 
         currentImageLoadingTask = Nuke.loadImage(with: request, options: options, into: self, completion: completion)

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -116,6 +116,11 @@ Builds SlackClone app
 fastlane build_messenger_clone
 ```
 Builds MessengerClone app
+### build_youtube_clone
+```
+fastlane build_youtube_clone
+```
+Builds YouTubeClone app
 ### build_docs_snippets
 ```
 fastlane build_docs_snippets


### PR DESCRIPTION
This will allow users to inject their HTTP headers to image loading requests

Would look like:
```swift
class CustomImageCDN: StreamImageCDN {
    override func urlRequest(forImage url: URL) -> URLRequest {
        var request = URLRequest(url: url)
        request.setValue("Custom!", forHTTPHeaderField: "X-Custom-Header")
        return request
    }
}
```
and inject the class somewhere...
```swift
Components.default.imageCDN = CustomImageCDN()
```