### PR TITLE
[CIS-1308] Fix message not pinned when expiration date is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Using Xcode 13 & CocoaPods should load all the required assets. [#1602](https://github.com/GetStream/stream-chat-swift/pull/1602)
 - Make the NukeImageLoader initialiser accessible [#1600](https://github.com/GetStream/stream-chat-swift/issues/1600)
+- Fix message not pinned when there is no expiration date [#1603](https://github.com/GetStream/stream-chat-swift/issues/1603)
 
 ### ✅ Added
 - Added a new `make` API within our ChatChannelListVC so it's easier to instantiate, this eliminates the need to setup within the ViewController lifecycle [#1597](https://github.com/GetStream/stream-chat-swift/issues/1597)

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -627,12 +627,11 @@ private extension ChatMessage {
         
         if dto.pinned,
            let pinnedAt = dto.pinnedAt,
-           let pinnedBy = dto.pinnedBy,
-           let pinExpires = dto.pinExpires {
+           let pinnedBy = dto.pinnedBy {
             pinDetails = .init(
                 pinnedAt: pinnedAt,
                 pinnedBy: pinnedBy.asModel(),
-                expiresAt: pinExpires
+                expiresAt: dto.pinExpires
             )
         } else {
             pinDetails = nil

--- a/Sources/StreamChat/Models/ChatMessage.swift
+++ b/Sources/StreamChat/Models/ChatMessage.swift
@@ -332,7 +332,7 @@ public struct MessagePinDetails {
     public let pinnedBy: ChatUser
 
     /// Date when the message pin expires. An nil value means that message does not expire
-    public let expiresAt: Date
+    public let expiresAt: Date?
 }
 
 /// A possible additional local state of the message. Applies only for the messages of the current user.

--- a/Sources/StreamChat/Models/ChatMessage_Tests.swift
+++ b/Sources/StreamChat/Models/ChatMessage_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 final class ChatMessage_Tests: XCTestCase {
-    func test_isPinnedShouldReturnTrue() {
+    func test_isPinned_whenHasPinDetails_shouldReturnTrue() {
         let message = ChatMessage.mock(
             id: .anonymous,
             cid: .unique,
@@ -22,7 +22,7 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertTrue(message.isPinned)
     }
     
-    func test_isPinnedShouldReturnFalse() {
+    func test_isPinned_whenEmptyPinDetails_shouldReturnFalse() {
         let message = ChatMessage.mock(
             id: .anonymous,
             cid: .unique,
@@ -32,6 +32,22 @@ final class ChatMessage_Tests: XCTestCase {
         )
         
         XCTAssertFalse(message.isPinned)
+    }
+
+    func test_isPinned_whenEmptyExpireDate_shouldReturnTrue() {
+        let message = ChatMessage.mock(
+            id: .anonymous,
+            cid: .unique,
+            text: "Text",
+            author: ChatUser.mock(id: .anonymous),
+            pinDetails: MessagePinDetails(
+                pinnedAt: Date.distantPast,
+                pinnedBy: ChatUser.mock(id: .anonymous),
+                expiresAt: nil
+            )
+        )
+
+        XCTAssertTrue(message.isPinned)
     }
     
     func test_attachmentWithId_whenAttachmentDoesNotExist_returnsNil() {


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1308

### 🎯 Goal
A message should be pinned when there is no expiration date, and `pinned = true`.

### 🛠 Implementation
`MessagePinDetails` should have an optional expiration date just like the documentation states.

### 🧪 Testing
Unit Tests were added to prove it now works properly.

### 🎨 Changes
N/A

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
