### PR TITLE
[CIS-1049] Add the `Combine` guide for the SDK

### DIFF
--- a/docusaurus/docs/iOS/combine/channels.md
+++ b/docusaurus/docs/iOS/combine/channels.md
@@ -1,0 +1,247 @@
+---
+title: Channel Controllers
+---
+
+## ChannelListController
+
+`ChatChannelListController` allows you to observe a list of chat channels based on the provided query and to paginate channels.
+
+### Publishers in `ChannelListController`
+
+To receive a queried list of channels, you can use the `channelsChangesPublisher` provided by the `ChatChannelListController`
+
+```swift
+ channelListController
+            .channelsChangesPublisher
+            .sink(receiveValue: { 
+                // process the channel changes here
+            })
+            .store(in: &cancellables)
+```
+
+## ChannelController
+
+`ChatChannelController` allows you to observe and mutate data for one channel.
+
+### Publishers in `ChannelController`
+
+The `channelChangePublisher` will emit a new value every time the channel changes.
+
+```swift
+channelController
+            .channelChangePublisher
+            .sink(receiveValue: { 
+                // Process the updated channel data here
+            })
+            .store(in: &cancellables)
+```
+
+The `messagesChangesPublisher` will emit a new value every time the list of the messages matching the query changes.
+
+```swift
+channelController
+            .messagesChangesPublisher
+            .sink(receiveValue: { 
+                //Process the messages changes here 
+            })
+            .store(in: &cancellables)
+```
+
+The `memberEventPublisher` will emit a new value every time a member event is received.
+
+```swift
+channelController
+            .memberEventPublisher
+            .sink(receiveValue: { 
+                // Process the member events here
+            })
+            .store(in: &cancellables)
+```
+
+The `typingUsersPublisher` will emit a new value every time typing users change.
+
+```swift
+channelController
+            .typingUsersPublisher
+            .sink(receiveValue: { 
+                // Process the changes related to typing users here
+            })
+            .store(in: &cancellables)
+```
+
+### Example: Typing Indicator
+
+Let's build a simple `UIView` that shows which user is currently typing in the channel using the `typingUsersPublisher`
+
+```swift
+
+class TypingIndicatorView: UIView {
+    var labelView: UILabel = {
+        var label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        addSubview(labelView)
+
+        NSLayoutConstraint.activate([
+            labelView.topAnchor.constraint(equalTo: topAnchor),
+            labelView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            labelView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            labelView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setTypingUsers(_ typingUsers: Set<ChatUser>) {
+        guard let typingUser = typingUsers.first else {
+            labelView.text = ""
+            return
+        }
+        
+        labelView.text = "\(typingUser.name ?? typingUser.id) is typing ..."
+    }
+}
+
+class ViewController: UIViewController {
+    var controller: ChatChannelController!
+    var cancellables: Set<AnyCancellable> = []
+
+    var typingIndicatorView: TypingIndicatorView = {
+        var view = TypingIndicatorView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let cid = ChannelId.init(type:.messaging, id:"the-id-of-the-channel")
+        controller = ChatClient.shared.channelController(for: cid)
+        controller.synchronize()
+
+        controller.typingUsersPublisher
+            .receive(on: RunLoop.main)
+            .sink { [weak self] typingUsers in
+                let otherUsersTyping = typingUsers.filter({ $0.id != self?.controller.client.currentUserId })
+                self?.typingIndicatorView.setTypingUsers(otherUsersTyping)
+            }.store(in: &cancellables)
+        
+        navigationItem.titleView = typingIndicatorView
+    }
+}
+
+```
+
+## ChatChannelMemberListController
+
+`ChatChannelMemberListController` allows you to observe and mutate data and observing changes for a list of channel members based on the provided query.
+
+### Publishers in `MemberListController`
+
+The `membersChanges` publisher will emit a new value whenever the list of channel members based on the provided query changes.
+
+```swift
+ memberListController
+            .membersChangesPublisher
+            .sink(receiveValue: { 
+                // Use the member list here
+             })
+            .store(in: &cancellables)
+```
+
+### Example: Listing Members
+
+This example uses the `membersChangesPublisher` to observe the changes to the members on the channel `messaging:123`
+
+```swift
+class MembersSearchResultsView: UIView {
+    var labelView: UILabel = {
+        var label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        addSubview(labelView)
+
+        NSLayoutConstraint.activate([
+            labelView.topAnchor.constraint(equalTo: topAnchor),
+            labelView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            labelView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            labelView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setMembers(_ members: [ChatChannelMember]) {
+        let membersStr = members.map { $0.name ?? $0.id }.joined(separator: ", ")
+        labelView.text = membersStr
+    }
+}
+
+class ViewController: UIViewController {
+    var controller: ChatChannelMemberListController!
+    var cancellables: Set<AnyCancellable> = []
+    
+    var membersSearchResultsView: MembersSearchResultsView = {
+        var view = MembersSearchResultsView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let cid = ChannelId.init(type:.messaging, id:"123")
+        let query = ChannelMemberListQuery.init(cid: cid)
+        
+        controller = ChatClient.shared.memberListController(query: query)
+        
+        controller.synchronize {error in
+            if error != nil {
+                log.assertionFailure(error!)
+            }
+        }
+        
+        controller.membersChangesPublisher
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                if let updatedMembers = self?.controller.members {
+                    self?.membersSearchResultsView.setMembers(Array(updatedMembers))
+                }
+            }.store(in: &cancellables)
+        
+        navigationItem.titleView = membersSearchResultsView
+    }
+}
+
+```
+
+## ChannelMemberController
+
+`ChatChannelMemberController` allows you to observe and mutate data and observing changes of a specific chat member.
+
+### Publishers in `ChannelMemberController`
+
+The `memberChangePublisher` emits a new value protocol every time the member changes.
+
+```swift
+ memberController
+            .memberChangePublisher
+            .sink(receiveValue: {  
+                // Process the member changes here.
+            })
+            .store(in: &cancellables)
+```

