### PR TITLE
Stream v2.6.9: RxSwift + RxGestures bump to last version (v6)

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,8 +1,8 @@
 github "daltoniam/Starscream" ~> 4.0
 
-github "ReactiveX/RxSwift" ~> 5.1
+github "ReactiveX/RxSwift" ~> 6.2.0
 
 github "kean/Nuke" ~> 8.4
 github "SnapKit/SnapKit" ~> 5.0
 github "kirualex/SwiftyGif" ~> 5.2.0
-github "RxSwiftCommunity/RxGesture" ~> 3.0
+github "RxSwiftCommunity/RxGesture" ~> 4.0.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
-github "ReactiveX/RxSwift" "5.1.1"
-github "RxSwiftCommunity/RxGesture" "3.0.3"
+github "ReactiveX/RxSwift" "6.2.0"
+github "RxSwiftCommunity/RxGesture" "4.0.2"
 github "SnapKit/SnapKit" "5.0.1"
 github "daltoniam/Starscream" "4.0.4"
 github "kean/Nuke" "8.4.1"

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/RxSwiftCommunity/RxGesture.git",
         "state": {
           "branch": null,
-          "revision": "d62d313d1f9dcff6c367ef98a0581831187a28ac",
-          "version": "3.0.1"
+          "revision": "e29e65a58c2f670677d17df9a18e846b87e78592",
+          "version": "4.0.2"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {
           "branch": null,
-          "revision": "002d325b0bdee94e7882e1114af5ff4fe1e96afa",
-          "version": "5.1.1"
+          "revision": "7c17a6ccca06b5c107cfa4284e634562ddaf5951",
+          "version": "6.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -24,9 +24,9 @@ let package = Package(
         .package(url: "https://github.com/kean/Nuke.git", from: "8.4.0"),
         .package(url: "https://github.com/SnapKit/SnapKit.git", from: "5.0.0"),
         .package(url: "https://github.com/kirualex/SwiftyGif.git", from: "5.2.0"),
-        .package(url: "https://github.com/RxSwiftCommunity/RxGesture.git", from: "3.0.0"),
+        .package(url: "https://github.com/RxSwiftCommunity/RxGesture.git", from: "4.0.2"),
         // Core
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.1.0"),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.2.0"),
         // Client
         .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.0"),
     ],

--- a/StreamChat.podspec
+++ b/StreamChat.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |spec|
   spec.dependency "Nuke", "~> 8.4"
   spec.dependency "SnapKit", "~> 5.0"
   spec.dependency "SwiftyGif", "~> 5.2.0"
-  spec.dependency "RxGesture", "~> 3.0"
+  spec.dependency "RxGesture", "~> 4.0.2"
 end

--- a/StreamChatCore.podspec
+++ b/StreamChatCore.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |spec|
   spec.framework = "Foundation", "UIKit"
     
   spec.dependency "StreamChatClient", "#{spec.version}"
-  spec.dependency "RxSwift", "~> 5.1"
-  spec.dependency "RxCocoa", "~> 5.1"
+  spec.dependency "RxSwift", "~> 6.2.0"
+  spec.dependency "RxCocoa", "~> 6.2.0"
 end


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Hi,

In our project we are still using `Stream 2.6.9` and we need to update to `RxSwift 6`.
This PR is just a version bump to `RxSwift 6` and `RxGestures` (`Carthage` + `Cocoapods` + `SPM`).

Tested in our app, it's working fine 😊 

Thanks for your work!
