### PR TITLE
[CIS-1405] Fix own reactions regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+
+- Fix regression for reactions left by the current user being not accurate [#1680](https://github.com/GetStream/stream-chat-swift/issues/1680)
 
 # [4.5.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.5.1)
 _December 01, 2021_

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController_Tests.swift
@@ -609,7 +609,7 @@ class ChannelController_Tests: XCTestCase {
         )
         // Save the message payload and check `channel.lastMessageAt` is updated
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: newerMessagePayload, for: channelId)
+            try $0.saveMessage(payload: newerMessagePayload, for: channelId, syncOwnReactions: true)
         }
         channel = try XCTUnwrap(client.databaseContainer.viewContext.channel(cid: channelId))
         XCTAssertEqual(channel.lastMessageAt, newerMessagePayload.createdAt)
@@ -891,7 +891,7 @@ class ChannelController_Tests: XCTestCase {
         )
         _ = try waitFor {
             client.databaseContainer.write({ session in
-                try session.saveMessage(payload: newMessagePayload, for: self.channelId)
+                try session.saveMessage(payload: newMessagePayload, for: self.channelId, syncOwnReactions: true)
             }, completion: $0)
         }
         
@@ -916,8 +916,8 @@ class ChannelController_Tests: XCTestCase {
         let message2: MessagePayload = .dummy(messageId: .unique, authorUserId: .unique)
         
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: message1, for: self.channelId)
-            try $0.saveMessage(payload: message2, for: self.channelId)
+            try $0.saveMessage(payload: message1, for: self.channelId, syncOwnReactions: true)
+            try $0.saveMessage(payload: message2, for: self.channelId, syncOwnReactions: true)
         }
         
         // Check the order of messages is correct
@@ -942,8 +942,8 @@ class ChannelController_Tests: XCTestCase {
         let message2: MessagePayload = .dummy(messageId: .unique, authorUserId: .unique)
         
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: message1, for: self.channelId)
-            try $0.saveMessage(payload: message2, for: self.channelId)
+            try $0.saveMessage(payload: message1, for: self.channelId, syncOwnReactions: true)
+            try $0.saveMessage(payload: message2, for: self.channelId, syncOwnReactions: true)
         }
         
         // Check the order of messages is correct
@@ -980,10 +980,10 @@ class ChannelController_Tests: XCTestCase {
         )
         
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: message1, for: self.channelId)
-            try $0.saveMessage(payload: message2, for: self.channelId)
-            try $0.saveMessage(payload: reply1, for: self.channelId)
-            try $0.saveMessage(payload: reply2, for: self.channelId)
+            try $0.saveMessage(payload: message1, for: self.channelId, syncOwnReactions: true)
+            try $0.saveMessage(payload: message2, for: self.channelId, syncOwnReactions: true)
+            try $0.saveMessage(payload: reply1, for: self.channelId, syncOwnReactions: true)
+            try $0.saveMessage(payload: reply2, for: self.channelId, syncOwnReactions: true)
         }
         
         // Check the relevant reply is shown in channel
@@ -1011,8 +1011,8 @@ class ChannelController_Tests: XCTestCase {
         )
         
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: message1, for: self.channelId)
-            try $0.saveMessage(payload: ephemeralMessage, for: self.channelId)
+            try $0.saveMessage(payload: message1, for: self.channelId, syncOwnReactions: true)
+            try $0.saveMessage(payload: ephemeralMessage, for: self.channelId, syncOwnReactions: true)
         }
         
         // Check the relevant ephemeral message is not shown in channel
@@ -1046,8 +1046,8 @@ class ChannelController_Tests: XCTestCase {
         )
 
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: incomingDeletedMessage, for: self.channelId)
-            try $0.saveMessage(payload: outgoingDeletedMessage, for: self.channelId)
+            try $0.saveMessage(payload: incomingDeletedMessage, for: self.channelId, syncOwnReactions: true)
+            try $0.saveMessage(payload: outgoingDeletedMessage, for: self.channelId, syncOwnReactions: true)
         }
 
         // Only outgoing deleted messages are returned by controller
