### PR TITLE
Make `ChatMessageReactionData.init` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ A new `ChatChannelVC` is introduced that represents the old `ChatMessageListVC`,
 - Fix crash when accessing `ChatMessage.attachmentCounts` on <iOS13 with in-memory storage turned ON
 - Fix `isCommandsEnabled` not disabling the typing commands [#1416](https://github.com/GetStream/stream-chat-swift/pull/1416)
 - Fix filters with wrong Date encoding strategy [#1420](https://github.com/GetStream/stream-chat-swift/pull/1420)
+- Fix `ChatMessageReactionData.init` not public [#1425](https://github.com/GetStream/stream-chat-swift/pull/1425)
 
 # [4.0.0-beta.11](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0-beta.11)
 _August 13, 2021_

--- a/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactions+Types.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactions+Types.swift
@@ -9,6 +9,12 @@ public struct ChatMessageReactionData {
     public let type: MessageReactionType
     public let score: Int
     public let isChosenByCurrentUser: Bool
+
+    public init(type: MessageReactionType, score: Int, isChosenByCurrentUser: Bool) {
+        self.type = type
+        self.score = score
+        self.isChosenByCurrentUser = isChosenByCurrentUser
+    }
 }
 
 public enum ChatMessageReactionsBubbleStyle {


### PR DESCRIPTION
## Description of the pull request
Makes the init public, which is required by a client.