### PR TITLE
Fix Logger not logging when custom subsystem is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix message list jumps when message received [#1542](https://github.com/GetStream/stream-chat-swift/pull/1542)
 - Fix broken constraint in the `ComposerView`, we have made the `BottomContainer` a standard `UIStackView` [#1545](https://github.com/GetStream/stream-chat-swift/pull/1545)
 - Fix `ChannelListSortingKey.hasUnread` causing a crash when used [#1561](https://github.com/GetStream/stream-chat-swift/issues/1561)
+- Fix Logger not logging when custom `subsystem` is specified [#1559](https://github.com/GetStream/stream-chat-swift/issues/1559)
 
 ### 🔄 Changed
 - `LogConfig` changes after logger was used will now take affect [#1522](https://github.com/GetStream/stream-chat-swift/issues/1522)

--- a/Sources/StreamChat/Utils/Logger/Logger.swift
+++ b/Sources/StreamChat/Utils/Logger/Logger.swift
@@ -19,7 +19,9 @@ public struct LogSubsystem: OptionSet {
     /// All subsystems within the SDK.
     public static let all: LogSubsystem = [.database, .httpRequests, .webSocket, .other]
     
-    static let other = Self(rawValue: 1 << 0)
+    /// The subsystem responsible for any other part of the SDK.
+    /// This is the default subsystem value for logging, to be used when `subsystem` is not specified.
+    public static let other = Self(rawValue: 1 << 0)
     
     /// The subsystem responsible for database operations.
     public static let database = Self(rawValue: 1 << 1)
@@ -202,7 +204,7 @@ public class Logger {
         fileName: StaticString = #file,
         lineNumber: UInt = #line,
         message: @autoclosure () -> Any,
-        subsystems: LogSubsystem = .all
+        subsystems: LogSubsystem = .other
     ) {
         log(
             level,
@@ -229,7 +231,7 @@ public class Logger {
         fileName: StaticString = #file,
         lineNumber: UInt = #line,
         message: @autoclosure () -> Any,
-        subsystems: LogSubsystem = .all
+        subsystems: LogSubsystem = .other
     ) {
         let enabledDestinations = destinations.filter { $0.isEnabled(level: level, subsystems: subsystems) }
         guard !enabledDestinations.isEmpty else { return }
@@ -260,7 +262,7 @@ public class Logger {
     ///   - lineNumber: Line number of the caller
     public func info(
         _ message: @autoclosure () -> Any,
-        subsystems: LogSubsystem = .all,
+        subsystems: LogSubsystem = .other,
         functionName: StaticString = #function,
         fileName: StaticString = #file,
         lineNumber: UInt = #line
@@ -284,7 +286,7 @@ public class Logger {
     ///   - lineNumber: Line number of the caller
     public func debug(
         _ message: @autoclosure () -> Any,
-        subsystems: LogSubsystem = .all,
+        subsystems: LogSubsystem = .other,
         functionName: StaticString = #function,
         fileName: StaticString = #file,
         lineNumber: UInt = #line
@@ -308,7 +310,7 @@ public class Logger {
     ///   - lineNumber: Line number of the caller
     public func warning(
         _ message: @autoclosure () -> Any,
-        subsystems: LogSubsystem = .all,
+        subsystems: LogSubsystem = .other,
         functionName: StaticString = #function,
         fileName: StaticString = #file,
         lineNumber: UInt = #line
@@ -332,7 +334,7 @@ public class Logger {
     ///   - lineNumber: Line number of the caller
     public func error(
         _ message: @autoclosure () -> Any,
-        subsystems: LogSubsystem = .all,
+        subsystems: LogSubsystem = .other,
         functionName: StaticString = #function,
         fileName: StaticString = #file,
         lineNumber: UInt = #line
@@ -356,7 +358,7 @@ public class Logger {
     public func assert(
         _ condition: @autoclosure () -> Bool,
         _ message: @autoclosure () -> Any,
-        subsystems: LogSubsystem = .all,
+        subsystems: LogSubsystem = .other,
         functionName: StaticString = #function,
         fileName: StaticString = #file,
         lineNumber: UInt = #line
@@ -380,7 +382,7 @@ public class Logger {
     ///   - message: A custom message to log if `condition` is evaluated to false.
     public func assertionFailure(
         _ message: @autoclosure () -> Any,
-        subsystems: LogSubsystem = .all,
+        subsystems: LogSubsystem = .other,
         functionName: StaticString = #function,
         fileName: StaticString = #file,
         lineNumber: UInt = #line


### PR DESCRIPTION
### 🎯 Goal

The issue came because when `subsystem` was not specified, `all` was used. If one customized the allowed subsystems, let's say `.all.subtracting(.database)`, logs from other places failed to print since `.all.subtracting(.database).contains(.all)` is `false`. 

### 🛠 Implementation

Logs from unspecified subsystems should come from `other` subsystem by default, to prevent this issue. Also it makes more sense: if one only wants logs from database, ws and http, they'd do `.all.subtracting(.other)`

### 🧪 Testing

Specify `LogConfig.subsystems = .all.subtracting(.database).contains(.all)` in `main` branch and see that it doesn't print logs from unspecified subsystems (for example, middlewares)

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
