### PR TITLE
Make LogDestination fields public and accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Increase tappable area surrounding the ShareButton inside the GalleryVC [#1640](https://github.com/GetStream/stream-chat-swift/pull/1640)
 - Fix giphy action message (ephemeral message) in a thread is also shown in the channel [#1641](https://github.com/GetStream/stream-chat-swift/issues/1641)
 
+### 🔄 Changed
+- Make `LogDetails` fields `public` so they are be accessible. Typical usage is when overriding `process(logDetails:)` when subclassing `BaseLogDestination` [#1650](https://github.com/GetStream/stream-chat-swift/issues/1650)
+
 # [4.5.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.5.0)
 _November 16, 2021_
 

--- a/Sources/StreamChat/Utils/Logger/Destination/LogDestination.swift
+++ b/Sources/StreamChat/Utils/Logger/Destination/LogDestination.swift
@@ -19,16 +19,16 @@ public enum LogLevel: Int {
 
 /// Encapsulates the components of a log message.
 public struct LogDetails {
-    let loggerIdentifier: String
+    public let loggerIdentifier: String
     
-    let level: LogLevel
-    let date: Date
-    let message: String
-    let threadName: String
+    public let level: LogLevel
+    public let date: Date
+    public let message: String
+    public let threadName: String
     
-    let functionName: StaticString
-    let fileName: StaticString
-    let lineNumber: UInt
+    public let functionName: StaticString
+    public let fileName: StaticString
+    public let lineNumber: UInt
 }
 
 public protocol LogDestination {


### PR DESCRIPTION
### 🎯 Goal

Integrators aiming to route SDK logs to their own logs couldn't access `LogDetails` fields

### 🛠 Implementation

We actually missed this during testing, the fields should've been public

### 🧪 Testing

Try to subclass `BaseLogDestination` and override `process` func to access `logDetails` fields

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
