### PR TITLE
CIS-1113 Fix inconsistent/wrong RawJSON number type handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### 🐞 Fixed
+- Fix incorrect RawJSON number handling, the `.integer` case is no longer supported and is replaced by `.number` [#1375](https://github.com/GetStream/stream-chat-swift/pull/1375)
+
 ### 🔄 Changed
 
 # [4.0.0-beta.11](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.11)

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/CustomDataHashMap_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/CustomDataHashMap_Tests.swift
@@ -16,7 +16,7 @@ extension ChannelDetailPayload: DecodableEntity {}
 
 class CustomDataHashMap_Tests: XCTestCase {
     func test_UserWebSocketPayloadEncodeWithCustomMap() throws {
-        let extraData: [String: RawJSON] = ["how-many-roads": .integer(42)]
+        let extraData: [String: RawJSON] = ["how-many-roads": .number(42)]
         let userInfo = UserInfo(id: "44", name: "tommaso", imageURL: nil, extraData: extraData)
         let payload = UserWebSocketPayload(userInfo: userInfo)
         let encoded = try! JSONEncoder.default.encode(payload)
@@ -35,15 +35,15 @@ class CustomDataHashMap_Tests: XCTestCase {
         let payload = try JSONDecoder.default.decode(entity.self, from: jsonData)
         
         XCTAssertEqual(payload.extraData["secret_note"], .string("Anakin is Vader!"))
-        XCTAssertEqual(payload.extraData["good_movies_count"], .integer(3))
+        XCTAssertEqual(payload.extraData["good_movies_count"], .number(3))
         XCTAssertEqual(payload.extraData["awesome"], .bool(true))
         XCTAssertEqual(payload.extraData["nested_stuff"], .dictionary(
             [
-                "how_many_times": .integer(42), "small": .double(0.001),
+                "how_many_times": .number(42), "small": .double(0.001),
                 "colors": .array([
                     .string("blue"),
                     .string("yellow"),
-                    .integer(42)
+                    .number(42)
                 ])
             ]
         ))

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/FlagMessagePayload_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/FlagMessagePayload_Tests.swift
@@ -30,7 +30,7 @@ final class FlagMessagePayload_Tests: XCTestCase {
         // Assert current user payload is deserialized correctly.
         let currentUser = payload.currentUser
         XCTAssertEqual(currentUser.id, "broken-waterfall-5")
-        XCTAssertEqual(currentUser.extraData, ["secret_note": .string("broken-waterfall-5 is Vader ;-)"), "team": .integer(1)])
+        XCTAssertEqual(currentUser.extraData, ["secret_note": .string("broken-waterfall-5 is Vader ;-)"), "team": .number(1)])
         
         // Assert flagged message data is deserialized correctly.
         XCTAssertEqual(payload.flaggedMessageId, "5961F803-1613-4891-B14C-7511BC719D35")

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/FlagUserPayload_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/FlagUserPayload_Tests.swift
@@ -33,7 +33,7 @@ final class FlagUserPayload_Tests: XCTestCase {
         // Assert current user payload is deserialized correctly.
         let currentUser = payload.currentUser
         XCTAssertEqual(currentUser.id, "broken-waterfall-5")
-        XCTAssertEqual(currentUser.extraData, ["secret_note": .string("broken-waterfall-5 is Vader ;-)"), "team": .integer(1)])
+        XCTAssertEqual(currentUser.extraData, ["secret_note": .string("broken-waterfall-5 is Vader ;-)"), "team": .number(1)])
         // Assert flagged user payload is deserialized correctly.
         let flaggedUser = payload.flaggedUser
         XCTAssertEqual(flaggedUser.id, "steep-moon-9")

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON.swift
@@ -8,13 +8,14 @@ import Foundation
 /// Used to store and operate objects of unknown structure that's not possible to decode.
 /// https://forums.swift.org/t/new-unevaluated-type-for-decoder-to-allow-later-re-encoding-of-data-with-unknown-structure/11117
 public indirect enum RawJSON: Codable, Hashable {
-    case double(Double)
+    case number(Double)
     case string(String)
-    case integer(Int)
     case bool(Bool)
     case dictionary([String: RawJSON])
     case array([RawJSON])
     case `nil`
+
+    static let double = number
 
     public init(from decoder: Decoder) throws {
         let singleValueContainer = try decoder.singleValueContainer()
@@ -24,11 +25,8 @@ public indirect enum RawJSON: Codable, Hashable {
         } else if let value = try? singleValueContainer.decode(String.self) {
             self = .string(value)
             return
-        } else if let value = try? singleValueContainer.decode(Int.self) {
-            self = .integer(value)
-            return
         } else if let value = try? singleValueContainer.decode(Double.self) {
-            self = .double(value)
+            self = .number(value)
             return
         } else if let value = try? singleValueContainer.decode([String: RawJSON].self) {
             self = .dictionary(value)
@@ -49,10 +47,8 @@ public indirect enum RawJSON: Codable, Hashable {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        
         switch self {
-        case let .integer(value): try container.encode(value)
-        case let .double(value): try container.encode(value)
+        case let .number(value): try container.encode(value)
         case let .bool(value): try container.encode(value)
         case let .string(value): try container.encode(value)
         case let .array(value): try container.encode(value)

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON_Tests.swift
@@ -15,8 +15,11 @@ final class RawJSON_Tests: XCTestCase {
         let tests = [
             test.init(value: .dictionary(["k": .bool(false)]), expected: "{\"k\": false}"),
             test.init(value: .dictionary(["k": .bool(true)]), expected: "{\"k\": true}"),
-            test.init(value: .dictionary(["k": .double(3.14)]), expected: "{\"k\": 3.14}"),
-            test.init(value: .dictionary(["k": .integer(3)]), expected: "{\"k\": 3}"),
+            test.init(value: .dictionary(["k": .number(3.14)]), expected: "{\"k\": 3.14}"),
+            test.init(value: .dictionary(["k": .number(3)]), expected: "{\"k\": 3}"),
+            test.init(value: .dictionary(["k": .number(-3)]), expected: "{\"k\": -3}"),
+            test.init(value: .dictionary(["k": .number(0)]), expected: "{\"k\": 0}"),
+            test.init(value: .dictionary(["k": .double(0.1)]), expected: "{\"k\": 0.1}"),
             test.init(value: .dictionary(["k": .string("asd")]), expected: "{\"k\": \"asd\"}")
         ]
         
@@ -35,8 +38,10 @@ final class RawJSON_Tests: XCTestCase {
         let tests = [
             test.init(value: "{\"k\": false}", expected: .dictionary(["k": .bool(false)])),
             test.init(value: "{\"k\": true}", expected: .dictionary(["k": .bool(true)])),
+            test.init(value: "{\"k\": 3}", expected: .dictionary(["k": .number(3)])),
+            test.init(value: "{\"k\": 3.14}", expected: .dictionary(["k": .number(3.14)])),
             test.init(value: "{\"k\": 3.14}", expected: .dictionary(["k": .double(3.14)])),
-            test.init(value: "{\"k\": 3}", expected: .dictionary(["k": .integer(3)])),
+            test.init(value: "{\"k\": 3}", expected: .dictionary(["k": .number(3)])),
             test.init(value: "{\"k\": \"asd\"}", expected: .dictionary(["k": .string("asd")]))
         ]
         

--- a/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
@@ -361,7 +361,7 @@ class MessageDTO_Tests: XCTestCase {
             type: TestAttachmentPayload.type,
             payload: .dictionary([
                 "name": .string(testPayload.name),
-                "number": .integer(testPayload.number)
+                "number": .number(Double(testPayload.number))
             ])
         )
 

--- a/Sources/StreamChat/Models/Attachments/ChatMessageAudioAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageAudioAttachment.swift
@@ -44,7 +44,7 @@ extension AudioAttachmentPayload: Encodable {
         var values = extraData ?? [:]
         values[AttachmentCodingKeys.title.rawValue] = title.map { .string($0) }
         values[AttachmentCodingKeys.assetURL.rawValue] = .string(audioURL.absoluteString)
-        values[AttachmentFile.CodingKeys.size.rawValue] = .integer(Int(file.size))
+        values[AttachmentFile.CodingKeys.size.rawValue] = .number(Double(file.size))
         values[AttachmentFile.CodingKeys.mimeType.rawValue] = file.mimeType.map { .string($0) }
         try values.encode(to: encoder)
     }

--- a/Sources/StreamChat/Models/Attachments/ChatMessageFileAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageFileAttachment.swift
@@ -44,7 +44,7 @@ extension FileAttachmentPayload: Encodable {
         var values = extraData ?? [:]
         values[AttachmentCodingKeys.title.rawValue] = title.map { .string($0) }
         values[AttachmentCodingKeys.assetURL.rawValue] = .string(assetURL.absoluteString)
-        values[AttachmentFile.CodingKeys.size.rawValue] = .integer(Int(file.size))
+        values[AttachmentFile.CodingKeys.size.rawValue] = .number(Double(Int(file.size)))
         values[AttachmentFile.CodingKeys.mimeType.rawValue] = file.mimeType.map { .string($0) }
         try values.encode(to: encoder)
     }

--- a/Sources/StreamChat/Models/Attachments/ChatMessageVideoAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageVideoAttachment.swift
@@ -44,7 +44,7 @@ extension VideoAttachmentPayload: Encodable {
         var values = extraData ?? [:]
         values[AttachmentCodingKeys.title.rawValue] = title.map { .string($0) }
         values[AttachmentCodingKeys.assetURL.rawValue] = .string(videoURL.absoluteString)
-        values[AttachmentFile.CodingKeys.size.rawValue] = .integer(Int(file.size))
+        values[AttachmentFile.CodingKeys.size.rawValue] = .number(Double(Int(file.size)))
         values[AttachmentFile.CodingKeys.mimeType.rawValue] = file.mimeType.map { .string($0) }
         try values.encode(to: encoder)
     }


### PR DESCRIPTION
The initial implementation of RawJSON had `double` and `integer` types. This made decoding incorrect because integer values can be Int and Double and the decoder would always decode them as Int.

This PR removes `.integer` from RawJSON, adds a new case `.number` and keeps `.double` around as an "alias" of `.number`