### PR TITLE
[CIS-1087] Fix data races in message list's message count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+- Fixed race condition on `ChatMessageListVC` and `ChatThreadVC` that caused `UITableView` crashes [#1347](https://github.com/GetStream/stream-chat-swift/pull/1347)
 - Added `GalleryAttachmentViewInjector.galleryViewAspectRatio` to control the aspect ratio of a gallery inside a message cell [#1300](https://github.com/GetStream/stream-chat-swift/pull/1300)
 
 # [4.0.0-beta.9](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.9)

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -171,6 +171,7 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
     /// Updates the table view data with given `changes`.
     open func updateMessages(
         with changes: [ListChange<ChatMessage>],
+        onMessagesCountUpdate: () -> Void = {},
         completion: (() -> Void)? = nil
     ) {
         var shouldScrollToBottom = false
@@ -178,6 +179,7 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
         guard let _ = collectionUpdatesMapper.mapToSetsOfIndexPaths(
             changes: changes,
             onConflict: {
+                onMessagesCountUpdate()
                 reloadData()
             }
         ) else { return }
@@ -210,6 +212,7 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
                     self.deleteRows(at: [index], with: .fade)
                 }
             }
+            onMessagesCountUpdate()
         }, completion: { _ in
             if shouldScrollToBottom {
                 self.scrollToBottomAction = .init { [weak self] in

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -96,6 +96,11 @@ open class ChatThreadVC:
         messageComposerVC.setDelegate(self)
         messageComposerVC.channelController = channelController
         messageComposerVC.userSearchController = userSuggestionSearchController
+
+        messageController.delegate = self
+        messageController.synchronize()
+        messageController.loadPreviousReplies()
+
         if let message = messageController.message {
             messageComposerVC.content.threadMessage = message
         }
@@ -104,10 +109,6 @@ open class ChatThreadVC:
 
         channelController.setDelegate(self)
         channelController.synchronize()
-
-        messageController.delegate = self
-        messageController.synchronize()
-        messageController.loadPreviousReplies()
 
         if let cid = channelController.cid {
             headerView.channelController = channelController.client.channelController(for: cid)

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -28,6 +28,9 @@ open class ChatThreadVC:
 
     /// Controller for observing data changes within the parent thread message.
     open var messageController: ChatMessageController!
+    
+    /// We use private property for channels count so we can update it inside `performBatchUpdates` as [documented](https://developer.apple.com/documentation/uikit/uicollectionview/1618045-performbatchupdates#discussion)
+    private var numberOfMessages = 0
 
     /// Observer responsible for setting the correct offset when keyboard frame is changed
     open lazy var keyboardObserver = ChatMessageListKeyboardObserver(
@@ -79,6 +82,7 @@ open class ChatThreadVC:
 
     override open func setUp() {
         super.setUp()
+        updateNumberOfMessages()
 
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress))
         longPress.minimumPressDuration = 0.33
@@ -235,7 +239,7 @@ open class ChatThreadVC:
     }
 
     open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        messages.count
+        numberOfMessages
     }
 
     open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -290,7 +294,11 @@ open class ChatThreadVC:
 
     /// Updates the collection view data with given `changes`.
     open func updateMessages(with changes: [ListChange<ChatMessage>], completion: (() -> Void)? = nil) {
-        listView.updateMessages(with: changes, completion: completion)
+        listView.updateMessages(
+            with: changes,
+            onMessagesCountUpdate: updateNumberOfMessages,
+            completion: completion
+        )
     }
 
     /// Presents custom actions controller with all possible actions with the selected message.
@@ -496,6 +504,10 @@ open class ChatThreadVC:
         return DateFormatter
             .messageListDateOverlay
             .string(from: messageForIndexPath(indexPath).createdAt)
+    }
+    
+    private func updateNumberOfMessages() {
+        numberOfMessages = messages.count
     }
     
     // MARK: - UIGestureRecognizerDelegate


### PR DESCRIPTION
My idea was the following:
From the reports on the issue it seemed like the issue is in messages count going out of sync with view's state, so I though of caching message's count and only updating it when we need it

And then I noticed that for channel list there actually already was such a mechanism and it seems like channel list does not experience this kind of issues

The only difference of the suggested fix from the one on the channel list is that message list's structure is a little bit more complicated because it has a VC and a view, but essentially it's the same