### PR TITLE
[CIS-1226] Fix key for `created_by` channel list query filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - `LogConfig.subsystems` for customizing subsysems where logger should be active [#1522](https://github.com/GetStream/stream-chat-swift/issues/1522)
 
+### 🐞 Fixed
+- Fix incorrect key in `created_by` filter used in channel list query [#1544](https://github.com/GetStream/stream-chat-swift/issues/1544)
+
 ### 🔄 Changed
 - `LogConfig` changes after logger was used will now take affect [#1522](https://github.com/GetStream/stream-chat-swift/issues/1522)
 

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -41,7 +41,7 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
     static var lastMessageAt: FilterKey<Scope, Date> { "last_message_at" }
     
     /// A filter key for matching the `createdBy` value.
-    static var createdBy: FilterKey<Scope, UserId> { "created_by" }
+    static var createdBy: FilterKey<Scope, UserId> { "created_by_id" }
     
     /// A filter key for matching the `createdAt` value.
     static var createdAt: FilterKey<Scope, Date> { "created_at" }

--- a/Sources/StreamChat/Query/ChannelListQuery_Tests.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery_Tests.swift
@@ -14,7 +14,7 @@ final class ChannelListFilterScope_Tests: XCTestCase {
         XCTAssertEqual(Key<URL>.imageURL.rawValue, ChannelCodingKeys.imageURL.rawValue)
         XCTAssertEqual(Key<ChannelType>.type.rawValue, ChannelCodingKeys.typeRawValue.rawValue)
         XCTAssertEqual(Key<Date>.lastMessageAt.rawValue, ChannelCodingKeys.lastMessageAt.rawValue)
-        XCTAssertEqual(Key<UserId>.createdBy.rawValue, ChannelCodingKeys.createdBy.rawValue)
+        XCTAssertEqual(Key<UserId>.createdBy.rawValue, "created_by_id")
         XCTAssertEqual(Key<Date>.createdAt.rawValue, ChannelCodingKeys.createdAt.rawValue)
         XCTAssertEqual(Key<Date>.updatedAt.rawValue, ChannelCodingKeys.updatedAt.rawValue)
         XCTAssertEqual(Key<Date>.deletedAt.rawValue, ChannelCodingKeys.deletedAt.rawValue)


### PR DESCRIPTION
### 🔗 Issue Link

CIS-1226

### 🎯 Goal

Fix channel list not working correctly if the underlying query has `created_by` filter

### 🛠 Implementation

Fix `created_by` filter key

### 🧪 Testing

Unit tests are updated to check the filter has the correct key. 
To see it in action in `DemoApp` update channel list query filter to `.equal(.createdBy, to: currentUserId)`

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
