### PR TITLE
[CIS-1223] Fix API requests being cancelled on first connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix crash after `ChatClient` disconnection [#1532](https://github.com/GetStream/stream-chat-swift/pull/1532)
 - Fix when sending a new message UI flickers [#1536](https://github.com/GetStream/stream-chat-swift/pull/1536)
 - Fix crash on `GalleryVC` happening on iPad when share button is clicked [#1537](https://github.com/GetStream/stream-chat-swift/pull/1537)
+- Fix pending API requests being cancelled when client is connecting for the first time [#1538](https://github.com/GetStream/stream-chat-swift/issues/1538)
 
 ### ✅ Added
 - Make it possible to customize video asset (e.g. include custom HTTP header) before it's preview/content is loaded [#1510](https://github.com/GetStream/stream-chat-swift/pull/1510)

--- a/Sources/StreamChat/Workers/ChatClientUpdater.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater.swift
@@ -15,7 +15,21 @@ class ChatClientUpdater {
         userInfo: UserInfo?,
         newToken: Token
     ) throws {
-        guard newToken.userId == client.currentUserId else {
+        guard let currentUserId = client.currentUserId else {
+            // Set the current user id
+            client.currentUserId = newToken.userId
+            // Set the token
+            client.currentToken = newToken
+            // Set the web-socket endpoint
+            client.webSocketClient?.connectEndpoint = .webSocketConnect(userInfo: userInfo ?? .init(id: newToken.userId))
+            // Create background workers
+            client.createBackgroundWorkers()
+            // Provide the token to pending API requests
+            client.completeTokenWaiters(token: newToken)
+            return
+        }
+        
+        guard newToken.userId == currentUserId else {
             // Cancel all API requests since they are related to the previous user.
             client.completeTokenWaiters(token: nil)
 


### PR DESCRIPTION
### 🔗 Issue Link

CIS-1223

### 🎯 Goal

To fix pending API requests being cancelled when chat client is connected for the first time.

### 🛠 Implementation

Added the check to explicitly handle the first connect.

### 🧪 Testing

The way to see the fix in action is to have a `ChannelVC` that connects a client in `setUp` after calling `super.setUp` where the channel request is initiated: 
```swift
final class ChannelVC: ChatChannelVC {
    var token: Token!
    var userId: UserId!

    override func setUp() {
        super.setUp()

        client.connectUser(
            userInfo: .init(id: userId),
            token: token
        )
    }
    
    deinit {
        client.disconnect()
    }
}
```

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