@@ -1081,8 +1081,8 @@ class ChannelController_Tests: XCTestCase {
         )
 
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: incomingDeletedMessage, for: self.channelId)
-            try $0.saveMessage(payload: outgoingDeletedMessage, for: self.channelId)
+            try $0.saveMessage(payload: incomingDeletedMessage, for: self.channelId, syncOwnReactions: true)
+            try $0.saveMessage(payload: outgoingDeletedMessage, for: self.channelId, syncOwnReactions: true)
         }
 
         // Both outgoing and incoming messages should NOT be visible
@@ -1116,8 +1116,8 @@ class ChannelController_Tests: XCTestCase {
         )
 
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: incomingDeletedMessage, for: self.channelId)
-            try $0.saveMessage(payload: outgoingDeletedMessage, for: self.channelId)
+            try $0.saveMessage(payload: incomingDeletedMessage, for: self.channelId, syncOwnReactions: true)
+            try $0.saveMessage(payload: outgoingDeletedMessage, for: self.channelId, syncOwnReactions: true)
         }
 
         // Both outgoing and incoming messages should be visible
@@ -1172,8 +1172,8 @@ class ChannelController_Tests: XCTestCase {
         )
         
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: shadowedMessage, for: self.channelId)
-            try $0.saveMessage(payload: nonShadowedMessage, for: self.channelId)
+            try $0.saveMessage(payload: shadowedMessage, for: self.channelId, syncOwnReactions: true)
+            try $0.saveMessage(payload: nonShadowedMessage, for: self.channelId, syncOwnReactions: true)
         }
         
         // Both messages should be visible
@@ -1204,8 +1204,8 @@ class ChannelController_Tests: XCTestCase {
         )
         
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: shadowedMessage, for: self.channelId)
-            try $0.saveMessage(payload: nonShadowedMessage, for: self.channelId)
+            try $0.saveMessage(payload: shadowedMessage, for: self.channelId, syncOwnReactions: true)
+            try $0.saveMessage(payload: nonShadowedMessage, for: self.channelId, syncOwnReactions: true)
         }
         
         // Only non-shadowed message should be visible

--- a/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
@@ -155,7 +155,7 @@ final class MessageController_Tests: XCTestCase {
             text: .unique
         )
         try client.databaseContainer.writeSynchronously { session in
-            try session.saveMessage(payload: messagePayload, for: self.cid)
+            try session.saveMessage(payload: messagePayload, for: self.cid, syncOwnReactions: true)
         }
         
         // Assert the controller's `message` is up-to-date
@@ -210,8 +210,8 @@ final class MessageController_Tests: XCTestCase {
         )
         
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: reply1, for: self.cid)
-            try $0.saveMessage(payload: reply2, for: self.cid)
+            try $0.saveMessage(payload: reply1, for: self.cid, syncOwnReactions: true)
+            try $0.saveMessage(payload: reply2, for: self.cid, syncOwnReactions: true)
         }
         
         // Set top-to-bottom ordering
@@ -280,9 +280,9 @@ final class MessageController_Tests: XCTestCase {
         
         // Save messages
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: reply1, for: cid)
-            try $0.saveMessage(payload: reply2, for: cid)
-            try $0.saveMessage(payload: reply3, for: cid)
+            try $0.saveMessage(payload: reply1, for: cid, syncOwnReactions: true)
+            try $0.saveMessage(payload: reply2, for: cid, syncOwnReactions: true)
+            try $0.saveMessage(payload: reply3, for: cid, syncOwnReactions: true)
         }
         
         // Check if the replies are correct
@@ -331,8 +331,8 @@ final class MessageController_Tests: XCTestCase {
 
         // Save messages
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: ownReply, for: cid)
-            try $0.saveMessage(payload: otherReply, for: cid)
+            try $0.saveMessage(payload: ownReply, for: cid, syncOwnReactions: true)
+            try $0.saveMessage(payload: otherReply, for: cid, syncOwnReactions: true)
         }
 
         // Only own reply should be visible
