### PR TITLE
[CIS-1273] Ensure optional Core Data attributes map to optional Swift types

### DIFF
--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -15,9 +15,9 @@ class AttachmentDTO: NSManagedObject {
     }
 
     /// An attachment type.
-    @NSManaged private var type: String
+    @NSManaged private var type: String?
     var attachmentType: AttachmentType {
-        get { .init(rawValue: type) }
+        get { AttachmentType(rawValue: type ?? AttachmentType.unknown.rawValue) }
         set { type = newValue.rawValue }
     }
 
@@ -25,7 +25,9 @@ class AttachmentDTO: NSManagedObject {
     @NSManaged private var localStateRaw: String
     @NSManaged private var localProgress: Double
     var localState: LocalAttachmentState? {
-        get { LocalAttachmentState(rawValue: localStateRaw, progress: localProgress) }
+        get {
+            LocalAttachmentState(rawValue: localStateRaw, progress: localProgress)
+        }
         set {
             localStateRaw = newValue?.rawValue ?? ""
             localProgress = newValue?.progress ?? 0
@@ -221,6 +223,8 @@ extension AttachmentDTO {
 extension LocalAttachmentState {
     var rawValue: String {
         switch self {
+        case .unknown:
+            return ""
         case .pendingUpload:
             return "pendingUpload"
         case .uploading:
@@ -251,8 +255,10 @@ extension LocalAttachmentState {
             self = .uploadingFailed
         case LocalAttachmentState.uploaded.rawValue:
             self = .uploaded
+        case LocalAttachmentState.unknown.rawValue:
+            self = .unknown
         default:
-            return nil
+            self = .unknown
         }
     }
 }

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO_Tests.swift
@@ -37,7 +37,7 @@ class AttachmentDTO_Tests: XCTestCase {
 
         // Assert attachment has correct values.
         XCTAssertEqual(loadedAttachment.attachmentID, attachmentId)
-        XCTAssertEqual(loadedAttachment.localState, nil)
+        XCTAssertEqual(loadedAttachment.localState, .unknown)
         XCTAssertEqual(loadedAttachment.attachmentType, attachment.type)
         XCTAssertEqual(loadedAttachment.message.id, messageId)
         XCTAssertEqual(loadedAttachment.channel.cid, cid.rawValue)
@@ -72,7 +72,7 @@ class AttachmentDTO_Tests: XCTestCase {
 
         // Assert attachment has correct values.
         XCTAssertEqual(loadedAttachment.attachmentID, attachmentId)
-        XCTAssertEqual(loadedAttachment.localState, nil)
+        XCTAssertEqual(loadedAttachment.localState, .unknown)
         XCTAssertEqual(loadedAttachment.attachmentType, attachment.type)
         XCTAssertEqual(loadedAttachment.message.id, messageId)
         XCTAssertEqual(loadedAttachment.channel.cid, cid.rawValue)
@@ -107,7 +107,7 @@ class AttachmentDTO_Tests: XCTestCase {
 
         // Assert attachment has correct values.
         XCTAssertEqual(loadedAttachment.attachmentID, attachmentId)
-        XCTAssertEqual(loadedAttachment.localState, nil)
+        XCTAssertEqual(loadedAttachment.localState, .unknown)
         XCTAssertEqual(loadedAttachment.attachmentType, attachment.type)
         XCTAssertEqual(loadedAttachment.message.id, messageId)
         XCTAssertEqual(loadedAttachment.channel.cid, cid.rawValue)
@@ -270,7 +270,7 @@ class AttachmentDTO_Tests: XCTestCase {
 
         // Assert attachment local file URL and state are nil.
         XCTAssertNil(loadedAttachment?.localURL)
-        XCTAssertNil(loadedAttachment?.localState)
+        XCTAssertEqual(loadedAttachment?.localState, .unknown)
     }
 
     func test_attachmentChange_triggerMessageUpdate() throws {

--- a/Sources/StreamChat/Database/DTOs/ChannelMuteDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelMuteDTO.swift
@@ -8,7 +8,7 @@ import Foundation
 @objc(ChannelMuteDTO)
 final class ChannelMuteDTO: NSManagedObject {
     @NSManaged var createdAt: Date
-    @NSManaged var updatedAt: Date
+    @NSManaged var updatedAt: Date?
     @NSManaged var channel: ChannelDTO
     @NSManaged var user: UserDTO
 

--- a/Sources/StreamChat/Database/DTOs/ChannelReadDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelReadDTO.swift
@@ -7,7 +7,7 @@ import Foundation
 
 @objc(ChannelReadDTO)
 class ChannelReadDTO: NSManagedObject {
-    @NSManaged var lastReadAt: Date
+    @NSManaged var lastReadAt: Date?
     @NSManaged var unreadMessageCount: Int32
     
     // MARK: - Relationships
@@ -124,6 +124,10 @@ extension NSManagedObjectContext {
 
 extension ChatChannelRead {
     fileprivate static func create(fromDTO dto: ChannelReadDTO) -> ChatChannelRead {
-        .init(lastReadAt: dto.lastReadAt, unreadMessagesCount: Int(dto.unreadMessageCount), user: dto.user.asModel())
+        .init(
+            lastReadAt: dto.lastReadAt ?? Date.distantPast,
+            unreadMessagesCount: Int(dto.unreadMessageCount),
+            user: dto.user.asModel()
+        )
     }
 }

--- a/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
@@ -20,7 +20,7 @@ class MessageDTO_Tests: XCTestCase {
         super.tearDown()
     }
     
-    func test_messagePayload_isStoredAndLoadedFromDB() {
+    func test_messagePayload_isStoredAndLoadedFromDB() throws {
         let userId: UserId = .unique
         let messageId: MessageId = .unique
         let channelId: ChannelId = .unique
@@ -143,7 +143,7 @@ class MessageDTO_Tests: XCTestCase {
         )
         XCTAssertEqual(Int32(messagePayload.replyCount), loadedMessage?.replyCount)
         XCTAssertEqual(messagePayload.extraData, loadedMessage.map {
-            try? JSONDecoder.default.decode([String: RawJSON].self, from: $0.extraData)
+            try? JSONDecoder.default.decode([String: RawJSON].self, from: $0.extraData!)
         })
         XCTAssertEqual(messagePayload.reactionScores, loadedMessage?.reactionScores.mapKeys { reaction in
             MessageReactionType(rawValue: reaction)
@@ -228,7 +228,7 @@ class MessageDTO_Tests: XCTestCase {
             )
             Assert.willBeEqual(Int32(messagePayload.replyCount), loadedMessage?.replyCount)
             Assert.willBeEqual(messagePayload.extraData, loadedMessage.map {
-                try? JSONDecoder.default.decode([String: RawJSON].self, from: $0.extraData)
+                try? JSONDecoder.default.decode([String: RawJSON].self, from: $0.extraData!)
             })
             Assert.willBeEqual(messagePayload.reactionScores, loadedMessage?.reactionScores.mapKeys { reaction in
                 MessageReactionType(rawValue: reaction)

--- a/Sources/StreamChat/Database/DTOs/MessageSearchQueryDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageSearchQueryDTO.swift
@@ -7,7 +7,7 @@ import CoreData
 @objc(MessageSearchQueryDTO)
 class MessageSearchQueryDTO: NSManagedObject {
     /// Unique identifier of the query/
-    @NSManaged var filterHash: String
+    @NSManaged var filterHash: String?
     
     @NSManaged var messages: Set<MessageDTO>
     

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19206" systemVersion="20G165" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21C52" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
-        <attribute name="localProgress" optional="YES" attributeType="Double" minValueString="0" maxValueString="1" defaultValueString="0.0" usesScalarValueType="YES"/>
-        <attribute name="localStateRaw" optional="YES" attributeType="String" defaultValueString=""/>
+        <attribute name="localProgress" attributeType="Double" minValueString="0" maxValueString="1" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="localStateRaw" attributeType="String" defaultValueString=""/>
         <attribute name="localURL" optional="YES" attributeType="URI"/>
         <attribute name="type" optional="YES" attributeType="String"/>
         <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="attachments" inverseEntity="ChannelDTO"/>
@@ -18,7 +18,7 @@
     <entity name="ChannelDTO" representedClassName="ChannelDTO" syncable="YES">
         <attribute name="cid" attributeType="String"/>
         <attribute name="config" attributeType="Binary"/>
-        <attribute name="cooldownDuration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="cooldownDuration" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="defaultSortingAt" attributeType="Date" usesScalarValueType="NO" spotlightIndexingEnabled="YES"/>
         <attribute name="deletedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -32,9 +32,9 @@
         <attribute name="oldestMessageAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="team" optional="YES" attributeType="String"/>
         <attribute name="truncatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="typeRawValue" optional="YES" attributeType="String"/>
+        <attribute name="typeRawValue" attributeType="String" defaultValueString=""/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="watcherCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="watcherCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="attachments" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AttachmentDTO" inverseName="channel" inverseEntity="AttachmentDTO"/>
         <relationship name="createdBy" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="createdChannels" inverseEntity="UserDTO"/>
         <relationship name="currentlyTypingUsers" toMany="YES" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="typingIn" inverseEntity="UserDTO"/>
@@ -92,22 +92,22 @@
         </uniquenessConstraints>
     </entity>
     <entity name="ChannelMuteDTO" representedClassName="ChannelMuteDTO" syncable="YES">
-        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="mutes" inverseEntity="ChannelDTO"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="channelMutes" inverseEntity="UserDTO"/>
     </entity>
     <entity name="ChannelReadDTO" representedClassName="ChannelReadDTO" syncable="YES">
         <attribute name="lastReadAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="unreadMessageCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="unreadMessageCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="reads" inverseEntity="ChannelDTO"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="channelReads" inverseEntity="UserDTO"/>
     </entity>
     <entity name="CurrentUserDTO" representedClassName="CurrentUserDTO" syncable="YES">
         <attribute name="lastReceivedEventDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="uniquenessKey" attributeType="String" defaultValueString="this is an immmutable arbitrary key which makes sure we have only once instance of CurrentUserDTO in the db"/>
-        <attribute name="unreadChannelsCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="unreadMessagesCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="unreadChannelsCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="unreadMessagesCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="currentDevice" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DeviceDTO" inverseName="relationship" inverseEntity="DeviceDTO"/>
         <relationship name="devices" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DeviceDTO" inverseName="user" inverseEntity="DeviceDTO"/>
         <relationship name="flaggedMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="flaggedBy" inverseEntity="MessageDTO"/>
@@ -122,7 +122,7 @@
     </entity>
     <entity name="DeviceDTO" representedClassName="DeviceDTO" syncable="YES">
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="id" attributeType="String"/>
         <relationship name="relationship" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CurrentUserDTO" inverseName="currentDevice" inverseEntity="CurrentUserDTO"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CurrentUserDTO" inverseName="devices" inverseEntity="CurrentUserDTO"/>
         <uniquenessConstraints>
@@ -138,7 +138,7 @@
         <attribute name="inviteAcceptedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="inviteRejectedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="isBanned" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="isInvited" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isInvited" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isShadowBanned" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="memberCreatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="memberUpdatedAt" attributeType="Date" usesScalarValueType="NO"/>
@@ -165,10 +165,10 @@
         <attribute name="id" attributeType="String"/>
         <attribute name="isShadowed" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isSilent" attributeType="Boolean" usesScalarValueType="YES"/>
-        <attribute name="latestReactions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
+        <attribute name="latestReactions" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
         <attribute name="locallyCreatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="localMessageStateRaw" optional="YES" attributeType="String"/>
-        <attribute name="ownReactions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
+        <attribute name="ownReactions" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
         <attribute name="parentMessageId" optional="YES" attributeType="String"/>
         <attribute name="pinExpires" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="pinned" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
@@ -210,8 +210,8 @@
     <entity name="MessageReactionDTO" representedClassName="MessageReactionDTO" syncable="YES">
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="extraData" optional="YES" attributeType="Binary"/>
-        <attribute name="id" optional="YES" attributeType="String"/>
-        <attribute name="localStateRaw" optional="YES" attributeType="String"/>
+        <attribute name="id" attributeType="String"/>
+        <attribute name="localStateRaw" attributeType="String" defaultValueString=""/>
         <attribute name="score" attributeType="Integer 64" defaultValueString="1" usesScalarValueType="YES"/>
         <attribute name="type" attributeType="String"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -243,7 +243,7 @@
         <attribute name="extraData" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="imageURL" optional="YES" attributeType="URI"/>
-        <attribute name="isBanned" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isBanned" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isOnline" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="lastActivityAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
@@ -290,19 +290,19 @@
         </uniquenessConstraints>
     </entity>
     <elements>
-        <element name="AttachmentDTO" positionX="9" positionY="153" width="128" height="164"/>
-        <element name="ChannelDTO" positionX="0" positionY="0" width="128" height="523"/>
+        <element name="AttachmentDTO" positionX="9" positionY="153" width="128" height="149"/>
+        <element name="ChannelDTO" positionX="0" positionY="0" width="128" height="509"/>
         <element name="ChannelListQueryDTO" positionX="0" positionY="0" width="128" height="88"/>
         <element name="ChannelMemberListQueryDTO" positionX="9" positionY="153" width="128" height="88"/>
         <element name="ChannelMuteDTO" positionX="9" positionY="162" width="128" height="89"/>
-        <element name="ChannelReadDTO" positionX="9" positionY="153" width="128" height="103"/>
+        <element name="ChannelReadDTO" positionX="9" positionY="153" width="128" height="89"/>
         <element name="CurrentUserDTO" positionX="0" positionY="0" width="128" height="179"/>
         <element name="DeviceDTO" positionX="9" positionY="153" width="128" height="89"/>
-        <element name="MemberDTO" positionX="0" positionY="0" width="128" height="254"/>
+        <element name="MemberDTO" positionX="0" positionY="0" width="128" height="239"/>
         <element name="MessageDTO" positionX="160" positionY="192" width="128" height="614"/>
         <element name="MessageReactionDTO" positionX="160" positionY="192" width="128" height="179"/>
         <element name="MessageSearchQueryDTO" positionX="9" positionY="162" width="128" height="59"/>
-        <element name="UserDTO" positionX="0" positionY="0" width="128" height="433"/>
+        <element name="UserDTO" positionX="0" positionY="0" width="128" height="419"/>
         <element name="UserListQueryDTO" positionX="9" positionY="153" width="128" height="103"/>
     </elements>
 </model>

--- a/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
+++ b/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
@@ -23,6 +23,8 @@ enum AttachmentCodingKeys: String, CodingKey, CaseIterable {
 
 /// A local state of the attachment. Applies only for attachments linked to the new messages sent from current device.
 public enum LocalAttachmentState: Hashable {
+    /// The current state is unknown
+    case unknown
     /// The attachment is waiting to be uploaded.
     case pendingUpload
     /// The attachment is currently being uploaded. The progress in [0, 1] range.

--- a/Sources/StreamChat/Models/ChatMessage.swift
+++ b/Sources/StreamChat/Models/ChatMessage.swift
@@ -358,6 +358,9 @@ public enum LocalMessageState: String {
 }
 
 public enum LocalReactionState: String {
+    ///  The reaction state is unknown
+    case unknown = ""
+    
     /// The reaction is waiting to be sent to the server
     case pendingSend
 

--- a/Sources/StreamChat/Models/MuteDetails.swift
+++ b/Sources/StreamChat/Models/MuteDetails.swift
@@ -9,5 +9,5 @@ public struct MuteDetails: Equatable {
     /// The time when the mute action was taken.
     public let createdAt: Date
     /// The time when the mute was updated.
-    public let updatedAt: Date
+    public let updatedAt: Date?
 }

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware.swift
@@ -72,7 +72,7 @@ struct ChannelReadUpdaterMiddleware: EventMiddleware {
 
         // Try to get the existing channel read for the current user
         if let read = session.loadChannelRead(cid: cid, userId: currentUserId) {
-            if message.createdAt > read.lastReadAt {
+            if message.createdAt > read.lastReadAt ?? Date.distantPast {
                 read.unreadMessageCount += 1
             }
         } else {

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -1093,7 +1093,7 @@ final class MessageUpdater_Tests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(reactionReloaded.localState, nil)
+        XCTAssertEqual(reactionReloaded.localState, .unknown)
     }
 
     // MARK: - Pinning message

--- a/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery+UploadingOverlay.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Attachments/ChatMessageImageGallery+UploadingOverlay.swift
@@ -99,7 +99,7 @@ extension ChatMessageGalleryView {
             
             actionButton.content = content.flatMap {
                 switch $0.state {
-                case .pendingUpload, .uploading:
+                case .pendingUpload, .uploading, .unknown:
                     // TODO: Return `.cancel` when it's is supported.
                     return nil
                 case .uploadingFailed:
@@ -116,7 +116,7 @@ extension ChatMessageGalleryView {
                     return NumberFormatter.uploadingPercentage.string(from: .init(value: progress))
                 case .pendingUpload:
                     return NumberFormatter.uploadingPercentage.string(from: 0)
-                case .uploaded:
+                case .uploaded, .unknown:
                     return nil
                 case .uploadingFailed:
                     return L10n.Message.Sending.attachmentUploadingFailed
@@ -157,7 +157,7 @@ extension AttachmentUploadingState {
             return "\(uploadedSize)/\(file.sizeString)"
         case .pendingUpload:
             return "0/\(file.sizeString)"
-        case .uploaded, .uploadingFailed:
+        case .uploaded, .uploadingFailed, .unknown:
             return file.sizeString
         }
     }


### PR DESCRIPTION
### 🔗 Issue Link
[CIS-1273](https://stream-io.atlassian.net/browse/CIS-1273)

### 🎯 Goal

A number of differences between the Core Data model and the ManagedObjects were present. This pull request removes those issues. When applicable a sensible default is chosen for what Core Data describes as primitive types.

### 🛠 Implementation

Several model definitions were changed, several managed object classes were changed, several sensible default values were chosen.
### 🧪 Testing

Run through the app. No crashes should occur.

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
