### PR TITLE
[CIS-558] MessageComposer - Limit the maximum height of composer's textview and add scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix hiding already hidden channels not working [#1327](https://github.com/GetStream/stream-chat-swift/issues/1327)
 - Fix compilation for Xcode 13 beta 3 where SDK could not compile because of unvailability of `UIApplication.shared` [#1333](https://github.com/GetStream/stream-chat-swift/pull/1333)
 - Fix member removed from a Channel is still present is MemberListController.members [#1323](https://github.com/GetStream/stream-chat-swift/issues/1323)
+- Fix composer input field height for long text [#1335](https://github.com/GetStream/stream-chat-swift/issues/1335)
 
 ### 🔄 Changed
 - `ContainerStackView` doesn't `assert` when trying to remove a subview, these operations are now no-op [#1328](https://github.com/GetStream/stream-chat-swift/issues/1328)

--- a/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
+++ b/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
@@ -34,6 +34,22 @@ open class InputTextView: UITextView, AppearanceProvider {
         }
     }
     
+    /// The minimum height of the text view.
+    /// When there is no content in the text view OR the height of the content is less than this value,
+    /// the text view will be of this height
+    open var minimumHeight: CGFloat {
+        38.0
+    }
+    
+    /// The constraint responsible for setting the height of the text view.
+    open var heightConstraint: NSLayoutConstraint?
+    
+    /// The maximum height of the text view.
+    /// When the content in the text view is greater than this height, scrolling will be enabled and the text view's height will be restricted to this value
+    open var maximumHeight: CGFloat {
+        120.0
+    }
+    
     override open var attributedText: NSAttributedString! {
         didSet {
             textDidChangeProgrammatically()
@@ -82,7 +98,9 @@ open class InputTextView: UITextView, AppearanceProvider {
         )
         placeholderLabel.pin(anchors: [.centerY], to: self)
         
-        isScrollEnabled = false
+        heightConstraint = heightAnchor.constraint(equalToConstant: minimumHeight)
+        heightConstraint?.isActive = true
+        isScrollEnabled = true
     }
 
     /// Sets the given text in the current caret position.
@@ -105,6 +123,29 @@ open class InputTextView: UITextView, AppearanceProvider {
         
     @objc open func handleTextChange() {
         placeholderLabel.isHidden = !text.isEmpty
+        setTextViewHeight()
+    }
+
+    open func setTextViewHeight() {
+        var heightToSet = minimumHeight
+
+        if contentSize.height <= minimumHeight {
+            heightToSet = minimumHeight
+        } else if contentSize.height >= maximumHeight {
+            heightToSet = maximumHeight
+        } else {
+            heightToSet = contentSize.height
+        }
+
+        heightConstraint?.constant = heightToSet
+        layoutIfNeeded()
+
+        // This is due to bug in UITextView where the scroll sometimes disables
+        // when a very long text is pasted in it.
+        // Doing this ensures that it doesn't happen
+        // Reference: https://stackoverflow.com/a/33194525/3825788
+        isScrollEnabled = false
+        isScrollEnabled = true
     }
     
     // MARK: - Actions on the UITextView


### PR DESCRIPTION
### What does this PR do
- This PR enables us to limit the maximum height of the composer's textView before it enables scrolling behaviour. By this, we enhance the User Experience by not letting the textView grow to full screen. It fixes [this](https://github.com/GetStream/stream-chat-swift/issues/1335) reported issue.

![Simulator Screen Recording - iPhone 12 Pro - 2021-07-22 at 13 51 40](https://user-images.githubusercontent.com/11807135/126609862-952f0a12-2516-45b1-8e01-0f1cfcf6df4c.gif)


