### PR TITLE
Make attachment payloads `Hashable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix keyboard handling when navigation bar or tab bar are not translucent [#1470](https://github.com/GetStream/stream-chat-swift/pull/1470) [#1464](https://github.com/GetStream/stream-chat-swift/pull/1464)
 
 ### 🔄 Changed
+- Attachments types are now `Hashable` [1469](https://github.com/GetStream/stream-chat-swift/pull/1469/files)
 
 # [4.0.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.1)
 _September 17, 2021_

--- a/Sources/StreamChat/Models/Attachments/ChatMessageAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageAttachment.swift
@@ -33,9 +33,10 @@ public extension ChatMessageAttachment {
 }
 
 extension ChatMessageAttachment: Equatable where Payload: Equatable {}
+extension ChatMessageAttachment: Hashable where Payload: Hashable {}
 
 /// A type representing the uploading state for attachments that require prior uploading.
-public struct AttachmentUploadingState: Equatable {
+public struct AttachmentUploadingState: Hashable {
     /// The local file URL that is being uploaded.
     public let localFileURL: URL
 

--- a/Sources/StreamChat/Models/Attachments/ChatMessageAudioAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageAudioAttachment.swift
@@ -35,7 +35,7 @@ public struct AudioAttachmentPayload: AttachmentPayload {
     }
 }
 
-extension AudioAttachmentPayload: Equatable {}
+extension AudioAttachmentPayload: Hashable {}
 
 // MARK: - Encodable
 

--- a/Sources/StreamChat/Models/Attachments/ChatMessageFileAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageFileAttachment.swift
@@ -35,7 +35,7 @@ public struct FileAttachmentPayload: AttachmentPayload {
     }
 }
 
-extension FileAttachmentPayload: Equatable {}
+extension FileAttachmentPayload: Hashable {}
 
 // MARK: - Encodable
 

--- a/Sources/StreamChat/Models/Attachments/ChatMessageGiphyAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageGiphyAttachment.swift
@@ -23,7 +23,7 @@ public struct GiphyAttachmentPayload: AttachmentPayload {
     public var actions: [AttachmentAction]
 }
 
-extension GiphyAttachmentPayload: Equatable {}
+extension GiphyAttachmentPayload: Hashable {}
 
 // MARK: - Encodable
 

--- a/Sources/StreamChat/Models/Attachments/ChatMessageImageAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageImageAttachment.swift
@@ -35,7 +35,7 @@ public struct ImageAttachmentPayload: AttachmentPayload {
     }
 }
 
-extension ImageAttachmentPayload: Equatable {}
+extension ImageAttachmentPayload: Hashable {}
 
 // MARK: - Encodable
 

--- a/Sources/StreamChat/Models/Attachments/ChatMessageLinkAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageLinkAttachment.swift
@@ -32,7 +32,7 @@ public struct LinkAttachmentPayload: AttachmentPayload {
     public var previewURL: URL?
 }
 
-extension LinkAttachmentPayload: Equatable {}
+extension LinkAttachmentPayload: Hashable {}
 
 // MARK: - Encodable
 

--- a/Sources/StreamChat/Models/Attachments/ChatMessageVideoAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageVideoAttachment.swift
@@ -35,7 +35,7 @@ public struct VideoAttachmentPayload: AttachmentPayload {
     }
 }
 
-extension VideoAttachmentPayload: Equatable {}
+extension VideoAttachmentPayload: Hashable {}
 
 // MARK: - Encodable
 


### PR DESCRIPTION
**This PR** makes built-it attachment payloads (and attachments with such payloads) `Hashable`