### PR TITLE
Fix Xcode 13 beta 3 AppExtension compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix deleted last message's appearance on channels list [#1318](https://github.com/GetStream/stream-chat-swift/pull/1318)
 - Fix reaction bubbles sometimes not being aligned to bubble on short incoming message [#1320](https://github.com/GetStream/stream-chat-swift/pull/1320)
 - Fix hiding already hidden channels not working [#1327](https://github.com/GetStream/stream-chat-swift/issues/1327)
+- Fix compilation for Xcode 13 beta 3 where SDK could not compile because of unvailability of `UIApplication.shared` [#1333](https://github.com/GetStream/stream-chat-swift/pull/1333)
 
 ### 🔄 Changed
 - `ContainerStackView` doesn't `assert` when trying to remove a subview, these operations are now no-op [#1328](https://github.com/GetStream/stream-chat-swift/issues/1328)

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC+SwiftUI.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC+SwiftUI.swift
@@ -5,11 +5,13 @@
 import StreamChat
 import SwiftUI
 
-@available(iOS 13.0, *)
 /// A `UIViewControllerRepresentable` subclass which wraps `ChatChannelListVC` and shows list of channels.
+@available(iOS 13.0, *)
+@available(iOSApplicationExtension, unavailable)
 public typealias ChatChannelList = SwiftUIViewControllerRepresentable<_ChatChannelListVC<NoExtraData>>
 
 @available(iOS 13.0, *)
+@available(iOSApplicationExtension, unavailable)
 public extension SwiftUIViewControllerRepresentable where ViewController: _ChatChannelListVC<NoExtraData> {
     @available(*, deprecated, renamed: "asView")
     init(controller: _ChatChannelListController<NoExtraData>) {
@@ -21,6 +23,7 @@ public extension SwiftUIViewControllerRepresentable where ViewController: _ChatC
 }
 
 @available(iOS 13.0, *)
+@available(iOSApplicationExtension, unavailable)
 extension _ChatChannelListVC {
     /// A SwiftUI View that wraps `_ChatChannelListVC` and shows list of messages.
     @available(*, deprecated, renamed: "asView")
@@ -29,6 +32,7 @@ extension _ChatChannelListVC {
     }
 }
 
+@available(iOSApplicationExtension, unavailable)
 extension _ChatChannelListVC: SwiftUIRepresentable {
     public var content: _ChatChannelListController<ExtraData> {
         get {

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -6,9 +6,11 @@ import StreamChat
 import UIKit
 
 /// A `UIViewController` subclass  that shows list of channels.
+@available(iOSApplicationExtension, unavailable)
 public typealias ChatChannelListVC = _ChatChannelListVC<NoExtraData>
 
 /// A `UIViewController` subclass  that shows list of channels.
+@available(iOSApplicationExtension, unavailable)
 open class _ChatChannelListVC<ExtraData: ExtraDataTypes>: _ViewController,
     UICollectionViewDataSource,
     UICollectionViewDelegate,

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/AttachmentViewCatalog.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/AttachmentViewCatalog.swift
@@ -8,11 +8,13 @@ import StreamChat
 /// A class that is used to determine the AttachmentViewInjector to use for rendering one message's attachments.
 /// If your application uses custom attachment types, you will need to create a subclass and override the attachmentViewInjectorClassFor
 /// method so that the correct AttachmentViewInjector is used.
+@available(iOSApplicationExtension, unavailable)
 public typealias AttachmentViewCatalog = _AttachmentViewCatalog<NoExtraData>
 
 /// A class that is used to determine the AttachmentViewInjector to use for rendering one message's attachments.
 /// If your application uses custom attachment types, you will need to create a subclass and override the attachmentViewInjectorClassFor
 /// method so that the correct AttachmentViewInjector is used.
+@available(iOSApplicationExtension, unavailable)
 open class _AttachmentViewCatalog<ExtraData: ExtraDataTypes> {
     open class func attachmentViewInjectorClassFor(
         message: _ChatMessage<ExtraData>,

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/LinkAttachmentViewInjector.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/LinkAttachmentViewInjector.swift
@@ -6,6 +6,7 @@ import StreamChat
 import UIKit
 
 /// The delegate used in `LinkAttachmentViewInjector` to communicate user interactions.
+@available(iOSApplicationExtension, unavailable)
 public protocol LinkPreviewViewDelegate: ChatMessageContentViewDelegate {
     /// Called when the user taps the link preview.
     func didTapOnLinkAttachment(
@@ -15,9 +16,11 @@ public protocol LinkPreviewViewDelegate: ChatMessageContentViewDelegate {
 }
 
 /// View injector for showing link attachments.
+@available(iOSApplicationExtension, unavailable)
 public typealias LinkAttachmentViewInjector = _LinkAttachmentViewInjector<NoExtraData>
 
 /// View injector for showing link attachments.
+@available(iOSApplicationExtension, unavailable)
 open class _LinkAttachmentViewInjector<ExtraData: ExtraDataTypes>: _AttachmentViewInjector<ExtraData> {
     open private(set) lazy var linkPreviewView = contentView
         .components

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC+SwiftUI.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC+SwiftUI.swift
@@ -5,6 +5,7 @@
 import StreamChat
 import SwiftUI
 
+@available(iOSApplicationExtension, unavailable)
 extension _ChatMessageListVC: SwiftUIRepresentable {
     public var content: _ChatChannelController<ExtraData> {
         get {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -6,9 +6,11 @@ import StreamChat
 import UIKit
 
 /// Controller that shows list of messages and composer together in the selected channel.
+@available(iOSApplicationExtension, unavailable)
 public typealias ChatMessageListVC = _ChatMessageListVC<NoExtraData>
 
 /// Controller that shows list of messages and composer together in the selected channel.
+@available(iOSApplicationExtension, unavailable)
 open class _ChatMessageListVC<ExtraData: ExtraDataTypes>:
     _ViewController,
     ThemeProvider,

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -6,9 +6,11 @@ import StreamChat
 import UIKit
 
 /// Controller responsible for displaying message thread.
+@available(iOSApplicationExtension, unavailable)
 public typealias ChatThreadVC = _ChatThreadVC<NoExtraData>
 
 /// Controller responsible for displaying message thread.
+@available(iOSApplicationExtension, unavailable)
 open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
     _ViewController,
     ThemeProvider,
@@ -508,6 +510,7 @@ open class _ChatThreadVC<ExtraData: ExtraDataTypes>:
     }
 }
 
+@available(iOSApplicationExtension, unavailable)
 extension ChatThreadVC: SwiftUIRepresentable {
     public var content: (
         channelController: _ChatChannelController<ExtraData>,

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -86,6 +86,7 @@ public struct _Components<ExtraData: ExtraDataTypes> {
     public var playerView: PlayerView.Type = PlayerView.self
 
     /// The View Controller used to display content of the message, i.e. in the channel detail message list.
+    @available(iOSApplicationExtension, unavailable)
     public var messageListVC: _ChatMessageListVC<ExtraData>.Type = _ChatMessageListVC<ExtraData>.self
 
     /// The view that shows the message list.
@@ -97,6 +98,7 @@ public struct _Components<ExtraData: ExtraDataTypes> {
         ChatMessageListScrollOverlayView.self
     
     /// The View Controller used to display the detail of a message thread.
+    @available(iOSApplicationExtension, unavailable)
     public var threadVC: _ChatThreadVC<ExtraData>.Type = _ChatThreadVC<ExtraData>.self
 
     /// The view that displays channel information on the thread header.
@@ -129,12 +131,14 @@ public struct _Components<ExtraData: ExtraDataTypes> {
     public var messageBubbleView: _ChatMessageBubbleView<ExtraData>.Type = _ChatMessageBubbleView<ExtraData>.self
 
     /// The class responsible for returning the correct attachment view injector from a message
+    @available(iOSApplicationExtension, unavailable)
     public var attachmentViewCatalog: _AttachmentViewCatalog<ExtraData>.Type = _AttachmentViewCatalog<ExtraData>.self
 
     /// The injector used to inject gallery attachment views.
     public var galleryAttachmentInjector: _AttachmentViewInjector<ExtraData>.Type = _GalleryAttachmentViewInjector<ExtraData>.self
 
     /// The injector used to inject link attachment views.
+    @available(iOSApplicationExtension, unavailable)
     public var linkAttachmentInjector: _AttachmentViewInjector<ExtraData>.Type = _LinkAttachmentViewInjector<ExtraData>.self
 
     /// The injector used for injecting giphy attachment views
@@ -330,6 +334,7 @@ public struct _Components<ExtraData: ExtraDataTypes> {
     public var navigationVC: NavigationVC.Type = NavigationVC.self
 
     /// The router responsible for navigation on channel list screen.
+    @available(iOSApplicationExtension, unavailable)
     public var channelListRouter: _ChatChannelListRouter<ExtraData>.Type = _ChatChannelListRouter<ExtraData>.self
 
     /// The router responsible for navigation on message list screen.

--- a/Sources/StreamChatUI/Navigation/ChatChannelListRouter.swift
+++ b/Sources/StreamChatUI/Navigation/ChatChannelListRouter.swift
@@ -6,9 +6,11 @@ import StreamChat
 import UIKit
 
 /// A `NavigationRouter` subclass that handles navigation actions of `ChatChannelListVC`.
+@available(iOSApplicationExtension, unavailable)
 public typealias ChatChannelListRouter = _ChatChannelListRouter<NoExtraData>
 
 /// A `NavigationRouter` subclass that handles navigation actions of `ChatChannelListVC`.
+@available(iOSApplicationExtension, unavailable)
 open class _ChatChannelListRouter<ExtraData: ExtraDataTypes>:
     NavigationRouter<_ChatChannelListVC<ExtraData>>,
     ComponentsProvider

--- a/Sources/StreamChatUI/Navigation/ChatMessageListRouter.swift
+++ b/Sources/StreamChatUI/Navigation/ChatMessageListRouter.swift
@@ -62,6 +62,7 @@ open class _ChatMessageListRouter<ExtraData: ExtraDataTypes>:
     ///
     /// - Parameter url: The URL of the link to preview.
     ///
+    @available(iOSApplicationExtension, unavailable)
     open func showLinkPreview(link: URL) {
         UIApplication.shared.open(link)
     }
@@ -85,6 +86,7 @@ open class _ChatMessageListRouter<ExtraData: ExtraDataTypes>:
     ///   - cid: The `cid` of the channel the message belongs to.
     ///   - client: The current `ChatClient` instance.
     ///
+    @available(iOSApplicationExtension, unavailable)
     open func showThread(
         messageId: MessageId,
         cid: ChannelId,


### PR DESCRIPTION
# What this PR do:
- Fix SDK compilation issue for Xcode 13 beta 3  by marking functions leading to calling `UIApplication.shared.open` as `unavailable` for `iOSAppExtension`
# How to test it
- Run Attached demo project in Xcode 13 beta 3 and see if it compiles.
[TestingApp.zip](https://github.com/GetStream/stream-chat-swift/files/6904707/TestingApp.zip)


SPM Team is looking for different solutions to the problem, you can take a look at discussion here: 

https://forums.swift.org/t/set-application-extension-api-only-on-a-spm-package/39333/24