### PR TITLE
Fix keyboard over composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix keyboard showing over composer [#1506](https://github.com/GetStream/stream-chat-swift/pull/1506)
 
 # [4.0.3](https://github.com/GetStream/stream-chat-swift/releases/tag/4.0.3)
 _October 01, 2021_

--- a/Sources/StreamChatUI/Composer/ComposerKeyboardHandler.swift
+++ b/Sources/StreamChatUI/Composer/ComposerKeyboardHandler.swift
@@ -67,12 +67,20 @@ open class ComposerKeyboardHandler: KeyboardHandler {
         // When showing, we set the bottom constraint equal to the keyboard height + original value
         // The value is actually negative, so that the composer view goes up
 
-        if notification.name == UIResponder.keyboardWillHideNotification {
+        let isHidingKeyboard = notification.name == UIResponder.keyboardWillHideNotification
+        if isHidingKeyboard {
             composerBottomConstraint?.constant = originalBottomConstraintValue
         } else {
             let convertedKeyboardFrame = composerParentView.convert(frame, from: UIScreen.main.coordinateSpace)
             let intersectedKeyboardHeight = composerParentView.frame.intersection(convertedKeyboardFrame).height
-            composerBottomConstraint?.constant = -(intersectedKeyboardHeight + originalBottomConstraintValue)
+
+            let rootTabBar = composerParentView.window?.rootViewController?.tabBarController?.tabBar
+            let shouldAddTabBarHeight = rootTabBar != nil && rootTabBar!.isTranslucent == false
+            let rootTabBarHeight = shouldAddTabBarHeight ? rootTabBar!.frame.height : 0
+
+            composerBottomConstraint?.constant = -(
+                intersectedKeyboardHeight + originalBottomConstraintValue + rootTabBarHeight
+            )
         }
 
         UIView.animate(

--- a/Sources/StreamChatUI/Composer/ComposerKeyboardHandler.swift
+++ b/Sources/StreamChatUI/Composer/ComposerKeyboardHandler.swift
@@ -59,8 +59,7 @@ open class ComposerKeyboardHandler: KeyboardHandler {
               let frame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
               let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
               let curve = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt,
-              let composerParentView = composerParentVC?.view,
-              let rootView = composerParentView.window?.rootViewController?.view else {
+              let composerParentView = composerParentVC?.view else {
             return
         }
 
@@ -71,7 +70,7 @@ open class ComposerKeyboardHandler: KeyboardHandler {
         if notification.name == UIResponder.keyboardWillHideNotification {
             composerBottomConstraint?.constant = originalBottomConstraintValue
         } else {
-            let convertedKeyboardFrame = rootView.convert(frame, from: UIScreen.main.coordinateSpace)
+            let convertedKeyboardFrame = composerParentView.convert(frame, from: UIScreen.main.coordinateSpace)
             let intersectedKeyboardHeight = composerParentView.frame.intersection(convertedKeyboardFrame).height
             composerBottomConstraint?.constant = -(intersectedKeyboardHeight + originalBottomConstraintValue)
         }


### PR DESCRIPTION
## Description of the pull request
- Fixes keyboard going over the composer input
- Adds debug options to QA the different keyboard handling scenarios

Related issue: https://github.com/GetStream/stream-chat-swift/issues/1494

### Test Plan 1
- Slide a channel from the channel list to the left and tap on "..."
- Select "Change Nav Bar Translucency"
- Chose "Not Translucent"
- Tap on "..." again
- Select "Change channel presentation style"
- Chose "Embedded in Tab Bar"
- Tap on the channel to present it
- Tap on the composer
- Keyboard should not go over the composer

### Test Plan 2
- Slide a channel from the channel list to the left and tap on "..."
- Select "Change channel presentation style"
- Chose "Modally"
- Tap on the channel to present it
- Tap on the composer
- Keyboard should not go over the composer

### Test Plan Results

#### Test Plan 1
https://user-images.githubusercontent.com/12814114/135936689-6b3b49e7-f396-4a15-b792-d75149861930.mp4

#### Test Plan 2
https://user-images.githubusercontent.com/12814114/135936681-0b7731b1-3164-4d29-8a02-aa986ddc9823.mp4


