### PR TITLE
[CIS-1262, CIS-1293] Fix message list jumps and cell not resizing on edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Make the NukeImageLoader initialiser accessible [#1600](https://github.com/GetStream/stream-chat-swift/issues/1600)
 - Fix message not pinned when there is no expiration date [#1603](https://github.com/GetStream/stream-chat-swift/issues/1603)
 - Fix uploaded videos' mime types were not encoded correctly [#1604](https://github.com/GetStream/stream-chat-swift/issues/1604)
+- Fix message list scrolling jumps when a new message is received [#1605](https://github.com/GetStream/stream-chat-swift/pull/1605)
+- Fix message cell not resized after editing a message with bigger/smaller content [#1605](https://github.com/GetStream/stream-chat-swift/pull/1605)
 
 ### ✅ Added
 - Added a new `make` API within our ChatChannelListVC so it's easier to instantiate, this eliminates the need to setup within the ViewController lifecycle [#1597](https://github.com/GetStream/stream-chat-swift/issues/1597)

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -286,12 +286,12 @@ open class ChatChannelListVC: _ViewController,
         didChangeChannels changes: [ListChange<ChatChannel>]
     ) {
         guard let indices = collectionUpdatesMapper.mapToSetsOfIndexPaths(
-            changes: changes,
-            onConflict: {
-                channelsCount = controller.channels.count
-                collectionView.reloadData()
-            }
-        ) else { return }
+            changes: changes
+        ) else {
+            channelsCount = controller.channels.count
+            collectionView.reloadData()
+            return
+        }
 
         collectionView.performBatchUpdates(
             {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -172,19 +172,21 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
         with changes: [ListChange<ChatMessage>],
         completion: (() -> Void)? = nil
     ) {
+        defer {
+            completion?()
+        }
+
         guard let _ = collectionUpdatesMapper.mapToSetsOfIndexPaths(
             changes: changes,
             onConflict: {
                 reloadData()
             }
         ) else {
-            completion?()
             return
         }
 
         if changes.count > 1 {
             reloadData()
-            completion?()
             return
         }
 
@@ -199,7 +201,6 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
                         // +1 instead of -1 because the message list is inverted
                         let previousIndex = IndexPath(row: index.row + 1, section: index.section)
                         self.reloadRows(at: [previousIndex], with: .none)
-                        completion?()
                     }
                 }
 
@@ -211,15 +212,12 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
 
             case let .move(_, fromIndex: fromIndex, toIndex: toIndex):
                 self.moveRow(at: fromIndex, to: toIndex)
-                completion?()
 
             case let .update(_, index: index):
                 self.reloadRows(at: [index], with: .automatic)
-                completion?()
 
             case .remove:
                 self.reloadData()
-                completion?()
             }
         }
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -194,6 +194,7 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
                     self.performBatchUpdates {
                         self.insertRows(at: [index], with: .none)
                     } completion: { _ in
+                        guard self.numberOfRows(inSection: index.section) > 1 else { return }
                         // Update previous row to remove timestamp if needed
                         // +1 instead of -1 because the message list is inverted
                         let previousIndex = IndexPath(row: index.row + 1, section: index.section)

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -176,12 +176,9 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
             completion?()
         }
 
-        guard let _ = collectionUpdatesMapper.mapToSetsOfIndexPaths(
-            changes: changes,
-            onConflict: {
-                reloadData()
-            }
-        ) else {
+        let hasConflictUpdates = collectionUpdatesMapper.mapToSetsOfIndexPaths(changes: changes) == nil
+        if hasConflictUpdates {
+            reloadData()
             return
         }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -228,11 +228,13 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
                 cellBeforeUpdateReuseIdentifier == cellAfterUpdateReuseIdentifier,
                 cellBeforeUpdateMessage?.id == cellAfterUpdateMessage?.id,
                 cellBeforeUpdateMessage?.type == cellAfterUpdateMessage?.type,
-                cellBeforeUpdateMessage?.deletedAt == cellAfterUpdateMessage?.deletedAt {
+                cellBeforeUpdateMessage?.deletedAt == cellAfterUpdateMessage?.deletedAt,
+                cellBeforeUpdateMessage?.text == cellAfterUpdateMessage?.text {
                 // If identifiers and messages match we can simply update the current cell with new content
                 cellBeforeUpdate?.messageContentView?.content = cellAfterUpdateMessage
             } else {
-                // If identifiers does not match we do a reload to let the table view dequeue another cell
+                // If identifiers do not match or the cell size will need to change, ex: Editing text
+                // we do a reload to let the table view dequeue another cell
                 // with the layout fitting the updated message.
                 indexPathToReload.append(indexPath)
             }

--- a/Sources/StreamChatUI/Utils/CollectionUpdatesMapper.swift
+++ b/Sources/StreamChatUI/Utils/CollectionUpdatesMapper.swift
@@ -32,10 +32,9 @@ final class CollectionUpdatesMapper {
     /// Verify if there are conflicts in changes and if there are call `onConflict`
     /// - Parameters:
     ///   - changes: changes
-    ///   - onConflict: Is called when a conflict occurs
+    /// - Returns: Returns the indices mapped to sets. Returns nil if there were conflicts.
     func mapToSetsOfIndexPaths<Item>(
-        changes: [ListChange<Item>],
-        onConflict: () -> Void
+        changes: [ListChange<Item>]
     ) -> Indexes? {
         var allIndexes = Set<IndexPath>()
         var moveIndexes = Set<IndexPathMove>()
@@ -72,14 +71,6 @@ final class CollectionUpdatesMapper {
         }
         
         if hasConflicts {
-            onConflict()
-            
-            logConflicts(
-                moves: moveIndexes,
-                inserts: insertIndexes,
-                updates: updateIndexes,
-                removes: removeIndexes
-            )
             return nil
         }
         
@@ -88,27 +79,6 @@ final class CollectionUpdatesMapper {
             insert: insertIndexes,
             remove: removeIndexes,
             update: updateIndexes
-        )
-    }
-    
-    private func logConflicts(
-        moves: Set<IndexPathMove>,
-        inserts: Set<IndexPath>,
-        updates: Set<IndexPath>,
-        removes: Set<IndexPath>
-    ) {
-        log.error(
-            """
-
-            ⚠️ Inconsistent updates from ChatChannelListController.
-            🙏 Please copy the following log and open an issue at: https://github.com/GetStream/stream-chat-swift/issues
-
-            Moves: \(moves)
-            Inserts: \(inserts)
-            updates: \(updates)
-            removes: \(removes)
-
-            """
         )
     }
 }

--- a/Sources/StreamChatUI/Utils/CollectionUpdatesMapper_Tests.swift
+++ b/Sources/StreamChatUI/Utils/CollectionUpdatesMapper_Tests.swift
@@ -8,9 +8,8 @@ import Foundation
 import XCTest
 
 final class CollectionUpdatesMapper_Tests: XCTestCase {
-    func test_hasConflicts_callsOnConflict_returnsNil() {
+    func test_hasConflicts_returnsNil() {
         let mapper = CollectionUpdatesMapper()
-        var onConflictWasCalled = false
         
         let changes: [ListChange<Int>] = [
             .update(0, index: .init(row: 0, section: 0)),
@@ -24,17 +23,14 @@ final class CollectionUpdatesMapper_Tests: XCTestCase {
         ]
 
         let indices = mapper.mapToSetsOfIndexPaths(
-            changes: changes,
-            onConflict: { onConflictWasCalled = true }
+            changes: changes
         )
-        
-        XCTAssertTrue(onConflictWasCalled)
+
         XCTAssertNil(indices)
     }
     
-    func test_hasNoConflicts_doesNotCallOnConflict_returnsIndices() {
+    func test_hasNoConflicts_returnsIndices() {
         let mapper = CollectionUpdatesMapper()
-        var onConflictWasCalled = false
         
         let changes: [ListChange<Int>] = [
             .update(0, index: .init(row: 0, section: 0)),
@@ -47,11 +43,9 @@ final class CollectionUpdatesMapper_Tests: XCTestCase {
         ]
 
         let indices = mapper.mapToSetsOfIndexPaths(
-            changes: changes,
-            onConflict: { onConflictWasCalled = true }
+            changes: changes
         )
         
-        XCTAssertFalse(onConflictWasCalled)
         XCTAssertEqual(
             indices?.update,
             [


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1262
CIS-1293

### 🎯 Goal
- Fix message list scrolling jumps when a new message is received.
- Fix message cell size not updated when editing a message with bigger/smaller content.
- **Bonus:**
     - Fix not executing the `completion` of `updateMessages()` which was not being called ever.
     - Removes the list changes conflicts log.

### 🛠 Implementation
- Scrolling jumps fix: Whenever the message list is reloaded, it re-calculates the message cell's height, causing a scrolling jump. When using `performBatchUpdates` this is not an issue. Use `performBatchUpdates` only for inserts. We also need to reload the previous cell to make sure the timestamp is removed if needed.
- Message cell resize fix: When a message is edited, previously we were just updating the message cell content and not reloading the cell. Now, if the text of the message is different, we also reload the cell, to re-calculate the cell size.

### 🧪 Testing
- Scrolling jumps fix: 
    1. Scroll up in the message list
    2. Send a message from another device
    3. Verify that the message list doesn't move
- Message cell resize fix:
   1. Edit a message with more lines of text than it had before
   2. Verify the cell changes its size.

### 🎨 Changes
| Message cell resize fix |  Scrolling jumps fix |
| --- | --- |
| <video src="https://user-images.githubusercontent.com/12814114/141162863-ef1803a2-8da8-4645-9fa6-2eecb120cf61.mp4"> | <video src="https://user-images.githubusercontent.com/12814114/141162941-9f54c514-537e-418f-aa48-e21787fdef8d.mp4"> |

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
