### PR TITLE
[CIS-1037] Fix misplaced reaction bubbles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix message list header displaying incorrectly the online status for the current user instead of the other one [#1294](https://github.com/GetStream/stream-chat-swift/pull/1294)
 - Fix deleted last message's appearance on channels list [#1318](https://github.com/GetStream/stream-chat-swift/pull/1318)
+- Fix reaction bubbles sometimes not being aligned to bubble on short incoming message [#1320](https://github.com/GetStream/stream-chat-swift/pull/1320)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
@@ -332,8 +332,9 @@ open class _ChatMessageContentView<ExtraData: ExtraDataTypes>: _View, ThemeProvi
                 bubbleToReactionsConstraint,
                 reactionsBubbleView.centerXAnchor.pin(
                     equalTo: options.contains(.flipped) ?
-                        mainContainer.leadingAnchor :
-                        mainContainer.trailingAnchor
+                        (bubbleView ?? bubbleContentContainer).leadingAnchor :
+                        (bubbleView ?? bubbleContentContainer).trailingAnchor,
+                    constant: options.contains(.flipped) ? -8 : 8
                 )
             ]
             .compactMap { $0 }


### PR DESCRIPTION
# What this PR do:
- Fixes misplaced reaction bubbles on short messages caused by pinning the center X anchor to mainContainer instead of `bubbleView`/`bubbleContentContainer`. The width of `mainContainer` obviously expanded when there were threads or timestamp and it was longer than the bubble message (if user wrote short message...) 
# How to test it
- Go to an chat which contains short messages and scroll through the chat to find out if the reactions are pinned right
# Where you can start
-  `ChatMessageContentView.swift ` 

Before: 

<img width="452" alt="Before" src="https://user-images.githubusercontent.com/17381941/127087780-afafb8f1-91e0-472b-ad04-25a8dccdcbfd.png">


After: 
<img width="452" alt="After" src="https://user-images.githubusercontent.com/17381941/127087890-ae28c1d7-96db-41c0-afdb-5f8244768a2b.png">
