### PR TITLE
[CIS-1165] Fix last event date being overriden by `HealthCheckEvent`

### DIFF
--- a/Sources/StreamChat/APIClient/ChatRemoteNotificationHandler.swift
+++ b/Sources/StreamChat/APIClient/ChatRemoteNotificationHandler.swift
@@ -84,16 +84,15 @@ public class ChatRemoteNotificationHandler {
     }
 
     private func obtainLastSyncDate(completion: @escaping (Date?) -> Void) {
-        var lastReceivedEventDate: Date?
-        database.viewContext.performAndWait {
-            lastReceivedEventDate = self.database.viewContext.currentUser?.lastReceivedEventDate
+        let context = database.viewContext
+        context.perform {
+            completion(context.currentUser?.lastSyncedAt)
         }
-        completion(lastReceivedEventDate)
     }
 
-    private func bumpLastSyncDate(lastReceivedEventDate: Date, completion: @escaping () -> Void) {
+    private func bumpLastSyncDate(_ lastSyncedAt: Date, completion: @escaping () -> Void) {
         database.write { session in
-            session.currentUser?.lastReceivedEventDate = lastReceivedEventDate
+            session.currentUser?.lastSyncedAt = lastSyncedAt
         } completion: { error in
             if let error = error {
                 log.error(error)
@@ -146,7 +145,7 @@ public class ChatRemoteNotificationHandler {
                     ) {
                         let mostRecentEventDate = payload.eventPayloads.compactMap(\.createdAt).sorted().last
                         self.bumpLastSyncDate(
-                            lastReceivedEventDate: mostRecentEventDate ?? lastSyncAt,
+                            mostRecentEventDate ?? lastSyncAt,
                             completion: completion
                         )
                     }

--- a/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
@@ -10,10 +10,10 @@ class CurrentUserDTO: NSManagedObject {
     @NSManaged var unreadChannelsCount: Int64
     @NSManaged var unreadMessagesCount: Int64
     
-    /// Into this field the creation date of last locally received event is saved.
-    /// The date later serves as reference date for `/sync` endpoint
-    /// that returns all events that happen after the given date
-    @NSManaged var lastReceivedEventDate: Date?
+    /// This fields stores the timestamp of most recent event returned from `/sync` endpoint.
+    /// When reconnect happens, `/sync` endpoint is called with this date
+    /// and returns all events that happen after the given date
+    @NSManaged var lastSyncedAt: Date?
 
     @NSManaged var flaggedUsers: Set<UserDTO>
     @NSManaged var flaggedMessages: Set<MessageDTO>

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -304,7 +304,7 @@ extension DatabaseSession {
         }
         
         if let currentUser = currentUser, let date = payload.createdAt {
-            currentUser.lastReceivedEventDate = date
+            currentUser.lastSyncedAt = date
         }
         
         // Save message data (must be always done after the channel data!)

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -303,10 +303,6 @@ extension DatabaseSession {
             try saveCurrentUserUnreadCount(count: unreadCount)
         }
         
-        if let currentUser = currentUser, let date = payload.createdAt {
-            currentUser.lastSyncedAt = date
-        }
-        
         // Save message data (must be always done after the channel data!)
         if let message = payload.message {
             if let cid = payload.cid {

--- a/Sources/StreamChat/Database/DatabaseSession_Tests.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Tests.swift
@@ -296,7 +296,7 @@ class DatabaseSession_Tests: StressTestCase {
         let currentUser = database.viewContext.currentUser
         
         // Assert `eventPayload.createdAt` is taked as last received event date
-        XCTAssertEqual(currentUser?.lastReceivedEventDate, eventPayload.createdAt)
+        XCTAssertEqual(currentUser?.lastSyncedAt, eventPayload.createdAt)
     }
     
     func test_saveEvent_doesntResetLastReceivedEventDate_whenEventCreatedAtValueIsNil() throws {
@@ -322,7 +322,7 @@ class DatabaseSession_Tests: StressTestCase {
         // Load current user
         let currentUser = database.viewContext.currentUser
         
-        // Assert `lastReceivedEventDate` is nil
-        XCTAssertNil(currentUser?.lastReceivedEventDate)
+        // Assert `lastSyncedAt` is nil
+        XCTAssertNil(currentUser?.lastSyncedAt)
     }
 }

--- a/Sources/StreamChat/Database/DatabaseSession_Tests.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Tests.swift
@@ -272,7 +272,17 @@ class DatabaseSession_Tests: StressTestCase {
         }
     }
     
-    func test_saveEvent_resetsLastReceivedEventDate_withEventCreatedAtValue() throws {
+    func test_saveEvent_doesNotChangeLastSyncedDate() throws {
+        let lastSyncedAt: Date = .unique
+        
+        // Create current user in database.
+        try database.createCurrentUser()
+        
+        // Update `lastSyncedAt` value
+        try database.writeSynchronously { session in
+            session.currentUser?.lastSyncedAt = lastSyncedAt
+        }
+        
         // Create event payload with specific `createdAt` date
         let eventPayload = EventPayload(
             eventType: .messageNew,
@@ -295,8 +305,8 @@ class DatabaseSession_Tests: StressTestCase {
         // Load current user
         let currentUser = database.viewContext.currentUser
         
-        // Assert `eventPayload.createdAt` is taked as last received event date
-        XCTAssertEqual(currentUser?.lastSyncedAt, eventPayload.createdAt)
+        // Assert `eventPayload.createdAt` was not updated
+        XCTAssertEqual(currentUser?.lastSyncedAt, lastSyncedAt)
     }
     
     func test_saveEvent_doesntResetLastReceivedEventDate_whenEventCreatedAtValueIsNil() throws {

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20E241" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20F71" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
@@ -103,7 +103,7 @@
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="channelReads" inverseEntity="UserDTO"/>
     </entity>
     <entity name="CurrentUserDTO" representedClassName="CurrentUserDTO" syncable="YES">
-        <attribute name="lastReceivedEventDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastSyncedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="uniquenessKey" attributeType="String" defaultValueString="this is an immmutable arbitrary key which makes sure we have only once instance of CurrentUserDTO in the db"/>
         <attribute name="unreadChannelsCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="unreadMessagesCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater.swift
@@ -135,11 +135,12 @@ class ConnectionRecoveryUpdater: EventWorker {
             case let .success(payload):
                 // The sync call was successful.
                 // We schedule all events for existing channels for processing...
-                self.eventNotificationCenter.process(payload.eventPayloads)
-                
-                // ... and refetch the existing queries to see if there are some new channels
-                completion()
-                
+                self.eventNotificationCenter.addToCurrentBatchAndProcessImmediately(
+                    payload.eventPayloads.compactMap { try? $0.event() }
+                ) {
+                    // ... and refetch the existing queries to see if there are some new channels
+                    completion()
+                }
             case let .failure(error):
                 log.info(
                     """
@@ -174,24 +175,6 @@ class ConnectionRecoveryUpdater: EventWorker {
         } catch {
             log.error("Internal error: Failed to fetch [ChannelDTO]: \(error)")
             return []
-        }
-    }
-}
-
-// MARK: - Extensions
-
-extension EventNotificationCenter {
-    /// The method is used to convert incoming event payloads into events and calls `process(_:)` for each event
-    /// that was successfully decoded.
-    ///
-    /// - Parameter payloads: The event payloads
-    func process(_ payloads: [EventPayload]) {
-        payloads.forEach {
-            do {
-                process(try $0.event())
-            } catch {
-                log.error("Failed to transform a payload into an event: \($0)")
-            }
         }
     }
 }

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater.swift
@@ -9,13 +9,13 @@ import Foundation
 /// was not connected to the web-socket.
 ///
 /// The object listens for `ConnectionStatusUpdated` events
-/// and remembers the `CurrentUserDTO.lastReceivedEventDate` when status becomes `connecting`.
+/// and remembers the `CurrentUserDTO.lastSyncedAt` when status becomes `connecting`.
 ///
 /// When the status becomes `connected` the `/sync` endpoint is called
-/// with `lastReceivedEventDate` and `cids` of watched channels.
+/// with `lastSyncedAt` and `cids` of watched channels.
 ///
-/// We remember `lastReceivedEventDate` when state becomes `connecting` to catch the last event date
-/// before the `HealthCheck` override the `lastReceivedEventDate` with the recent date.
+/// We remember `lastSyncedAt` when state becomes `connecting` to catch the last event date
+/// before the `HealthCheck` override the `lastSyncedAt` with the recent date.
 ///
 class ConnectionRecoveryUpdater: EventWorker {
     // MARK: - Properties
@@ -96,7 +96,7 @@ class ConnectionRecoveryUpdater: EventWorker {
     
     private func obtainLastSyncDate() {
         database.backgroundReadOnlyContext.perform { [weak self] in
-            self?.lastSyncedAt = self?.database.backgroundReadOnlyContext.currentUser?.lastReceivedEventDate
+            self?.lastSyncedAt = self?.database.backgroundReadOnlyContext.currentUser?.lastSyncedAt
         }
     }
     

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater.swift
@@ -8,21 +8,32 @@ import Foundation
 /// The type is designed to obtain missing events that happened in watched channels while user
 /// was not connected to the web-socket.
 ///
-/// The object listens for `ConnectionStatusUpdated` events
-/// and remembers the `CurrentUserDTO.lastSyncedAt` when status becomes `connecting`.
+/// The object listens for `ConnectionStatusUpdated` events and when the status becomes `connected` the `/sync` endpoint is called
+/// with `lastSyncedAt` and `cids` of locally existed channels linked to at least one query.
 ///
-/// When the status becomes `connected` the `/sync` endpoint is called
-/// with `lastSyncedAt` and `cids` of watched channels.
+/// Case 1:
+/// If `/sync` succeds and returns events, channel list queries are re-fetched considering all locally existed channels as synced.
+/// If re-fetch succeeds, `lastSyncedAt` is set to most recent event timestamp (received from `/sync`).
+/// If re-fetch fails, `lastSyncedAt` stays the same.
 ///
-/// We remember `lastSyncedAt` when state becomes `connecting` to catch the last event date
-/// before the `HealthCheck` override the `lastSyncedAt` with the recent date.
+/// Case 2:
+/// If `/sync` succeds and returns zero events, channel list queries are re-fetched considering all locally existed channels as synced.
+/// If re-fetch succeeds, `lastSyncedAt` is set to current date.
+/// If re-fetch fails, `lastSyncedAt` stays the same.
+///
+/// Case 3:
+/// If `/sync` fails with error, channel list queries are re-fetched considering all locally existed channels as out of sync.
+/// If re-fetch succeeds, `lastSyncedAt` is set to current date otherwise.
+/// If re-fetch fails, `lastSyncedAt` stays the same.
+///
+/// If `ConnectionRecoveryUpdater` is created with `useSyncEndpoint == false`, the connection recovery logic behaves as
+/// described in `Case 3`.
 ///
 class ConnectionRecoveryUpdater: EventWorker {
     // MARK: - Properties
     
     private var connectionObserver: EventObserver?
     private let databaseCleanupUpdater: DatabaseCleanupUpdater
-    @Atomic private var lastSyncedAt: Date?
     private let useSyncEndpoint: Bool
     
     // MARK: - Init
@@ -83,8 +94,6 @@ class ConnectionRecoveryUpdater: EventWorker {
             transform: { $0 as? ConnectionStatusUpdated },
             callback: { [unowned self] in
                 switch $0.webSocketConnectionState {
-                case .connecting:
-                    self.obtainLastSyncDate()
                 case .connected:
                     fetchAndReplayMissingEvents()
                 default:
@@ -94,87 +103,98 @@ class ConnectionRecoveryUpdater: EventWorker {
         )
     }
     
-    private func obtainLastSyncDate() {
-        database.backgroundReadOnlyContext.perform { [weak self] in
-            self?.lastSyncedAt = self?.database.backgroundReadOnlyContext.currentUser?.lastSyncedAt
-        }
-    }
-    
     private func fetchAndReplayMissingEvents() {
-        database.backgroundReadOnlyContext.perform { [weak self, useSyncEndpoint] in
-            let refetchExistingQueries: () -> Void = {
-                self?.databaseCleanupUpdater.refetchExistingChannelListQueries()
+        database.write { [weak self, useSyncEndpoint] session in
+            guard let currentUser = session.currentUser else {
+                log.error("In `connected` state current user must exist in database")
+                return
             }
             
-            if useSyncEndpoint {
-                self?.sync(completion: refetchExistingQueries)
-            } else {
-                refetchExistingQueries()
+            guard let lastSyncedAt = currentUser.lastSyncedAt else {
+                log.debug("There's no previous session, remembering the current date as last sync date")
+                currentUser.lastSyncedAt = Date()
+                return
             }
-        }
-    }
-
-    private func sync(completion: @escaping () -> Void) {
-        guard let lastSyncedAt = lastSyncedAt else { return }
-        
-        let watchedChannelIDs = allChannels.map(\.cid).compactMap { try? ChannelId(cid: $0) }
-        
-        guard !watchedChannelIDs.isEmpty else {
-            log.info("Skipping `/sync` endpoint call as there are no channels to watch.")
-            return
-        }
-        
-        let endpoint: Endpoint<MissingEventsPayload> = .missingEvents(
-            since: lastSyncedAt,
-            cids: watchedChannelIDs
-        )
-        
-        apiClient.request(endpoint: endpoint) { [weak self] in
-            guard let self = self else { return }
-            switch $0 {
-            case let .success(payload):
-                // The sync call was successful.
-                // We schedule all events for existing channels for processing...
-                self.eventNotificationCenter.addToCurrentBatchAndProcessImmediately(
-                    payload.eventPayloads.compactMap { try? $0.event() }
-                ) {
-                    // ... and refetch the existing queries to see if there are some new channels
-                    completion()
-                }
-            case let .failure(error):
-                log.info(
-                    """
-                    Backend couldn't handle replaying missing events - there was too many (>1000) events to replay. \
-                    Cleaning local channels data and refetching it from scratch
-                    """
-                )
-                
-                if error.isTooManyMissingEventsToSyncError {
-                    // The sync call failed...
-                    self.database.write {
-                        // First we need to clean up existing data
-                        try self.databaseCleanupUpdater.resetExistingChannelsData(session: $0)
-                    } completion: { error in
-                        if let error = error {
-                            log.error("Failed cleaning up channels data: \(error).")
-                            return
-                        }
-                        // Then we have to refetch existing channel list queries
-                        completion()
-                    }
+            
+            guard useSyncEndpoint else {
+                log.debug("Ignore `/sync` and re-fetch local queries")
+                self?.refetchLocalQueries()
+                return
+            }
+            
+            let queriesRequest = NSFetchRequest<ChannelListQueryDTO>(entityName: ChannelListQueryDTO.entityName)
+            let queries = (try? (session as! NSManagedObjectContext).fetch(queriesRequest)) ?? []
+            let cids = Set(
+                queries
+                    .flatMap(\.channels)
+                    .compactMap { try? ChannelId(cid: $0.cid) }
+                    .prefix(1000)
+            )
+            
+            self?.getMissingEvents(for: cids, since: lastSyncedAt) {
+                switch $0 {
+                case let .success(payload):
+                    let mostRecentEventTimestamp = payload
+                        .eventPayloads
+                        .compactMap(\.createdAt)
+                        .sorted()
+                        .last
+                    
+                    self?.refetchLocalQueries(
+                        syncedChannelIDs: cids,
+                        bumpLastSyncDateTo: mostRecentEventTimestamp ?? lastSyncedAt
+                    )
+                case .failure:
+                    self?.refetchLocalQueries()
                 }
             }
         }
     }
     
-    private var allChannels: [ChannelDTO] {
-        do {
-            let request = ChannelDTO.allChannelsFetchRequest
-            request.fetchLimit = 1000
-            return try database.backgroundReadOnlyContext.fetch(request)
-        } catch {
-            log.error("Internal error: Failed to fetch [ChannelDTO]: \(error)")
-            return []
+    private func getMissingEvents(
+        for cids: Set<ChannelId>,
+        since lastSyncedAt: Date,
+        completion: @escaping (Result<MissingEventsPayload, Error>) -> Void
+    ) {
+        log.debug("Will fetch missing events for \(cids) starting from \(lastSyncedAt)")
+        
+        apiClient.request(
+            endpoint: .missingEvents(since: lastSyncedAt, cids: .init(cids))
+        ) { [weak self] in
+            switch $0 {
+            case let .success(payload):
+                log.debug("Did receive \(payload.eventPayloads.count) missing events: \(payload.eventPayloads)")
+                
+                self?.eventNotificationCenter.addToCurrentBatchAndProcessImmediately(
+                    payload.eventPayloads.compactMap { try? $0.event() }
+                ) {
+                    completion(.success(payload))
+                }
+            case let .failure(error):
+                log.debug("Fail to get missing events: \(error)")
+                
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    private func refetchLocalQueries(
+        syncedChannelIDs: Set<ChannelId> = [],
+        bumpLastSyncDateTo newValue: Date = Date()
+    ) {
+        databaseCleanupUpdater.syncChannelListQueries(
+            syncedChannelIDs: syncedChannelIDs
+        ) { [weak self] in
+            switch $0 {
+            case .success:
+                self?.database.write { session in
+                    log.debug("Bumping `lastSyncedAt` to \(newValue)")
+                    
+                    session.currentUser?.lastSyncedAt = newValue
+                }
+            case let .failure(error):
+                log.error("Channel list queries re-fetch has failed: \(error)")
+            }
         }
     }
 }

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater_Tests.swift
@@ -63,10 +63,10 @@ final class ConnectionRecoveryUpdater_Tests: StressTestCase {
         // Create current user in the database
         try database.createCurrentUser()
         
-        // Set `lastReceivedEventDate` field
+        // Set `lastSyncedAt` field
         try database.writeSynchronously {
             let dto = try XCTUnwrap($0.currentUser)
-            dto.lastReceivedEventDate = Date()
+            dto.lastSyncedAt = Date()
         }
         
         // Simulate `.connecting` connection state of a web-socket
@@ -94,12 +94,12 @@ final class ConnectionRecoveryUpdater_Tests: StressTestCase {
         try database.createCurrentUser()
         
         // Create channel in the database
-        try database.createChannel(cid: cid)
+        try database.createChannel(cid: cid, withQuery: true)
 
-        // Set `lastReceivedEventDate`
+        // Set `lastSyncedAt`
         try database.writeSynchronously { session in
             let currentUser = try XCTUnwrap(session.currentUser)
-            currentUser.lastReceivedEventDate = lastReceivedEventDate
+            currentUser.lastSyncedAt = lastReceivedEventDate
         }
         
         // Simulate `.connecting` connection state of a web-socket
@@ -131,12 +131,12 @@ final class ConnectionRecoveryUpdater_Tests: StressTestCase {
         try database.createCurrentUser()
         
         // Create channel in the database
-        try database.createChannel(cid: cid)
+        try database.createChannel(cid: cid, withQuery: true)
         
-        // Set `lastReceivedEventDate`
+        // Set `lastSyncedAt`
         try database.writeSynchronously { session in
             let currentUser = try XCTUnwrap(session.currentUser)
-            currentUser.lastReceivedEventDate = Date()
+            currentUser.lastSyncedAt = Date()
         }
         
         // Simulate `.connecting` connection state of a web-socket
@@ -174,7 +174,7 @@ final class ConnectionRecoveryUpdater_Tests: StressTestCase {
 
         try database.writeSynchronously { session in
             let currentUser = try XCTUnwrap(session.currentUser)
-            currentUser.lastReceivedEventDate = Date()
+            currentUser.lastSyncedAt = Date()
         }
         
         webSocketClient.simulateConnectionStatus(.connecting)
@@ -226,7 +226,7 @@ final class ConnectionRecoveryUpdater_Tests: StressTestCase {
         
         try database.writeSynchronously { session in
             let currentUser = try XCTUnwrap(session.currentUser)
-            currentUser.lastReceivedEventDate = .unique
+            currentUser.lastSyncedAt = .unique
         }
         
         webSocketClient.simulateConnectionStatus(.connecting)
@@ -263,7 +263,7 @@ final class ConnectionRecoveryUpdater_Tests: StressTestCase {
 
         try database.writeSynchronously { session in
             let currentUser = try XCTUnwrap(session.currentUser)
-            currentUser.lastReceivedEventDate = .unique
+            currentUser.lastSyncedAt = .unique
         }
 
         webSocketClient.simulateConnectionStatus(.connecting)
@@ -305,10 +305,10 @@ final class ConnectionRecoveryUpdater_Tests: StressTestCase {
         // Create channel in the database
         try database.createChannel()
         
-        // Set `lastReceivedEventDate`
+        // Set `lastSyncedAt`
         try database.writeSynchronously { session in
             let currentUser = try XCTUnwrap(session.currentUser)
-            currentUser.lastReceivedEventDate = Date()
+            currentUser.lastSyncedAt = Date()
         }
         
         // Simulate `.connecting` connection state of a web-socket

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater_Tests.swift
@@ -239,11 +239,14 @@ final class ConnectionRecoveryUpdater_Tests: StressTestCase {
         // Assert a network request is created
         AssertAsync.willBeEqual(apiClient.request_allRecordedCalls.count, 1)
         
+        // Create event logger to track posted events
+        let eventLogger = EventLogger(eventCenter)
+
         // Simulate successful response
         apiClient.test_simulateResponse(Result<MissingEventsPayload, Error>.success(payload))
         
         // Assert events from payload are published
-        AssertAsync.willBeEqual(eventCenter.process_loggedEvents.map(\.asEquatable), events.map(\.asEquatable))
+        AssertAsync.willBeEqual(eventLogger.equatableEvents, events.map(\.asEquatable))
     }
 
     func test_existingQueriesAreRefetched_ifSuccessfulResponseComes() throws {

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater_Tests.swift
@@ -29,7 +29,7 @@ final class ConnectionRecoveryUpdater_Tests: StressTestCase {
             eventNotificationCenter: webSocketClient.eventNotificationCenter,
             apiClient: apiClient,
             databaseCleanupUpdater: channelDatabaseCleanupUpdater,
-            useSyncEndpoint: false
+            useSyncEndpoint: true
         )
     }
     
@@ -48,262 +48,462 @@ final class ConnectionRecoveryUpdater_Tests: StressTestCase {
     
     // MARK: - Tests
     
-    func test_endpointIsNotCalled_ifThereIsNoCurrentUser() throws {
-        // Simulate `.connecting` connection state of a web-socket
-        webSocketClient.simulateConnectionStatus(.connecting)
+    func test_whenConnectedFirstTime_currentDateIsUsedAsSyncDateAndQueriesAreNotFetched() throws {
+        // Create current user in database without last sync date
+        try database.createCurrentUser()
         
         // Simulate `.connected` connection state of a web-socket
         webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
         
-        // Assert endpoint is not called as `lastSyncAt` is unknown
-        AssertAsync.staysTrue(apiClient.request_endpoint == nil)
+        // Load current user
+        let currentUser = try XCTUnwrap(database.viewContext.currentUser)
+        
+        AssertAsync {
+            // Assert /sync is not called
+            Assert.staysTrue(self.apiClient.request_endpoint == nil)
+            // Assert queries are not refetched
+            Assert.staysTrue(self.channelDatabaseCleanupUpdater.syncChannelListQueries_syncedChannelIDs == nil)
+            // Assert `lastSyncedAt` is updated with current date
+            Assert.willNotBeNil(currentUser.lastSyncedAt)
+        }
     }
     
-    func test_endpointIsNotCalled_ifThereAreNoWatchedChannels() throws {
+    func test_whenSyncIsNotUsedAndRefetchFails_lastSyncDateStaysTheSame() throws {
+        // Create updates that should not use `/sync` endpoint
+        updater = ConnectionRecoveryUpdater(
+            database: database,
+            eventNotificationCenter: webSocketClient.eventNotificationCenter,
+            apiClient: apiClient,
+            databaseCleanupUpdater: channelDatabaseCleanupUpdater,
+            useSyncEndpoint: false
+        )
+        
+        // Create current user in database
+        try database.createCurrentUser()
+        
+        // Set `lastSyncedAt` field
+        let lastSyncedAt = Date.unique
+        try database.writeSynchronously {
+            $0.currentUser?.lastSyncedAt = lastSyncedAt
+        }
+        
+        // Create channels linked to queries
+        let cids: Set<ChannelId> = [.unique, .unique, .unique]
+        for cid in cids {
+            try database.createChannel(cid: cid, withQuery: true)
+        }
+        
+        // Simulate `.connected` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        
+        AssertAsync {
+            // Assert /sync is not called
+            Assert.staysTrue(self.apiClient.request_endpoint == nil)
+            // Assert queries are refetched without synced channels given
+            Assert.willBeEqual(self.channelDatabaseCleanupUpdater.syncChannelListQueries_syncedChannelIDs, [])
+        }
+        
+        // Simulate failed queries refetch
+        channelDatabaseCleanupUpdater.syncChannelListQueries_completion?(
+            .failure(ClientError(.unique))
+        )
+            
+        // Load current user
+        let currentUser = try XCTUnwrap(database.viewContext.currentUser)
+        
+        // Assert `lastSyncedAt` stays the same
+        AssertAsync.staysEqual(currentUser.lastSyncedAt, lastSyncedAt)
+    }
+    
+    func test_whenSyncIsNotUsedAndRefetchSucceeds_lastSyncDateIsBumped() throws {
+        // Create updates that should not use `/sync` endpoint
+        updater = ConnectionRecoveryUpdater(
+            database: database,
+            eventNotificationCenter: webSocketClient.eventNotificationCenter,
+            apiClient: apiClient,
+            databaseCleanupUpdater: channelDatabaseCleanupUpdater,
+            useSyncEndpoint: false
+        )
+        
+        // Create current user in database
+        try database.createCurrentUser()
+        
+        // Set `lastSyncedAt` field
+        let lastSyncedAt = Date.unique
+        try database.writeSynchronously {
+            $0.currentUser?.lastSyncedAt = lastSyncedAt
+        }
+        
+        // Create channels linked to queries
+        let cids: Set<ChannelId> = [.unique, .unique, .unique]
+        for cid in cids {
+            try database.createChannel(cid: cid, withQuery: true)
+        }
+        
+        // Simulate `.connected` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        
+        AssertAsync {
+            // Assert /sync is not called
+            Assert.staysTrue(self.apiClient.request_endpoint == nil)
+            // Assert queries are refetched without synced channels given
+            Assert.willBeEqual(self.channelDatabaseCleanupUpdater.syncChannelListQueries_syncedChannelIDs, [])
+        }
+        
+        // Simulate successful queries refetch
+        channelDatabaseCleanupUpdater.syncChannelListQueries_completion?(.success(()))
+            
+        // Load current user
+        let currentUser = try XCTUnwrap(database.viewContext.currentUser)
+            
+        // Assert `lastSyncedAt` is updated with current date
+        AssertAsync.willBeTrue(currentUser.lastSyncedAt! > lastSyncedAt)
+    }
+    
+    func test_whenSyncReturnsEvents_eventsArePosted() throws {
         // Create current user in the database
         try database.createCurrentUser()
         
         // Set `lastSyncedAt` field
         try database.writeSynchronously {
-            let dto = try XCTUnwrap($0.currentUser)
-            dto.lastSyncedAt = Date()
+            $0.currentUser?.lastSyncedAt = Date()
         }
-        
-        // Simulate `.connecting` connection state of a web-socket
-        webSocketClient.simulateConnectionStatus(.connecting)
         
         // Simulate `.connected` connection state of a web-socket
         webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
         
-        // Assert endpoint is not called as there are no watched channels
-        AssertAsync.staysTrue(apiClient.request_endpoint == nil)
+        // Assert /sync is called
+        AssertAsync.willBeTrue(apiClient.request_endpoint != nil)
+        
+        // Setup event logger
+        let eventLogger = EventLogger(webSocketClient.init_eventNotificationCenter)
+        
+        // Simulate successful response
+        let payload = MissingEventsPayload(
+            eventPayloads: [
+                .init(eventType: .messageNew),
+                .init(eventType: .channelHidden)
+            ]
+        )
+        apiClient.test_simulateResponse(.success(payload))
+        
+        // Assert received events are posted
+        AssertAsync.willBeEqual(
+            eventLogger.equatableEvents,
+            payload
+                .eventPayloads
+                .compactMap { try? $0.event() }
+                .map(\.asEquatable)
+        )
     }
     
-    func test_endpointIsCalled_whenStatusBecomesConnected() throws {
-        updater = ConnectionRecoveryUpdater(
-            database: database,
-            eventNotificationCenter: webSocketClient.eventNotificationCenter,
-            apiClient: apiClient,
-            databaseCleanupUpdater: channelDatabaseCleanupUpdater,
-            useSyncEndpoint: true
-        )
-        let cid: ChannelId = .unique
-        let lastReceivedEventDate: Date = .unique
-        
+    func test_whenSyncReturnsEventsAndRefetchSucceeds_lastSyncIsSetToMostRecentEventTimestamp() throws {
         // Create current user in the database
         try database.createCurrentUser()
         
-        // Create channel in the database
-        try database.createChannel(cid: cid, withQuery: true)
-
-        // Set `lastSyncedAt`
-        try database.writeSynchronously { session in
-            let currentUser = try XCTUnwrap(session.currentUser)
-            currentUser.lastSyncedAt = lastReceivedEventDate
+        // Set `lastSyncedAt` field
+        try database.writeSynchronously {
+            $0.currentUser?.lastSyncedAt = Date()
         }
         
-        // Simulate `.connecting` connection state of a web-socket
-        webSocketClient.simulateConnectionStatus(.connecting)
+        // Create channels linked to queries
+        let cids: Set<ChannelId> = [.unique, .unique, .unique]
+        for cid in cids {
+            try database.createChannel(cid: cid, withQuery: true)
+        }
         
         // Simulate `.connected` connection state of a web-socket
         webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
         
-        // Assert endpoint is called with correct values
-        let endpoint: Endpoint<MissingEventsPayload> = .missingEvents(
-            since: lastReceivedEventDate,
-            cids: [cid]
+        // Assert /sync is called
+        AssertAsync.willBeTrue(apiClient.request_endpoint != nil)
+        
+        // Simulate successful /sync response
+        let olderEvent = EventPayload(
+            eventType: .messageNew,
+            createdAt: Date()
         )
-        
-        AssertAsync.willBeEqual(apiClient.request_endpoint, AnyEndpoint(endpoint))
-    }
-    
-    func test_noEventsArePublished_ifErrorResponseComes() throws {
-        updater = ConnectionRecoveryUpdater(
-            database: database,
-            eventNotificationCenter: webSocketClient.eventNotificationCenter,
-            apiClient: apiClient,
-            databaseCleanupUpdater: channelDatabaseCleanupUpdater,
-            useSyncEndpoint: true
+        let newerEvent = EventPayload(
+            eventType: .messageNew,
+            createdAt: Date().addingTimeInterval(10)
         )
-        let cid: ChannelId = .unique
-
-        // Create current user in the database
-        try database.createCurrentUser()
-        
-        // Create channel in the database
-        try database.createChannel(cid: cid, withQuery: true)
-        
-        // Set `lastSyncedAt`
-        try database.writeSynchronously { session in
-            let currentUser = try XCTUnwrap(session.currentUser)
-            currentUser.lastSyncedAt = Date()
-        }
-        
-        // Simulate `.connecting` connection state of a web-socket
-        webSocketClient.simulateConnectionStatus(.connecting)
-        
-        // Simulate `.connected` connection state of a web-socket
-        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
-        
-        // Get access to EventNotificationCenter to check for events and remove already logged events
-        let eventCenter = webSocketClient.init_eventNotificationCenter as! EventNotificationCenterMock
-        eventCenter.process_loggedEvents = []
-        
-        // Assert a network request is created
-        AssertAsync.willBeEqual(apiClient.request_allRecordedCalls.count, 1)
-        
-        // Simulate error response
-        apiClient.test_simulateResponse(Result<MissingEventsPayload, Error>.failure(TestError()))
-        
-        // Assert no events are published
-        AssertAsync.staysTrue(eventCenter.process_loggedEvents.isEmpty)
-    }
-    
-    func test_whenBackendRespondsWith400_callsChannelListCleanUp() throws {
-        updater = ConnectionRecoveryUpdater(
-            database: database,
-            eventNotificationCenter: webSocketClient.eventNotificationCenter,
-            apiClient: apiClient,
-            databaseCleanupUpdater: channelDatabaseCleanupUpdater,
-            useSyncEndpoint: true
-        )
-        let cid: ChannelId = .unique
-
-        try database.createCurrentUser()
-        try database.createChannel(cid: cid)
-
-        try database.writeSynchronously { session in
-            let currentUser = try XCTUnwrap(session.currentUser)
-            currentUser.lastSyncedAt = Date()
-        }
-        
-        webSocketClient.simulateConnectionStatus(.connecting)
-        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
-
-        AssertAsync.willBeEqual(apiClient.request_allRecordedCalls.count, 1)
-
-        var refetchCalled = false
-        channelDatabaseCleanupUpdater.refetchExistingChannelListQueries_body = {
-            refetchCalled = true
-        }
-
-        var cleanupCalledWithSession: DatabaseSession?
-        channelDatabaseCleanupUpdater.resetExistingChannelsData_body = { session in
-            cleanupCalledWithSession = session
-            // Check refetch wasn't called yet
-            XCTAssertFalse(refetchCalled)
-        }
-        
         apiClient.test_simulateResponse(
-            Result<MissingEventsPayload, Error>.failure(
-                ClientError(with: ErrorPayload(code: 0, message: "", statusCode: 400))
+            .success(
+                MissingEventsPayload(
+                    eventPayloads: [olderEvent, newerEvent]
+                )
             )
         )
-
-        AssertAsync {
-            Assert.willBeTrue(refetchCalled)
-            Assert.willBeEqual(cleanupCalledWithSession as? NSManagedObjectContext, self.database.writableContext)
-        }
+        
+        // Assert `syncChannelListQueries` is invoked with local channels as synced
+        AssertAsync.willBeEqual(
+            channelDatabaseCleanupUpdater.syncChannelListQueries_syncedChannelIDs,
+            cids
+        )
+        
+        // Simulate successful queries refetch
+        channelDatabaseCleanupUpdater.syncChannelListQueries_completion?(.success(()))
+        
+        // Load current user
+        let currentUser = try XCTUnwrap(database.viewContext.currentUser)
+        
+        // Assert `lastSyncedAt` equals most recent event timestamp
+        AssertAsync.willBeEqual(currentUser.lastSyncedAt, newerEvent.createdAt)
     }
     
-    func test_eventsFromPayloadArePublished_ifSuccessfulResponseComes() throws {
-        updater = ConnectionRecoveryUpdater(
-            database: database,
-            eventNotificationCenter: webSocketClient.eventNotificationCenter,
-            apiClient: apiClient,
-            databaseCleanupUpdater: channelDatabaseCleanupUpdater,
-            useSyncEndpoint: true
-        )
-        let json = XCTestCase.mockData(fromFile: "MissingEventsPayload")
-        let payload = try JSONDecoder.default.decode(MissingEventsPayload.self, from: json)
-        let events = payload.eventPayloads.compactMap { try? $0.event() }
-        
+    func test_whenSyncReturnsEventsButRefetchFails_lastSyncDateStaysTheSame() throws {
         // Create current user in the database
         try database.createCurrentUser()
         
-        // Create channel in the database
-        try database.createChannel(cid: (events.first as! ChannelSpecificEvent).cid)
-        
-        try database.writeSynchronously { session in
-            let currentUser = try XCTUnwrap(session.currentUser)
-            currentUser.lastSyncedAt = .unique
+        // Set `lastSyncedAt` field
+        let lastSyncedAt = Date()
+        try database.writeSynchronously {
+            $0.currentUser?.lastSyncedAt = lastSyncedAt
         }
         
-        webSocketClient.simulateConnectionStatus(.connecting)
+        // Create channels linked to queries
+        let cids: Set<ChannelId> = [.unique, .unique, .unique]
+        for cid in cids {
+            try database.createChannel(cid: cid, withQuery: true)
+        }
+        
+        // Simulate `.connected` connection state of a web-socket
         webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
         
-        // Get access to EventNotificationCenter to check for events and remove already logged events
-        let eventCenter = webSocketClient.init_eventNotificationCenter as! EventNotificationCenterMock
-        eventCenter.process_loggedEvents = []
-
-        // Assert a network request is created
-        AssertAsync.willBeEqual(apiClient.request_allRecordedCalls.count, 1)
+        // Assert /sync is called
+        AssertAsync.willBeTrue(apiClient.request_endpoint != nil)
         
-        // Create event logger to track posted events
-        let eventLogger = EventLogger(eventCenter)
-
-        // Simulate successful response
-        apiClient.test_simulateResponse(Result<MissingEventsPayload, Error>.success(payload))
-        
-        // Assert events from payload are published
-        AssertAsync.willBeEqual(eventLogger.equatableEvents, events.map(\.asEquatable))
-    }
-
-    func test_existingQueriesAreRefetched_ifSuccessfulResponseComes() throws {
-        updater = ConnectionRecoveryUpdater(
-            database: database,
-            eventNotificationCenter: webSocketClient.eventNotificationCenter,
-            apiClient: apiClient,
-            databaseCleanupUpdater: channelDatabaseCleanupUpdater,
-            useSyncEndpoint: true
+        // Simulate successful /sync response
+        let olderEvent = EventPayload(
+            eventType: .messageNew,
+            createdAt: Date()
         )
-        // Create the current user and a channel in the database
-        try database.createCurrentUser()
-        try database.createChannel(cid: .unique)
-
-        try database.writeSynchronously { session in
-            let currentUser = try XCTUnwrap(session.currentUser)
-            currentUser.lastSyncedAt = .unique
-        }
-
-        webSocketClient.simulateConnectionStatus(.connecting)
-        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
-
-        // Assert a network request is created
-        AssertAsync.willBeEqual(apiClient.request_allRecordedCalls.count, 1)
-
-        // Set up callbacks
-        var resetChannelsDataCalled = false
-        channelDatabaseCleanupUpdater.resetExistingChannelsData_body = { _ in resetChannelsDataCalled = true }
-
-        var refetchQueriesCalled = false
-        channelDatabaseCleanupUpdater.refetchExistingChannelListQueries_body = { refetchQueriesCalled = true }
-
-        // Simulate successful response
+        let newerEvent = EventPayload(
+            eventType: .messageNew,
+            createdAt: Date().addingTimeInterval(10)
+        )
         apiClient.test_simulateResponse(
-            Result<MissingEventsPayload, Error>.success(MissingEventsPayload(eventPayloads: []))
+            .success(
+                MissingEventsPayload(
+                    eventPayloads: [olderEvent, newerEvent]
+                )
+            )
         )
-
-        // Assert only `refetchExistingChannelListQueries` is called
-        AssertAsync {
-            Assert.willBeTrue(refetchQueriesCalled)
-            Assert.staysFalse(resetChannelsDataCalled)
+        
+        // Assert `syncChannelListQueries` is invoked with local channels as synced
+        AssertAsync.willBeEqual(
+            channelDatabaseCleanupUpdater.syncChannelListQueries_syncedChannelIDs,
+            cids
+        )
+        
+        // Simulate failed queries refetch
+        channelDatabaseCleanupUpdater.syncChannelListQueries_completion?(
+            .failure(ClientError(.unique))
+        )
+        
+        // Load current user
+        let currentUser = try XCTUnwrap(database.viewContext.currentUser)
+        
+        // Assert `lastSyncedAt` stays the same
+        AssertAsync.staysEqual(currentUser.lastSyncedAt, lastSyncedAt)
+    }
+    
+    func test_whenSyncReturnsZeroEventsAndRefetchSucceeds_lastSyncDateStaysTheSame() throws {
+        // Create current user in the database
+        try database.createCurrentUser()
+        
+        // Set `lastSyncedAt` field
+        let lastSyncedAt: Date = .unique
+        try database.writeSynchronously {
+            $0.currentUser?.lastSyncedAt = lastSyncedAt
         }
+        
+        // Create channels linked to queries
+        let cids: Set<ChannelId> = [.unique, .unique, .unique]
+        for cid in cids {
+            try database.createChannel(cid: cid, withQuery: true)
+        }
+        
+        // Simulate `.connected` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        
+        // Assert /sync is called
+        AssertAsync.willBeTrue(apiClient.request_endpoint != nil)
+        
+        // Simulate successful /sync response
+        apiClient.test_simulateResponse(
+            .success(MissingEventsPayload(eventPayloads: []))
+        )
+        
+        // Assert `syncChannelListQueries` is invoked with local channels as synced
+        AssertAsync.willBeEqual(
+            channelDatabaseCleanupUpdater.syncChannelListQueries_syncedChannelIDs,
+            cids
+        )
+        
+        // Simulate successful queries refetch
+        channelDatabaseCleanupUpdater.syncChannelListQueries_completion?(.success(()))
+        
+        // Load current user
+        let currentUser = try XCTUnwrap(database.viewContext.currentUser)
+        
+        // Assert `lastSyncedAt` stays the same
+        AssertAsync.staysEqual(currentUser.lastSyncedAt, lastSyncedAt)
+    }
+    
+    func test_whenSyncReturnsZeroEventsAndRefetchFails_lastSyncDateStaysTheSame() throws {
+        // Create current user in the database
+        try database.createCurrentUser()
+        
+        // Set `lastSyncedAt` field
+        let lastSyncedAt: Date = .unique
+        try database.writeSynchronously {
+            $0.currentUser?.lastSyncedAt = lastSyncedAt
+        }
+        
+        // Create channels linked to queries
+        let cids: Set<ChannelId> = [.unique, .unique, .unique]
+        for cid in cids {
+            try database.createChannel(cid: cid, withQuery: true)
+        }
+        
+        // Simulate `.connected` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        
+        // Assert /sync is called
+        AssertAsync.willBeTrue(apiClient.request_endpoint != nil)
+        
+        // Simulate successful /sync response
+        apiClient.test_simulateResponse(
+            .success(MissingEventsPayload(eventPayloads: []))
+        )
+        
+        // Assert `syncChannelListQueries` is invoked with local channels as synced
+        AssertAsync.willBeEqual(
+            channelDatabaseCleanupUpdater.syncChannelListQueries_syncedChannelIDs,
+            cids
+        )
+        
+        // Simulate failed queries refetch
+        channelDatabaseCleanupUpdater.syncChannelListQueries_completion?(
+            .failure(ClientError(.unique))
+        )
+        
+        // Load current user
+        let currentUser = try XCTUnwrap(database.viewContext.currentUser)
+        
+        // Assert `lastSyncedAt` stays the same
+        AssertAsync.staysEqual(currentUser.lastSyncedAt, lastSyncedAt)
+    }
+    
+    func test_whenSyncFailsButRefetchSucceeds_lastSyncDateIsChangedToCurrentDate() throws {
+        // Create current user in the database
+        try database.createCurrentUser()
+        
+        // Set `lastSyncedAt` field
+        let lastSyncedAt = Date()
+        try database.writeSynchronously {
+            $0.currentUser?.lastSyncedAt = lastSyncedAt
+        }
+        
+        // Create channels linked to queries
+        let cids: Set<ChannelId> = [.unique, .unique, .unique]
+        for cid in cids {
+            try database.createChannel(cid: cid, withQuery: true)
+        }
+        
+        // Simulate `.connected` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        
+        // Assert /sync is called
+        AssertAsync.willBeTrue(apiClient.request_endpoint != nil)
+        
+        // Simulate error from /sync endpoint
+        let tooManyEventsError = ClientError(
+            with: ErrorPayload(
+                code: 0,
+                message: "",
+                statusCode: 400
+            )
+        )
+        apiClient.test_simulateResponse(
+            Result<MissingEventsPayload, Error>.failure(tooManyEventsError)
+        )
+        
+        // Assert `syncChannelListQueries` is invoked with empty synced channels
+        AssertAsync.willBeEqual(
+            channelDatabaseCleanupUpdater.syncChannelListQueries_syncedChannelIDs,
+            []
+        )
+        
+        // Simulate successful queries refetch
+        channelDatabaseCleanupUpdater.syncChannelListQueries_completion?(.success(()))
+        
+        // Load current user
+        let currentUser = try XCTUnwrap(database.viewContext.currentUser)
+        
+        // Assert `lastSyncedAt` is updated with the current date
+        AssertAsync.willBeTrue(currentUser.lastSyncedAt! > lastSyncedAt)
+    }
+    
+    func test_whenSyncAndRefetchFail_lastSyncDateStaysTheSame() throws {
+        // Create current user in the database
+        try database.createCurrentUser()
+        
+        // Set `lastSyncedAt` field
+        let lastSyncedAt: Date = .unique
+        try database.writeSynchronously {
+            $0.currentUser?.lastSyncedAt = lastSyncedAt
+        }
+        
+        // Create channels linked to queries
+        let cids: Set<ChannelId> = [.unique, .unique, .unique]
+        for cid in cids {
+            try database.createChannel(cid: cid, withQuery: true)
+        }
+        
+        // Simulate `.connected` connection state of a web-socket
+        webSocketClient.simulateConnectionStatus(.connected(connectionId: .unique))
+        
+        // Assert /sync is called
+        AssertAsync.willBeTrue(apiClient.request_endpoint != nil)
+        
+        // Simulate too many events error from /sync
+        let tooManyEventsError = ClientError(
+            with: ErrorPayload(
+                code: 0,
+                message: "",
+                statusCode: 400
+            )
+        )
+        apiClient.test_simulateResponse(
+            Result<MissingEventsPayload, Error>.failure(tooManyEventsError)
+        )
+        
+        // Assert `syncChannelListQueries` is invoked with empty synced channels
+        AssertAsync.willBeEqual(
+            channelDatabaseCleanupUpdater.syncChannelListQueries_syncedChannelIDs,
+            []
+        )
+        
+        // Simulate failed queries refetch
+        channelDatabaseCleanupUpdater.syncChannelListQueries_completion?(
+            .failure(ClientError(.unique))
+        )
+        
+        // Load current user
+        let currentUser = try XCTUnwrap(database.viewContext.currentUser)
+        
+        // Assert `lastSyncedAt` stays the same
+        AssertAsync.staysEqual(currentUser.lastSyncedAt, lastSyncedAt)
     }
     
     func test_eventPublisher_doesNotRetainItself() throws {
-        updater = ConnectionRecoveryUpdater(
-            database: database,
-            eventNotificationCenter: webSocketClient.eventNotificationCenter,
-            apiClient: apiClient,
-            databaseCleanupUpdater: channelDatabaseCleanupUpdater,
-            useSyncEndpoint: true
-        )
         // Create current user in the database
         try database.createCurrentUser()
         
         // Create channel in the database
-        try database.createChannel()
+        try database.createChannel(withQuery: true)
         
         // Set `lastSyncedAt`
         try database.writeSynchronously { session in
@@ -325,9 +525,7 @@ final class ConnectionRecoveryUpdater_Tests: StressTestCase {
                 MissingEventsPayload(eventPayloads: [])
             )
         )
-        
-        channelDatabaseCleanupUpdater.refetchExistingChannelListQueries_body()
-        
+                
         // Assert
         AssertAsync.canBeReleased(&updater)
     }

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater.swift
@@ -31,6 +31,11 @@ class DatabaseCleanupUpdater: Worker {
         )
     }
     
+    func syncChannelListQueries(
+        syncedChannelIDs: Set<ChannelId>,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {}
+    
     /// Resets all existing channels data without removing the data from the database. This is used mainly to clean-up
     /// existing relations between the objects, and prepare the channels for full refetching.
     ///

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Mock.swift
@@ -15,4 +15,14 @@ final class DatabaseCleanupUpdater_Mock: DatabaseCleanupUpdater {
     override func refetchExistingChannelListQueries() {
         refetchExistingChannelListQueries_body()
     }
+    
+    var syncChannelListQueries_syncedChannelIDs: Set<ChannelId>?
+    var syncChannelListQueries_completion: ((Result<Void, Error>) -> Void)?
+    override func syncChannelListQueries(
+        syncedChannelIDs: Set<ChannelId>,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        syncChannelListQueries_syncedChannelIDs = syncedChannelIDs
+        syncChannelListQueries_completion = completion
+    }
 }

--- a/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
@@ -76,6 +76,8 @@ class DatabaseContainerMock: DatabaseContainer {
         
         try super.recreatePersistentStore()
     }
+    
+    @Atomic var write_called = false
 
     /// `true` if there is currently an active writing session
     @Atomic var isWriteSessionInProgress: Bool = false
@@ -84,6 +86,8 @@ class DatabaseContainerMock: DatabaseContainer {
     @Atomic var writeSessionCounter: Int = 0
     
     override func write(_ actions: @escaping (DatabaseSession) throws -> Void, completion: @escaping (Error?) -> Void) {
+        write_called = true
+        
         let wrappedActions: ((DatabaseSession) throws -> Void) = { session in
             self.isWriteSessionInProgress = true
             try actions(session)


### PR DESCRIPTION
This PR changes the way we update local data on reconnect. Instead of tracking `lastReceivedEventDate` and bumping it each time new event is observed we use `lastSyncedAt` date which is bumped depending on `/sync` and queries refetch results.

**Case 1**
If `/sync` succeeds and returns events, channel list queries are re-fetched considering all locally existed channels as synced.
If re-fetch succeeds, `lastSyncedAt` is set to most recent event timestamp (received from `/sync`).
If re-fetch fails, `lastSyncedAt` stays the same.

**Case 2**
If `/sync` succeeds and returns zero events, channel list queries are re-fetched considering all locally existed channels as synced.
If re-fetch succeeds, `lastSyncedAt` is set to current date.
If re-fetch fails, `lastSyncedAt` stays the same.

**Case 3**
If `/sync` fails with error, channel list queries are re-fetched considering all locally existed channels as out of sync.
If re-fetch succeeds, `lastSyncedAt` is set to current date otherwise.
If re-fetch fails, `lastSyncedAt` stays the same.

*** When session begins, we receive all events from previous session + those we've missed (this is needed to avoid event gaps because of web-socket connection not being stable). We should save events to db to know which events we've never seen and should be saved/published.