### PR TITLE
CIS-1172 Do not make a weak ref to self, too easy to get confused

### DIFF
--- a/Sources/StreamChat/APIClient/APIClient_Tests.swift
+++ b/Sources/StreamChat/APIClient/APIClient_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-class APIClient_Tests: StressTestCase {
+class APIClient_Tests: XCTestCase {
     var apiClient: APIClient!
     
     var apiKey: APIKey!

--- a/Sources/StreamChat/APIClient/StreamCDNClient_Tests.swift
+++ b/Sources/StreamChat/APIClient/StreamCDNClient_Tests.swift
@@ -8,7 +8,7 @@ import StreamChat
 import StreamChatTestTools
 import XCTest
 
-class StreamCDNClient_Tests: StressTestCase {
+class StreamCDNClient_Tests: XCTestCase {
     func test_uploadFileEncoderIsCalledWithEndpoint() throws {
         let builder = Builder()
         let client = builder.make()

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-class ChatClient_Tests: StressTestCase {
+class ChatClient_Tests: XCTestCase {
     var userId: UserId!
     private var testEnv: TestEnvironment!
     private var time: VirtualTime!

--- a/Sources/StreamChat/Config/TokenProvider_Tests.swift
+++ b/Sources/StreamChat/Config/TokenProvider_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-final class TokenProvider_Tests: StressTestCase {
+final class TokenProvider_Tests: XCTestCase {
     func test_anonymousProvider_propagatesToken() throws {
         // Get token from `anonymous` provider.
         let token = try waitFor { UserConnectionProvider.anonymous.getToken(.mock, $0) }.get()

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-class ChannelController_Tests: StressTestCase {
+class ChannelController_Tests: XCTestCase {
     fileprivate var env: TestEnvironment!
     
     var client: ChatClient!

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-class ChannelListController_Tests: StressTestCase {
+class ChannelListController_Tests: XCTestCase {
     fileprivate var env: TestEnvironment!
     
     var client: ChatClient!

--- a/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-final class ChatChannelWatcherListController_Tests: StressTestCase {
+final class ChatChannelWatcherListController_Tests: XCTestCase {
     private var env: TestEnvironment!
 
     var query: ChannelWatcherListQuery!

--- a/Sources/StreamChat/Controllers/ConnectionController/ConnectionController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ConnectionController/ConnectionController_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-final class ChatConnectionController_Tests: StressTestCase {
+final class ChatConnectionController_Tests: XCTestCase {
     private var env: TestEnvironment!
     private var client: ChatClient!
     private var controller: ChatConnectionController!

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -103,7 +103,7 @@ public class CurrentChatUserController: DataController, DelegateCallable, DataSt
         // Unlike the other DataControllers, this one does not make a remote call when synchronising.
         // But we can assume that if we wait for the connection of the WebSocket, it means the local data
         // is in sync with the remote server, so we can set the state to remoteDataFetched.
-        client.provideConnectionId { [weak self] connectionId in
+        client.provideConnectionId { connectionId in
             var error: ClientError?
             if connectionId == nil {
                 error = ClientError.ConnectionNotSuccessful()

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -108,8 +108,8 @@ public class CurrentChatUserController: DataController, DelegateCallable, DataSt
             if connectionId == nil {
                 error = ClientError.ConnectionNotSuccessful()
             }
-            self?.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(error!)
-            self?.callback { completion?(error) }
+            self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(error!)
+            self.callback { completion?(error) }
         }
     }
     

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-final class CurrentUserController_Tests: StressTestCase {
+final class CurrentUserController_Tests: XCTestCase {
     private var env: TestEnvironment!
     private var client: ChatClient!
     private var controller: CurrentChatUserController!

--- a/Sources/StreamChat/Controllers/EventsController/ChannelEventsController_Tests.swift
+++ b/Sources/StreamChat/Controllers/EventsController/ChannelEventsController_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-final class ChannelEventsController_Tests: StressTestCase {
+final class ChannelEventsController_Tests: XCTestCase {
     var apiClient: APIClientMock!
     var database: DatabaseContainerMock!
     var notificationCenter: EventNotificationCenterMock!

--- a/Sources/StreamChat/Controllers/EventsController/EventsController_Tests.swift
+++ b/Sources/StreamChat/Controllers/EventsController/EventsController_Tests.swift
@@ -6,7 +6,7 @@
 import StreamChatTestTools
 import XCTest
 
-final class EventsController_Tests: StressTestCase {
+final class EventsController_Tests: XCTestCase {
     var client: ChatClient!
     var controller: EventsController!
     var callbackQueueID: UUID!

--- a/Sources/StreamChat/Controllers/MemberController/MemberController_Tests.swift
+++ b/Sources/StreamChat/Controllers/MemberController/MemberController_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-final class MemberController_Tests: StressTestCase {
+final class MemberController_Tests: XCTestCase {
     fileprivate var env: TestEnvironment!
 
     var userId: UserId!

--- a/Sources/StreamChat/Controllers/MemberListController/MemberListController_Tests.swift
+++ b/Sources/StreamChat/Controllers/MemberListController/MemberListController_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-final class MemberListController_Tests: StressTestCase {
+final class MemberListController_Tests: XCTestCase {
     private var env: TestEnvironment!
     
     var query: ChannelMemberListQuery!

--- a/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-final class MessageController_Tests: StressTestCase {
+final class MessageController_Tests: XCTestCase {
     private var env: TestEnvironment!
     private var client: ChatClient!
     

--- a/Sources/StreamChat/Controllers/SearchControllers/UserSearchController/UserSearchController_Tests.swift
+++ b/Sources/StreamChat/Controllers/SearchControllers/UserSearchController/UserSearchController_Tests.swift
@@ -7,7 +7,7 @@ import Foundation
 @testable import StreamChatTestTools
 import XCTest
 
-class UserSearchController_Tests: StressTestCase {
+class UserSearchController_Tests: XCTestCase {
     fileprivate var env: TestEnvironment!
     
     var client: ChatClient!

--- a/Sources/StreamChat/Controllers/UserController/UserController_Tests.swift
+++ b/Sources/StreamChat/Controllers/UserController/UserController_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-final class UserController_Tests: StressTestCase {
+final class UserController_Tests: XCTestCase {
     fileprivate var env: TestEnvironment!
     
     var userId: UserId!

--- a/Sources/StreamChat/Controllers/UserListController/UserListController_Tests.swift
+++ b/Sources/StreamChat/Controllers/UserListController/UserListController_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-class UserListController_Tests: StressTestCase {
+class UserListController_Tests: XCTestCase {
     fileprivate var env: TestEnvironment!
     
     var client: ChatClient!

--- a/Sources/StreamChat/Database/DataStore_Tests.swift
+++ b/Sources/StreamChat/Database/DataStore_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-class DataStore_Tests: StressTestCase {
+class DataStore_Tests: XCTestCase {
     var _client: ChatClient!
     
     override func setUp() {

--- a/Sources/StreamChat/Database/DatabaseContainer_Tests.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-class DatabaseContainer_Tests: StressTestCase {
+class DatabaseContainer_Tests: XCTestCase {
     func test_databaseContainer_isInitialized_withInMemoryPreset() {
         XCTAssertNoThrow(try DatabaseContainer(kind: .inMemory))
     }

--- a/Sources/StreamChat/Database/DatabaseSession_Tests.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-class DatabaseSession_Tests: StressTestCase {
+class DatabaseSession_Tests: XCTestCase {
     var database: DatabaseContainerMock!
     
     override func setUp() {

--- a/Sources/StreamChat/Utils/Dictionary_Tests.swift
+++ b/Sources/StreamChat/Utils/Dictionary_Tests.swift
@@ -5,7 +5,7 @@
 @testable import StreamChat
 import XCTest
 
-final class Dictionary_Tests: StressTestCase {
+final class Dictionary_Tests: XCTestCase {
     func test_mapKeys() {
         // Declare key transformation closure.
         let keyTransform: (String) -> String = {

--- a/Sources/StreamChat/Utils/LazyCachedMapCollection_Tests.swift
+++ b/Sources/StreamChat/Utils/LazyCachedMapCollection_Tests.swift
@@ -5,7 +5,7 @@
 @testable import StreamChat
 import XCTest
 
-class LazyCachedMapCollection_Tests: StressTestCase {
+class LazyCachedMapCollection_Tests: XCTestCase {
     func test_mapIsLazy() {
         // Arrange: Prepare sequence that records transformations
         var mapped: Set<Int> = []

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-class WebSocketClient_Tests: StressTestCase {
+class WebSocketClient_Tests: XCTestCase {
     struct TestEvent: Event, Equatable {
         let id = UUID()
     }

--- a/Sources/StreamChat/Workers/Background/AttachmentUploader_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/AttachmentUploader_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-final class AttachmentUploader_Tests: StressTestCase {
+final class AttachmentUploader_Tests: XCTestCase {
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!
     var database: DatabaseContainerMock!

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-final class ConnectionRecoveryUpdater_Tests: StressTestCase {
+final class ConnectionRecoveryUpdater_Tests: XCTestCase {
     var database: DatabaseContainerMock!
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-final class DatabaseCleanupUpdater_Tests: StressTestCase {
+final class DatabaseCleanupUpdater_Tests: XCTestCase {
     var database: DatabaseContainerMock!
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!

--- a/Sources/StreamChat/Workers/Background/MessageEditor_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/MessageEditor_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-final class MessageEditor_Tests: StressTestCase {
+final class MessageEditor_Tests: XCTestCase {
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!
     var database: DatabaseContainerMock!

--- a/Sources/StreamChat/Workers/Background/MessageSender_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/MessageSender_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-class MessageSender_Tests: StressTestCase {
+class MessageSender_Tests: XCTestCase {
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!
     var database: DatabaseContainerMock!

--- a/Sources/StreamChat/Workers/Background/NewUserQueryUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/NewUserQueryUpdater_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-class NewUserQueryUpdater_Tests: StressTestCase {
+class NewUserQueryUpdater_Tests: XCTestCase {
     private var env: TestEnvironment!
     
     var database: DatabaseContainerMock!

--- a/Sources/StreamChat/Workers/ChannelListUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-class ChannelListUpdater_Tests: StressTestCase {
+class ChannelListUpdater_Tests: XCTestCase {
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!
     var database: DatabaseContainer!

--- a/Sources/StreamChat/Workers/ChannelMemberListUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelMemberListUpdater_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-final class ChannelMemberListUpdater_Tests: StressTestCase {
+final class ChannelMemberListUpdater_Tests: XCTestCase {
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!
     var database: DatabaseContainerMock!

--- a/Sources/StreamChat/Workers/ChannelMemberUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelMemberUpdater_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-final class ChannelMemberUpdater_Tests: StressTestCase {
+final class ChannelMemberUpdater_Tests: XCTestCase {
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!
     var database: DatabaseContainerMock!

--- a/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-class ChannelUpdater_Tests: StressTestCase {
+class ChannelUpdater_Tests: XCTestCase {
     var apiClient: APIClientMock!
     var database: DatabaseContainerMock!
     

--- a/Sources/StreamChat/Workers/ChatClientUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-final class ChatClientUpdater_Tests_Tests: StressTestCase {
+final class ChatClientUpdater_Tests_Tests: XCTestCase {
     // MARK: Disconnect
 
     func test_disconnect_doesNothing_ifClientIsPassive() {

--- a/Sources/StreamChat/Workers/CurrentUserUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/CurrentUserUpdater_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-final class CurrentUserUpdater_Tests: StressTestCase {
+final class CurrentUserUpdater_Tests: XCTestCase {
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!
     var database: DatabaseContainerMock!

--- a/Sources/StreamChat/Workers/EventSender_Tests.swift
+++ b/Sources/StreamChat/Workers/EventSender_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-final class EventSender_Tests: StressTestCase {
+final class EventSender_Tests: XCTestCase {
     var apiClient: APIClientMock!
     var database: DatabaseContainer!
     var sender: EventSender!

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-final class MessageUpdater_Tests: StressTestCase {
+final class MessageUpdater_Tests: XCTestCase {
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!
     var database: DatabaseContainerMock!

--- a/Sources/StreamChat/Workers/TypingEventSender_Tests.swift
+++ b/Sources/StreamChat/Workers/TypingEventSender_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-class TypingEventsSender_Tests: StressTestCase {
+class TypingEventsSender_Tests: XCTestCase {
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!
     var database: DatabaseContainerMock!

--- a/Sources/StreamChat/Workers/UserListUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/UserListUpdater_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-class UserListUpdater_Tests: StressTestCase {
+class UserListUpdater_Tests: XCTestCase {
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!
     var database: DatabaseContainer!

--- a/Sources/StreamChat/Workers/UserUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/UserUpdater_Tests.swift
@@ -6,7 +6,7 @@
 @testable import StreamChatTestTools
 import XCTest
 
-final class UserUpdater_Tests: StressTestCase {
+final class UserUpdater_Tests: XCTestCase {
     var webSocketClient: WebSocketClientMock!
     var apiClient: APIClientMock!
     var database: DatabaseContainerMock!


### PR DESCRIPTION
Removes the `weak self` to avoid issues like these: https://github.com/GetStream/stream-chat-swift/issues/1447