### PR TITLE
Added identifier for tracking the usage of the different SDKs

### DIFF
--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -189,8 +189,19 @@ public class ChatClient {
     
     /// Stream-specific request headers.
     private let sessionHeaders: [String: String] = [
-        "X-Stream-Client": "stream-chat-swift-client-v\(SystemEnvironment.version)"
+        "X-Stream-Client": "stream-chat-\(sdkIdentifier)-client-v\(SystemEnvironment.version)"
     ]
+    
+    /// Identifies which SDK is being used.
+    private static var sdkIdentifier: String {
+        #if canImport(StreamChatSwiftUI)
+        return "swiftui"
+        #elseif canImport(StreamChatUI)
+        return "uikit"
+        #else
+        return "swift"
+        #endif
+    }
     
     /// The current connection id
     @Atomic var connectionId: String?

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -1343,7 +1343,7 @@ extension ChatClient_Tests {
         let headers = config.httpAdditionalHeaders as? [String: String] ?? [:]
         XCTAssertEqual(
             headers["X-Stream-Client"],
-            "stream-chat-swift-client-v\(SystemEnvironment.version)"
+            "stream-chat-uikit-client-v\(SystemEnvironment.version)"
         )
     }
 }

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -1195,7 +1195,7 @@ class ChatClient_Tests: XCTestCase {
             eventWorkerBuilders: [],
             environment: testEnv.environment
         )
-        let prefix = "stream-chat-uikit-client-v"
+        let prefix = "stream-chat-swift-client-v"
         
         // When
         client.connectAnonymousUser()
@@ -1343,7 +1343,7 @@ extension ChatClient_Tests {
         let headers = config.httpAdditionalHeaders as? [String: String] ?? [:]
         XCTAssertEqual(
             headers["X-Stream-Client"],
-            "stream-chat-uikit-client-v\(SystemEnvironment.version)"
+            "stream-chat-swift-client-v\(SystemEnvironment.version)"
         )
     }
 }

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -1185,6 +1185,26 @@ class ChatClient_Tests: XCTestCase {
         testEnv.backgroundTaskScheduler?.startListeningForAppStateUpdates_onForeground?()
         XCTAssertEqual(testEnv.clientUpdater?.connect_called, true)
     }
+    
+    // Test identifier setup
+    func test_sessionHeaders_sdkIdentifier_correctValue() {
+        // Given
+        let client = ChatClient(
+            config: inMemoryStorageConfig,
+            workerBuilders: workerBuilders,
+            eventWorkerBuilders: [],
+            environment: testEnv.environment
+        )
+        let prefix = "stream-chat-uikit-client-v"
+        
+        // When
+        client.connectAnonymousUser()
+        
+        // Then
+        let sessionHeaders = client.apiClient.session.configuration.httpAdditionalHeaders
+        let streamHeader = sessionHeaders!["X-Stream-Client"] as! String
+        XCTAssert(streamHeader.starts(with: prefix))
+    }
 }
 
 class TestWorker: Worker {


### PR DESCRIPTION
### 🔗 Issue Link
[JIRA](https://stream-io.atlassian.net/browse/SWUI-33)

### 🎯 Goal

We need to track the usage of the different SDKs (low-level client, UIKit and SwiftUI), via the custom HTTP header X-Stream-Client.

### 🛠 Implementation

In the implementation, we're relying on whether the appropriate SDK can be imported, using the `canImport` macro.

The currently provided values are "swiftui", "uikit" and "swift". The other option would be to keep "swift" for "uikit", for backward compatibility, and use something like "llc" for the low-level client.

### 🧪 Testing

Test the DemoApp in this repo, by putting a breakpoint after setting the `httpAdditionalHeaders` in `ChatClient`, after line  186.

Test the DemoAppSwiftUI app in https://github.com/GetStream/stream-chat-swiftui. Note that you will need to setup the Swift package dependency to this branch (feature/tracking-sdks).

### 🎨 Changes

Not really visible changes.

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