--- a/docusaurus/docs/iOS/combine/combine-overview.md
+++ b/docusaurus/docs/iOS/combine/combine-overview.md
@@ -1,0 +1,29 @@
+---
+title: Overview
+---
+
+The `StreamChat` framework ships with controllers that are fully compatible with `Combine`.
+You can use these combine-compatible controllers to observe the changes to the controllers, and build your own views to consume the data.
+
+Each controller exposes publishers based on the kind of data they control and allow you to observe changes. You can find examples on how to build your own views using these publishers here.
+
+## Using the `Combine` extensions of Controllers
+
+When using combine extensions of the controllers, you need to call the `synchronize` method on your controller instance before starting to observe the publishers.
+This is done to avoid the side-effects from initialization and to make sure that the controller is ready to be used.
+
+i.e. a channel controller needs to watch a channel before its publisher can emit changes.
+
+It's a best practice to pass the synchronize a completion block to handle error cases. However, error handling is optional, and you can use synchronize as a fire and forget method.
+
+```swift
+    /// ...
+    controller.synchronize { error in
+        /// something did not work with the controller setup
+        if error != nil {
+            log.assertionFailure(error!)
+            return
+        }
+    }
+    /// ...
+```

--- a/docusaurus/docs/iOS/combine/combine-overview.md
+++ b/docusaurus/docs/iOS/combine/combine-overview.md
@@ -2,8 +2,8 @@
 title: Overview
 ---
 
-The `StreamChat` framework ships with controllers that are fully compatible with `Combine`.
-You can use these combine-compatible controllers to observe the changes to the controllers, and build your own views to consume the data.
+The `StreamChat` framework ships with `Combine` publishers out of the box.
+`Combine` publishers are exposed by `StreamChat` controller classes, these publishers allow you to observe data and to build your own views.
 
 Each controller exposes publishers based on the kind of data they control and allow you to observe changes. You can find examples on how to build your own views using these publishers here.
 

