### PR TITLE
[CIS-1174] Fix message list wrong content inset when typing events disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Update `ChatClient` to disconnect immediately when the Internet connection disappears [#1449](https://github.com/GetStream/stream-chat-swift/issues/1449)
 
+### 🐞 Fixed
+- Fix message list wrong content inset when typing events disabled [#1455](https://github.com/GetStream/stream-chat-swift/pull/1455)
+
 # [4.0.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0)
 _September 10, 2021_
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -62,6 +62,11 @@ open class ChatMessageListVC:
     /// The height of the typing indicator view
     open private(set) var typingIndicatorViewHeight: CGFloat = 22
 
+    /// A Boolean value indicating whether the typing events are enabled.
+    open var isTypingEventsEnabled: Bool {
+        dataSource?.channel(for: self)?.config.typingEventsEnabled == true
+    }
+
     /// A button to scroll the collection view to the bottom.
     /// Visible when there is unread message and the collection view is not at the bottom already.
     open private(set) lazy var scrollToLatestMessageButton: ScrollToLatestMessageButton = components
@@ -102,13 +107,13 @@ open class ChatMessageListVC:
 
         view.addSubview(listView)
         listView.pin(anchors: [.top, .leading, .trailing, .bottom], to: view)
-        
-        if dataSource?.channel(for: self)?.config.typingEventsEnabled == true {
+
+        typingIndicatorView.isHidden = true
+        if isTypingEventsEnabled {
             view.addSubview(typingIndicatorView)
             typingIndicatorView.heightAnchor.pin(equalToConstant: typingIndicatorViewHeight).isActive = true
             typingIndicatorView.pin(anchors: [.leading, .trailing], to: view)
             typingIndicatorView.bottomAnchor.pin(equalTo: listView.bottomAnchor).isActive = true
-            typingIndicatorView.isHidden = true
         }
         
         view.addSubview(scrollToLatestMessageButton)
@@ -263,6 +268,8 @@ open class ChatMessageListVC:
     /// Shows typing Indicator.
     /// - Parameter typingUsers: typing users gotten from `channelController`
     open func showTypingIndicator(typingUsers: [ChatUser]) {
+        guard isTypingEventsEnabled else { return }
+
         if typingIndicatorView.isHidden {
             Animate {
                 self.listView.contentInset.top += self.typingIndicatorViewHeight
@@ -287,7 +294,7 @@ open class ChatMessageListVC:
     
     /// Hides typing Indicator.
     open func hideTypingIndicator() {
-        guard typingIndicatorView.isVisible else { return }
+        guard isTypingEventsEnabled, typingIndicatorView.isVisible else { return }
 
         typingIndicatorView.isHidden = true
 


### PR DESCRIPTION
## Description of the pull request
Fixes the message list having a wrong content inset when typing events disabled. 
Also, it makes the implementation a little more robust. 