### PR TITLE
[CIS-1157] Introduce linking delegate callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### ✅ Added
+- Introduce `shouldLinkNewChannel` and `shouldLinkUpdatedChannel` delegate callbacks to `ChannelListController`. With these, one can control and link new/updated channels to the existing controller. [#1438](https://github.com/GetStream/stream-chat-swift/issues/1438)
 
 # [4.0.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0)
 _September 10, 2021_

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -77,6 +77,7 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
                 }
                 $0.controller(self, didChangeChannels: changes)
             }
+            self?.handleLinkedChannels(changes)
         }
 
         observer.onWillChange = { [weak self] in
@@ -90,6 +91,20 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
             }
         }
 
+        return observer
+    }()
+    
+    lazy var updatedChannelObserver: ListDatabaseObserver<ChatChannel, ChannelDTO> = {
+        let observer = self.environment.createChannelListDatabaseObserver(
+            client.databaseContainer.viewContext,
+            ChannelDTO.channelsFetchRequest(notLinkedTo: query),
+            { $0.asModel() }
+        )
+        
+        observer.onChange = { [weak self] changes in
+            self?.handleUnlinkedChannels(changes)
+        }
+        
         return observer
     }()
     
@@ -181,6 +196,7 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
         guard state == .initialized else { return }
         do {
             try channelListObserver.startObserving()
+            try updatedChannelObserver.startObserving()
             state = .localDataFetched
         } catch {
             state = .localDataFetchFailed(ClientError(with: error))
@@ -195,6 +211,58 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
     ///
     public func setDelegate<Delegate: ChatChannelListControllerDelegate>(_ delegate: Delegate) {
         multicastDelegate.mainDelegate = AnyChannelListControllerDelegate(delegate)
+    }
+    
+    private func handleUnlinkedChannels(_ changes: [ListChange<ChatChannel>]) {
+        let channels = changes.compactMap { change -> ChatChannel? in
+            switch change {
+            case let .insert(channel, _):
+                return (delegate?.controller(self, shouldLinkNewChannel: channel) ?? false) ? channel : nil
+            case let .update(channel, _):
+                return (delegate?.controller(self, shouldLinkUpdatedChannel: channel) ?? false) ? channel : nil
+            default: return nil
+            }
+        }
+        link(channels: channels)
+    }
+    
+    private func handleLinkedChannels(_ changes: [ListChange<ChatChannel>]) {
+        let channels = changes.compactMap { change -> ChatChannel? in
+            switch change {
+            case let .update(channel, _):
+                return (delegate?.controller(self, shouldUnlinkUpdatedChannel: channel) ?? false) ? channel : nil
+            default: return nil
+            }
+        }
+        unlink(channels: channels)
+    }
+    
+    private func link(channels: [ChatChannel]) {
+        guard !channels.isEmpty else { return }
+        client.databaseContainer.write { session in
+            for channel in channels {
+                guard let channelDTO = session.channel(cid: channel.cid) else {
+                    log.error("Channel \(channel.cid) cannot be found in database.")
+                    continue
+                }
+                let query = session.saveQuery(query: self.query)
+                query.channels.insert(channelDTO)
+            }
+        }
+    }
+    
+    private func unlink(channels: [ChatChannel]) {
+        guard !channels.isEmpty else { return }
+        client.databaseContainer.write { session in
+            for channel in channels {
+                guard let channelDTO = session.channel(cid: channel.cid) else {
+                    log.error("Channel \(channel.cid) cannot be found in database.")
+                    continue
+                }
+                let query = session.saveQuery(query: self.query)
+                query.channels.remove(channelDTO)
+            }
+        }
     }
 
     // MARK: - Actions
@@ -286,6 +354,36 @@ public protocol ChatChannelListControllerDelegate: DataControllerStateDelegate {
         _ controller: ChatChannelListController,
         didChangeChannels changes: [ListChange<ChatChannel>]
     )
+    
+    /// The controller asks the delegate if the newly inserted `ChatChannel` should be linked to this Controller's query.
+    /// Defaults to `false`
+    /// - Parameters:
+    ///   - controller: The controller,
+    ///   - shouldLinkNewChannel: The newly inserted `ChatChannel` instance. This instance is not linked to the controller's query.
+    func controller(
+        _ controller: ChatChannelListController,
+        shouldLinkNewChannel channel: ChatChannel
+    ) -> Bool
+    
+    /// The controller asks the delegate if the newly updated `ChatChannel` should be linked to this Controller's query.
+    /// Defaults to `false`
+    /// - Parameters:
+    ///   - controller: The controller,
+    ///   - shouldLinkUpdatedChannel: The newly updated `ChatChannel` instance. This instance is not linked to the controller's query.
+    func controller(
+        _ controller: ChatChannelListController,
+        shouldLinkUpdatedChannel channel: ChatChannel
+    ) -> Bool
+    
+    /// The controller asks the delegate if the newly updated `ChatChannel` should be unlinked from this Controller's query.
+    /// Defaults to `false`
+    /// - Parameters:
+    ///   - controller: The controller,
+    ///   - shouldUnlinkUpdatedChannel: The newly updated `ChatChannel` instance. This instance is linked to the controller's query.
+    func controller(
+        _ controller: ChatChannelListController,
+        shouldUnlinkUpdatedChannel channel: ChatChannel
+    ) -> Bool
 }
 
 public extension ChatChannelListControllerDelegate {
@@ -295,6 +393,21 @@ public extension ChatChannelListControllerDelegate {
         _ controller: ChatChannelListController,
         didChangeChannels changes: [ListChange<ChatChannel>]
     ) {}
+    
+    func controller(
+        _ controller: ChatChannelListController,
+        shouldLinkNewChannel channel: ChatChannel
+    ) -> Bool { false }
+    
+    func controller(
+        _ controller: ChatChannelListController,
+        shouldLinkUpdatedChannel channel: ChatChannel
+    ) -> Bool { false }
+    
+    func controller(
+        _ controller: ChatChannelListController,
+        shouldUnlinkUpdatedChannel channel: ChatChannel
+    ) -> Bool { false }
 }
 
 extension ClientError {
@@ -310,6 +423,9 @@ class AnyChannelListControllerDelegate: ChatChannelListControllerDelegate {
     private var _controllerDidChangeChannels: (ChatChannelListController, [ListChange<ChatChannel>])
         -> Void
     private var _controllerDidChangeState: (DataController, DataController.State) -> Void
+    private var _controllerShouldLinkNewChannel: (ChatChannelListController, ChatChannel) -> Bool
+    private var _controllerShouldLinkUpdatedChannel: (ChatChannelListController, ChatChannel) -> Bool
+    private var _controllerShouldUnlinkUpdatedChannel: (ChatChannelListController, ChatChannel) -> Bool
     
     weak var wrappedDelegate: AnyObject?
     
@@ -318,12 +434,18 @@ class AnyChannelListControllerDelegate: ChatChannelListControllerDelegate {
         controllerDidChangeState: @escaping (DataController, DataController.State) -> Void,
         controllerWillChangeChannels: @escaping (ChatChannelListController) -> Void,
         controllerDidChangeChannels: @escaping (ChatChannelListController, [ListChange<ChatChannel>])
-            -> Void
+            -> Void,
+        controllerShouldLinkNewChannel: @escaping (ChatChannelListController, ChatChannel) -> Bool,
+        controllerShouldLinkUpdatedChannel: @escaping (ChatChannelListController, ChatChannel) -> Bool,
+        controllerShouldUnlinkUpdatedChannel: @escaping (ChatChannelListController, ChatChannel) -> Bool
     ) {
         self.wrappedDelegate = wrappedDelegate
         _controllerDidChangeState = controllerDidChangeState
         _controllerWillChangeChannels = controllerWillChangeChannels
         _controllerDidChangeChannels = controllerDidChangeChannels
+        _controllerShouldLinkNewChannel = controllerShouldLinkNewChannel
+        _controllerShouldLinkUpdatedChannel = controllerShouldLinkUpdatedChannel
+        _controllerShouldUnlinkUpdatedChannel = controllerShouldUnlinkUpdatedChannel
     }
 
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
@@ -340,16 +462,17 @@ class AnyChannelListControllerDelegate: ChatChannelListControllerDelegate {
     ) {
         _controllerDidChangeChannels(controller, changes)
     }
-}
-
-extension AnyChannelListControllerDelegate {
-    convenience init<Delegate: ChatChannelListControllerDelegate>(_ delegate: Delegate) {
-        self.init(
-            wrappedDelegate: delegate,
-            controllerDidChangeState: { [weak delegate] in delegate?.controller($0, didChangeState: $1) },
-            controllerWillChangeChannels: { [weak delegate] in delegate?.controllerWillChangeChannels($0) },
-            controllerDidChangeChannels: { [weak delegate] in delegate?.controller($0, didChangeChannels: $1) }
-        )
+    
+    func controller(_ controller: ChatChannelListController, shouldLinkNewChannel channel: ChatChannel) -> Bool {
+        _controllerShouldLinkNewChannel(controller, channel)
+    }
+    
+    func controller(_ controller: ChatChannelListController, shouldLinkUpdatedChannel channel: ChatChannel) -> Bool {
+        _controllerShouldLinkUpdatedChannel(controller, channel)
+    }
+    
+    func controller(_ controller: ChatChannelListController, shouldUnlinkUpdatedChannel channel: ChatChannel) -> Bool {
+        _controllerShouldUnlinkUpdatedChannel(controller, channel)
     }
 }
 
@@ -359,7 +482,14 @@ extension AnyChannelListControllerDelegate {
             wrappedDelegate: delegate,
             controllerDidChangeState: { [weak delegate] in delegate?.controller($0, didChangeState: $1) },
             controllerWillChangeChannels: { [weak delegate] in delegate?.controllerWillChangeChannels($0) },
-            controllerDidChangeChannels: { [weak delegate] in delegate?.controller($0, didChangeChannels: $1) }
+            controllerDidChangeChannels: { [weak delegate] in delegate?.controller($0, didChangeChannels: $1) },
+            controllerShouldLinkNewChannel: { [weak delegate] in delegate?.controller($0, shouldLinkNewChannel: $1) ?? false },
+            controllerShouldLinkUpdatedChannel: { [weak delegate] in
+                delegate?.controller($0, shouldLinkUpdatedChannel: $1) ?? false
+            },
+            controllerShouldUnlinkUpdatedChannel: { [weak delegate] in
+                delegate?.controller($0, shouldUnlinkUpdatedChannel: $1) ?? false
+            }
         )
     }
 }

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -19,6 +19,8 @@ class ChannelListController_Tests: StressTestCase {
     /// Workaround for unwrapping **controllerCallbackQueueID!** in each closure that captures it
     private var callbackQueueID: UUID { controllerCallbackQueueID }
     
+    var database: DatabaseContainerMock { client.databaseContainer as! DatabaseContainerMock }
+    
     override func setUp() {
         super.setUp()
         
@@ -255,6 +257,190 @@ class ChannelListController_Tests: StressTestCase {
         
         // Assert the resulting value is updated
         AssertAsync.willBeEqual(controller.channels.map(\.cid), [cid])
+    }
+    
+    func test_newChannel_callsLinkHook() throws {
+        // Create wrapper test delegate
+        class TestLinkDelegate: ChatChannelListControllerDelegate {
+            let shouldLinkNewChannel: (ChatChannel) -> Bool
+            let shouldLinkUpdatedChannel: (ChatChannel) -> Bool
+            init(
+                shouldLinkNewChannel: @escaping (ChatChannel) -> Bool,
+                shouldLinkUpdatedChannel: @escaping (ChatChannel) -> Bool
+            ) {
+                self.shouldLinkNewChannel = shouldLinkNewChannel
+                self.shouldLinkUpdatedChannel = shouldLinkUpdatedChannel
+            }
+            
+            func controller(_ controller: ChatChannelListController, shouldLinkNewChannel channel: ChatChannel) -> Bool {
+                shouldLinkNewChannel(channel)
+            }
+            
+            func controller(_ controller: ChatChannelListController, shouldLinkUpdatedChannel channel: ChatChannel) -> Bool {
+                shouldLinkUpdatedChannel(channel)
+            }
+        }
+        
+        // Simulate `synchronize` call
+        controller.synchronize()
+        
+        // Simulate changes in the DB:
+        // Add the channel to the DB
+        let cid: ChannelId = .unique
+        _ = try waitFor {
+            client.databaseContainer.write({ session in
+                try session.saveChannel(payload: self.dummyPayload(with: cid), query: self.query)
+            }, completion: $0)
+        }
+        
+        // Assert the resulting value is updated
+        AssertAsync.willBeEqual(controller.channels.map(\.cid), [cid])
+        
+        let newCid: ChannelId = .unique
+        
+        // Create and assign delegate
+        let delegate = TestLinkDelegate(shouldLinkNewChannel: { channel in
+            channel.cid != newCid
+        }, shouldLinkUpdatedChannel: { _ in
+            false
+        })
+        controller.delegate = delegate
+        
+        // Insert a new channel to DB
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: .dummy(cid: newCid), query: nil)
+        }
+        
+        // Assert the resulting value is not inserted
+        AssertAsync.willBeEqual(controller.channels.map(\.cid), [cid])
+        
+        // Insert a new channel to DB
+        let insertedCid = ChannelId.unique
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: .dummy(cid: insertedCid), query: nil)
+        }
+        
+        // Assert the resulting value is inserted
+        AssertAsync.willBeEqual(controller.channels.map(\.cid.rawValue).sorted(), [cid.rawValue, insertedCid.rawValue].sorted())
+    }
+    
+    func test_updatedChannel_callsLinkHook() throws {
+        // Create wrapper test delegate
+        class TestLinkDelegate: ChatChannelListControllerDelegate {
+            let shouldLinkNewChannel: (ChatChannel) -> Bool
+            let shouldLinkUpdatedChannel: (ChatChannel) -> Bool
+            init(
+                shouldLinkNewChannel: @escaping (ChatChannel) -> Bool,
+                shouldLinkUpdatedChannel: @escaping (ChatChannel) -> Bool
+            ) {
+                self.shouldLinkNewChannel = shouldLinkNewChannel
+                self.shouldLinkUpdatedChannel = shouldLinkUpdatedChannel
+            }
+            
+            func controller(_ controller: ChatChannelListController, shouldLinkNewChannel channel: ChatChannel) -> Bool {
+                shouldLinkNewChannel(channel)
+            }
+                 
+            func controller(_ controller: ChatChannelListController, shouldLinkUpdatedChannel channel: ChatChannel) -> Bool {
+                shouldLinkUpdatedChannel(channel)
+            }
+        }
+        
+        // Simulate `synchronize` call
+        controller.synchronize()
+        
+        // Add the channel to the DB
+        let cid: ChannelId = .unique
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: self.dummyPayload(with: cid), query: self.query)
+        }
+        
+        // Assert the resulting value is updated
+        AssertAsync.willBeEqual(controller.channels.map(\.cid), [cid])
+        
+        let shouldBeInsertedCid: ChannelId = .unique
+        let shouldBeExcludedCid: ChannelId = .unique
+        
+        // Create and assign delegate
+        let delegate = TestLinkDelegate(shouldLinkNewChannel: { _ in
+            false
+        }, shouldLinkUpdatedChannel: { channel in
+            channel.cid == shouldBeInsertedCid
+        })
+        controller.delegate = delegate
+        
+        // Insert 2 channels to cid
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: .dummy(cid: shouldBeInsertedCid), query: nil)
+            try session.saveChannel(payload: .dummy(cid: shouldBeExcludedCid), query: nil)
+        }
+        
+        // Assert that 2 new channels are not linked
+        AssertAsync.willBeEqual(controller.channels.map(\.cid), [cid])
+        
+        // Update `shouldBeExcludedCid`
+        try database.writeSynchronously { session in
+            let dto = try XCTUnwrap(session.channel(cid: shouldBeExcludedCid))
+            dto.updatedAt = .unique
+        }
+        
+        // Assert that updated channel is not linked
+        AssertAsync.willBeEqual(controller.channels.map(\.cid), [cid])
+        
+        // Update `shouldBeInsertedCid`
+        try database.writeSynchronously { session in
+            let dto = try XCTUnwrap(session.channel(cid: shouldBeInsertedCid))
+            dto.updatedAt = .unique
+        }
+
+        // Assert that updated channel is linked
+        AssertAsync.willBeEqual(
+            controller.channels.map(\.cid.rawValue).sorted(),
+            [cid.rawValue, shouldBeInsertedCid.rawValue].sorted()
+        )
+    }
+    
+    func test_updatedChannel_callsUnlinkHook() throws {
+        // Create wrapper test delegate
+        class TestLinkDelegate: ChatChannelListControllerDelegate {
+            let shouldUnlinkUpdatedChannel: (ChatChannel) -> Bool
+            init(
+                shouldUnlinkUpdatedChannel: @escaping (ChatChannel) -> Bool
+            ) {
+                self.shouldUnlinkUpdatedChannel = shouldUnlinkUpdatedChannel
+            }
+            
+            func controller(_ controller: ChatChannelListController, shouldUnlinkUpdatedChannel channel: ChatChannel) -> Bool {
+                shouldUnlinkUpdatedChannel(channel)
+            }
+        }
+        
+        // Simulate `synchronize` call
+        controller.synchronize()
+        
+        // Add the channel to the DB
+        let cid: ChannelId = .unique
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: self.dummyPayload(with: cid), query: self.query)
+        }
+        
+        // Assert the resulting value is updated
+        AssertAsync.willBeEqual(controller.channels.map(\.cid), [cid])
+        
+        // Create and assign delegate
+        let delegate = TestLinkDelegate(shouldUnlinkUpdatedChannel: { channel in
+            channel.cid == cid
+        })
+        controller.delegate = delegate
+        
+        // Update linked channel
+        try database.writeSynchronously { session in
+            let channelDTO = session.channel(cid: cid)
+            channelDTO?.updatedAt = .unique
+        }
+        
+        // Assert that new channel is unlinked
+        AssertAsync.willBeEqual(controller.channels.map(\.cid), [])
     }
     
     // MARK: - Delegate tests

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -285,6 +285,18 @@ extension ChannelDTO {
         ])
         return request
     }
