### PR TITLE
[CIS-1252] Make the `NukeImageLoader` initialiser accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Make the NukeImageLoader initialiser accessible [#1600](https://github.com/GetStream/stream-chat-swift/issues/1600)
 
 # [4.3.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.3.0)
 _November 03, 2021_

--- a/Sources/StreamChatUI/Utils/ImageLoading/NukeImageLoader.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/NukeImageLoader.swift
@@ -10,6 +10,8 @@ extension ImageTask: Cancellable {}
 /// The class which is resposible for loading images from URLs.
 /// Internally uses `Nuke`'s shared object of `ImagePipeline` to load the image.
 open class NukeImageLoader: ImageLoading {
+    public init() {}
+
     @discardableResult
     open func loadImage(
         using urlRequest: URLRequest,


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1252
https://github.com/GetStream/stream-chat-swift/issues/1562

### 🎯 Goal
Make the `NukeImageLoader` Overridable.

### 🛠 Implementation
Simply make the `init()` accessible. Although the class was already open and with open functions, the init was not accessible, which prohibited using the custom subclass by the customer.

### 🧪 Testing
N/A

### 🎨 Changes
N/A

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