--- a/docusaurus/docs/iOS/combine/connection.md
+++ b/docusaurus/docs/iOS/combine/connection.md
@@ -1,0 +1,73 @@
+---
+title: Connection
+---
+
+## ConnectionController
+
+`ChatConnectionController` allows you to connect/disconnect the `ChatClient` and observe connection events.
+
+## Publishers in `ChatConnectionController`
+
+The `connectionStatusPublisher` will emit a new value every time the connection status changes.
+
+```swift
+connectionController.connectionStatusPublisher
+            .sink(receiveValue: { 
+                // Use the connection status here
+            })
+            .store(in: &cancellables)
+```
+
+## Example: Connection Status
+
+Let's build a simple UIView that shows the current connection status.
+
+```swift
+class ConnectionStatusView: UIView {
+    var status = ConnectionStatus.connecting {
+        didSet {
+            labelView.text = "Connection status: \(status)"
+        }
+    }
+    var labelView: UILabel = {
+        var label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        addSubview(labelView)
+        NSLayoutConstraint.activate([
+            labelView.topAnchor.constraint(equalTo: topAnchor),
+            labelView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            labelView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            labelView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+class ViewController: UIViewController {
+    var controller: ChatConnectionController!
+    var cancellables: Set<AnyCancellable> = []
+    
+    var connectionStatusView: ConnectionStatusView = {
+        var view = ConnectionStatusView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        controller = ChatClient.shared.connectionController()
+        
+        controller.connectionStatusPublisher.receive(on: RunLoop.main).sink { [weak self] connectionStatus in
+            self?.connectionStatusView.status = connectionStatus
+        }.store(in: &cancellables)
+
+        navigationItem.titleView = connectionStatusView
+    }
+}
+```

--- a/docusaurus/docs/iOS/combine/events.md
+++ b/docusaurus/docs/iOS/combine/events.md
@@ -1,3 +1,57 @@
 ---
 title: Events
 ---
+
+## EventsController
+
+`EventsController` allows you subscribe to the system events published by the SDK.
+
+### Publishers in `EventsController`
+
+The `allEventsPublisher` will emit a new value every time an event is published by the SDK.
+
+```swift
+ eventsController
+                .allEventsPublisher
+                .sink { 
+                    print($0) // Process the event here
+                }.store(in: &cancellables)
+```
+
+The `EventsController` also allows you to subscribe to specific events using the `public func eventPublisher<T: Event>(_ eventType: T.Type)` method.
+This method returns a publisher that can be used to observe a specific event of type `T`.
+
+```swift
+ // Subscribe for `MessageUpdatedEvent`
+eventsController
+                .eventPublisher(MessageUpdatedEvent.self) // The type of the event you want to observe
+                .filter { [messageId = messageController.messageId] in 
+                    $0.messageId == messageId 
+                }
+                .sink { 
+                    print($0) // Process the update to the message
+                }
+                .store(in: &cancellables)
+```
+
+## Example: Subscribing to the `MessageNewEvent`
+
+```swift
+class YourCustomChannelListVC: ChatChannelListVC {
+    var eventsController: EventsController!
+    var cancellables: Set<AnyCancellable> = []
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        eventsController = controller.client.eventsController()
+        eventsController
+            .eventPublisher(MessageNewEvent.self)
+            .receive(on: RunLoop.main)
+            .sink { messageNewEvent in
+                // do what you need with the event
+                print(messageNewEvent.messageId)
+            }
+    }
+}
+```

--- a/docusaurus/docs/iOS/combine/events.md
+++ b/docusaurus/docs/iOS/combine/events.md
@@ -1,0 +1,3 @@
+---
+title: Events
+---

