### PR TITLE
[CIS-1156] Use remote config to disable threads and mutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ A new `ChatChannelVC` is introduced that represents the old `ChatMessageListVC`,
 - For non-DM channels, the avatar is now shown as a combination of the avatars of the last active members of the channel [#1344](https://github.com/GetStream/stream-chat-swift/pull/1344)
 - New DateFormatter methods `rfc3339Date` and `rfc3339DateString` [#1403](https://github.com/GetStream/stream-chat-swift/pull/1403)
 - Add a new `isMentionsEnabled` flag to make it easier to disable the user mentions in the ComposerVC [#1416](https://github.com/GetStream/stream-chat-swift/pull/1416)
+- Use remote config to disable mute actions [#1418](https://github.com/GetStream/stream-chat-swift/pull/1418)
+- Use remote config to disable thread info from message options [#1418](https://github.com/GetStream/stream-chat-swift/pull/1418)
 
 ### 🐞 Fixed
 - Fix incorrect RawJSON number handling, the `.integer` case is no longer supported and is replaced by `.number` [#1375](https://github.com/GetStream/stream-chat-swift/pull/1375)

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
@@ -80,7 +80,7 @@ open class ChatMessageLayoutOptionsResolver {
         if hasQuotedMessage(message) {
             options.insert(.quotedMessage)
         }
-        if message.isRootOfThread || message.isPartOfThread {
+        if channel.config.repliesEnabled && (message.isRootOfThread || message.isPartOfThread) {
             options.insert(.threadInfo)
             // The bubbles with thread look like continuous bubbles
             options.insert(.continuousBubble)

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver_Tests.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver_Tests.swift
@@ -888,6 +888,76 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
         }
     }
 
+    func test_optionsForMessage_whenRepliesEnabled_includesThreadInfo() {
+        // Create deleted thread root message
+        let messageThreadRoot: ChatMessage = .mock(
+            id: .unique,
+            cid: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            replyCount: 10,
+            latestReplies: [
+                .mock(id: .unique, cid: .unique, text: .unique, author: .mock(id: .unique))
+            ]
+        )
+
+        // Create deleted thread part message
+        let messageThreadPart: ChatMessage = .mock(
+            id: .unique,
+            cid: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            parentMessageId: messageThreadRoot.id
+        )
+
+        for threadMessage in [messageThreadRoot, messageThreadPart] {
+            // Calculate layout options for the message
+            let layoutOptions = optionsResolver.optionsForMessage(
+                at: .init(item: 0, section: 0),
+                in: .mock(cid: .unique, config: .mock(repliesEnabled: true)),
+                with: .init([threadMessage]),
+                appearance: appearance
+            )
+
+            XCTAssertTrue(layoutOptions.contains(.threadInfo))
+        }
+    }
+
+    func test_optionsForMessage_whenRepliesDisabled_doesNotIncludeThreadInfo() {
+        // Create deleted thread root message
+        let messageThreadRoot: ChatMessage = .mock(
+            id: .unique,
+            cid: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            replyCount: 10,
+            latestReplies: [
+                .mock(id: .unique, cid: .unique, text: .unique, author: .mock(id: .unique))
+            ]
+        )
+
+        // Create deleted thread part message
+        let messageThreadPart: ChatMessage = .mock(
+            id: .unique,
+            cid: .unique,
+            text: .unique,
+            author: .mock(id: .unique),
+            parentMessageId: messageThreadRoot.id
+        )
+
+        for threadMessage in [messageThreadRoot, messageThreadPart] {
+            // Calculate layout options for the message
+            let layoutOptions = optionsResolver.optionsForMessage(
+                at: .init(item: 0, section: 0),
+                in: .mock(cid: .unique, config: .mock(repliesEnabled: false)),
+                with: .init([threadMessage]),
+                appearance: appearance
+            )
+
+            XCTAssertFalse(layoutOptions.contains(.threadInfo))
+        }
+    }
+
     // MARK: - Reactions
 
     func test_optionsForMessage_whenMessageIsDeleted_doesNotIncludeReactions() {

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
@@ -93,14 +93,17 @@ open class ChatMessageActionsVC: _ViewController, ThemeProvider {
 
             if message.isSentByCurrentUser {
                 actions += [editActionItem(), deleteActionItem()]
-            } else if currentUser.mutedUsers.contains(message.author) {
-                actions.append(
-                    unmuteActionItem()
-                )
-            } else {
-                actions.append(
-                    muteActionItem()
-                )
+
+            } else if channelConfig.mutesEnabled {
+                if currentUser.mutedUsers.contains(message.author) {
+                    actions.append(
+                        unmuteActionItem()
+                    )
+                } else {
+                    actions.append(
+                        muteActionItem()
+                    )
+                }
             }
 
             return actions

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
@@ -95,15 +95,8 @@ open class ChatMessageActionsVC: _ViewController, ThemeProvider {
                 actions += [editActionItem(), deleteActionItem()]
 
             } else if channelConfig.mutesEnabled {
-                if currentUser.mutedUsers.contains(message.author) {
-                    actions.append(
-                        unmuteActionItem()
-                    )
-                } else {
-                    actions.append(
-                        muteActionItem()
-                    )
-                }
+                let isMuted = currentUser.mutedUsers.contains(message.author)
+                actions.append(isMuted ? unmuteActionItem() : muteActionItem())
             }
 
             return actions

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC_Tests.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC_Tests.swift
@@ -75,6 +75,18 @@ class ChatMessageActionsVC_Tests: XCTestCase {
 
         XCTAssert(vc.alertsRouter is TestAlertsRouter)
     }
+
+    func test_messageActions_whenMutesEnabled_containsMuteAction() {
+        vc.channelConfig = .mock(mutesEnabled: true)
+
+        XCTAssertTrue(vc.messageActions.contains(where: { $0 is MuteUserActionItem }))
+    }
+
+    func test_messageActions_whenMutesDisabled_doesNotContainMuteAction() {
+        vc.channelConfig = .mock(mutesEnabled: false)
+
+        XCTAssertFalse(vc.messageActions.contains(where: { $0 is MuteUserActionItem }))
+    }
 }
 
 private extension UIViewController {


### PR DESCRIPTION
## Description of the pull request
- Removes `.threadInfo` from the message options in case threads are disabled
- Removes mute actions in case mutes are disabled