### PR TITLE
Fix date formatter for decoder thread-safety

### DIFF
--- a/Sources/StreamChat/APIClient/RequestDecoder_Tests.swift
+++ b/Sources/StreamChat/APIClient/RequestDecoder_Tests.swift
@@ -62,6 +62,24 @@ class RequestDecoder_Tests: XCTestCase {
             XCTAssert(error is ClientError.ExpiredToken)
         }
     }
+
+    func test_decodingDateThreadSafe() throws {
+        struct TestModel: Decodable {
+            let date: Date
+        }
+
+        let json = "{\"date\": \"2021-05-13T22:10:31.960878Z\"}"
+
+        DispatchQueue.concurrentPerform(iterations: 1000) { _ in
+            if let data = json.data(using: .utf8) {
+                do {
+                    _ = try JSONDecoder.stream.decode(TestModel.self, from: data)
+                } catch {
+                    XCTFail("\(error)")
+                }
+            }
+        }
+    }
 }
 
 private struct TestUser: Codable, Equatable {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
The global static date formatter, `JSONDecoder.default` and `JSONDecoder.stream`, are reused and the `dateFormatter` property is updated from multiple threads. This causes the JSON decoding to randomly fail:

```
An error occured while fetching the channel list | Error: dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "channels", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "messages", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0), MessagePayloadsCodingKeys(stringValue: "user", intValue: nil), UserPayloadsCodingKeys(stringValue: "last_active", intValue: nil)], debugDescription: "Invalid date: 2021-09-28T08:17:18.030196604Z", underlyingError: nil)) | Context: ["app_state": "active"]
```

This fix separates each `DateFormatter` as its own static instance so the mutable properties aren't changed on the fly. See the included test fail without this fix and after.