### PR TITLE
[CIS-1338] Fix ephemeral messages in threads also shown in channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix memory leak in GalleryVC [#1631](https://github.com/GetStream/stream-chat-swift/pull/1631)
 - Increase tappable area surrounding the ShareButton inside the GalleryVC [#1640](https://github.com/GetStream/stream-chat-swift/pull/1640)
+- Fix giphy action message (ephemeral message) in a thread is also shown in the channel [#1641](https://github.com/GetStream/stream-chat-swift/issues/1641)
 
 # [4.5.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.5.0)
 _November 16, 2021_

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -152,6 +152,13 @@ class MessageDTO: NSManagedObject {
             .init(format: "type == %@ AND showReplyInChannel == 1", MessageType.reply.rawValue)
         ])
         
+        // When an ephemeral message (like a giphy) exists in a thread reply,
+        // it shouldn't be visible in the main channel.
+        let ephemeralRepliesPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [
+            .init(format: "type != %@", MessageType.ephemeral.rawValue),
+            .init(format: "type == %@ AND parentMessageId == nil", MessageType.ephemeral.rawValue)
+        ])
+        
         // Some pinned messages might be in the local database, but should not be fetched
         // if they do not belong to the regular channel query.
         let ignoreOlderMessagesPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [
@@ -162,6 +169,7 @@ class MessageDTO: NSManagedObject {
         var subpredicates = [
             channelMessage,
             messageTypePredicate,
+            ephemeralRepliesPredicate,
             nonTruncatedMessagesPredicate(),
             ignoreOlderMessagesPredicate,
             deletedMessagesPredicate(deletedMessagesVisibility: deletedMessagesVisibility)


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1338

### 🎯 Goal
When a giphy action is sent in a thread, backend replies with an ephemeral message. This message shouldn't be shown in main channel, but it does.

### 🛠 Implementation
Turned out we don't filter out ephemeral messages for threads.

### 🧪 Testing
Send a giphy action in a thread and check the main channel.


### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
