### PR TITLE
CIS-1231 Replace unowned vars with regular vars to avoid crashes

### DIFF
--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryUpdater_Tests.swift
@@ -38,9 +38,7 @@ final class ConnectionRecoveryUpdater_Tests: XCTestCase {
 
         AssertAsync {
             Assert.canBeReleased(&updater)
-            Assert.canBeReleased(&database)
             Assert.canBeReleased(&webSocketClient)
-            Assert.canBeReleased(&apiClient)
         }
         
         super.tearDown()

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Tests.swift
@@ -34,9 +34,7 @@ final class DatabaseCleanupUpdater_Tests: XCTestCase {
         
         AssertAsync {
             Assert.canBeReleased(&databaseCleanupUpdater)
-            Assert.canBeReleased(&database)
             Assert.canBeReleased(&webSocketClient)
-            Assert.canBeReleased(&apiClient)
         }
         
         super.tearDown()

--- a/Sources/StreamChat/Workers/TypingEventSender_Tests.swift
+++ b/Sources/StreamChat/Workers/TypingEventSender_Tests.swift
@@ -29,7 +29,6 @@ class TypingEventsSender_Tests: XCTestCase {
     
     override func tearDown() {
         apiClient.cleanUp()
-        AssertAsync.canBeReleased(&database)
         super.tearDown()
     }
     

--- a/Sources/StreamChat/Workers/Worker.swift
+++ b/Sources/StreamChat/Workers/Worker.swift
@@ -16,22 +16,20 @@ typealias EventWorkerBuilder = (
     _ apiClient: APIClient
 ) -> Worker
 
-// This is a super-class instead of protocol because we need to be sure, `unowned` is used for socket client and api client
-class Worker: NSObject { // TODO: remove NSObject
-    unowned let database: DatabaseContainer
-    unowned let apiClient: APIClient
-    
-    init(database: DatabaseContainer, apiClient: APIClient) {
+class Worker {
+    let database: DatabaseContainer
+    let apiClient: APIClient
+
+    public init(database: DatabaseContainer, apiClient: APIClient) {
         self.database = database
         self.apiClient = apiClient
-        super.init()
     }
 }
 
 class EventWorker: Worker {
-    unowned let eventNotificationCenter: EventNotificationCenter
-    
-    init(
+    let eventNotificationCenter: EventNotificationCenter
+
+    public init(
         database: DatabaseContainer,
         eventNotificationCenter: EventNotificationCenter,
         apiClient: APIClient


### PR DESCRIPTION
The goal is to reduce the chance of crashing by tripping on unowned vars. Worker and EventWorker classes now use strong refs to `apiClient`, `database` and `eventNotificationCenter`.

### ☑️ Checklist

- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
