### PR TITLE
Fix getting started documentation on creating ChannelListVC

### DIFF
--- a/docusaurus/docs/iOS/basics/getting-started.md
+++ b/docusaurus/docs/iOS/basics/getting-started.md
@@ -73,13 +73,13 @@ import StreamChatUI
 class ViewController: ChatChannelListVC {
     
     override func viewDidLoad() {
-        super.viewDidLoad()
-
         /// the query used to retrieve channels
         let query = ChannelListQuery.init(filter: .containMembers(userIds: [ChatClient.shared.currentUserId!]))
         
         /// create a controller and assign it to this view controller
         self.controller = ChatClient.shared.channelListController(query: query)
+
+        super.viewDidLoad()
     }
 }
 ```


### PR DESCRIPTION
### 🎯 Goal

On our Getting Started documentation, we were proposing code that would lead to a crash

### 🛠 Implementation

`ChatChannelListVC` expects `controller` to be assigned before `viewDidLoad` is called. So, we're safe if we assign `controller` in a subclass's `viewDidLoad` as long as it's assigned before `super.viewDidLoad()` is invoked

### 🧪 Testing

Try to follow our Getting Started guide.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)

#skip_changelog
