### PR TITLE
[CIS-1355, CIS-1356, CIS-1366] Use OSS as default integration source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@ frameworks: clean
 	echo "👉 Creating dynamic libraries. Will take a while... Logs available: DerivedData/fastlane.log"
 	bundle exec fastlane build_xcframeworks > DerivedData/fastlane.log
 	echo "👉 Creating compressed archives"
-	# Adding ".xcframework" in the zip name is on purpose, since Carthage looks out for this pattern.
-	make zip_artifacts name="StreamChat-All.xcframework" pattern=./*.xcframework
+	make zip_artifacts name="StreamChat-All" pattern=./*.xcframework
 	make zip_artifacts name="StreamChat" pattern=./StreamChat.xcframework
 	make zip_artifacts name="StreamChatUI" pattern=./StreamChatUI.xcframework
 

--- a/StreamChat-XCFrameworks.podspec
+++ b/StreamChat-XCFrameworks.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |spec|
-  spec.name = "StreamChat-OSS"
+  spec.name = "StreamChat-XCFrameworks"
   spec.version = "4.5.0"
   spec.summary = "StreamChat iOS Client"
   spec.description = "stream-chat-swift is the official Swift client for Stream Chat, a service for building chat applications."
@@ -17,9 +17,9 @@ Pod::Spec.new do |spec|
   spec.framework = "Foundation"
   spec.ios.framework = "UIKit"
 
-  spec.module_name = "StreamChat"
-  spec.source = { :git => "https://github.com/GetStream/stream-chat-swift.git", :tag => "#{spec.version}" }
-  spec.source_files  = ["Sources/StreamChat/**/*.swift", "Sources/StreamStarscream/**/*.swift"]
-  spec.exclude_files = ["Sources/StreamChat/**/*_Tests.swift", "Sources/StreamChat/**/*_Mock.swift"]
-  spec.resource_bundles = { "StreamChat" => ["Sources/StreamChat/**/*.xcdatamodeld"] }
+  spec.source = { :http => "https://github.com/GetStream/stream-chat-swift/releases/download/#{spec.version}/#{spec.name}.xcframework.zip" }
+  spec.vendored_frameworks = "#{spec.name}.xcframework"
+  spec.preserve_paths = "#{spec.name}.xcframework/*"
+
+  spec.cocoapods_version = ">= 1.11.0"
 end

--- a/StreamChat-XCFrameworks.podspec
+++ b/StreamChat-XCFrameworks.podspec
@@ -17,9 +17,10 @@ Pod::Spec.new do |spec|
   spec.framework = "Foundation"
   spec.ios.framework = "UIKit"
 
-  spec.source = { :http => "https://github.com/GetStream/stream-chat-swift/releases/download/#{spec.version}/#{spec.name}.xcframework.zip" }
-  spec.vendored_frameworks = "#{spec.name}.xcframework"
-  spec.preserve_paths = "#{spec.name}.xcframework/*"
+  spec.module_name = "StreamChat"
+  spec.source = { :http => "https://github.com/GetStream/stream-chat-swift/releases/download/#{spec.version}/#{spec.module_name}.zip" }
+  spec.vendored_frameworks = "#{spec.module_name}.xcframework"
+  spec.preserve_paths = "#{spec.module_name}.xcframework/*"
 
   spec.cocoapods_version = ">= 1.11.0"
 end

--- a/StreamChat.podspec
+++ b/StreamChat.podspec
@@ -17,9 +17,9 @@ Pod::Spec.new do |spec|
   spec.framework = "Foundation"
   spec.ios.framework = "UIKit"
 
-  spec.source = { :http => "https://github.com/GetStream/stream-chat-swift/releases/download/#{spec.version}/#{spec.name}.xcframework.zip" }
-  spec.vendored_frameworks = "#{spec.name}.xcframework"
-  spec.preserve_paths = "#{spec.name}.xcframework/*"
-
-  spec.cocoapods_version = ">= 1.11.0"
+  spec.module_name = "StreamChat"
+  spec.source = { :git => "https://github.com/GetStream/stream-chat-swift.git", :tag => "#{spec.version}" }
+  spec.source_files  = ["Sources/StreamChat/**/*.swift", "Sources/StreamStarscream/**/*.swift"]
+  spec.exclude_files = ["Sources/StreamChat/**/*_Tests.swift", "Sources/StreamChat/**/*_Mock.swift"]
+  spec.resource_bundles = { "StreamChat" => ["Sources/StreamChat/**/*.xcdatamodeld"] }
 end

--- a/StreamChatArtifacts.json
+++ b/StreamChatArtifacts.json
@@ -1,0 +1,3 @@
+{
+	"4.2.0": "https://github.com/GetStream/stream-chat-swift/releases/download/2.6.1/StreamChat-All.zip"
+}

