### PR TITLE
Fix TypingEventSender inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix `stopTyping` can be called on `TypingEventSender` after calling `startTyping` [#1649](https://github.com/GetStream/stream-chat-swift/issues/1649)
 
 # [4.5.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.5.1)
 _December 01, 2021_


### PR DESCRIPTION
### 🎯 Goal

It was not possible to call `stopTyping` after calling `startTyping` in `TypingEventSender`. It was designed around `keystroke`, with `startTyping` being used as a helper

### 🛠 Implementation

`startTyping` or `stopTyping` now doesn't depend on `keystroke`, tested with new unit tests, which do fail without the changes.

### 🧪 Testing

Run `TypingEventSender_Tests`

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
