### PR TITLE
Fix outdated paths in pre-commit hook

### DIFF
--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -2,12 +2,9 @@
 
 ./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'Sources/*.swift' '!*Generated*'
 ./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'Tests/*.swift'
-./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'Sample/*.swift'
+./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'StreamChatSample/*.swift'
 ./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'DemoApp/*.swift'
-./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'SlackClone/*.swift'
-./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'iMessageClone/*.swift'
-./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'MessengerClone/*.swift'
-./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'YouTubeClone/*.swift'
+./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'Examples/*.swift'
 ./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat stdin' 'Integration/*.swift'
 ./hooks/git-format-staged --formatter 'mint run swiftformat --config .swiftformat-snippets stdin' 'DocsSnippets/*.swift'
 


### PR DESCRIPTION
### 🎯 Goal

Fix outdated paths that formatter should process in pre-commit hook

### 🧪 Testing

Set invalid indention in example/sample app, commit the changes and see the formatting being corrected

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
