### PR TITLE
[CIS-1251] Giving the Bundle resources a unique name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🐞 Fixed
+- Using Xcode 13 & CocoaPods should load all the required assets. [#1602](https://github.com/GetStream/stream-chat-swift/pull/1602)
 - Make the NukeImageLoader initialiser accessible [#1600](https://github.com/GetStream/stream-chat-swift/issues/1600)
 
 ### ✅ Added

--- a/Sources/StreamChatUI/Utils/Bundle+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/Bundle+Extensions.swift
@@ -18,7 +18,7 @@ extension Bundle {
         // See https://github.com/GetStream/stream-chat-swift/issues/774
         #if COCOAPODS
         return Bundle(for: BundleIdentifyingClass.self)
-            .url(forResource: "StreamChatUI", withExtension: "bundle")
+            .url(forResource: "StreamChatUIResources", withExtension: "bundle")
             .flatMap(Bundle.init(url:))!
         #elseif SWIFT_PACKAGE
         return Bundle.module

--- a/StreamChatUI.podspec
+++ b/StreamChatUI.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |spec|
     spec.version = "4.3.0"
     spec.summary = "StreamChat UI Components"
     spec.description = "StreamChatUI SDK offers flexible UI components able to display data provided by StreamChat SDK."
-  
+
     spec.homepage = "https://getstream.io/chat/"
     spec.license = { :type => "BSD-3", :file => "LICENSE" }
     spec.author = { "getstream.io" => "support@getstream.io" }
@@ -12,15 +12,14 @@ Pod::Spec.new do |spec|
     spec.platform = :ios, "11.0"
     spec.source = { :git => "https://github.com/GetStream/stream-chat-swift.git", :tag => "#{spec.version}" }
     spec.requires_arc = true
-  
+
     spec.source_files = "Sources/StreamChatUI/**/*.swift"
     spec.exclude_files = ["Sources/StreamChatUI/**/*_Tests.swift", "Sources/StreamChatUI/**/*_Mock.swift"]
-    spec.resource_bundles = { "StreamChatUI" => ["Sources/StreamChatUI/Resources/**/*"] }
-  
+    spec.resource_bundles = { "StreamChatUIResources" => ["Sources/StreamChatUI/Resources/**/*"] }
+
     spec.framework = "Foundation", "UIKit"
-  
+
     spec.dependency "StreamChat", "#{spec.version}"
     spec.dependency "Nuke", "~> 10.0"
     spec.dependency "SwiftyGif", "~> 5.0"
   end
-  


### PR DESCRIPTION
### 🔗 Issue Link
https://stream-io.atlassian.net/browse/CIS-1251

### 🎯 Goal

This was an ongoing issue when pulling our resources from the Bundle file. This is only affecting Xcode 13 but this bundle name has to be unique otherwise it's clashing with the target membership.

### 🛠 Implementation

Gave the Bundle a unique name and updated the Bundle location in the Swift class.

### 🧪 Testing

I have tested this by having a sample cocoapods integrated StreamChatUI application and uploaded to TestFlight, the result is that all the assets are now loaded.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
