### PR TITLE
[CIS-1152] Fix connection recovery

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,6 +51,7 @@ var streamChatSourcesExcluded: [String] { [
     "Database/DatabaseSession_Mock.swift",
     "Database/DatabaseSession_Tests.swift",
     "Database/DTOs/UserDTO_Tests.swift",
+    "Database/DTOs/ChannelListQueryDTO_Tests.swift",
     "Database/DTOs/ChannelMuteDTO_Tests.swift",
     "Database/DTOs/ChannelDTO_Tests.swift",
     "Database/DTOs/CurrentUserDTO_Tests.swift",

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -42,9 +42,6 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
             client.apiClient
         )
     
-    private var connectionObserver: EventObserver?
-    private let requestedChannelsLimit = 25
-
     /// A Boolean value that returns wether pagination is finished
     public private(set) var hasLoadedAllPreviousChannels: Bool = false
 
@@ -70,11 +67,18 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
         )
         
         observer.onChange = { [weak self] changes in
-            self?.delegateCallback { [weak self] in
+            self?.delegateCallback {
                 guard let self = self else {
                     log.warning("Callback called while self is nil")
                     return
                 }
+                
+                for change in changes {
+                    if case .remove = change {
+                        self.hasLoadedAllPreviousChannels = false
+                    }
+                }
+                
                 $0.controller(self, didChangeChannels: changes)
             }
             self?.handleLinkedChannels(changes)
@@ -129,60 +133,14 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
     
     override public func synchronize(_ completion: ((_ error: Error?) -> Void)? = nil) {
         startChannelListObserverIfNeeded()
-        setupEventObserversIfNeeded(completion: completion)
-    }
-    
-    private func setupEventObserversIfNeeded(completion: ((_ error: Error?) -> Void)? = nil) {
-        guard !client.config.isLocalStorageEnabled else {
-            return updateChannelList(trumpExistingChannels: false, completion)
-        }
         
-        updateChannelList(trumpExistingChannels: channels.count > requestedChannelsLimit) { [weak self] error in
-            completion?(error)
-            
-            guard let self = self else { return }
-            self.connectionObserver = nil
-            // We can't setup event observers in connectionless mode
-            guard let webSocketClient = self.client.webSocketClient else { return }
-            let center = webSocketClient.eventNotificationCenter
-            // We setup a `Connected` Event observer so every time we're connected,
-            // we refresh the channel list
-            self.connectionObserver = EventObserver(
-                notificationCenter: center,
-                transform: { $0 as? ConnectionStatusUpdated },
-                callback: { [weak self] in
-                    guard let self = self else {
-                        log.warning("Callback called while self is nil")
-                        return
-                    }
-
-                    switch $0.webSocketConnectionState {
-                    case .connected:
-                        self.updateChannelList(trumpExistingChannels: self.channels.count > self.requestedChannelsLimit)
-                    default:
-                        break
-                    }
-                }
-            )
-        }
-    }
-    
-    private func updateChannelList(
-        trumpExistingChannels: Bool,
-        _ completion: ((_ error: Error?) -> Void)? = nil
-    ) {
-        worker.update(
-            channelListQuery: query,
-            trumpExistingChannels: trumpExistingChannels
-        ) { result in
-            switch result {
-            case .success:
-                self.state = .remoteDataFetched
-                self.callback { completion?(nil) }
-            case let .failure(error):
+        queryChannels(offset: 0) { error in
+            if let error = error {
                 self.state = .remoteDataFetchFailed(ClientError(with: error))
-                self.callback { completion?(error) }
+            } else {
+                self.state = .remoteDataFetched
             }
+            self.callback { completion?(error) }
         }
     }
     
@@ -278,22 +236,8 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
         limit: Int? = nil,
         completion: ((Error?) -> Void)? = nil
     ) {
-        if hasLoadedAllPreviousChannels {
-            completion?(nil)
-            return
-        }
-
-        let limit = limit ?? requestedChannelsLimit
-        var updatedQuery = query
-        updatedQuery.pagination = Pagination(pageSize: limit, offset: channels.count)
-        worker.update(channelListQuery: updatedQuery) { result in
-            switch result {
-            case let .success(payload):
-                self.hasLoadedAllPreviousChannels = payload.channels.count < limit
-                self.callback { completion?(nil) }
-            case let .failure(error):
-                self.callback { completion?(error) }
-            }
+        queryChannels(limit: limit) { error in
+            self.callback { completion?(error) }
         }
     }
 
@@ -305,6 +249,33 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
         worker.markAllRead { error in
             self.callback {
                 completion?(error)
+            }
+        }
+    }
+    
+    private func queryChannels(
+        offset: Int? = nil,
+        limit: Int? = nil,
+        completion: @escaping (Error?) -> Void
+    ) {
+        guard !hasLoadedAllPreviousChannels else {
+            completion(nil)
+            return
+        }
+        
+        var updatedQuery = query
+        updatedQuery.pagination = Pagination(
+            pageSize: limit ?? query.pagination.pageSize,
+            offset: offset ?? channels.count
+        )
+        
+        worker.update(channelListQuery: updatedQuery) {
+            switch $0 {
+            case let .success(payload):
+                self.hasLoadedAllPreviousChannels = payload.channels.count < updatedQuery.pagination.pageSize
+                completion(nil)
+            case let .failure(error):
+                completion(error)
             }
         }
     }

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -19,6 +19,11 @@ class ChannelDTO: NSManagedObject {
     @NSManaged var defaultSortingAt: Date
     @NSManaged var updatedAt: Date
     @NSManaged var lastMessageAt: Date?
+    
+    // This field lives only locally and is not populated from the payload.
+    // The main purpose of having this is to keep track of channels that are
+    // open to correctly synchronize them on reconnect.
+    @NSManaged var isBeingRead: Bool
 
     // The oldest message of the channel we have locally coming from a regular channel query.
     // This property only lives locally, and it is useful to filter out older pinned messages
@@ -128,6 +133,7 @@ extension ChannelDTO: EphemeralValuesContainer {
         currentlyTypingUsers.removeAll()
         watchers.removeAll()
         watcherCount = 0
+        isBeingRead = false
     }
 }
 
@@ -415,6 +421,7 @@ extension ChatChannel {
             latestMessages: { fetchMessages() },
             pinnedMessages: { dto.pinnedMessages.map { $0.asModel() } },
             muteDetails: fetchMuteDetails,
+            isBeingRead: dto.isBeingRead,
             underlyingContext: dto.managedObjectContext
         )
     }

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -259,10 +259,10 @@ extension ChannelDTO {
         let request = NSFetchRequest<ChannelDTO>(entityName: ChannelDTO.entityName)
         
         // Fetch results controller requires at least one sorting descriptor.
-        let sortDescriptors = query.sort.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
+        let sortDescriptors = query.sort.map { $0.key.sortDescriptor(isAscending: $0.isAscending) }
         request.sortDescriptors = sortDescriptors.isEmpty ? [ChannelListSortingKey.defaultSortDescriptor] : sortDescriptors
         
-        let matchingQuery = NSPredicate(format: "ANY queries.filterHash == %@", query.filter.filterHash)
+        let matchingQuery = NSPredicate(format: "ANY queries.queryHash == %@", query.queryHash)
         let notDeleted = NSPredicate(format: "deletedAt == nil")
 
         // This is not 100% correct and should be ideally solved differently. This makes it impossible
@@ -298,7 +298,7 @@ extension ChannelDTO {
         // Channels which are not linked to this query
         request.predicate = NSCompoundPredicate(
             notPredicateWithSubpredicate: NSPredicate(
-                format: "ANY queries.filterHash == %@", query.filter.filterHash
+                format: "ANY queries.queryHash == %@", query.queryHash
             )
         )
         return request

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
@@ -493,22 +493,23 @@ class ChannelDTO_Tests: XCTestCase {
     /// `ChannelListSortingKey` test for sort descriptor and encoded value.
     func test_channelListSortingKey() {
         let encoder = JSONEncoder.stream
-
-        var channelListSortingKey = ChannelListSortingKey.default
-        XCTAssertEqual(encoder.encodedString(channelListSortingKey), "updated_at")
-        XCTAssertEqual(
-            channelListSortingKey.sortDescriptor(isAscending: true),
-            NSSortDescriptor(key: "defaultSortingAt", ascending: true)
-        )
-        XCTAssertEqual(
-            channelListSortingKey.sortDescriptor(isAscending: false),
-            NSSortDescriptor(key: "defaultSortingAt", ascending: false)
-        )
+        
         XCTAssertEqual(
             ChannelListSortingKey.defaultSortDescriptor,
             NSSortDescriptor(key: "defaultSortingAt", ascending: false)
         )
 
+        var channelListSortingKey = ChannelListSortingKey.updatedAt
+        XCTAssertEqual(encoder.encodedString(channelListSortingKey), "updated_at")
+        XCTAssertEqual(
+            channelListSortingKey.sortDescriptor(isAscending: false),
+            NSSortDescriptor(key: "updatedAt", ascending: false)
+        )
+        XCTAssertEqual(
+            channelListSortingKey.sortDescriptor(isAscending: true),
+            NSSortDescriptor(key: "updatedAt", ascending: true)
+        )
+        
         channelListSortingKey = .createdAt
         XCTAssertEqual(encoder.encodedString(channelListSortingKey), "created_at")
         XCTAssertEqual(

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
@@ -465,12 +465,12 @@ class ChannelDTO_Tests: XCTestCase {
             .map(\.channel.updatedAt)
             .sorted(by: { $0 > $1 })
 
-        // Save the channels to DB. It doesn't matter which query we use because the filter for both of them is the same.
+        // Save the channels to DB and link to both queries.
         try! database.writeSynchronously { session in
-            try session.saveChannel(payload: payload1, query: queryWithDefaultSorting)
-            try session.saveChannel(payload: payload2, query: queryWithDefaultSorting)
-            try session.saveChannel(payload: payload3, query: queryWithDefaultSorting)
-            try session.saveChannel(payload: payload4, query: queryWithDefaultSorting)
+            for payload in [payload1, payload2, payload3, payload4] {
+                try session.saveChannel(payload: payload, query: queryWithDefaultSorting)
+                try session.saveChannel(payload: payload, query: queryWithUpdatedAtSorting)
+            }
         }
 
         // A fetch request with a default sorting.

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO_Tests.swift
@@ -673,4 +673,31 @@ class ChannelDTO_Tests: XCTestCase {
             Assert.willBeEqual(channel.watcherCount, 0)
         }
     }
+    
+    func test_resetEphemeralValues_resetsIsBeingReadField() throws {
+        let cid: ChannelId = .unique
+        
+        // Create channel in the database
+        try database.createChannel(cid: cid)
+        
+        // Set `isBeingRead` to `true`
+        try database.writeSynchronously { session in
+            let channel = try XCTUnwrap(session.channel(cid: cid))
+            channel.isBeingRead = true
+        }
+        
+        // Load the channel
+        var channel: ChatChannel {
+            database.viewContext.channel(cid: cid)!.asModel()
+        }
+        
+        // Assert `isBeingRead` is set to `true`
+        XCTAssertTrue(channel.isBeingRead)
+        
+        // Simulate `resetEphemeralValues`
+        database.resetEphemeralValues()
+        
+        // Assert `isBeingRead` is set to `false`
+        AssertAsync.willBeFalse(channel.isBeingRead)
+    }
 }

--- a/Sources/StreamChat/Database/DTOs/ChannelListQueryDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelListQueryDTO.swift
@@ -7,46 +7,95 @@ import CoreData
 @objc(ChannelListQueryDTO)
 class ChannelListQueryDTO: NSManagedObject {
     /// Unique identifier of the query/
-    @NSManaged var filterHash: String
+    @NSManaged var queryHash: String
     
     /// Serialized `Filter` JSON which can be used in cases the query needs to be repeated, i.e. for newly created channels.
     @NSManaged var filterJSONData: Data
+    
+    /// Serialized `[Sorting<ChannelListSortingKey>]` JSON which can be used in cases the query needs to be repeated, i.e. when connection comes back.
+    @NSManaged var sortingJSONData: Data
     
     // MARK: - Relationships
     
     @NSManaged var channels: Set<ChannelDTO>
     
-    static func load(filterHash: String, context: NSManagedObjectContext) -> ChannelListQueryDTO? {
+    static func allQueriesFetchRequest() -> NSFetchRequest<ChannelListQueryDTO> {
         let request = NSFetchRequest<ChannelListQueryDTO>(entityName: ChannelListQueryDTO.entityName)
-        request.predicate = NSPredicate(format: "filterHash == %@", filterHash)
+        request.sortDescriptors = [.init(keyPath: \ChannelListQueryDTO.queryHash, ascending: true)]
+        return request
+    }
+    
+    static func load(queryHash: String, context: NSManagedObjectContext) -> ChannelListQueryDTO? {
+        let request = NSFetchRequest<ChannelListQueryDTO>(entityName: ChannelListQueryDTO.entityName)
+        request.predicate = NSPredicate(format: "queryHash == %@", queryHash)
         return try? context.fetch(request).first
     }
 }
 
-extension NSManagedObjectContext {
-    func channelListQuery(filterHash: String) -> ChannelListQueryDTO? {
-        ChannelListQueryDTO.load(filterHash: filterHash, context: self)
+extension NSManagedObjectContext: ChannelListQueryDatabaseSession {
+    func channelListQuery(queryHash: String) -> ChannelListQueryDTO? {
+        ChannelListQueryDTO.load(queryHash: queryHash, context: self)
     }
     
     func saveQuery(query: ChannelListQuery) -> ChannelListQueryDTO {
-        if let existingDTO = ChannelListQueryDTO.load(filterHash: query.filter.filterHash, context: self) {
+        if let existingDTO = channelListQuery(queryHash: query.queryHash) {
             return existingDTO
         }
         
         let newDTO = NSEntityDescription
             .insertNewObject(forEntityName: ChannelListQueryDTO.entityName, into: self) as! ChannelListQueryDTO
-        newDTO.filterHash = query.filter.filterHash
+        newDTO.queryHash = query.queryHash
         
-        let jsonData: Data
         do {
-            jsonData = try JSONEncoder.default.encode(query.filter)
+            newDTO.sortingJSONData = try JSONEncoder.default.encode(query.sort)
         } catch {
-            log.error("Failed encoding query Filter data with error: \(error).")
-            jsonData = Data()
+            log.error("Failed encoding query sort data with error: \(error).")
+            newDTO.sortingJSONData = Data()
         }
         
-        newDTO.filterJSONData = jsonData
+        do {
+            newDTO.filterJSONData = try JSONEncoder.default.encode(query.filter)
+        } catch {
+            log.error("Failed encoding query Filter data with error: \(error).")
+            newDTO.filterJSONData = Data()
+        }
         
         return newDTO
+    }
+    
+    func loadChannelListQueries() -> [ChannelListQueryDTO] {
+        let request = ChannelListQueryDTO.allQueriesFetchRequest()
+        do {
+            return try fetch(request)
+        } catch {
+            log.assertionFailure("Failed to load channel list queries")
+            return []
+        }
+    }
+}
+
+extension ChannelListQueryDTO {
+    func asModel() -> ChannelListQuery? {
+        do {
+            let decoder = JSONDecoder.default
+            
+            var query = ChannelListQuery(
+                filter: try decoder.decode(
+                    Filter<ChannelListFilterScope>.self,
+                    from: filterJSONData
+                ),
+                sort: try decoder.decode(
+                    [Sorting<ChannelListSortingKey>].self,
+                    from: sortingJSONData
+                )
+            )
+            
+            query.explicitHash = queryHash
+            
+            return query
+        } catch {
+            log.error("Internal error. Failed to decode channel list query: \(error)")
+            return nil
+        }
     }
 }

--- a/Sources/StreamChat/Database/DTOs/ChannelListQueryDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelListQueryDTO_Tests.swift
@@ -1,0 +1,117 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class ChannelListQueryDTO_Tests: XCTestCase {
+    var database: DatabaseContainer!
+
+    override func setUp() {
+        super.setUp()
+        
+        database = DatabaseContainerMock()
+    }
+
+    func test_saveQuery_createsCorrectQueryInDatabase() throws {
+        // Save query to database
+        let query = ChannelListQuery(
+            filter: .and([.exists(.cid), .in(.cid, values: [.unique, .unique])]),
+            sort: [
+                .init(key: .updatedAt),
+                .init(key: .memberCount, isAscending: true)
+            ]
+        )
+        try database.writeSynchronously { session in
+            _ = session.saveQuery(query: query)
+        }
+        
+        // Load all queries
+        let allQueriesRequest = NSFetchRequest<ChannelListQueryDTO>(entityName: ChannelListQueryDTO.entityName)
+        let allQueries = try database.viewContext.fetch(allQueriesRequest)
+        
+        // Assert a single query is exists in database
+        XCTAssertEqual(allQueries.count, 1)
+        
+        try assert(queryDTO: allQueries[0], matches: query)
+    }
+    
+    func test_channelListQuery_loadsCorrectQuery() throws {
+        // Save query to database
+        let query = ChannelListQuery(
+            filter: .and([.exists(.cid), .in(.cid, values: [.unique, .unique])]),
+            sort: [
+                .init(key: .updatedAt),
+                .init(key: .memberCount, isAscending: true)
+            ]
+        )
+        try database.createChannelListQuery(query)
+        
+        // Load query from database
+        let queryDTO = try XCTUnwrap(database.viewContext.channelListQuery(queryHash: query.queryHash))
+        
+        // Assert database query has correct fields
+        try assert(queryDTO: queryDTO, matches: query)
+    }
+    
+    func test_loadAllQueries_returnsAllLocallyExistedQueries() throws {
+        // Save 2 queries to database
+        let query1 = ChannelListQuery(
+            filter: .and([.exists(.cid), .in(.cid, values: [.unique, .unique])]),
+            sort: [
+                .init(key: .updatedAt),
+                .init(key: .memberCount, isAscending: true)
+            ]
+        )
+        let query2 = ChannelListQuery(
+            filter: .exists(.cid)
+        )
+        try database.createChannelListQuery(query1)
+        try database.createChannelListQuery(query2)
+        
+        // Load all queries
+        let queryDTOs = database.viewContext.loadChannelListQueries()
+        
+        // Assert correct queries are loaded
+        XCTAssertEqual(queryDTOs.count, 2)
+        let query1DTO = try XCTUnwrap(queryDTOs.first(where: { $0.queryHash == query1.queryHash }))
+        let query2DTO = try XCTUnwrap(queryDTOs.first(where: { $0.queryHash == query2.queryHash }))
+        try assert(queryDTO: query1DTO, matches: query1)
+        try assert(queryDTO: query2DTO, matches: query2)
+    }
+    
+    func test_asModel_returnsModelWithCorrectHashAndEncoding() throws {
+        // Save query to database
+        let query = ChannelListQuery(
+            filter: .and([.exists(.cid), .in(.cid, values: [.unique, .unique])]),
+            sort: [
+                .init(key: .memberCount, isAscending: true),
+                .init(key: .lastMessageAt, isAscending: false)
+            ]
+        )
+        try database.createChannelListQuery(query)
+        
+        // Load a query from database and parse a model
+        let request = NSFetchRequest<ChannelListQueryDTO>(entityName: ChannelListQueryDTO.entityName)
+        request.predicate = NSPredicate(format: "queryHash == %@", query.queryHash)
+        let queryDTO = try XCTUnwrap(try database.viewContext.fetch(request).first)
+        let queryModel = try XCTUnwrap(queryDTO.asModel())
+        
+        // Assert hash matches
+        XCTAssertEqual(queryModel.queryHash, query.queryHash)
+        // Assert query encoding matches
+        XCTAssertEqual(
+            try JSONEncoder.default.encode(queryModel),
+            try JSONEncoder.default.encode(query)
+        )
+    }
+    
+    private func assert(queryDTO: ChannelListQueryDTO, matches query: ChannelListQuery) throws {
+        XCTAssertEqual(queryDTO.queryHash, query.queryHash)
+        XCTAssertEqual(queryDTO.filterJSONData, try JSONEncoder.default.encode(query.filter))
+        XCTAssertEqual(queryDTO.sortingJSONData, try JSONEncoder.default.encode(query.sort))
+    }
+}

--- a/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
@@ -10,10 +10,10 @@ class CurrentUserDTO: NSManagedObject {
     @NSManaged var unreadChannelsCount: Int64
     @NSManaged var unreadMessagesCount: Int64
     
-    /// Into this field the creation date of last locally received event is saved.
-    /// The date later serves as reference date for `/sync` endpoint
-    /// that returns all events that happen after the given date
-    @NSManaged var lastReceivedEventDate: Date?
+    /// This fields stores the timestamp of most recent event returned from `/sync` endpoint.
+    /// When reconnect happens, `/sync` endpoint is called with this date
+    /// and returns all events that happen after the given date
+    @NSManaged var lastSyncedAt: Date?
 
     @NSManaged var flaggedUsers: Set<UserDTO>
     @NSManaged var flaggedMessages: Set<MessageDTO>

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -232,6 +232,17 @@ protocol MemberListQueryDatabaseSession {
     func saveQuery(_ query: ChannelMemberListQuery) throws -> ChannelMemberListQueryDTO
 }
 
+protocol ChannelListQueryDatabaseSession {
+    /// Creates a new `ChannelListQueryDTO` object in the database based in the given `ChannelListQuery`.
+    func saveQuery(query: ChannelListQuery) -> ChannelListQueryDTO
+    
+    /// Fetches `ChannelListQueryDTO` entity for the given `queryHash`.
+    func channelListQuery(queryHash: String) -> ChannelListQueryDTO?
+    
+    /// Fetches all `ChannelListQueryDTO` persisted in the database.
+    func loadChannelListQueries() -> [ChannelListQueryDTO]
+}
+
 protocol AttachmentDatabaseSession {
     /// Fetches `AttachmentDTO`entity for the given `id`.
     func attachment(id: AttachmentId) -> AttachmentDTO?
@@ -261,7 +272,8 @@ protocol DatabaseSession: UserDatabaseSession,
     MemberDatabaseSession,
     MemberListQueryDatabaseSession,
     AttachmentDatabaseSession,
-    ChannelMuteDatabaseSession {}
+    ChannelMuteDatabaseSession,
+    ChannelListQueryDatabaseSession {}
 
 extension DatabaseSession {
     @discardableResult

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -317,10 +317,6 @@ extension DatabaseSession {
             try saveCurrentUserUnreadCount(count: unreadCount)
         }
         
-        if let currentUser = currentUser, let date = payload.createdAt {
-            currentUser.lastReceivedEventDate = date
-        }
-        
         // Save message data (must be always done after the channel data!)
         if let message = payload.message {
             if let cid = payload.cid {

--- a/Sources/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Mock.swift
@@ -169,6 +169,14 @@ extension DatabaseSessionMock {
         underlyingSession.saveQuery(query: query)
     }
     
+    func channelListQuery(queryHash: String) -> ChannelListQueryDTO? {
+        underlyingSession.channelListQuery(queryHash: queryHash)
+    }
+    
+    func loadChannelListQueries() -> [ChannelListQueryDTO] {
+        underlyingSession.loadChannelListQueries()
+    }
+    
     func saveChannel(
         payload: ChannelPayload,
         query: ChannelListQuery?

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20E241" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20F71" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
@@ -25,6 +25,7 @@
         <attribute name="extraData" attributeType="Binary"/>
         <attribute name="hiddenAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="imageURL" optional="YES" attributeType="URI"/>
+        <attribute name="isBeingRead" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isFrozen" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="lastMessageAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="memberCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -68,15 +68,16 @@
         </uniquenessConstraints>
     </entity>
     <entity name="ChannelListQueryDTO" representedClassName="ChannelListQueryDTO" syncable="YES">
-        <attribute name="filterHash" attributeType="String"/>
         <attribute name="filterJSONData" attributeType="Binary"/>
+        <attribute name="queryHash" attributeType="String"/>
+        <attribute name="sortingJSONData" attributeType="Binary"/>
         <relationship name="channels" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="queries" inverseEntity="ChannelDTO"/>
-        <fetchIndex name="filterHash">
-            <fetchIndexElement property="filterHash" type="Binary" order="ascending"/>
+        <fetchIndex name="queryHash">
+            <fetchIndexElement property="queryHash" type="Binary" order="ascending"/>
         </fetchIndex>
         <uniquenessConstraints>
             <uniquenessConstraint>
-                <constraint value="filterHash"/>
+                <constraint value="queryHash"/>
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -105,7 +105,7 @@
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="channelReads" inverseEntity="UserDTO"/>
     </entity>
     <entity name="CurrentUserDTO" representedClassName="CurrentUserDTO" syncable="YES">
-        <attribute name="lastReceivedEventDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastSyncedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="uniquenessKey" attributeType="String" defaultValueString="this is an immmutable arbitrary key which makes sure we have only once instance of CurrentUserDTO in the db"/>
         <attribute name="unreadChannelsCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="unreadMessagesCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -136,6 +136,9 @@ public struct ChatChannel {
     
     /// Additional data associated with the channel.
     public let extraData: [String: RawJSON]
+    
+    /// Says whether the channel is being read locally.
+    let isBeingRead: Bool
 
     // MARK: - Internal
     
@@ -170,6 +173,7 @@ public struct ChatChannel {
         latestMessages: @escaping (() -> [ChatMessage]) = { [] },
         pinnedMessages: @escaping (() -> [ChatMessage]) = { [] },
         muteDetails: @escaping () -> MuteDetails?,
+        isBeingRead: Bool,
         underlyingContext: NSManagedObjectContext?
     ) {
         self.cid = cid
@@ -188,6 +192,7 @@ public struct ChatChannel {
         self.memberCount = memberCount
         self.reads = reads
         self.cooldownDuration = cooldownDuration
+        self.isBeingRead = isBeingRead
         self.extraData = extraData
         
         $_unreadCount = (unreadCount, underlyingContext)

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -87,6 +87,11 @@ public struct ChannelListQuery: Encodable {
     /// Query options.
     var options: QueryOptions = [.watch]
     
+    /// We set query hash explicitely when we load it from the database.
+    /// This is needed because `filter` with value of some custom type (e.g. `ChannelId`)
+    /// looses this info in encode -> decode process which affect filter.filterHash and query hash.
+    var explicitHash: String?
+    
     /// Init a channels query.
     /// - Parameters:
     ///   - filter: a channels filter.
@@ -116,5 +121,16 @@ public struct ChannelListQuery: Encodable {
         try container.encode(messagesLimit, forKey: .messagesLimit)
         try options.encode(to: encoder)
         try pagination.encode(to: encoder)
+    }
+}
+
+extension ChannelListQuery {
+    var queryHash: String {
+        let components = [
+            filter.filterHash,
+            sort.map(\.description).joined()
+        ].filter { !$0.isEmpty }
+        
+        return explicitHash ?? components.joined(separator: "-")
     }
 }

--- a/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
+++ b/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
@@ -6,42 +6,17 @@ import Foundation
 
 /// `ChannelListSortingKey` is keys by which you can get sorted channels after query.
 public enum ChannelListSortingKey: String, SortingKey {
-    /// The default sorting is by the last massage date or a channel created date. The same as by `updatedDate`.
-    case `default` = "defaultSortingAt"
     /// Sort channels by date they were created.
-    case createdAt
+    case createdAt = "created_at"
     /// Sort channels by date they were updated.
-    case updatedAt
+    case updatedAt = "updated_at"
     /// Sort channels by the last message date..
-    case lastMessageAt
+    case lastMessageAt = "last_message_at"
     /// Sort channels by number of members.
-    case memberCount
+    case memberCount = "member_count"
     /// Sort channels by `cid`.
     /// **Note**: This sorting option can extend your response waiting time if used as primary one.
     case cid
-    /// Sort channels by unread state. When using this sorting key, every unread channel weighs the same,
-    /// so they're sorted by `updatedAt`
-    case hasUnread
-    /// Sort channels by their unread count.
-    case unreadCount
-    
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        let value: String
-        
-        switch self {
-        case .default: value = "updated_at"
-        case .createdAt: value = "created_at"
-        case .updatedAt: value = "updated_at"
-        case .lastMessageAt: value = "last_message_at"
-        case .memberCount: value = "member_count"
-        case .cid: value = "cid"
-        case .hasUnread: value = "has_unread"
-        case .unreadCount: value = "unread_count"
-        }
-        
-        try container.encode(value)
-    }
 }
 
 extension ChannelListSortingKey {
@@ -50,8 +25,18 @@ extension ChannelListSortingKey {
         return .init(keyPath: dateKeyPath, ascending: false)
     }()
     
-    func sortDescriptor(isAscending: Bool) -> NSSortDescriptor? {
-        .init(key: rawValue, ascending: isAscending)
+    func sortDescriptor(isAscending: Bool) -> NSSortDescriptor {
+        .init(key: sortDescriptorKey, ascending: isAscending)
+    }
+    
+    var sortDescriptorKey: String {
+        switch self {
+        case .updatedAt: return "updatedAt"
+        case .createdAt: return "createdAt"
+        case .memberCount: return "memberCount"
+        case .lastMessageAt: return "lastMessageAt"
+        case .cid: return "cid"
+        }
     }
 }
 

--- a/Sources/StreamChat/Query/Sorting/Sorting.swift
+++ b/Sources/StreamChat/Query/Sorting/Sorting.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// A sorting key protocol.
-public protocol SortingKey: Encodable {}
+public protocol SortingKey: Codable {}
 
 /// Sorting options.
 ///
@@ -14,7 +14,7 @@ public protocol SortingKey: Encodable {}
 /// // Sort channels by the last message date:
 /// let sorting = Sorting("lastMessageDate")
 /// ```
-public struct Sorting<Key: SortingKey>: Encodable, CustomStringConvertible {
+public struct Sorting<Key: SortingKey>: SortingKey, CustomStringConvertible {
     /// A sorting field name.
     public let key: Key
     /// A sorting direction.

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater.swift
@@ -8,21 +8,32 @@ import Foundation
 /// The type is designed to obtain missing events that happened in watched channels while user
 /// was not connected to the web-socket.
 ///
-/// The object listens for `ConnectionStatusUpdated` events
-/// and remembers the `CurrentUserDTO.lastReceivedEventDate` when status becomes `connecting`.
+/// The object listens for `ConnectionStatusUpdated` events and when the status becomes `connected` the `/sync` endpoint is called
+/// with `lastSyncedAt` and `cids` of locally existed channels linked to at least one query.
 ///
-/// When the status becomes `connected` the `/sync` endpoint is called
-/// with `lastReceivedEventDate` and `cids` of watched channels.
+/// Case 1:
+/// If `/sync` succeds and returns events, channel list queries are re-fetched considering all locally existed channels as synced.
+/// If re-fetch succeeds, `lastSyncedAt` is set to most recent event timestamp (received from `/sync`).
+/// If re-fetch fails, `lastSyncedAt` stays the same.
 ///
-/// We remember `lastReceivedEventDate` when state becomes `connecting` to catch the last event date
-/// before the `HealthCheck` override the `lastReceivedEventDate` with the recent date.
+/// Case 2:
+/// If `/sync` succeds and returns zero events, channel list queries are re-fetched considering all locally existed channels as synced.
+/// If re-fetch succeeds, `lastSyncedAt` is set to current date.
+/// If re-fetch fails, `lastSyncedAt` stays the same.
+///
+/// Case 3:
+/// If `/sync` fails with error, channel list queries are re-fetched considering all locally existed channels as out of sync.
+/// If re-fetch succeeds, `lastSyncedAt` is set to current date otherwise.
+/// If re-fetch fails, `lastSyncedAt` stays the same.
+///
+/// If `ConnectionRecoveryUpdater` is created with `useSyncEndpoint == false`, the connection recovery logic behaves as
+/// described in `Case 3`.
 ///
 class ConnectionRecoveryUpdater: EventWorker {
     // MARK: - Properties
     
     private var connectionObserver: EventObserver?
     private let databaseCleanupUpdater: DatabaseCleanupUpdater
-    @Atomic private var lastSyncedAt: Date?
     private let useSyncEndpoint: Bool
     
     // MARK: - Init
@@ -88,8 +99,6 @@ class ConnectionRecoveryUpdater: EventWorker {
                 }
 
                 switch $0.webSocketConnectionState {
-                case .connecting:
-                    self.obtainLastSyncDate()
                 case .connected:
                     self.fetchAndReplayMissingEvents()
                 default:
@@ -99,103 +108,98 @@ class ConnectionRecoveryUpdater: EventWorker {
         )
     }
     
-    private func obtainLastSyncDate() {
-        database.backgroundReadOnlyContext.perform { [weak self] in
-            self?.lastSyncedAt = self?.database.backgroundReadOnlyContext.currentUser?.lastReceivedEventDate
-        }
-    }
-    
     private func fetchAndReplayMissingEvents() {
-        database.backgroundReadOnlyContext.perform { [weak self, useSyncEndpoint] in
-            let refetchExistingQueries: () -> Void = {
-                self?.databaseCleanupUpdater.refetchExistingChannelListQueries()
+        database.write { [weak self, useSyncEndpoint] session in
+            guard let currentUser = session.currentUser else {
+                log.error("In `connected` state current user must exist in database")
+                return
             }
             
-            if useSyncEndpoint {
-                self?.sync(completion: refetchExistingQueries)
-            } else {
-                refetchExistingQueries()
+            guard let lastSyncedAt = currentUser.lastSyncedAt else {
+                log.debug("There's no previous session, remembering the current date as last sync date")
+                currentUser.lastSyncedAt = Date()
+                return
             }
-        }
-    }
-
-    private func sync(completion: @escaping () -> Void) {
-        guard let lastSyncedAt = lastSyncedAt else { return }
-        
-        let watchedChannelIDs = allChannels.map(\.cid).compactMap { try? ChannelId(cid: $0) }
-        
-        guard !watchedChannelIDs.isEmpty else {
-            log.info("Skipping `/sync` endpoint call as there are no channels to watch.")
-            return
-        }
-        
-        let endpoint: Endpoint<MissingEventsPayload> = .missingEvents(
-            since: lastSyncedAt,
-            cids: watchedChannelIDs
-        )
-        
-        apiClient.request(endpoint: endpoint) { [weak self] in
-            guard let self = self else { return }
-            switch $0 {
-            case let .success(payload):
-                // The sync call was successful.
-                // We schedule all events for existing channels for processing...
-                self.eventNotificationCenter.process(payload.eventPayloads)
-                
-                // ... and refetch the existing queries to see if there are some new channels
-                completion()
-                
-            case let .failure(error):
-                log.info(
-                    """
-                    Backend couldn't handle replaying missing events - there was too many (>1000) events to replay. \
-                    Cleaning local channels data and refetching it from scratch
-                    """
-                )
-                
-                if error.isTooManyMissingEventsToSyncError {
-                    // The sync call failed...
-                    self.database.write {
-                        // First we need to clean up existing data
-                        try self.databaseCleanupUpdater.resetExistingChannelsData(session: $0)
-                    } completion: { error in
-                        if let error = error {
-                            log.error("Failed cleaning up channels data: \(error).")
-                            return
-                        }
-                        // Then we have to refetch existing channel list queries
-                        completion()
-                    }
+            
+            guard useSyncEndpoint else {
+                log.debug("Ignore `/sync` and re-fetch local queries")
+                self?.refetchLocalQueries()
+                return
+            }
+            
+            let queriesRequest = NSFetchRequest<ChannelListQueryDTO>(entityName: ChannelListQueryDTO.entityName)
+            let queries = (try? (session as! NSManagedObjectContext).fetch(queriesRequest)) ?? []
+            let cids = Set(
+                queries
+                    .flatMap(\.channels)
+                    .compactMap { try? ChannelId(cid: $0.cid) }
+                    .prefix(1000)
+            )
+            
+            self?.getMissingEvents(for: cids, since: lastSyncedAt) {
+                switch $0 {
+                case let .success(payload):
+                    let mostRecentEventTimestamp = payload
+                        .eventPayloads
+                        .compactMap(\.createdAt)
+                        .sorted()
+                        .last
+                    
+                    self?.refetchLocalQueries(
+                        syncedChannelIDs: cids,
+                        bumpLastSyncDateTo: mostRecentEventTimestamp ?? lastSyncedAt
+                    )
+                case .failure:
+                    self?.refetchLocalQueries()
                 }
             }
         }
     }
     
-    private var allChannels: [ChannelDTO] {
-        do {
-            let request = ChannelDTO.allChannelsFetchRequest
-            request.fetchLimit = 1000
-            return try database.backgroundReadOnlyContext.fetch(request)
-        } catch {
-            log.error("Internal error: Failed to fetch [ChannelDTO]: \(error)")
-            return []
+    private func getMissingEvents(
+        for cids: Set<ChannelId>,
+        since lastSyncedAt: Date,
+        completion: @escaping (Result<MissingEventsPayload, Error>) -> Void
+    ) {
+        log.debug("Will fetch missing events for \(cids) starting from \(lastSyncedAt)")
+        
+        apiClient.request(
+            endpoint: .missingEvents(since: lastSyncedAt, cids: .init(cids))
+        ) { [weak self] in
+            switch $0 {
+            case let .success(payload):
+                log.debug("Did receive \(payload.eventPayloads.count) missing events: \(payload.eventPayloads)")
+                
+                self?.eventNotificationCenter.feedEventsToMiddlewares(
+                    payload.eventPayloads.compactMap { try? $0.event() },
+                    shouldPostEvents: false
+                ) {
+                    completion(.success(payload))
+                }
+            case let .failure(error):
+                log.debug("Fail to get missing events: \(error)")
+                
+                completion(.failure(error))
+            }
         }
     }
-}
-
-// MARK: - Extensions
-
-extension EventNotificationCenter {
-    /// The method is used to convert incoming event payloads into events and calls `process(_:)` for each event
-    /// that was successfully decoded.
-    ///
-    /// - Parameter payloads: The event payloads
-    func process(_ payloads: [EventPayload]) {
-        payloads.forEach {
-            do {
-                process(try $0.event())
-            } catch {
-                log.error("Failed to transform a payload into an event: \($0)")
+    
+    private func refetchLocalQueries(
+        syncedChannelIDs: Set<ChannelId> = [],
+        bumpLastSyncDateTo newValue: Date = Date()
+    ) {
+        databaseCleanupUpdater.syncChannelListQueries(
+            syncedChannelIDs: syncedChannelIDs
+        ) { [weak self] in
+            switch $0 {
+            case .success:
+                self?.database.write { session in
+                    log.debug("Bumping `lastSyncedAt` to \(newValue)")
+                    
+                    session.currentUser?.lastSyncedAt = newValue
+                }
+            case let .failure(error):
+                log.error("Channel list queries re-fetch has failed: \(error)")
             }
         }
     }

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater.swift
@@ -31,43 +31,197 @@ class DatabaseCleanupUpdater: Worker {
         )
     }
     
-    /// Resets all existing channels data without removing the data from the database. This is used mainly to clean-up
-    /// existing relations between the objects, and prepare the channels for full refetching.
-    ///
-    /// - Parameter session: session for writing into the database.
-    ///
-    func resetExistingChannelsData(session: DatabaseSession) throws {
-        if let channels = try (session as? NSManagedObjectContext)?
-            .fetch(ChannelDTO.allChannelsFetchRequest) {
-            channels.forEach {
-                $0.resetLocalData()
+    func syncChannelListQueries(
+        syncedChannelIDs: Set<ChannelId>,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        log.debug("Will sync channel queries. Synced channels: \(syncedChannelIDs)")
+        
+        fetchLocalQueries { [weak self] localQueries in
+            let group = DispatchGroup()
+            let semaphore = DispatchSemaphore(value: 1)
+            
+            var results: [String: Result<Void, Error>] = [:]
+            for query in localQueries {
+                group.enter()
+                self?.syncChannelListQuery(query, syncedChannelIDs: syncedChannelIDs) {
+                    semaphore.wait()
+                    results[query.queryHash] = $0
+                    semaphore.signal()
+                    group.leave()
+                }
+            }
+            
+            group.notify(queue: .main) {
+                let failedQueryHashes = Set(
+                    results.compactMap { queryHash, result in result.error == nil ? nil : queryHash }
+                )
+                
+                if failedQueryHashes.isEmpty {
+                    completion(.success(()))
+                } else {
+                    let error = ClientError.ChannelListQueriesRefetchError(failedQueryHashes)
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Private
+
+private extension DatabaseCleanupUpdater {
+    func syncChannelListQuery(
+        _ query: ChannelListQuery,
+        syncedChannelIDs: Set<ChannelId>,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        log.debug("Will sync channel query: \(query.queryHash). Synced channels: \(syncedChannelIDs)")
+        
+        // Fetch 1st page and start watching those channels
+        channelListUpdater.fetch(query) { [weak self] in
+            switch $0 {
+            case let .success(firstPage):
+                self?.updateChannelList(
+                    query,
+                    syncedChannelIDs: syncedChannelIDs,
+                    firstPageOfChannels: firstPage,
+                    completion: completion
+                )
+            case let .failure(error):
+                completion(.failure(error))
             }
         }
     }
     
-    /// Finds the existing channel list queries in the database and refetches them.
-    func refetchExistingChannelListQueries() {
-        let context = database.backgroundReadOnlyContext
-        context.perform { [weak self] in
-            do {
-                let queriesDTOs = try context.fetch(
-                    NSFetchRequest<ChannelListQueryDTO>(
-                        entityName: ChannelListQueryDTO.entityName
-                    )
-                )
-                let queries: [ChannelListQuery] = try queriesDTOs.map {
-                    try $0.asChannelListQuery()
-                }
-                queries.forEach {
-                    self?.channelListUpdater.update(channelListQuery: $0) { result in
-                        if case let .failure(error) = result {
-                            log.error("Internal error. Failed to update ChannelListQueries for the new channel: \(error)")
-                        }
-                    }
-                }
-            } catch {
-                log.error("Internal error: Failed to fetch [ChannelListQueryDTO]: \(error)")
+    func updateChannelList(
+        _ query: ChannelListQuery,
+        syncedChannelIDs: Set<ChannelId>,
+        firstPageOfChannels: ChannelListPayload,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        database.write { [weak self] session in
+            guard let queryDTO = session.channelListQuery(queryHash: query.queryHash) else {
+                completion(.success(()))
+                return
             }
+            
+            let cidsBeingRead = queryDTO.cidsBeingRead
+            let cidsSyncedAndWatched = syncedChannelIDs.intersection(firstPageOfChannels.cids)
+            let cidsToKeepLocalData = cidsSyncedAndWatched.union(cidsBeingRead)
+            
+            // Reset channels that are not synced or watched ignoring ones that are being read
+            let channelsToReset = queryDTO.channels.filter { !cidsToKeepLocalData.contains($0.channelId) }
+            log
+                .debug(
+                    "Will reset \(channelsToReset.count) channels: \(channelsToReset.map(\.channelId)) in query: \(query.queryHash)"
+                )
+            channelsToReset.forEach { $0.resetLocalData() }
+            
+            // Unlink all channels from a query
+            queryDTO.channels.removeAll()
+            
+            // Link channels from 1st page to query
+            for channel in firstPageOfChannels.channels {
+                do {
+                    try session.saveChannel(payload: channel, query: query)
+                } catch {
+                    log.error("Failed to save channel: \(channel). Error: \(error)")
+                }
+            }
+            
+            // Update channels that are being read
+            self?.updateMessageLists(
+                query: query,
+                cidsSyncedAndWatched: cidsSyncedAndWatched,
+                completion: completion
+            )
+        }
+    }
+    
+    func updateMessageLists(
+        query: ChannelListQuery,
+        cidsSyncedAndWatched: Set<ChannelId>,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        log.debug("Will sync and watch channels being read for \(query.queryHash)")
+        fetchChannelsBeingRead(in: query) { [weak self] cidsBeingRead in
+            guard !cidsBeingRead.isEmpty else {
+                log.debug("No channels being read in \(query.queryHash)")
+                completion(.success(()))
+                return
+            }
+            
+            // Get cids of channels that were not returned from API and therefore are not watched
+            let cidsBeingReadOutOfSync = cidsBeingRead.subtracting(cidsSyncedAndWatched)
+            
+            // Create a query to start watching ALL events for channels
+            var cidsBeingReadQuery = ChannelListQuery(
+                filter: .in(.cid, values: .init(cidsBeingRead)),
+                pageSize: cidsBeingRead.count,
+                messagesLimit: cidsBeingReadOutOfSync.isEmpty ? 0 : .messagesPageSize
+            )
+            cidsBeingReadQuery.options = .all
+            
+            self?.channelListUpdater.fetch(cidsBeingReadQuery) {
+                switch $0 {
+                case let .success(payload):
+                    self?.database.write { session in
+                        // Reset local data for channels
+                        cidsBeingReadOutOfSync
+                            .compactMap { session.channel(cid: $0) }
+                            .forEach { $0.resetLocalData() }
+                        
+                        // Save channels to database
+                        for channel in payload.channels {
+                            do {
+                                try session.saveChannel(payload: channel)
+                            } catch {
+                                log.error("Failed to save channel being read: \(channel). Error: \(error)")
+                            }
+                        }
+                        
+                        completion(.success(()))
+                    }
+                case let .failure(error):
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+    
+    func fetchChannelsBeingRead(in query: ChannelListQuery, completion: @escaping (Set<ChannelId>) -> Void) {
+        let context = database.backgroundReadOnlyContext
+        context.perform {
+            let cidsBeingRead = Set(
+                context
+                    .channelListQuery(queryHash: query.queryHash)?
+                    .cidsBeingRead ?? []
+            )
+            
+            completion(cidsBeingRead)
+        }
+    }
+    
+    func fetchLocalQueries(completion: @escaping ([ChannelListQuery]) -> Void) {
+        let context = database.backgroundReadOnlyContext
+        context.perform {
+            let queries = context
+                .loadChannelListQueries()
+                .compactMap { $0.asModel() }
+            
+            completion(queries)
+        }
+    }
+}
+
+extension ClientError {
+    class ChannelListQueriesRefetchError: ClientError {
+        let failedQueryHashes: Set<String>
+        
+        init(_ failedQueryHashes: Set<String>) {
+            self.failedQueryHashes = failedQueryHashes
+            super.init("Re-fetch has failed for the following queries: \(failedQueryHashes)")
         }
     }
 }
@@ -90,17 +244,20 @@ private extension ChannelDTO {
         reads = []
         queries = []
     }
+    
+    var channelId: ChannelId {
+        try! .init(cid: cid)
+    }
 }
 
 private extension ChannelListQueryDTO {
-    /// Converts ChannelListQueryDTO to _ChannelListQuery
-    /// - Throws: Decoding error
-    /// - Returns: Domain model for _ChannelListQuery
-    func asChannelListQuery() throws -> ChannelListQuery {
-        let encodedFilter = try JSONDecoder.default
-            .decode(Filter<ChannelListFilterScope>.self, from: filterJSONData)
-        var updatedFilter: Filter<ChannelListFilterScope> = encodedFilter
-        updatedFilter.explicitHash = filterHash
-        return ChannelListQuery(filter: updatedFilter)
+    var cidsBeingRead: Set<ChannelId> {
+        Set(channels.filter(\.isBeingRead).map(\.channelId))
+    }
+}
+
+private extension ChannelListPayload {
+    var cids: Set<ChannelId> {
+        Set(channels.map(\.channel).map(\.cid))
     }
 }

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Mock.swift
@@ -6,13 +6,19 @@
 import StreamChat
 
 final class DatabaseCleanupUpdater_Mock: DatabaseCleanupUpdater {
-    var resetExistingChannelsData_body: (DatabaseSession) -> Void = { _ in }
-    override func resetExistingChannelsData(session: DatabaseSession) {
-        resetExistingChannelsData_body(session)
+    var syncChannelListQueries_syncedChannelIDs: Set<ChannelId>?
+    var syncChannelListQueries_completion: ((Result<Void, Error>) -> Void)?
+    
+    override func syncChannelListQueries(
+        syncedChannelIDs: Set<ChannelId>,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        syncChannelListQueries_syncedChannelIDs = syncedChannelIDs
+        syncChannelListQueries_completion = completion
     }
-
-    var refetchExistingChannelListQueries_body: () -> Void = {}
-    override func refetchExistingChannelListQueries() {
-        refetchExistingChannelListQueries_body()
+    
+    func cleanUp() {
+        syncChannelListQueries_syncedChannelIDs = nil
+        syncChannelListQueries_completion = nil
     }
 }

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Tests.swift
@@ -42,69 +42,125 @@ final class DatabaseCleanupUpdater_Tests: StressTestCase {
         super.tearDown()
     }
     
-    func test_resetExistingChannelsData_cleansChannelsData() throws {
-        let cid1 = ChannelId.unique
-        let cid2 = ChannelId.unique
+    func test_whenSync_allLocalQueriesAreFetched() throws {
+        // Create first query in database
+        let cid1: ChannelId = .unique
+        let query1 = ChannelListQuery(filter: .in(.cid, values: [cid1]))
+        try database.createChannelListQuery(query1)
+
+        // Create secon query in database
+        let cid2: ChannelId = .unique
+        let query2 = ChannelListQuery(filter: .in(.cid, values: [cid2]))
+        try database.createChannelListQuery(query2)
+
+        let testCases: [Set<ChannelId>] = [
+            [],
+            [cid1],
+            [cid1, cid2]
+        ]
         
-        try database.createChannel(
-            cid: cid1,
-            withMessages: true,
-            withQuery: true,
-            hiddenAt: .unique,
-            needsRefreshQueries: false
-        )
-        
-        try database.createChannel(
-            cid: cid2,
-            withMessages: true,
-            withQuery: true,
-            hiddenAt: .unique,
-            needsRefreshQueries: false
-        )
-        
-        try databaseCleanupUpdater?.resetExistingChannelsData(session: database.viewContext)
-        
-        let channel1 = try XCTUnwrap(database.viewContext.channel(cid: cid1))
-        let channel2 = try XCTUnwrap(database.viewContext.channel(cid: cid2))
-        
-        AssertAsync {
-            Assert.willBeTrue(channel1.isClearedOutProperly)
-            Assert.willBeTrue(channel2.isClearedOutProperly)
+        for syncedChannels in testCases {
+            // Trigger queries sync with specific list of synced channels
+            databaseCleanupUpdater?.syncChannelListQueries(syncedChannelIDs: syncedChannels) { _ in }
+
+            // Assert all queries are fetched no matter what synced channels are
+            AssertAsync.willBeEqual(
+                Set(channelListUpdater.fetch_channelListQueries.map(\.queryHash)),
+                Set([query1, query2].map(\.queryHash))
+            )
         }
     }
-    
-    func test_refetchExistingChannelListQueries_updateQueries() throws {
-        let filter1 = Filter<ChannelListFilterScope>.query(.cid, text: .unique)
-        let query1 = ChannelListQuery(filter: filter1)
-        try database.createChannelListQuery(filter: filter1)
-        
-        let filter2 = Filter<ChannelListFilterScope>.query(.cid, text: .unique)
-        let query2 = ChannelListQuery(filter: filter2)
-        try database.createChannelListQuery(filter: filter2)
-        
-        databaseCleanupUpdater?.refetchExistingChannelListQueries()
-        
-        AssertAsync.willBeEqual(
-            channelListUpdater.update_queries,
-            [query1, query2]
-        )
-    }
-        
-    func test_refetchExistingChannelListQueries_whenDatabaseCleanupUpdaterIsDeallocated_doesNotUpdateQueries() throws {
-        // Create a channel list query to be refetched.
-        try database.createChannelListQuery(filter: .query(.cid, text: .unique))
-    
-        // Initiate channel list queries refetch.
-        databaseCleanupUpdater?.refetchExistingChannelListQueries()
-        
-        // Simulate database-cleanup-updater deallocation.
-        databaseCleanupUpdater = nil
-        
-        // Assert the `channelListUpdater` was not asked to update queries.
-        AssertAsync.staysTrue(
-            channelListUpdater.update_queries.isEmpty
-        )
-    }
+
+//
+//    func test_whenFetchSucceeds_localQueriesAreProperlyUpdated() throws {
+//        // Create 1st query with 2 channels in database
+//        let query1 = ChannelListQuery(filter: .exists(.cid), sort: [.init(key: .updatedAt)])
+//        let query1LocalCid1: ChannelId = .unique
+//        let query1LocalCid2: ChannelId = .unique
+//        try database.writeSynchronously { session in
+//            for cid in [query1LocalCid1, query1LocalCid2] {
+//                try session.saveChannel(payload: .dummy(cid: cid), query: query1)
+//            }
+//        }
+//
+//        // Create 2nd query with 2 channels in database
+//        let query2 = ChannelListQuery(filter: .exists(.cid), sort: [.init(key: .lastMessageAt)])
+//        let query2LocalCid1: ChannelId = .unique
+//        let query2LocalCid2: ChannelId = .unique
+//        try database.writeSynchronously { session in
+//            for cid in [query2LocalCid1, query2LocalCid2] {
+//                try session.saveChannel(payload: .dummy(cid: cid), query: query2)
+//            }
+//        }
+//
+//        // Trigger queries sync
+//        let cids = [query1LocalCid1, query1LocalCid2, query2LocalCid1, query2LocalCid2]
+//        databaseCleanupUpdater?.syncChannelListQueries(syncedChannelIDs: .init(cids)) { _ in }
+//
+//        // Wait both queries to be fetched
+//        AssertAsync.willBeEqual(channelListUpdater.fetch_channelListQueries.count, 2)
+//
+//        // Simulate response for query 1
+//        let query1NewCid: ChannelId = .unique
+//        let query1FirstPageCIDs = [query1LocalCid1, query1NewCid]
+//        let query1Index = try XCTUnwrap(channelListUpdater.fetch_channelListQueries.firstIndex(of: query1))
+//        channelListUpdater.fetch_completions[query1Index](.success(
+//            .init(channels: query1FirstPageCIDs.map { cid in
+//                .init(
+//                    channel: .dummy(cid: cid),
+//                    watcherCount: 0,
+//                    watchers: [],
+//                    members: [],
+//                    membership: nil,
+//                    messages: [],
+//                    pinnedMessages: [],
+//                    channelReads: []
+//                )
+//            })
+//        ))
+//
+//        // Simulate response for query 2
+//        let query2NewCid: ChannelId = .unique
+//        let query2FirstPageCIDs = [query2NewCid, query2LocalCid1]
+//        let query2Index = try XCTUnwrap(channelListUpdater.fetch_channelListQueries.firstIndex(of: query2))
+//        channelListUpdater.fetch_completions[query2Index](.success(
+//            .init(channels: query2FirstPageCIDs.map { cid in
+//                .init(
+//                    channel: .dummy(cid: cid),
+//                    watcherCount: 0,
+//                    watchers: [],
+//                    members: [],
+//                    membership: nil,
+//                    messages: [],
+//                    pinnedMessages: [],
+//                    channelReads: []
+//                )
+//            })
+//        ))
+//
+//        var query1CIDs: Set<ChannelId> {
+//            Set(
+//                database.viewContext
+//                    .channelListQuery(queryHash: query1.queryHash)!
+//                    .channels
+//                    .map { try! ChannelId(cid: $0.cid) }
+//            )
+//        }
+//
+//        var query2CIDs: Set<ChannelId> {
+//            Set(
+//                database.viewContext
+//                    .channelListQuery(queryHash: query2.queryHash)!
+//                    .channels
+//                    .map { try! ChannelId(cid: $0.cid) }
+//            )
+//        }
+//
+//        AssertAsync {
+//            Assert.willBeEqual(query1CIDs, Set(query1FirstPageCIDs))
+//            Assert.willBeEqual(query2CIDs, Set(query2FirstPageCIDs))
+//        }
+//    }
 }
 
 extension ChannelListQuery: Equatable {

--- a/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/NewChannelQueryUpdater_Tests.swift
@@ -44,45 +44,57 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
         super.tearDown()
     }
     
-    func test_update_called_forEachQuery() throws {
-        let filter1: Filter<ChannelListFilterScope> = .equal(.frozen, to: true)
-        let filter2: Filter<ChannelListFilterScope> = .equal(.cid, to: .unique)
+    func test_fetch_called_forEachQuery() throws {
+        // Save 2 queries to database
+        let query1 = ChannelListQuery(filter: .equal(.frozen, to: true))
+        let query2 = ChannelListQuery(filter: .equal(.cid, to: .unique))
         
-        try database.createChannelListQuery(filter: filter1)
-        try database.createChannelListQuery(filter: filter2)
-                
-        try database.createChannel()
+        try database.createChannelListQuery(query1)
+        try database.createChannelListQuery(query2)
         
-        // Assert `update(channelListQuery` called for each query in DB
+        // Save new channel to database
+        let cid: ChannelId = .unique
+        try database.createChannel(cid: cid, withQuery: false)
+       
+        // Assert `fetch(channelListQuery)` is called for each query in DB
+        let updatedQuery1 = ChannelListQuery(filter: .and([query1.filter, .equal(.cid, to: cid)]))
+        let updatedQuery2 = ChannelListQuery(filter: .and([query2.filter, .equal(.cid, to: cid)]))
         AssertAsync.willBeEqual(
-            env!.channelQueryUpdater?.update_queries.map(\.filter.filterHash).sorted(),
-            [filter1, filter2].map(\.filterHash).sorted()
+            Set(env!.channelQueryUpdater!.fetch_channelListQueries.map(\.queryHash)),
+            Set([updatedQuery1, updatedQuery2].map(\.queryHash))
         )
     }
 
-    func test_update_notCalled_whenNeedsRefreshQueries_isFalse() throws {
-        let filter: Filter<ChannelListFilterScope> = .equal(.frozen, to: true)
-        try database.createChannelListQuery(filter: filter)
+    func test_fetch_notCalled_whenNeedsRefreshQueries_isFalse() throws {
+        // Save a query to database
+        let query = ChannelListQuery(filter: .equal(.frozen, to: true))
+        try database.createChannelListQuery(query)
 
-        try database.writeSynchronously { session in
-            let dto = try session.saveChannel(payload: XCTestCase().dummyPayload(with: .unique))
-            dto.needsRefreshQueries = false
-        }
+        // Save a channel to database that we should not try to link to queries
+        let cid: ChannelId = .unique
+        try database.createChannel(cid: cid, needsRefreshQueries: false)
 
-        // Assert `update(channelListQuery:)` is not called
-        AssertAsync.staysTrue(env!.channelQueryUpdater?.update_queries.isEmpty == true)
+        // Assert `fetch(channelListQuery:)` is not called
+        AssertAsync.staysTrue(env!.channelQueryUpdater!.fetch_channelListQueries.isEmpty)
     }
 
-    func test_update_called_forExistingChannel() throws {
+    func test_fetch_called_forExistingChannel() throws {
         // Deinitialize newChannelQueryUpdater
         newChannelQueryUpdater = nil
         
-        let filter: Filter<ChannelListFilterScope> = .equal(.cid, to: .unique)
-        try database.createChannelListQuery(filter: filter)
-        try database.createChannel(cid: .unique)
+        // Save 2 queries to database
+        let query1 = ChannelListQuery(filter: .equal(.frozen, to: true))
+        let query2 = ChannelListQuery(filter: .equal(.cid, to: .unique))
         
-        // Assert `update(channelListQuery` is not called
-        AssertAsync.willBeTrue(env!.channelQueryUpdater?.update_queries.isEmpty)
+        try database.createChannelListQuery(query1)
+        try database.createChannelListQuery(query2)
+        
+        // Save a channel to database
+        let cid: ChannelId = .unique
+        try database.createChannel(cid: cid)
+        
+        // Assert `fetch(channelListQuery)` is not called
+        AssertAsync.willBeTrue(env!.channelQueryUpdater?.fetch_channelListQueries.isEmpty)
         
         // Create `newChannelQueryUpdater`
         newChannelQueryUpdater = NewChannelQueryUpdater(
@@ -91,18 +103,23 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
             env: env.environment
         )
         
-        // Assert `update(channelListQuery` called for channel that was in DB before observing started
-        AssertAsync.willBeEqual(env!.channelQueryUpdater?.update_queries.first?.filter.filterHash, filter.filterHash)
+        // Assert `fetch(channelListQuery)` is called for each query in DB
+        let updatedQuery1 = ChannelListQuery(filter: .and([query1.filter, .equal(.cid, to: cid)]))
+        let updatedQuery2 = ChannelListQuery(filter: .and([query2.filter, .equal(.cid, to: cid)]))
+        AssertAsync.willBeEqual(
+            Set(env!.channelQueryUpdater!.fetch_channelListQueries.map(\.queryHash)),
+            Set([updatedQuery1, updatedQuery2].map(\.queryHash))
+        )
     }
 
     func test_updater_setsNeedsRefreshQueries_toFalse() throws {
-        let filter: Filter<ChannelListFilterScope> = .equal(.frozen, to: true)
-        try database.createChannelListQuery(filter: filter)
+        let query = ChannelListQuery(filter: .equal(.frozen, to: true))
+        try database.createChannelListQuery(query)
 
         let cid: ChannelId = .unique
         try database.createChannel(cid: cid)
 
-        AssertAsync.willBeEqual(env!.channelQueryUpdater?.update_queries.count, 1)
+        AssertAsync.willBeEqual(env!.channelQueryUpdater?.fetch_channelListQueries.count, 1)
 
         AssertAsync.willBeEqual(database.viewContext.channel(cid: cid)?.needsRefreshQueries, false)
 
@@ -112,33 +129,17 @@ class NewChannelQueryUpdater_Tests: StressTestCase {
             channelDTO?.needsRefreshQueries = true
         }
 
-        AssertAsync.willBeEqual(env!.channelQueryUpdater?.update_queries.count, 2)
+        AssertAsync.willBeEqual(env!.channelQueryUpdater?.fetch_channelListQueries.count, 2)
         AssertAsync.willBeEqual(database.viewContext.channel(cid: cid)?.needsRefreshQueries, false)
-    }
-
-    func test_filter_isModified() throws {
-        let cid: ChannelId = .unique
-        let filter: Filter<ChannelListFilterScope> = .equal(.cid, to: .unique)
-        
-        try database.createChannelListQuery(filter: filter)
-        try database.createChannel(cid: cid)
-        
-        let expectedFilter: Filter = .and([filter, .equal("cid", to: cid)])
-        
-        // Assert `update(channelListQuery` called with modified query
-        AssertAsync {
-            Assert.willBeEqual(self.env!.channelQueryUpdater?.update_queries.first?.filter.filterHash, filter.filterHash)
-            Assert.willBeEqual(self.env!.channelQueryUpdater?.update_queries.first?.filter.description, expectedFilter.description)
-        }
     }
     
     func test_newChannelQueryUpdater_doesNotRetainItself() throws {
-        let filter: Filter<ChannelListFilterScope> = .equal(.cid, to: .unique)
-        try database.createChannelListQuery(filter: filter)
+        let query = ChannelListQuery(filter: .equal(.cid, to: .unique))
+        try database.createChannelListQuery(query)
         try database.createChannel()
         
-        // Assert `update(channelListQuery` is called
-        AssertAsync.willBeEqual(env!.channelQueryUpdater?.update_queries.first?.filter.filterHash, filter.filterHash)
+        // Assert `fetch(channelListQuery)` is called
+        AssertAsync.willBeTrue(env!.channelQueryUpdater?.fetch_channelListQueries.isEmpty == false)
         
         // Assert `newChannelQueryUpdater` can be released even though network response hasn't come yet
         AssertAsync.canBeReleased(&newChannelQueryUpdater)

--- a/Sources/StreamChat/Workers/ChannelListUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater.swift
@@ -6,6 +6,21 @@ import CoreData
 
 /// Makes a channels query call to the backend and updates the local storage with the results.
 class ChannelListUpdater: Worker {
+    /// Makes a channels query call to the backend and calls completion with results.
+    ///
+    /// - Parameters:
+    ///   - channelListQuery: The query to be fetched.
+    ///   - completion: The completion.
+    func fetch(
+        _ channelListQuery: ChannelListQuery,
+        completion: @escaping (Result<ChannelListPayload, Error>) -> Void
+    ) {
+        apiClient.request(
+            endpoint: .channels(query: channelListQuery),
+            completion: completion
+        )
+    }
+    
     /// Makes a channels query call to the backend and updates the local storage with the results.
     ///
     /// - Parameters:

--- a/Sources/StreamChat/Workers/ChannelListUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater_Mock.swift
@@ -35,7 +35,6 @@ class ChannelListUpdaterMock: ChannelListUpdater {
     
     override func update(
         channelListQuery: ChannelListQuery,
-        trumpExistingChannels: Bool = false,
         completion: ((Result<ChannelListPayload, Error>) -> Void)? = nil
     ) {
         _update_queries.mutate { $0.append(channelListQuery) }

--- a/Sources/StreamChat/Workers/ChannelListUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater_Mock.swift
@@ -7,16 +7,30 @@ import XCTest
 
 /// Mock implementation of ChannelListUpdater
 class ChannelListUpdaterMock: ChannelListUpdater {
+    @Atomic var fetch_channelListQueries: [ChannelListQuery] = []
+    @Atomic var fetch_completions: [(Result<ChannelListPayload, Error>) -> Void] = []
+    
     @Atomic var update_queries: [ChannelListQuery] = []
     @Atomic var update_completion: ((Result<ChannelListPayload, Error>) -> Void)? = nil
     
     @Atomic var markAllRead_completion: ((Error?) -> Void)?
     
     func cleanUp() {
+        fetch_channelListQueries.removeAll()
+        fetch_completions.removeAll()
+        
         update_queries.removeAll()
         update_completion = nil
         
         markAllRead_completion = nil
+    }
+    
+    override func fetch(
+        _ channelListQuery: ChannelListQuery,
+        completion: @escaping (Result<ChannelListPayload, Error>) -> Void
+    ) {
+        _fetch_channelListQueries.mutate { $0.append(channelListQuery) }
+        _fetch_completions.mutate { $0.append(completion) }
     }
     
     override func update(

--- a/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
@@ -159,30 +159,23 @@ extension DatabaseContainer {
             }
             
             if withQuery {
-                let filter: Filter<ChannelListFilterScope> = .equal(.name, to: "luke:skywalker")
-                let queryDTO = NSEntityDescription.insertNewObject(
-                    forEntityName: ChannelListQueryDTO.entityName,
-                    into: session as! NSManagedObjectContext
-                ) as! ChannelListQueryDTO
-                queryDTO.filterHash = filter.filterHash
-                queryDTO.filterJSONData = try JSONEncoder.default.encode(filter)
+                let query = ChannelListQuery(filter: .equal(.cid, to: cid))
+                let queryDTO = session.saveQuery(query: query)
                 dto.queries = [queryDTO]
             }
+        }
+    }
+    
+    func createChannelListQuery(_ query: ChannelListQuery) throws {
+        try writeSynchronously { session in
+            _ = session.saveQuery(query: query)
         }
     }
     
     func createChannelListQuery(
         filter: Filter<ChannelListFilterScope> = .query(.cid, text: .unique)
     ) throws {
-        try writeSynchronously { session in
-            let dto = NSEntityDescription
-                .insertNewObject(
-                    forEntityName: ChannelListQueryDTO.entityName,
-                    into: session as! NSManagedObjectContext
-                ) as! ChannelListQueryDTO
-            dto.filterHash = filter.filterHash
-            dto.filterJSONData = try JSONEncoder.default.encode(filter)
-        }
+        try createChannelListQuery(.init(filter: filter))
     }
     
     func createUserListQuery(filter: Filter<UserListFilterScope> = .query(.id, text: .unique)) throws {

--- a/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
@@ -76,6 +76,8 @@ class DatabaseContainerMock: DatabaseContainer {
         
         try super.recreatePersistentStore()
     }
+    
+    @Atomic var write_called = false
 
     /// `true` if there is currently an active writing session
     @Atomic var isWriteSessionInProgress: Bool = false
@@ -84,6 +86,8 @@ class DatabaseContainerMock: DatabaseContainer {
     @Atomic var writeSessionCounter: Int = 0
     
     override func write(_ actions: @escaping (DatabaseSession) throws -> Void, completion: @escaping (Error?) -> Void) {
+        write_called = true
+        
         let wrappedActions: ((DatabaseSession) throws -> Void) = { session in
             self.isWriteSessionInProgress = true
             try actions(session)

--- a/Sources/StreamChatTestTools/Models/ChatChannel_Mock.swift
+++ b/Sources/StreamChatTestTools/Models/ChatChannel_Mock.swift
@@ -80,7 +80,8 @@ public extension ChatChannel {
         reads: [ChatChannelRead] = [],
         extraData: [String: RawJSON] = [:],
         latestMessages: [ChatMessage] = [],
-        muteDetails: MuteDetails? = nil
+        muteDetails: MuteDetails? = nil,
+        isBeingRead: Bool = false
     ) -> Self {
         self.init(
             cid: cid,
@@ -104,6 +105,7 @@ public extension ChatChannel {
             extraData: extraData,
             latestMessages: { latestMessages },
             muteDetails: { muteDetails },
+            isBeingRead: isBeingRead,
             underlyingContext: nil
         )
     }
@@ -128,7 +130,8 @@ public extension ChatChannel {
         reads: [ChatChannelRead] = [],
         extraData: [String: RawJSON] = [:],
         latestMessages: [ChatMessage] = [],
-        muteDetails: MuteDetails? = nil
+        muteDetails: MuteDetails? = nil,
+        isBeingRead: Bool = false
     ) -> Self {
         self.init(
             cid: .init(type: .messaging, id: "!members" + .newUniqueId),
@@ -151,6 +154,7 @@ public extension ChatChannel {
             extraData: extraData,
             latestMessages: { latestMessages },
             muteDetails: { muteDetails },
+            isBeingRead: isBeingRead,
             underlyingContext: nil
         )
     }
@@ -175,7 +179,8 @@ public extension ChatChannel {
         reads: [ChatChannelRead] = [],
         extraData: [String: RawJSON] = [:],
         latestMessages: [ChatMessage] = [],
-        muteDetails: MuteDetails? = nil
+        muteDetails: MuteDetails? = nil,
+        isBeingRead: Bool = false
     ) -> Self {
         self.init(
             cid: .init(type: .messaging, id: .newUniqueId),
@@ -198,6 +203,7 @@ public extension ChatChannel {
             extraData: extraData,
             latestMessages: { latestMessages },
             muteDetails: { muteDetails },
+            isBeingRead: isBeingRead,
             underlyingContext: nil
         )
     }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -526,6 +526,7 @@
 		843F0BC526775D2D00B342CB /* VideoPreviewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843F0BC426775D2D00B342CB /* VideoPreviewLoader.swift */; };
 		843F0BC72677640000B342CB /* VideoAttachmentGalleryPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843F0BC62677640000B342CB /* VideoAttachmentGalleryPreview.swift */; };
 		843F0BCD2677667000B342CB /* AttachmentActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843F0BCC2677667000B342CB /* AttachmentActionButton.swift */; };
+		8447DA0826EBC6950061F9E0 /* ChannelListQueryDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8447DA0726EBC6950061F9E0 /* ChannelListQueryDTO_Tests.swift */; };
 		847D60292679EDD300FB701D /* GalleryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847D60282679EDD300FB701D /* GalleryCollectionViewCell.swift */; };
 		847D602B2679EED400FB701D /* VideoAttachmentGalleryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847D602A2679EED400FB701D /* VideoAttachmentGalleryCell.swift */; };
 		847D602D2679EF8A00FB701D /* VideoPlaybackControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847D602C2679EF8A00FB701D /* VideoPlaybackControlView.swift */; };
@@ -1931,6 +1932,7 @@
 		843F0BC426775D2D00B342CB /* VideoPreviewLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPreviewLoader.swift; sourceTree = "<group>"; };
 		843F0BC62677640000B342CB /* VideoAttachmentGalleryPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentGalleryPreview.swift; sourceTree = "<group>"; };
 		843F0BCC2677667000B342CB /* AttachmentActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentActionButton.swift; sourceTree = "<group>"; };
+		8447DA0726EBC6950061F9E0 /* ChannelListQueryDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListQueryDTO_Tests.swift; sourceTree = "<group>"; };
 		847D60282679EDD300FB701D /* GalleryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryCollectionViewCell.swift; sourceTree = "<group>"; };
 		847D602A2679EED400FB701D /* VideoAttachmentGalleryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentGalleryCell.swift; sourceTree = "<group>"; };
 		847D602C2679EF8A00FB701D /* VideoPlaybackControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlaybackControlView.swift; sourceTree = "<group>"; };
@@ -2963,6 +2965,7 @@
 				79877A1E2498E50D00015F8B /* ChannelDTO_Tests.swift */,
 				796FD215250654940076C99B /* ChannelReadDTO.swift */,
 				7964F3A3249A0ACF002A09EC /* ChannelListQueryDTO.swift */,
+				8447DA0726EBC6950061F9E0 /* ChannelListQueryDTO_Tests.swift */,
 				7978FBBB26E16295002CA2DF /* MessageSearchQueryDTO.swift */,
 				7991D83A24F5427E00D21BA3 /* EphemeralValuesContainer.swift */,
 				882C575F252C7CC400E60C44 /* ChannelMemberListQueryDTO.swift */,
@@ -6686,6 +6689,7 @@
 				DA7229E424E140600074503A /* ChannelEditDetailPayload_Tests.swift in Sources */,
 				799C9462247D78E2001F1104 /* WaitFor.swift in Sources */,
 				88DA57EA2631E82B00FA8C53 /* MutedChannelPayload_Tests.swift in Sources */,
+				8447DA0826EBC6950061F9E0 /* ChannelListQueryDTO_Tests.swift in Sources */,
 				88AA92882547332000BFA0C3 /* MessageReactionPayload.swift in Sources */,
 				8A0D64A924E57A560017A3C0 /* GuestUserTokenRequestPayload_Tests.swift in Sources */,
 				79280F732487CD3100CDEB89 /* Atomic_Tests.swift in Sources */,


### PR DESCRIPTION
**This PR** fixes the way we sync data when connection comes back.

Connection recovery logic involves 2 steps:
1. calling `/sync` to get the events we've missed
2. re-fetching channel list queries to:
- get new channels
- pick up the latest ordering
- start watching the channels

**Step 1 (/sync)**

In `ConnectionRecoveryUpdater` when `connected` event is observed we call `/sync` endpoint with all locally existed channels and `lastSyncAt` date persisted in database. If `/sync` succeeds we apply the events we've received which makes locally existed channels up-to-date. If `/sync` fails, all locally existed channels are out-of-sync and we should reset it.

**Step 2 (re-fetching queries)**
When we refetch a first page of channels (with `.watch` option) from backend for the given `query`, we unlink all locally existed channels from a query and link only channels we received from backend (the first page). This guarantees the local channel list query matches the remote one. For local channels that were **synced** (on step 1) and returned from API we preserve the message history. If local channel was not synced OR not returned from API, the message history is cleared.

At the same time, we should gracefully handle channels that are being read (`Channel.isBeingRead` is set to `true` when channel is opened, and reset to `false` when it is closed). If a channel that is being read is synced and returned from API, we keep it's local history and make additional query with [`.watch, .presense`] options to start getting all the events. If a channel that is being read was not synced, we query is but then reset the local history (since it can be outdated) and save only message we received from API (the first page of messages).