### PR TITLE
Added ability to handle tap-on-avatar event

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
@@ -24,6 +24,11 @@ public protocol ChatMessageContentViewDelegate: AnyObject {
     /// - Parameter indexPath: The index path of the cell displaying the content view. Equals to `nil` when
     /// the content view is displayed outside the collection/table view.
     func messageContentViewDidTapOnQuotedMessage(_ indexPath: IndexPath?)
+	
+	/// Gets called when avatar view is tapped.
+	/// - Parameter indexPath: The index path of the cell displaying the content view. Equals to `nil` when
+	/// the content view is displayed outside the collection/table view.
+	func messageContentViewDidTapOnAvatarView(_ indexPath: IndexPath?)
 }
 
 /// A view that displays the message content.
@@ -560,6 +565,11 @@ open class ChatMessageContentView: _View, ThemeProvider {
         delegate?.messageContentViewDidTapOnQuotedMessage(indexPath?())
     }
 
+	/// Handles tap on `avatarView` and forwards the action to the delegate.
+	@objc open func handleTapOnAvatarView() {
+		delegate?.messageContentViewDidTapOnAvatarView(indexPath?())
+	}
+	
     // MARK: - Setups
 
     /// Instantiates, configures and assigns `textView` when called for the first time.
@@ -588,6 +598,7 @@ open class ChatMessageContentView: _View, ThemeProvider {
                 .init()
                 .withoutAutoresizingMaskConstraints
         }
+		authorAvatarView?.addTarget(self, action: #selector(handleTapOnAvatarView), for: .touchUpInside)
         return authorAvatarView!
     }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -388,6 +388,14 @@ open class ChatMessageListVC:
                 "Tapped a quoted message. To customize the behavior, override messageContentViewDidTapOnQuotedMessage. Path: \(indexPath)"
             )
     }
+	
+	open func messageContentViewDidTapOnAvatarView(_ indexPath: IndexPath?) {
+		guard let indexPath = indexPath else { return log.error("IndexPath is not available") }
+		log
+			.info(
+				"Tapped an avatarView. To customize the behavior, override messageContentViewDidTapOnAvatarView. Path: \(indexPath)"
+			)
+	}
 
     // MARK: - GalleryContentViewDelegate
 

--- a/Sources/StreamChatUI/CommonViews/AvatarView/ChatAvatarView.swift
+++ b/Sources/StreamChatUI/CommonViews/AvatarView/ChatAvatarView.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 /// A view that displays the avatar image. By default a circular image.
-open class ChatAvatarView: _View {
+open class ChatAvatarView: _Control {
     /// The `UIImageView` instance that shows the avatar image.
     open private(set) var imageView: UIImageView = UIImageView().withoutAutoresizingMaskConstraints
     


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Added `messageContentViewDidTapOnAvatarView` to `ChatMessageContentViewDelegate` which is called when user tap on avatarView on message.