### PR TITLE
[CIS-1072] Fix hiding already hidden channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix message list header displaying incorrectly the online status for the current user instead of the other one [#1294](https://github.com/GetStream/stream-chat-swift/pull/1294)
 - Fix deleted last message's appearance on channels list [#1318](https://github.com/GetStream/stream-chat-swift/pull/1318)
 - Fix reaction bubbles sometimes not being aligned to bubble on short incoming message [#1320](https://github.com/GetStream/stream-chat-swift/pull/1320)
+- Fix hiding already hidden channels not working [#1327](https://github.com/GetStream/stream-chat-swift/issues/1327)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -85,8 +85,25 @@ class ChannelUpdater<ExtraData: ExtraDataTypes>: Worker {
     ///   - clearHistory: Flag to remove channel history.
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     func hideChannel(cid: ChannelId, clearHistory: Bool, completion: ((Error?) -> Void)? = nil) {
-        apiClient.request(endpoint: .hideChannel(cid: cid, clearHistory: clearHistory)) {
-            completion?($0.error)
+        apiClient.request(endpoint: .hideChannel(cid: cid, clearHistory: clearHistory)) { [weak self] result in
+            if result.error == nil {
+                // If the API call is a success, we mark the channel as hidden
+                // We do this because if the channel was already hidden, but the SDK
+                // is not aware of this, we won't get `channel.hidden` event and we won't
+                // hide the channel
+                self?.database.write {
+                    if let channel = $0.channel(cid: cid) {
+                        channel.hiddenAt = Date()
+                        if clearHistory {
+                            channel.truncatedAt = Date()
+                        }
+                    }
+                } completion: {
+                    completion?($0)
+                }
+            } else {
+                completion?(result.error)
+            }
         }
     }
     

--- a/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
@@ -425,6 +425,60 @@ class ChannelUpdater_Tests: StressTestCase {
         let referenceEndpoint: Endpoint<EmptyResponse> = .hideChannel(cid: channelID, clearHistory: clearHistory)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
     }
+    
+    func test_hideChannel_hidesChannel_onSuccessfulAPIResponse() throws {
+        // This test is for the case where the channel is already hidden on backend
+        // But SDK is not aware of this (so channel.hiddenAt is not set)
+        // Consecutive `hideChannel` calls won't generate `channel.hidden` events
+        // and SDK has no way to learn channel was hidden
+        // So, ChannelUpdater marks the Channel as hidden on successful API response
+        
+        // Create a channel in DB
+        let cid = ChannelId.unique
+        
+        try database.writeSynchronously {
+            try $0.saveChannel(payload: self.dummyPayload(with: cid))
+        }
+        
+        var channel: ChannelDTO? {
+            database.viewContext.channel(cid: cid)
+        }
+        
+        // Assert that channel is not hidden
+        XCTAssertNil(channel?.hiddenAt)
+        
+        // Call hideChannel
+        var completionCalled = false
+        channelUpdater.hideChannel(cid: cid, clearHistory: false) { error in
+            XCTAssertNotNil(error)
+            completionCalled = true
+        }
+        
+        // Simulate API response with failure
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(TestError()))
+        
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+        
+        // Ensure channel is not marked as hidden
+        XCTAssertNil(channel?.hiddenAt)
+        
+        // Call hideChannel
+        completionCalled = false
+        channelUpdater.hideChannel(cid: cid, clearHistory: false) { error in
+            XCTAssertNil(error)
+            completionCalled = true
+        }
+        
+        // Simulate API response with failure
+        apiClient.test_simulateResponse(Result<EmptyResponse, Error>.success(.init()))
+        
+        // Assert completion is called
+        AssertAsync.willBeTrue(completionCalled)
+        
+        // Ensure channel is marked as hidden
+        XCTAssertNotNil(channel?.hiddenAt)
+    }
 
     func test_hideChannel_successfulResponse_isPropagatedToCompletion() {
         // Simulate `hideChannel(cid:, clearHistory:, completion:)` call


### PR DESCRIPTION
This fix is for the case where the channel is already hidden on backend but SDK is not aware of this (so channel.hiddenAt is not set)
Consecutive `hideChannel` calls won't generate `channel.hidden` events and SDK has no way to learn channel was hidden
So, ChannelUpdater marks the Channel as hidden on successful API response
