### PR TITLE
Fix MOV attachment mime type encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Using Xcode 13 & CocoaPods should load all the required assets. [#1602](https://github.com/GetStream/stream-chat-swift/pull/1602)
 - Make the NukeImageLoader initialiser accessible [#1600](https://github.com/GetStream/stream-chat-swift/issues/1600)
 - Fix message not pinned when there is no expiration date [#1603](https://github.com/GetStream/stream-chat-swift/issues/1603)
+- Fix uploaded videos' mime types were not encoded correctly [#1604](https://github.com/GetStream/stream-chat-swift/issues/1604)
 
 ### ✅ Added
 - Added a new `make` API within our ChatChannelListVC so it's easier to instantiate, this eliminates the need to setup within the ViewController lifecycle [#1597](https://github.com/GetStream/stream-chat-swift/issues/1597)

--- a/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
+++ b/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
@@ -215,6 +215,10 @@ public enum AttachmentFileType: String, Codable, Equatable, CaseIterable {
     ///
     /// - Parameter ext: a file extension.
     public init(ext: String) {
+        // We've seen that iOS sometimes uppercases the filename (and also extension)
+        // which breaks our file type detection code.
+        // We lowercase it for extra safety
+        let ext = ext.lowercased()
         if ext == "jpg" {
             self = .jpeg
             return

--- a/Sources/StreamChat/Models/Attachments/AttachmentTypes_Tests.swift
+++ b/Sources/StreamChat/Models/Attachments/AttachmentTypes_Tests.swift
@@ -28,6 +28,14 @@ class AttachmentTypes_Tests: XCTestCase {
         }
     }
     
+    func test_attachmentFileType_isUnaffected_byUppercase() {
+        let types = AttachmentFileType.allCases
+        
+        for type in types {
+            XCTAssertEqual(type, AttachmentFileType(ext: type.rawValue.uppercased()))
+        }
+    }
+    
     func test_action_encodedAndDecodedCorrectly() throws {
         let action: AttachmentAction = .init(
             name: .unique,


### PR DESCRIPTION
### 🎯 Goal

Android SDK wasn't able to parse our video attachments.

### 🛠 Implementation

It turned out that iOS reports the file name uppercased (eg TRIMMED_FILE123.MOV) and we couldn't detect it was a video (MOV) so we encoded it as generic (octet-stream)

### 🧪 Testing

Enable logs and upload a video attachment, check the encoded mime type.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
