### PR TITLE
[CIS-1184] Fix keyboard handling when navigation bar is not translucent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🐞 Fixed
-- Fix token expiration refresh mechanism for API endpoints
+- Fix token expiration refresh mechanism for API endpoints [#1446](https://github.com/GetStream/stream-chat-swift/pull/1446)
+- Fix keyboard handling when navigation bar is not translucent [#1464](https://github.com/GetStream/stream-chat-swift/pull/1464)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChatUI/Composer/ComposerKeyboardHandler.swift
+++ b/Sources/StreamChatUI/Composer/ComposerKeyboardHandler.swift
@@ -18,6 +18,8 @@ open class ComposerKeyboardHandler: KeyboardHandler {
     public weak var composerParentVC: UIViewController?
     public weak var composerBottomConstraint: NSLayoutConstraint?
 
+    public let originalBottomConstraintValue: CGFloat
+
     /// The component for handling keyboard events and adjust the composer.
     /// - Parameters:
     ///   - composerParentVC: The parent view controller of the composer.
@@ -28,13 +30,21 @@ open class ComposerKeyboardHandler: KeyboardHandler {
     ) {
         self.composerParentVC = composerParentVC
         self.composerBottomConstraint = composerBottomConstraint
+        originalBottomConstraintValue = composerBottomConstraint?.constant ?? 0
     }
 
     open func start() {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(keyboardWillChangeFrame),
-            name: UIResponder.keyboardWillChangeFrameNotification,
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillChangeFrame),
+            name: UIResponder.keyboardWillShowNotification,
             object: nil
         )
     }
@@ -53,11 +63,17 @@ open class ComposerKeyboardHandler: KeyboardHandler {
             return
         }
 
-        let convertedKeyboardFrame = composerParentView.convert(frame, from: UIScreen.main.coordinateSpace)
+        // When hiding, we reset the bottom constraint to the original value
+        // When showing, we set the bottom constraint equal to the keyboard height + original value
+        // The value is actually negative, so that the composer view goes up
 
-        let intersectedKeyboardHeight = composerParentView.frame.intersection(convertedKeyboardFrame).height
-
-        composerBottomConstraint?.constant = -intersectedKeyboardHeight
+        if notification.name == UIResponder.keyboardWillHideNotification {
+            composerBottomConstraint?.constant = originalBottomConstraintValue
+        } else {
+            let convertedKeyboardFrame = composerParentView.convert(frame, from: UIScreen.main.coordinateSpace)
+            let intersectedKeyboardHeight = composerParentView.frame.intersection(convertedKeyboardFrame).height
+            composerBottomConstraint?.constant = -(intersectedKeyboardHeight + originalBottomConstraintValue)
+        }
 
         UIView.animate(
             withDuration: duration,


### PR DESCRIPTION
## Description of the pull request

### Problem
For applications that are using `navigationController.navigationBar.isTranslucent = false` the keyboard handling wasn't working correctly. The reason being is that the keyboard height is not reported with the same value for when the keyboard is being dismissed, and this caused the composer view to have an extra space when hiding.

### Solution
The proposed solution is much more robust and also more flexible. If previously the customer changed the bottom constraint value, it wouldn't work anyway, because we always assumed that value was 0, so the constraint would increase and decrease only accounting for the keyboard height, which is not correct. The correct approach is to distinguish when the keyboard is hiding or showing, and if it is hiding, we reset it with the original value, if it is showing, we decrease the bottom constraint with the original value plus the keyboard height.