### PR TITLE
[CIS-1079] Fix CoreData misuse when creating Direct Messaging channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix compilation for Xcode 13 beta 3 where SDK could not compile because of unvailability of `UIApplication.shared` [#1333](https://github.com/GetStream/stream-chat-swift/pull/1333)
 - Fix member removed from a Channel is still present is MemberListController.members [#1323](https://github.com/GetStream/stream-chat-swift/issues/1323)
 - Fix composer input field height for long text [#1335](https://github.com/GetStream/stream-chat-swift/issues/1335)
+- Fix creating direct messaging channels creates CoreData misuse [#1337](https://github.com/GetStream/stream-chat-swift/issues/1337)
 
 ### 🔄 Changed
 - `ContainerStackView` doesn't `assert` when trying to remove a subview, these operations are now no-op [#1328](https://github.com/GetStream/stream-chat-swift/issues/1328)

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -309,15 +309,17 @@ public class _ChatChannelController<ExtraData: ExtraDataTypes>: DataController, 
         _messagesObserver.computeValue = { [unowned self] in
             guard let cid = self.cid else { return nil }
             let sortAscending = self.listOrdering == .topToBottom ? false : true
-            let deletedMessageVisibility = self.client.databaseContainer.viewContext
-                .deletedMessagesVisibility ?? .visibleForCurrentUser
+            var deletedMessageVisibility: ChatClientConfig.DeletedMessageVisibility?
+            self.client.databaseContainer.viewContext.performAndWait {
+                deletedMessageVisibility = self.client.databaseContainer.viewContext.deletedMessagesVisibility
+            }
 
             let observer = ListDatabaseObserver(
                 context: self.client.databaseContainer.viewContext,
                 fetchRequest: MessageDTO.messagesFetchRequest(
                     for: cid,
                     sortAscending: sortAscending,
-                    deletedMessagesVisibility: deletedMessageVisibility
+                    deletedMessagesVisibility: deletedMessageVisibility ?? .visibleForCurrentUser
                 ),
                 itemCreator: { $0.asModel() as _ChatMessage<ExtraData> }
             )


### PR DESCRIPTION
CoreData entities should be accessed from their own queues only.

Resolves #1336 