### PR TITLE
[CIS-1244, CIS-1188] Respect API limit for max # of attachments per message in `ComposerVC`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `ChannelListController` can now correctly give a list of hidden channels [#1529](https://github.com/GetStream/stream-chat-swift/issues/1529)
 - `ChatChannel.isHidden` is now exposed [#1529](https://github.com/GetStream/stream-chat-swift/issues/1529)
 - Add `name` sort option for member list queries [#1576](https://github.com/GetStream/stream-chat-swift/issues/1576)
+- Update `ComposerVC` to respect API limitation and show an alert when > 10 attachments are added to the message. [#1579](https://github.com/GetStream/stream-chat-swift/issues/1579)
 
 ### 🐞 Fixed
 - Fix incorrect key in `created_by` filter used in channel list query [#1544](https://github.com/GetStream/stream-chat-swift/issues/1544)

--- a/DemoApp/DemoAppCoordinator.swift
+++ b/DemoApp/DemoAppCoordinator.swift
@@ -90,8 +90,14 @@ final class DemoAppCoordinator: NSObject, UNUserNotificationCenterDelegate {
         Components.default.channelListRouter = DemoChatChannelListRouter.self
         Components.default.channelVC = CustomChannelVC.self
         Components.default.messageContentView = CustomMessageContentView.self
+        
+        let localizationProvider = Appearance.default.localizationProvider
         Appearance.default.localizationProvider = { key, table in
-            Bundle.main.localizedString(forKey: key, value: nil, table: table)
+            let localizedString = localizationProvider(key, table)
+            
+            return localizedString == key
+                ? Bundle.main.localizedString(forKey: key, value: nil, table: table)
+                : localizedString
         }
 
         // Channels with the current user

--- a/Sources/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources/StreamChat/Config/ChatClientConfig.swift
@@ -125,6 +125,11 @@ public struct ChatClientConfig {
             return StreamCDNClient.maxAttachmentSize
         }
     }
+    
+    /// Returns max number of attachments that can be attached to a message.
+    ///
+    /// The current limit is `10`.
+    public let maxAttachmentCountPerMessage = 10
 
     /// Specifies the visibility of deleted messages.
     public enum DeletedMessageVisibility {

--- a/Sources/StreamChatUI/Generated/L10n.swift
+++ b/Sources/StreamChatUI/Generated/L10n.swift
@@ -23,6 +23,10 @@ internal enum L10n {
   }
 
   internal enum Attachment {
+    /// The max number of attachments per message is %d.
+    internal static func maxCountExceeded(_ p1: Int) -> String {
+      return L10n.tr("Localizable", "attachment.max-count-exceeded", p1)
+    }
     /// Attachment size exceed the limit.
     internal static var maxSizeExceeded: String { L10n.tr("Localizable", "attachment.max-size-exceeded") }
   }

--- a/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
@@ -55,6 +55,8 @@
 "current-selection" = "%d of %d";
 
 "attachment.max-size-exceeded" = "Attachment size exceed the limit.";
+"attachment.max-count-exceeded" = "The max number of attachments per message is %d.";
+
 "dates.time-ago-seconds-plural" = "last seen %d seconds ago";
 "dates.time-ago-seconds-singular" = "last seen just one second ago";
 "dates.time-ago-minutes-singular" = "last seen one minute ago";


### PR DESCRIPTION
### 🔗 Issue Link

CIS-1244, CIS-1188

### 🎯 Goal

Prevent a user from sending a message that contains > 10 attachments as it will be rejected by the backend anyways.
Fix max size validation not being applied to `file` attachments.

### 🛠 Implementation

Update `ComposerVC` to validate the current # of attachments and throw the error if it exceeds the limit.

### 🧪 Testing

Steps for manual testing:
- Run `DemoApp`
- Sign in as any user
- Open any channel (with attachments enabled)
- Try to add > 10 attachments
- See the alert being shown saying about the limitation

### 🎨 Changes

https://user-images.githubusercontent.com/12818985/138731585-c7fe44da-5ffd-41b1-afdd-e40a23661703.mp4

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
