### PR TITLE
Small hotfix to include subclasses within the new `make` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+### ✅ Added
+- Added a new `make` API within our ChatChannelListVC so it's easier to instantiate, this eliminates the need to setup within the ViewController lifecycle [#1597](https://github.com/GetStream/stream-chat-swift/issues/1597)
+
 # [4.3.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.3.0)
 _November 03, 2021_
 

--- a/DemoApp/DemoAppCoordinator.swift
+++ b/DemoApp/DemoAppCoordinator.swift
@@ -104,7 +104,7 @@ final class DemoAppCoordinator: NSObject, UNUserNotificationCenterDelegate {
         // Channels with the current user
         let controller = ChatClient.shared
             .channelListController(query: .init(filter: .containMembers(userIds: [userCredentials.id])))
-        let chatList = ChatChannelListVC.make(with: controller)
+        let chatList = DemoChannelListVC.make(with: controller)
         
         connectionController = ChatClient.shared.connectionController()
         connectionController?.delegate = connectionDelegate

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -80,7 +80,7 @@ open class ChatChannelListVC: _ViewController,
             }
             chatChannelListVC = localViewControllerFromStoryboard
         } else {
-            chatChannelListVC = ChatChannelListVC()
+            chatChannelListVC = Self()
         }
         
         // Set the Controller on the ViewController


### PR DESCRIPTION
### 🎯 Goal

In the new `make` function we have just introduced we want to enable subclasses still and set our own custom implementation as the default.

### 🧪 Testing

Our visible override should be shown (we have additional buttons in the navigation bar)

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
