### PR TITLE
[CIS-1329] Get rid of `Filter.explicitHash`

### DIFF
--- a/DemoApp/CreateChatViewController.swift
+++ b/DemoApp/CreateChatViewController.swift
@@ -65,8 +65,8 @@ class CreateChatViewController: UIViewController {
     
     var searchController: ChatUserSearchController!
     
-    var users: LazyCachedMapCollection<ChatUser> {
-        searchController.users
+    var users: [ChatUser] {
+        searchController.userArray
     }
     
     var selectedUserIds: Set<String> {

--- a/DemoApp/CreateGroupViewController.swift
+++ b/DemoApp/CreateGroupViewController.swift
@@ -49,8 +49,8 @@ class CreateGroupViewController: UIViewController {
     
     var searchController: ChatUserSearchController!
     
-    var users: LazyCachedMapCollection<ChatUser> {
-        searchController.users
+    var users: [ChatUser] {
+        searchController.userArray
     }
     
     var selectedUsers = [ChatUser]()

--- a/Sources/StreamChat/Database/DTOs/ChannelListQueryDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelListQueryDTO.swift
@@ -21,6 +21,15 @@ class ChannelListQueryDTO: NSManagedObject {
         request.predicate = NSPredicate(format: "filterHash == %@", filterHash)
         return try? context.fetch(request).first
     }
+    
+    /// The fetch request that returns all existed queries from the database.
+    static var allQueriesFetchRequest: NSFetchRequest<ChannelListQueryDTO> {
+        let request = NSFetchRequest<ChannelListQueryDTO>(entityName: ChannelListQueryDTO.entityName)
+        request.sortDescriptors = [
+            NSSortDescriptor(keyPath: \ChannelListQueryDTO.filterHash, ascending: false)
+        ]
+        return request
+    }
 }
 
 extension NSManagedObjectContext {
@@ -48,5 +57,18 @@ extension NSManagedObjectContext {
         newDTO.filterJSONData = jsonData
         
         return newDTO
+    }
+    
+    func loadAllChannelListQueries() -> [ChannelListQueryDTO] {
+        let queries: [ChannelListQueryDTO]
+        
+        do {
+            queries = try fetch(ChannelListQueryDTO.allQueriesFetchRequest)
+        } catch {
+            log.error("Failed to load channel list queries from the database: \(error).")
+            queries = []
+        }
+        
+        return queries
     }
 }

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -190,6 +190,10 @@ protocol ChannelDatabaseSession {
     /// - Parameter filterHash: The filter hash.
     func channelListQuery(filterHash: String) -> ChannelListQueryDTO?
     
+    /// Loads all channel list queries from the database.
+    /// - Returns: The array of channel list queries.
+    func loadAllChannelListQueries() -> [ChannelListQueryDTO]
+    
     @discardableResult func saveQuery(query: ChannelListQuery) -> ChannelListQueryDTO
     
     /// Fetches `ChannelDTO` with the given `cid` from the database.

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -17,6 +17,10 @@ protocol UserDatabaseSession {
     @discardableResult
     func saveQuery(query: UserListQuery) throws -> UserListQueryDTO?
     
+    /// Load user list query with the given hash.
+    /// - Returns: The query hash.
+    func userListQuery(filterHash: String) -> UserListQueryDTO?
+    
     /// Fetches `UserDTO` with the given `id` from the DB. Returns `nil` if no `UserDTO` matching the `id` exists.
     func user(id: UserId) -> UserDTO?
     

--- a/Sources/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Mock.swift
@@ -69,6 +69,10 @@ extension DatabaseSessionMock {
         return try underlyingSession.saveQuery(query: query)
     }
     
+    func userListQuery(filterHash: String) -> UserListQueryDTO? {
+        underlyingSession.userListQuery(filterHash: filterHash)
+    }
+    
     func user(id: UserId) -> UserDTO? {
         underlyingSession.user(id: id)
     }

--- a/Sources/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Mock.swift
@@ -206,6 +206,10 @@ extension DatabaseSessionMock {
         underlyingSession.channelListQuery(filterHash: filterHash)
     }
     
+    func loadAllChannelListQueries() -> [ChannelListQueryDTO] {
+        underlyingSession.loadAllChannelListQueries()
+    }
+    
     func saveChannel(
         payload: ChannelPayload,
         query: ChannelListQuery?

--- a/Sources/StreamChat/Deprecations.swift
+++ b/Sources/StreamChat/Deprecations.swift
@@ -210,3 +210,10 @@ public typealias NotificationInviteRejected = NotificationInviteRejectedEvent
 
 @available(*, deprecated, renamed: "NotificationInviteAcceptedEvent")
 public typealias NotificationInviteAccepted = NotificationInviteAcceptedEvent
+
+public extension ChatUserSearchController {
+    @available(*, deprecated, message: "Please, switch to `userArray: [ChatUser]`")
+    var users: LazyCachedMapCollection<ChatUser> {
+        .init(source: userArray, map: { $0 })
+    }
+}

--- a/Sources/StreamChat/Query/Filter.swift
+++ b/Sources/StreamChat/Query/Filter.swift
@@ -98,11 +98,6 @@ public struct Filter<Scope: FilterScope> {
     /// The "right-hand" side of the filter. Specifies the value the filter should match.
     public let value: FilterValue
     
-    /// Set this value if you want to alter the hash of the filter. This is handy when you want to change the filter
-    /// but you want the changed filter to have the same hash as the original filter (for example, when you use the
-    /// hash to identify queries).
-    var explicitHash: String?
-    
     /// Creates a new instance of `Filter`.
     ///
     /// Learn more about how to create simple, advanced, and custom filters in our [cheat sheet](https://github.com/GetStream/stream-chat-swift/wiki/StreamChat-SDK-Cheat-Sheet#query-filters).
@@ -240,7 +235,7 @@ public extension Filter {
 extension Filter {
     /// Filter hash that can be used to uniquely identify a filter.
     var filterHash: String {
-        explicitHash ?? String(describing: self)
+        String(describing: self)
     }
 }
 

--- a/Sources/StreamChat/Query/UserListQuery.swift
+++ b/Sources/StreamChat/Query/UserListQuery.swift
@@ -121,6 +121,25 @@ extension UserListQuery {
     static func user(withID userId: UserId) -> Self {
         .init(filter: .equal(.id, to: userId))
     }
+    
+    /// Builds `UserListQuery` for a user with the search term that sorts users by name ascending.
+    ///
+    /// - Parameter term: The search term. If `nil` or empty the pseudo-filter is used to fetch all users
+    /// - Returns: The query.
+    static func search(term: String?) -> Self {
+        var query = UserListQuery(sort: [.init(key: .name, isAscending: true)])
+        
+        if let term = term, !term.isEmpty {
+            query.filter = .or([
+                .autocomplete(.name, text: term),
+                .autocomplete(.id, text: term)
+            ])
+        } else {
+            query.filter = .exists(.id)
+        }
+        
+        return query
+    }
 }
 
 // Backend expects empty object for "filter_conditions" in case no filter specified.

--- a/Sources/StreamChat/Query/UserListQuery_Tests.swift
+++ b/Sources/StreamChat/Query/UserListQuery_Tests.swift
@@ -66,6 +66,46 @@ class UserListQuery_Tests: XCTestCase {
         AssertJSONEqual(actualJSON, expectedJSON)
     }
     
+    func test_searchQuery_whenNilSearchTermIsGiven_fallbacksToFilterEveryUserMatchesTo() {
+        // Declare search query with nil search term
+        let query: UserListQuery = .search(term: nil)
+        
+        // Assert filter all users match to is used
+        XCTAssertEqual(query.filter, .exists(.id))
+    }
+    
+    func test_searchQuery_whenEmptySearchTermIsGiven_fallbacksToFilterEveryUserMatchesTo() {
+        // Declare search query with empty search term
+        let query: UserListQuery = .search(term: "")
+        
+        // Assert filter all users match to is used
+        XCTAssertEqual(query.filter, .exists(.id))
+    }
+    
+    func test_searchQuery_whenValidSearchTermIsGiven_usesAutocompletionFilter() {
+        // Declare search term
+        let searchTerm: String = .unique
+        
+        // Declare search query with the given search term
+        let query: UserListQuery = .search(term: searchTerm)
+        
+        // Assert autocompletion filter is used
+        XCTAssertEqual(query.filter, .or([
+            .autocomplete(.name, text: searchTerm),
+            .autocomplete(.id, text: searchTerm)
+        ]))
+    }
+    
+    func test_searchQuery_alwaysSortsByName() {
+        for searchTerm in [nil, "", .unique] {
+            // Declare a query with the given search term
+            let query: UserListQuery = .search(term: searchTerm)
+            
+            // Assert query sorts users by name ascending
+            XCTAssertTrue(query.sort.contains(.init(key: .name, isAscending: true)))
+        }
+    }
+    
     func test_safeSorting_added() {
         // Sortings without safe option
         let sortings: [[Sorting<UserListSortingKey>]] = [

--- a/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/DatabaseCleanupUpdater_Tests.swift
@@ -81,8 +81,8 @@ final class DatabaseCleanupUpdater_Tests: XCTestCase {
         databaseCleanupUpdater?.refetchExistingChannelListQueries()
         
         AssertAsync.willBeEqual(
-            channelListUpdater.update_queries,
-            [query1, query2]
+            Set(channelListUpdater.fetch_queries.map(\.filter.filterHash)),
+            Set([query1, query2].map(\.filter.filterHash))
         )
     }
         

--- a/Sources/StreamChat/Workers/Background/NewUserQueryUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/NewUserQueryUpdater_Tests.swift
@@ -53,22 +53,23 @@ class NewUserQueryUpdater_Tests: XCTestCase {
                 
         try database.createUser()
         
-        // Assert `update(userListQuery` called for each query in DB
-        AssertAsync.willBeEqual(
-            env!.userQueryUpdater?.update_queries.compactMap(\.filter?.filterHash).sorted(),
-            [filter1, filter2].map(\.filterHash).sorted()
-        )
+        // Assert `fetch(userListQuery:)` called for both queries
+        AssertAsync.willBeEqual(env!.userQueryUpdater!.fetch_queries.count, 2)
     }
     
     func test_update_called_forExistingUser() throws {
         // Deinitialize newUserQueryUpdater
         newUserQueryUpdater = nil
         
+        // Save user list query to database
         let filter: Filter<UserListFilterScope> = .notEqual(.id, to: .unique)
         try database.createUserListQuery(filter: filter)
-        try database.createUser(id: .unique)
         
-        // Assert `update(userListQuery` is not called
+        // Save user to database
+        let userId: UserId = .unique
+        try database.createUser(id: userId)
+        
+        // Assert `fetch(userListQuery)` is not called yet
         AssertAsync.willBeTrue(env!.userQueryUpdater?.update_queries.isEmpty)
         
         // Create `newUserQueryUpdater`
@@ -78,8 +79,9 @@ class NewUserQueryUpdater_Tests: XCTestCase {
             env: env.environment
         )
         
-        // Assert `update(userListQuery` called for user that was in DB before observing started
-        AssertAsync.willBeEqual(env!.userQueryUpdater?.update_queries.first?.filter?.filterHash, filter.filterHash)
+        // Assert `fetch(userListQuery)` called for user that was in DB before observing started
+        let expectedFilter: Filter<UserListFilterScope> = .and([filter, .equal("id", to: userId)])
+        AssertAsync.willBeEqual(env!.userQueryUpdater?.fetch_queries.first?.filter, expectedFilter)
     }
     
     func test_filter_isModified() throws {
@@ -91,11 +93,8 @@ class NewUserQueryUpdater_Tests: XCTestCase {
         
         let expectedFilter: Filter = .and([filter, .equal(.id, to: id)])
         
-        // Assert `update(userListQuery` called with modified query
-        AssertAsync {
-            Assert.willBeEqual(self.env!.userQueryUpdater?.update_queries.first?.filter?.filterHash, filter.filterHash)
-            Assert.willBeEqual(self.env!.userQueryUpdater?.update_queries.first?.filter?.description, expectedFilter.description)
-        }
+        // Assert `fetch` is called with modified query
+        AssertAsync.willBeEqual(env!.userQueryUpdater?.fetch_queries.first?.filter, expectedFilter)
     }
     
     func test_newUserQueryUpdater_doesNotRetainItself() throws {
@@ -103,8 +102,8 @@ class NewUserQueryUpdater_Tests: XCTestCase {
         try database.createUserListQuery(filter: filter)
         try database.createUser()
         
-        // Assert `update(userListQuery` is called
-        AssertAsync.willBeEqual(env!.userQueryUpdater?.update_queries.first?.filter?.filterHash, filter.filterHash)
+        // Assert `fetch` is called
+        AssertAsync.willBeFalse(env!.userQueryUpdater?.fetch_queries.isEmpty)
         
         // Assert `newUserQueryUpdater` can be released even though network response hasn't come yet
         AssertAsync.canBeReleased(&newUserQueryUpdater)
@@ -112,23 +111,27 @@ class NewUserQueryUpdater_Tests: XCTestCase {
     
     func test_updater_ignoresNonObservedQueries() throws {
         let filter1: Filter<UserListFilterScope> = .equal(.id, to: .unique)
-        
+
         try database.createUserListQuery(filter: filter1)
-        
+
         var nonObservedQuery = UserListQuery(filter: .equal(.name, to: .unique))
         nonObservedQuery.shouldBeUpdatedInBackground = false
-        
+
         try database.writeSynchronously { session in
             try session.saveQuery(query: nonObservedQuery)
         }
-        
-        try database.createUser()
-        
-        // Assert `update(userListQuery` called for only observed query in DB
-        AssertAsync.willBeEqual(
-            env!.userQueryUpdater?.update_queries.compactMap(\.filter?.filterHash).sorted(),
-            [filter1].map(\.filterHash).sorted()
-        )
+
+        // Save user to database
+        let userId: UserId = .unique
+        try database.createUser(id: userId)
+
+        let expectedFilter: Filter<UserListFilterScope> = .and([filter1, .equal("id", to: userId)])
+
+        // Assert `fetch` called for only observed query in DB
+        AssertAsync {
+            Assert.willBeEqual(self.env!.userQueryUpdater?.fetch_queries.first?.filter, expectedFilter)
+            Assert.willBeEqual(self.env!.userQueryUpdater?.fetch_queries.count, 1)
+        }
     }
 }
 

--- a/Sources/StreamChat/Workers/ChannelListUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater_Mock.swift
@@ -10,11 +10,17 @@ class ChannelListUpdaterMock: ChannelListUpdater {
     @Atomic var update_queries: [ChannelListQuery] = []
     @Atomic var update_completion: ((Result<ChannelListPayload, Error>) -> Void)? = nil
     
+    @Atomic var fetch_queries: [ChannelListQuery] = []
+    @Atomic var fetch_completion: ((Result<ChannelListPayload, Error>) -> Void)? = nil
+    
     @Atomic var markAllRead_completion: ((Error?) -> Void)?
     
     func cleanUp() {
         update_queries.removeAll()
         update_completion = nil
+        
+        fetch_queries.removeAll()
+        fetch_completion = nil
         
         markAllRead_completion = nil
     }
@@ -30,5 +36,13 @@ class ChannelListUpdaterMock: ChannelListUpdater {
     
     override func markAllRead(completion: ((Error?) -> Void)? = nil) {
         markAllRead_completion = completion
+    }
+    
+    override func fetch(
+        channelListQuery: ChannelListQuery,
+        completion: @escaping (Result<ChannelListPayload, Error>) -> Void
+    ) {
+        _fetch_queries.mutate { $0.append(channelListQuery) }
+        fetch_completion = completion
     }
 }

--- a/Sources/StreamChat/Workers/ChannelListUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater_Tests.swift
@@ -114,6 +114,58 @@ class ChannelListUpdater_Tests: XCTestCase {
         }
     }
     
+    // MARK: - Fetch
+    
+    func test_fetch_makesCorrectAPICall() {
+        // Simulate `fetch` call
+        let query = ChannelListQuery(filter: .in(.members, values: [.unique]))
+        listUpdater.fetch(channelListQuery: query, completion: { _ in })
+        
+        let referenceEndpoint: Endpoint<ChannelListPayload> = .channels(query: query)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
+    }
+    
+    func test_fetch_successfulResponse_isPropagatedToCompletion() {
+        // Simulate `fetch` call
+        let query = ChannelListQuery(filter: .in(.members, values: [.unique]))
+        var channelListPayload: ChannelListPayload?
+        listUpdater.fetch(channelListQuery: query, completion: { result in
+            channelListPayload = try? result.get()
+        })
+        
+        // Simulate API response with channel data
+        let cid = ChannelId(type: .messaging, id: .unique)
+        let payload = ChannelListPayload(channels: [dummyPayload(with: cid)])
+        apiClient.test_simulateResponse(.success(payload))
+        
+        AssertAsync.willBeEqual(
+            Set(payload.channels.map(\.channel.cid)),
+            Set(channelListPayload?.channels.map(\.channel.cid) ?? [])
+        )
+    }
+    
+    func test_fetch_errorResponse_isPropagatedToCompletion() {
+        // Simulate `fetch` call
+        let query = ChannelListQuery(filter: .in(.members, values: [.unique]))
+        var completionCalledError: Error?
+        listUpdater.update(channelListQuery: query, completion: { completionCalledError = $0.error })
+        
+        // Simulate API response with failure
+        let error = TestError()
+        apiClient.test_simulateResponse(Result<ChannelListPayload, Error>.failure(error))
+        
+        // Assert the completion is called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, error)
+    }
+    
+    func test_fetch_doesNotRetainSelf() {
+        // Simulate `fetch` call
+        listUpdater.fetch(channelListQuery: .init(filter: .in(.members, values: [.unique])), completion: { _ in })
+        
+        // Assert updater can be deallocated without waiting for the API response.
+        AssertAsync.canBeReleased(&listUpdater)
+    }
+    
     // MARK: - Mark all read
     
     func test_markAllRead_makesCorrectAPICall() {

--- a/Sources/StreamChat/Workers/UserListUpdater.swift
+++ b/Sources/StreamChat/Workers/UserListUpdater.swift
@@ -22,31 +22,46 @@ class UserListUpdater: Worker {
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     ///
     func update(userListQuery: UserListQuery, policy: UpdatePolicy = .merge, completion: ((Error?) -> Void)? = nil) {
-        apiClient
-            .request(endpoint: .users(query: userListQuery)) { (result: Result<UserListPayload, Error>) in
-                switch result {
-                case let .success(userListPayload):
-                    self.database.write { session in
-                        if case .replace = policy {
-                            let dto = try session.saveQuery(query: userListQuery)
-                            dto?.users.removeAll()
-                        }
-                        
-                        try userListPayload.users.forEach {
-                            try session.saveUser(payload: $0, query: userListQuery)
-                        }
-                    } completion: { error in
-                        if let error = error {
-                            log.error("Failed to save `UserListPayload` to the database. Error: \(error)")
-                            completion?(error)
-                        } else {
-                            completion?(nil)
-                        }
+        fetch(userListQuery: userListQuery) {
+            switch $0 {
+            case let .success(userListPayload):
+                self.database.write { session in
+                    if case .replace = policy {
+                        let dto = try session.saveQuery(query: userListQuery)
+                        dto?.users.removeAll()
                     }
                     
-                case let .failure(error):
-                    completion?(error)
+                    try userListPayload.users.forEach {
+                        try session.saveUser(payload: $0, query: userListQuery)
+                    }
+                } completion: { error in
+                    if let error = error {
+                        log.error("Failed to save `UserListPayload` to the database. Error: \(error)")
+                        completion?(error)
+                    } else {
+                        completion?(nil)
+                    }
                 }
+                
+            case let .failure(error):
+                completion?(error)
             }
+        }
+    }
+    
+    /// Makes a users query call to the backend and returns the results via completion.
+    ///
+    /// - Parameters:
+    ///   - userListQuery: The query to fetch.
+    ///   - completion: The completion to call with the results.
+    ///
+    func fetch(
+        userListQuery: UserListQuery,
+        completion: @escaping (Result<UserListPayload, Error>) -> Void
+    ) {
+        apiClient.request(
+            endpoint: .users(query: userListQuery),
+            completion: completion
+        )
     }
 }

--- a/Sources/StreamChat/Workers/UserListUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/UserListUpdater_Mock.swift
@@ -11,10 +11,16 @@ class UserListUpdaterMock: UserListUpdater {
     @Atomic var update_policy: UpdatePolicy?
     @Atomic var update_completion: ((Error?) -> Void)?
     
+    @Atomic var fetch_queries: [UserListQuery] = []
+    @Atomic var fetch_completion: ((Result<UserListPayload, Error>) -> Void)?
+    
     func cleanUp() {
         update_queries.removeAll()
         update_policy = nil
         update_completion = nil
+        
+        fetch_queries.removeAll()
+        fetch_completion = nil
     }
         
     override func update(
@@ -25,5 +31,13 @@ class UserListUpdaterMock: UserListUpdater {
         _update_queries.mutate { $0.append(userListQuery) }
         update_policy = policy
         update_completion = completion
+    }
+    
+    override func fetch(
+        userListQuery: UserListQuery,
+        completion: @escaping (Result<UserListPayload, Error>) -> Void
+    ) {
+        _fetch_queries.mutate { $0.append(userListQuery) }
+        fetch_completion = completion
     }
 }

--- a/Sources/StreamChat/Workers/UserListUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/UserListUpdater_Tests.swift
@@ -214,4 +214,57 @@ class UserListUpdater_Tests: XCTestCase {
         
         AssertAsync.willBeTrue(completionCalled)
     }
+    
+    // MARK: - Fetch
+    
+    func test_fetch_makesCorrectAPICall() {
+        // Simulate `fetch` call
+        let query = UserListQuery(filter: .equal(.id, to: "Luke"))
+        listUpdater.fetch(userListQuery: query, completion: { _ in })
+        
+        let referenceEndpoint: Endpoint<UserListPayload> = .users(query: query)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
+    }
+    
+    func test_fetch_whenSuccess_payloadIsPropagatedToCompletion() {
+        // Simulate `fetch` call
+        let query = UserListQuery(filter: .equal(.id, to: "Luke"))
+        var userListPayload: UserListPayload?
+        listUpdater.fetch(userListQuery: query, completion: { result in
+            XCTAssertNil(result.error)
+            userListPayload = try? result.get()
+        })
+        
+        // Simualte API response with user data
+        let payload = UserListPayload(users: [dummyUser])
+        apiClient.test_simulateResponse(.success(payload))
+        
+        AssertAsync.willBeEqual(
+            Set(payload.users.map(\.id)),
+            Set(userListPayload?.users.map(\.id) ?? [])
+        )
+    }
+    
+    func test_fetch_whenFailure_errorIsPropagatedToCompletion() {
+        // Simulate `fetch` call
+        let query = UserListQuery(filter: .equal(.id, to: "Luke"))
+        var completionCalledError: Error?
+        listUpdater.fetch(userListQuery: query, completion: { completionCalledError = $0.error })
+        
+        // Simualte API response with failure
+        let error = TestError()
+        apiClient.test_simulateResponse(Result<UserListPayload, Error>.failure(error))
+        
+        // Assert the completion is called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, error)
+    }
+    
+    func test_fetch_doesNotRetainSelf() {
+        // Simulate `fetch` call
+        let query = UserListQuery(filter: .equal(.id, to: "Luke"))
+        listUpdater.fetch(userListQuery: query, completion: { _ in })
+        
+        // Assert updater can be released
+        AssertAsync.canBeReleased(&listUpdater)
+    }
 }

--- a/Sources/StreamChat/Workers/UserListUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/UserListUpdater_Tests.swift
@@ -139,9 +139,7 @@ class UserListUpdater_Tests: XCTestCase {
     
     func test_removePolicy_takesAffect() throws {
         // Create query
-        let filterHash = String.unique
-        var query = UserListQuery(filter: .equal(.id, to: "Luke"))
-        query.filter?.explicitHash = filterHash
+        let query = UserListQuery(filter: .equal(.id, to: "Luke"))
         // Simulate `update` call
         // This call doesn't need `policy` argument specified since
         // it's the first call for this query, hence there's no data to `replace` or `merge` to
@@ -178,7 +176,7 @@ class UserListUpdater_Tests: XCTestCase {
         
         // Assert first user is not linked to the query anymore
         var queryDTO: UserListQueryDTO? {
-            database.viewContext.userListQuery(filterHash: filterHash)
+            database.viewContext.userListQuery(filterHash: query.filter!.filterHash)
         }
         
         // Assert only 1 user is linked to query

--- a/Sources/StreamChatTestTools/Controllers/ChatUserSearchController_Mock.swift
+++ b/Sources/StreamChatTestTools/Controllers/ChatUserSearchController_Mock.swift
@@ -11,7 +11,7 @@ public class ChatUserSearchController_Mock: ChatUserSearchController {
     }
     
     public var users_mock: [ChatUser]?
-    override public var users: LazyCachedMapCollection<ChatUser> {
-        users_mock.map { $0.lazyCachedMap { $0 } } ?? super.users
+    override public var userArray: [ChatUser] {
+        users_mock ?? super.userArray
     }
 }

--- a/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsVC.swift
+++ b/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsVC.swift
@@ -260,7 +260,7 @@ open class ChatMessageComposerSuggestionsMentionDataSource: NSObject,
         _ controller: ChatUserSearchController,
         didChangeUsers changes: [ListChange<ChatUser>]
     ) {
-        usersCache = searchController.users.map { $0 }
+        usersCache = searchController.userArray
         collectionView.reloadData()
     }
 }


### PR DESCRIPTION
### 🔗 Issue Link

CIS-1329

### 🎯 Goal

The goal of this PR is to remove the explicit hash from the `Filter` type and the extra complexity/indirections that it's causing. 

It was initially introduced for background workers that try to link the newly inserted entity to local queries by sending the API request with `.and([originalFilter, .equals("id", to: entity.id)])` filter. If the entity was returned from the APIs the query should be updated with a new entity and filter so if `explicitHash` was not set another query is created in the database because the new filter hash is different from the hash of the original filter.

Now we are moving towards removing background workers for all the queries and moving the decision to the controller level which is more flexible, reduces the # of API calls from the client but still allows to sort/filter by custom fields.

### 🛠 Implementation

- Existed background workers are updated to manually link the new entity to the original local query
- `ChatUserSearchController` is updated to store search results in memory without `UserListQuery` persited in database

### 🧪 Testing

To test changes applied to `ChatUserSearchController`:
- Run `DemoApp`
- Sign in as any user, wait for channel list to be loaded
- Tap `+` icon to open new channel flow
- Play with the search field and search results pagination

To test changes in `DatabaseCleanupUpdater`:
- Run `DemoApp`
- Sign in as any user
- Turn OFF the Internet
- Send a message from another user
- Turn ON the Internet
- See that new message appears in channel/channel preview

### 🎨 Changes

⚠️ This is pointing to an integration branch. No changes will be made to `main` until this feature is complete

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
