### PR TITLE
[CIS-1102] Fix creating custom Channel Types with uppercase letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix jumps when presenting message popup actions in a modal [#1361](https://github.com/GetStream/stream-chat-swift/issues/1361)
+- Fix custom Channel Types not allowing uppercase letters [#1361](https://github.com/GetStream/stream-chat-swift/issues/1361)
 
 # [4.0.0-beta.10](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.10)
 _August 11, 2021_

--- a/Sources/StreamChat/Models/ChannelType.swift
+++ b/Sources/StreamChat/Models/ChannelType.swift
@@ -76,7 +76,9 @@ public enum ChannelType: Codable, Hashable {
     
     /// Check that custom types have valid `rawValue`
     private static func assertCustomTypeValue(_ value: String) {
-        let allowedCharacters = CharacterSet.lowercaseLetters.union(CharacterSet(charactersIn: "0123456789_"))
+        let allowedCharacters = CharacterSet.lowercaseLetters
+            .union(CharacterSet.uppercaseLetters)
+            .union(CharacterSet(charactersIn: "0123456789_"))
         let valueCharacters = CharacterSet(charactersIn: value)
         log.assert(
             valueCharacters.isSubset(of: allowedCharacters),


### PR DESCRIPTION
Backend allows this so client should too