--- a/docusaurus/docs/iOS/combine/messages.md
+++ b/docusaurus/docs/iOS/combine/messages.md
@@ -1,0 +1,113 @@
+---
+title: Message Controllers
+---
+
+## MessageController
+
+`ChatMessageController` allows you to observe and mutate data and observing changes for one message and its replies.
+
+### Publishers in `ChatMessageController`
+
+The `messageChangePublisher` emits a new value every time the message changes.
+
+```swift
+messageController
+            .messageChangePublisher
+            .sink(receiveValue: { 
+                // Process the changes in the message here
+            })
+            .store(in: &cancellables)
+```
+
+The `repliesChangesPublisher` emits a new value every time the list of the replies of the message has some changes.
+
+```swift
+messageController
+            .repliesChangesPublisher
+            .sink(receiveValue: { 
+                // Process the changes to message replies here
+            })
+            .store(in: &cancellables)
+```
+
+### Example: Message Detail
+
+```swift
+class MessageDetailView: UIView {
+    var message: ChatMessage! {
+        didSet {
+            updateContent()
+        }
+    }
+    
+    var labelView: UILabel = {
+        var label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        addSubview(labelView)
+
+        NSLayoutConstraint.activate([
+            labelView.topAnchor.constraint(equalTo: topAnchor),
+            labelView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            labelView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            labelView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    func updateContent() {
+        let messageText = message?.text ?? ""
+        let repliesCount = message?.replyCount ?? 0
+
+        labelView.text = "Text: \(messageText) Replies: \(repliesCount)"
+    }
+}
+
+class ViewController: UIViewController {
+    var controller: ChatMessageController!
+    var cancellables: Set<AnyCancellable> = []
+
+    var messageDetailView: MessageDetailView = {
+        var view = MessageDetailView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let cid = ChannelId(type: .messaging, id: "E9BF5FCE-1")
+        controller = ChatClient.shared.messageController(cid: cid, messageId: "91AC67C6-C2AF-486E-8552-08E6F9B48D85")
+
+        controller.synchronize { error in
+            if error != nil {
+                log.assertionFailure(error!)
+                return
+            }
+            /// set the intial state to the view
+            self.messageDetailView.message = self.controller.message
+        }
+        
+        controller.messageChangePublisher.receive(on: RunLoop.main).sink { [weak self] messageChange in
+            print("Message changed!")
+            self?.messageDetailView.message = self?.controller.message
+        }.store(in: &cancellables)
+        
+        controller.repliesChangesPublisher.receive(on: RunLoop.main).sink { [weak self] messageChange in
+            print("Replies changed!")
+            self?.messageDetailView.message = self?.controller.message
+        }.store(in: &cancellables)
+
+        navigationItem.titleView = messageDetailView
+    }
+}
+
+```

--- a/docusaurus/docs/iOS/combine/users.md
+++ b/docusaurus/docs/iOS/combine/users.md
@@ -1,0 +1,127 @@
+---
+title: User Controllers
+---
+
+## CurrentUserController
+
+`CurrentChatUserController` allows you to observe and mutate the current user.
+
+### Publishers in `CurrentUserController`
+
+The `currentUserChangePublisher` emits a new value every time the current user changes.
+
+```swift
+currentUserController
+            .currentUserChangePublisher
+            .sink(receiveValue: { 
+                // Use the new user here
+            })
+            .store(in: &cancellables)
+```
+
+The `unreadCountPublisher` emits a new value every time the unread count changes.
+
+```swift
+currentUserController
+            .unreadCountPublisher
+            .sink(receiveValue: { 
+                // Use the unread count value here
+            })
+            .store(in: &cancellables)
+```
+
+### Example: Unread Count
+
+Let's build a simple UIView that shows the current unread count for the current user.
+
+```swift
+class UnreadCountIndicatorView: UIView {
+
+    var unreadCount = 0 {
+        didSet {
+            unreadCountLabelView.text = "You have \(unreadCount) unread messages"
+        }
+    }
+
+    var unreadCountLabelView: UILabel = {
+        var label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        addSubview(unreadCountLabelView)
+        NSLayoutConstraint.activate([
+            unreadCountLabelView.topAnchor.constraint(equalTo: topAnchor),
+            unreadCountLabelView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            unreadCountLabelView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            unreadCountLabelView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+class ViewController: UIViewController {
+    var currentUserController: CurrentChatUserController!
+    var cancellables: Set<AnyCancellable> = []
+    
+    var unreadCountIndicatorView: UnreadCountIndicatorView = {
+        var view = UnreadCountIndicatorView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        currentUserController = ChatClient.shared.currentUserController()
+        currentUserController.synchronize()
+        
+        currentUserController.unreadCountPublisher
+            .receive(on: RunLoop.main)
+            .sink { [weak self] unreadCount in
+            self?.unreadCountIndicatorView.unreadCount = unreadCount.messages
+        }.store(in: &cancellables)
+        
+        navigationItem.titleView = unreadCountIndicatorView
+    }
+}
+```
+
+## UserListController
+
+`ChatUserListController` allows you to observe a list of users based on the provided query.
+
+### Publishers in `ChatUserListController`
+
+The `usersChangesPublisher` will emit a new value every time there is a change in the list of the users that match the query.
+
+```swift
+userListController
+            .usersChangesPublisher
+            .sink(receiveValue: { 
+                // Use the new users here
+            })
+            .store(in: &cancellables)
+```
+
+## UserController
+
+`ChatUserController` allows you to observe and mutate the current user.
+
+### Publishers in `ChatUserController`
+
+The `userChangePublisher` will emit a new value every time the user changes.
+
+```swift
+userController
+            .userChangePublisher
+            .sink(receiveValue: { 
+                // Use the new user here
+            })
+            .store(in: &cancellables)
+```

