### PR TITLE
[CIS-1152] Fix connection recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ A new `ChatChannelVC` is introduced that represents the old `ChatMessageListVC`,
 - Fix mention suggester now supports `options.minimumRequiredCharacters` equal to 0 and sorts results with same score consistently
 - Fix filters with wrong Date encoding strategy [#1420](https://github.com/GetStream/stream-chat-swift/pull/1420)
 - Fix message height is now calculated correctly when a message is updated [#1424](https://github.com/GetStream/stream-chat-swift/pull/1424)
+- Fix list of channels being broken after connection recovery [#1426](https://github.com/GetStream/stream-chat-swift/pull/1426)
 
 # [4.0.0-beta.11](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.11)
 _August 13, 2021_

--- a/Sources/StreamChat/APIClient/ChatRemoteNotificationHandler.swift
+++ b/Sources/StreamChat/APIClient/ChatRemoteNotificationHandler.swift
@@ -127,7 +127,7 @@ public class ChatRemoteNotificationHandler {
                 return
             }
 
-            let cids = results.compactMap { try? ChannelId(cid: $0.cid) }
+            let cids = results.map { $0.channelId }
             guard !cids.isEmpty else {
                 completion()
                 return

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
@@ -40,7 +40,7 @@ class AttachmentDTO_Tests: XCTestCase {
         XCTAssertEqual(loadedAttachment.localState, nil)
         XCTAssertEqual(loadedAttachment.attachmentType, attachment.type)
         XCTAssertEqual(loadedAttachment.message.id, messageId)
-        XCTAssertEqual(loadedAttachment.channel.cid, cid.rawValue)
+        XCTAssertEqual(loadedAttachment.channel.channelId, cid)
 
         let imagePayload = attachment.decodedImagePayload
         let imageAttachmentModel = try XCTUnwrap(
@@ -75,7 +75,7 @@ class AttachmentDTO_Tests: XCTestCase {
         XCTAssertEqual(loadedAttachment.localState, nil)
         XCTAssertEqual(loadedAttachment.attachmentType, attachment.type)
         XCTAssertEqual(loadedAttachment.message.id, messageId)
-        XCTAssertEqual(loadedAttachment.channel.cid, cid.rawValue)
+        XCTAssertEqual(loadedAttachment.channel.channelId, cid)
 
         let giphyPayload = attachment.decodedGiphyPayload
         let giphyAttachmentWithActionsPayload = try XCTUnwrap(
@@ -110,7 +110,7 @@ class AttachmentDTO_Tests: XCTestCase {
         XCTAssertEqual(loadedAttachment.localState, nil)
         XCTAssertEqual(loadedAttachment.attachmentType, attachment.type)
         XCTAssertEqual(loadedAttachment.message.id, messageId)
-        XCTAssertEqual(loadedAttachment.channel.cid, cid.rawValue)
+        XCTAssertEqual(loadedAttachment.channel.channelId, cid)
 
         let giphyPayload = attachment.decodedGiphyPayload
         let giphyAttachmentWithoutActionsPayload = try XCTUnwrap(
@@ -146,7 +146,7 @@ class AttachmentDTO_Tests: XCTestCase {
         XCTAssertEqual(loadedAttachment.localState, .pendingUpload)
         XCTAssertEqual(loadedAttachment.attachmentType, attachmentEnvelope.type)
         XCTAssertEqual(loadedAttachment.message.id, messageId)
-        XCTAssertEqual(loadedAttachment.channel.cid, cid.rawValue)
+        XCTAssertEqual(loadedAttachment.channel.channelId, cid)
 
         let fileAttachment = try XCTUnwrap(
             loadedAttachment
@@ -185,7 +185,7 @@ class AttachmentDTO_Tests: XCTestCase {
         XCTAssertEqual(loadedAttachment.localState, .uploaded)
         XCTAssertEqual(loadedAttachment.attachmentType, attachmentEnvelope.type)
         XCTAssertEqual(loadedAttachment.message.id, messageId)
-        XCTAssertEqual(loadedAttachment.channel.cid, cid.rawValue)
+        XCTAssertEqual(loadedAttachment.channel.channelId, cid)
 
         let attachmentModel = try XCTUnwrap(
             loadedAttachment

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -251,7 +251,7 @@ extension ChannelDTO {
         let sortDescriptors = query.sort.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
         request.sortDescriptors = sortDescriptors.isEmpty ? [ChannelListSortingKey.defaultSortDescriptor] : sortDescriptors
         
-        let matchingQuery = NSPredicate(format: "ANY queries.filterHash == %@", query.filter.filterHash)
+        let matchingQuery = NSPredicate(format: "ANY queries.queryHash == %@", query.queryHash)
         let notDeleted = NSPredicate(format: "deletedAt == nil")
 
         // This is not 100% correct and should be ideally solved differently. This makes it impossible

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -237,15 +237,6 @@ extension NSManagedObjectContext {
     func channel(cid: ChannelId) -> ChannelDTO? {
         ChannelDTO.load(cid: cid, context: self)
     }
-    
-    func deleteChannels(query: ChannelListQuery) throws {
-        guard let fetchRequest = ChannelDTO.channelListFetchRequest(
-            query: query
-        ) as? NSFetchRequest<NSFetchRequestResult> else { return }
-        let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-        try execute(deleteRequest)
-        try save()
-    }
 }
 
 // To get the data from the DB

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
@@ -440,7 +440,7 @@ class ChannelDTO_Tests: XCTestCase {
         }
         
         XCTAssertEqual(loadedChannels.count, 1)
-        XCTAssertEqual(loadedChannels.first?.cid, channel1Id.rawValue)
+        XCTAssertEqual(loadedChannels.first?.channelId, channel1Id)
     }
     
     func test_channelListQuery_withSorting() {
@@ -570,8 +570,8 @@ class ChannelDTO_Tests: XCTestCase {
         let loadedChannels: [ChannelDTO] = try database.viewContext.fetch(fetchRequest)
 
         XCTAssertEqual(loadedChannels.count, 2)
-        XCTAssertTrue(loadedChannels.contains { $0.cid == visibleCid1.rawValue })
-        XCTAssertTrue(loadedChannels.contains { $0.cid == visibleCid2.rawValue })
+        XCTAssertTrue(loadedChannels.contains { $0.channelId == visibleCid1 })
+        XCTAssertTrue(loadedChannels.contains { $0.channelId == visibleCid2 })
     }
     
     func test_channelUnreadCount_calculatedCorrectly() {

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
@@ -465,12 +465,12 @@ class ChannelDTO_Tests: XCTestCase {
             .map(\.channel.updatedAt)
             .sorted(by: { $0 > $1 })
 
-        // Save the channels to DB. It doesn't matter which query we use because the filter for both of them is the same.
+        // Save the channels to DB and link to both queries.
         try! database.writeSynchronously { session in
-            try session.saveChannel(payload: payload1, query: queryWithDefaultSorting)
-            try session.saveChannel(payload: payload2, query: queryWithDefaultSorting)
-            try session.saveChannel(payload: payload3, query: queryWithDefaultSorting)
-            try session.saveChannel(payload: payload4, query: queryWithDefaultSorting)
+            for payload in [payload1, payload2, payload3, payload4] {
+                try session.saveChannel(payload: payload, query: queryWithDefaultSorting)
+                try session.saveChannel(payload: payload, query: queryWithUpdatedAtSorting)
+            }
         }
 
         // A fetch request with a default sorting.

--- a/Sources/StreamChat/Database/DTOs/ChannelMuteDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelMuteDTO_Tests.swift
@@ -83,9 +83,9 @@ final class ChannelMuteDTO_Tests: XCTestCase {
 
             // Assert mutes match payloads.
             for mute in channelMutes {
-                let payload = try XCTUnwrap(mutePayloads.first(where: { $0.mutedChannel.cid.rawValue == mute.channel.cid }))
+                let payload = try XCTUnwrap(mutePayloads.first(where: { $0.mutedChannel.cid == mute.channel.channelId }))
                 XCTAssertEqual(mute.user.id, payload.user.id)
-                XCTAssertEqual(mute.channel.cid, payload.mutedChannel.cid.rawValue)
+                XCTAssertEqual(mute.channel.channelId, payload.mutedChannel.cid)
                 XCTAssertEqual(mute.createdAt, payload.createdAt)
                 XCTAssertEqual(mute.updatedAt, payload.updatedAt)
             }
@@ -130,7 +130,7 @@ final class ChannelMuteDTO_Tests: XCTestCase {
             for mute in channelMutes {
                 let payload = try XCTUnwrap(mutePayloads.first(where: { $0.user.id == mute.user.id }))
                 XCTAssertEqual(mute.user.id, payload.user.id)
-                XCTAssertEqual(mute.channel.cid, payload.mutedChannel.cid.rawValue)
+                XCTAssertEqual(mute.channel.channelId, payload.mutedChannel.cid)
                 XCTAssertEqual(mute.createdAt, payload.createdAt)
                 XCTAssertEqual(mute.updatedAt, payload.updatedAt)
             }
@@ -160,7 +160,7 @@ final class ChannelMuteDTO_Tests: XCTestCase {
             )
             // Assert correct mute is loaded.
             XCTAssertEqual(mute.user.id, payload.user.id)
-            XCTAssertEqual(mute.channel.cid, payload.mutedChannel.cid.rawValue)
+            XCTAssertEqual(mute.channel.channelId, payload.mutedChannel.cid)
             XCTAssertEqual(mute.createdAt, payload.createdAt)
             XCTAssertEqual(mute.updatedAt, payload.updatedAt)
         }

--- a/Sources/StreamChat/Database/DTOs/ChannelReadDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelReadDTO.swift
@@ -21,7 +21,7 @@ class ChannelReadDTO: NSManagedObject {
         // When the read is updated, we need to propagate this change up to holding channel
         if hasPersistentChangedValues, !channel.hasChanges {
             // this will not change object, but mark it as dirty, triggering updates
-            channel.cid = channel.cid
+            channel.name = channel.name
         }
     }
     

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -535,7 +535,7 @@ private extension ChatMessage {
         let context = dto.managedObjectContext!
         
         id = dto.id
-        cid = dto.channel.map { try! ChannelId(cid: $0.cid) }
+        cid = dto.channel?.channelId
         text = dto.text
         type = MessageType(rawValue: dto.type) ?? .regular
         command = dto.command

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -159,8 +159,6 @@ protocol ChannelDatabaseSession {
     
     /// Fetches `ChannelDTO` with the given `cid` from the database.
     func channel(cid: ChannelId) -> ChannelDTO?
-    
-    func deleteChannels(query: ChannelListQuery) throws
 }
 
 protocol ChannelReadDatabaseSession {
@@ -225,6 +223,16 @@ protocol MemberListQueryDatabaseSession {
     func saveQuery(_ query: ChannelMemberListQuery) throws -> ChannelMemberListQueryDTO
 }
 
+protocol ChannelListQueryDatabaseSession {
+    func saveQuery(query: ChannelListQuery) -> ChannelListQueryDTO
+    
+    func channelListQuery(filterHash: String) -> ChannelListQueryDTO?
+
+    func loadChannelListQueries() -> [ChannelListQueryDTO]
+    
+    func delete(_ query: ChannelListQuery)
+}
+
 protocol AttachmentDatabaseSession {
     /// Fetches `AttachmentDTO`entity for the given `id`.
     func attachment(id: AttachmentId) -> AttachmentDTO?
@@ -254,7 +262,8 @@ protocol DatabaseSession: UserDatabaseSession,
     MemberDatabaseSession,
     MemberListQueryDatabaseSession,
     AttachmentDatabaseSession,
-    ChannelMuteDatabaseSession {}
+    ChannelMuteDatabaseSession,
+    ChannelListQueryDatabaseSession {}
 
 extension DatabaseSession {
     @discardableResult

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -226,7 +226,7 @@ protocol MemberListQueryDatabaseSession {
 protocol ChannelListQueryDatabaseSession {
     func saveQuery(query: ChannelListQuery) -> ChannelListQueryDTO
     
-    func channelListQuery(filterHash: String) -> ChannelListQueryDTO?
+    func channelListQuery(queryHash: String) -> ChannelListQueryDTO?
 
     func loadChannelListQueries() -> [ChannelListQueryDTO]
     

--- a/Sources/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Mock.swift
@@ -21,6 +21,22 @@ class DatabaseSessionMock: DatabaseSession {
 // Here start the boilerplate that forwards and intercepts the session calls if needed
 
 extension DatabaseSessionMock {
+    func saveQuery(query: ChannelListQuery) -> ChannelListQueryDTO {
+        underlyingSession.saveQuery(query: query)
+    }
+    
+    func channelListQuery(queryHash: String) -> ChannelListQueryDTO? {
+        underlyingSession.channelListQuery(queryHash: queryHash)
+    }
+    
+    func delete(_ query: ChannelListQuery) {
+        underlyingSession.delete(query)
+    }
+    
+    func loadChannelListQueries() -> [ChannelListQueryDTO] {
+        underlyingSession.loadChannelListQueries()
+    }
+    
     func saveCurrentUserDevices(_ devices: [DevicePayload], clearExisting: Bool) throws {
         try throwErrorIfNeeded()
         try underlyingSession.saveCurrentUserDevices(devices, clearExisting: clearExisting)
@@ -230,10 +246,6 @@ extension DatabaseSessionMock {
 
     func loadChannelMute(cid: ChannelId, userId: String) -> ChannelMuteDTO? {
         underlyingSession.loadChannelMute(cid: cid, userId: userId)
-    }
-    
-    func deleteChannels(query: ChannelListQuery) throws {
-        try underlyingSession.deleteChannels(query: query)
     }
 }
 

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -93,15 +93,16 @@
         </uniquenessConstraints>
     </entity>
     <entity name="ChannelListQueryDTO" representedClassName="ChannelListQueryDTO" syncable="YES">
-        <attribute name="filterHash" attributeType="String"/>
         <attribute name="filterJSONData" attributeType="Binary"/>
+        <attribute name="queryHash" attributeType="String"/>
+        <attribute name="sortingJSONData" attributeType="Binary"/>
         <relationship name="channels" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="queries" inverseEntity="ChannelDTO"/>
-        <fetchIndex name="filterHash">
-            <fetchIndexElement property="filterHash" type="Binary" order="ascending"/>
+        <fetchIndex name="queryHash">
+            <fetchIndexElement property="queryHash" type="Binary" order="ascending"/>
         </fetchIndex>
         <uniquenessConstraints>
             <uniquenessConstraint>
-                <constraint value="filterHash"/>
+                <constraint value="queryHash"/>
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -118,3 +118,13 @@ public struct ChannelListQuery: Encodable {
         try pagination.encode(to: encoder)
     }
 }
+
+extension ChannelListQuery {
+    var queryHash: String {
+        let components = [
+            filter.filterHash,
+            sort.map(\.description).joined()
+        ]
+        return components.joined(separator: "-")
+    }
+}

--- a/Sources/StreamChat/Query/Sorting/Sorting.swift
+++ b/Sources/StreamChat/Query/Sorting/Sorting.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// A sorting key protocol.
-public protocol SortingKey: Encodable {}
+public protocol SortingKey: Codable {}
 
 /// Sorting options.
 ///
@@ -14,7 +14,7 @@ public protocol SortingKey: Encodable {}
 /// // Sort channels by the last message date:
 /// let sorting = Sorting("lastMessageDate")
 /// ```
-public struct Sorting<Key: SortingKey>: Encodable, CustomStringConvertible {
+public struct Sorting<Key: SortingKey>: SortingKey, CustomStringConvertible {
     /// A sorting field name.
     public let key: Key
     /// A sorting direction.

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -25,7 +25,7 @@ class WebSocketClient {
 
             if event.connectionStatus != previousStatus {
                 // Publish Connection event with the new state
-                eventNotificationCenter.process(event)
+                eventNotificationCenter.post(event)
             }
         }
     }

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater.swift
@@ -117,7 +117,7 @@ class ConnectionRecoveryUpdater: EventWorker {
     private func sync(completion: @escaping () -> Void) {
         guard let lastSyncedAt = lastSyncedAt else { return }
         
-        let watchedChannelIDs = allChannels.map(\.cid).compactMap { try? ChannelId(cid: $0) }
+        let watchedChannelIDs = allChannels.map(\.channelId)
         
         guard !watchedChannelIDs.isEmpty else {
             log.info("Skipping `/sync` endpoint call as there are no channels to watch.")

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater.swift
@@ -55,8 +55,8 @@ class DatabaseCleanupUpdater: Worker {
                         entityName: ChannelListQueryDTO.entityName
                     )
                 )
-                let queries: [ChannelListQuery] = try queriesDTOs.map {
-                    try $0.asChannelListQuery()
+                let queries: [ChannelListQuery] = queriesDTOs.compactMap {
+                    $0.asModel()
                 }
                 queries.forEach {
                     self?.channelListUpdater.update(channelListQuery: $0) { result in
@@ -89,18 +89,5 @@ private extension ChannelDTO {
         currentlyTypingUsers = []
         reads = []
         queries = []
-    }
-}
-
-private extension ChannelListQueryDTO {
-    /// Converts ChannelListQueryDTO to _ChannelListQuery
-    /// - Throws: Decoding error
-    /// - Returns: Domain model for _ChannelListQuery
-    func asChannelListQuery() throws -> ChannelListQuery {
-        let encodedFilter = try JSONDecoder.default
-            .decode(Filter<ChannelListFilterScope>.self, from: filterJSONData)
-        var updatedFilter: Filter<ChannelListFilterScope> = encodedFilter
-        updatedFilter.explicitHash = filterHash
-        return ChannelListQuery(filter: updatedFilter)
     }
 }

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater.swift
@@ -72,7 +72,7 @@ class DatabaseCleanupUpdater: Worker {
     }
 }
 
-private extension ChannelDTO {
+extension ChannelDTO {
     /// Resets local channel data
     func resetLocalData() {
         messages = []

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater.swift
@@ -31,43 +31,86 @@ class DatabaseCleanupUpdater: Worker {
         )
     }
     
-    /// Resets all existing channels data without removing the data from the database. This is used mainly to clean-up
-    /// existing relations between the objects, and prepare the channels for full refetching.
-    ///
-    /// - Parameter session: session for writing into the database.
-    ///
-    func resetExistingChannelsData(session: DatabaseSession) throws {
-        if let channels = try (session as? NSManagedObjectContext)?
-            .fetch(ChannelDTO.allChannelsFetchRequest) {
-            channels.forEach {
-                $0.resetLocalData()
-            }
-        }
-    }
-    
-    /// Finds the existing channel list queries in the database and refetches them.
-    func refetchExistingChannelListQueries() {
-        let context = database.backgroundReadOnlyContext
-        context.perform { [weak self] in
-            do {
-                let queriesDTOs = try context.fetch(
-                    NSFetchRequest<ChannelListQueryDTO>(
-                        entityName: ChannelListQueryDTO.entityName
-                    )
-                )
-                let queries: [ChannelListQuery] = queriesDTOs.compactMap {
-                    $0.asModel()
-                }
-                queries.forEach {
-                    self?.channelListUpdater.update(channelListQuery: $0) { result in
-                        if case let .failure(error) = result {
-                            log.error("Internal error. Failed to update ChannelListQueries for the new channel: \(error)")
+    func syncChannelListQueries(syncedChannelIDs: Set<ChannelId>) {
+        log.debug("Will sync channel queries. Synced channels: \(syncedChannelIDs)")
+        
+        fetchLocalQueries { [weak self] localQueries in
+            self?.fetchFirstPage(of: localQueries) { remoteQueries in
+                self?.database.write { session in
+                    for (queryHash, queryResult) in remoteQueries {
+                        switch queryResult {
+                        case let .success(firstPage):
+                            log.debug("Did load first page of channels for \(queryHash)")
+                                                        
+                            // Load local query
+                            guard let queryDTO = session.channelListQuery(queryHash: queryHash) else {
+                                assertionFailure("Channel list query no longer exists: \(queryHash)")
+                                continue
+                            }
+                            
+                            // Reset out-dated and unwatched channels
+                            let watchedChannelIDs = Set(firstPage.channels.map(\.channel.cid))
+                            let watchedAndSyncedChannelIDs = watchedChannelIDs.intersection(syncedChannelIDs)
+                            queryDTO.channels
+                                .filter { !watchedAndSyncedChannelIDs.contains($0.channelId) }
+                                .forEach { $0.resetLocalData() }
+                            
+                            // Unlink all channels from a query
+                            queryDTO.channels.removeAll()
+                            
+                            // Link channels from first page to query
+                            for channel in firstPage.channels {
+                                try session.saveChannel(
+                                    payload: channel,
+                                    query: queryDTO.asModel()
+                                )
+                            }
+                        case let .failure(error):
+                            log.error("Failed to re-fetch channel list query \(queryHash) \(error)")
                         }
                     }
                 }
-            } catch {
-                log.error("Internal error: Failed to fetch [ChannelListQueryDTO]: \(error)")
             }
+        }
+    }
+}
+
+// MARK: - Private
+
+private extension DatabaseCleanupUpdater {
+    func fetchLocalQueries(completion: @escaping ([ChannelListQuery]) -> Void) {
+        let context = database.backgroundReadOnlyContext
+        context.perform {
+            let queries = context
+                .loadChannelListQueries()
+                .compactMap { $0.asModel() }
+            
+            completion(queries)
+        }
+    }
+    
+    func fetchFirstPage(
+        of queries: [ChannelListQuery],
+        completion: @escaping ([String: Result<ChannelListPayload, Error>]) -> Void
+    ) {
+        let group = DispatchGroup()
+        let semaphore = DispatchSemaphore(value: 1)
+        
+        var results: [String: Result<ChannelListPayload, Error>] = [:]
+        for query in queries {
+            group.enter()
+            
+            log.debug("Will fetch first page of channels for \(query)")
+            channelListUpdater.fetch(query) {
+                semaphore.wait()
+                results[query.queryHash] = $0
+                semaphore.signal()
+                group.leave()
+            }
+        }
+        
+        group.notify(queue: .main) {
+            completion(results)
         }
     }
 }

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Mock.swift
@@ -6,13 +6,13 @@
 import StreamChat
 
 final class DatabaseCleanupUpdater_Mock: DatabaseCleanupUpdater {
-    var resetExistingChannelsData_body: (DatabaseSession) -> Void = { _ in }
-    override func resetExistingChannelsData(session: DatabaseSession) {
-        resetExistingChannelsData_body(session)
+    var syncChannelListQueries_syncedChannelIDs: Set<ChannelId>?
+    
+    override func syncChannelListQueries(syncedChannelIDs: Set<ChannelId>) {
+        syncChannelListQueries_syncedChannelIDs = syncedChannelIDs
     }
-
-    var refetchExistingChannelListQueries_body: () -> Void = {}
-    override func refetchExistingChannelListQueries() {
-        refetchExistingChannelListQueries_body()
+    
+    func cleanUp() {
+        syncChannelListQueries_syncedChannelIDs = nil
     }
 }

--- a/Sources/StreamChat/Workers/Background/MessageSender.swift
+++ b/Sources/StreamChat/Workers/Background/MessageSender.swift
@@ -67,7 +67,7 @@ class MessageSender: Worker {
             switch change {
             case .insert(let dto, index: _), .update(let dto, index: _):
                 database.backgroundReadOnlyContext.performAndWait {
-                    guard let cid = dto.channel.map({ try! ChannelId(cid: $0.cid) }) else {
+                    guard let cid = dto.channel?.channelId else {
                         log.error("Skipping sending of the message \(dto.id) because the channel info is missing.")
                         return
                     }
@@ -152,7 +152,7 @@ private class MessageSendingQueue {
                     return
                 }
                 
-                guard let cid = dto.channel.map({ try! ChannelId(cid: $0.cid) }) else {
+                guard let cid = dto.channel?.channelId else {
                     log.info("Skipping sending message with id \(dto.id) because it doesn't have a valid channel.")
                     self?.removeRequestAndContinue(request)
                     return

--- a/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
@@ -23,19 +23,9 @@ final class NewChannelQueryUpdater: Worker {
     
     private lazy var channelsObserver: ListDatabaseObserver = .init(
         context: self.database.backgroundReadOnlyContext,
-        fetchRequest: ChannelDTO.channelWithoutQueryFetchRequest
+        fetchRequest: ChannelDTO.channelWithoutQueryFetchRequest,
+        itemCreator: { $0.asModel() }
     )
-    
-    private var queries: [ChannelListQueryDTO] {
-        do {
-            let queries = try database.backgroundReadOnlyContext
-                .fetch(NSFetchRequest<ChannelListQueryDTO>(entityName: ChannelListQueryDTO.entityName))
-            return queries
-        } catch {
-            log.error("Internal error: Failed to fetch [ChannelListQueryDTO]: \(error)")
-        }
-        return []
-    }
     
     init(database: DatabaseContainer, apiClient: APIClient, env: Environment) {
         environment = env
@@ -60,25 +50,26 @@ final class NewChannelQueryUpdater: Worker {
                     self?.handle(changes: changes)
                 }
                 try self?.channelsObserver.startObserving()
-                self?.channelsObserver.items.forEach { self?.updateChannelListQuery(for: $0) }
+                self?.channelsObserver.items.forEach {
+                    self?.linkChannelToExistedQueries($0.cid)
+                }
             } catch {
                 log.error("Error starting NewChannelQueryUpdater observer: \(error)")
             }
         }
     }
     
-    private func handle(changes: [ListChange<ChannelDTO>]) {
+    private func handle(changes: [ListChange<ChatChannel>]) {
         // Observe `ChannelDTO` insertions
         changes.forEach { change in
             switch change {
-            case let .insert(channelDTO, _):
-                let cid = channelDTO.channelId
-                
+            case let .insert(channel, _):
+                let cid = channel.cid
                 database.write {
                     let dto = $0.channel(cid: cid)
                     dto?.needsRefreshQueries = false
                 } completion: { _ in
-                    self.updateChannelListQuery(for: channelDTO)
+                    self.linkChannelToExistedQueries(cid)
                 }
 
             default: return
@@ -86,31 +77,54 @@ final class NewChannelQueryUpdater: Worker {
         }
     }
     
-    private func updateChannelListQuery(for channelDTO: ChannelDTO) {
-        database.backgroundReadOnlyContext.perform { [weak self] in
-            guard let queries = self?.queries else { return }
-            
-            var updatedQueries: [ChannelListQuery] = []
-            
-            do {
-                updatedQueries = try queries.map {
-                    // Modify original query filter
-                    try $0.asChannelListQueryWithUpdatedFilter(filterToAdd: .equal("cid", to: channelDTO.channelId.rawValue))
-                }
-                
-            } catch {
-                log.error("Internal error. Failed to update ChannelListQueries for the new channel: \(error)")
-            }
-            
-            // Send `update(channelListQuery:` requests so corresponding queries will be linked to the channel
-            updatedQueries.forEach {
-                self?.channelListUpdater.update(channelListQuery: $0) { result in
-                    if case let .failure(error) = result {
-                        log.error("Internal error. Failed to update ChannelListQueries for the new channel: \(error)")
-                    }
-                }
+    private func linkChannelToExistedQueries(_ cid: ChannelId) {
+        fetchExistedQueries { [weak self] queries in
+            for query in queries {
+                self?.linkChannelToQueryIfNeeded(cid, query: query)
             }
         }
+    }
+    
+    private func linkChannelToQueryIfNeeded(_ cid: ChannelId, query: ChannelListQuery) {
+        var queryWithNewChannel = ChannelListQuery(
+            filter: .and([query.filter, .equal(.cid, to: cid)]),
+            pageSize: 1
+        )
+        queryWithNewChannel.options = []
+        
+        channelListUpdater.fetch(queryWithNewChannel) { [weak self] in
+            switch $0 {
+            case let .success(payload):
+                guard let channel = payload.channels.first(where: { $0.channel.cid == cid }) else {
+                    return
+                }
+                
+                self?.save(channel, andLinkTo: query)
+            case let .failure(error):
+                log.error("Failed to check if query should include new channel: \(error)")
+            }
+        }
+    }
+    
+    private func fetchExistedQueries(_ completion: @escaping ([ChannelListQuery]) -> Void) {
+        let context = database.backgroundReadOnlyContext
+        context.perform {
+            let queries = context
+                .loadChannelListQueries()
+                .compactMap { $0.asModel() }
+            
+            completion(queries)
+        }
+    }
+    
+    private func save(_ channel: ChannelPayload, andLinkTo query: ChannelListQuery) {
+        database.write({ session in
+            _ = try session.saveChannel(payload: channel, query: query)
+        }, completion: { error in
+            if let error = error {
+                log.error("Failed to link new channel: \(channel.channel.cid) to query \(error)")
+            }
+        })
     }
 }
 
@@ -124,16 +138,16 @@ extension NewChannelQueryUpdater {
 }
 
 private extension ChannelListQueryDTO {
-    func asChannelListQueryWithUpdatedFilter(
-        filterToAdd filter: Filter<ChannelListFilterScope>
-    ) throws -> ChannelListQuery {
-        let encodedFilter = try JSONDecoder.default
-            .decode(Filter<ChannelListFilterScope>.self, from: filterJSONData)
-        
-        // We need to pass original `filterHash` so channel will be linked to original query, not the modified one
-        var updatedFilter: Filter<ChannelListFilterScope> = .and([encodedFilter, filter])
-        updatedFilter.explicitHash = filterHash
-        
-        return ChannelListQuery(filter: updatedFilter)
+    func asModel() -> ChannelListQuery? {
+        do {
+            let filter = try JSONDecoder
+                .default
+                .decode(Filter<ChannelListFilterScope>.self, from: filterJSONData)
+            
+            return .init(filter: filter)
+        } catch {
+            log.error("Internal error. Failed to decode channel list query filter: \(error)")
+            return nil
+        }
     }
 }

--- a/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
@@ -136,18 +136,3 @@ extension NewChannelQueryUpdater {
         ) -> ChannelListUpdater = ChannelListUpdater.init
     }
 }
-
-private extension ChannelListQueryDTO {
-    func asModel() -> ChannelListQuery? {
-        do {
-            let filter = try JSONDecoder
-                .default
-                .decode(Filter<ChannelListFilterScope>.self, from: filterJSONData)
-            
-            return .init(filter: filter)
-        } catch {
-            log.error("Internal error. Failed to decode channel list query filter: \(error)")
-            return nil
-        }
-    }
-}

--- a/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater.swift
@@ -72,10 +72,10 @@ final class NewChannelQueryUpdater: Worker {
         changes.forEach { change in
             switch change {
             case let .insert(channelDTO, _):
-                let cid = channelDTO.cid
+                let cid = channelDTO.channelId
                 
                 database.write {
-                    let dto = $0.channel(cid: try! ChannelId(cid: cid))
+                    let dto = $0.channel(cid: cid)
                     dto?.needsRefreshQueries = false
                 } completion: { _ in
                     self.updateChannelListQuery(for: channelDTO)
@@ -95,7 +95,7 @@ final class NewChannelQueryUpdater: Worker {
             do {
                 updatedQueries = try queries.map {
                     // Modify original query filter
-                    try $0.asChannelListQueryWithUpdatedFilter(filterToAdd: .equal("cid", to: channelDTO.cid))
+                    try $0.asChannelListQueryWithUpdatedFilter(filterToAdd: .equal("cid", to: channelDTO.channelId.rawValue))
                 }
                 
             } catch {

--- a/Sources/StreamChat/Workers/ChannelListUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater.swift
@@ -38,6 +38,7 @@ class ChannelListUpdater: Worker {
                 self?.database.write { session in
                     if trumpExistingChannels {
                         let query = session.channelListQuery(queryHash: channelListQuery.queryHash)
+                        query?.channels.forEach { $0.resetLocalData() }
                         query?.channels.removeAll()
                     }
                     

--- a/Sources/StreamChat/Workers/ChannelListUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater.swift
@@ -36,9 +36,9 @@ class ChannelListUpdater: Worker {
             switch $0 {
             case let .success(channelListPayload):
                 self?.database.write { session in
-                    
                     if trumpExistingChannels {
-                        try session.deleteChannels(query: channelListQuery)
+                        let query = session.channelListQuery(queryHash: channelListQuery.queryHash)
+                        query?.channels.removeAll()
                     }
                     
                     try channelListPayload.channels.forEach {

--- a/Sources/StreamChat/Workers/ChannelListUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater_Mock.swift
@@ -8,7 +8,7 @@ import XCTest
 /// Mock implementation of ChannelListUpdater
 class ChannelListUpdaterMock: ChannelListUpdater {
     @Atomic var fetch_channelListQueries: [ChannelListQuery] = []
-    @Atomic var fetch_completion: ((Result<ChannelListPayload, Error>) -> Void)? = nil
+    @Atomic var fetch_completions: [(Result<ChannelListPayload, Error>) -> Void] = []
     
     @Atomic var update_queries: [ChannelListQuery] = []
     @Atomic var update_completion: ((Result<ChannelListPayload, Error>) -> Void)? = nil
@@ -17,7 +17,7 @@ class ChannelListUpdaterMock: ChannelListUpdater {
     
     func cleanUp() {
         fetch_channelListQueries.removeAll()
-        fetch_completion = nil
+        fetch_completions.removeAll()
         
         update_queries.removeAll()
         update_completion = nil
@@ -30,7 +30,7 @@ class ChannelListUpdaterMock: ChannelListUpdater {
         completion: @escaping (Result<ChannelListPayload, Error>) -> Void
     ) {
         _fetch_channelListQueries.mutate { $0.append(channelListQuery) }
-        fetch_completion = completion
+        _fetch_completions.mutate { $0.append(completion) }
     }
     
     override func update(

--- a/Sources/StreamChat/Workers/ChannelListUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater_Mock.swift
@@ -7,16 +7,30 @@ import XCTest
 
 /// Mock implementation of ChannelListUpdater
 class ChannelListUpdaterMock: ChannelListUpdater {
+    @Atomic var fetch_channelListQueries: [ChannelListQuery] = []
+    @Atomic var fetch_completion: ((Result<ChannelListPayload, Error>) -> Void)? = nil
+    
     @Atomic var update_queries: [ChannelListQuery] = []
     @Atomic var update_completion: ((Result<ChannelListPayload, Error>) -> Void)? = nil
     
     @Atomic var markAllRead_completion: ((Error?) -> Void)?
     
     func cleanUp() {
+        fetch_channelListQueries.removeAll()
+        fetch_completion = nil
+        
         update_queries.removeAll()
         update_completion = nil
         
         markAllRead_completion = nil
+    }
+    
+    override func fetch(
+        _ channelListQuery: ChannelListQuery,
+        completion: @escaping (Result<ChannelListPayload, Error>) -> Void
+    ) {
+        _fetch_channelListQueries.mutate { $0.append(channelListQuery) }
+        fetch_completion = completion
     }
     
     override func update(

--- a/Sources/StreamChat/Workers/EventNotificationCenter.swift
+++ b/Sources/StreamChat/Workers/EventNotificationCenter.swift
@@ -62,6 +62,10 @@ class EventNotificationCenter: NotificationCenter {
         }
     }
     
+    func post(_ eventToPublish: Event) {
+        post(Notification(newEventReceived: eventToPublish, sender: self))
+    }
+    
     /// Starts the timer and schedules the processing of events
     private func scheduleProcessing() {
         DispatchQueue.main.asyncAfter(deadline: .now() + eventBatchPeriod) { [weak self] in
@@ -79,7 +83,7 @@ class EventNotificationCenter: NotificationCenter {
                         let eventToPublish = self.middlewares.process(event: event, session: session)
                     else { return }
 
-                    self.post(Notification(newEventReceived: eventToPublish, sender: self))
+                    self.post(eventToPublish)
                 }
             }
         }

--- a/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
@@ -159,30 +159,23 @@ extension DatabaseContainer {
             }
             
             if withQuery {
-                let filter: Filter<ChannelListFilterScope> = .equal(.name, to: "luke:skywalker")
-                let queryDTO = NSEntityDescription.insertNewObject(
-                    forEntityName: ChannelListQueryDTO.entityName,
-                    into: session as! NSManagedObjectContext
-                ) as! ChannelListQueryDTO
-                queryDTO.filterHash = filter.filterHash
-                queryDTO.filterJSONData = try JSONEncoder.default.encode(filter)
+                let query = ChannelListQuery(filter: .equal(.cid, to: cid))
+                let queryDTO = session.saveQuery(query: query)
                 dto.queries = [queryDTO]
             }
+        }
+    }
+    
+    func createChannelListQuery(_ query: ChannelListQuery) throws {
+        try writeSynchronously { session in
+            _ = session.saveQuery(query: query)
         }
     }
     
     func createChannelListQuery(
         filter: Filter<ChannelListFilterScope> = .query(.cid, text: .unique)
     ) throws {
-        try writeSynchronously { session in
-            let dto = NSEntityDescription
-                .insertNewObject(
-                    forEntityName: ChannelListQueryDTO.entityName,
-                    into: session as! NSManagedObjectContext
-                ) as! ChannelListQueryDTO
-            dto.filterHash = filter.filterHash
-            dto.filterJSONData = try JSONEncoder.default.encode(filter)
-        }
+        try createChannelListQuery(.init(filter: filter))
     }
     
     func createUserListQuery(filter: Filter<UserListFilterScope> = .query(.id, text: .unique)) throws {


### PR DESCRIPTION
This PR changes the way we sync when connection is back.

When internet connection is back it's not enough to call `/sync` but we should also refetch existed channel queries because there can be channels user was invited to/became a member of while being offline. Since we don't know anything about these new channels, they can be inserted in any position of a locally existed channel list, we do a refetch. We also have to refetch a query to start `watching` it to get channel events.

**Channel list**

Initially, connection recovery logic lived in `ConnectionRecoveryUpdater` but it was not correct: the `ChannelListQueryDTO` we get from DB does not contain `sort` option so if it was different from default one we did sync a different query. The only place where we have correct `ChannelListQuery` is `ChannelListController` so now this object is responsible for syncing the query it manages. 

Here is how channel list query sync happens:
1. connection comes back
2. we refetch the 1st page of a query (first 20 channels) and we start watching them because of [.watch] option included
4. we unlink all locally existed channels from a local query (so only 1st recently fetched page of channels is displayed)
5. we unlink all messages from the channels we didn't get with the first page because we are no longer watching them so messages of local channels can be outdated

**Active channel**

While for channel list we can refetch the query, we should carefully handle the channel that is being read when connection comes back. For active channels we call `/sync` with a single `cid` to get events that we've missed. Since we ask for single channel events, chances to exceed 1k event limit are low. To track active channels `isBeingRead` flag is introduced which is set to `true` when `ChannelController` is synchronised and set back to `false` when `ChannelController` is deallocated. 

If `/sync` is successful we start `watching` the channel. If `/sync` fails we reset the channel history (by unlinking all messages from this channel) and refetch the first page of messages.