### PR TITLE
[CIS-1120] Fix pagination on all lists

### DIFF
--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -637,9 +637,7 @@ public extension ChatChannelController {
             completion?(nil)
             return
         }
-        
         channelQuery.pagination = MessagesPagination(pageSize: limit, parameter: .lessThan(messageId))
-    
         updater.update(channelQuery: channelQuery, completion: { result in
             switch result {
             case let .success(payload):

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -65,7 +65,7 @@ class ChannelListController_Tests: StressTestCase {
         controller.synchronize()
         
         // Simulate successful network call.
-        env.channelListUpdater?.update_completion?(nil)
+        env.channelListUpdater?.update_completion?(.success(ChannelListPayload(channels: [])))
         
         // Check if state changed after successful network call.
         XCTAssertEqual(controller.state, .remoteDataFetched)
@@ -91,7 +91,7 @@ class ChannelListController_Tests: StressTestCase {
         
         // Simulate failed network call.
         let error = TestError()
-        env.channelListUpdater?.update_completion?(error)
+        env.channelListUpdater?.update_completion?(.failure(error))
         
         // Check if state changed after failed network call.
         XCTAssertEqual(controller.state, .remoteDataFetchFailed(ClientError(with: error)))
@@ -154,7 +154,7 @@ class ChannelListController_Tests: StressTestCase {
         XCTAssertFalse(completionCalled)
         
         // Simulate successful update
-        env.channelListUpdater!.update_completion?(nil)
+        env.channelListUpdater!.update_completion?(.success(ChannelListPayload(channels: [])))
         // Release reference of completion so we can deallocate stuff
         env.channelListUpdater!.update_completion = nil
         
@@ -191,7 +191,7 @@ class ChannelListController_Tests: StressTestCase {
         XCTAssertFalse(completionCalled)
         
         // Simulate successful update
-        env.channelListUpdater!.update_completion?(nil)
+        env.channelListUpdater!.update_completion?(.success(ChannelListPayload(channels: [])))
         // Release reference of completion so we can deallocate stuff
         env.channelListUpdater!.update_completion = nil
         
@@ -213,7 +213,7 @@ class ChannelListController_Tests: StressTestCase {
         
         // Simulate failed udpate
         let testError = TestError()
-        env.channelListUpdater!.update_completion?(testError)
+        env.channelListUpdater!.update_completion?(.failure(testError))
         
         // Completion should be called with the error
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
@@ -232,7 +232,7 @@ class ChannelListController_Tests: StressTestCase {
         }
         
         // Simulate successful network call.
-        env.channelListUpdater?.update_completion?(nil)
+        env.channelListUpdater?.update_completion?(.success(ChannelListPayload(channels: [])))
 
         // Assert the channels are loaded
         XCTAssertEqual(controller.channels.map(\.cid), [channelId])
@@ -283,7 +283,7 @@ class ChannelListController_Tests: StressTestCase {
         controller.synchronize()
             
         // Simulate network call response
-        env.channelListUpdater?.update_completion?(nil)
+        env.channelListUpdater?.update_completion?(.success(ChannelListPayload(channels: [])))
         
         // Assert delegate is notified about state changes
         AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)
@@ -301,7 +301,7 @@ class ChannelListController_Tests: StressTestCase {
         controller.synchronize()
         
         // Simulate network call response
-        env.channelListUpdater?.update_completion?(nil)
+        env.channelListUpdater?.update_completion?(.success(ChannelListPayload(channels: [])))
         
         // Assert delegate is notified about state changes
         AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)
@@ -424,7 +424,7 @@ class ChannelListController_Tests: StressTestCase {
         controller = nil
         
         // Simulate successful update
-        env!.channelListUpdater?.update_completion?(nil)
+        env!.channelListUpdater?.update_completion?(.success(ChannelListPayload(channels: [])))
         // Release reference of completion so we can deallocate stuff
         env.channelListUpdater!.update_completion = nil
         
@@ -444,7 +444,7 @@ class ChannelListController_Tests: StressTestCase {
         
         // Simulate failed udpate
         let testError = TestError()
-        env.channelListUpdater!.update_completion?(testError)
+        env.channelListUpdater!.update_completion?(.failure(testError))
         
         // Completion should be called with the error
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)

--- a/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
@@ -914,7 +914,7 @@ final class MessageController_Tests: StressTestCase {
         
         // Simulate network response with the error
         let networkError = TestError()
-        env.messageUpdater.loadReplies_completion?(networkError)
+        env.messageUpdater.loadReplies_completion?(.failure(networkError))
         
         // Assert error is propagated
         AssertAsync.willBeEqual(completionError as? TestError, networkError)
@@ -937,7 +937,7 @@ final class MessageController_Tests: StressTestCase {
         controller = nil
         
         // Simulate successful network response
-        env.messageUpdater.loadReplies_completion?(nil)
+        env.messageUpdater.loadReplies_completion?(.success(MessageRepliesPayload(messages: [])))
         // Release reference of completion so we can deallocate stuff
         env.messageUpdater.loadReplies_completion = nil
         
@@ -979,7 +979,7 @@ final class MessageController_Tests: StressTestCase {
         
         // Simulate network response with the error
         let networkError = TestError()
-        env.messageUpdater.loadReplies_completion?(networkError)
+        env.messageUpdater.loadReplies_completion?(.failure(networkError))
         
         // Assert error is propagated
         AssertAsync.willBeEqual(completionError as? TestError, networkError)
@@ -1002,7 +1002,7 @@ final class MessageController_Tests: StressTestCase {
         controller = nil
         
         // Simulate successful network response
-        env.messageUpdater.loadReplies_completion?(nil)
+        env.messageUpdater.loadReplies_completion?(.success(MessageRepliesPayload(messages: [])))
         // Release reference of completion so we can deallocate stuff
         env.messageUpdater.loadReplies_completion = nil
         

--- a/Sources/StreamChat/Utils/Atomic.swift
+++ b/Sources/StreamChat/Utils/Atomic.swift
@@ -57,3 +57,18 @@ public class Atomic<T> {
         _wrappedValue = wrappedValue
     }
 }
+
+extension Atomic where T: Equatable {
+    public func compareAndSwap(old: T, new: T) -> Bool {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        
+        if _wrappedValue == old {
+            _wrappedValue = new
+            return true
+        }
+        return false
+    }
+}

--- a/Sources/StreamChat/Utils/Atomic.swift
+++ b/Sources/StreamChat/Utils/Atomic.swift
@@ -59,6 +59,8 @@ public class Atomic<T> {
 }
 
 extension Atomic where T: Equatable {
+    /// Updates the value to `new` if the current value is `old`
+    /// if the swap happens true is returned
     public func compareAndSwap(old: T, new: T) -> Bool {
         lock.lock()
         defer {

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater.swift
@@ -58,10 +58,9 @@ class DatabaseCleanupUpdater: Worker {
                 let queries: [ChannelListQuery] = try queriesDTOs.map {
                     try $0.asChannelListQuery()
                 }
-                
                 queries.forEach {
-                    self?.channelListUpdater.update(channelListQuery: $0) { error in
-                        if let error = error {
+                    self?.channelListUpdater.update(channelListQuery: $0) { result in
+                        if case let .failure(error) = result {
                             log.error("Internal error. Failed to update ChannelListQueries for the new channel: \(error)")
                         }
                     }

--- a/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
@@ -104,10 +104,9 @@ final class NewChannelQueryUpdater: Worker {
             
             // Send `update(channelListQuery:` requests so corresponding queries will be linked to the channel
             updatedQueries.forEach {
-                self?.channelListUpdater.update(channelListQuery: $0) { error in
-                    if let error = error {
-                        log
-                            .error("Internal error. Failed to update ChannelListQueries for the new channel: \(error)")
+                self?.channelListUpdater.update(channelListQuery: $0) { result in
+                    if case let .failure(error) = result {
+                        log.error("Internal error. Failed to update ChannelListQueries for the new channel: \(error)")
                     }
                 }
             }

--- a/Sources/StreamChat/Workers/ChannelListUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater.swift
@@ -25,10 +25,10 @@ class ChannelListUpdater: Worker {
                 switch result {
                 case let .success(channelListPayload):
                     self?.database.write { session in
-                        // TODO: this is not working well, we need a better approach to remove channels that are not in-sync
-//                        if trumpExistingChannels {
-//                            try session.deleteChannels(query: channelListQuery)
-//                        }
+                        
+                        if trumpExistingChannels {
+                            try session.deleteChannels(query: channelListQuery)
+                        }
                         
                         try channelListPayload.channels.forEach {
                             try session.saveChannel(payload: $0, query: channelListQuery)

--- a/Sources/StreamChat/Workers/ChannelListUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater.swift
@@ -25,10 +25,10 @@ class ChannelListUpdater: Worker {
                 switch result {
                 case let .success(channelListPayload):
                     self?.database.write { session in
-                        
-                        if trumpExistingChannels {
-                            try session.deleteChannels(query: channelListQuery)
-                        }
+                        // TODO: this is not working well, we need a better approach to remove channels that are not in-sync
+//                        if trumpExistingChannels {
+//                            try session.deleteChannels(query: channelListQuery)
+//                        }
                         
                         try channelListPayload.channels.forEach {
                             try session.saveChannel(payload: $0, query: channelListQuery)

--- a/Sources/StreamChat/Workers/ChannelListUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater.swift
@@ -15,7 +15,7 @@ class ChannelListUpdater: Worker {
     func update(
         channelListQuery: ChannelListQuery,
         trumpExistingChannels: Bool = false,
-        completion: ((Error?) -> Void)? = nil
+        completion: ((Result<ChannelListPayload, Error>) -> Void)? = nil
     ) {
         apiClient
             .request(endpoint: .channels(query: channelListQuery)) { [weak self] (result: Result<
@@ -36,13 +36,13 @@ class ChannelListUpdater: Worker {
                     } completion: { error in
                         if let error = error {
                             log.error("Failed to save `ChannelListPayload` to the database. Error: \(error)")
-                            completion?(error)
+                            completion?(.failure(error))
                         } else {
-                            completion?(nil)
+                            completion?(.success(channelListPayload))
                         }
                     }
                 case let .failure(error):
-                    completion?(error)
+                    completion?(.failure(error))
                 }
             }
     }

--- a/Sources/StreamChat/Workers/ChannelListUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater_Mock.swift
@@ -8,7 +8,7 @@ import XCTest
 /// Mock implementation of ChannelListUpdater
 class ChannelListUpdaterMock: ChannelListUpdater {
     @Atomic var update_queries: [ChannelListQuery] = []
-    @Atomic var update_completion: ((Error?) -> Void)?
+    @Atomic var update_completion: ((Result<ChannelListPayload, Error>) -> Void)? = nil
     
     @Atomic var markAllRead_completion: ((Error?) -> Void)?
     
@@ -22,7 +22,7 @@ class ChannelListUpdaterMock: ChannelListUpdater {
     override func update(
         channelListQuery: ChannelListQuery,
         trumpExistingChannels: Bool = false,
-        completion: ((Error?) -> Void)? = nil
+        completion: ((Result<ChannelListPayload, Error>) -> Void)? = nil
     ) {
         _update_queries.mutate { $0.append(channelListQuery) }
         update_completion = completion

--- a/Sources/StreamChat/Workers/ChannelListUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater_Tests.swift
@@ -49,8 +49,8 @@ class ChannelListUpdater_Tests: StressTestCase {
         // Simulate `update` call
         let query = ChannelListQuery(filter: .in(.members, values: [.unique]))
         var completionCalled = false
-        listUpdater.update(channelListQuery: query, completion: { error in
-            XCTAssertNil(error)
+        listUpdater.update(channelListQuery: query, completion: { result in
+            XCTAssertNil(result.error)
             completionCalled = true
         })
         
@@ -73,7 +73,7 @@ class ChannelListUpdater_Tests: StressTestCase {
         // Simulate `update` call
         let query = ChannelListQuery(filter: .in(.members, values: [.unique]))
         var completionCalledError: Error?
-        listUpdater.update(channelListQuery: query, completion: { completionCalledError = $0 })
+        listUpdater.update(channelListQuery: query, completion: { completionCalledError = $0.error })
         
         // Simulate API response with failure
         let error = TestError()

--- a/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -35,7 +35,7 @@ final class MessageUpdaterMock: MessageUpdater {
     @Atomic var loadReplies_cid: ChannelId?
     @Atomic var loadReplies_messageId: MessageId?
     @Atomic var loadReplies_pagination: MessagesPagination?
-    @Atomic var loadReplies_completion: ((Error?) -> Void)?
+    @Atomic var loadReplies_completion: ((Result<MessageRepliesPayload, Error>) -> Void)? = nil
     
     @Atomic var flagMessage_flag: Bool?
     @Atomic var flagMessage_messageId: MessageId?
@@ -191,7 +191,7 @@ final class MessageUpdaterMock: MessageUpdater {
         cid: ChannelId,
         messageId: MessageId,
         pagination: MessagesPagination,
-        completion: ((Error?) -> Void)? = nil
+        completion: ((Result<MessageRepliesPayload, Error>) -> Void)? = nil
     ) {
         loadReplies_cid = cid
         loadReplies_messageId = messageId

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -508,7 +508,7 @@ final class MessageUpdater_Tests: StressTestCase {
         // Simulate `loadReplies` call
         var completionCalledError: Error?
         messageUpdater.loadReplies(cid: .unique, messageId: .unique, pagination: .init(pageSize: 25)) {
-            completionCalledError = $0
+            completionCalledError = $0.error
         }
         
         // Simulate API response with failure
@@ -533,7 +533,7 @@ final class MessageUpdater_Tests: StressTestCase {
         // Simulate `loadReplies` call
         var completionCalledError: Error?
         messageUpdater.loadReplies(cid: cid, messageId: .unique, pagination: .init(pageSize: 25)) {
-            completionCalledError = $0
+            completionCalledError = $0.error
         }
         
         // Simulate API response with success


### PR DESCRIPTION
Ensures that Thread, MessageList and ChannelList

- Do not perform more than 1 API call in parallel to fetch prev/nex page
- Start fetching results at the right time 
- Stop paginating results when there is no more to fetch