### PR TITLE
Fix not selecting composer suggestions

### DIFF
--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -668,15 +668,16 @@ open class ComposerVC: _ViewController,
 
     /// Shows the suggestions view
     open func showSuggestions() {
-        if !suggestionsVC.isPresented {
-            addChildViewController(suggestionsVC, targetView: view)
-            
+        if !suggestionsVC.isPresented, let parent = parent {
+            parent.addChildViewController(suggestionsVC, targetView: parent.view)
+
             let suggestionsView = suggestionsVC.view!
             suggestionsView.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
-                suggestionsView.leadingAnchor.pin(equalTo: view.leadingAnchor),
-                suggestionsView.trailingAnchor.pin(equalTo: view.trailingAnchor),
-                composerView.topAnchor.pin(equalToSystemSpacingBelow: suggestionsView.bottomAnchor)
+                suggestionsView.leadingAnchor.pin(equalTo: parent.view.leadingAnchor),
+                suggestionsView.trailingAnchor.pin(equalTo: parent.view.trailingAnchor),
+                composerView.topAnchor.pin(equalToSystemSpacingBelow: suggestionsView.bottomAnchor),
+                suggestionsView.topAnchor.pin(greaterThanOrEqualTo: parent.view.safeAreaLayoutGuide.topAnchor)
             ])
         }
     }


### PR DESCRIPTION
## Description of the pull request
This bug was introduced after moving the suggestions to be a child view controller of the composer. This creates a problem because the suggestions are outside of the Composer's bounds and so it doesn't get touch events. The `showSuggestions()` implementation was reverted to add the childViewController into the parent of the composer. 