### PR TITLE
[CIS-1043] Fix delete message action causing a crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix an issue where member role sent from backend was not recognized by the SDK [#1288](https://github.com/GetStream/stream-chat-swift/pull/1288)
 - Fix crash in `ChannelListUpdater` caused by the lifetime not aligned with `ChatClient` [#1289](https://github.com/GetStream/stream-chat-swift/pull/1289)
 - Fix composer allowing sending whitespace only messages [#1293](https://github.com/GetStream/stream-chat-swift/issues/1293)
+- Fix a crash that would occur on deleting a message [#1298](https://github.com/GetStream/stream-chat-swift/pull/1298)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -251,7 +251,14 @@ open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
         _ overlay: ChatMessageListScrollOverlayView,
         textForItemAt indexPath: IndexPath
     ) -> String? {
-        DateFormatter
+        // When a message from a channel is deleted,
+        // and the visibility of deleted messages is set to `alwaysHidden`,
+        // the messages list won't contain the message and hence it would crash
+        guard channelController.messages.indices.contains(indexPath.item) else {
+            return nil
+        }
+        
+        return DateFormatter
             .messageListDateOverlay
             .string(from: channelController.messages[indexPath.item].createdAt)
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -511,7 +511,14 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
         _ overlay: ChatMessageListScrollOverlayView,
         textForItemAt indexPath: IndexPath
     ) -> String? {
-        DateFormatter
+        // When a message from a channel is deleted,
+        // and the visibility of deleted messages is set to `alwaysHidden`,
+        // the messages list won't contain the message and hence it would crash
+        guard channelController.messages.indices.contains(indexPath.item) else {
+            return nil
+        }
+        
+        return DateFormatter
             .messageListDateOverlay
             .string(from: messageForIndexPath(indexPath).createdAt)
     }


### PR DESCRIPTION
### What does this PR do
- This PR fixes [this](https://github.com/GetStream/stream-chat-swift/issues/1295) issue where a crash would occur when deleting a message from a channel when the deleted messages visibility is set to `alwaysHidden`