--- a/docusaurus/sidebars-ios.json
+++ b/docusaurus/sidebars-ios.json
@@ -23,7 +23,7 @@
       ]
     },
     {
-      "Controllers with Combine" : [
+      "Combine" : [
         "combine/combine-overview",
         "combine/connection",
         "combine/channels",

--- a/docusaurus/sidebars-ios.json
+++ b/docusaurus/sidebars-ios.json
@@ -28,7 +28,8 @@
         "combine/connection",
         "combine/channels",
         "combine/users",
-        "combine/messages"
+        "combine/messages",
+        "combine/events"
       ]
     },
     {

--- a/docusaurus/sidebars-ios.json
+++ b/docusaurus/sidebars-ios.json
@@ -23,6 +23,12 @@
       ]
     },
     {
+      "Controllers with Combine" : [
+        "combine/combine-overview",
+        "combine/channels"
+      ]
+    },
+    {
       "Core Components": [
         "components/channel-list",
         "components/message-list",

--- a/docusaurus/sidebars-ios.json
+++ b/docusaurus/sidebars-ios.json
@@ -25,7 +25,8 @@
     {
       "Controllers with Combine" : [
         "combine/combine-overview",
-        "combine/channels"
+        "combine/channels",
+        "combine/connection"
       ]
     },
     {

--- a/docusaurus/sidebars-ios.json
+++ b/docusaurus/sidebars-ios.json
@@ -25,8 +25,9 @@
     {
       "Controllers with Combine" : [
         "combine/combine-overview",
+        "combine/connection",
         "combine/channels",
-        "combine/connection"
+        "combine/users"
       ]
     },
     {

--- a/docusaurus/sidebars-ios.json
+++ b/docusaurus/sidebars-ios.json
@@ -27,7 +27,8 @@
         "combine/combine-overview",
         "combine/connection",
         "combine/channels",
-        "combine/users"
+        "combine/users",
+        "combine/messages"
       ]
     },
     {


### PR DESCRIPTION
## What does this PR do

### This PR adds a guide for using the `Combine` components in the SDK with relevant examples
- For each controller delegate in our SDK, we also provide relevant publishers for clients that want to use `Combine` to observe the data. They can be referred to in the `Controller+Combine.swift` files
- Using these publishers, they can observe changes to the data and update their views accordingly

### We have documented this in the following way:
- Have a separate `Combine` section in the docs
- Have a separate page for each of the controllers
- In each of those pages, list down all the publishers provided by the controller, add a code snippet to use the publisher AND create some sample `UIKit` views to consume the data from these publishers.

**NOTE**: We do not cover `SwiftUI` examples here as for `SwiftUI`, we can use the `ObservableObject` versions of the controllers instead of using the publishers directly(This is the preferred approach)
This will be covered in the `SwiftUI` guide.