### PR TITLE
[CIS-1159] Provide different Objc name for `InputTextView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ A new `ChatChannelVC` is introduced that represents the old `ChatMessageListVC`,
 - Add a new `isMentionsEnabled` flag to make it easier to disable the user mentions in the ComposerVC [#1416](https://github.com/GetStream/stream-chat-swift/pull/1416)
 - Use remote config to disable mute actions [#1418](https://github.com/GetStream/stream-chat-swift/pull/1418)
 - Use remote config to disable thread info from message options [#1418](https://github.com/GetStream/stream-chat-swift/pull/1418)
+- Provide different Objc name for InputTextView [#1420](https://github.com/GetStream/stream-chat-swift/pull/1421)
 
 ### 🐞 Fixed
 - Fix incorrect RawJSON number handling, the `.integer` case is no longer supported and is replaced by `.number` [#1375](https://github.com/GetStream/stream-chat-swift/pull/1375)

--- a/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
+++ b/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
@@ -16,6 +16,7 @@ public protocol InputTextViewClipboardAttachmentDelegate: AnyObject {
 
 /// A view for inputting text with placeholder support. Since it is a subclass
 /// of `UITextView`, the `UITextViewDelegate` can be used to observe text changes.
+@objc(StreamInputTextView)
 open class InputTextView: UITextView, AppearanceProvider {
     /// The delegate which gets notified when an attachment is pasted into the text view
     open weak var clipboardAttachmentDelegate: InputTextViewClipboardAttachmentDelegate?


### PR DESCRIPTION
## Description of the pull request
A customer that is using MessageKit with Stream and is using Objc could not compile the app since MessageKit also contains an `InputTextView`. To fix this, we can provide a different name for Objc only.