### PR TITLE
Removing folder structure within resource key for package.swift file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
             name: "StreamChatUI",
             dependencies: ["StreamChat", "Nuke", "SwiftyGif"],
             exclude: ["README.md", "Info.plist", "Generated/L10n_template.stencil"] + streamChatUIFilesExcluded,
-            resources: [.process("Sources/StreamChatUI/Resources")]
+            resources: [.process("Resources")]
         )
     ]
 )


### PR DESCRIPTION
This will remove the warning when building the project. We no longer need to specify the folder structure.