### PR TITLE
Fix `ChannelListSortingKey.hasUnread` causing a crash when used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix message list jumps when new reaction added [#1542](https://github.com/GetStream/stream-chat-swift/pull/1542)
 - Fix message list jumps when message received [#1542](https://github.com/GetStream/stream-chat-swift/pull/1542)
 - Fix broken constraint in the `ComposerView`, we have made the `BottomContainer` a standard `UIStackView` [#1545](https://github.com/GetStream/stream-chat-swift/pull/1545)
+- Fix `ChannelListSortingKey.hasUnread` causing a crash when used [#1561](https://github.com/GetStream/stream-chat-swift/issues/1561)
 
 ### 🔄 Changed
 - `LogConfig` changes after logger was used will now take affect [#1522](https://github.com/GetStream/stream-chat-swift/issues/1522)

--- a/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
+++ b/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
@@ -25,6 +25,19 @@ public enum ChannelListSortingKey: String, SortingKey {
     /// Sort channels by their unread count.
     case unreadCount
     
+    private var canUseAsSortDescriptor: Bool {
+        switch self {
+        case .createdAt: return true
+        case .updatedAt: return true
+        case .lastMessageAt: return true
+        case .memberCount: return true
+        case .cid: return true
+        case .hasUnread: return false
+        case .unreadCount: return true
+        case .default: return true
+        }
+    }
+    
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         let value: String
@@ -51,7 +64,7 @@ extension ChannelListSortingKey {
     }()
     
     func sortDescriptor(isAscending: Bool) -> NSSortDescriptor? {
-        .init(key: rawValue, ascending: isAscending)
+        canUseAsSortDescriptor ? .init(key: rawValue, ascending: isAscending) : nil
     }
 }
 


### PR DESCRIPTION
### 🎯 Goal

Prevent the crash when `hasUnread` sorting is used

### 🛠 Implementation

This is because `hasUnread` is not defined in our DB model so it can't be a sorting key in CoreData
`ChannelListSortingKey` now has a private computed property `canUseAsSortDescriptor`

### 🧪 Testing

Use this `ChannelListController` in DemoApp:
```swift
.channelListController(query: .init(filter: .containMembers(userIds: [userCredentials.id]), sort: [.init(key: .hasUnread)]))
```

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
