### PR TITLE
Local notifications support (showcase for CIS-1081)

### DIFF
--- a/DemoApp/ChatPresenter.swift
+++ b/DemoApp/ChatPresenter.swift
@@ -195,22 +195,48 @@ class DemoChatChannelListRouter: ChatChannelListRouter {
     }
 }
 
-class DemoChannelListVC: ChatChannelListVC {
+class DemoChannelListVC: ChatChannelListVC, EventsControllerDelegate {
     /// The `UIButton` instance used for navigating to new channel screen creation,
     lazy var createChannelButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(named: "pencil")!, for: .normal)
         return button
     }()
+    
+    lazy var eventsController: EventsController = controller.client.eventsController()
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: createChannelButton)
         createChannelButton.addTarget(self, action: #selector(didTapCreateNewChannel), for: .touchUpInside)
+        
+        eventsController.delegate = self
     }
 
     @objc open func didTapCreateNewChannel(_ sender: Any) {
         (router as! DemoChatChannelListRouter).showCreateNewChannelFlow()
+    }
+    
+    func eventsController(_ controller: EventsController, didReceiveEvent event: Event) {
+        guard let event = event as? MessageNewEvent else { return }
+        
+        let message = event.message
+        
+        let content = UNMutableNotificationContent()
+        content.title = "\(message.author.name ?? message.author.id) @ \(event.channel.name ?? event.channel.cid.id)"
+        content.body = message.text
+        
+        let request = UNNotificationRequest(
+            identifier: message.id,
+            content: content,
+            trigger: nil
+        )
+        
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                log.error("Error when showing local notification: \(error)")
+            }
+        }
     }
 }

--- a/DemoApp/DemoAppCoordinator.swift
+++ b/DemoApp/DemoAppCoordinator.swift
@@ -27,6 +27,14 @@ final class DemoAppCoordinator: NSObject, UNUserNotificationCenterDelegate {
     
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .badge, .sound, .list])
+    }
+    
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {

--- a/DemoApp/LoginViewController.swift
+++ b/DemoApp/LoginViewController.swift
@@ -60,6 +60,16 @@ class LoginViewController: UIViewController {
             tableView.deselectRow(at: selectedRow, animated: true)
         }
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _, error in
+            if let error = error {
+                log.error("Error when enabling notifications: \(error)")
+            }
+        }
+    }
 }
 
 extension LoginViewController: UITableViewDelegate, UITableViewDataSource {


### PR DESCRIPTION
**This PR** is a showcase for #1459. It updates channel list to listen to `MessageNewEvent` event and show local notification with data from exposed models (`event.message` & `event.channel`).