### PR TITLE
[CIS-1137] Remove redundant background task cancelation

### DIFF
--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads_Tests.swift
@@ -46,7 +46,7 @@ class MessagePayload_Tests: XCTestCase {
         let box = try JSONDecoder.default.decode(MessagePayload.Boxed.self, from: messageJSONWithCorruptedAttachments)
         let payload = box.message
 
-        var messageCustomData = messageCustomData
+        var messageCustomData = self.messageCustomData
         messageCustomData["tau"] = .double(6.28)
 
         XCTAssertEqual(payload.id, "7baa1533-3294-4c0c-9a62-c9d0928bf733")

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -403,8 +403,6 @@ public class ChatClient {
         
         let succeed = scheduler.beginTask { [weak self] in
             self?.clientUpdater.disconnect(source: .systemInitiated)
-            // We need to call `endBackgroundTask` else our app will be killed
-            self?.cancelBackgroundTaskIfNeeded()
         }
         
         if !succeed {

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -925,9 +925,6 @@ class ChatClient_Tests: StressTestCase {
         
         // Assert that `disconnect` is called
         XCTAssertEqual(testEnv.clientUpdater?.disconnect_called, true)
-        
-        // Assert that background task is cancelled
-        XCTAssertEqual(testEnv.backgroundTaskScheduler?.endBackgroundTask_called, true)
     }
     
     func test_backgroundTaskCancelled_whenAppIsForegrounded() {


### PR DESCRIPTION
I investigated [this](https://github.com/GetStream/stream-chat-swift/issues/1377) issue and spotted this inconsistency
We don't need to pass it inside expiration handler because this is called in `BackgroundTaskScheduler` after the expiration handler. It's unclear if this caused any issues but it makes sense to fix it anyway