### PR TITLE
Fix `imageURL` encoding during `connectUser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### 🐞 Fixed
+- Fix `imageURL` is incorrectly encoded as `image_url` during `connectUser` [#1523](https://github.com/GetStream/stream-chat-swift/issues/1523)
+
 ### ✅ Added
 - Make it possible to customize video asset (e.g. include custom HTTP header) before it's preview/content is loaded [#1510](https://github.com/GetStream/stream-chat-swift/pull/1510)
 

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/CustomDataHashMap_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/CustomDataHashMap_Tests.swift
@@ -17,11 +17,13 @@ extension ChannelDetailPayload: DecodableEntity {}
 class CustomDataHashMap_Tests: XCTestCase {
     func test_UserWebSocketPayloadEncodeWithCustomMap() throws {
         let extraData: [String: RawJSON] = ["how-many-roads": .number(42)]
-        let userInfo = UserInfo(id: "44", name: "tommaso", imageURL: nil, extraData: extraData)
+        let imageURL = URL.unique()
+        let userInfo = UserInfo(id: "44", name: "tommaso", imageURL: imageURL, extraData: extraData)
         let payload = UserWebSocketPayload(userInfo: userInfo)
         let encoded = try! JSONEncoder.default.encode(payload)
         let jsonStr = String(data: encoded, encoding: .utf8)
-        XCTAssertEqual(jsonStr, "{\"id\":\"44\",\"name\":\"tommaso\",\"how-many-roads\":42}")
+        let imageStr = imageURL.debugDescription.replacingOccurrences(of: "/", with: "\\/")
+        XCTAssertEqual(jsonStr, "{\"id\":\"44\",\"name\":\"tommaso\",\"image\":\"\(imageStr)\",\"how-many-roads\":42}")
     }
 
     func assertEmptyCustomData<T>(_ entity: T.Type, _ fileName: String) throws where T: DecodableEntity {

--- a/Sources/StreamChat/WebSocketClient/WebSocketConnectPayload.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketConnectPayload.swift
@@ -26,7 +26,7 @@ struct UserWebSocketPayload: Encodable {
     private enum CodingKeys: String, CodingKey, CaseIterable {
         case id
         case name
-        case imageURL = "image_url"
+        case imageURL = "image"
     }
 
     let id: String

--- a/Sources/StreamChat/WebSocketClient/WebSocketConnectPayload_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketConnectPayload_Tests.swift
@@ -29,7 +29,7 @@ class WebSocketConnectPayload_Tests: XCTestCase {
             "user_details": [
                 "id": payload.userDetails.id,
                 "name": payload.userDetails.name!,
-                "image_url": "https://path/to/image",
+                "image": "https://path/to/image",
                 "color": "blue"
             ]
         ]


### PR DESCRIPTION
In turn, user images were not correctly displayed