### PR TITLE
Make `messageComposerBottomConstraint` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Dynamic height for the composer attachment previews [#1480](https://github.com/GetStream/stream-chat-swift/pull/1480)
 - Fix `shouldAddNewChannelToList` and `shouldListUpdatedChannel` delegate funcs are not overridable in ChannelListVC subclasses [#1497](https://github.com/GetStream/stream-chat-swift/issues/1497)
+- Make messageComposerBottomConstraint public [#1501](https://github.com/GetStream/stream-chat-swift/pull/1501)
 
 # [4.0.2](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.2)
 _September 24, 2021_

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -55,7 +55,7 @@ open class ChatChannelVC:
         .channelAvatarView.init()
         .withoutAutoresizingMaskConstraints
 
-    private var messageComposerBottomConstraint: NSLayoutConstraint?
+    public var messageComposerBottomConstraint: NSLayoutConstraint?
 
     @Atomic private var loadingPreviousMessages: Bool = false
 

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -48,7 +48,7 @@ open class ChatThreadVC:
         .threadHeaderView.init()
         .withoutAutoresizingMaskConstraints
 
-    private var messageComposerBottomConstraint: NSLayoutConstraint?
+    public var messageComposerBottomConstraint: NSLayoutConstraint?
 
     @Atomic private var loadingPreviousMessages: Bool = false
 


### PR DESCRIPTION
## Description of the pull request
Some customers require this property to be public and it doesn't make sense to make it private anyways. 