### PR TITLE
[CIS-1320] Stop persisting open channels

### DIFF
--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -47,9 +47,6 @@ class ChannelDTO: NSManagedObject {
 
     // The channel list queries the channel is a part of
     @NSManaged var queries: Set<ChannelListQueryDTO>
-    
-    /// Channel list queries the channel is open in (the subset of `queries`)
-    @NSManaged var openIn: Set<ChannelListQueryDTO>
 
     // MARK: - Relationships
     
@@ -122,7 +119,6 @@ class ChannelDTO: NSManagedObject {
 
 extension ChannelDTO: EphemeralValuesContainer {
     func resetEphemeralValues() {
-        openIn.removeAll()
         currentlyTypingUsers.removeAll()
         watchers.removeAll()
         watcherCount = 0

--- a/Sources/StreamChat/Database/DTOs/ChannelListQueryDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelListQueryDTO.swift
@@ -16,9 +16,6 @@ class ChannelListQueryDTO: NSManagedObject {
     
     @NSManaged var channels: Set<ChannelDTO>
     
-    /// Channels that are being read by the current user (the subset of `channels`)
-    @NSManaged var openChannels: Set<ChannelDTO>
-    
     static func load(filterHash: String, context: NSManagedObjectContext) -> ChannelListQueryDTO? {
         let request = NSFetchRequest<ChannelListQueryDTO>(entityName: ChannelListQueryDTO.entityName)
         request.predicate = NSPredicate(format: "filterHash == %@", filterHash)

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19206" systemVersion="20G165" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19461" systemVersion="21A559" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
@@ -43,7 +43,6 @@
         <relationship name="membership" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MemberDTO" inverseName="membershipChannel" inverseEntity="MemberDTO"/>
         <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="channel" inverseEntity="MessageDTO"/>
         <relationship name="mutes" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelMuteDTO" inverseName="channel" inverseEntity="ChannelMuteDTO"/>
-        <relationship name="openIn" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelListQueryDTO" inverseName="openChannels" inverseEntity="ChannelListQueryDTO"/>
         <relationship name="pinnedMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="pinnedChannel" inverseEntity="MessageDTO"/>
         <relationship name="queries" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelListQueryDTO" inverseName="channels" inverseEntity="ChannelListQueryDTO"/>
         <relationship name="reads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelReadDTO" inverseName="channel" inverseEntity="ChannelReadDTO"/>
@@ -70,7 +69,6 @@
         <attribute name="filterHash" attributeType="String"/>
         <attribute name="filterJSONData" attributeType="Binary"/>
         <relationship name="channels" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="queries" inverseEntity="ChannelDTO"/>
-        <relationship name="openChannels" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="openIn" inverseEntity="ChannelDTO"/>
         <fetchIndex name="filterHash">
             <fetchIndexElement property="filterHash" type="Binary" order="ascending"/>
         </fetchIndex>

--- a/Sources/StreamChat/Query/ChannelListQuery_Tests.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery_Tests.swift
@@ -50,18 +50,6 @@ final class ChannelListFilterScope_Tests: XCTestCase {
         }
     }
     
-    func test_uniqueForChannel() {
-        // Create channel identifier
-        let cid: ChannelId = .unique
-        
-        // Create query unique for channel
-        let query: ChannelListQuery = .unique(for: cid)
-        
-        // Assert correct query is created
-        XCTAssertEqual(query, .init(filter: .equal(.cid, to: cid)))
-        XCTAssertEqual(query.filter.filterHash, cid.rawValue)
-    }
-    
     func test_hiddenFilter_valueIsDetected() {
         let hiddenValue = Bool.random()
         let testValues: [(Filter<ChannelListFilterScope>, Bool?)] = [


### PR DESCRIPTION
### 🔗 Issue Link

CIS-1320

### 🎯 Goal

It was decided to stop persisting active channel list queries/open channels in the database and have references to active components in memory.

### 🛠 Implementation

Remove relation between `ChannelListQueryDTO <->> ChannelDTO`, stop labeling a channel as open.

### 🎨 Changes

⚠️ This is pointing to an integration branch. No changes will be made to `main` until this feature is complete

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