+    
+    static func channelsFetchRequest(notLinkedTo query: ChannelListQuery) -> NSFetchRequest<ChannelDTO> {
+        let request = NSFetchRequest<ChannelDTO>(entityName: ChannelDTO.entityName)
+        request.sortDescriptors = [ChannelListSortingKey.defaultSortDescriptor]
+        // Channels which are not linked to this query
+        request.predicate = NSCompoundPredicate(
+            notPredicateWithSubpredicate: NSPredicate(
+                format: "ANY queries.filterHash == %@", query.filter.filterHash
+            )
+        )
+        return request
+    }
 }
 
 extension ChannelDTO {

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -162,6 +162,8 @@ protocol ChannelDatabaseSession {
         query: ChannelListQuery?
     ) throws -> ChannelDTO
     
+    @discardableResult func saveQuery(query: ChannelListQuery) -> ChannelListQueryDTO
+    
     /// Fetches `ChannelDTO` with the given `cid` from the database.
     func channel(cid: ChannelId) -> ChannelDTO?
     

--- a/Sources/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Mock.swift
@@ -165,6 +165,10 @@ extension DatabaseSessionMock {
         underlyingSession.loadChannelReads(for: userId)
     }
     
+    func saveQuery(query: ChannelListQuery) -> ChannelListQueryDTO {
+        underlyingSession.saveQuery(query: query)
+    }
+    
     func saveChannel(
         payload: ChannelPayload,
         query: ChannelListQuery?

--- a/Sources/StreamChatTestTools/ChatClient_Mock.swift
+++ b/Sources/StreamChatTestTools/ChatClient_Mock.swift
@@ -25,6 +25,15 @@ public extension ChatClient {
                         eventNotificationCenter: $3,
                         internetConnection: $4
                     )
+                },
+                databaseContainerBuilder: {
+                    try DatabaseContainerMock(
+                        kind: $0,
+                        shouldFlushOnStart: $1,
+                        shouldResetEphemeralValuesOnStart: $2,
+                        localCachingSettings: $3,
+                        deletedMessagesVisibility: $4
+                    )
                 }
             ),
             tokenExpirationRetryStrategy: DefaultReconnectionStrategy()


### PR DESCRIPTION
These new delegate funcs will be called for any inserted/updated channels which is not linked to the controller's query. Users will have a way to link new/updated channels to the query, without the need for `NewChannelQueryUpdater`