### PR TITLE
[CIS-1177] Fix typing events always disabled when channel opened without cache from Channel List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix message list wrong content inset when typing events disabled [#1455](https://github.com/GetStream/stream-chat-swift/pull/1455)
 - Fix message list unwanted scrolling when typing indicator shown [#1456](https://github.com/GetStream/stream-chat-swift/pull/1456)
+- Fix typing events always disabled when channel opened without cache from Channel List [#1458](https://github.com/GetStream/stream-chat-swift/pull/1458)
 
 # [4.0.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.0)
 _September 10, 2021_

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -108,13 +108,11 @@ open class ChatMessageListVC:
         view.addSubview(listView)
         listView.pin(anchors: [.top, .leading, .trailing, .bottom], to: view)
 
+        view.addSubview(typingIndicatorView)
         typingIndicatorView.isHidden = true
-        if isTypingEventsEnabled {
-            view.addSubview(typingIndicatorView)
-            typingIndicatorView.heightAnchor.pin(equalToConstant: typingIndicatorViewHeight).isActive = true
-            typingIndicatorView.pin(anchors: [.leading, .trailing], to: view)
-            typingIndicatorView.bottomAnchor.pin(equalTo: listView.bottomAnchor).isActive = true
-        }
+        typingIndicatorView.heightAnchor.pin(equalToConstant: typingIndicatorViewHeight).isActive = true
+        typingIndicatorView.pin(anchors: [.leading, .trailing], to: view)
+        typingIndicatorView.bottomAnchor.pin(equalTo: listView.bottomAnchor).isActive = true
         
         view.addSubview(scrollToLatestMessageButton)
         listView.bottomAnchor.pin(equalToSystemSpacingBelow: scrollToLatestMessageButton.bottomAnchor).isActive = true


### PR DESCRIPTION
## Description of the pull request
When opening a channel without coming from a channel list, the typing events would be disabled even if the config had them enabled. The reason is that the `ChatMessageListVC.setUp` function is called before the `ChatChannelVC` finishing the synchronization, so at that time the channel config, won't be available. 

This fixes the issue by always adding the typing indicator view as a subview in the `setUp` function. And only uses the config when showing the typing indicator, if it is enabled, it sets `isHidden = true` , if not, it remains hidden. 