### PR TITLE
[CIS-1135] Fix user mention suggestions not showing all members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix message list and thread index out of range issue on `tableView(_:cellForRowAt:)` [#1373](https://github.com/GetStream/stream-chat-swift/pull/1373)
 - Fix crash when dismissing gallery images [#1383](https://github.com/GetStream/stream-chat-swift/pull/1383)
 - Improve pagination efficiency [#1381](https://github.com/GetStream/stream-chat-swift/pull/1381)
+- Fix user mention suggestions not showing all members [#1390](https://github.com/GetStream/stream-chat-swift/pull/1381)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources/StreamChat/Config/ChatClientConfig.swift
@@ -146,9 +146,9 @@ extension ChatClientConfig {
     /// `ChatChannel` specific local caching and model serialization settings.
     public struct ChatChannel: Equatable {
         /// Limit the max number of watchers included in `ChatChannel.lastActiveWatchers`.
-        public var lastActiveWatchersLimit = 5
+        public var lastActiveWatchersLimit = 100
         /// Limit the max number of members included in `ChatChannel.lastActiveMembers`.
-        public var lastActiveMembersLimit = 5
+        public var lastActiveMembersLimit = 100
         /// Limit the max number of messages included in `ChatChannel.latestMessages`.
         public var latestMessagesLimit = 5
     }

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -81,8 +81,11 @@ extension MemberDTO {
     static func loadLastActiveMembers(cid: ChannelId, context: NSManagedObjectContext) -> [MemberDTO] {
         let request = NSFetchRequest<MemberDTO>(entityName: MemberDTO.entityName)
         request.predicate = NSPredicate(format: "channel.cid == %@", cid.rawValue)
-        request.sortDescriptors = [ChannelMemberListSortingKey.lastActiveSortDescriptor]
-        request.fetchLimit = context.localCachingSettings?.chatChannel.lastActiveMembersLimit ?? 5
+        request.sortDescriptors = [
+            ChannelMemberListSortingKey.lastActiveSortDescriptor,
+            ChannelMemberListSortingKey.defaultSortDescriptor
+        ]
+        request.fetchLimit = context.localCachingSettings?.chatChannel.lastActiveMembersLimit ?? 100
         return load(by: request, context: context)
     }
 }

--- a/Sources/StreamChat/Database/DTOs/UserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/UserDTO.swift
@@ -92,9 +92,12 @@ extension UserDTO {
     
     static func loadLastActiveWatchers(cid: ChannelId, context: NSManagedObjectContext) -> [UserDTO] {
         let request = NSFetchRequest<UserDTO>(entityName: UserDTO.entityName)
-        request.sortDescriptors = [UserListSortingKey.lastActiveSortDescriptor]
+        request.sortDescriptors = [
+            UserListSortingKey.lastActiveSortDescriptor,
+            UserListSortingKey.defaultSortDescriptor
+        ]
         request.predicate = NSPredicate(format: "ANY watchedChannels.cid == %@", cid.rawValue)
-        request.fetchLimit = context.localCachingSettings?.chatChannel.lastActiveWatchersLimit ?? 5
+        request.fetchLimit = context.localCachingSettings?.chatChannel.lastActiveWatchersLimit ?? 100
         return load(by: request, context: context)
     }
 }

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -185,6 +185,9 @@ open class ComposerVC: _ViewController,
     /// A controller that manages the channel that the composer is creating content for.
     open var channelController: ChatChannelController?
 
+    /// A controller that manages the members of the channel.
+    open var memberListController: ChatChannelMemberListController?
+
     /// The channel config. If it's a new channel, an empty config should be created. (Not yet supported right now)
     public var channelConfig: ChannelConfig? {
         channelController?.channel?.config
@@ -243,6 +246,12 @@ open class ComposerVC: _ViewController,
 
     override open func setUp() {
         super.setUp()
+
+        let client = channelController?.client
+        if let cid = channelController?.cid {
+            memberListController = client?.memberListController(query: .init(cid: cid))
+            memberListController?.synchronize()
+        }
 
         composerView.inputMessageView.textView.delegate = self
         
@@ -646,7 +655,7 @@ open class ComposerVC: _ViewController,
             )
         } else {
             usersCache = searchUsers(
-                channel.watchers.map { $0 } + channel.cachedMembers.map { $0 },
+                channel.watchers.map { $0 } + (memberListController?.members.compactMap { $0 } ?? []),
                 by: typingMention,
                 excludingId: currentUserId
             )

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -185,9 +185,6 @@ open class ComposerVC: _ViewController,
     /// A controller that manages the channel that the composer is creating content for.
     open var channelController: ChatChannelController?
 
-    /// A controller that manages the members of the channel.
-    open var memberListController: ChatChannelMemberListController?
-
     /// The channel config. If it's a new channel, an empty config should be created. (Not yet supported right now)
     public var channelConfig: ChannelConfig? {
         channelController?.channel?.config
@@ -246,12 +243,6 @@ open class ComposerVC: _ViewController,
 
     override open func setUp() {
         super.setUp()
-
-        let client = channelController?.client
-        if let cid = channelController?.cid {
-            memberListController = client?.memberListController(query: .init(cid: cid))
-            memberListController?.synchronize()
-        }
 
         composerView.inputMessageView.textView.delegate = self
         
@@ -655,7 +646,7 @@ open class ComposerVC: _ViewController,
             )
         } else {
             usersCache = searchUsers(
-                channel.watchers.map { $0 } + (memberListController?.members.compactMap { $0 } ?? []),
+                channel.watchers.map { $0 } + channel.cachedMembers.map { $0 },
                 by: typingMention,
                 excludingId: currentUserId
             )


### PR DESCRIPTION
## Description of the pull request
The members that had a missing `lastActiveAt` weren't being fetched. So the sort descriptors should be `lastActiveAt` and the default so that the members and watchers are ordered by last active first, and then the default descriptor, in case the DTO doesn't have `lastActiveAt` 