### PR TITLE
Remove Group By from DTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ A new `ChatChannelVC` is introduced that represents the old `ChatMessageListVC`,
 - Fix thread avatar view not displaying latest reply author avatar [#1398](https://github.com/GetStream/stream-chat-swift/pull/1398)
 - Fix crash on incorrect date string parsing [#1403](https://github.com/GetStream/stream-chat-swift/pull/1403)
 - Fix threads not showing all the responses if there were responses that were also sent to the channel [#1413](https://github.com/GetStream/stream-chat-swift/pull/1413)
+- Fix support for iOS 12 when Core Data uses in-memory storage
 
 # [4.0.0-beta.11](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.11)
 _August 13, 2021_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ A new `ChatChannelVC` is introduced that represents the old `ChatMessageListVC`,
 - Fix thread avatar view not displaying latest reply author avatar [#1398](https://github.com/GetStream/stream-chat-swift/pull/1398)
 - Fix crash on incorrect date string parsing [#1403](https://github.com/GetStream/stream-chat-swift/pull/1403)
 - Fix threads not showing all the responses if there were responses that were also sent to the channel [#1413](https://github.com/GetStream/stream-chat-swift/pull/1413)
-- Fix support for iOS 12 when Core Data uses in-memory storage
+- Fix crash when accessing `ChatMessage.attachmentCounts` on <iOS13 with in-memory storage turned ON
 
 # [4.0.0-beta.11](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.11)
 _August 13, 2021_

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -169,7 +169,6 @@ extension ChatMessage {
             currentUserReactions: { [] },
             isSentByCurrentUser: false,
             pinDetails: nil,
-            attachmentCounts: [:],
             underlyingContext: nil
         )
     }

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController+SwiftUI_Tests.swift
@@ -169,7 +169,7 @@ extension ChatMessage {
             currentUserReactions: { [] },
             isSentByCurrentUser: false,
             pinDetails: nil,
-            attachmentCounts: { [:] },
+            attachmentCounts: [:],
             underlyingContext: nil
         )
     }

--- a/Sources/StreamChat/Models/ChatMessage.swift
+++ b/Sources/StreamChat/Models/ChatMessage.swift
@@ -94,10 +94,12 @@ public struct ChatMessage {
     @CoreDataLazy internal var _attachments: [AnyChatMessageAttachment]
 
     /// The overall attachment count by attachment type.
-    public var attachmentCounts: [AttachmentType: Int] { _attachmentCounts }
+    public var attachmentCounts: [AttachmentType: Int] {
+        _attachments.reduce(into: [:]) { counts, attachment in
+            counts[attachment.type] = (counts[attachment.type] ?? 0) + 1
+        }
+    }
 
-    @CoreDataLazy internal var _attachmentCounts: [AttachmentType: Int]
-        
     /// A list of latest 25 replies to this message.
     ///
     /// - Important: The `latestReplies` property is loaded and evaluated lazily to maintain high performance.
@@ -168,7 +170,7 @@ public struct ChatMessage {
         currentUserReactions: @escaping () -> Set<ChatMessageReaction>,
         isSentByCurrentUser: Bool,
         pinDetails: MessagePinDetails?,
-        attachmentCounts: @escaping () -> [AttachmentType: Int],
+        attachmentCounts: [AttachmentType: Int],
         underlyingContext: NSManagedObjectContext?
     ) {
         self.id = id
@@ -200,7 +202,6 @@ public struct ChatMessage {
         $_latestReactions = (latestReactions, underlyingContext)
         $_currentUserReactions = (currentUserReactions, underlyingContext)
         $_quotedMessage = (quotedMessage, underlyingContext)
-        $_attachmentCounts = (attachmentCounts, underlyingContext)
     }
 }
 

--- a/Sources/StreamChat/Models/ChatMessage.swift
+++ b/Sources/StreamChat/Models/ChatMessage.swift
@@ -170,7 +170,6 @@ public struct ChatMessage {
         currentUserReactions: @escaping () -> Set<ChatMessageReaction>,
         isSentByCurrentUser: Bool,
         pinDetails: MessagePinDetails?,
-        attachmentCounts: [AttachmentType: Int],
         underlyingContext: NSManagedObjectContext?
     ) {
         self.id = id

--- a/Sources/StreamChatTestTools/Models/ChatMessage_Mock.swift
+++ b/Sources/StreamChatTestTools/Models/ChatMessage_Mock.swift
@@ -6,7 +6,7 @@ import Foundation
 @testable import StreamChat
 
 public extension ChatMessage {
-    /// Creates a new `_ChatMessage` object from the provided data.
+    /// Creates a new `ChatMessage` object from the provided data.
     static func mock(
         id: MessageId,
         cid: ChannelId,
@@ -67,7 +67,7 @@ public extension ChatMessage {
             currentUserReactions: { currentUserReactions },
             isSentByCurrentUser: isSentByCurrentUser,
             pinDetails: pinDetails,
-            attachmentCounts: { attachmentCounts },
+            attachmentCounts: attachmentCounts,
             underlyingContext: nil
         )
     }

--- a/Sources/StreamChatTestTools/Models/ChatMessage_Mock.swift
+++ b/Sources/StreamChatTestTools/Models/ChatMessage_Mock.swift
@@ -35,8 +35,7 @@ public extension ChatMessage {
         latestReactions: Set<ChatMessageReaction> = [],
         currentUserReactions: Set<ChatMessageReaction> = [],
         isSentByCurrentUser: Bool = false,
-        pinDetails: MessagePinDetails? = nil,
-        attachmentCounts: [AttachmentType: Int] = [:]
+        pinDetails: MessagePinDetails? = nil
     ) -> Self {
         .init(
             id: id,
@@ -67,7 +66,6 @@ public extension ChatMessage {
             currentUserReactions: { currentUserReactions },
             isSentByCurrentUser: isSentByCurrentUser,
             pinDetails: pinDetails,
-            attachmentCounts: attachmentCounts,
             underlyingContext: nil
         )
     }

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/AttachmentViewCatalog.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/AttachmentViewCatalog.swift
@@ -14,8 +14,7 @@ open class AttachmentViewCatalog {
         message: ChatMessage,
         components: Components
     ) -> AttachmentViewInjector.Type? {
-        // Do not show attachments for deleted messages
-        guard !message.isDeleted else { return nil }
+        if message.isDeleted { return nil }
         
         let attachmentCounts = message.attachmentCounts
         


### PR DESCRIPTION
Rewrite `attachmentCounts` to not use Core Data (previous approach with GROUP BY did not work on iOS 12 with in memory storage)