### PR TITLE
[CIS-1153] Fix an issue with thread replies not being shown if there was a reply that was also sent to a channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ A new `ChatChannelVC` is introduced that represents the old `ChatMessageListVC`,
 - Improve pagination efficiency [#1381](https://github.com/GetStream/stream-chat-swift/pull/1381)
 - Fix user mention suggestions not showing all members [#1390](https://github.com/GetStream/stream-chat-swift/pull/1381)
 - Fix thread avatar view not displaying latest reply author avatar [#1398](https://github.com/GetStream/stream-chat-swift/pull/1398)
+- Fix threads not showing all the responses if there were responses that were also sent to the channel [#1413](https://github.com/GetStream/stream-chat-swift/pull/1413)
 
 # [4.0.0-beta.11](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.11)
 _August 13, 2021_

--- a/Sources/StreamChat/Controllers/ListDatabaseObserver_Mock.swift
+++ b/Sources/StreamChat/Controllers/ListDatabaseObserver_Mock.swift
@@ -16,4 +16,9 @@ final class ListDatabaseObserverMock<Item, DTO: NSManagedObject>: ListDatabaseOb
             try super.startObserving()
         }
     }
+    
+    var items_mock: LazyCachedMapCollection<Item>?
+    override var items: LazyCachedMapCollection<Item> {
+        items_mock ?? super.items
+    }
 }


### PR DESCRIPTION
An issue was reported here:
https://github.com/GetStream/stream-chat-swift/issues/1389

It's easily reproducible with the local storage disabled, but when it disabled the behaviour is also not entirely correct

What's happening:

If there was a thread reply that was also sent to the channel, you get it when you fetch the channel. Then when you open the original thread, this problematic reply is in core data already, so `replies.last` won't return nil, even though the only reply in this collection has nothing to do with the last message. So we would take this `replies.last` reply and use it to start our pagination with, ignoring all the messages that are younger