### PR TITLE
Fix Injection of the component videoAttachmentGalleryCell to GalleryVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### 🐞 Fixed
+- Fix Injection of the component `videoAttachmentGalleryCell` to `GalleryVC`, so customers will be able to use their subclass.
+
 ### 🔄 Changed
 
 # [4.0.3](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.3)

--- a/Sources/StreamChatUI/Gallery/GalleryVC.swift
+++ b/Sources/StreamChatUI/Gallery/GalleryVC.swift
@@ -157,8 +157,8 @@ open class GalleryVC:
             forCellWithReuseIdentifier: ImageAttachmentGalleryCell.reuseId
         )
         attachmentsCollectionView.register(
-            VideoAttachmentGalleryCell.self,
-            forCellWithReuseIdentifier: VideoAttachmentGalleryCell.reuseId
+            components.videoAttachmentGalleryCell.self,
+            forCellWithReuseIdentifier: components.videoAttachmentGalleryCell.reuseId
         )
         attachmentsCollectionView.contentInsetAdjustmentBehavior = .never
         attachmentsCollectionView.isPagingEnabled = true
@@ -415,7 +415,7 @@ open class GalleryVC:
         case .image:
             return ImageAttachmentGalleryCell.reuseId
         case .video:
-            return VideoAttachmentGalleryCell.reuseId
+            return components.videoAttachmentGalleryCell.reuseId
         default:
             return nil
         }


### PR DESCRIPTION


# Submit a pull request

## CLA

- [X ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)
I could not find any current test for the video in the project, but I tested this with my own application and it worked as expected, and also I executed the GalleryVCTest and it passed.

## Description of the pull request
After creating a subclass of VideoAttachmentGalleryCell and testing with my app, I realize that my code was not executing so I looked at the GalleryVC to make sure the cell was registering correctly my subclass, and then I found out that the collection view was registering the VideoAttachmentGalleryCell class instead of injecting from the components, so this PR fixes that issue allowing users to inject their own subclass.