### PR TITLE
[CIS-1184] Fix composer keyboard handler when tabBar not translucent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix token expiration refresh mechanism for API endpoints [#1446](https://github.com/GetStream/stream-chat-swift/pull/1446)
-- Fix keyboard handling when navigation bar is not translucent [#1464](https://github.com/GetStream/stream-chat-swift/pull/1464)
+- Fix keyboard handling when navigation bar or tab bar are not translucent [#1470](https://github.com/GetStream/stream-chat-swift/pull/1470) [#1464](https://github.com/GetStream/stream-chat-swift/pull/1464)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChatUI/Composer/ComposerKeyboardHandler.swift
+++ b/Sources/StreamChatUI/Composer/ComposerKeyboardHandler.swift
@@ -59,7 +59,8 @@ open class ComposerKeyboardHandler: KeyboardHandler {
               let frame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
               let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
               let curve = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt,
-              let composerParentView = composerParentVC?.view else {
+              let composerParentView = composerParentVC?.view,
+              let rootView = composerParentView.window?.rootViewController?.view else {
             return
         }
 
@@ -70,7 +71,7 @@ open class ComposerKeyboardHandler: KeyboardHandler {
         if notification.name == UIResponder.keyboardWillHideNotification {
             composerBottomConstraint?.constant = originalBottomConstraintValue
         } else {
-            let convertedKeyboardFrame = composerParentView.convert(frame, from: UIScreen.main.coordinateSpace)
+            let convertedKeyboardFrame = rootView.convert(frame, from: UIScreen.main.coordinateSpace)
             let intersectedKeyboardHeight = composerParentView.frame.intersection(convertedKeyboardFrame).height
             composerBottomConstraint?.constant = -(intersectedKeyboardHeight + originalBottomConstraintValue)
         }


### PR DESCRIPTION
## Description of the pull request
When the tabBar is not translucent the keyboard handling was not working properly because it changes the coordinate space of the composer view by adding the tabBar height to the origin of the composer view. For this to work in any case, what we need is to get the root view of the app which has all the info about tab bar's and nav bars when converting the keyboard frame to the current coordinate space. 