@@ -380,8 +380,8 @@ final class MessageController_Tests: XCTestCase {
 
         // Save messages
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: ownReply, for: cid)
-            try $0.saveMessage(payload: otherReply, for: cid)
+            try $0.saveMessage(payload: ownReply, for: cid, syncOwnReactions: true)
+            try $0.saveMessage(payload: otherReply, for: cid, syncOwnReactions: true)
         }
 
         // both deleted replies should be hidden
@@ -429,8 +429,8 @@ final class MessageController_Tests: XCTestCase {
 
         // Save messages
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: ownReply, for: cid)
-            try $0.saveMessage(payload: otherReply, for: cid)
+            try $0.saveMessage(payload: ownReply, for: cid, syncOwnReactions: true)
+            try $0.saveMessage(payload: otherReply, for: cid, syncOwnReactions: true)
         }
 
         // both deleted replies should be visible
@@ -478,8 +478,8 @@ final class MessageController_Tests: XCTestCase {
         
         // Save messages
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: nonShadowedReply, for: cid)
-            try $0.saveMessage(payload: shadowedReply, for: cid)
+            try $0.saveMessage(payload: nonShadowedReply, for: cid, syncOwnReactions: true)
+            try $0.saveMessage(payload: shadowedReply, for: cid, syncOwnReactions: true)
         }
         
         // all replies should be visible
