### PR TITLE
CIS-1110 Fix time ago formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix custom Channel Types not allowing uppercase letters [#1361](https://github.com/GetStream/stream-chat-swift/issues/1361)
 - Fix `ChatMessageGalleryView.ImagePreview` not compiling in Obj-c [#1363](https://github.com/GetStream/stream-chat-swift/pull/1363)
 - Fix force unwrap crashes on unknown user roles cases [#1365](https://github.com/GetStream/stream-chat-swift/pull/1365)
+- Fix "last seen at" representation to use other units other than minutes [#1368](https://github.com/GetStream/stream-chat-swift/pull/1368)
 
 # [4.0.0-beta.10](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.10)
 _August 11, 2021_

--- a/DemoApp/cs.lproj/Localizable.strings
+++ b/DemoApp/cs.lproj/Localizable.strings
@@ -51,7 +51,6 @@
 "message.sending.attachment-uploading-failed" = "NAHRÁVÁNÍ SOUBORU SELHALO";
 
 "message.title.online" = "Online";
-"message.title.see-minutes-ago" = "Viděno před %@";
 "message.title.offline" = "Offline";
 "message.title.group" = "%d členů, %d online";
 
@@ -59,5 +58,17 @@
 
 "attachment.max-size-exceeded" = "Velikost přílohy překročila limit.";
 
-// MARK: -  DemoApp Strings
+"dates.time-ago-seconds-plural" = "%d seconds ago";
+"dates.time-ago-seconds-singular" = "just one second ago";
+"dates.time-ago-minutes-singular" = "one minute ago";
+"dates.time-ago-minutes-plural" = "%d minutes ago";
+"dates.time-ago-hours-singular" = "one hour ago";
+"dates.time-ago-hours-plural" = "%d hours ago";
+"dates.time-ago-days-singular" = "one day ago";
+"dates.time-ago-days-plural" = "%d days ago";
+"dates.time-ago-weeks-singular" = "one week ago";
+"dates.time-ago-weeks-plural" = "%d weeks ago";
+"dates.time-ago-months-singular" = "one month ago";
+"dates.time-ago-months-plural" = "%d months ago";
 
+// MARK: -  DemoApp Strings

--- a/DemoApp/cs.lproj/Localizable.strings
+++ b/DemoApp/cs.lproj/Localizable.strings
@@ -58,17 +58,17 @@
 
 "attachment.max-size-exceeded" = "Velikost přílohy překročila limit.";
 
-"dates.time-ago-seconds-plural" = "%d seconds ago";
-"dates.time-ago-seconds-singular" = "just one second ago";
-"dates.time-ago-minutes-singular" = "one minute ago";
-"dates.time-ago-minutes-plural" = "%d minutes ago";
-"dates.time-ago-hours-singular" = "one hour ago";
-"dates.time-ago-hours-plural" = "%d hours ago";
-"dates.time-ago-days-singular" = "one day ago";
-"dates.time-ago-days-plural" = "%d days ago";
-"dates.time-ago-weeks-singular" = "one week ago";
-"dates.time-ago-weeks-plural" = "%d weeks ago";
-"dates.time-ago-months-singular" = "one month ago";
-"dates.time-ago-months-plural" = "%d months ago";
+"dates.time-ago-seconds-plural" = "last seen %d seconds ago";
+"dates.time-ago-seconds-singular" = "last seen just one second ago";
+"dates.time-ago-minutes-singular" = "last seen one minute ago";
+"dates.time-ago-minutes-plural" = "last seen %d minutes ago";
+"dates.time-ago-hours-singular" = "last seen one hour ago";
+"dates.time-ago-hours-plural" = "last seen %d hours ago";
+"dates.time-ago-days-singular" = "last seen one day ago";
+"dates.time-ago-days-plural" = "last seen %d days ago";
+"dates.time-ago-weeks-singular" = "last seen one week ago";
+"dates.time-ago-weeks-plural" = "last seen %d weeks ago";
+"dates.time-ago-months-singular" = "last seen one month ago";
+"dates.time-ago-months-plural" = "last seen %d months ago";
 
 // MARK: -  DemoApp Strings

--- a/DemoApp/en.lproj/Localizable.strings
+++ b/DemoApp/en.lproj/Localizable.strings
@@ -51,12 +51,22 @@
 "message.sending.attachment-uploading-failed" = "UPLOADING FAILED";
 
 "message.title.online" = "Online";
-"message.title.see-minutes-ago" = "Seen %@ ago";
 "message.title.offline" = "Offline";
 "message.title.group" = "%d members, %d online";
 
 "current-selection" = "%d of %d";
 
 "attachment.max-size-exceeded" = "Attachment size exceed the limit.";
-
+"dates.time-ago-seconds-plural" = "%d seconds ago";
+"dates.time-ago-seconds-singular" = "just one second ago";
+"dates.time-ago-minutes-singular" = "one minute ago";
+"dates.time-ago-minutes-plural" = "%d minutes ago";
+"dates.time-ago-hours-singular" = "one hour ago";
+"dates.time-ago-hours-plural" = "%d hours ago";
+"dates.time-ago-days-singular" = "one day ago";
+"dates.time-ago-days-plural" = "%d days ago";
+"dates.time-ago-weeks-singular" = "one week ago";
+"dates.time-ago-weeks-plural" = "%d weeks ago";
+"dates.time-ago-months-singular" = "one month ago";
+"dates.time-ago-months-plural" = "%d months ago";
 // MARK: -  DemoApp Strings

--- a/DemoApp/en.lproj/Localizable.strings
+++ b/DemoApp/en.lproj/Localizable.strings
@@ -57,16 +57,17 @@
 "current-selection" = "%d of %d";
 
 "attachment.max-size-exceeded" = "Attachment size exceed the limit.";
-"dates.time-ago-seconds-plural" = "%d seconds ago";
-"dates.time-ago-seconds-singular" = "just one second ago";
-"dates.time-ago-minutes-singular" = "one minute ago";
-"dates.time-ago-minutes-plural" = "%d minutes ago";
-"dates.time-ago-hours-singular" = "one hour ago";
-"dates.time-ago-hours-plural" = "%d hours ago";
-"dates.time-ago-days-singular" = "one day ago";
-"dates.time-ago-days-plural" = "%d days ago";
-"dates.time-ago-weeks-singular" = "one week ago";
-"dates.time-ago-weeks-plural" = "%d weeks ago";
-"dates.time-ago-months-singular" = "one month ago";
-"dates.time-ago-months-plural" = "%d months ago";
+"dates.time-ago-seconds-plural" = "last seen %d seconds ago";
+"dates.time-ago-seconds-singular" = "last seen just one second ago";
+"dates.time-ago-minutes-singular" = "last seen one minute ago";
+"dates.time-ago-minutes-plural" = "last seen %d minutes ago";
+"dates.time-ago-hours-singular" = "last seen one hour ago";
+"dates.time-ago-hours-plural" = "last seen %d hours ago";
+"dates.time-ago-days-singular" = "last seen one day ago";
+"dates.time-ago-days-plural" = "last seen %d days ago";
+"dates.time-ago-weeks-singular" = "last seen one week ago";
+"dates.time-ago-weeks-plural" = "last seen %d weeks ago";
+"dates.time-ago-months-singular" = "last seen one month ago";
+"dates.time-ago-months-plural" = "last seen %d months ago";
+
 // MARK: -  DemoApp Strings

--- a/Package.swift
+++ b/Package.swift
@@ -772,6 +772,7 @@ var streamChatUIFilesExcluded: [String] { [
     "Utils/ComponentsProvider_Tests.swift",
     "Utils/AppearanceProvider_Tests.swift",
     "Utils/ImageCDN_Tests.swift",
+    "Utils/DateUtils_Tests.swift",
     "ChatChannelList/ChatChannelUnreadCountView+SwiftUI_Tests.swift",
     "ChatChannelList/ChatChannelListCollectionViewCell_Tests.swift",
     "ChatChannelList/ChatChannelListItemView+SwiftUI_Tests.swift",

--- a/Sources/StreamChatUI/ChatMessageList/ChatChannelHeaderView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatChannelHeaderView.swift
@@ -77,9 +77,8 @@ open class ChatChannelHeaderView:
 
             if member.isOnline {
                 return L10n.Message.Title.online
-            } else if let minutes = member.lastActiveAt
-                .flatMap({ DateComponentsFormatter.minutes.string(from: $0, to: Date()) }) {
-                return L10n.Message.Title.seeMinutesAgo(minutes)
+            } else if let lastActiveAt = member.lastActiveAt, let timeAgo = DateUtils.timeAgo(relativeTo: lastActiveAt) {
+                return timeAgo
             } else {
                 return L10n.Message.Title.offline
             }

--- a/Sources/StreamChatUI/ChatMessageList/ChatChannelHeaderView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatChannelHeaderView.swift
@@ -17,6 +17,9 @@ open class ChatChannelHeaderView:
         }
     }
 
+    /// Returns the date formater function used to represent when the user was last seen online
+    open var lastSeenDateFormatter: (Date) -> String? { DateUtils.timeAgo }
+
     /// The user id of the current logged in user.
     open var currentUserId: UserId? {
         channelController?.client.currentUserId
@@ -77,7 +80,7 @@ open class ChatChannelHeaderView:
 
             if member.isOnline {
                 return L10n.Message.Title.online
-            } else if let lastActiveAt = member.lastActiveAt, let timeAgo = DateUtils.timeAgo(relativeTo: lastActiveAt) {
+            } else if let lastActiveAt = member.lastActiveAt, let timeAgo = lastSeenDateFormatter(lastActiveAt) {
                 return timeAgo
             } else {
                 return L10n.Message.Title.offline

--- a/Sources/StreamChatUI/Gallery/GalleryVC.swift
+++ b/Sources/StreamChatUI/Gallery/GalleryVC.swift
@@ -46,6 +46,9 @@ open class GalleryVC:
         return videos + images
     }
     
+    /// Returns the date formater function used to represent when the user was last seen online
+    open var lastSeenDateFormatter: (Date) -> String? { DateUtils.timeAgo }
+
     /// Controller for handling the transition for dismissal
     open var transitionController: ZoomTransitionController!
     
@@ -259,7 +262,7 @@ open class GalleryVC:
         } else {
             if
                 let lastActive = content.message.author.lastActiveAt,
-                let timeAgo = DateUtils.timeAgo(relativeTo: lastActive) {
+                let timeAgo = lastSeenDateFormatter(lastActive) {
                 dateLabel.text = timeAgo
             } else {
                 dateLabel.text = L10n.Message.Title.offline

--- a/Sources/StreamChatUI/Gallery/GalleryVC.swift
+++ b/Sources/StreamChatUI/Gallery/GalleryVC.swift
@@ -259,8 +259,8 @@ open class GalleryVC:
         } else {
             if
                 let lastActive = content.message.author.lastActiveAt,
-                let minutes = dateFormatter.string(from: lastActive, to: Date()) {
-                dateLabel.text = L10n.Message.Title.seeMinutesAgo(minutes)
+                let timeAgo = DateUtils.timeAgo(relativeTo: lastActive) {
+                dateLabel.text = timeAgo
             } else {
                 dateLabel.text = L10n.Message.Title.offline
             }

--- a/Sources/StreamChatUI/Generated/L10n.swift
+++ b/Sources/StreamChatUI/Generated/L10n.swift
@@ -85,6 +85,45 @@ internal enum L10n {
     }
   }
 
+  internal enum Dates {
+    /// %d days ago
+    internal static func timeAgoDaysPlural(_ p1: Int) -> String {
+      return L10n.tr("Localizable", "dates.time-ago-days-plural", p1)
+    }
+    /// one day ago
+    internal static var timeAgoDaysSingular: String { L10n.tr("Localizable", "dates.time-ago-days-singular") }
+    /// %d hours ago
+    internal static func timeAgoHoursPlural(_ p1: Int) -> String {
+      return L10n.tr("Localizable", "dates.time-ago-hours-plural", p1)
+    }
+    /// one hour ago
+    internal static var timeAgoHoursSingular: String { L10n.tr("Localizable", "dates.time-ago-hours-singular") }
+    /// %d minutes ago
+    internal static func timeAgoMinutesPlural(_ p1: Int) -> String {
+      return L10n.tr("Localizable", "dates.time-ago-minutes-plural", p1)
+    }
+    /// one minute ago
+    internal static var timeAgoMinutesSingular: String { L10n.tr("Localizable", "dates.time-ago-minutes-singular") }
+    /// %d months ago
+    internal static func timeAgoMonthsPlural(_ p1: Int) -> String {
+      return L10n.tr("Localizable", "dates.time-ago-months-plural", p1)
+    }
+    /// one month ago
+    internal static var timeAgoMonthsSingular: String { L10n.tr("Localizable", "dates.time-ago-months-singular") }
+    /// %d seconds ago
+    internal static func timeAgoSecondsPlural(_ p1: Int) -> String {
+      return L10n.tr("Localizable", "dates.time-ago-seconds-plural", p1)
+    }
+    /// just one second ago
+    internal static var timeAgoSecondsSingular: String { L10n.tr("Localizable", "dates.time-ago-seconds-singular") }
+    /// %d weeks ago
+    internal static func timeAgoWeeksPlural(_ p1: Int) -> String {
+      return L10n.tr("Localizable", "dates.time-ago-weeks-plural", p1)
+    }
+    /// one week ago
+    internal static var timeAgoWeeksSingular: String { L10n.tr("Localizable", "dates.time-ago-weeks-singular") }
+  }
+
   internal enum Message {
     /// Message deleted
     internal static var deletedMessagePlaceholder: String { L10n.tr("Localizable", "message.deleted-message-placeholder") }
@@ -143,10 +182,6 @@ internal enum L10n {
       internal static var offline: String { L10n.tr("Localizable", "message.title.offline") }
       /// Online
       internal static var online: String { L10n.tr("Localizable", "message.title.online") }
-      /// Seen %@ ago
-      internal static func seeMinutesAgo(_ p1: Any) -> String {
-        return L10n.tr("Localizable", "message.title.see-minutes-ago", String(describing: p1))
-      }
     }
   }
 

--- a/Sources/StreamChatUI/Generated/L10n.swift
+++ b/Sources/StreamChatUI/Generated/L10n.swift
@@ -86,41 +86,41 @@ internal enum L10n {
   }
 
   internal enum Dates {
-    /// %d days ago
+    /// last seen %d days ago
     internal static func timeAgoDaysPlural(_ p1: Int) -> String {
       return L10n.tr("Localizable", "dates.time-ago-days-plural", p1)
     }
-    /// one day ago
+    /// last seen one day ago
     internal static var timeAgoDaysSingular: String { L10n.tr("Localizable", "dates.time-ago-days-singular") }
-    /// %d hours ago
+    /// last seen %d hours ago
     internal static func timeAgoHoursPlural(_ p1: Int) -> String {
       return L10n.tr("Localizable", "dates.time-ago-hours-plural", p1)
     }
-    /// one hour ago
+    /// last seen one hour ago
     internal static var timeAgoHoursSingular: String { L10n.tr("Localizable", "dates.time-ago-hours-singular") }
-    /// %d minutes ago
+    /// last seen %d minutes ago
     internal static func timeAgoMinutesPlural(_ p1: Int) -> String {
       return L10n.tr("Localizable", "dates.time-ago-minutes-plural", p1)
     }
-    /// one minute ago
+    /// last seen one minute ago
     internal static var timeAgoMinutesSingular: String { L10n.tr("Localizable", "dates.time-ago-minutes-singular") }
-    /// %d months ago
+    /// last seen %d months ago
     internal static func timeAgoMonthsPlural(_ p1: Int) -> String {
       return L10n.tr("Localizable", "dates.time-ago-months-plural", p1)
     }
-    /// one month ago
+    /// last seen one month ago
     internal static var timeAgoMonthsSingular: String { L10n.tr("Localizable", "dates.time-ago-months-singular") }
-    /// %d seconds ago
+    /// last seen %d seconds ago
     internal static func timeAgoSecondsPlural(_ p1: Int) -> String {
       return L10n.tr("Localizable", "dates.time-ago-seconds-plural", p1)
     }
-    /// just one second ago
+    /// last seen just one second ago
     internal static var timeAgoSecondsSingular: String { L10n.tr("Localizable", "dates.time-ago-seconds-singular") }
-    /// %d weeks ago
+    /// last seen %d weeks ago
     internal static func timeAgoWeeksPlural(_ p1: Int) -> String {
       return L10n.tr("Localizable", "dates.time-ago-weeks-plural", p1)
     }
-    /// one week ago
+    /// last seen one week ago
     internal static var timeAgoWeeksSingular: String { L10n.tr("Localizable", "dates.time-ago-weeks-singular") }
   }
 

--- a/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
@@ -49,10 +49,21 @@
 "message.sending.attachment-uploading-failed" = "UPLOADING FAILED";
 
 "message.title.online" = "Online";
-"message.title.see-minutes-ago" = "Seen %@ ago";
 "message.title.offline" = "Offline";
 "message.title.group" = "%d members, %d online";
 
 "current-selection" = "%d of %d";
 
 "attachment.max-size-exceeded" = "Attachment size exceed the limit.";
+"dates.time-ago-seconds-plural" = "%d seconds ago";
+"dates.time-ago-seconds-singular" = "just one second ago";
+"dates.time-ago-minutes-singular" = "one minute ago";
+"dates.time-ago-minutes-plural" = "%d minutes ago";
+"dates.time-ago-hours-singular" = "one hour ago";
+"dates.time-ago-hours-plural" = "%d hours ago";
+"dates.time-ago-days-singular" = "one day ago";
+"dates.time-ago-days-plural" = "%d days ago";
+"dates.time-ago-weeks-singular" = "one week ago";
+"dates.time-ago-weeks-plural" = "%d weeks ago";
+"dates.time-ago-months-singular" = "one month ago";
+"dates.time-ago-months-plural" = "%d months ago";

--- a/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
@@ -55,15 +55,15 @@
 "current-selection" = "%d of %d";
 
 "attachment.max-size-exceeded" = "Attachment size exceed the limit.";
-"dates.time-ago-seconds-plural" = "%d seconds ago";
-"dates.time-ago-seconds-singular" = "just one second ago";
-"dates.time-ago-minutes-singular" = "one minute ago";
-"dates.time-ago-minutes-plural" = "%d minutes ago";
-"dates.time-ago-hours-singular" = "one hour ago";
-"dates.time-ago-hours-plural" = "%d hours ago";
-"dates.time-ago-days-singular" = "one day ago";
-"dates.time-ago-days-plural" = "%d days ago";
-"dates.time-ago-weeks-singular" = "one week ago";
-"dates.time-ago-weeks-plural" = "%d weeks ago";
-"dates.time-ago-months-singular" = "one month ago";
-"dates.time-ago-months-plural" = "%d months ago";
+"dates.time-ago-seconds-plural" = "last seen %d seconds ago";
+"dates.time-ago-seconds-singular" = "last seen just one second ago";
+"dates.time-ago-minutes-singular" = "last seen one minute ago";
+"dates.time-ago-minutes-plural" = "last seen %d minutes ago";
+"dates.time-ago-hours-singular" = "last seen one hour ago";
+"dates.time-ago-hours-plural" = "last seen %d hours ago";
+"dates.time-ago-days-singular" = "last seen one day ago";
+"dates.time-ago-days-plural" = "last seen %d days ago";
+"dates.time-ago-weeks-singular" = "last seen one week ago";
+"dates.time-ago-weeks-plural" = "last seen %d weeks ago";
+"dates.time-ago-months-singular" = "last seen one month ago";
+"dates.time-ago-months-plural" = "last seen %d months ago";

--- a/Sources/StreamChatUI/Utils/DateUtils.swift
+++ b/Sources/StreamChatUI/Utils/DateUtils.swift
@@ -1,0 +1,53 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+class DateUtils {
+    /// timeAgo formats a date into a string like "15 minutes ago"
+    static func timeAgo(relativeTo date: Date) -> String? {
+        let now = Date()
+        let calendar = Calendar.current
+
+        if now < date {
+            return nil
+        }
+
+        guard
+            let minuteAgo = calendar.date(byAdding: .minute, value: -1, to: now),
+            let hourAgo = calendar.date(byAdding: .hour, value: -1, to: now),
+            let dayAgo = calendar.date(byAdding: .day, value: -1, to: now),
+            let weekAgo = calendar.date(byAdding: .day, value: -7, to: now),
+            let monthAgo = calendar.date(byAdding: .day, value: -31, to: now)
+        else { return nil }
+        
+        if minuteAgo < date {
+            let diff = calendar.dateComponents([.second], from: date, to: now).second ?? 0
+            return diff > 1 ? L10n.Dates.timeAgoSecondsPlural(diff) : L10n.Dates.timeAgoSecondsSingular
+        }
+        
+        if hourAgo < date {
+            let diff = calendar.dateComponents([.minute], from: date, to: now).minute ?? 0
+            return diff > 1 ? L10n.Dates.timeAgoMinutesPlural(diff) : L10n.Dates.timeAgoMinutesSingular
+        }
+        
+        if dayAgo < date {
+            let diff = calendar.dateComponents([.hour], from: date, to: now).hour ?? 0
+            return diff > 1 ? L10n.Dates.timeAgoHoursPlural(diff) : L10n.Dates.timeAgoHoursSingular
+        }
+        
+        if weekAgo < date {
+            let diff = calendar.dateComponents([.day], from: date, to: now).day ?? 0
+            return diff > 1 ? L10n.Dates.timeAgoDaysPlural(diff) : L10n.Dates.timeAgoDaysSingular
+        }
+        
+        if monthAgo < date {
+            let diff = calendar.dateComponents([.weekOfYear], from: date, to: now).weekOfYear ?? 0
+            return diff > 1 ? L10n.Dates.timeAgoWeeksPlural(diff) : L10n.Dates.timeAgoWeeksSingular
+        }
+
+        let diff = calendar.dateComponents([.month], from: date, to: now).month ?? 0
+        return diff > 1 ? L10n.Dates.timeAgoMonthsPlural(diff) : L10n.Dates.timeAgoMonthsSingular
+    }
+}

--- a/Sources/StreamChatUI/Utils/DateUtils_Tests.swift
+++ b/Sources/StreamChatUI/Utils/DateUtils_Tests.swift
@@ -1,0 +1,48 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatUI
+import XCTest
+
+class DateUtils_Tests: XCTestCase {
+    func test_timeAgoNow() throws {
+        XCTAssertEqual(DateUtils.timeAgo(relativeTo: Date()), "just one second ago")
+    }
+    
+    func test_timeAgoFuture() throws {
+        let date = Calendar.current.date(byAdding: .second, value: 60, to: Date())!
+        XCTAssertEqual(DateUtils.timeAgo(relativeTo: date), nil)
+    }
+
+    func test_timeAgo1MinuteAgo() throws {
+        let date = Calendar.current.date(byAdding: .second, value: -60, to: Date())!
+        XCTAssertEqual(DateUtils.timeAgo(relativeTo: date), "one minute ago")
+    }
+
+    func test_timeAgo59SecondsAgo() throws {
+        let date = Calendar.current.date(byAdding: .second, value: -59, to: Date())!
+        XCTAssertEqual(DateUtils.timeAgo(relativeTo: date), "59 seconds ago")
+    }
+
+    func test_timeAgo42SecondsAgo() throws {
+        let date = Calendar.current.date(byAdding: .second, value: -42, to: Date())!
+        XCTAssertEqual(DateUtils.timeAgo(relativeTo: date), "42 seconds ago")
+    }
+    
+    func test_timeAgo42MinutesAgo() throws {
+        let date = Calendar.current.date(byAdding: .minute, value: -42, to: Date())!
+        XCTAssertEqual(DateUtils.timeAgo(relativeTo: date), "42 minutes ago")
+    }
+    
+    func test_timeAgo42DaysAgo() throws {
+        let date = Calendar.current.date(byAdding: .day, value: -42, to: Date())!
+        XCTAssertEqual(DateUtils.timeAgo(relativeTo: date), "one month ago")
+    }
+    
+    func test_timeAgo42WeeksAgo() throws {
+        let date = Calendar.current.date(byAdding: .day, value: -42 * 7, to: Date())!
+        XCTAssertEqual(DateUtils.timeAgo(relativeTo: date), "9 months ago")
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		430156F226B4523A0006E7EA /* WebSocketConnectPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430156F126B4523A0006E7EA /* WebSocketConnectPayload_Tests.swift */; };
 		43016E1426B7189D0054E805 /* CustomMessageContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43016E1326B7189D0054E805 /* CustomMessageContentView.swift */; };
 		43016E1626B734410054E805 /* ChatUser+CustomFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43016E1526B734410054E805 /* ChatUser+CustomFields.swift */; };
+		439AFF9826C563BA000A441E /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439AFF9726C563BA000A441E /* DateUtils.swift */; };
+		439AFF9A26C568DD000A441E /* DateUtils_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439AFF9926C568DD000A441E /* DateUtils_Tests.swift */; };
 		43ABF8B526C2CD900034BD62 /* ComposerVC_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43ABF8B326C2B7140034BD62 /* ComposerVC_Tests.swift */; };
 		43ABF8B726C513D20034BD62 /* CurrentUserCustomRole.json in Resources */ = {isa = PBXBuildFile; fileRef = 43ABF8B626C513D20034BD62 /* CurrentUserCustomRole.json */; };
 		43BAAD492664F59600323D8E /* UserStopTypingThread.json in Resources */ = {isa = PBXBuildFile; fileRef = 43BAAD472664F59600323D8E /* UserStopTypingThread.json */; };
@@ -1388,6 +1390,8 @@
 		430156F126B4523A0006E7EA /* WebSocketConnectPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketConnectPayload_Tests.swift; sourceTree = "<group>"; };
 		43016E1326B7189D0054E805 /* CustomMessageContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomMessageContentView.swift; sourceTree = "<group>"; };
 		43016E1526B734410054E805 /* ChatUser+CustomFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatUser+CustomFields.swift"; sourceTree = "<group>"; };
+		439AFF9726C563BA000A441E /* DateUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateUtils.swift; sourceTree = "<group>"; };
+		439AFF9926C568DD000A441E /* DateUtils_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateUtils_Tests.swift; sourceTree = "<group>"; };
 		43ABF8B326C2B7140034BD62 /* ComposerVC_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerVC_Tests.swift; sourceTree = "<group>"; };
 		43ABF8B626C513D20034BD62 /* CurrentUserCustomRole.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = CurrentUserCustomRole.json; sourceTree = "<group>"; };
 		43BAAD472664F59600323D8E /* UserStopTypingThread.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UserStopTypingThread.json; sourceTree = "<group>"; };
@@ -4096,6 +4100,8 @@
 				ACDB5412269C6F2A007CD465 /* String+Extensions_Tests.swift */,
 				640FE0D426A568C3006CE703 /* CollectionUpdatesMapper.swift */,
 				640FE0F526A57903006CE703 /* CollectionUpdatesMapper_Tests.swift */,
+				439AFF9726C563BA000A441E /* DateUtils.swift */,
+				439AFF9926C568DD000A441E /* DateUtils_Tests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -5729,6 +5735,7 @@
 				228C7EE52583AF4800AAE9E3 /* UITextView+Extensions.swift in Sources */,
 				8803E9E726398F4E002B2A7B /* ChatMessageBubbleView.swift in Sources */,
 				22FF4365256E943F00133910 /* ChatSuggestionsVC.swift in Sources */,
+				439AFF9826C563BA000A441E /* DateUtils.swift in Sources */,
 				22A0921725682880001FE9F0 /* ChatNavigationBar.swift in Sources */,
 				AD87D0A1263C7823008B466C /* AttachmentButton.swift in Sources */,
 				22753599257C442300D1FDB6 /* SendButton.swift in Sources */,
@@ -5879,6 +5886,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				43ABF8B526C2CD900034BD62 /* ComposerVC_Tests.swift in Sources */,
+				439AFF9A26C568DD000A441E /* DateUtils_Tests.swift in Sources */,
 				7920578A264166C9002B145B /* ChatChannel.swift in Sources */,
 				2208241625DEE8070033544B /* ChatChannelListCollectionViewCell_Tests.swift in Sources */,
 				79B4F14325D3F0F70063FFB5 /* ChannelId.swift in Sources */,

--- a/Tests/StreamChatUITests/en.lproj/TestLocalizable.strings
+++ b/Tests/StreamChatUITests/en.lproj/TestLocalizable.strings
@@ -49,7 +49,6 @@
 "message.sending.attachment-uploading-failed" = "UPLOADING FAILED";
 
 "message.title.online" = "Online";
-"message.title.see-minutes-ago" = "Seen %@ ago";
 "message.title.offline" = "Offline";
 "message.title.group" = "%d members, %d online";
 


### PR DESCRIPTION
Adds a utility formatter to represent a date in the past as a string, I used a homegrown approach to support iOS < 13



### Before
![IMG_3DDD4C3D11A8-1](https://user-images.githubusercontent.com/88735/129220999-c635f0f0-36e3-4c53-8c69-a1e29f571826.jpeg)

## After
![IMG_5E22E5BA9C0D-1](https://user-images.githubusercontent.com/88735/129220990-a74794ce-b164-4ed3-a6c6-586d0483c9ee.jpeg)
