### PR TITLE
Take video and image cell types from components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Safely unwrap images to prevent crashes on images from bundle [#1502](https://github.com/GetStream/stream-chat-swift/pull/1502)
+- Take `VideoAttachmentGalleryCell` and `ImageAttachmentGalleryCell` types used in `GalleryVC` from `Components` [#1509](https://github.com/GetStream/stream-chat-swift/pull/1509)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -165,6 +165,9 @@ public struct Components {
     /// The view that shows an image attachment preview inside message cell.
     public var imageAttachmentGalleryPreview: ChatMessageGalleryView.ImagePreview.Type = ChatMessageGalleryView.ImagePreview.self
     
+    /// The view that shows an image attachment in full-screen gallery.
+    public var imageAttachmentGalleryCell: ImageAttachmentGalleryCell.Type = ImageAttachmentGalleryCell.self
+    
     /// The view that shows a video attachment in full-screen gallery.
     public var videoAttachmentGalleryCell: VideoAttachmentGalleryCell.Type = VideoAttachmentGalleryCell.self
     

--- a/Sources/StreamChatUI/Gallery/GalleryVC.swift
+++ b/Sources/StreamChatUI/Gallery/GalleryVC.swift
@@ -153,12 +153,12 @@ open class GalleryVC:
         attachmentsFlowLayout.minimumLineSpacing = 0
                 
         attachmentsCollectionView.register(
-            ImageAttachmentGalleryCell.self,
-            forCellWithReuseIdentifier: ImageAttachmentGalleryCell.reuseId
+            components.imageAttachmentGalleryCell.self,
+            forCellWithReuseIdentifier: components.imageAttachmentGalleryCell.reuseId
         )
         attachmentsCollectionView.register(
-            VideoAttachmentGalleryCell.self,
-            forCellWithReuseIdentifier: VideoAttachmentGalleryCell.reuseId
+            components.videoAttachmentGalleryCell.self,
+            forCellWithReuseIdentifier: components.videoAttachmentGalleryCell.reuseId
         )
         attachmentsCollectionView.contentInsetAdjustmentBehavior = .never
         attachmentsCollectionView.isPagingEnabled = true
@@ -413,9 +413,9 @@ open class GalleryVC:
         
         switch item.type {
         case .image:
-            return ImageAttachmentGalleryCell.reuseId
+            return components.imageAttachmentGalleryCell.reuseId
         case .video:
-            return VideoAttachmentGalleryCell.reuseId
+            return components.videoAttachmentGalleryCell.reuseId
         default:
             return nil
         }

--- a/Sources/StreamChatUI/Gallery/GalleryVC_Tests.swift
+++ b/Sources/StreamChatUI/Gallery/GalleryVC_Tests.swift
@@ -15,33 +15,20 @@ final class GalleryVC_Tests: XCTestCase {
         super.setUp()
         
         content = .init(
-            message: .mock(
-                id: .unique,
-                cid: .unique,
-                text: "",
-                author: .mock(
+            message: makeMessage(with: [
+                ChatMessageImageAttachment.mock(
                     id: .unique,
-                    name: "Author"
-                ),
-                createdAt: Date(timeIntervalSinceReferenceDate: 0),
-                attachments: [
-                    ChatMessageImageAttachment.mock(
-                        id: .unique,
-                        imageURL: TestImages.yoda.url
-                    ).asAnyAttachment,
-                    ChatMessageImageAttachment.mock(
-                        id: .unique,
-                        imageURL: TestImages.chewbacca.url
-                    ).asAnyAttachment
-                ]
-            ),
+                    imageURL: TestImages.yoda.url
+                ).asAnyAttachment,
+                ChatMessageImageAttachment.mock(
+                    id: .unique,
+                    imageURL: TestImages.chewbacca.url
+                ).asAnyAttachment
+            ]),
             currentPage: 0
         )
         
-        vc = GalleryVC()
-        vc.components = .mock
-        vc.content = content
-        vc.attachmentsCollectionView.reloadData()
+        vc = makeGalleryVC(content: content)
     }
     
     override func tearDown() {
@@ -53,6 +40,66 @@ final class GalleryVC_Tests: XCTestCase {
     
     func test_defaultAppearance() {
         AssertSnapshot(vc)
+    }
+    
+    func test_customImageAttachmentCellInjection() {
+        // Declare custom image cell type
+        class Cell: ImageAttachmentGalleryCell {}
+        
+        // Create components and inject custom image cell
+        var components = Components.mock
+        components.imageAttachmentGalleryCell = Cell.self
+        
+        // Make a gallery controller with custom components injected
+        let vc = makeGalleryVC(content: content, components: components)
+        vc.viewDidLoad()
+        
+        // Get the cell
+        let cell = vc.collectionView(vc.attachmentsCollectionView, cellForItemAt: .init(item: 0, section: 0))
+        
+        // Assert cell is of custom type
+        XCTAssertTrue(cell is Cell)
+    }
+    
+    func test_customVideoAttachmentCellInjection() {
+        // Declare custom video cell type
+        class Cell: VideoAttachmentGalleryCell {}
+        
+        // Create components and inject custom video cell
+        var components = Components.mock
+        components.videoAttachmentGalleryCell = Cell.self
+        
+        // Create video attachment
+        let videoAttachment = ChatMessageVideoAttachment(
+            id: .unique,
+            type: .video,
+            payload: .init(
+                title: .unique,
+                videoRemoteURL: TestImages.chewbacca.url,
+                file: try! .init(url: TestImages.chewbacca.url),
+                extraData: nil
+            ),
+            uploadingState: nil
+        )
+
+        // Make a gallery controller with custom components injected
+        let vc = makeGalleryVC(
+            content: .init(
+                message: makeMessage(with: [
+                    videoAttachment.asAnyAttachment,
+                    videoAttachment.asAnyAttachment
+                ]),
+                currentPage: 0
+            ),
+            components: components
+        )
+        vc.viewDidLoad()
+        
+        // Get the cell
+        let cell = vc.collectionView(vc.attachmentsCollectionView, cellForItemAt: .init(item: 0, section: 0))
+        
+        // Assert cell is of custom type
+        XCTAssertTrue(cell is Cell)
     }
     
     func test_appearanceCustomization_usingUIConfig() {
@@ -78,5 +125,27 @@ final class GalleryVC_Tests: XCTestCase {
         vc.content = content
 
         AssertSnapshot(vc)
+    }
+    
+    private func makeGalleryVC(content: GalleryVC.Content, components: Components = .mock) -> GalleryVC {
+        let vc = GalleryVC()
+        vc.components = components
+        vc.content = content
+        vc.attachmentsCollectionView.reloadData()
+        return vc
+    }
+    
+    private func makeMessage(with attachments: [AnyChatMessageAttachment]) -> ChatMessage {
+        .mock(
+            id: .unique,
+            cid: .unique,
+            text: "",
+            author: .mock(
+                id: .unique,
+                name: "Author"
+            ),
+            createdAt: Date(timeIntervalSinceReferenceDate: 0),
+            attachments: attachments
+        )
     }
 }


### PR DESCRIPTION
**This PR** fixes the issue with `Image/VideoAttachmentGalleryCell` not taken from component.