### PR TITLE
[BW] Resolves compile time warnings, including publicizing the previously deprecated ChatMessageLayoutOptions APIs

### DIFF
--- a/Scripts/removePublicDeclaracions.sh
+++ b/Scripts/removePublicDeclaracions.sh
@@ -34,5 +34,6 @@ do
 	if [[ $directory == *"Starscream"* ]]; then
 		`sed -i '' -e 's/WebSocketClient/StarscreamWebSocketClient/g' $f`
 		`sed -i '' -e 's/ConnectionEvent/StarscreamConnectionEvent/g' $f`
+		`sed -i '' -e 's/: class {/: AnyObject {/g' $f`
 	fi
 done

--- a/Sources/StreamChat/StreamStarscream/Engine/Engine.swift
+++ b/Sources/StreamChat/StreamStarscream/Engine/Engine.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol EngineDelegate: class {
+protocol EngineDelegate: AnyObject {
     func didReceive(event: WebSocketEvent)
 }
 

--- a/Sources/StreamChat/StreamStarscream/Framer/FrameCollector.swift
+++ b/Sources/StreamChat/StreamStarscream/Framer/FrameCollector.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-protocol FrameCollectorDelegate: class {
+protocol FrameCollectorDelegate: AnyObject {
     func didForm(event: FrameCollector.Event)
     func decompress(data: Data, isFinal: Bool) -> Data?
 }

--- a/Sources/StreamChat/StreamStarscream/Framer/Framer.swift
+++ b/Sources/StreamChat/StreamStarscream/Framer/Framer.swift
@@ -71,7 +71,7 @@ enum FrameEvent {
     case error(Error)
 }
 
-protocol FramerEventClient: class {
+protocol FramerEventClient: AnyObject {
     func frameProcessed(event: FrameEvent)
 }
 

--- a/Sources/StreamChat/StreamStarscream/Framer/HTTPHandler.swift
+++ b/Sources/StreamChat/StreamStarscream/Framer/HTTPHandler.swift
@@ -94,7 +94,7 @@ enum HTTPEvent {
     case failure(Error)
 }
 
-protocol HTTPHandlerDelegate: class {
+protocol HTTPHandlerDelegate: AnyObject {
     func didReceiveHTTP(event: HTTPEvent)
 }
 
@@ -104,7 +104,7 @@ protocol HTTPHandler {
     func parse(data: Data) -> Int
 }
 
-protocol HTTPServerDelegate: class {
+protocol HTTPServerDelegate: AnyObject {
     func didReceive(event: HTTPEvent)
 }
 

--- a/Sources/StreamChat/StreamStarscream/Security/Security.swift
+++ b/Sources/StreamChat/StreamStarscream/Security/Security.swift
@@ -34,12 +34,12 @@ enum PinningState {
 
 // CertificatePinning protocol provides an interface for Transports to handle Certificate
 // or Public Key Pinning.
-protocol CertificatePinning: class {
+protocol CertificatePinning: AnyObject {
     func evaluateTrust(trust: SecTrust, domain: String?, completion: ((PinningState) -> ()))
 }
 
 // validates the "Sec-WebSocket-Accept" header as defined 1.3 of the RFC 6455
 // https://tools.ietf.org/html/rfc6455#section-1.3
-protocol HeaderValidator: class {
+protocol HeaderValidator: AnyObject {
     func validate(headers: [String: String], key: String) -> Error?
 }

--- a/Sources/StreamChat/StreamStarscream/Server/Server.swift
+++ b/Sources/StreamChat/StreamStarscream/Server/Server.swift
@@ -36,7 +36,7 @@ protocol Connection {
     func write(data: Data, opcode: FrameOpCode)
 }
 
-protocol ConnectionDelegate: class {
+protocol ConnectionDelegate: AnyObject {
     func didReceive(event: ServerEvent)
 }
 

--- a/Sources/StreamChat/StreamStarscream/Starscream/WebSocket.swift
+++ b/Sources/StreamChat/StreamStarscream/Starscream/WebSocket.swift
@@ -41,7 +41,7 @@ struct WSError: Error {
     }
 }
 
-protocol StarscreamWebSocketClient: class {
+protocol StarscreamWebSocketClient: AnyObject {
     func connect()
     func disconnect(closeCode: UInt16)
     func write(string: String, completion: (() -> ())?)
@@ -87,7 +87,7 @@ enum WebSocketEvent {
     case cancelled
 }
 
-protocol WebSocketDelegate: class {
+protocol WebSocketDelegate: AnyObject {
     func didReceive(event: WebSocketEvent, client: WebSocket)
 }
 

--- a/Sources/StreamChat/StreamStarscream/Transport/Transport.swift
+++ b/Sources/StreamChat/StreamStarscream/Transport/Transport.swift
@@ -42,11 +42,11 @@ enum ConnectionState {
     case receive(Data)
 }
 
-protocol TransportEventClient: class {
+protocol TransportEventClient: AnyObject {
     func connectionChanged(state: ConnectionState)
 }
 
-protocol Transport: class {
+protocol Transport: AnyObject {
     func register(delegate: TransportEventClient)
     func connect(url: URL, timeout: Double, certificatePinning: CertificatePinning?)
     func disconnect()

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptions.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptions.swift
@@ -14,7 +14,10 @@ extension ChatMessageLayoutOptions: Identifiable {
         // Since it is a Set, we need to sort it to make sure the value doesn't change per call.
         map(\.rawValue).sorted().joined(separator: "-")
     }
-    
+}
+
+/// Helper functions for handling set of `ChatMessageLayoutOption`.
+extension ChatMessageLayoutOptions {
     public mutating func remove(_ options: ChatMessageLayoutOptions) {
         self = subtracting(options)
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptions.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptions.swift
@@ -14,6 +14,14 @@ extension ChatMessageLayoutOptions: Identifiable {
         // Since it is a Set, we need to sort it to make sure the value doesn't change per call.
         map(\.rawValue).sorted().joined(separator: "-")
     }
+    
+    public mutating func remove(_ options: ChatMessageLayoutOptions) {
+        self = subtracting(options)
+    }
+
+    public mutating func insert(_ options: ChatMessageLayoutOptions) {
+        options.forEach { self.insert($0) }
+    }
 }
 
 /// Each message layout option is used to define which views will be part of the message cell.

--- a/Sources/StreamChatUI/Deprecations.swift
+++ b/Sources/StreamChatUI/Deprecations.swift
@@ -181,16 +181,6 @@ extension ChatMessageLayoutOptions {
         id
     }
 
-    @available(*, deprecated, message: "use `remove(_ member: ChatMessageLayoutOption)` instead.")
-    public mutating func remove(_ options: ChatMessageLayoutOptions) {
-        self = subtracting(options)
-    }
-
-    @available(*, deprecated, message: "use `insert(_ member: ChatMessageLayoutOption)` instead.")
-    public mutating func insert(_ options: ChatMessageLayoutOptions) {
-        options.forEach { self.insert($0) }
-    }
-
     @available(*, deprecated, message: "use `subtracting(_ other: Sequence)` instead.")
     public mutating func subtracting(_ option: ChatMessageLayoutOption) {
         self = subtracting([option])


### PR DESCRIPTION
### 🎯 Goal

Get rid of compile-time warnings

### 🧪 Testing

* Check the CI log for any occurrences of compile-time warnings

### 🎨 Changes

* Replace conformances of `class` with `AnyObject`.
* Publicize previously deprecated convenience `ChatMessageLayoutOptions` APIs to not cause warnings in integrators project

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
