### PR TITLE
Fix channel is not updated for NotificationRemovedFromChannel event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix broken constraint in the `ComposerView`, we have made the `BottomContainer` a standard `UIStackView` [#1545](https://github.com/GetStream/stream-chat-swift/pull/1545)
 - Fix `ChannelListSortingKey.hasUnread` causing a crash when used [#1561](https://github.com/GetStream/stream-chat-swift/issues/1561)
 - Fix Logger not logging when custom `subsystem` is specified [#1559](https://github.com/GetStream/stream-chat-swift/issues/1559)
+- Fix channel not updated when a member is removed [#1560](https://github.com/GetStream/stream-chat-swift/issues/1560)
 
 ### 🔄 Changed
 - `LogConfig` changes after logger was used will now take affect [#1522](https://github.com/GetStream/stream-chat-swift/issues/1522)

--- a/DemoApp/ChatPresenter.swift
+++ b/DemoApp/ChatPresenter.swift
@@ -280,4 +280,12 @@ class DemoChannelListVC: ChatChannelListVC {
     @objc open func didTapCreateNewChannel(_ sender: Any) {
         (router as! DemoChatChannelListRouter).showCreateNewChannelFlow()
     }
+    
+    override func controller(_ controller: ChatChannelListController, shouldListUpdatedChannel channel: ChatChannel) -> Bool {
+        channel.lastActiveMembers.contains(where: { $0.id == controller.client.currentUserId })
+    }
+    
+    override func controller(_ controller: ChatChannelListController, shouldAddNewChannelToList channel: ChatChannel) -> Bool {
+        channel.lastActiveMembers.contains(where: { $0.id == controller.client.currentUserId })
+    }
 }


### PR DESCRIPTION
### 🎯 Goal

`NotificationRemovedFromChannel` event to be correctly handled

### 🛠 Implementation

Before we implemented the `shouldListUpdatedChannel` delegate methods, we had `NewChannelQueryUpdater` which made an API call for updated channels to see if they still belonged to a query. This was useful for member events too. We removed that updater and now channel updates do not cause API calls.
We still relied on this for `NotificationRemovedFromChannel` event, which we shouldn't do.

### 🧪 Testing

Take 2 phones
Login with different users
Create a channel with those 2 users
Remove 1 user from the other phone

### ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] Changelog is updated with client-facing changes
- [X] New code is covered by unit tests
- [X] Affected documentation updated (docusaurus, tutorial, CMS (task created)
