### PR TITLE
[CIS-1362] Store web-socket disconnection source

### DIFF
--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -638,7 +638,8 @@ extension ChatClient: ConnectionStateDelegate {
                 shouldNotifyConnectionIdWaiters = true
             }
             connectionId = nil
-        case .connecting,
+        case .initialized,
+             .connecting,
              .disconnecting,
              .waitingForConnectionId,
              .waitingForReconnect:

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -629,8 +629,8 @@ extension ChatClient: ConnectionStateDelegate {
         case let .connected(connectionId: id):
             shouldNotifyConnectionIdWaiters = true
             connectionId = id
-        case let .disconnected(error: error):
-            if let error = error,
+        case let .disconnected(source):
+            if let error = source.serverError,
                error.isTokenExpiredError {
                 refreshToken(error: error, completion: nil)
                 shouldNotifyConnectionIdWaiters = false

--- a/Sources/StreamChat/ChatClient_Mock.swift
+++ b/Sources/StreamChat/ChatClient_Mock.swift
@@ -32,7 +32,10 @@ extension ChatClient {
 
     func simulateProvidedConnectionId(connectionId: ConnectionId?) {
         guard let connectionId = connectionId else {
-            webSocketClient(mockWebSocketClient, didUpdateConnectionState: .disconnected(error: nil))
+            webSocketClient(
+                mockWebSocketClient,
+                didUpdateConnectionState: .disconnected(source: .serverInitiated(error: nil))
+            )
             return
         }
         webSocketClient(mockWebSocketClient, didUpdateConnectionState: .connected(connectionId: connectionId))

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -240,7 +240,7 @@ class ChatClient_Tests: XCTestCase {
         
         // Simulate disconnected state
         testEnv.webSocketClient?.connectionStateDelegate?
-            .webSocketClient(testEnv.webSocketClient!, didUpdateConnectionState: .disconnected())
+            .webSocketClient(testEnv.webSocketClient!, didUpdateConnectionState: .disconnected(source: .systemInitiated))
         
         // Assert client is disconnected
         XCTAssertEqual(client.connectionStatus, .disconnected())
@@ -381,7 +381,7 @@ class ChatClient_Tests: XCTestCase {
 
         // Simulate web-socket disconnection.
         let error = ClientError(with: TestError())
-        client.webSocketClient?.simulateConnectionStatus(.disconnected(error: error))
+        client.webSocketClient?.simulateConnectionStatus(.disconnected(source: .serverInitiated(error: error)))
 
         // Assert the WSConnectionState is exposed as ChatClientConnectionStatus
         XCTAssertEqual(client.connectionStatus, .disconnected(error: error))
@@ -459,7 +459,10 @@ class ChatClient_Tests: XCTestCase {
         // Simulate WebSocketConnection change to "disconnected"
         let error = ClientError(with: TestError())
         testEnv.webSocketClient?.connectionStateDelegate?
-            .webSocketClient(testEnv.webSocketClient!, didUpdateConnectionState: .disconnected(error: error))
+            .webSocketClient(
+                testEnv.webSocketClient!,
+                didUpdateConnectionState: .disconnected(source: .serverInitiated(error: error))
+            )
         
         // Assert the provided connection id is `nil`
         XCTAssertNil(providedConnectionId)
@@ -502,7 +505,7 @@ class ChatClient_Tests: XCTestCase {
             .connectionStateDelegate?
             .webSocketClient(
                 testEnv.webSocketClient!,
-                didUpdateConnectionState: .disconnected(error: error)
+                didUpdateConnectionState: .disconnected(source: .serverInitiated(error: error))
             )
         
         time.run(numberOfSeconds: 0.6)
@@ -514,7 +517,7 @@ class ChatClient_Tests: XCTestCase {
             .connectionStateDelegate?
             .webSocketClient(
                 testEnv.webSocketClient!,
-                didUpdateConnectionState: .disconnected(error: error)
+                didUpdateConnectionState: .disconnected(source: .serverInitiated(error: error))
             )
         
         // Does not call secondary token refresh right away
@@ -941,7 +944,10 @@ class ChatClient_Tests: XCTestCase {
         
         // Simulate .disconnected state
         testEnv.webSocketClient?.connectionStateDelegate?
-            .webSocketClient(testEnv.webSocketClient!, didUpdateConnectionState: .disconnected(error: nil))
+            .webSocketClient(
+                testEnv.webSocketClient!,
+                didUpdateConnectionState: .disconnected(source: .serverInitiated(error: nil))
+            )
         
         // Simulate going into background
         testEnv.backgroundTaskScheduler!.startListeningForAppStateUpdates_onBackground?()

--- a/Sources/StreamChat/WebSocketClient/ConnectionStatus.swift
+++ b/Sources/StreamChat/WebSocketClient/ConnectionStatus.swift
@@ -32,8 +32,8 @@ extension ConnectionStatus {
         case .initialized:
             self = .initialized
             
-        case let .disconnected(error: error):
-            self = .disconnected(error: error)
+        case let .disconnected(source):
+            self = .disconnected(error: source.serverError)
             
         case .connecting, .waitingForConnectionId, .waitingForReconnect:
             self = .connecting
@@ -64,13 +64,20 @@ enum WebSocketConnectionState: Equatable {
         
         /// `WebSocketPingController` didn't get a pong response.
         case noPongReceived
+        
+        /// Returns the underlaying error if connection cut was initiated by the server.
+        var serverError: ClientError? {
+            guard case let .serverInitiated(error) = self else { return nil }
+            
+            return error
+        }
     }
     
     /// The initial state meaning that  there was no atempt to connect yet.
     case initialized
     
-    /// The web socket is not connected. Optionally contains an error, if the connection was disconnected due to an error.
-    case disconnected(error: ClientError? = nil)
+    /// The web socket is not connected. Contains the source/reason why the disconnection has happened.
+    case disconnected(source: DisconnectionSource)
     
     /// The web socket is connecting
     case connecting

--- a/Sources/StreamChat/WebSocketClient/ConnectionStatus.swift
+++ b/Sources/StreamChat/WebSocketClient/ConnectionStatus.swift
@@ -29,6 +29,9 @@ extension ConnectionStatus {
     // In internal initializer used for convering internal `WebSocketConnectionState` to `ChatClientConnectionStatus`.
     init(webSocketConnectionState: WebSocketConnectionState) {
         switch webSocketConnectionState {
+        case .initialized:
+            self = .initialized
+            
         case let .disconnected(error: error):
             self = .disconnected(error: error)
             
@@ -62,6 +65,9 @@ enum WebSocketConnectionState: Equatable {
         /// `WebSocketPingController` didn't get a pong response.
         case noPongReceived
     }
+    
+    /// The initial state meaning that  there was no atempt to connect yet.
+    case initialized
     
     /// The web socket is not connected. Optionally contains an error, if the connection was disconnected due to an error.
     case disconnected(error: ClientError? = nil)

--- a/Sources/StreamChat/WebSocketClient/ConnectionStatus_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/ConnectionStatus_Tests.swift
@@ -10,7 +10,6 @@ class ChatClientConnectionStatus_Tests: XCTestCase {
         let testError = ClientError(with: TestError())
         let pairs: [(WebSocketConnectionState, ConnectionStatus)] = [
             (.initialized, .initialized),
-            (.disconnected(error: testError), .disconnected(error: testError)),
             (.connecting, .connecting),
             (.waitingForConnectionId, .connecting),
             (.waitingForReconnect(error: testError), .connecting),
@@ -18,11 +17,38 @@ class ChatClientConnectionStatus_Tests: XCTestCase {
             (.disconnecting(source: .noPongReceived), .disconnecting),
             (.disconnecting(source: .serverInitiated(error: testError)), .disconnecting),
             (.disconnecting(source: .systemInitiated), .disconnecting),
-            (.disconnecting(source: .userInitiated), .disconnecting)
+            (.disconnecting(source: .userInitiated), .disconnecting),
+            (.disconnected(source: .userInitiated), .disconnected(error: nil)),
+            (.disconnected(source: .systemInitiated), .disconnected(error: nil)),
+            (.disconnected(source: .noPongReceived), .disconnected(error: nil)),
+            (.disconnected(source: .serverInitiated(error: nil)), .disconnected(error: nil)),
+            (.disconnected(source: .serverInitiated(error: testError)), .disconnected(error: testError))
         ]
         
         pairs.forEach {
             XCTAssertEqual($1, ConnectionStatus(webSocketConnectionState: $0))
+        }
+    }
+}
+
+final class WebSocketConnectionState_Tests: XCTestCase {
+    func test_disconnectionSource_serverError() {
+        // Create test error
+        let testError = ClientError(with: TestError())
+        
+        // Create pairs of disconnection source and expected server error
+        let testCases: [(WebSocketConnectionState.DisconnectionSource, ClientError?)] = [
+            (.userInitiated, nil),
+            (.systemInitiated, nil),
+            (.noPongReceived, nil),
+            (.serverInitiated(error: nil), nil),
+            (.serverInitiated(error: testError), testError)
+        ]
+        
+        // Iterate pairs
+        testCases.forEach { source, serverError in
+            // Assert returned server error matches expected one
+            XCTAssertEqual(source.serverError, serverError)
         }
     }
 }

--- a/Sources/StreamChat/WebSocketClient/ConnectionStatus_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/ConnectionStatus_Tests.swift
@@ -9,6 +9,7 @@ class ChatClientConnectionStatus_Tests: XCTestCase {
     func test_wsConnectionState_isTranslatedCorrectly() {
         let testError = ClientError(with: TestError())
         let pairs: [(WebSocketConnectionState, ConnectionStatus)] = [
+            (.initialized, .initialized),
             (.disconnected(error: testError), .disconnected(error: testError)),
             (.connecting, .connecting),
             (.waitingForConnectionId, .connecting),

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -9,7 +9,7 @@ class WebSocketClient {
     let eventNotificationCenter: EventNotificationCenter
     
     /// The current state the web socket connection.
-    @Atomic private(set) var connectionState: WebSocketConnectionState = .disconnected() {
+    @Atomic private(set) var connectionState: WebSocketConnectionState = .initialized {
         didSet {
             log.info("Web socket connection state changed: \(connectionState)", subsystems: .webSocket)
             connectionStateDelegate?.webSocketClient(self, didUpdateConnectionState: connectionState)

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
@@ -132,7 +132,7 @@ class WebSocketClient_Tests: XCTestCase {
     // MARK: - Connection tests
     
     func test_connectionFlow() {
-        assert(webSocketClient.connectionState == .disconnected())
+        assert(webSocketClient.connectionState == .initialized)
         
         // Simulate response from the encoder
         let request = URLRequest(url: .unique())

--- a/Sources/StreamChat/Workers/ChatClientUpdater.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater.swift
@@ -144,8 +144,8 @@ class ChatClientUpdater {
                 completion?(nil)
             } else {
                 // Try to get a concrete error
-                if case let .disconnected(error) = client?.webSocketClient?.connectionState {
-                    completion?(ClientError.ConnectionNotSuccessful(with: error))
+                if case let .disconnected(source) = client?.webSocketClient?.connectionState {
+                    completion?(ClientError.ConnectionNotSuccessful(with: source.serverError))
                 } else {
                     completion?(ClientError.ConnectionNotSuccessful())
                 }

--- a/Sources/StreamChat/Workers/ChatClientUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater_Tests.swift
@@ -159,8 +159,8 @@ final class ChatClientUpdater_Tests: XCTestCase {
             XCTAssertEqual(client.connectionIdWaiters.count, 1)
 
             if let error = connectionError {
-                // Simulate web socket `disconnected` state with the specific error.
-                client.mockWebSocketClient.simulateConnectionStatus(.disconnected(error: error))
+                // Simulate web socket `disconnected` state initiated by the server with the specific error.
+                client.mockWebSocketClient.simulateConnectionStatus(.disconnected(source: .serverInitiated(error: error)))
             }
 
             // Simulate error while establishing a connection.


### PR DESCRIPTION
### 🔗 Issue Link

Task: CIS-1319
Sub-task: CIS-1362

### 🎯 Goal

Store the source of disconnection. This info is needed for CIS-1319 to decide whether the LLC should reconnect automatically when:
- app goes from background to foreground
- the Internet connection comes back

### 🛠 Implementation

1. Introduced `initialized` state to be clear that there was no attempt to connect yet.
2. When disconnection is initiated by the client/user the disconnection source get stored as the associated value in the `disconnected` state

### 🧪 Testing

Unit tests are updated to cover the changes.

### 🎨 Changes

N/A

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
