### PR TITLE
[CIS-1081] Expose Event data, try 2

### DIFF
--- a/DemoApp/AppDelegate.swift
+++ b/DemoApp/AppDelegate.swift
@@ -6,13 +6,22 @@ import StreamChat
 import UIKit
 
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         // Override point for customization after application launch.
-        true
+        UNUserNotificationCenter.current().delegate = self
+        return true
+    }
+    
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .badge, .sound, .list])
     }
 
     func application(

--- a/DemoApp/ChatPresenter.swift
+++ b/DemoApp/ChatPresenter.swift
@@ -195,22 +195,48 @@ class DemoChatChannelListRouter: ChatChannelListRouter {
     }
 }
 
-class DemoChannelListVC: ChatChannelListVC {
+class DemoChannelListVC: ChatChannelListVC, EventsControllerDelegate {
     /// The `UIButton` instance used for navigating to new channel screen creation,
     lazy var createChannelButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(named: "pencil")!, for: .normal)
         return button
     }()
+    
+    lazy var eventsController: EventsController = controller.client.eventsController()
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: createChannelButton)
         createChannelButton.addTarget(self, action: #selector(didTapCreateNewChannel), for: .touchUpInside)
+        
+        eventsController.delegate = self
     }
 
     @objc open func didTapCreateNewChannel(_ sender: Any) {
         (router as! DemoChatChannelListRouter).showCreateNewChannelFlow()
+    }
+    
+    func eventsController(_ controller: EventsController, didReceiveEvent event: Event) {
+        let dataStore = controller.dataStore
+        switch event {
+        case let event as MessageNewEvent:
+            if let message = dataStore.message(id: event.messageId), let channel = dataStore.channel(cid: event.cid) {
+                // Show local notification for the event
+                let content = UNMutableNotificationContent()
+                content.title = "\(message.author.name ?? message.author.id) @ \(channel.name ?? channel.cid.id)"
+                content.body = message.text
+                
+                let request = UNNotificationRequest(identifier: message.id, content: content, trigger: nil)
+                UNUserNotificationCenter.current().add(request) { error in
+                    if let error = error {
+                        log.error("Error when showing local notification: \(error)")
+                    }
+                }
+            }
+        default:
+            break
+        }
     }
 }

--- a/DemoApp/LoginViewController.swift
+++ b/DemoApp/LoginViewController.swift
@@ -60,6 +60,16 @@ class LoginViewController: UIViewController {
             tableView.deselectRow(at: selectedRow, animated: true)
         }
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _, error in
+            if let error = error {
+                log.error("Error when enabling notifications: \(error)")
+            }
+        }
+    }
 }
 
 extension LoginViewController: UITableViewDelegate, UITableViewDataSource {

--- a/Sources/StreamChat/Controllers/EventsController/ChannelEventsController.swift
+++ b/Sources/StreamChat/Controllers/EventsController/ChannelEventsController.swift
@@ -12,6 +12,7 @@ public extension ChatClient {
     /// - Returns: A new instance of `ChannelEventsController`.
     func channelEventsController(for cid: ChannelId) -> ChannelEventsController {
         .init(
+            client: self,
             cidProvider: { cid },
             eventSender: .init(database: databaseContainer, apiClient: apiClient),
             notificationCenter: eventNotificationCenter
@@ -26,6 +27,7 @@ public extension ChatChannelController {
     /// - Returns: A new instance of `ChannelEventsController`.
     func eventsController() -> ChannelEventsController {
         .init(
+            client: client,
             cidProvider: { self.cid },
             eventSender: .init(
                 database: client.databaseContainer,
@@ -54,6 +56,7 @@ public class ChannelEventsController: EventsController {
     ///   - eventSender: An event sender.
     ///   - notificationCenter: A notification center.
     init(
+        client: ChatClient,
         cidProvider: @escaping () -> ChannelId?,
         eventSender: EventSender,
         notificationCenter: EventNotificationCenter
@@ -61,7 +64,7 @@ public class ChannelEventsController: EventsController {
         self.cidProvider = cidProvider
         self.eventSender = eventSender
         
-        super.init(notificationCenter: notificationCenter)
+        super.init(client: client, notificationCenter: notificationCenter)
     }
 
     /// Sends a custom event to the channel with `cid`.

--- a/Sources/StreamChat/Controllers/EventsController/EventsController.swift
+++ b/Sources/StreamChat/Controllers/EventsController/EventsController.swift
@@ -9,7 +9,7 @@ public extension ChatClient {
     ///
     /// - Returns: A new instance of `EventsController`.
     func eventsController() -> EventsController {
-        .init(notificationCenter: eventNotificationCenter)
+        .init(client: self, notificationCenter: eventNotificationCenter)
     }
 }
 
@@ -23,7 +23,10 @@ public protocol EventsControllerDelegate: AnyObject {
 }
 
 /// `EventsController` is a controller class which allows to observe custom and system events.
-public class EventsController: Controller, DelegateCallable {
+public class EventsController: Controller, DelegateCallable, DataStoreProvider {
+    // The Client instance this controller belongs to.
+    public let client: ChatClient
+    
     // An underlaying observer listening for events.
     private var observer: EventObserver!
     
@@ -48,7 +51,8 @@ public class EventsController: Controller, DelegateCallable {
     /// Create a new instance of `EventsController`.
     ///
     /// - Parameter notificationCenter: A notification center that is listened for events.
-    init(notificationCenter: EventNotificationCenter) {
+    init(client: ChatClient, notificationCenter: EventNotificationCenter) {
+        self.client = client
         observer = .init(
             notificationCenter: notificationCenter,
             transform: { $0 },


### PR DESCRIPTION
We already have `DataStore` built in for getting data directly from DB. This can be used to get event data trivially. That's not ideal since we still can't do `event.message` or `event.channel`