### PR TITLE
Fixing dark mode for creating a named group

### DIFF
--- a/DemoApp/NameGroupViewController.swift
+++ b/DemoApp/NameGroupViewController.swift
@@ -77,7 +77,7 @@ class NameGroupViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
         title = "Name of Group Chat"
         
         navigationItem.rightBarButtonItem = doneButton


### PR DESCRIPTION
### 🎯 Goal

I noticed that dark mode wasn't updating correctly when creating a named group.

### 🛠 Implementation

The backgroundColor was hardcoded to .white and this should be .systemBackground so it's consistent across the demo app.

### 🧪 Testing

I made the change and ran the app using Dark Mode, then compared the result. Images attached.

### 🎨 Changes

<img src="https://user-images.githubusercontent.com/1519998/137465322-8dd10a2d-6adf-4102-a452-223b4cff99a1.png" width="280"><img src="https://user-images.githubusercontent.com/1519998/137465339-83d99d35-eff2-49f7-a89c-8c9a2fbc97d6.png" width="280">

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
