### PR TITLE
[CIS-1071] Fix member removed from Channel still present in MemberListController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix reaction bubbles sometimes not being aligned to bubble on short incoming message [#1320](https://github.com/GetStream/stream-chat-swift/pull/1320)
 - Fix hiding already hidden channels not working [#1327](https://github.com/GetStream/stream-chat-swift/issues/1327)
 - Fix compilation for Xcode 13 beta 3 where SDK could not compile because of unvailability of `UIApplication.shared` [#1333](https://github.com/GetStream/stream-chat-swift/pull/1333)
+- Fix member removed from a Channel is still present is MemberListController.members [#1323](https://github.com/GetStream/stream-chat-swift/issues/1323)
 
 ### 🔄 Changed
 - `ContainerStackView` doesn't `assert` when trying to remove a subview, these operations are now no-op [#1328](https://github.com/GetStream/stream-chat-swift/issues/1328)

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -26,6 +26,7 @@ class MemberDTO: NSManagedObject {
     // MARK: - Relationships
     
     @NSManaged var user: UserDTO
+    @NSManaged var queries: Set<ChannelMemberListQueryDTO>
     
     private static func createId(userId: String, channeldId: ChannelId) -> String {
         channeldId.rawValue + userId

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware.swift
@@ -28,7 +28,12 @@ struct MemberEventMiddleware<ExtraData: ExtraDataTypes>: EventMiddleware {
                     // No need to throw MemberNotFound error here
                     break
                 }
+                // We remove the member from the channel
                 channel.members.remove(member)
+                
+                // If there are any MemberListQueries observing this channel,
+                // we need to update them too
+                member.queries.removeAll()
 
             default:
                 break

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware_Tests.swift
@@ -128,6 +128,22 @@ final class MemberEventMiddleware_Tests: XCTestCase {
         // Save channel's member's id so we can remove it
         let memberId = channel.members.first!.user.id
         
+        // Create MemberListQuery for the channel
+        let query = ChannelMemberListQuery(cid: cid)
+        
+        // Link the member to a MemberListQuery
+        try database.writeSynchronously {
+            try $0.saveQuery(query)
+            try $0.saveMember(payload: .dummy(userId: memberId), channelId: cid, query: query)
+        }
+        
+        var queryDTO = try XCTUnwrap(
+            database.viewContext.channelMemberListQuery(queryHash: query.queryHash)
+        )
+        
+        // Assert that member is linked to the query
+        XCTAssertEqual(queryDTO.members.count, 1)
+        
         // Create MemberRemovedEvent payload
         let eventPayload: EventPayload<NoExtraData> = .init(
             eventType: .memberRemoved,
@@ -145,6 +161,14 @@ final class MemberEventMiddleware_Tests: XCTestCase {
         channel = try XCTUnwrap(
             database.viewContext.channel(cid: cid)
         )
+        
+        // Load the query again
+        queryDTO = try XCTUnwrap(
+            database.viewContext.channelMemberListQuery(queryHash: query.queryHash)
+        )
+        
+        // Assert that member is not linked to the query anymore
+        XCTAssertEqual(queryDTO.members.count, 0)
         
         // Assert event is forwarded.
         XCTAssertTrue(forwardedEvent is MemberRemovedEvent)


### PR DESCRIPTION
This happened because we forgot to update the queries of Member when it's removed. A similar bug may be present in MemberAdded and MemberUpdated events. For those events, we need to re-fetch the queries, since Client doesn't have a way to apply filters.
