### PR TITLE
[CIS-1207, CIS-1232] Fix crash and swapping the long-pressed message on `ChatMessagePopupVC`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - `flag` command is no longer visible on Composer [#1590](https://github.com/GetStream/stream-chat-swift/issues/1590)
+- Fix long-pressed message being swapped with newly received message if both have the same visual style [#1596](https://github.com/GetStream/stream-chat-swift/issues/1596)
+- Fix crash when message actions pop-up is dismissed with the selected message being outside the visible area of message list [#1596](https://github.com/GetStream/stream-chat-swift/issues/1596)
 
 ### 🔄 Changed
 - The message action icons were changed to be a bit more darker color [#1583](https://github.com/GetStream/stream-chat-swift/issues/1583)
+- The long-pressed message view is no longer moved across `ChatMessageListVC` and `ChatMessagePopupVC` hierarchies [#1596](https://github.com/GetStream/stream-chat-swift/issues/1596)
 
 ### ✅ Added
 - Added Flag message action [#1583](https://github.com/GetStream/stream-chat-swift/issues/1583)
 - Added handling of "shadowed" messages (messages from shadow banned users). The behavior is controlled by `ChatClientConfig.shouldShowShadowedMessages` and defaults to `false`. [#1591](https://github.com/GetStream/stream-chat-swift/issues/1591)
+- Add message actions transition controller to `Components` [#1596](https://github.com/GetStream/stream-chat-swift/issues/1596)
 
 # [4.2.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.2.0)
 _October 26, 2021_

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -93,6 +93,10 @@ public struct Components {
     /// The View Controller used to display content of the message, i.e. in the channel detail message list.
     @available(iOSApplicationExtension, unavailable)
     public var messageListVC: ChatMessageListVC.Type = ChatMessageListVC.self
+    
+    /// The controller that handles `ChatMessageListVC <-> ChatMessagePopUp` transition.
+    public var messageActionsTransitionController: ChatMessageActionsTransitionController.Type =
+        ChatMessageActionsTransitionController.self
 
     /// The view that shows the message list.
     public var messageListView: ChatMessageListView.Type = ChatMessageListView

--- a/Sources/StreamChatUI/Deprecations.swift
+++ b/Sources/StreamChatUI/Deprecations.swift
@@ -6,6 +6,9 @@ import StreamChat
 
 /// - NOTE: Deprecations of the next major release.
 
+@available(*, deprecated, renamed: "ChatMessageActionsTransitionController")
+public typealias MessageActionsTransitionController = ChatMessageActionsTransitionController
+
 @available(*, deprecated, renamed: "VideoLoading")
 public typealias VideoPreviewLoader = VideoLoading
 

--- a/Sources/StreamChatUI/MessageActionsPopup/MessageActionsTransitionController.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/MessageActionsTransitionController.swift
@@ -6,25 +6,50 @@ import Foundation
 import StreamChat
 import UIKit
 
-/// Transitions controller for `ChatMessagePopupVC`.
-open class MessageActionsTransitionController: NSObject, UIViewControllerTransitioningDelegate,
+/// The controller that handles `ChatMessageListVC <-> ChatMessagePopUp` transition.
+open class ChatMessageActionsTransitionController: NSObject, UIViewControllerTransitioningDelegate,
     UIViewControllerAnimatedTransitioning {
     /// Indicates if the transition is for presenting or dismissing.
     open var isPresenting: Bool = false
-    /// `messageContentView`'s initial frame.
-    open var messageContentViewFrame: CGRect = .zero
-    /// `messageContentView`'s constraints to be activated after dismissal.
-    open var messageContentViewActivateConstraints: [NSLayoutConstraint] = []
-    /// Constraints to be deactivated after dismissal.
-    open var messageContentViewDeactivateConstraints: [NSLayoutConstraint] = []
-    /// `messageContentView` instance that is animated.
-    open weak var messageContentView: ChatMessageContentView?
-    /// `messageContentView`'s initial superview.
-    open weak var messageContentViewSuperview: UIView?
-    /// Top anchor for main container.
-    open var mainContainerTopAnchor: NSLayoutConstraint?
+    
     /// Feedback generator.
     public private(set) lazy var impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
+    
+    /// The currently selected message identifier.
+    public internal(set) var selectedMessageId: MessageId?
+    
+    /// The message list view controller.
+    public private(set) weak var messageListVC: ChatMessageListVC?
+    
+    /// The frame the message view's snapshot animates to when pop-up is being dismissed.
+    open var selectedMessageContentViewFrame: CGRect? {
+        guard let messageContentView = selectedMessageCell?.messageContentView else { return nil }
+        
+        let reactionsBubbleHeight = messageContentView.reactionsBubbleView?.frame.height ?? 0
+        
+        var frame = messageContentView.superview?.convert(messageContentView.frame, to: nil) ?? .zero
+        frame.size.height -= reactionsBubbleHeight / 2
+        frame.origin.y += reactionsBubbleHeight / 2
+        return frame
+    }
+    
+    /// The message cell that displays the selected message.
+    open var selectedMessageCell: ChatMessageCell? {
+        messageListVC?
+            .listView
+            .visibleCells
+            .compactMap { $0 as? ChatMessageCell }
+            .first(where: { $0.messageContentView?.content?.id == selectedMessageId })
+    }
+    
+    /// Creates transition controller used to animate message actions pop-up for the message displayed by the given message list view controller.
+    ///
+    /// - Parameter messageListVC: The view controller displaying the message list to animate to/from.
+    public required init(messageListVC: ChatMessageListVC?) {
+        super.init()
+        
+        self.messageListVC = messageListVC
+    }
     
     public func animationController(
         forPresented presented: UIViewController,
@@ -56,112 +81,65 @@ open class MessageActionsTransitionController: NSObject, UIViewControllerTransit
     open func animatePresent(using transitionContext: UIViewControllerContextTransitioning) {
         guard
             let toVC = transitionContext.viewController(forKey: .to) as? ChatMessagePopupVC,
-            let fromVC = transitionContext.viewController(forKey: .from),
-            let messageContentView = self.messageContentView,
-            let messageContentViewSuperview = messageContentView.superview
+            let originalMessageContentView = selectedMessageCell?.messageContentView
         else { return }
-
-        self.messageContentViewSuperview = messageContentViewSuperview
-
-        let messageContentViewSnapshot = messageContentView.snapshotView(afterScreenUpdates: true)
-        if let messageContentViewSnapshot = messageContentViewSnapshot {
-            messageContentViewSnapshot.frame = messageContentViewSuperview.convert(messageContentView.frame, to: fromVC.view)
-            transitionContext.containerView.addSubview(messageContentViewSnapshot)
-        }
-    
-        messageContentView.isHidden = true
         
-        // Prepare `messageContentView` and update its frame to be without reactions.
-        if messageContentView.reactionsBubbleView?.isVisible == true {
-            messageContentView.reactionsBubbleView?.isVisible = false
-            messageContentView.bubbleToReactionsConstraint?.isActive = false
-            mainContainerTopAnchor = messageContentView.mainContainer.topAnchor.pin(equalTo: messageContentView.topAnchor)
-            mainContainerTopAnchor?.isActive = true
-        }
-        messageContentView.setNeedsLayout()
-        messageContentView.layoutIfNeeded()
-        var messageContentViewFrame = messageContentView.superview!.convert(messageContentView.frame, to: nil)
-        self.messageContentViewFrame = messageContentViewFrame
-        let allMessageContentViewSuperviewConstraints = Set(messageContentView.superview!.constraints)
-        messageContentView.removeFromSuperview()
-        messageContentViewActivateConstraints = Array(
-            allMessageContentViewSuperviewConstraints.subtracting(messageContentViewSuperview.constraints)
-        )
-        messageContentViewDeactivateConstraints = [
-            messageContentViewSuperview.widthAnchor.constraint(equalToConstant: messageContentViewFrame.width),
-            messageContentViewSuperview.heightAnchor.constraint(equalToConstant: messageContentViewFrame.height)
-        ]
-        NSLayoutConstraint.deactivate(messageContentViewActivateConstraints)
-        NSLayoutConstraint.activate(messageContentViewDeactivateConstraints)
-        messageContentViewFrame.size = messageContentView.systemLayoutSizeFitting(
-            CGSize(width: messageContentViewFrame.width, height: UIView.layoutFittingCompressedSize.height),
-            withHorizontalFittingPriority: .streamRequire,
-            verticalFittingPriority: .streamLow
-        )
-
-        toVC.messageViewFrame = messageContentViewFrame
-        toVC.setUpLayout()
+        selectedMessageId = originalMessageContentView.content?.id
+        
+        let messageViewFrame = selectedMessageContentViewFrame ?? .zero
+        let messageViewType = type(of: originalMessageContentView)
+        let messageAttachmentInjectorType = originalMessageContentView.attachmentViewInjector.map { type(of: $0) }
+        let messageLayoutOptions = originalMessageContentView.layoutOptions?.subtracting(.reactions) ?? []
+        let message = originalMessageContentView.content
+        
+        let messageView = messageViewType.init()
+        messageView.setUpLayoutIfNeeded(options: messageLayoutOptions, attachmentViewInjectorType: messageAttachmentInjectorType)
+        messageView.frame = messageViewFrame
+        messageView.content = message
         
         transitionContext.containerView.addSubview(toVC.view)
-
-        let fromVCSnapshot = fromVC.view.snapshotView(afterScreenUpdates: true)
-        if let fromVCSnapshot = fromVCSnapshot {
-            // Make sure the snapshot is added to the bottom of the container, in case the container
-            // is bigger than the snapshot (for the case the popup is being presented in a modal)
-            let newY = transitionContext.containerView.frame.size.height - fromVC.view.frame.size.height
-            fromVCSnapshot.frame = fromVC.view.frame
-            fromVCSnapshot.frame.origin.y += newY
-            fromVC.view.isHidden = true
-        }
-
-        let blurView = UIVisualEffectView()
-        blurView.frame = toVC.view.frame
-
-        let reactionsSnapshot: UIView?
-        if let reactionsController = toVC.reactionsController {
-            reactionsSnapshot = reactionsController.view.snapshotView(afterScreenUpdates: true)
-            reactionsSnapshot?.frame = reactionsController.view.superview!.convert(reactionsController.view.frame, to: nil)
-            reactionsSnapshot?.transform = CGAffineTransform(scaleX: 0, y: 0)
-            reactionsSnapshot?.alpha = 0.0
-        } else {
-            reactionsSnapshot = nil
-        }
-        
-        let actionsSnapshot = toVC.actionsController.view.snapshotView(afterScreenUpdates: true)
-        if let actionsSnapshot = actionsSnapshot {
-            let actionsFrame = toVC.actionsController.view.superview!.convert(toVC.actionsController.view.frame, to: nil)
-            actionsSnapshot.frame = actionsFrame
-            actionsSnapshot.transform = CGAffineTransform(scaleX: 0, y: 0)
-            actionsSnapshot.alpha = 0.0
-        }
-        
-        if let messageContentViewSnapshot = messageContentViewSnapshot {
-            fromVCSnapshot.map { transitionContext.containerView.insertSubview($0, belowSubview: messageContentViewSnapshot) }
-            transitionContext.containerView.insertSubview(blurView, belowSubview: messageContentViewSnapshot)
-            reactionsSnapshot.map { transitionContext.containerView.insertSubview($0, belowSubview: messageContentViewSnapshot) }
-            actionsSnapshot.map { transitionContext.containerView.insertSubview($0, belowSubview: messageContentViewSnapshot) }
-        }
-
         toVC.view.isHidden = true
+        toVC.messageContentView = messageView
+        toVC.messageViewFrame = messageViewFrame
+        toVC.setUpLayout()
+        
+        let blurView = UIVisualEffectView()
+        blurView.frame = transitionContext.finalFrame(for: toVC)
+        
+        let reactionsSnapshot: UIView? = {
+            guard let view = toVC.reactionsController?.view else { return nil }
+            
+            let snapshot = view.snapshotView(afterScreenUpdates: true)
+            snapshot?.frame = view.superview?.convert(view.frame, to: nil) ?? .zero
+            snapshot?.transform = .init(scaleX: 0, y: 0)
+            snapshot?.alpha = 0.0
+            return snapshot
+        }()
+        
+        let actionsSnapshot: UIView? = {
+            guard let view = toVC.actionsController.view else { return nil }
+            
+            let snapshot = view.snapshotView(afterScreenUpdates: true)
+            snapshot?.frame = view.superview?.convert(view.frame, to: nil) ?? .zero
+            snapshot?.transform = .init(scaleX: 0, y: 0)
+            snapshot?.alpha = 0.0
+            return snapshot
+        }()
+        
+        let transitionSubviews = [blurView, reactionsSnapshot, actionsSnapshot, messageView].compactMap { $0 }
+        transitionSubviews.forEach(transitionContext.containerView.addSubview)
+        messageView.mainContainer.layoutMargins = originalMessageContentView.mainContainer.layoutMargins
 
-        messageContentView.isHidden = false
-        
-        transitionContext.containerView.addSubview(messageContentView)
-        messageContentView.frame = messageContentViewFrame
-        messageContentView.translatesAutoresizingMaskIntoConstraints = true
-        
-        messageContentViewSnapshot?.removeFromSuperview()
-        
         let duration = transitionDuration(using: transitionContext)
         UIView.animate(
             withDuration: 0.2 * duration,
             delay: 0,
             options: [.curveEaseOut],
             animations: {
-                messageContentView.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
+                messageView.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
             },
-            completion: { [self] _ in
-                impactFeedbackGenerator.impactOccurred()
+            completion: { _ in
+                self.impactFeedbackGenerator.impactOccurred()
             }
         )
         UIView.animate(
@@ -171,31 +149,26 @@ open class MessageActionsTransitionController: NSObject, UIViewControllerTransit
             initialSpringVelocity: 4,
             options: [.curveEaseInOut],
             animations: {
-                actionsSnapshot?.transform = .identity
-                actionsSnapshot?.alpha = 1.0
-                reactionsSnapshot?.transform = .identity
-                reactionsSnapshot?.alpha = 1.0
-                messageContentView.transform = .identity
-                messageContentView.frame.origin = toVC.messageContentContainerView.superview!.convert(
+                messageView.transform = .identity
+                messageView.frame = toVC.messageContentContainerView.superview?.convert(
                     toVC.messageContentContainerView.frame,
                     to: nil
-                )
-                .origin
-                if let effect = (toVC.blurView as? UIVisualEffectView)?.effect {
-                    blurView.effect = effect
-                }
+                ) ?? .zero
+                
+                actionsSnapshot?.transform = .identity
+                actionsSnapshot?.alpha = 1.0
+                
+                reactionsSnapshot?.transform = .identity
+                reactionsSnapshot?.alpha = 1.0
+                
+                blurView.effect = (toVC.blurView as? UIVisualEffectView)?.effect
             },
             completion: { _ in
+                transitionSubviews.forEach { $0.removeFromSuperview() }
+                
+                toVC.messageContentContainerView.embed(messageView.withoutAutoresizingMaskConstraints)
+                
                 toVC.view.isHidden = false
-                fromVC.view.isHidden = false
-                messageContentView.isHidden = false
-                toVC.messageContentContainerView.addSubview(messageContentView)
-                messageContentView.translatesAutoresizingMaskIntoConstraints = false
-                toVC.messageContentContainerView.embed(messageContentView)
-                fromVCSnapshot?.removeFromSuperview()
-                blurView.removeFromSuperview()
-                reactionsSnapshot?.removeFromSuperview()
-                actionsSnapshot?.removeFromSuperview()
                 
                 transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
             }
@@ -206,100 +179,70 @@ open class MessageActionsTransitionController: NSObject, UIViewControllerTransit
     open func animateDismiss(using transitionContext: UIViewControllerContextTransitioning) {
         guard
             let fromVC = transitionContext.viewController(forKey: .from) as? ChatMessagePopupVC,
-            let toVC = transitionContext.viewController(forKey: .to),
-            let messageContentView = self.messageContentView
+            let toVC = transitionContext.viewController(forKey: .to)
         else { return }
         
-        let messageContentViewSnapshot = messageContentView.snapshotView(afterScreenUpdates: true)
-        if let messageContentViewSnapshot = messageContentViewSnapshot {
-            messageContentViewSnapshot.frame = messageContentView.convert(messageContentView.frame, to: fromVC.view)
-            transitionContext.containerView.addSubview(messageContentViewSnapshot)
-        }
-        
-        messageContentView.isHidden = true
-        
-        let toVCSnapshot = toVC.view.snapshotView(afterScreenUpdates: true)
-        if let toVCSnapshot = toVCSnapshot {
-            transitionContext.containerView.addSubview(toVCSnapshot)
-            // Make sure the snapshot is added to the bottom of the container, in case the container
-            // is bigger than the snapshot (for the case the popup is being presented in a modal)
-            let newY = transitionContext.containerView.frame.size.height - toVC.view.frame.size.height
-            toVCSnapshot.frame = toVC.view.frame
-            toVCSnapshot.frame.origin.y += newY
-            toVC.view.isHidden = true
-        }
-
         let blurView = UIVisualEffectView()
-        if let effect = (fromVC.blurView as? UIVisualEffectView)?.effect {
-            blurView.effect = effect
-        }
-        blurView.frame = fromVC.view.frame
+        blurView.effect = (fromVC.blurView as? UIVisualEffectView)?.effect
+        blurView.frame = transitionContext.finalFrame(for: toVC)
         
-        let reactionsSnapshot: UIView?
-        if let reactionsController = fromVC.reactionsController {
-            reactionsSnapshot = reactionsController.view.snapshotView(afterScreenUpdates: true)
-            reactionsSnapshot?.frame = reactionsController.view.superview!.convert(reactionsController.view.frame, to: nil)
-            reactionsSnapshot?.transform = .identity
-            reactionsSnapshot.map(transitionContext.containerView.addSubview)
-        } else {
-            reactionsSnapshot = nil
-        }
+        let reactionsSnapshot: UIView? = {
+            guard let view = fromVC.reactionsController?.view else { return nil }
+            
+            let snapshot = view.snapshotView(afterScreenUpdates: true)
+            snapshot?.frame = view.superview?.convert(view.frame, to: nil) ?? .zero
+            return snapshot
+        }()
         
-        let actionsSnapshot = fromVC.actionsController.view.snapshotView(afterScreenUpdates: true)
-        if let actionsSnapshot = actionsSnapshot {
-            actionsSnapshot.frame = fromVC.actionsController.view.superview!.convert(fromVC.actionsController.view.frame, to: nil)
-            transitionContext.containerView.addSubview(actionsSnapshot)
-        }
+        let actionsSnapshot: UIView? = {
+            guard let view = fromVC.actionsController.view else { return nil }
+            
+            let snapshot = view.snapshotView(afterScreenUpdates: true)
+            snapshot?.frame = view.superview?.convert(view.frame, to: nil) ?? .zero
+            return snapshot
+        }()
         
-        if let messageContentViewSnapshot = messageContentViewSnapshot {
-            toVCSnapshot.map { transitionContext.containerView.insertSubview($0, belowSubview: messageContentViewSnapshot) }
-            transitionContext.containerView.insertSubview(blurView, belowSubview: messageContentViewSnapshot)
-            reactionsSnapshot.map { transitionContext.containerView.insertSubview($0, belowSubview: messageContentViewSnapshot) }
-            actionsSnapshot.map { transitionContext.containerView.insertSubview($0, belowSubview: messageContentViewSnapshot) }
-        }
-
-        messageContentView.isHidden = false
-        let frame = messageContentView.convert(messageContentView.frame, to: fromVC.view)
-        messageContentView.removeFromSuperview()
-        transitionContext.containerView.addSubview(messageContentView)
-        messageContentView.translatesAutoresizingMaskIntoConstraints = true
-        messageContentView.frame = frame
+        let messageView = fromVC.messageContentView!
+        let frame = fromVC.messageContentContainerView.convert(messageView.frame, to: transitionContext.containerView)
+        messageView.removeFromSuperview()
+        messageView.frame = frame
+        messageView.translatesAutoresizingMaskIntoConstraints = true
         
-        messageContentViewSnapshot?.removeFromSuperview()
+        let transitionSubviews = [blurView, reactionsSnapshot, actionsSnapshot, messageView].compactMap { $0 }
+        transitionSubviews.forEach(transitionContext.containerView.addSubview)
         
         fromVC.view.isHidden = true
+        
+        selectedMessageCell?.messageContentView?.isHidden = true
         
         let duration = transitionDuration(using: transitionContext)
         UIView.animate(
             withDuration: duration,
             delay: 0,
-            animations: { [self] in
+            animations: {
+                if let frame = self.selectedMessageContentViewFrame {
+                    messageView.frame = frame
+                } else {
+                    messageView.transform = CGAffineTransform(scaleX: 0.01, y: 0.01)
+                    messageView.alpha = 0.0
+                }
+                
                 actionsSnapshot?.transform = CGAffineTransform(scaleX: 0.01, y: 0.01)
-                reactionsSnapshot?.transform = CGAffineTransform(scaleX: 0.01, y: 0.01)
                 actionsSnapshot?.alpha = 0.0
+                
+                reactionsSnapshot?.transform = CGAffineTransform(scaleX: 0.01, y: 0.01)
                 reactionsSnapshot?.alpha = 0.0
-                messageContentView.frame = messageContentViewFrame
+                
                 blurView.effect = nil
             },
-            completion: { [self] _ in
-                toVC.view.isHidden = false
-                fromVC.view.isHidden = false
-                messageContentView.translatesAutoresizingMaskIntoConstraints = false
-                if let mainContainerTopAnchor = mainContainerTopAnchor {
-                    mainContainerTopAnchor.isActive = false
-                    messageContentView.reactionsBubbleView?.isVisible = true
-                    messageContentView.bubbleToReactionsConstraint?.isActive = true
-                }
-                messageContentView.removeFromSuperview()
-                messageContentViewSuperview?.addSubview(messageContentView)
-                NSLayoutConstraint.activate(messageContentViewActivateConstraints)
-                NSLayoutConstraint.deactivate(messageContentViewDeactivateConstraints)
-                toVCSnapshot?.removeFromSuperview()
-                blurView.removeFromSuperview()
-                reactionsSnapshot?.removeFromSuperview()
-                actionsSnapshot?.removeFromSuperview()
+            completion: { _ in
+                transitionSubviews.forEach { $0.removeFromSuperview() }
                 
+                self.selectedMessageCell?.messageContentView?.isHidden = false
+
                 transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+                
+                self.selectedMessageId = nil
             }
         )
     }

--- a/Sources/StreamChatUI/Navigation/ChatMessageListRouter.swift
+++ b/Sources/StreamChatUI/Navigation/ChatMessageListRouter.swift
@@ -14,8 +14,10 @@ open class ChatMessageListRouter:
     ComponentsProvider
 {
     /// The transition controller used to animate `ChatMessagePopupVC` transition.
-    open private(set) lazy var messagePopUpTransitionController = MessageActionsTransitionController()
-
+    open private(set) lazy var messagePopUpTransitionController: ChatMessageActionsTransitionController = components
+        .messageActionsTransitionController
+        .init(messageListVC: rootViewController as? ChatMessageListVC)
+    
     /// Feedback generator used when presenting actions controller on selected message
     open var impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
 
@@ -50,7 +52,7 @@ open class ChatMessageListRouter:
         popup.modalPresentationStyle = .overFullScreen
         popup.transitioningDelegate = messagePopUpTransitionController
 
-        messagePopUpTransitionController.messageContentView = messageContentView
+        messagePopUpTransitionController.selectedMessageId = messageContentView.content?.id
         
         rootViewController.present(popup, animated: true)
     }


### PR DESCRIPTION
### 🔗 Issue Link

CIS-1207, CIS-1232

### 🎯 Goal

- Fix crash when `ChatMessagePopupVC` is dismissed when the message is outside the visible area of the message list
- Fix behavior when a long-pressed message is swapped with a newly received message when they have the same style

### 🛠 Implementation

Stop passing `ChatMessageContentView` across the message list and pop-up view hierarchies and pass the copy instead. 

Therefore, the following subviews are removed from `MessageActionsTransitionController`:
- messageContentViewFrame
- messageContentViewActivateConstraints
- messageContentViewDeactivateConstraints
- messageContentView
- messageContentViewSuperview
- mainContainerTopAnchor

### 🧪 Testing

Manual testing:
- Launch `DemoApp` on 2 devices
- Sign in as `Luke` and `Leia`
- Open the channel where both users are members
- Send text message as `Luke`, observe the message received by `Leia`
- Long press the message by `Leia`
- Send another text message as `Luke`

**Expected result:** 
The message long-pressed by `Leia` is not swapped with the new message

### 🎨 Changes

The message inside the pop-up is not swapped:

https://user-images.githubusercontent.com/12818985/140047965-18b7957a-0803-43f9-86be-f1bf540531ec.mov

When the pop-up is shown giffy restarts but plays smoothly because the actual view is used while the transition and not the snapshot:

https://user-images.githubusercontent.com/12818985/140048297-5a3d7c1f-18f1-40b6-8263-7874992be1c2.mp4

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
