### PR TITLE
[CIS-1120] Fix making multiple requests when loading more messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix incorrect RawJSON number handling, the `.integer` case is no longer supported and is replaced by `.number` [#1375](https://github.com/GetStream/stream-chat-swift/pull/1375)
-- Fix message list and thread index out of range issue on `tableView(_:cellForRowAt:)` [1373](https://github.com/GetStream/stream-chat-swift/pull/1373)
+- Fix message list and thread index out of range issue on `tableView(_:cellForRowAt:)` [#1373](https://github.com/GetStream/stream-chat-swift/pull/1373)
+- Fix message list dismissing on a modal when scrolling [#1364](https://github.com/GetStream/stream-chat-swift/pull/1364)
+- Fix making multiple requests when loading more messages [#1380](https://github.com/GetStream/stream-chat-swift/pull/1380)
 
 ### 🔄 Changed
 
@@ -18,7 +20,6 @@ _August 13, 2021_
 - Fix `ChatMessageGalleryView.ImagePreview` not compiling in Obj-c [#1363](https://github.com/GetStream/stream-chat-swift/pull/1363)
 - Fix force unwrap crashes on unknown user roles cases [#1365](https://github.com/GetStream/stream-chat-swift/pull/1365)
 - Fix "last seen at" representation to use other units other than minutes [#1368](https://github.com/GetStream/stream-chat-swift/pull/1368)
-- Fix message list dismissing on a modal when scrolling [#1364](https://github.com/GetStream/stream-chat-swift/pull/1364)
 
 # [4.0.0-beta.10](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.10)
 _August 11, 2021_

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -244,7 +244,7 @@ open class ChatMessageListVC:
     }
 
     open func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        if channelController.state == .remoteDataFetched && indexPath.row + 1 >= tableView.numberOfRows(inSection: 0) - 5 {
+        if channelController.state == .remoteDataFetched && indexPath.row + 1 == tableView.numberOfRows(inSection: 0) - 5 {
             channelController.loadPreviousMessages()
         }
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -179,7 +179,7 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
         guard let _ = collectionUpdatesMapper.mapToSetsOfIndexPaths(
             changes: changes,
             onConflict: {
-                onMessagesCountUpdate()
+                onMessagesUpdate()
                 reloadData()
             }
         ) else { return }
@@ -212,7 +212,7 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
                     self.deleteRows(at: [index], with: .fade)
                 }
             }
-            onMessagesCountUpdate()
+            onMessagesUpdate()
         }, completion: { _ in
             if shouldScrollToBottom {
                 self.scrollToBottomAction = .init { [weak self] in

--- a/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatThreadVC.swift
@@ -245,7 +245,7 @@ open class ChatThreadVC:
     }
     
     open func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        if messageController.state == .remoteDataFetched && indexPath.row + 1 >= tableView.numberOfRows(inSection: 0) - 5 {
+        if messageController.state == .remoteDataFetched && indexPath.row + 1 == tableView.numberOfRows(inSection: 0) - 5 {
             messageController.loadPreviousReplies()
         }
     }


### PR DESCRIPTION
## Description of the pull request
When fetching more messages (pagination) in the message list, the request was done multiple times since it was triggered when each of the last 5 messages appeared, instead of being triggered only once, when the last 5th messages appeared. 