### PR TITLE
[CIS-1247] Adding new factory method to create ChatChannelListVC

### DIFF
--- a/DemoApp/DemoAppCoordinator.swift
+++ b/DemoApp/DemoAppCoordinator.swift
@@ -104,7 +104,7 @@ final class DemoAppCoordinator: NSObject, UNUserNotificationCenterDelegate {
         // Channels with the current user
         let controller = ChatClient.shared
             .channelListController(query: .init(filter: .containMembers(userIds: [userCredentials.id])))
-        let chatList = ChatChannelListVC.createChannelVC(controller)
+        let chatList = ChatChannelListVC.make(with: controller)
         
         connectionController = ChatClient.shared.connectionController()
         connectionController?.delegate = connectionDelegate

--- a/DemoApp/DemoAppCoordinator.swift
+++ b/DemoApp/DemoAppCoordinator.swift
@@ -104,7 +104,7 @@ final class DemoAppCoordinator: NSObject, UNUserNotificationCenterDelegate {
         // Channels with the current user
         let controller = ChatClient.shared
             .channelListController(query: .init(filter: .containMembers(userIds: [userCredentials.id])))
-        let chatList = ChatChannelListVC.createChannelVC(controller, storyboard: nil, storyboardId: nil)
+        let chatList = ChatChannelListVC.createChannelVC(controller)
         
         connectionController = ChatClient.shared.connectionController()
         connectionController?.delegate = connectionDelegate

--- a/DemoApp/DemoAppCoordinator.swift
+++ b/DemoApp/DemoAppCoordinator.swift
@@ -104,8 +104,7 @@ final class DemoAppCoordinator: NSObject, UNUserNotificationCenterDelegate {
         // Channels with the current user
         let controller = ChatClient.shared
             .channelListController(query: .init(filter: .containMembers(userIds: [userCredentials.id])))
-        let chatList = DemoChannelListVC()
-        chatList.controller = controller
+        let chatList = ChatChannelListVC.createChannelVC(controller, storyboard: nil, storyboardId: nil)
         
         connectionController = ChatClient.shared.connectionController()
         connectionController?.delegate = connectionDelegate

--- a/DocsSnippets/01-UX/00-Quick-Start/02-Channels-Code.swift
+++ b/DocsSnippets/01-UX/00-Quick-Start/02-Channels-Code.swift
@@ -26,7 +26,7 @@ func snippet_ux_quick_start_channels_code() {
                         )
                     )
                 )
-            let channelList = ChatChannelListVC.createChannelVC(channelListController, storyboard: nil, storyboardId: nil)
+            let channelList = ChatChannelListVC.make(with: channelListController)
             
             let window = UIWindow(windowScene: scene)
             window.rootViewController = UINavigationController(rootViewController: channelList)

--- a/DocsSnippets/01-UX/00-Quick-Start/02-Channels-Code.swift
+++ b/DocsSnippets/01-UX/00-Quick-Start/02-Channels-Code.swift
@@ -18,7 +18,6 @@ func snippet_ux_quick_start_channels_code() {
         func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
             guard let scene = scene as? UIWindowScene else { return }
             
-            let channelList = ChatChannelListVC()
             let channelListController = chatClient
                 .channelListController(
                     query: ChannelListQuery(
@@ -27,7 +26,7 @@ func snippet_ux_quick_start_channels_code() {
                         )
                     )
                 )
-            channelList.controller = channelListController
+            let channelList = ChatChannelListVC.createChannelVC(channelListController, storyboard: nil, storyboardId: nil)
             
             let window = UIWindow(windowScene: scene)
             window.rootViewController = UINavigationController(rootViewController: channelList)

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -61,7 +61,7 @@ open class ChatChannelListVC: _ViewController,
     /// Create a new ChatChannelListViewController
     /// - Parameters:
     ///   - controller: Your created ChatChannelListController with required query
-    ///   - storyboard: The storyboard to instanciate your ViewController from
+    ///   - storyboard: The storyboard to instantiate your ViewController from
     ///   - storyboardId: The storyboardId that is set in your Storyboard reference
     /// - Returns: A newly created ChatChannelListViewController
     public static func make(

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -58,12 +58,12 @@ open class ChatChannelListVC: _ViewController,
     /// Used for mapping `ListChanges` to sets of `IndexPath` and verifying possible conflicts
     private let collectionUpdatesMapper = CollectionUpdatesMapper()
     
-    /// Create a new ChatChannelListViewController
+    /// Create a new `ChatChannelListViewController`
     /// - Parameters:
-    ///   - controller: Your created ChatChannelListController with required query
-    ///   - storyboard: The storyboard to instantiate your ViewController from
-    ///   - storyboardId: The storyboardId that is set in your Storyboard reference
-    /// - Returns: A newly created ChatChannelListViewController
+    ///   - controller: Your created `ChatChannelListController` with required query
+    ///   - storyboard: The storyboard to instantiate your `ViewController` from
+    ///   - storyboardId: The `storyboardId` that is set in your `UIStoryboard` reference
+    /// - Returns: A newly created `ChatChannelListViewController`
     public static func make(
         with controller: ChatChannelListController,
         storyboard: UIStoryboard? = nil,

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -64,8 +64,8 @@ open class ChatChannelListVC: _ViewController,
     ///   - storyboard: The storyboard to instanciate your ViewController from
     ///   - storyboardId: The storyboardId that is set in your Storyboard reference
     /// - Returns: A newly created ChatChannelListViewController
-    public static func createChannelVC(
-        _ controller: ChatChannelListController,
+    public static func make(
+        with controller: ChatChannelListController,
         storyboard: UIStoryboard? = nil,
         storyboardId: String? = nil
     ) -> ChatChannelListVC {

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -66,14 +66,13 @@ open class ChatChannelListVC: _ViewController,
     /// - Returns: A newly created ChatChannelListViewController
     public static func createChannelVC(
         _ controller: ChatChannelListController,
-        storyboard: UIStoryboard?,
+        storyboard: UIStoryboard? = nil,
         storyboardId: String? = nil
     ) -> ChatChannelListVC {
         var chatChannelListVC: ChatChannelListVC!
         
-        if let storyboardId = storyboardId {
-            let storyboard = storyboard
-            chatChannelListVC = storyboard?.instantiateViewController(withIdentifier: storyboardId) as? ChatChannelListVC
+        if let storyboardId = storyboardId, let storyboard = storyboard {
+            chatChannelListVC = storyboard.instantiateViewController(withIdentifier: storyboardId) as? ChatChannelListVC
         } else {
             chatChannelListVC = ChatChannelListVC()
         }

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -71,13 +71,23 @@ open class ChatChannelListVC: _ViewController,
     ) -> ChatChannelListVC {
         var chatChannelListVC: ChatChannelListVC!
         
+        // Check if we have a UIStoryboard and/or StoryboardId
         if let storyboardId = storyboardId, let storyboard = storyboard {
-            chatChannelListVC = storyboard.instantiateViewController(withIdentifier: storyboardId) as? ChatChannelListVC
+            // Safely unwrap the ViewController from the Storyboard
+            guard let localViewControllerFromStoryboard = storyboard
+                .instantiateViewController(withIdentifier: storyboardId) as? ChatChannelListVC else {
+                fatalError("Failed to load from UIStoryboard, please check your storyboardId and/or UIStoryboard reference.")
+            }
+            chatChannelListVC = localViewControllerFromStoryboard
         } else {
             chatChannelListVC = ChatChannelListVC()
         }
+        
+        // Set the Controller on the ViewController
         chatChannelListVC.controller = controller
         chatChannelListVC.setUp()
+        
+        // Return the newly created ChatChannelListVC
         return chatChannelListVC
     }
 

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -57,6 +57,30 @@ open class ChatChannelListVC: _ViewController,
 
     /// Used for mapping `ListChanges` to sets of `IndexPath` and verifying possible conflicts
     private let collectionUpdatesMapper = CollectionUpdatesMapper()
+    
+    /// Create a new ChatChannelListViewController
+    /// - Parameters:
+    ///   - controller: Your created ChatChannelListController with required query
+    ///   - storyboard: The storyboard to instanciate your ViewController from
+    ///   - storyboardId: The storyboardId that is set in your Storyboard reference
+    /// - Returns: A newly created ChatChannelListViewController
+    public static func createChannelVC(
+        _ controller: ChatChannelListController,
+        storyboard: UIStoryboard?,
+        storyboardId: String? = nil
+    ) -> ChatChannelListVC {
+        var chatChannelListVC: ChatChannelListVC!
+        
+        if let storyboardId = storyboardId {
+            let storyboard = storyboard
+            chatChannelListVC = storyboard?.instantiateViewController(withIdentifier: storyboardId) as? ChatChannelListVC
+        } else {
+            chatChannelListVC = ChatChannelListVC()
+        }
+        chatChannelListVC.controller = controller
+        chatChannelListVC.setUp()
+        return chatChannelListVC
+    }
 
     override open func setUp() {
         super.setUp()

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC_Tests.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC_Tests.swift
@@ -156,6 +156,14 @@ class ChatChannelListVC_Tests: XCTestCase {
         AssertSnapshot(vc, isEmbeddedInNavigationController: true, variants: .onlyUserInterfaceStyles)
     }
     
+    func test_makeChatChannelListVC() {
+        let mockedController = ChatChannelListController_Mock.mock()
+        let mockChatChannelListVC = TestChatChannelListVC.make(with: mockedController)
+        
+        XCTAssertNotNil(mockChatChannelListVC)
+        XCTAssert(mockChatChannelListVC.isKind(of: ChatChannelListVC.self))
+    }
+    
     func test_router_openCurrentUserProfile() {
         vc.executeLifecycleMethods()
         

--- a/StreamChatSample/LoginViewController.swift
+++ b/StreamChatSample/LoginViewController.swift
@@ -125,7 +125,7 @@ extension LoginViewController {
             #endif
         case streamDesignCell:
             
-            let channelList = ChatChannelListVC.createChannelVC(channelListController, storyboard: nil, storyboardId: nil)
+            let channelList = ChatChannelListVC.make(with: channelListController)
    
             let navigation = channelList.components.navigationVC.init(
                 rootViewController: channelList

--- a/StreamChatSample/LoginViewController.swift
+++ b/StreamChatSample/LoginViewController.swift
@@ -125,9 +125,7 @@ extension LoginViewController {
             #endif
         case streamDesignCell:
             
-            let channelList = ChatChannelListVC()
-            
-            channelList.controller = channelListController
+            let channelList = ChatChannelListVC.createChannelVC(channelListController, storyboard: nil, storyboardId: nil)
    
             let navigation = channelList.components.navigationVC.init(
                 rootViewController: channelList

--- a/docusaurus/docs/iOS/basics/getting-started.md
+++ b/docusaurus/docs/iOS/basics/getting-started.md
@@ -78,7 +78,7 @@ This will create a brand new UIViewController that is subclassing the ChatChanne
 ```swift
 let query = ChannelListQuery(filter: .containMembers(userIds: [userId]))
 let controller = ChatClient.shared.channelListController(query: query)
-let channelList = DemoChannelList.createChannelVC(controller)
+let channelList = DemoChannelList.make(with: controller)
 ```
 
 When deciding to push your `UIViewController` on to the `NavigationStack`, you can use our factory method to instantiate this `ViewController`. We also support `UIStoryboard` by passing in the reference of the `UIStoryboard` and the `StoryboardId`.

--- a/docusaurus/docs/iOS/basics/getting-started.md
+++ b/docusaurus/docs/iOS/basics/getting-started.md
@@ -56,7 +56,7 @@ ChatClient.shared.connectUser(
 - You can grab your API Key and API Secret from the [dashboard](https://getstream.io/dashboard/)
 - You can use the token generator [here](https://getstream.io/chat/docs/ios-swift/token_generator/?language=swift)
 
-This example has the user and its token hard-coded. The best practice is to fetch the user and generate a valid chat token on your backend infrastructure. 
+This example has the user and its token hard-coded. The best practice is to fetch the user and generate a valid chat token on your backend infrastructure.
 
 In the next step, we are adding the channel list and message list screens to our app. If this is a new application, make sure to embed your view controller in a navigation controller.
 
@@ -70,20 +70,19 @@ import StreamChat
 import StreamChatUI
 
 
-class ViewController: ChatChannelListVC {
-    
-    override func viewDidLoad() {
-        /// the query used to retrieve channels
-        let query = ChannelListQuery.init(filter: .containMembers(userIds: [ChatClient.shared.currentUserId!]))
-        
-        /// create a controller and assign it to this view controller
-        self.controller = ChatClient.shared.channelListController(query: query)
-
-        super.viewDidLoad()
-    }
-}
+class ViewController: ChatChannelListVC {}
 ```
 
-The snippet above changes the parent class of `ViewController` to `ChatChannelListVC` and uses the `channelListController` to specify which channels we want to retrieve. 
+This will create a brand new UIViewController that is subclassing the ChatChannelListVC.
+
+```swift
+let query = ChannelListQuery(filter: .containMembers(userIds: [userId]))
+let controller = ChatClient.shared.channelListController(query: query)
+let channelList = DemoChannelList.createChannelVC(controller, storyboard: nil, storyboardId: nil)
+```
+
+When deciding to push your `UIViewController` on to the `NavigationStack`, you can use our factory method to instantiate this `ViewController`. We also support `UIStoryboard` by passing in the reference of the `UIStoryboard` and the `StoryboardId`.
+
+The snippet above will also create the `ChatChannelListController` with the specified query. In this case the query will load all the channels that you're currently a member of.
 
 `ChannelListQuery` allows us to define the channels to fetch and their order. Here we are listing channels where the current user is a member. By default tapping on a channel will navigate to `ChatMessageListVC`.

--- a/docusaurus/docs/iOS/basics/getting-started.md
+++ b/docusaurus/docs/iOS/basics/getting-started.md
@@ -70,7 +70,7 @@ import StreamChat
 import StreamChatUI
 
 
-class ViewController: ChatChannelListVC {}
+class DemoChannelList: ChatChannelListVC {}
 ```
 
 This will create a brand new UIViewController that is subclassing the ChatChannelListVC.
@@ -78,7 +78,7 @@ This will create a brand new UIViewController that is subclassing the ChatChanne
 ```swift
 let query = ChannelListQuery(filter: .containMembers(userIds: [userId]))
 let controller = ChatClient.shared.channelListController(query: query)
-let channelList = DemoChannelList.createChannelVC(controller, storyboard: nil, storyboardId: nil)
+let channelList = DemoChannelList.createChannelVC(controller)
 ```
 
 When deciding to push your `UIViewController` on to the `NavigationStack`, you can use our factory method to instantiate this `ViewController`. We also support `UIStoryboard` by passing in the reference of the `UIStoryboard` and the `StoryboardId`.


### PR DESCRIPTION
### 🔗 Issue Link
https://stream-io.atlassian.net/browse/CIS-1247

### 🎯 Goal

Introduce a new factory method to instantiate a ChatChannelListVC so that we're not relying on ViewController lifecycle. This will prevent a crash if `super` is called before instantiating. 

### 🛠 Implementation

New factory method that will take a UIStoryboard and/or UIStoryboardId if these aren't resolved then we return a newly created ChatChannelListVC with the controller that is passed in.

### 🧪 Testing

The implementation will look something like this:

`let controller = ChatClient.shared.channelListController(query: .init(filter: .containMembers(userIds: [userCredentials.id])))`
`let chatList = ChatChannelListVC.make(with: controller, storyboard: nil, storyboardId: nil)`

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
