### PR TITLE
[CIS-1038] Fix composer allowing whitespace only messages to be sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix an issue where member role sent from backend was not recognized by the SDK [#1288](https://github.com/GetStream/stream-chat-swift/pull/1288)
 - Fix crash in `ChannelListUpdater` caused by the lifetime not aligned with `ChatClient` [#1289](https://github.com/GetStream/stream-chat-swift/pull/1289)
+- Fix composer allowing sending whitespace only messages [#1293](https://github.com/GetStream/stream-chat-swift/issues/1293)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -63,7 +63,7 @@ open class _ComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
 
         /// A boolean that checks if the message contains any content.
         public var isEmpty: Bool {
-            text.isEmpty && attachments.isEmpty
+            text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && attachments.isEmpty
         }
 
         /// A boolean that checks if the composer is replying in a thread
@@ -386,7 +386,7 @@ open class _ComposerVC<ExtraData: ExtraDataTypes>: _ViewController,
         if let command = content.command {
             text = "/\(command.name) " + content.text
         } else {
-            text = content.text
+            text = content.text.trimmingCharacters(in: .whitespacesAndNewlines)
         }
 
         if let editingMessage = content.editingMessage {


### PR DESCRIPTION
Composer send button should be disabled when the message is only whitespace. Sending whitespace only message breaks our UI.

Also, backend trims the whitespace when the message is published. If we send the message with leading/trailing whitespace, the UI first shows the message, but when backend sends the actual message, UI jumps. So it's better to send trimmed message to backend, to prevent UI jumps.