### PR TITLE
Fixing unit tests for using closure in Xcode 13

### DIFF
--- a/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
@@ -151,7 +151,9 @@ class MessageDTO_Tests: XCTestCase {
             Assert.willBeEqual(messagePayload.extraData, loadedMessage.map {
                 try? JSONDecoder.default.decode([String: RawJSON].self, from: $0.extraData)
             })
-            Assert.willBeEqual(messagePayload.reactionScores, loadedMessage?.reactionScores.mapKeys(MessageReactionType.init))
+            Assert.willBeEqual(messagePayload.reactionScores, loadedMessage?.reactionScores.mapKeys { reaction in
+                MessageReactionType(rawValue: reaction)
+            })
             Assert.willBeEqual(loadedMessage?.reactions, loadedReactions)
             Assert.willBeEqual(messagePayload.isSilent, loadedMessage?.isSilent)
             Assert.willBeEqual(
@@ -233,7 +235,9 @@ class MessageDTO_Tests: XCTestCase {
             Assert.willBeEqual(messagePayload.extraData, loadedMessage.map {
                 try? JSONDecoder.default.decode([String: RawJSON].self, from: $0.extraData)
             })
-            Assert.willBeEqual(messagePayload.reactionScores, loadedMessage?.reactionScores.mapKeys(MessageReactionType.init))
+            Assert.willBeEqual(messagePayload.reactionScores, loadedMessage?.reactionScores.mapKeys { reaction in
+                MessageReactionType(rawValue: reaction)
+            })
             Assert.willBeEqual(loadedMessage?.reactions, loadedReactions)
             Assert.willBeEqual(messagePayload.isSilent, loadedMessage?.isSilent)
             Assert.willBeEqual(


### PR DESCRIPTION
This PR will set the image key name to `image` for the User object.