### PR TITLE
[CIS-1081] Expose models on Events

### DIFF
--- a/DemoApp/AppDelegate.swift
+++ b/DemoApp/AppDelegate.swift
@@ -5,13 +5,14 @@
 import UIKit
 
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         // Override point for customization after application launch.
-        true
+        UNUserNotificationCenter.current().delegate = self
+        return true
     }
 
     // MARK: UISceneSession Lifecycle
@@ -24,5 +25,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+    
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .badge, .sound])
     }
 }

--- a/DemoApp/LoginViewController.swift
+++ b/DemoApp/LoginViewController.swift
@@ -60,6 +60,16 @@ class LoginViewController: UIViewController {
             tableView.deselectRow(at: selectedRow, animated: true)
         }
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _, error in
+            if let error = error {
+                log.error("Error when enabling notifications: \(error)")
+            }
+        }
+    }
 }
 
 extension LoginViewController: UITableViewDelegate, UITableViewDataSource {

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController+Combine.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController+Combine.swift
@@ -23,7 +23,7 @@ extension ChatChannelController {
     }
     
     /// A publisher emitting a new value every time member event received.
-    public var memberEventPublisher: AnyPublisher<MemberEvent, Never> {
+    public var memberEventPublisher: AnyPublisher<Event, Never> {
         basePublishers.memberEvent.keepAlive(self)
     }
     
@@ -49,7 +49,7 @@ extension ChatChannelController {
         let messagesChanges: PassthroughSubject<[ListChange<ChatMessage>], Never> = .init()
         
         /// A backing subject for `memberEventPublisher`.
-        let memberEvent: PassthroughSubject<MemberEvent, Never> = .init()
+        let memberEvent: PassthroughSubject<Event, Never> = .init()
         
         /// A backing subject for `typingUsersPublisher`.
         let typingUsers: PassthroughSubject<Set<ChatUser>, Never> = .init()
@@ -83,7 +83,7 @@ extension ChatChannelController.BasePublishers: ChatChannelControllerDelegate {
         messagesChanges.send(changes)
     }
 
-    func channelController(_ channelController: ChatChannelController, didReceiveMemberEvent event: MemberEvent) {
+    func channelController(_ channelController: ChatChannelController, didReceiveMemberEvent event: Event) {
         memberEvent.send(event)
     }
     

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1158,7 +1158,7 @@ public protocol ChatChannelControllerDelegate: DataControllerStateDelegate {
     )
 
     /// The controller received a `MemberEvent` related to the channel it observes.
-    func channelController(_ channelController: ChatChannelController, didReceiveMemberEvent: MemberEvent)
+    func channelController(_ channelController: ChatChannelController, didReceiveMemberEvent: Event)
     
     /// The controller received a change related to users typing in the channel it observes.
     func channelController(
@@ -1178,7 +1178,7 @@ public extension ChatChannelControllerDelegate {
         didUpdateMessages changes: [ListChange<ChatMessage>]
     ) {}
 
-    func channelController(_ channelController: ChatChannelController, didReceiveMemberEvent: MemberEvent) {}
+    func channelController(_ channelController: ChatChannelController, didReceiveMemberEvent: Event) {}
     
     func channelController(
         _ channelController: ChatChannelController,
@@ -1203,7 +1203,7 @@ class AnyChannelControllerDelegate: ChatChannelControllerDelegate {
     
     private var _controllerDidReceiveMemberEvent: (
         ChatChannelController,
-        MemberEvent
+        Event
     ) -> Void
     
     private var _controllerDidChangeTypingUsers: (
@@ -1226,7 +1226,7 @@ class AnyChannelControllerDelegate: ChatChannelControllerDelegate {
         ) -> Void,
         controllerDidReceiveMemberEvent: @escaping (
             ChatChannelController,
-            MemberEvent
+            Event
         ) -> Void,
         controllerDidChangeTypingUsers: @escaping (
             ChatChannelController,
@@ -1261,7 +1261,7 @@ class AnyChannelControllerDelegate: ChatChannelControllerDelegate {
     
     func channelController(
         _ controller: ChatChannelController,
-        didReceiveMemberEvent event: MemberEvent
+        didReceiveMemberEvent event: Event
     ) {
         _controllerDidReceiveMemberEvent(controller, event)
     }

--- a/Sources/StreamChat/WebSocketClient/Events/ChannelEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/ChannelEvents.swift
@@ -7,6 +7,7 @@ import Foundation
 public struct ChannelUpdatedEvent: ChannelSpecificEvent {
     public let cid: ChannelId
 
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -19,6 +20,7 @@ public struct ChannelDeletedEvent: ChannelSpecificEvent {
     public let cid: ChannelId
     public let deletedAt: Date
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -30,6 +32,8 @@ public struct ChannelDeletedEvent: ChannelSpecificEvent {
 
 public struct ChannelTruncatedEvent: ChannelSpecificEvent {
     public let cid: ChannelId
+    
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -40,6 +44,8 @@ public struct ChannelTruncatedEvent: ChannelSpecificEvent {
 
 public struct ChannelVisibleEvent: ChannelSpecificEvent {
     public let cid: ChannelId
+    
+    var savedData: SavedEventData?
     let payload: Any
 
     init(from response: EventPayload) throws {
@@ -52,6 +58,8 @@ public struct ChannelHiddenEvent: ChannelSpecificEvent {
     public let cid: ChannelId
     public let hiddenAt: Date
     public let isHistoryCleared: Bool
+    
+    var savedData: SavedEventData?
     let payload: Any
 
     init(from response: EventPayload) throws {

--- a/Sources/StreamChat/WebSocketClient/Events/ConnectionEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/ConnectionEvents.swift
@@ -11,6 +11,7 @@ public protocol ConnectionEvent: Event {
 public struct HealthCheckEvent: ConnectionEvent, EventWithPayload {
     public let connectionId: String
     
+    var savedData: SavedEventData?
     var payload: Any
     
     init(from eventResponse: EventPayload) throws {

--- a/Sources/StreamChat/WebSocketClient/Events/Event.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/Event.swift
@@ -2,16 +2,94 @@
 // Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
+import CoreData
 import Foundation
 
 /// An `Event` object representing an event in the chat system.
-public protocol Event {}
+public protocol Event {
+    func user() -> ChatUser?
+    func currentUser() -> CurrentChatUser?
+    func channel() -> ChatChannel?
+    func member() -> ChatChannelMember?
+    func unreadCount() -> UnreadCount?
+    func message() -> ChatMessage?
+}
+
+extension Event {
+    public func user() -> ChatUser? {
+        (self as? EventWithPayload)?.savedData?.user
+    }
+    
+    public func currentUser() -> CurrentChatUser? {
+        (self as? EventWithPayload)?.savedData?.currentUser
+    }
+    
+    public func channel() -> ChatChannel? {
+        (self as? EventWithPayload)?.savedData?.channel
+    }
+    
+    public func member() -> ChatChannelMember? {
+        (self as? EventWithPayload)?.savedData?.member
+    }
+    
+    public func unreadCount() -> UnreadCount? {
+        (self as? EventWithPayload)?.savedData?.unreadCount
+    }
+    
+    public func message() -> ChatMessage? {
+        if let eventWithPayload = self as? EventWithPayload {
+            if let savedData = eventWithPayload.savedData {
+                if let message = savedData.message {
+                    return message
+                } else {
+                    print("### no message")
+                    return nil
+                }
+            } else {
+                print("### no savedData")
+                return nil
+            }
+        } else {
+            print("### not eventWithPayload")
+            return nil
+        }
+    }
+}
+
+/// Helper object for accessing event data after it's saved to CoreData.
+public class SavedEventData {
+    @CoreDataLazy var user: ChatUser?
+    @CoreDataLazy var currentUser: CurrentChatUser?
+    @CoreDataLazy var channel: ChatChannel?
+    @CoreDataLazy var member: ChatChannelMember?
+    @CoreDataLazy var unreadCount: UnreadCount?
+    @CoreDataLazy var message: ChatMessage?
+    
+    init(
+        user: @escaping (() -> ChatUser?) = { nil },
+        currentUser: @escaping (() -> CurrentChatUser?) = { nil },
+        channel: @escaping (() -> ChatChannel?) = { nil },
+        member: @escaping (() -> ChatChannelMember?) = { nil },
+        unreadCount: @escaping (() -> UnreadCount?) = { nil },
+        message: @escaping (() -> ChatMessage?) = { nil },
+        underlyingContext: NSManagedObjectContext?
+    ) {
+        $user = (user, underlyingContext)
+        $currentUser = (currentUser, underlyingContext)
+        $channel = (channel, underlyingContext)
+        $member = (member, underlyingContext)
+        $unreadCount = (unreadCount, underlyingContext)
+        $message = (message, underlyingContext)
+    }
+}
 
 /// An internal protocol marking the Events carrying the payload. This payload can be then used for additional work,
 /// i.e. for storing the data to the database.
 protocol EventWithPayload: Event {
     /// Type-erased event payload. Cast it to `EventPayload` when you need to use it.
     var payload: Any { get }
+    /// Actual, persisted event data
+    var savedData: SavedEventData? { get set }
 }
 
 /// A protocol for any `UserEvent` where it has a `user` payload.

--- a/Sources/StreamChat/WebSocketClient/Events/Event.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/Event.swift
@@ -25,9 +25,8 @@ protocol ChannelSpecificEvent: EventWithPayload {
 }
 
 /// A protocol for any `MemberEvent` where it has a `member`, and `channel` payload.
-public protocol MemberEvent: Event {
+protocol MemberEvent: ChannelSpecificEvent {
     var memberUserId: UserId { get }
-    var cid: ChannelId { get }
 }
 
 /// A protocol for any `MessageEvent` where it has a `user`, `channel` and `message` payloads.

--- a/Sources/StreamChat/WebSocketClient/Events/MemberEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/MemberEvents.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct MemberAddedEvent: MemberEvent, ChannelSpecificEvent, EventWithPayload {
+public struct MemberAddedEvent: MemberEvent {
     public let memberUserId: UserId
     public let cid: ChannelId
     
@@ -17,7 +17,7 @@ public struct MemberAddedEvent: MemberEvent, ChannelSpecificEvent, EventWithPayl
     }
 }
 
-public struct MemberUpdatedEvent: MemberEvent, ChannelSpecificEvent, EventWithPayload {
+public struct MemberUpdatedEvent: MemberEvent {
     public let memberUserId: UserId
     public let cid: ChannelId
     
@@ -30,7 +30,7 @@ public struct MemberUpdatedEvent: MemberEvent, ChannelSpecificEvent, EventWithPa
     }
 }
 
-public struct MemberRemovedEvent: MemberEvent, ChannelSpecificEvent, EventWithPayload {
+public struct MemberRemovedEvent: MemberEvent {
     public var memberUserId: UserId
     public let cid: ChannelId
     

--- a/Sources/StreamChat/WebSocketClient/Events/MemberEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/MemberEvents.swift
@@ -8,6 +8,7 @@ public struct MemberAddedEvent: MemberEvent {
     public let memberUserId: UserId
     public let cid: ChannelId
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -21,6 +22,7 @@ public struct MemberUpdatedEvent: MemberEvent {
     public let memberUserId: UserId
     public let cid: ChannelId
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -34,6 +36,7 @@ public struct MemberRemovedEvent: MemberEvent {
     public var memberUserId: UserId
     public let cid: ChannelId
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {

--- a/Sources/StreamChat/WebSocketClient/Events/MessageEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/MessageEvents.swift
@@ -12,6 +12,7 @@ public struct MessageNewEvent: MessageSpecificEvent {
     public let watcherCount: Int?
     public let unreadCount: UnreadCount?
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -31,6 +32,7 @@ public struct MessageUpdatedEvent: MessageSpecificEvent {
     public let messageId: MessageId
     public let updatedAt: Date
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -48,6 +50,7 @@ public struct MessageDeletedEvent: MessageSpecificEvent {
     public let messageId: MessageId
     public let deletedAt: Date
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -69,6 +72,7 @@ public struct MessageReadEvent: UserSpecificEvent, ChannelSpecificEvent {
     public let readAt: Date
     public let unreadCount: UnreadCount?
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {

--- a/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
@@ -10,6 +10,8 @@ public struct NotificationMessageNewEvent: MessageSpecificEvent {
     public let messageId: MessageId
     public let createdAt: Date
     public let unreadCount: UnreadCount?
+    
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -25,6 +27,8 @@ public struct NotificationMessageNewEvent: MessageSpecificEvent {
 public struct NotificationMarkAllReadEvent: UserSpecificEvent {
     public let userId: UserId
     public let readAt: Date
+    
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -39,6 +43,8 @@ public struct NotificationMarkReadEvent: UserSpecificEvent, ChannelSpecificEvent
     public let cid: ChannelId
     public let readAt: Date
     public let unreadCount: UnreadCount
+    
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -52,6 +58,8 @@ public struct NotificationMarkReadEvent: UserSpecificEvent, ChannelSpecificEvent
 
 public struct NotificationMutesUpdatedEvent: CurrentUserEvent {
     public let currentUserId: UserId
+    
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -62,6 +70,8 @@ public struct NotificationMutesUpdatedEvent: CurrentUserEvent {
 
 public struct NotificationAddedToChannelEvent: ChannelSpecificEvent {
     public let cid: ChannelId
+    
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -74,6 +84,7 @@ public struct NotificationRemovedFromChannelEvent: CurrentUserEvent, ChannelSpec
     public let currentUserId: UserId
     public let cid: ChannelId
 
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -85,6 +96,8 @@ public struct NotificationRemovedFromChannelEvent: CurrentUserEvent, ChannelSpec
 
 public struct NotificationChannelMutesUpdatedEvent: UserSpecificEvent {
     public let userId: UserId
+    
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -97,6 +110,7 @@ public struct NotificationInvitedEvent: MemberEvent {
     public let memberUserId: UserId
     public let cid: ChannelId
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -110,6 +124,7 @@ public struct NotificationInviteAccepted: MemberEvent {
     public let memberUserId: UserId
     public let cid: ChannelId
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -123,6 +138,7 @@ public struct NotificationInviteRejected: MemberEvent {
     public let memberUserId: UserId
     public let cid: ChannelId
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {

--- a/Sources/StreamChat/WebSocketClient/Events/ReactionEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/ReactionEvents.swift
@@ -12,6 +12,7 @@ public struct ReactionNewEvent: ReactionEvent {
     public let reactionScore: Int
     public let createdAt: Date
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -33,6 +34,7 @@ public struct ReactionUpdatedEvent: ReactionEvent {
     public let reactionScore: Int
     public let updatedAt: Date
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -53,6 +55,7 @@ public struct ReactionDeletedEvent: ReactionEvent {
     public let reactionType: MessageReactionType
     public let reactionScore: Int
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {

--- a/Sources/StreamChat/WebSocketClient/Events/TypingEvent.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/TypingEvent.swift
@@ -11,6 +11,7 @@ public struct TypingEvent: UserSpecificEvent, ChannelSpecificEvent {
     public let parentId: MessageId?
     public let isThread: Bool
 
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {

--- a/Sources/StreamChat/WebSocketClient/Events/UserEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/UserEvents.swift
@@ -8,6 +8,7 @@ public struct UserPresenceChangedEvent: UserSpecificEvent {
     public let userId: UserId
     public let createdAt: Date?
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -21,6 +22,7 @@ public struct UserUpdatedEvent: UserSpecificEvent {
     public let userId: UserId
     public let createdAt: Date?
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -39,6 +41,7 @@ public struct UserWatchingEvent: UserSpecificEvent, ChannelSpecificEvent {
     public let watcherCount: Int
     public let isStarted: Bool
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -56,6 +59,8 @@ public struct UserWatchingEvent: UserSpecificEvent, ChannelSpecificEvent {
 public struct UserGloballyBannedEvent: UserSpecificEvent {
     var userId: UserId
     var createdAt: Date?
+    
+    var savedData: SavedEventData?
     var payload: Any
     
     init(from response: EventPayload) throws {
@@ -73,6 +78,7 @@ public struct UserBannedEvent: UserSpecificEvent, ChannelSpecificEvent {
     public let reason: String?
     public let expiredAt: Date?
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {
@@ -89,6 +95,8 @@ public struct UserBannedEvent: UserSpecificEvent, ChannelSpecificEvent {
 public struct UserGloballyUnbannedEvent: UserSpecificEvent {
     var userId: UserId
     var createdAt: Date?
+    
+    var savedData: SavedEventData?
     var payload: Any
     
     init(from response: EventPayload) throws {
@@ -103,6 +111,7 @@ public struct UserUnbannedEvent: UserSpecificEvent, ChannelSpecificEvent {
     public let userId: UserId
     public let createdAt: Date?
     
+    var savedData: SavedEventData?
     let payload: Any
     
     init(from response: EventPayload) throws {

--- a/Sources/StreamChatUI/ChatMessageList/ChatChannelHeaderView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatChannelHeaderView.swift
@@ -127,7 +127,7 @@ open class ChatChannelHeaderView:
 
     open func channelController(
         _ channelController: ChatChannelController,
-        didReceiveMemberEvent: MemberEvent
+        didReceiveMemberEvent: Event
     ) {
         // By default the header view is not interested in member events
         // but this can be overridden by subclassing this component.

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadHeaderView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadHeaderView.swift
@@ -80,7 +80,7 @@ open class ChatThreadHeaderView:
 
     open func channelController(
         _ channelController: ChatChannelController,
-        didReceiveMemberEvent: MemberEvent
+        didReceiveMemberEvent: Event
     ) {
         // By default the header view is not interested in member events
         // but this can be overridden by subclassing this component.


### PR DESCRIPTION
Missing:
- Changelog
- Tests

The way this works, we put a helper object to the event, and we put closures to helper object to fetch the data from DB. The closure is ran lazily when users access the fields (or never ran)