--- a/StreamChatUI-XCFrameworks.podspec
+++ b/StreamChatUI-XCFrameworks.podspec
@@ -15,9 +15,10 @@ Pod::Spec.new do |spec|
 
   spec.framework = "Foundation", "UIKit"
 
-  spec.source = { :http => "https://github.com/GetStream/stream-chat-swift/releases/download/#{spec.version}/#{spec.name}.xcframework.zip" }
-  spec.vendored_frameworks = "#{spec.name}.xcframework"
-  spec.preserve_paths = "#{spec.name}.xcframework/*"
+  spec.module_name = "StreamChatUI"
+  spec.source = { :http => "https://github.com/GetStream/stream-chat-swift/releases/download//#{spec.version}/#{spec.module_name}.zip" }
+  spec.vendored_frameworks = "#{spec.module_name}.xcframework"
+  spec.preserve_paths = "#{spec.module_name}.xcframework/*"
 
   spec.dependency "StreamChat-XCFrameworks", "#{spec.version}"
 

--- a/StreamChatUI-XCFrameworks.podspec
+++ b/StreamChatUI-XCFrameworks.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |spec|
-  spec.name = "StreamChatUI-OSS"
+  spec.name = "StreamChatUI-XCFrameworks"
   spec.version = "4.5.0"
   spec.summary = "StreamChat UI Components"
   spec.description = "StreamChatUI SDK offers flexible UI components able to display data provided by StreamChat SDK."
@@ -15,11 +15,11 @@ Pod::Spec.new do |spec|
 
   spec.framework = "Foundation", "UIKit"
 
-  spec.module_name = "StreamChatUI"
-  spec.source = { :git => "https://github.com/GetStream/stream-chat-swift.git", :tag => "#{spec.version}" }
-  spec.source_files  = ["Sources/StreamChatUI/**/*.swift", "Sources/StreamNuke/**/*.swift", "Sources/StreamSwiftyGif/**/*.swift"]
-  spec.exclude_files = ["Sources/StreamChatUI/**/*_Tests.swift", "Sources/StreamChatUI/**/*_Mock.swift"]
-  spec.resource_bundles = { "StreamChatUIResources" => ["Sources/StreamChatUI/Resources/**/*"] }
+  spec.source = { :http => "https://github.com/GetStream/stream-chat-swift/releases/download/#{spec.version}/#{spec.name}.xcframework.zip" }
+  spec.vendored_frameworks = "#{spec.name}.xcframework"
+  spec.preserve_paths = "#{spec.name}.xcframework/*"
 
-  spec.dependency "StreamChat-OSS", "#{spec.version}"
+  spec.dependency "StreamChat-XCFrameworks", "#{spec.version}"
+
+  spec.cocoapods_version = ">= 1.11.0"
 end

--- a/StreamChatUI.podspec
+++ b/StreamChatUI.podspec
@@ -15,11 +15,11 @@ Pod::Spec.new do |spec|
 
   spec.framework = "Foundation", "UIKit"
 
-  spec.source = { :http => "https://github.com/GetStream/stream-chat-swift/releases/download/#{spec.version}/#{spec.name}.xcframework.zip" }
-  spec.vendored_frameworks = "#{spec.name}.xcframework"
-  spec.preserve_paths = "#{spec.name}.xcframework/*"
+  spec.module_name = "StreamChatUI"
+  spec.source = { :git => "https://github.com/GetStream/stream-chat-swift.git", :tag => "#{spec.version}" }
+  spec.source_files  = ["Sources/StreamChatUI/**/*.swift", "Sources/StreamNuke/**/*.swift", "Sources/StreamSwiftyGif/**/*.swift"]
+  spec.exclude_files = ["Sources/StreamChatUI/**/*_Tests.swift", "Sources/StreamChatUI/**/*_Mock.swift"]
+  spec.resource_bundles = { "StreamChatUIResources" => ["Sources/StreamChatUI/Resources/**/*"] }
 
   spec.dependency "StreamChat", "#{spec.version}"
-
-  spec.cocoapods_version = ">= 1.11.0"
 end


### PR DESCRIPTION
### 🔗 Issue Link
https://stream-io.atlassian.net/browse/CIS-1355
https://stream-io.atlassian.net/browse/CIS-1356
https://stream-io.atlassian.net/browse/CIS-1366

### 🎯 Goal

For now, xcframeworks/Module stable binaries are going to be soft launched to make sure it is working as expected without widely announcing it.

### 🛠 Implementation

- Main podspec definitions point to OSS
- Artifacts don't contain `xcframework` in the name for Carthage not to pick them automatically
- Add json to reference artifacts from Carthage

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
