### PR TITLE
[CIS-1281] Improve `synchronize` messaging

### DIFF
--- a/Sources/StreamChatUI/CommonViews/BaseViews.swift
+++ b/Sources/StreamChatUI/CommonViews/BaseViews.swift
@@ -344,11 +344,17 @@ open class _ViewController: UIViewController, Customizable {
         updateContent()
     }
     
-    /// `setUp()` is an important function within the ViewController lifecycle
-    /// It's resposibility is to set the delegates and also call `synchronize()`
-    /// this will make sure your local & remote data is in sync.
-    /// If you override this method without calling `super.setUp()` it's important
-    /// to make sure `synchronize()` is called.
+    /**
+     A function that will be called on first launch of the `View` it's a function that can be used
+     for any initial setup work required by the `View` such as setting delegates or datasources
+     
+     `setUp()` is an important function within the ViewController lifecycle
+     It's resposibility is to set the delegates and also call `synchronize()`
+     this will make sure your local & remote data is in sync.
+     
+     - Important: If you override this method without calling `super.setUp()` it's important
+     to make sure `synchronize()` is called.
+     */
     open func setUp() { /* default empty implementation */ }
     open func setUpAppearance() { view.setNeedsLayout() }
     open func setUpLayout() { view.setNeedsLayout() }

