### PR TITLE
[CIS-1220] Fix crash on iPad when sharing from `GalleryVC`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `imageURL` is incorrectly encoded as `image_url` during `connectUser` [#1523](https://github.com/GetStream/stream-chat-swift/pull/1523)
 - Fix fallback to `Components.default` because of responder chain being broken in `ChatChannelVC/ChatThreadVC/ChatMessageCell` [#1519](https://github.com/GetStream/stream-chat-swift/pull/1519)
 - Fix crash after `ChatClient` disconnection [#1532](https://github.com/GetStream/stream-chat-swift/pull/1532)
+- Fix crash on `GalleryVC` happening on iPad when share button is clicked [#1537](https://github.com/GetStream/stream-chat-swift/pull/1537)
 
 ### ✅ Added
 - Make it possible to customize video asset (e.g. include custom HTTP header) before it's preview/content is loaded [#1510](https://github.com/GetStream/stream-chat-swift/pull/1510)

--- a/Sources/StreamChatUI/Gallery/GalleryVC.swift
+++ b/Sources/StreamChatUI/Gallery/GalleryVC.swift
@@ -316,6 +316,7 @@ open class GalleryVC:
             activityItems: [shareItem],
             applicationActivities: nil
         )
+        activityViewController.popoverPresentationController?.sourceView = shareButton
         present(activityViewController, animated: true)
     }
     


### PR DESCRIPTION
### 🔗 Issue Link

CIS-1220

### 🎯 Goal

Fix crash on iPad when `share` button is click on iPad

### 🛠 Implementation

The `sourceView` is set on share screen's popover presentation controller 

### 🧪 Testing

1. Run `DemoApp` on iPad
2. Connect as `Luke Skywalker`
3. Open a channel with a message containing image attachments
4. Tap on image attachment to open `GalleryVC`
5. Tap on `share` button

### 🎨 Changes

https://user-images.githubusercontent.com/12818985/136794468-9af03c9f-21ad-48a4-ad3a-4bab90973ff7.mp4

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
