### PR TITLE
Fix ChannelListController_Tests failing

### DIFF
--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -24,12 +24,8 @@ class ChannelListController_Tests: StressTestCase {
     override func setUp() {
         super.setUp()
         
-        setUp(isLocalStorageEnabled: true)
-    }
-    
-    private func setUp(isLocalStorageEnabled: Bool) {
         env = TestEnvironment()
-        client = ChatClient.mock(isLocalStorageEnabled: isLocalStorageEnabled)
+        client = ChatClient.mock(isLocalStorageEnabled: false)
         query = .init(filter: .in(.members, values: [.unique]))
         controller = ChatChannelListController(query: query, client: client, environment: env.environment)
         controllerCallbackQueueID = UUID()
@@ -169,8 +165,6 @@ class ChannelListController_Tests: StressTestCase {
     }
     
     func test_synchronize_callsChannelQueryUpdater_inOfflineMode() {
-        setUp(isLocalStorageEnabled: false)
-        
         let queueId = UUID()
         controller.callbackQueue = .testQueue(withId: queueId)
         


### PR DESCRIPTION
This is due to ChannelListController_Tests using ChatClientMock (and DatabaseContainerMock) and using onDisk caching. DatabaseContainerMock removed the DB file before the operations on it were not complete, and that caused undefined behavior. Switching to in-memory storage is safe.

#skip_changelog