--- a/Sources/StreamChatUI/CommonViews/BaseViews.swift
+++ b/Sources/StreamChatUI/CommonViews/BaseViews.swift
@@ -346,13 +346,13 @@ open class _ViewController: UIViewController, Customizable {
     
     /**
      A function that will be called on first launch of the `View` it's a function that can be used
-     for any initial setup work required by the `View` such as setting delegates or datasources
+     for any initial setup work required by the `View` such as setting delegates or data sources
      
      `setUp()` is an important function within the ViewController lifecycle
-     It's resposibility is to set the delegates and also call `synchronize()`
+     Its responsibility is to set the delegates and also call `synchronize()`
      this will make sure your local & remote data is in sync.
      
-     - Important: If you override this method without calling `super.setUp()` it's important
+     - Important: If you override this method without calling `super.setUp()`, it's essential
      to make sure `synchronize()` is called.
      */
     open func setUp() { /* default empty implementation */ }

--- a/Sources/StreamChatUI/CommonViews/BaseViews.swift
+++ b/Sources/StreamChatUI/CommonViews/BaseViews.swift
@@ -344,6 +344,11 @@ open class _ViewController: UIViewController, Customizable {
         updateContent()
     }
     
+    /// `setUp()` is an important function within the ViewController lifecycle
+    /// It's resposibility is to set the delegates and also call `synchronize()`
+    /// this will make sure your local & remote data is in sync.
+    /// If you override this method without calling `super.setUp()` it's important
+    /// to make sure `synchronize()` is called.
     open func setUp() { /* default empty implementation */ }
     open func setUpAppearance() { view.setNeedsLayout() }
     open func setUpLayout() { view.setNeedsLayout() }

--- a/docusaurus/docs/iOS/basics/getting-started.md
+++ b/docusaurus/docs/iOS/basics/getting-started.md
@@ -93,7 +93,7 @@ You now have your very first Stream Chat app showing a list of Channels, but you
 
 ```swift
 do {
-    try controller(createChannelWithId: ChannelId(type: .livestream, id: UUID().uuidString), name: channelName)
+    try client.controller(createChannelWithId: ChannelId(type: .livestream, id: UUID().uuidString), name: channelName)
 
     channelController.synchronize { error in
         if let error = error {
@@ -113,7 +113,7 @@ Your `ChannelId` has to be a unique ID and you can set this to anything, in this
 
 :::tip Using Synchronize
 
-After creating the channel `try controller(createChannelWithId: ChannelId(type: .livestream, id: UUID().uuidString), name: channelName)` it's important you call `synchronize()` after so the local and remote data is updated. You can read more about the importance of `synchronize()` [here](../../guides/importance-of-synchronize)..
+After creating the channel `try client.controller(createChannelWithId: ChannelId(type: .livestream, id: UUID().uuidString), name: channelName)` it's important you call `synchronize()` after so the local and remote data is updated. You can read more about the importance of `synchronize()` [here](../../guides/importance-of-synchronize)..
 
 :::
 

--- a/docusaurus/docs/iOS/basics/getting-started.md
+++ b/docusaurus/docs/iOS/basics/getting-started.md
@@ -86,3 +86,35 @@ When deciding to push your `UIViewController` on to the `NavigationStack`, you c
 The snippet above will also create the `ChatChannelListController` with the specified query. In this case the query will load all the channels that you're currently a member of.
 
 `ChannelListQuery` allows us to define the channels to fetch and their order. Here we are listing channels where the current user is a member. By default tapping on a channel will navigate to `ChatMessageListVC`.
+
+### Creating a Channel
+
+You now have your very first Stream Chat app showing a list of Channels, but you're probably wondering how you can create your very first channel.
+
+```swift
+do {
+    try controller(createChannelWithId: ChannelId(type: .livestream, id: UUID().uuidString), name: channelName)
+
+    channelController.synchronize { error in
+        if let error = error {
+            print(error)
+        }
+    }
+} catch {
+    print("Channel creation failed")
+}
+```
+
+You can access `createChannelWithId:` function on the `ChannelController` which allows you to pass some parameters and create your very first channel.
+
+The channel `type` is an enum that describes what the channel's intention is.
+
+Your `ChannelId` has to be a unique ID and you can set this to anything, in this example we're using the `UUID()` provided by Apple. Finally, you can pass through the name of the channel which is a `String` and also some additional parameters if required.
+
+:::tip Using Synchronize
+
+After creating the channel `try controller(createChannelWithId: ChannelId(type: .livestream, id: UUID().uuidString), name: channelName)` it's important you call `synchronize()` after so the local and remote data is updated. You can read more about the importance of `synchronize()` [here](../../guides/importance-of-synchronize)..
+
+:::
+
+Your `ChatChannelListVC` is updated and will display the newly created channel, congratulations!

--- a/docusaurus/docs/iOS/controllers/channels.md
+++ b/docusaurus/docs/iOS/controllers/channels.md
@@ -58,7 +58,7 @@ class TypingIndicatorView: UIView, ChatChannelControllerDelegate {
 
     override public init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         addSubview(labelView)
 
         NSLayoutConstraint.activate([
@@ -68,19 +68,19 @@ class TypingIndicatorView: UIView, ChatChannelControllerDelegate {
             labelView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
 
     func channelController(_ channelController: ChatChannelController, didChangeTypingUsers typingUsers: Set<ChatUser>) {
         let otherUsersTyping = typingUsers.filter({ $0.id != channelController.client.currentUserId })
-        
+
         guard let typingUser = otherUsersTyping.first else {
             labelView.text = ""
             return
         }
-        
+
         labelView.text = "\(typingUser.name ?? typingUser.id) is typing ..."
     }
 }
@@ -106,6 +106,12 @@ class ViewController: UIViewController {
     }
 }
 ```
+
+:::tip Using Synchronize
+
+After accessing the `ChatClient.shared.channelController(for: cid)` it's important you call `synchronize()` after so the local and remote data is updated. You can read more about the importance of `synchronize()` [here](../../guides/importance-of-synchronize)..
+
+:::
 
 ## ChannelMemberListController
 
@@ -136,7 +142,7 @@ class MembersSearchResultsView: UIView, ChatChannelMemberListControllerDelegate 
 
     override public init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         addSubview(labelView)
 
         NSLayoutConstraint.activate([
@@ -146,7 +152,7 @@ class MembersSearchResultsView: UIView, ChatChannelMemberListControllerDelegate 
             labelView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
@@ -170,10 +176,10 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         let cid = ChannelId.init(type:.messaging, id:"123")
         let query = ChannelMemberListQuery.init(cid: cid)
-        
+
         controller = ChatClient.shared.memberListController(query: query)
         controller.delegate = membersSearchResultsView
 
@@ -187,6 +193,12 @@ class ViewController: UIViewController {
     }
 }
 ```
+
+:::tip Using Synchronize
+
+After accessing the `ChatClient.shared.memberListController(query: query)` it's important you call `synchronize()` after so the local and remote data is updated. You can read more about the importance of `synchronize()` [here](../../guides/importance-of-synchronize)..
+
+:::
 
 ## ChannelMemberController
 

--- a/docusaurus/docs/iOS/controllers/messages.md
+++ b/docusaurus/docs/iOS/controllers/messages.md
@@ -33,7 +33,7 @@ class MessageDetailView: UIView, ChatMessageControllerDelegate {
             updateContent()
         }
     }
-    
+
     var labelView: UILabel = {
         var label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -42,7 +42,7 @@ class MessageDetailView: UIView, ChatMessageControllerDelegate {
 
     override public init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         addSubview(labelView)
 
         NSLayoutConstraint.activate([
@@ -52,7 +52,7 @@ class MessageDetailView: UIView, ChatMessageControllerDelegate {
             labelView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
@@ -85,7 +85,7 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         let cid = ChannelId(type: .messaging, id: "E9BF5FCE-1")
         controller = ChatClient.shared.messageController(cid: cid, messageId: "91AC67C6-C2AF-486E-8552-08E6F9B48D85")
         controller.delegate = messageDetailView
@@ -103,3 +103,9 @@ class ViewController: UIViewController {
     }
 }
 ```
+
+:::tip Using Synchronize
+
+After accessing the `ChatClient.shared.messageController(cid: cid, messageId: "91AC67C6-C2AF-486E-8552-08E6F9B48D85")` it's important you call `synchronize()` after so the local and remote data is updated. You can read more about the importance of `synchronize()` [here](../../guides/importance-of-synchronize)..
+
+:::

--- a/docusaurus/docs/iOS/controllers/users.md
+++ b/docusaurus/docs/iOS/controllers/users.md
@@ -15,7 +15,7 @@ Classes that conform to the `CurrentChatUserController` protocol will receive ch
 func currentUserController(
     _ controller: CurrentChatUserController, didChangeCurrentUserUnreadCount: UnreadCount
 )
-    
+
 /// The controller observed a change in the `CurrentUser` entity.
 func currentUserController(
     _ controller: CurrentChatUserController,
@@ -80,6 +80,12 @@ class ViewController: UIViewController {
 }
 ```
 
+:::tip Using Synchronize
+
+After accessing the `ChatClient.shared.currentUserController()` it's important you call `synchronize()` after so the local and remote data is updated. You can read more about the importance of `synchronize()` [here](../../guides/importance-of-synchronize)..
+
+:::
+
 ## UserListController
 
 `ChatUserListController` allows you to observe a list of users based on the provided query.
@@ -101,7 +107,7 @@ func controller(
 
 ### UserControllerDelegate
 
-Classes that conform to this protocol will receive changes to chat users. 
+Classes that conform to this protocol will receive changes to chat users.
 
 ```swift
 func userController(
@@ -145,7 +151,7 @@ class UsersListView: UIView, ChatUserSearchControllerDelegate {
 
     override public init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         addSubview(labelView)
 
         NSLayoutConstraint.activate([
@@ -155,7 +161,7 @@ class UsersListView: UIView, ChatUserSearchControllerDelegate {
             labelView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
@@ -177,8 +183,8 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        
+
+
         let query = UserListQuery.init(filter: .autocomplete(.name, text: "t"), sort: [], pageSize: 10)
         controller = ChatClient.shared.userSearchController()
         controller.delegate = usersListView

--- a/docusaurus/docs/iOS/guides/importance-of-synchronize.md
+++ b/docusaurus/docs/iOS/guides/importance-of-synchronize.md
@@ -25,7 +25,9 @@ channelController.freezeChannel()
 
 But as stated in the table above, if the Channel is not created in the backend yet, you'll need to call `synchronize()` first, else the action calls will fail.
 
-`Synchronize()` is automatically called within the `setUp()` function on each `View` or `ViewController` which will automatically update both local and remote data for you. It's important to note that if you implement your own custom implementation that you call `super.setUp()` so this function is called. If you implement your own UI completely then make sure you call `synchronize()` on the custom UI lifecycle.
+Also, if you create a channel without passing a `ChannelID` then you must call `synchronize()` every time.
+
+`synchronize()` is automatically called within the `setUp()` function on each `View` or `ViewController` which will automatically update both local and remote data for you. It's important to note that if you implement your own custom implementation that you call `super.setUp()` so this function is called. If you implement your own UI completely then make sure you call `synchronize()` on the custom UI lifecycle.
 
 Additionally, as with all StreamChat Controllers, `ChannelController` has `state` and a delegate function to observe it's `state`:
 

--- a/docusaurus/docs/iOS/guides/importance-of-synchronize.md
+++ b/docusaurus/docs/iOS/guides/importance-of-synchronize.md
@@ -25,6 +25,8 @@ channelController.freezeChannel()
 
 But as stated in the table above, if the Channel is not created in the backend yet, you'll need to call `synchronize()` first, else the action calls will fail.
 
+`Synchronize()` is automatically called within the `setUp()` function on each `View` or `ViewController` which will automatically update both local and remote data for you. It's important to note that if you implement your own custom implementation that you call `super.setUp()` so this function is called. If you implement your own UI completely then make sure you call `synchronize()` on the custom UI lifecycle.
+
 Additionally, as with all StreamChat Controllers, `ChannelController` has `state` and a delegate function to observe it's `state`:
 
 ```swift

--- a/docusaurus/docs/iOS/guides/importance-of-synchronize.md
+++ b/docusaurus/docs/iOS/guides/importance-of-synchronize.md
@@ -1,0 +1,34 @@
+---
+title: The Importance of Synchronize
+---
+
+## About `synchronize()`
+
+ Controllers are lightweight objects and they only fetch data when needed. When a controller is created, it doesn't fetch local or remote data until it needs it.
+
+`synchronize()` makes sure StreamChat's local database and backend is in sync. It queries the backend for the latest state of the Channel and updates the database. In addition, `synchronize()` call starts actually obversing the Channel for changes, so you will start getting live updates of the changes to the Channel, including it's messages.
+
+If you only need the local data, you can just access it after creation, like so:
+
+```swift
+let channelController = chatClient.channelController(for: ChannelId(type: .messaging, id: "general"))
+let channel = channelController.channel
+let messages = channelController.messages
+ ```
+
+In addition, you don't need to call `synchronize()` to be able to call actions on the channel, such as `freezeChannel`:
+
+```swift
+let channelController = chatClient.channelController(for: ChannelId(type: .messaging, id: "general"))
+channelController.freezeChannel()
+```
+
+But as stated in the table above, if the Channel is not created in the backend yet, you'll need to call `synchronize()` first, else the action calls will fail.
+
+Additionally, as with all StreamChat Controllers, `ChannelController` has `state` and a delegate function to observe it's `state`:
+
+```swift
+func controller(_ controller: DataController, didChangeState state: DataController.State)
+```
+
+You can use this delegate function to show any error states you might see. For more information, see [DataController Overview](404).

--- a/docusaurus/sidebars-ios.json
+++ b/docusaurus/sidebars-ios.json
@@ -55,6 +55,7 @@
     },
     {
       "Guides": [
+        "guides/importance-of-synchronize",
         "guides/customize-message-actions",
         "guides/push-notifications",
         "guides/working-with-attachments",


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1281

### 🎯 Goal

The improvements for `synchronize`. This PR is phase 1 of this project to really start improving how customers use `synchronize` and more importantly _when_ to use it. This PR is mainly focussing our documentation and guides as we move across to a more sustainable architecture in the near future.

### 🛠 Implementation

Mainly documentation, I have implemented a whole new guide focussed solely on `synchronize()` and added these tips throughout other documentation pieces. I have also added inline docs for the use of `setUp()`.

### 🧪 Testing

The testing here is mainly in the docs, have I covered everything?

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
