### PR TITLE
[CIS-1242] Fix memory leak in GalleryVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix memory leak in GalleryVC [#1631](https://github.com/GetStream/stream-chat-swift/pull/1631)
 
 # [4.5.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.5.0)
 _November 16, 2021_
@@ -13,7 +14,6 @@ _November 16, 2021_
 - Fix message cell not resized after editing a message with bigger/smaller content [#1605](https://github.com/GetStream/stream-chat-swift/pull/1605)
 - Improve send button tap responsiveness [#1626](https://github.com/GetStream/stream-chat-swift/pull/1626)
 - Dismiss suggestions popup when tapping outside [#1627](https://github.com/GetStream/stream-chat-swift/pull/1627)
-- Fix memory leak in GalleryVC [#1631](https://github.com/GetStream/stream-chat-swift/pull/1631)
 
 ### ✅ Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _November 16, 2021_
 - Fix message cell not resized after editing a message with bigger/smaller content [#1605](https://github.com/GetStream/stream-chat-swift/pull/1605)
 - Improve send button tap responsiveness [#1626](https://github.com/GetStream/stream-chat-swift/pull/1626)
 - Dismiss suggestions popup when tapping outside [#1627](https://github.com/GetStream/stream-chat-swift/pull/1627)
+- Fix memory leak in GalleryVC [#1631](https://github.com/GetStream/stream-chat-swift/pull/1631)
 
 ### ✅ Added
 

--- a/Sources/StreamChatUI/Gallery/ZoomDismissalInteractionController.swift
+++ b/Sources/StreamChatUI/Gallery/ZoomDismissalInteractionController.swift
@@ -7,7 +7,7 @@ import UIKit
 /// Controller for interactive dismissal.
 open class ZoomDismissalInteractionController: NSObject, UIViewControllerInteractiveTransitioning {
     /// Context of the current transition.
-    public var transitionContext: UIViewControllerContextTransitioning?
+    public weak var transitionContext: UIViewControllerContextTransitioning?
     /// Current transition's animator.
     public var animator: UIViewControllerAnimatedTransitioning?
     


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1242
Possibly related to https://github.com/GetStream/stream-chat-swift/issues/1601 (Not sure)

### 🎯 Goal
Fix memory leak of GalleryVC when opening the gallery preview. There was a memory leak caused by a forgotten weak ref of the transition context in the `ZoomDismissalInteractionController`.

### 🛠 Implementation
Make `ZoomDismissalInteractionController.transitionContext` a weak ref.

### 🧪 Testing
1. Open a channel
2. Open multiple times the gallery image preview
3. Go back to the channel list
4. Logout
5. Open the Memory Graph
6. Verify there are no `GalleryVC` instances in memory
(If you do these steps on main, you can see multiple instances of GalleryVC)

### 🎨 Changes
N/A

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