@@ -526,8 +526,8 @@ final class MessageController_Tests: XCTestCase {
         
         // Save messages
         try client.databaseContainer.writeSynchronously {
-            try $0.saveMessage(payload: nonShadowedReply, for: cid)
-            try $0.saveMessage(payload: shadowedReply, for: cid)
+            try $0.saveMessage(payload: nonShadowedReply, for: cid, syncOwnReactions: true)
+            try $0.saveMessage(payload: shadowedReply, for: cid, syncOwnReactions: true)
         }
         
         // only non-shadowed reply should be visible
@@ -596,7 +596,7 @@ final class MessageController_Tests: XCTestCase {
             authorUserId: currentUserId
         )
         try client.databaseContainer.writeSynchronously { session in
-            try session.saveMessage(payload: messagePayload, for: self.cid)
+            try session.saveMessage(payload: messagePayload, for: self.cid, syncOwnReactions: true)
         }
         env.messageUpdater.getMessage_completion?(nil)
         
@@ -633,7 +633,7 @@ final class MessageController_Tests: XCTestCase {
             text: "new text"
         )
         try client.databaseContainer.writeSynchronously { session in
-            try session.saveMessage(payload: messagePayload, for: self.cid)
+            try session.saveMessage(payload: messagePayload, for: self.cid, syncOwnReactions: true)
         }
         env.messageUpdater.getMessage_completion?(nil)
         
@@ -671,7 +671,7 @@ final class MessageController_Tests: XCTestCase {
         
         var replyModel: ChatMessage?
         try client.databaseContainer.writeSynchronously { session in
-            replyModel = try session.saveMessage(payload: reply, for: self.cid)!.asModel()
+            replyModel = try session.saveMessage(payload: reply, for: self.cid, syncOwnReactions: true)!.asModel()
         }
     
         // Assert `insert` entity change is received by the delegate

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -209,12 +209,12 @@ extension NSManagedObjectContext {
     ) throws -> ChannelDTO {
         let dto = try saveChannel(payload: payload.channel, query: query)
 
-        try payload.messages.forEach { _ = try saveMessage(payload: $0, channelDTO: dto) }
+        try payload.messages.forEach { _ = try saveMessage(payload: $0, channelDTO: dto, syncOwnReactions: true) }
 
         dto.updateOldestMessageAt(payload: payload)
 
         try payload.pinnedMessages.forEach {
-            _ = try saveMessage(payload: $0, channelDTO: dto)
+            _ = try saveMessage(payload: $0, channelDTO: dto, syncOwnReactions: true)
         }
         
         try payload.channelReads.forEach { _ = try saveChannelRead(payload: $0, for: payload.channel.cid) }

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -474,13 +474,13 @@ extension NSManagedObjectContext: MessageDatabaseSession {
 
         dto.latestReactions = payload
             .latestReactions
-            .compactMap { try? saveReaction(payload: $0, message: dto) }
+            .compactMap { try? saveReaction(payload: $0) }
             .map(\.id)
 
         if syncOwnReactions {
             dto.ownReactions = payload
                 .ownReactions
-                .compactMap { try? saveReaction(payload: $0, message: dto) }
+                .compactMap { try? saveReaction(payload: $0) }
                 .map(\.id)
         }
 
@@ -594,7 +594,12 @@ extension NSManagedObjectContext: MessageDatabaseSession {
             throw ClientError.MessageDoesNotExist(messageId: messageId)
         }
 
-        let dto = try MessageReactionDTO.loadOrCreate(messageId: messageId, type: type, user: currentUserDTO.user, context: self)
+        let dto = MessageReactionDTO.loadOrCreate(
+            message: message,
+            type: type,
+            user: currentUserDTO.user,
+            context: self
+        )
 
         // make sure we update the reactionScores for the message in a way that works for new or updated reactions
         let scoreDiff = Int64(score) - dto.score

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -598,17 +598,17 @@ extension NSManagedObjectContext: MessageDatabaseSession {
             throw ClientError.MessageDoesNotExist(messageId: messageId)
         }
 
-        let result = try MessageReactionDTO.loadOrCreate(messageId: messageId, type: type, user: currentUserDTO.user, context: self)
+        let dto = try MessageReactionDTO.loadOrCreate(messageId: messageId, type: type, user: currentUserDTO.user, context: self)
 
         // make sure we update the reactionScores for the message in a way that works for new or updated reactions
-        let scoreDiff = Int64(score) - result.dto.score
-        let newScore = max(0, message.reactionScores[type.rawValue] ?? Int(result.dto.score) + Int(scoreDiff))
+        let scoreDiff = Int64(score) - dto.score
+        let newScore = max(0, message.reactionScores[type.rawValue] ?? Int(dto.score) + Int(scoreDiff))
         message.reactionScores[type.rawValue] = newScore
 
-        result.dto.score = Int64(score)
-        result.dto.extraData = try JSONEncoder.default.encode(extraData)
+        dto.score = Int64(score)
+        dto.extraData = try JSONEncoder.default.encode(extraData)
 
-        let reactionId = MessageReactionDTO.createId(dto: result.dto)
+        let reactionId = MessageReactionDTO.createId(dto: dto)
 
         if message.latestReactions.filter({ $0 == reactionId }).isEmpty {
             message.latestReactions.append(reactionId)
@@ -618,7 +618,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
             message.ownReactions.append(reactionId)
         }
 
-        return result.dto
+        return dto
     }
 
     /// Removes the reaction for the current user to the message with id `messageId`

--- a/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO_Tests.swift
@@ -58,7 +58,7 @@ class MessageDTO_Tests: XCTestCase {
         
         try! database.writeSynchronously { session in
             // Save the message, it should also save the channel
-            try! session.saveMessage(payload: messagePayload, for: channelId)
+            try! session.saveMessage(payload: messagePayload, for: channelId, syncOwnReactions: true)
         }
 
         // Load the channel from the db and check the fields are correct
@@ -187,7 +187,7 @@ class MessageDTO_Tests: XCTestCase {
             try! session.saveChannel(payload: channelPayload, query: nil)
             
             // Save the message
-            try! session.saveMessage(payload: messagePayload, for: channelId)
+            try! session.saveMessage(payload: messagePayload, for: channelId, syncOwnReactions: true)
         }
         
         // Load the message from the db and check the fields are correct
@@ -266,7 +266,7 @@ class MessageDTO_Tests: XCTestCase {
                 channelDTO = try! session.saveChannel(payload: channelPayload, query: nil)
 
                 // Save the message
-                messageDTO = try! session.saveMessage(payload: payload, for: channelId)
+                messageDTO = try! session.saveMessage(payload: payload, for: channelId, syncOwnReactions: true)
             } completion: { _ in
                 completion((channelDTO, messageDTO))
             }
@@ -295,7 +295,7 @@ class MessageDTO_Tests: XCTestCase {
                 let channelDTO = try! session.saveChannel(payload: channelPayload, query: nil)
 
                 // Save the message
-                let messageDTO = try! session.saveMessage(payload: payload, channelDTO: channelDTO)
+                let messageDTO = try! session.saveMessage(payload: payload, channelDTO: channelDTO, syncOwnReactions: true)
                 completion((channelDTO, messageDTO))
             }
         }
@@ -330,7 +330,7 @@ class MessageDTO_Tests: XCTestCase {
                 channelDTO = try! session.saveChannel(payload: channelPayload, query: nil)
 
                 // Save the message
-                messageDTO = try! session.saveMessage(payload: payload, for: channelId)
+                messageDTO = try! session.saveMessage(payload: payload, for: channelId, syncOwnReactions: true)
 
                 XCTAssertTrue(messageDTO!.asModel().isPinned)
             } completion: { _ in
@@ -351,7 +351,7 @@ class MessageDTO_Tests: XCTestCase {
         XCTAssertThrowsError(
             try database.writeSynchronously {
                 // Both `payload.channel` and `cid` are nil
-                try $0.saveMessage(payload: payload, for: nil)
+                try $0.saveMessage(payload: payload, for: nil, syncOwnReactions: true)
             }
         ) { error in
             XCTAssert(error is ClientError.MessagePayloadSavingFailure)
@@ -371,7 +371,7 @@ class MessageDTO_Tests: XCTestCase {
             let channelDTO = try! session.saveChannel(payload: channelPayload, query: nil)
             
             // Save the message
-            let messageDTO = try! session.saveMessage(payload: messagePayload, channelDTO: channelDTO)
+            let messageDTO = try! session.saveMessage(payload: messagePayload, channelDTO: channelDTO, syncOwnReactions: true)
             // Make the extra data JSON invalid
             messageDTO.extraData = #"{"invalid": json}"#.data(using: .utf8)!
         }
@@ -437,7 +437,7 @@ class MessageDTO_Tests: XCTestCase {
         // Asynchronously save the payload to the db
         try database.writeSynchronously { session in
             // Save the message
-            try session.saveMessage(payload: messagePayload, for: channelId)
+            try session.saveMessage(payload: messagePayload, for: channelId, syncOwnReactions: true)
         }
         
         // Load the message from the db and check the fields are correct
@@ -588,7 +588,7 @@ class MessageDTO_Tests: XCTestCase {
             try! session.saveChannel(payload: channelPayload, query: nil)
             
             // Save the message
-            try! session.saveMessage(payload: messagePayload, for: channelId)
+            try! session.saveMessage(payload: messagePayload, for: channelId, syncOwnReactions: true)
         }
         
         // Set the local state of the message
@@ -606,7 +606,7 @@ class MessageDTO_Tests: XCTestCase {
         
         // Re-save the payload and check the local state is not overridden
         database.write { session in
-            try! session.saveMessage(payload: messagePayload, for: channelId)
+            try! session.saveMessage(payload: messagePayload, for: channelId, syncOwnReactions: true)
         }
         AssertAsync.staysEqual(loadedMessage?.localState, .pendingSend)
         
@@ -708,7 +708,7 @@ class MessageDTO_Tests: XCTestCase {
         )
 
         try database.writeSynchronously { session in
-            try session.saveMessage(payload: messagePayload, for: channelId)
+            try session.saveMessage(payload: messagePayload, for: channelId, syncOwnReactions: true)
         }
 
         // Act: Save payload again
@@ -971,7 +971,7 @@ class MessageDTO_Tests: XCTestCase {
         
         // Save reply payload
         try database.writeSynchronously { session in
-            try session.saveMessage(payload: payload, for: cid)
+            try session.saveMessage(payload: payload, for: cid, syncOwnReactions: true)
         }
         
         // Get parent message
@@ -1041,7 +1041,7 @@ class MessageDTO_Tests: XCTestCase {
         assert(olderMessagePayload.createdAt < channelPayload.channel.lastMessageAt!)
         // Save the message payload and check `channel.lastMessageAt` is not updated by older message
         try database.writeSynchronously {
-            try $0.saveMessage(payload: olderMessagePayload, for: channelId)
+            try $0.saveMessage(payload: olderMessagePayload, for: channelId, syncOwnReactions: true)
         }
         var channel = try XCTUnwrap(database.viewContext.channel(cid: channelId))
         XCTAssertEqual(channel.lastMessageAt, originalLastMessageAt)
@@ -1055,7 +1055,7 @@ class MessageDTO_Tests: XCTestCase {
         assert(newerMessagePayload.createdAt > channelPayload.channel.lastMessageAt!)
         // Save the message payload and check `channel.lastMessageAt` is updated
         try database.writeSynchronously {
-            try $0.saveMessage(payload: newerMessagePayload, for: channelId)
+            try $0.saveMessage(payload: newerMessagePayload, for: channelId, syncOwnReactions: true)
         }
         channel = try XCTUnwrap(database.viewContext.channel(cid: channelId))
         XCTAssertEqual(channel.lastMessageAt, newerMessagePayload.createdAt)
@@ -1120,7 +1120,7 @@ class MessageDTO_Tests: XCTestCase {
         try createdMessages.forEach { messagePayload in
             try database.writeSynchronously { session in
                 // Save the message
-                try session.saveMessage(payload: messagePayload, for: channelId)
+                try session.saveMessage(payload: messagePayload, for: channelId, syncOwnReactions: true)
             }
         }
 
@@ -1210,7 +1210,7 @@ class MessageDTO_Tests: XCTestCase {
         try createdMessages.forEach { messagePayload in
             try database.writeSynchronously { session in
                 // Save the message
-                try session.saveMessage(payload: messagePayload, for: channelId)
+                try session.saveMessage(payload: messagePayload, for: channelId, syncOwnReactions: true)
             }
         }
 

--- a/Sources/StreamChat/Database/DTOs/MessageReactionDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageReactionDTO.swift
@@ -77,11 +77,11 @@ extension MessageReactionDTO {
         type: MessageReactionType,
         user: UserDTO,
         context: NSManagedObjectContext
-    ) throws -> (dto: MessageReactionDTO, created: Bool) {
+    ) throws -> MessageReactionDTO {
         let userId = user.id
 
         if let existing = Self.load(userId: userId, messageId: message.id, type: type, context: context) {
-            return (existing, false)
+            return existing
         }
 
         let new = NSEntityDescription.insertNewObject(forEntityName: Self.entityName, into: context) as! MessageReactionDTO
@@ -89,7 +89,7 @@ extension MessageReactionDTO {
         new.type = type.rawValue
         new.message = message
         new.user = user
-        return (new, true)
+        return new
     }
 
     static func loadOrCreate(
@@ -97,11 +97,11 @@ extension MessageReactionDTO {
         type: MessageReactionType,
         user: UserDTO,
         context: NSManagedObjectContext
-    ) throws -> (dto: MessageReactionDTO, created: Bool) {
+    ) throws -> MessageReactionDTO {
         let userId = user.id
 
         if let existing = Self.load(userId: userId, messageId: messageId, type: type, context: context) {
-            return (existing, false)
+            return existing
         }
 
         guard let message = MessageDTO.load(id: messageId, context: context) else {
@@ -137,8 +137,9 @@ extension NSManagedObjectContext {
             context: self
         )
 
-        try populateFieldsBeforeSave(dto: result.dto, payload: payload)
-        return result.dto
+        try populateFieldsBeforeSave(dto: result, payload: payload)
+        
+        return result
     }
 
     @discardableResult
@@ -153,8 +154,9 @@ extension NSManagedObjectContext {
             context: self
         )
 
-        try populateFieldsBeforeSave(dto: result.dto, payload: payload)
-        return result.dto
+        try populateFieldsBeforeSave(dto: result, payload: payload)
+        
+        return result
     }
 
     func delete(reaction: MessageReactionDTO) {

--- a/Sources/StreamChat/Database/DTOs/MessageReactionDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageReactionDTO.swift
@@ -7,7 +7,7 @@ import Foundation
 
 @objc(MessageReactionDTO)
 final class MessageReactionDTO: NSManagedObject {
-    @NSManaged fileprivate var id: String
+    @NSManaged private(set) var id: String
 
     // holds the rawValue of LocalReactionState
     @NSManaged fileprivate var localStateRaw: String?
@@ -29,12 +29,6 @@ final class MessageReactionDTO: NSManagedObject {
         type: MessageReactionType
     ) -> String {
         [userId, messageId, type.rawValue].joined(separator: "/")
-    }
-    
-    static func createId(
-        dto: MessageReactionDTO
-    ) -> String {
-        createId(userId: dto.user.id, messageId: dto.message.id, type: .init(rawValue: dto.type))
     }
 }
 

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -394,8 +394,10 @@ extension DatabaseSession {
             switch event {
             case let event as ReactionNewEventDTO:
                 let reaction = try context.saveReaction(payload: event.reaction)
-                messageDTO.ownReactions.append(MessageReactionDTO.createId(dto: reaction))
-                messageDTO.ownReactions = Set(messageDTO.ownReactions).sorted()
+                
+                if !messageDTO.ownReactions.contains(reaction.id) {
+                    messageDTO.ownReactions.append(reaction.id)
+                }
             case let event as ReactionUpdatedEventDTO:
                 try context.saveReaction(payload: event.reaction)
             case let event as ReactionDeletedEventDTO:

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -369,6 +369,7 @@ extension DatabaseSession {
                         userId: event.user.id,
                         type: event.reaction.type
                     ) {
+                        dto.message.ownReactions.removeAll(where: { $0 == dto.id })
                         delete(reaction: dto)
                     }
                 default:

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -79,6 +79,8 @@ protocol MessageDatabaseSession {
     /// Throws an error if the save fails.
     ///
     /// You must either provide `cid` or `payload.channel` value must not be `nil`.
+    /// The `syncOwnReactions` should be set to `true` when the payload comes from an API response and `false` when the payload
+    /// is received via WS events. For performance reasons the API does not populate the `message.own_reactions` when sending events
     @discardableResult
     func saveMessage(
         payload: MessagePayload,
@@ -86,6 +88,11 @@ protocol MessageDatabaseSession {
         syncOwnReactions: Bool
     ) throws -> MessageDTO?
     
+    /// Saves the provided message payload to the DB. Return's the matching `MessageDTO` if the save was successful.
+    /// Throws an error if the save fails.
+    ///
+    /// The `syncOwnReactions` should be set to `true` when the payload comes from an API response and `false` when the payload
+    /// is received via WS events. For performance reasons the API does not populate the `message.own_reactions` when sending events
     @discardableResult
     func saveMessage(payload: MessagePayload, channelDTO: ChannelDTO, syncOwnReactions: Bool) throws -> MessageDTO
 

--- a/Sources/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Mock.swift
@@ -127,14 +127,14 @@ extension DatabaseSessionMock {
         )
     }
     
-    func saveMessage(payload: MessagePayload, channelDTO: ChannelDTO) throws -> MessageDTO {
+    func saveMessage(payload: MessagePayload, for cid: ChannelId?, syncOwnReactions: Bool) throws -> MessageDTO? {
         try throwErrorIfNeeded()
-        return try underlyingSession.saveMessage(payload: payload, channelDTO: channelDTO)
+        return try? underlyingSession.saveMessage(payload: payload, for: cid, syncOwnReactions: syncOwnReactions)
     }
-
-    func saveMessage(payload: MessagePayload, for cid: ChannelId?) throws -> MessageDTO? {
+    
+    func saveMessage(payload: MessagePayload, channelDTO: ChannelDTO, syncOwnReactions: Bool) throws -> MessageDTO {
         try throwErrorIfNeeded()
-        return try? underlyingSession.saveMessage(payload: payload, for: cid)
+        return try underlyingSession.saveMessage(payload: payload, channelDTO: channelDTO, syncOwnReactions: syncOwnReactions)
     }
     
     func pin(message: MessageDTO, pinning: MessagePinning) throws {

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
@@ -64,7 +64,7 @@ class EventDataProcessorMiddleware_Tests: XCTestCase {
             try session.saveChannel(payload: .dummy(cid: cid), query: nil)
             try session.saveMessage(
                 payload: .dummy(messageId: messageId, authorUserId: .unique, latestReactions: [reactionPayload]),
-                for: cid
+                for: cid, syncOwnReactions: true
             )
         }
 
@@ -107,7 +107,7 @@ class EventDataProcessorMiddleware_Tests: XCTestCase {
         
         try database.writeSynchronously { session in
             try session.saveChannel(payload: .dummy(cid: cid), query: nil)
-            try session.saveMessage(payload: messagePayload, for: cid)
+            try session.saveMessage(payload: messagePayload, for: cid, syncOwnReactions: true)
         }
 
         let user = UserPayload.dummy(userId: .unique)
@@ -159,7 +159,7 @@ class EventDataProcessorMiddleware_Tests: XCTestCase {
 
         try database.writeSynchronously { session in
             try session.saveChannel(payload: .dummy(cid: cid), query: nil)
-            try session.saveMessage(payload: messagePayload, for: cid)
+            try session.saveMessage(payload: messagePayload, for: cid, syncOwnReactions: true)
         }
 
         // Create reaction payload.

--- a/Sources/StreamChat/Workers/Background/MessageSender.swift
+++ b/Sources/StreamChat/Workers/Background/MessageSender.swift
@@ -202,7 +202,7 @@ private class MessageSendingQueue {
     
     private func saveSuccessfullySentMessage(cid: ChannelId, message: MessagePayload, completion: @escaping () -> Void) {
         database.write({
-            guard let messageDTO = try? $0.saveMessage(payload: message, for: cid) else {
+            guard let messageDTO = try? $0.saveMessage(payload: message, for: cid, syncOwnReactions: false) else {
                 return
             }
             if messageDTO.localMessageState == .sending {

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -20,7 +20,7 @@ class MessageUpdater: Worker {
             switch $0 {
             case let .success(boxed):
                 self.database.write({ session in
-                    try session.saveMessage(payload: boxed.message, for: cid)
+                    try session.saveMessage(payload: boxed.message, for: cid, syncOwnReactions: true)
                 }, completion: { error in
                     completion?(error)
                 })
@@ -187,7 +187,7 @@ class MessageUpdater: Worker {
             switch $0 {
             case let .success(payload):
                 self.database.write({ session in
-                    try payload.messages.forEach { try session.saveMessage(payload: $0, for: cid) }
+                    try payload.messages.forEach { try session.saveMessage(payload: $0, for: cid, syncOwnReactions: true) }
                 }, completion: { error in
                     if let error = error {
                         completion?(.failure(error))
@@ -517,7 +517,7 @@ class MessageUpdater: Worker {
                 switch $0 {
                 case let .success(payload):
                     self.database.write({ session in
-                        try session.saveMessage(payload: payload.message, for: cid)
+                        try session.saveMessage(payload: payload.message, for: cid, syncOwnReactions: true)
                     }, completion: { error in
                         completion?(error)
                     })

--- a/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
@@ -243,7 +243,7 @@ extension DatabaseContainer {
                 reactionCounts: reactionCounts
             )
             
-            let messageDTO = try session.saveMessage(payload: message, channelDTO: channelDTO)
+            let messageDTO = try session.saveMessage(payload: message, channelDTO: channelDTO, syncOwnReactions: true)
             messageDTO.localMessageState = localState
             messageDTO.reactionCounts = reactionCounts.mapKeys(\.rawValue)
             messageDTO.reactionScores = reactionScores.mapKeys(\.rawValue)
@@ -257,7 +257,7 @@ extension DatabaseContainer {
                     text: "Reply \(idx)"
                 )
                 
-                let replyDTO = try session.saveMessage(payload: reply, for: cid)!
+                let replyDTO = try session.saveMessage(payload: reply, for: cid, syncOwnReactions: true)!
                 messageDTO.replies.insert(replyDTO)
             }
         }


### PR DESCRIPTION
### 🎯 Goal

Optimistic reactions introduced a regression on the reactions for the current user. WS events never include the `own_reactions` field populated and this was not handled correctly leading to showing incorrect reaction status.

### 🛠 Implementation

The code that saves messages now exposes a `syncOwnReactions` parameter, this allows us to not sync `own_reactions` when handling events and vice versa when receiving messages from API responses.

### 🧪 Testing

Manually add reactions from different devices was enough to reproduce this problem.

### ☑️ Checklist

- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests