### PR TITLE
[CIS-1111] Copy messages to avoid out of sync table and collection crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix incorrect RawJSON number handling, the `.integer` case is no longer supported and is replaced by `.number` [#1375](https://github.com/GetStream/stream-chat-swift/pull/1375)
+- Fix message list and thread index out of range issue on `tableView(_:cellForRowAt:)` [1373](https://github.com/GetStream/stream-chat-swift/pull/1373)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -323,7 +323,7 @@ open class ChatMessageListVC:
     open func updateMessages(with changes: [ListChange<ChatMessage>], completion: (() -> Void)? = nil) {
         listView.updateMessages(
             with: changes,
-            onMessagesCountUpdate: updateMessageCache,
+            onMessagesUpdate: updateMessageCache,
             completion: completion
         )
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -252,8 +252,8 @@ open class ChatMessageListVC:
     ) -> String? {
         // When a message from a channel is deleted,
         // and the visibility of deleted messages is set to `alwaysHidden`,
-        // the messages list won't contain the message and hence it would crash
-        guard messageCache.indices.contains(indexPath.item) else {
+        // the messages list won't contain the message
+        guard messageCache.count <= indexPath.item else {
             return nil
         }
         

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -171,7 +171,7 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
     /// Updates the table view data with given `changes`.
     open func updateMessages(
         with changes: [ListChange<ChatMessage>],
-        onMessagesCountUpdate: () -> Void = {},
+        onMessagesUpdate: () -> Void = {},
         completion: (() -> Void)? = nil
     ) {
         var shouldScrollToBottom = false

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -305,7 +305,7 @@ open class ChatThreadVC:
     open func updateMessages(with changes: [ListChange<ChatMessage>], completion: (() -> Void)? = nil) {
         listView.updateMessages(
             with: changes,
-            onMessagesCountUpdate: updateNumberOfMessages,
+            onMessagesUpdate: updateNumberOfMessages,
             completion: completion
         )
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -29,9 +29,6 @@ open class ChatThreadVC:
     /// Controller for observing data changes within the parent thread message.
     open var messageController: ChatMessageController!
     
-    /// We use private property for channels count so we can update it inside `performBatchUpdates` as [documented](https://developer.apple.com/documentation/uikit/uicollectionview/1618045-performbatchupdates#discussion)
-    private var numberOfMessages = 0
-
     /// Observer responsible for setting the correct offset when keyboard frame is changed
     open lazy var keyboardObserver = ChatMessageListKeyboardObserver(
         containerView: view,
@@ -82,7 +79,7 @@ open class ChatThreadVC:
 
     override open func setUp() {
         super.setUp()
-        updateNumberOfMessages()
+        updateMessageCache()
 
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress))
         longPress.minimumPressDuration = 0.33
@@ -203,7 +200,7 @@ open class ChatThreadVC:
     open func cellLayoutOptionsForMessage(at indexPath: IndexPath) -> ChatMessageLayoutOptions {
         cellLayoutOptionsForMessage(
             at: indexPath,
-            messages: AnyRandomAccessCollection(messages)
+            messages: AnyRandomAccessCollection(messagesCache)
         )
     }
 
@@ -220,39 +217,19 @@ open class ChatThreadVC:
         return layoutOptions
     }
     
-    public var messages: [ChatMessage] {
-        /*
-         Thread replies are evaluated from DTOs when converting `messageController.replies` to an array.
-         Adding thread root message into replies would require `insert/append` API on lazy map which should
-         update both source collection and a cache to not break the indexing and keep 1-1 match with evaluated
-         and non-evaluated elements.
-         
-         We have evaluated thread root message in `messageController.message` but to get keep lazy map
-         working after an insert we also need an underlaying DTO to be added to source collection and it's getting
-         hard since the information about source collection `Element` type is available only during lazy map
-         initialization and does not get stored for later use.
-
-         It could be addressed on LLC side by tweaking an observer to fetch thread root message along with replies.
-         */
-        let replies = Array(messageController.replies)
-        
-        if let threadRootMessage = messageController.message {
-            return replies + [threadRootMessage]
-        } else {
-            return replies
-        }
-    }
+    /// We use private property and store a copy of the messages list so we can update it inside `performBatchUpdates` as [documented](https://developer.apple.com/documentation/uikit/uicollectionview/1618045-performbatchupdates#discussion)
+    public var messagesCache: [ChatMessage] = []
     
     open func numberOfSections(in tableView: UITableView) -> Int {
         1
     }
 
     open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        numberOfMessages
+        messagesCache.count
     }
 
     open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let message = messages[indexPath.row]
+        let message = messagesCache[indexPath.row]
 
         let cell: ChatMessageCell = listView.dequeueReusableCell(
             contentViewClass: cellContentClassForMessage(at: indexPath),
@@ -305,9 +282,19 @@ open class ChatThreadVC:
     open func updateMessages(with changes: [ListChange<ChatMessage>], completion: (() -> Void)? = nil) {
         listView.updateMessages(
             with: changes,
-            onMessagesUpdate: updateNumberOfMessages,
+            onMessagesUpdate: updateMessageCache,
             completion: completion
         )
+    }
+
+    private func updateMessageCache() {
+        let replies = Array(messageController.replies)
+
+        if let threadRootMessage = messageController.message {
+            messagesCache = replies + [threadRootMessage]
+        } else {
+            messagesCache = replies
+        }
     }
 
     /// Presents custom actions controller with all possible actions with the selected message.
@@ -365,7 +352,7 @@ open class ChatThreadVC:
         channelController.client
             .messageController(
                 cid: channelController.cid!,
-                messageId: messages[indexPath.item].id
+                messageId: messagesCache[indexPath.item].id
             )
             .dispatchEphemeralMessageAction(action)
     }
@@ -499,7 +486,7 @@ open class ChatThreadVC:
     }
 
     open func messageForIndexPath(_ indexPath: IndexPath) -> ChatMessage {
-        messages[indexPath.item]
+        messagesCache[indexPath.item]
     }
     
     open func scrollOverlay(
@@ -508,18 +495,14 @@ open class ChatThreadVC:
     ) -> String? {
         // When a message from a channel is deleted,
         // and the visibility of deleted messages is set to `alwaysHidden`,
-        // the messages list won't contain the message and hence it would crash
-        guard channelController.messages.indices.contains(indexPath.item) else {
+        // the messages list won't contain the message
+        guard messagesCache.count <= indexPath.item else {
             return nil
         }
         
         return DateFormatter
             .messageListDateOverlay
             .string(from: messageForIndexPath(indexPath).createdAt)
-    }
-    
-    private func updateNumberOfMessages() {
-        numberOfMessages = messages.count
     }
     
     // MARK: - UIGestureRecognizerDelegate

--- a/Sources/StreamChatUI/Utils/UIImageView+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/UIImageView+Extensions.swift
@@ -25,7 +25,7 @@ extension UIImageView {
         components: Components,
         completion: ((_ result: Result<ImageResponse, ImagePipeline.Error>) -> Void)? = nil
     ) -> ImageTask? {
-        guard !SystemEnvironment.isTests else {
+        if SystemEnvironment.isTests {
             // When running tests, we load the images synchronously
             if let url = url {
                 image = UIImage(data: try! Data(contentsOf: url))


### PR DESCRIPTION
Problem: `dataSource?.tableView(self, cellForRowAt: indexPath)` is used inside the code that update the message list. 

This does not work because it accesses `controller.messages` which is on a different state than the `tableView`.

The solution: keep a copy of `controller.messages` that is consistent with the state of the table view.