### PR TITLE
[CIS-1096] Fix an issue for ChatThreadVC opened from a deeplink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed race condition on `ChatMessageListVC` and `ChatThreadVC` that caused `UITableView` crashes [#1347](https://github.com/GetStream/stream-chat-swift/pull/1347)
 - Added `GalleryAttachmentViewInjector.galleryViewAspectRatio` to control the aspect ratio of a gallery inside a message cell [#1300](https://github.com/GetStream/stream-chat-swift/pull/1300)
+- Fixed an issue for `ChatThreadVC` opened from a deeplink when new replies are only added to the chat, but not to the replies thread [#1354](https://github.com/GetStream/stream-chat-swift/pull/1354)
 
 # [4.0.0-beta.9](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.9)
 _August 05, 2021_

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -97,13 +97,17 @@ open class ChatThreadVC:
         messageComposerVC.channelController = channelController
         messageComposerVC.userSearchController = userSuggestionSearchController
 
-        messageController.delegate = self
-        messageController.synchronize()
-        messageController.loadPreviousReplies()
-
-        if let message = messageController.message {
-            messageComposerVC.content.threadMessage = message
+        let updateMessageControllerMessage: () -> Void = { [messageController, messageComposerVC] in
+            if messageComposerVC.content.threadMessage == nil,
+               let message = messageController?.message {
+                messageComposerVC.content.threadMessage = message
+            }
         }
+        
+        messageController.delegate = self
+        messageController.synchronize { _ in updateMessageControllerMessage() }
+        messageController.loadPreviousReplies()
+        updateMessageControllerMessage()
 
         userSuggestionSearchController.search(term: nil)
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -105,14 +105,18 @@ open class ChatThreadVC:
         }
         
         messageController.delegate = self
-        messageController.synchronize { _ in updateMessageControllerMessage() }
-        messageController.loadPreviousReplies()
         updateMessageControllerMessage()
 
         userSuggestionSearchController.search(term: nil)
 
         channelController.setDelegate(self)
-        channelController.synchronize()
+        
+        channelController.synchronize { [messageController] _ in
+            messageController?.synchronize { _ in
+                updateMessageControllerMessage()
+                messageController?.loadPreviousReplies()
+            }
+        }
 
         if let cid = channelController.cid {
             headerView.channelController = channelController.client.channelController(for: cid)


### PR DESCRIPTION
...when new replies are only added to the main chat, but not to the replies thread

The fix makes sure that we set thread message to the ComposerVC after `synchronize` executes. There is still an edge case for really fast users with really slow connection though 🙂 
Before merging this we need to run it by Oscar