### PR TITLE
[CIS-1117] Change unowned to weak self in blocks

### DIFF
--- a/Sample/Samples/UserUpdateViewController.swift
+++ b/Sample/Samples/UserUpdateViewController.swift
@@ -71,7 +71,12 @@ class UserUpdateViewController: UITableViewController {
             title: cell?.textLabel?.text ?? "",
             initialValue: cell?.detailTextLabel?.text ?? ""
         )
-        inputVC.onChange = { [unowned self] newValue in
+        inputVC.onChange = { [weak self] newValue in
+            guard let self = self else {
+                log.warning("Callback called while self is nil")
+                return
+            }
+
             switch keyPath {
             case \ChatUser.name:
                 self.userName = newValue

--- a/Sources/StreamChat/APIClient/CDNClient.swift
+++ b/Sources/StreamChat/APIClient/CDNClient.swift
@@ -63,7 +63,7 @@ class StreamCDNClient: CDNClient {
         )
         let endpoint = Endpoint<FileUploadPayload>.uploadAttachment(with: attachment.id, type: attachment.type)
         
-        encoder.encodeRequest(for: endpoint) { [unowned self] (requestResult) in
+        encoder.encodeRequest(for: endpoint) { [weak self] (requestResult) in
             var urlRequest: URLRequest
             do {
                 urlRequest = try requestResult.get()
@@ -76,6 +76,11 @@ class StreamCDNClient: CDNClient {
             let data = multipartFormData.getMultipartFormData()
             urlRequest.addValue("multipart/form-data; boundary=\(MultipartFormData.boundary)", forHTTPHeaderField: "Content-Type")
             urlRequest.httpBody = data
+
+            guard let self = self else {
+                log.warning("Callback called while self is nil")
+                return
+            }
             
             let task = self.session.dataTask(with: urlRequest) { [decoder = self.decoder] (data, response, error) in
                 do {

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -286,11 +286,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
                 fetchRequest: ChannelDTO.fetchRequest(for: cid),
                 itemCreator: { $0.asModel() as ChatChannel }
             ).onChange { [weak self] change in
-                guard let self = self else {
-                    log.warning("Callback called while self is nil")
-                    return
-                }
-                self.delegateCallback { [weak self] in
+                self?.delegateCallback { [weak self] in
                     guard let self = self else {
                         log.warning("Callback called while self is nil")
                         return
@@ -299,11 +295,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
                 }
             }
             .onFieldChange(\.currentlyTypingUsers) { [weak self] change in
-                guard let self = self else {
-                    log.warning("Callback called while self is nil")
-                    return
-                }
-                self.delegateCallback { [weak self] in
+                self?.delegateCallback { [weak self] in
                     guard let self = self else {
                         log.warning("Callback called while self is nil")
                         return
@@ -343,12 +335,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
                 itemCreator: { $0.asModel() as ChatMessage }
             )
             observer.onChange = { [weak self] changes in
-                guard let self = self else {
-                    log.warning("Callback called while self is nil")
-                    return
-                }
-                
-                self.delegateCallback { [weak self] in
+                self?.delegateCallback { [weak self] in
                     guard let self = self else {
                         log.warning("Callback called while self is nil")
                         return
@@ -451,11 +438,11 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
         let center = webSocketClient.eventNotificationCenter
         eventObservers = [
             MemberEventObserver(notificationCenter: center, cid: cid) { [weak self] event in
-                guard let self = self else {
-                    log.warning("Callback called while self is nil")
-                    return
-                }
-                self.delegateCallback {
+                self?.delegateCallback { [weak self] in
+                    guard let self = self else {
+                        log.warning("Callback called while self is nil")
+                        return
+                    }
                     $0.channelController(self, didReceiveMemberEvent: event)
                 }
             }

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -70,23 +70,22 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
         )
         
         observer.onChange = { [weak self] changes in
-            guard let self = self else {
-                log.warning("Callback called while self is nil")
-                return
-            }
-
-            self.delegateCallback {
+            self?.delegateCallback { [weak self] in
+                guard let self = self else {
+                    log.warning("Callback called while self is nil")
+                    return
+                }
                 $0.controller(self, didChangeChannels: changes)
             }
         }
 
         observer.onWillChange = { [weak self] in
-            guard let self = self else {
-                log.warning("Callback called while self is nil")
-                return
-            }
+            self?.delegateCallback { [weak self] in
+                guard let self = self else {
+                    log.warning("Callback called while self is nil")
+                    return
+                }
 
-            self.delegateCallback {
                 $0.controllerWillChangeChannels(self)
             }
         }

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -69,13 +69,23 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
             { $0.asModel() }
         )
         
-        observer.onChange = { [unowned self] changes in
+        observer.onChange = { [weak self] changes in
+            guard let self = self else {
+                log.warning("Callback called while self is nil")
+                return
+            }
+
             self.delegateCallback {
                 $0.controller(self, didChangeChannels: changes)
             }
         }
 
-        observer.onWillChange = { [unowned self] in
+        observer.onWillChange = { [weak self] in
+            guard let self = self else {
+                log.warning("Callback called while self is nil")
+                return
+            }
+
             self.delegateCallback {
                 $0.controllerWillChangeChannels(self)
             }
@@ -126,7 +136,12 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
             self.connectionObserver = EventObserver(
                 notificationCenter: center,
                 transform: { $0 as? ConnectionStatusUpdated },
-                callback: { [unowned self] in
+                callback: { [weak self] in
+                    guard let self = self else {
+                        log.warning("Callback called while self is nil")
+                        return
+                    }
+
                     switch $0.webSocketConnectionState {
                     case .connected:
                         self.updateChannelList(trumpExistingChannels: self.channels.count > self.requestedChannelsLimit)

--- a/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.swift
@@ -103,7 +103,12 @@ public class ChatChannelWatcherListController: DataController, DelegateCallable,
             NSFetchedResultsController<UserDTO>.self
         )
         
-        observer.onChange = { [unowned self] changes in
+        observer.onChange = { [weak self] changes in
+            guard let self = self else {
+                log.warning("Callback called while self is nil")
+                return
+            }
+
             self.delegateCallback {
                 $0.channelWatcherListController(self, didChangeWatchers: changes)
             }

--- a/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.swift
@@ -104,12 +104,11 @@ public class ChatChannelWatcherListController: DataController, DelegateCallable,
         )
         
         observer.onChange = { [weak self] changes in
-            guard let self = self else {
-                log.warning("Callback called while self is nil")
-                return
-            }
-
-            self.delegateCallback {
+            self?.delegateCallback { [weak self] in
+                guard let self = self else {
+                    log.warning("Callback called while self is nil")
+                    return
+                }
                 $0.channelWatcherListController(self, didChangeWatchers: changes)
             }
         }

--- a/Sources/StreamChat/Controllers/ConnectionController/ConnectionController.swift
+++ b/Sources/StreamChat/Controllers/ConnectionController/ConnectionController.swift
@@ -65,12 +65,11 @@ public class ChatConnectionController: Controller, DelegateCallable, DataStorePr
         let observer = ConnectionEventObserver(
             notificationCenter: webSocketClient.eventNotificationCenter
         ) { [weak self] status in
-            guard let self = self else {
-                log.warning("Callback called while self is nil")
-                return
-            }
-
-            self.delegateCallback {
+            self?.delegateCallback { [weak self] in
+                guard let self = self else {
+                    log.warning("Callback called while self is nil")
+                    return
+                }
                 $0.connectionController(self, didUpdateConnectionStatus: status.connectionStatus)
             }
         }

--- a/Sources/StreamChat/Controllers/ConnectionController/ConnectionController.swift
+++ b/Sources/StreamChat/Controllers/ConnectionController/ConnectionController.swift
@@ -64,7 +64,12 @@ public class ChatConnectionController: Controller, DelegateCallable, DataStorePr
         guard let webSocketClient = client.webSocketClient else { return nil }
         let observer = ConnectionEventObserver(
             notificationCenter: webSocketClient.eventNotificationCenter
-        ) { [unowned self] status in
+        ) { [weak self] status in
+            guard let self = self else {
+                log.warning("Callback called while self is nil")
+                return
+            }
+
             self.delegateCallback {
                 $0.connectionController(self, didUpdateConnectionStatus: status.connectionStatus)
             }

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -31,12 +31,22 @@ public class CurrentChatUserController: DataController, DelegateCallable, DataSt
 
     /// Used for observing the current user changes in a database.
     private lazy var currentUserObserver = createUserObserver()
-        .onChange { [unowned self] change in
+        .onChange { [weak self] change in
+            guard let self = self else {
+                log.warning("Callback called while self is nil")
+                return
+            }
+
             self.delegateCallback {
                 $0.currentUserController(self, didChangeCurrentUser: change)
             }
         }
-        .onFieldChange(\.unreadCount) { [unowned self] change in
+        .onFieldChange(\.unreadCount) { [weak self] change in
+            guard let self = self else {
+                log.warning("Callback called while self is nil")
+                return
+            }
+
             self.delegateCallback {
                 $0.currentUserController(self, didChangeCurrentUserUnreadCount: change.unreadCount)
             }

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -32,22 +32,20 @@ public class CurrentChatUserController: DataController, DelegateCallable, DataSt
     /// Used for observing the current user changes in a database.
     private lazy var currentUserObserver = createUserObserver()
         .onChange { [weak self] change in
-            guard let self = self else {
-                log.warning("Callback called while self is nil")
-                return
-            }
-
-            self.delegateCallback {
+            self?.delegateCallback { [weak self] in
+                guard let self = self else {
+                    log.warning("Callback called while self is nil")
+                    return
+                }
                 $0.currentUserController(self, didChangeCurrentUser: change)
             }
         }
         .onFieldChange(\.unreadCount) { [weak self] change in
-            guard let self = self else {
-                log.warning("Callback called while self is nil")
-                return
-            }
-
-            self.delegateCallback {
+            self?.delegateCallback { [weak self] in
+                guard let self = self else {
+                    log.warning("Callback called while self is nil")
+                    return
+                }
                 $0.currentUserController(self, didChangeCurrentUserUnreadCount: change.unreadCount)
             }
         }

--- a/Sources/StreamChat/Controllers/EventsController/EventsController.swift
+++ b/Sources/StreamChat/Controllers/EventsController/EventsController.swift
@@ -52,7 +52,12 @@ public class EventsController: Controller, DelegateCallable {
         observer = .init(
             notificationCenter: notificationCenter,
             transform: { $0 },
-            callback: { [unowned self] event in
+            callback: { [weak self] event in
+                guard let self = self else {
+                    log.warning("Callback called while self is nil")
+                    return
+                }
+
                 guard self.shouldProcessEvent(event) else { return }
                 
                 self.delegateCallback {

--- a/Sources/StreamChat/Controllers/EventsController/EventsController.swift
+++ b/Sources/StreamChat/Controllers/EventsController/EventsController.swift
@@ -60,7 +60,12 @@ public class EventsController: Controller, DelegateCallable {
 
                 guard self.shouldProcessEvent(event) else { return }
                 
-                self.delegateCallback {
+                self.delegateCallback { [weak self] in
+                    guard let self = self else {
+                        log.warning("Callback called while self is nil")
+                        return
+                    }
+
                     $0.eventsController(self, didReceiveEvent: event)
                 }
             }

--- a/Sources/StreamChat/Controllers/MemberController/MemberController.swift
+++ b/Sources/StreamChat/Controllers/MemberController/MemberController.swift
@@ -61,12 +61,12 @@ public class ChatChannelMemberController: DataController, DelegateCallable, Data
     /// The observer used to track the user changes in the database.
     private lazy var memberObserver = createMemberObserver()
         .onChange { [weak self] change in
-            guard let self = self else {
-                log.warning("Callback called while self is nil")
-                return
-            }
+            self?.delegateCallback { [weak self] in
+                guard let self = self else {
+                    log.warning("Callback called while self is nil")
+                    return
+                }
 
-            self.delegateCallback {
                 $0.memberController(self, didUpdateMember: change)
             }
         }

--- a/Sources/StreamChat/Controllers/MemberController/MemberController.swift
+++ b/Sources/StreamChat/Controllers/MemberController/MemberController.swift
@@ -60,7 +60,12 @@ public class ChatChannelMemberController: DataController, DelegateCallable, Data
     
     /// The observer used to track the user changes in the database.
     private lazy var memberObserver = createMemberObserver()
-        .onChange { [unowned self] change in
+        .onChange { [weak self] change in
+            guard let self = self else {
+                log.warning("Callback called while self is nil")
+                return
+            }
+
             self.delegateCallback {
                 $0.memberController(self, didUpdateMember: change)
             }

--- a/Sources/StreamChat/Controllers/MemberListController/MemberListController.swift
+++ b/Sources/StreamChat/Controllers/MemberListController/MemberListController.swift
@@ -106,12 +106,12 @@ public class ChatChannelMemberListController: DataController, DelegateCallable, 
         )
         
         observer.onChange = { [weak self] changes in
-            guard let self = self else {
-                log.warning("Callback called while self is nil")
-                return
-            }
+            self?.delegateCallback { [weak self] in
+                guard let self = self else {
+                    log.warning("Callback called while self is nil")
+                    return
+                }
 
-            self.delegateCallback {
                 $0.memberListController(self, didChangeMembers: changes)
             }
         }

--- a/Sources/StreamChat/Controllers/MemberListController/MemberListController.swift
+++ b/Sources/StreamChat/Controllers/MemberListController/MemberListController.swift
@@ -105,7 +105,12 @@ public class ChatChannelMemberListController: DataController, DelegateCallable, 
             NSFetchedResultsController<MemberDTO>.self
         )
         
-        observer.onChange = { [unowned self] changes in
+        observer.onChange = { [weak self] changes in
+            guard let self = self else {
+                log.warning("Callback called while self is nil")
+                return
+            }
+
             self.delegateCallback {
                 $0.memberListController(self, didChangeMembers: changes)
             }

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -99,12 +99,7 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
     /// The observer used to listen to message updates
     private lazy var messageObserver = createMessageObserver()
         .onChange { [weak self] change in
-            guard let self = self else {
-                log.warning("Callback called while self is nil")
-                return
-            }
-
-            self.delegateCallback { [weak self] in
+            self?.delegateCallback { [weak self] in
                 guard let self = self else {
                     log.warning("Callback called while self is nil")
                     return
@@ -502,12 +497,7 @@ private extension ChatMessageController {
                 NSFetchedResultsController<MessageDTO>.self
             )
             observer.onChange = { [weak self] changes in
-                guard let self = self else {
-                    log.warning("Callback called while self is nil")
-                    return
-                }
-                
-                self.delegateCallback { [weak self] in
+                self?.delegateCallback { [weak self] in
                     guard let self = self else {
                         log.warning("Callback called while self is nil")
                         return

--- a/Sources/StreamChat/Controllers/SearchControllers/MessageSearchController/MessageSearchController.swift
+++ b/Sources/StreamChat/Controllers/SearchControllers/MessageSearchController/MessageSearchController.swift
@@ -92,8 +92,12 @@ public class ChatMessageSearchController: DataController, DelegateCallable, Data
                 ),
                 itemCreator: { $0.asModel() as ChatMessage }
             )
-            observer.onChange = { changes in
-                self.delegateCallback {
+            observer.onChange = { [weak self] changes in
+                self?.delegateCallback { [weak self] in
+                    guard let self = self else {
+                        log.warning("Callback called while self is nil")
+                        return
+                    }
                     $0.controller(self, didChangeMessages: changes)
                 }
             }

--- a/Sources/StreamChat/Controllers/SearchControllers/UserSearchController/UserSearchController.swift
+++ b/Sources/StreamChat/Controllers/SearchControllers/UserSearchController/UserSearchController.swift
@@ -67,12 +67,12 @@ public class ChatUserSearchController: DataController, DelegateCallable, DataSto
         )
         
         observer.onChange = { [weak self] changes in
-            guard let self = self else {
-                log.warning("Callback called while self is nil")
-                return
-            }
+            self?.delegateCallback { [weak self] in
+                guard let self = self else {
+                    log.warning("Callback called while self is nil")
+                    return
+                }
 
-            self.delegateCallback {
                 $0.controller(self, didChangeUsers: changes)
             }
         }

--- a/Sources/StreamChat/Controllers/SearchControllers/UserSearchController/UserSearchController.swift
+++ b/Sources/StreamChat/Controllers/SearchControllers/UserSearchController/UserSearchController.swift
@@ -66,7 +66,12 @@ public class ChatUserSearchController: DataController, DelegateCallable, DataSto
             { $0.asModel() }
         )
         
-        observer.onChange = { [unowned self] changes in
+        observer.onChange = { [weak self] changes in
+            guard let self = self else {
+                log.warning("Callback called while self is nil")
+                return
+            }
+
             self.delegateCallback {
                 $0.controller(self, didChangeUsers: changes)
             }

--- a/Sources/StreamChat/Controllers/UserController/UserController.swift
+++ b/Sources/StreamChat/Controllers/UserController/UserController.swift
@@ -49,7 +49,12 @@ public class ChatUserController: DataController, DelegateCallable, DataStoreProv
     
     /// The observer used to track the user changes in the database.
     private lazy var userObserver = createUserObserver()
-        .onChange { [unowned self] change in
+        .onChange { [weak self] change in
+            guard let self = self else {
+                log.warning("Callback called while self is nil")
+                return
+            }
+
             self.delegateCallback {
                 $0.userController(self, didUpdateUser: change)
             }

--- a/Sources/StreamChat/Controllers/UserController/UserController.swift
+++ b/Sources/StreamChat/Controllers/UserController/UserController.swift
@@ -50,12 +50,11 @@ public class ChatUserController: DataController, DelegateCallable, DataStoreProv
     /// The observer used to track the user changes in the database.
     private lazy var userObserver = createUserObserver()
         .onChange { [weak self] change in
-            guard let self = self else {
-                log.warning("Callback called while self is nil")
-                return
-            }
-
-            self.delegateCallback {
+            self?.delegateCallback { [weak self] in
+                guard let self = self else {
+                    log.warning("Callback called while self is nil")
+                    return
+                }
                 $0.userController(self, didUpdateUser: change)
             }
         }

--- a/Sources/StreamChat/Controllers/UserListController/UserListController.swift
+++ b/Sources/StreamChat/Controllers/UserListController/UserListController.swift
@@ -63,7 +63,12 @@ public class ChatUserListController: DataController, DelegateCallable, DataStore
             { $0.asModel() }
         )
         
-        observer.onChange = { [unowned self] changes in
+        observer.onChange = { [weak self] changes in
+            guard let self = self else {
+                log.warning("Callback called while self is nil")
+                return
+            }
+
             self.delegateCallback {
                 $0.controller(self, didChangeUsers: changes)
             }

--- a/Sources/StreamChat/Controllers/UserListController/UserListController.swift
+++ b/Sources/StreamChat/Controllers/UserListController/UserListController.swift
@@ -64,12 +64,12 @@ public class ChatUserListController: DataController, DelegateCallable, DataStore
         )
         
         observer.onChange = { [weak self] changes in
-            guard let self = self else {
-                log.warning("Callback called while self is nil")
-                return
-            }
+            self?.delegateCallback { [weak self] in
+                guard let self = self else {
+                    log.warning("Callback called while self is nil")
+                    return
+                }
 
-            self.delegateCallback {
                 $0.controller(self, didChangeUsers: changes)
             }
         }

--- a/Sources/StreamChat/Utils/InternetConnection/InternetConnection.swift
+++ b/Sources/StreamChat/Utils/InternetConnection/InternetConnection.swift
@@ -185,7 +185,7 @@ private extension InternetConnection {
         private func createMonitor() -> NWPathMonitor {
             let monitor = NWPathMonitor()
             
-            // We should be able to do `[unowned self]` here, but it seems `NWPathMonitor` sometimes calls the handler
+            // We should be able to do `[weak self]` here, but it seems `NWPathMonitor` sometimes calls the handler
             // event after `cancel()` has been called on it.
             monitor.pathUpdateHandler = { [weak self] in
                 self?.updateStatus(with: $0)
@@ -254,8 +254,8 @@ private extension InternetConnection {
             
             do {
                 reachability = try Reachability()
-                reachability?.whenReachable = { [unowned self] in self.updateStatus(with: $0) }
-                reachability?.whenUnreachable = { [unowned self] in self.updateStatus(with: $0) }
+                reachability?.whenReachable = { [weak self] in self?.updateStatus(with: $0) }
+                reachability?.whenUnreachable = { [weak self] in self?.updateStatus(with: $0) }
             } catch {
                 log.error(error)
             }

--- a/Sources/StreamChat/Utils/InternetConnection/Reachability_Vendor.swift
+++ b/Sources/StreamChat/Utils/InternetConnection/Reachability_Vendor.swift
@@ -192,7 +192,12 @@ extension Reachability {
 
 private extension Reachability {
     func setReachabilityFlags() throws {
-        try reachabilitySerialQueue.sync { [unowned self] in
+        try reachabilitySerialQueue.sync { [weak self] in
+            guard let self = self else {
+                log.warning("Callback called while self is nil")
+                return
+            }
+
             var flags = SCNetworkReachabilityFlags()
             if !SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags) {
                 self.stopNotifier()

--- a/Sources/StreamChat/Workers/Background/ChannelWatchStateUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/ChannelWatchStateUpdater.swift
@@ -38,7 +38,7 @@ final class ChannelWatchStateUpdater: EventWorker {
         webSocketConnectedObserver = WebSocketConnectedObserver(
             notificationCenter: eventNotificationCenter,
             filter: { $0.connectionStatus == .connected },
-            callback: { [unowned self] in self.watchChannels() }
+            callback: { [weak self] in self?.watchChannels() }
         )
     }
     

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater.swift
@@ -81,12 +81,17 @@ class ConnectionRecoveryUpdater: EventWorker {
         connectionObserver = EventObserver(
             notificationCenter: eventNotificationCenter,
             transform: { $0 as? ConnectionStatusUpdated },
-            callback: { [unowned self] in
+            callback: { [weak self] in
+                guard let self = self else {
+                    log.warning("Callback called while self is nil")
+                    return
+                }
+
                 switch $0.webSocketConnectionState {
                 case .connecting:
                     self.obtainLastSyncDate()
                 case .connected:
-                    fetchAndReplayMissingEvents()
+                    self.fetchAndReplayMissingEvents()
                 default:
                     break
                 }


### PR DESCRIPTION
[-] Added replacement of unowned self everywhere in blocks
    in production code to guard let self
[-] Added replacement of unowned self everywhere in blocks
    in test code
[-] Improving tests to be compilable

Test plan:
- Open freshly installed app
- Select c3po user
- Open chat list
- Open chat
- Send message
- View photos
- Open chat with unread count 
- Create new chat with multiple users
All Pass

React on message - does no add reaction instantly
