### PR TITLE
[CIS-1187] Fix channel list showing `currentUser.mutedChannels` initially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix token expiration refresh mechanism for API endpoints [#1446](https://github.com/GetStream/stream-chat-swift/pull/1446)
 - Fix keyboard handling when navigation bar or tab bar are not translucent [#1470](https://github.com/GetStream/stream-chat-swift/pull/1470) [#1464](https://github.com/GetStream/stream-chat-swift/pull/1464)
+- Fix `ChatChannelListVC` showing channels muted by the current user when default `shouldAddNewChannelToList/shouldListUpdatedChannel` delegate method implementations are used [#1476](https://github.com/GetStream/stream-chat-swift/pull/1476)
 
 ### 🔄 Changed
 - Attachments types are now `Hashable` [1469](https://github.com/GetStream/stream-chat-swift/pull/1469/files)

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -167,6 +167,10 @@ protocol ChannelDatabaseSession {
         query: ChannelListQuery?
     ) throws -> ChannelDTO
     
+    /// Loads channel list query with the given filter hash from the database.
+    /// - Parameter filterHash: The filter hash.
+    func channelListQuery(filterHash: String) -> ChannelListQueryDTO?
+    
     @discardableResult func saveQuery(query: ChannelListQuery) -> ChannelListQueryDTO
     
     /// Fetches `ChannelDTO` with the given `cid` from the database.

--- a/Sources/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Mock.swift
@@ -174,6 +174,10 @@ extension DatabaseSessionMock {
         underlyingSession.saveQuery(query: query)
     }
     
+    func channelListQuery(filterHash: String) -> ChannelListQueryDTO? {
+        underlyingSession.channelListQuery(filterHash: filterHash)
+    }
+    
     func saveChannel(
         payload: ChannelPayload,
         query: ChannelListQuery?


### PR DESCRIPTION
This **PR** fixes the bug when all updated/inserted channels are added to the channel list before the underlaying query is synced. The fix updates `ChannelListController` to handle unlinked channels only when the `controller.synchronize` is successfully completed.