### PR TITLE
[CIS-1316] Take sorting into account in `ChatChannelListQuery` hash

### DIFF
--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
@@ -195,7 +195,7 @@ class ChannelController_Tests: XCTestCase {
         // Load the channel list query from database
         let channelListQueryDTO = try XCTUnwrap(
             client.databaseContainer.viewContext.channelListQuery(
-                filterHash: channelListQuery.filter.filterHash
+                queryHash: channelListQuery.queryHash
             )
         )
         
@@ -242,7 +242,7 @@ class ChannelController_Tests: XCTestCase {
         let channelListQuery: ChannelListQuery = .unique(for: channelId)
         var queryDTO: ChannelListQueryDTO? {
             client.databaseContainer.viewContext.channelListQuery(
-                filterHash: channelListQuery.filter.filterHash
+                queryHash: channelListQuery.queryHash
             )
         }
                 

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -237,7 +237,7 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
     private func link(channels: [ChatChannel]) {
         guard !channels.isEmpty else { return }
         client.databaseContainer.write { session in
-            guard let queryDTO = session.channelListQuery(filterHash: self.query.filter.filterHash) else {
+            guard let queryDTO = session.channelListQuery(queryHash: self.query.queryHash) else {
                 log.debug("Channel list query has not yet created \(self.query)")
                 return
             }
@@ -255,7 +255,7 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
     private func unlink(channels: [ChatChannel]) {
         guard !channels.isEmpty else { return }
         client.databaseContainer.write { session in
-            guard let queryDTO = session.channelListQuery(filterHash: self.query.filter.filterHash) else {
+            guard let queryDTO = session.channelListQuery(queryHash: self.query.queryHash) else {
                 log.debug("Channel list query has not yet created \(self.query)")
                 return
             }

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -52,7 +52,7 @@ class ChannelListController_Tests: XCTestCase {
     func test_clientAndQueryAreCorrect() {
         let controller = client.channelListController(query: query)
         XCTAssert(controller.client === client)
-        XCTAssertEqual(controller.query.filter.filterHash, query.filter.filterHash)
+        XCTAssertEqual(controller.query.queryHash, query.queryHash)
     }
     
     // MARK: - Synchronize tests
@@ -149,7 +149,7 @@ class ChannelListController_Tests: XCTestCase {
         controller = nil
         
         // Assert the updater is called with the query
-        XCTAssertEqual(env.channelListUpdater!.update_queries.first?.filter.filterHash, query.filter.filterHash)
+        XCTAssertEqual(env.channelListUpdater!.update_queries.first?.queryHash, query.queryHash)
         // Completion shouldn't be called yet
         XCTAssertFalse(completionCalled)
         
@@ -184,7 +184,7 @@ class ChannelListController_Tests: XCTestCase {
         controller = nil
         
         // Assert the updater is called with the query
-        XCTAssertEqual(env.channelListUpdater?.update_queries.first?.filter.filterHash, query.filter.filterHash)
+        XCTAssertEqual(env.channelListUpdater?.update_queries.first?.queryHash, query.queryHash)
         // Completion shouldn't be called yet
         XCTAssertFalse(completionCalled)
         

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -255,7 +255,7 @@ extension NSManagedObjectContext {
     }
     
     func delete(query: ChannelListQuery) {
-        guard let dto = channelListQuery(filterHash: query.filter.filterHash) else { return }
+        guard let dto = channelListQuery(queryHash: query.queryHash) else { return }
         
         delete(dto)
     }
@@ -273,7 +273,7 @@ extension ChannelDTO {
         let sortDescriptors = query.sort.compactMap { $0.key.sortDescriptor(isAscending: $0.isAscending) }
         request.sortDescriptors = sortDescriptors.isEmpty ? [ChannelListSortingKey.defaultSortDescriptor] : sortDescriptors
         
-        let matchingQuery = NSPredicate(format: "ANY queries.filterHash == %@", query.filter.filterHash)
+        let matchingQuery = NSPredicate(format: "ANY queries.queryHash == %@", query.queryHash)
         let notDeleted = NSPredicate(format: "deletedAt == nil")
 
         // If the query contains a filter for the `isHidden` property,
@@ -297,7 +297,7 @@ extension ChannelDTO {
         // Channels which are not linked to this query
         request.predicate = NSCompoundPredicate(
             notPredicateWithSubpredicate: NSPredicate(
-                format: "ANY queries.filterHash == %@", query.filter.filterHash
+                format: "ANY queries.queryHash == %@", query.queryHash
             )
         )
         return request

--- a/Sources/StreamChat/Database/DTOs/ChannelListQueryDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelListQueryDTO.swift
@@ -7,7 +7,7 @@ import CoreData
 @objc(ChannelListQueryDTO)
 class ChannelListQueryDTO: NSManagedObject {
     /// Unique identifier of the query/
-    @NSManaged var filterHash: String
+    @NSManaged var queryHash: String
     
     /// Serialized `Filter` JSON which can be used in cases the query needs to be repeated, i.e. for newly created channels.
     @NSManaged var filterJSONData: Data
@@ -19,26 +19,26 @@ class ChannelListQueryDTO: NSManagedObject {
     /// Channels that are being read by the current user (the subset of `channels`)
     @NSManaged var openChannels: Set<ChannelDTO>
     
-    static func load(filterHash: String, context: NSManagedObjectContext) -> ChannelListQueryDTO? {
+    static func load(queryHash: String, context: NSManagedObjectContext) -> ChannelListQueryDTO? {
         let request = NSFetchRequest<ChannelListQueryDTO>(entityName: ChannelListQueryDTO.entityName)
-        request.predicate = NSPredicate(format: "filterHash == %@", filterHash)
+        request.predicate = NSPredicate(format: "queryHash == %@", queryHash)
         return try? context.fetch(request).first
     }
 }
 
 extension NSManagedObjectContext {
-    func channelListQuery(filterHash: String) -> ChannelListQueryDTO? {
-        ChannelListQueryDTO.load(filterHash: filterHash, context: self)
+    func channelListQuery(queryHash: String) -> ChannelListQueryDTO? {
+        ChannelListQueryDTO.load(queryHash: queryHash, context: self)
     }
     
     func saveQuery(query: ChannelListQuery) -> ChannelListQueryDTO {
-        if let existingDTO = ChannelListQueryDTO.load(filterHash: query.filter.filterHash, context: self) {
+        if let existingDTO = ChannelListQueryDTO.load(queryHash: query.queryHash, context: self) {
             return existingDTO
         }
         
         let newDTO = NSEntityDescription
             .insertNewObject(forEntityName: ChannelListQueryDTO.entityName, into: self) as! ChannelListQueryDTO
-        newDTO.filterHash = query.filter.filterHash
+        newDTO.queryHash = query.queryHash
         
         let jsonData: Data
         do {

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -177,9 +177,9 @@ protocol ChannelDatabaseSession {
         query: ChannelListQuery?
     ) throws -> ChannelDTO
     
-    /// Loads channel list query with the given filter hash from the database.
-    /// - Parameter filterHash: The filter hash.
-    func channelListQuery(filterHash: String) -> ChannelListQueryDTO?
+    /// Loads channel list query with the given hash from the database.
+    /// - Parameter queryHash: The query hash.
+    func channelListQuery(queryHash: String) -> ChannelListQueryDTO?
     
     @discardableResult func saveQuery(query: ChannelListQuery) -> ChannelListQueryDTO
     

--- a/Sources/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Mock.swift
@@ -187,8 +187,8 @@ extension DatabaseSessionMock {
         underlyingSession.saveQuery(query: query)
     }
     
-    func channelListQuery(filterHash: String) -> ChannelListQueryDTO? {
-        underlyingSession.channelListQuery(filterHash: filterHash)
+    func channelListQuery(queryHash: String) -> ChannelListQueryDTO? {
+        underlyingSession.channelListQuery(queryHash: queryHash)
     }
     
     func saveChannel(

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19461" systemVersion="20G165" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19461" systemVersion="21A559" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
@@ -67,16 +67,16 @@
         </uniquenessConstraints>
     </entity>
     <entity name="ChannelListQueryDTO" representedClassName="ChannelListQueryDTO" syncable="YES">
-        <attribute name="filterHash" attributeType="String"/>
         <attribute name="filterJSONData" attributeType="Binary"/>
+        <attribute name="queryHash" attributeType="String"/>
         <relationship name="channels" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="queries" inverseEntity="ChannelDTO"/>
         <relationship name="openChannels" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="openIn" inverseEntity="ChannelDTO"/>
-        <fetchIndex name="filterHash">
-            <fetchIndexElement property="filterHash" type="Binary" order="ascending"/>
+        <fetchIndex name="queryHash">
+            <fetchIndexElement property="queryHash" type="Binary" order="ascending"/>
         </fetchIndex>
         <uniquenessConstraints>
             <uniquenessConstraint>
-                <constraint value="filterHash"/>
+                <constraint value="queryHash"/>
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -135,3 +135,17 @@ public struct ChannelListQuery: Encodable {
         try pagination.encode(to: encoder)
     }
 }
+
+extension ChannelListQuery {
+    var queryHash: String {
+        let filterHash = filter.filterHash
+        
+        let sortingHash = sort
+            .map(\.description)
+            .joined(separator: ",")
+        
+        return [filterHash, sortingHash]
+            .filter { !$0.isEmpty }
+            .joined(separator: " | ")
+    }
+}

--- a/Sources/StreamChat/WebSocketClient/Events/ChannelEvents_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/ChannelEvents_Tests.swift
@@ -264,7 +264,7 @@ class ChannelEventsIntegration_Tests: XCTestCase {
 
         let channelId: ChannelId = ChannelId(type: .messaging, id: "default-channel-1")
         
-        try client.databaseContainer.createChannel(cid: channelId, withMessages: false, withQuery: false)
+        try client.databaseContainer.createChannel(cid: channelId, withMessages: false)
         XCTAssertNil(client.databaseContainer.viewContext.channel(cid: channelId)?.deletedAt)
         
         let unwrappedEvent = try XCTUnwrap(event)
@@ -281,7 +281,7 @@ class ChannelEventsIntegration_Tests: XCTestCase {
 
         let channelId: ChannelId = ChannelId(type: .messaging, id: "new_channel_7011")
         
-        try client.databaseContainer.createChannel(cid: channelId, withMessages: false, withQuery: false)
+        try client.databaseContainer.createChannel(cid: channelId, withMessages: false)
         XCTAssertNil(client.databaseContainer.viewContext.channel(cid: channelId)?.truncatedAt)
        
         let unwrappedEvent = try XCTUnwrap(event)
@@ -298,7 +298,7 @@ class ChannelEventsIntegration_Tests: XCTestCase {
 
         let channelId: ChannelId = ChannelId(type: .messaging, id: "default-channel-6")
         
-        try client.databaseContainer.createChannel(cid: channelId, withMessages: false, withQuery: false, isHidden: true)
+        try client.databaseContainer.createChannel(cid: channelId, withMessages: false, isHidden: true)
         XCTAssertEqual(client.databaseContainer.viewContext.channel(cid: channelId)?.isHidden, true)
        
         let unwrappedEvent = try XCTUnwrap(event)
@@ -315,7 +315,7 @@ class ChannelEventsIntegration_Tests: XCTestCase {
 
         let channelId: ChannelId = ChannelId(type: .messaging, id: "default-channel-6")
         
-        try client.databaseContainer.createChannel(cid: channelId, withMessages: false, withQuery: false)
+        try client.databaseContainer.createChannel(cid: channelId, withMessages: false)
         XCTAssertEqual(client.databaseContainer.viewContext.channel(cid: channelId)?.isHidden, false)
      
         let unwrappedEvent = try XCTUnwrap(event)
@@ -393,8 +393,7 @@ class ChannelEventsIntegration_Tests: XCTestCase {
         // For event to be received, we need to have channel:
         try client.databaseContainer.createChannel(
             cid: channelId,
-            withMessages: true,
-            withQuery: false
+            withMessages: true
         )
         
         try client.databaseContainer.writeSynchronously { session in

--- a/Sources/StreamChat/WebSocketClient/Events/MemberEvents_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/MemberEvents_Tests.swift
@@ -196,8 +196,7 @@ class MemberEventsIntegration_Tests: XCTestCase {
         // First create channel and member of that channel to be saved in database.
         try client.databaseContainer.createChannel(
             cid: channelId,
-            withMessages: false,
-            withQuery: false
+            withMessages: false
         )
         
         try! client.databaseContainer.createMember(

--- a/Sources/StreamChat/WebSocketClient/Events/MessageEvents_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/MessageEvents_Tests.swift
@@ -105,8 +105,7 @@ class MessageEventsIntegration_Tests: XCTestCase {
         // For message to be received, we need to have channel:
         try client.databaseContainer.createChannel(
             cid: .init(type: .messaging, id: "general"),
-            withMessages: true,
-            withQuery: false
+            withMessages: true
         )
         
         let unwrappedEvent = try XCTUnwrap(event)
@@ -124,8 +123,7 @@ class MessageEventsIntegration_Tests: XCTestCase {
         // For message to be received, we need to have channel:
         try client.databaseContainer.createChannel(
             cid: .init(type: .messaging, id: "general"),
-            withMessages: true,
-            withQuery: false
+            withMessages: true
         )
     
         let lastUpdateMessageTime: Date = .unique
@@ -160,8 +158,7 @@ class MessageEventsIntegration_Tests: XCTestCase {
         // For message to be received, we need to have channel:
         try client.databaseContainer.createChannel(
             cid: .init(type: .messaging, id: "general"),
-            withMessages: true,
-            withQuery: false
+            withMessages: true
         )
         
         try client.databaseContainer.createMessage(id: "1ff9f6d0-df70-4703-aef0-379f95ad7366", type: .regular)

--- a/Sources/StreamChat/WebSocketClient/Events/ReactionEvents_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/ReactionEvents_Tests.swift
@@ -81,8 +81,7 @@ class ReactionEventsIntegration_Tests: XCTestCase {
         // For message to be received, we need to have channel:
         try client.databaseContainer.createChannel(
             cid: .init(type: .messaging, id: "general"),
-            withMessages: true,
-            withQuery: false
+            withMessages: true
         )
         
         try client.databaseContainer.createMessage(
@@ -116,8 +115,7 @@ class ReactionEventsIntegration_Tests: XCTestCase {
         // For message to be received, we need to have channel:
         try client.databaseContainer.createChannel(
             cid: .init(type: .messaging, id: "general"),
-            withMessages: true,
-            withQuery: false
+            withMessages: true
         )
     
         let lastUpdateMessageTime = "2020-06-20 17:09:56 +0000"
@@ -155,8 +153,7 @@ class ReactionEventsIntegration_Tests: XCTestCase {
         // For message to be received, we need to have channel:
         try client.databaseContainer.createChannel(
             cid: .init(type: .messaging, id: "general"),
-            withMessages: true,
-            withQuery: false
+            withMessages: true
         )
         
         try client.databaseContainer.createMessage(

--- a/Sources/StreamChat/WebSocketClient/Events/TypingEvent_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/TypingEvent_Tests.swift
@@ -154,7 +154,7 @@ class TypingEventsIntegration_Tests: XCTestCase {
         let event = try eventDecoder.decode(from: json) as? TypingEventDTO
 
         let channelId: ChannelId = ChannelId(type: .messaging, id: "general")
-        try client.databaseContainer.createChannel(cid: channelId, withMessages: false, withQuery: false)
+        try client.databaseContainer.createChannel(cid: channelId, withMessages: false)
         try client.databaseContainer.createMember(userId: "luke_skywalker", role: .member, cid: channelId)
         
         let channel = try XCTUnwrap(client.databaseContainer.viewContext.channel(cid: channelId))
@@ -177,8 +177,7 @@ class TypingEventsIntegration_Tests: XCTestCase {
         let channelId: ChannelId = ChannelId(type: .messaging, id: "general")
         try client.databaseContainer.createChannel(
             cid: channelId,
-            withMessages: false,
-            withQuery: false
+            withMessages: false
         )
 
         try client.databaseContainer.createUser(id: "luke_skywalker")

--- a/Sources/StreamChat/WebSocketClient/Events/UserEvents_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/UserEvents_Tests.swift
@@ -307,8 +307,7 @@ class UserEventsIntegration_Tests: XCTestCase {
         
         try client.databaseContainer.createChannel(
             cid: .init(type: .messaging, id: "!members-dpwtNCSGs-VaJKfAVaeosq6FNNbvDDWldf231ypDWqE"),
-            withMessages: false,
-            withQuery: false
+            withMessages: false
         )
         
         let unwrappedEvent = try XCTUnwrap(event)
@@ -331,8 +330,7 @@ class UserEventsIntegration_Tests: XCTestCase {
         
         try client.databaseContainer.createChannel(
             cid: .init(type: .messaging, id: "!members-dpwtNCSGs-VaJKfAVaeosq6FNNbvDDWldf231ypDWqE"),
-            withMessages: false,
-            withQuery: false
+            withMessages: false
         )
         
         let unwrappedEvent = try XCTUnwrap(event)

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater.swift
@@ -97,7 +97,7 @@ private extension ChannelListQueryDTO {
         let encodedFilter = try JSONDecoder.default
             .decode(Filter<ChannelListFilterScope>.self, from: filterJSONData)
         var updatedFilter: Filter<ChannelListFilterScope> = encodedFilter
-        updatedFilter.explicitHash = filterHash
+        updatedFilter.explicitHash = queryHash
         return ChannelListQuery(filter: updatedFilter)
     }
 }

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Tests.swift
@@ -47,14 +47,14 @@ final class DatabaseCleanupUpdater_Tests: XCTestCase {
         try database.createChannel(
             cid: cid1,
             withMessages: true,
-            withQuery: true,
+            query: .mock(),
             isHidden: true
         )
         
         try database.createChannel(
             cid: cid2,
             withMessages: true,
-            withQuery: true,
+            query: .mock(),
             isHidden: true
         )
         
@@ -72,11 +72,11 @@ final class DatabaseCleanupUpdater_Tests: XCTestCase {
     func test_refetchExistingChannelListQueries_updateQueries() throws {
         let filter1 = Filter<ChannelListFilterScope>.query(.cid, text: .unique)
         let query1 = ChannelListQuery(filter: filter1)
-        try database.createChannelListQuery(filter: filter1)
+        try database.createChannelListQuery(query1)
         
         let filter2 = Filter<ChannelListFilterScope>.query(.cid, text: .unique)
         let query2 = ChannelListQuery(filter: filter2)
-        try database.createChannelListQuery(filter: filter2)
+        try database.createChannelListQuery(query2)
         
         databaseCleanupUpdater?.refetchExistingChannelListQueries()
         
@@ -88,7 +88,7 @@ final class DatabaseCleanupUpdater_Tests: XCTestCase {
         
     func test_refetchExistingChannelListQueries_whenDatabaseCleanupUpdaterIsDeallocated_doesNotUpdateQueries() throws {
         // Create a channel list query to be refetched.
-        try database.createChannelListQuery(filter: .query(.cid, text: .unique))
+        try database.createChannelListQuery()
     
         // Initiate channel list queries refetch.
         databaseCleanupUpdater?.refetchExistingChannelListQueries()

--- a/Sources/StreamChat/Workers/ChannelListUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater_Tests.swift
@@ -106,7 +106,7 @@ class ChannelListUpdater_Tests: XCTestCase {
         
         // Assert the data is stored in the DB
         var queryDTO: ChannelListQueryDTO? {
-            database.viewContext.channelListQuery(filterHash: query.filter.filterHash)
+            database.viewContext.channelListQuery(queryHash: query.queryHash)
         }
         AssertAsync {
             Assert.willBeTrue(queryDTO != nil)

--- a/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
@@ -141,7 +141,7 @@ extension DatabaseContainer {
     func createChannel(
         cid: ChannelId = .unique,
         withMessages: Bool = true,
-        withQuery: Bool = false,
+        query: ChannelListQuery? = nil,
         isHidden: Bool = false,
         channelReads: Set<ChannelReadDTO> = [],
         channelExtraData: [String: RawJSON] = [:]
@@ -158,30 +158,18 @@ extension DatabaseContainer {
                 dto.oldestMessageAt = .distantPast
             }
             
-            if withQuery {
-                let filter: Filter<ChannelListFilterScope> = .equal(.name, to: "luke:skywalker")
-                let queryDTO = NSEntityDescription.insertNewObject(
-                    forEntityName: ChannelListQueryDTO.entityName,
-                    into: session as! NSManagedObjectContext
-                ) as! ChannelListQueryDTO
-                queryDTO.filterHash = filter.filterHash
-                queryDTO.filterJSONData = try JSONEncoder.default.encode(filter)
+            if let query = query {
+                let queryDTO = session.saveQuery(query: query)
                 dto.queries = [queryDTO]
             }
         }
     }
     
     func createChannelListQuery(
-        filter: Filter<ChannelListFilterScope> = .query(.cid, text: .unique)
+        _ query: ChannelListQuery = .mock()
     ) throws {
         try writeSynchronously { session in
-            let dto = NSEntityDescription
-                .insertNewObject(
-                    forEntityName: ChannelListQueryDTO.entityName,
-                    into: session as! NSManagedObjectContext
-                ) as! ChannelListQueryDTO
-            dto.filterHash = filter.filterHash
-            dto.filterJSONData = try JSONEncoder.default.encode(filter)
+            session.saveQuery(query: query)
         }
     }
     

--- a/Sources/StreamChatTestTools/Models/ChannelListQuery_Mock.swift
+++ b/Sources/StreamChatTestTools/Models/ChannelListQuery_Mock.swift
@@ -1,0 +1,25 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+
+extension ChannelListQuery {
+    public static func mock(
+        filter: Filter<ChannelListFilterScope> = .equal(.hidden, to: false),
+        sort: [Sorting<ChannelListSortingKey>] = [.init(key: .updatedAt, isAscending: true)],
+        pagination: Pagination = .init(pageSize: 10, offset: 0),
+        messagesLimit: Int = 10,
+        watchOptions: QueryOptions = []
+    ) -> Self {
+        var query = ChannelListQuery(
+            filter: filter,
+            sort: sort,
+            pageSize: pagination.pageSize,
+            messagesLimit: messagesLimit
+        )
+        query.pagination = pagination
+        query.options = watchOptions
+        return query
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -558,6 +558,7 @@
 		84A43CB326A9A54700302763 /* EventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A43CB226A9A54700302763 /* EventSender.swift */; };
 		84AA4E3626F264610056A684 /* EventDTOConverterMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AA4E3526F264610056A684 /* EventDTOConverterMiddleware.swift */; };
 		84ABB015269F0A84003A4585 /* EventsController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84ABB014269F0A84003A4585 /* EventsController+Combine.swift */; };
+		84B078DE273D908100207DA9 /* ChannelListQuery_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B078DD273D908100207DA9 /* ChannelListQuery_Mock.swift */; };
 		84CC56EC267B3F6B00DF2784 /* AnyAttachmentPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CC56EA267B3D5900DF2784 /* AnyAttachmentPayload_Tests.swift */; };
 		84DA54DF2680C66A003A26CD /* PlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DA54DE2680C66A003A26CD /* PlayerView.swift */; };
 		84DCB84F269F46BE006CDF32 /* EventsController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DCB84E269F46BE006CDF32 /* EventsController_Tests.swift */; };
@@ -1968,6 +1969,7 @@
 		84A43CB226A9A54700302763 /* EventSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender.swift; sourceTree = "<group>"; };
 		84AA4E3526F264610056A684 /* EventDTOConverterMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDTOConverterMiddleware.swift; sourceTree = "<group>"; };
 		84ABB014269F0A84003A4585 /* EventsController+Combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "EventsController+Combine.swift"; sourceTree = "<group>"; };
+		84B078DD273D908100207DA9 /* ChannelListQuery_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListQuery_Mock.swift; sourceTree = "<group>"; };
 		84CC56EA267B3D5900DF2784 /* AnyAttachmentPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyAttachmentPayload_Tests.swift; sourceTree = "<group>"; };
 		84DA54DE2680C66A003A26CD /* PlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerView.swift; sourceTree = "<group>"; };
 		84DCB84E269F46BE006CDF32 /* EventsController_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsController_Tests.swift; sourceTree = "<group>"; };
@@ -3169,6 +3171,7 @@
 				ADFCCD0725C9B8D70024505D /* ChannelUnreadCount_Mock.swift */,
 				ADEA7EAF261C88E200CA2289 /* CurrentChatUser_Mock.swift */,
 				AD25070E272C156600BC14C4 /* ChatMessageReaction_Mock.swift */,
+				84B078DD273D908100207DA9 /* ChannelListQuery_Mock.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -6318,6 +6321,7 @@
 				F8788F36261DA083006019DD /* MessageAttachmentPayload.swift in Sources */,
 				793061722577BB48005CF846 /* ChatMessageController_Mock.swift in Sources */,
 				7930614E2577A1AF005CF846 /* ChatUser_Mock.swift in Sources */,
+				84B078DE273D908100207DA9 /* ChannelListQuery_Mock.swift in Sources */,
 				F8788EF7261D9D18006019DD /* WaitFor.swift in Sources */,
 				AD0169E625CAF235009EBAD2 /* CurrentChatUserController_Mock.swift in Sources */,
 				F8788F12261D9D92006019DD /* UnreadCount.swift in Sources */,


### PR DESCRIPTION
### 🔗 Issue Link

CIS-1316

### 🎯 Goal

Filter and sorting is what defines a query. This PR fixes the issue when queries with the same filter but different sorting were sharing the same database entity.

### 🛠 Implementation

Sort options are now taken into account when calculating a query hash.

### 🧪 Testing

N/A

### 🎨 Changes

N/A

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
