### PR TITLE
Introduce `LogConfig.destinationTypes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - Add support for pre-built XCFrameworks [#1665](https://github.com/GetStream/stream-chat-swift/pull/1665)
+- Added `LogConfig.destinationTypes` for ease of adding new destinations to logger [#1681](https://github.com/GetStream/stream-chat-swift/issues/1681)
 
 ### ✅ Added
 - Expose container embedding top & bottom containers by `ChatChannelListItemView` [#1670](https://github.com/GetStream/stream-chat-swift/issues/1670)

--- a/Sources/StreamChat/Utils/Logger/Destination/BaseLogDestination.swift
+++ b/Sources/StreamChat/Utils/Logger/Destination/BaseLogDestination.swift
@@ -38,22 +38,18 @@ open class BaseLogDestination: LogDestination {
     ///   - showLineNumber: Toggle for showing line number in logs
     ///   - showFunctionName: Toggle for showing function name in logs
     public required init(
-        identifier: String = "",
-        level: LogLevel = .debug,
-        subsystems: LogSubsystem = .all,
-        showDate: Bool = true,
-        dateFormatter: DateFormatter = {
-            let df = DateFormatter()
-            df.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
-            return df
-        }(),
-        formatters: [LogFormatter] = [],
-        showLevel: Bool = true,
-        showIdentifier: Bool = true,
-        showThreadName: Bool = true,
-        showFileName: Bool = true,
-        showLineNumber: Bool = true,
-        showFunctionName: Bool = true
+        identifier: String,
+        level: LogLevel,
+        subsystems: LogSubsystem,
+        showDate: Bool,
+        dateFormatter: DateFormatter,
+        formatters: [LogFormatter],
+        showLevel: Bool,
+        showIdentifier: Bool,
+        showThreadName: Bool,
+        showFileName: Bool,
+        showLineNumber: Bool,
+        showFunctionName: Bool
     ) {
         self.identifier = identifier
         self.level = level

--- a/Sources/StreamChat/Utils/Logger/Destination/LogDestination.swift
+++ b/Sources/StreamChat/Utils/Logger/Destination/LogDestination.swift
@@ -47,6 +47,20 @@ public protocol LogDestination {
     var showLineNumber: Bool { get set }
     var showFunctionName: Bool { get set }
     
+    init(
+        identifier: String,
+        level: LogLevel,
+        subsystems: LogSubsystem,
+        showDate: Bool,
+        dateFormatter: DateFormatter,
+        formatters: [LogFormatter],
+        showLevel: Bool,
+        showIdentifier: Bool,
+        showThreadName: Bool,
+        showFileName: Bool,
+        showLineNumber: Bool,
+        showFunctionName: Bool
+    )
     func isEnabled(level: LogLevel) -> Bool
     func isEnabled(level: LogLevel, subsystems: LogSubsystem) -> Bool
     func process(logDetails: LogDetails)

--- a/Sources/StreamChat/Utils/Logger/Logger.swift
+++ b/Sources/StreamChat/Utils/Logger/Logger.swift
@@ -121,25 +121,37 @@ public enum LogConfig {
         }
     }
     
+    /// Destination types this logger will use.
+    ///
+    /// Logger will initialize the destinations with its own parameters. If you want full control on the parameters, use `destinations` directly,
+    /// where you can pass parameters to destination initializers yourself.
+    public static var destinationTypes: [LogDestination.Type] = [ConsoleLogDestination.self] {
+        didSet {
+            invalidateLogger()
+        }
+    }
+    
     /// Destinations for the default logger. Please see `LogDestination`.
     /// Defaults to only `ConsoleLogDestination`, which only prints the messages.
     ///
     /// - Important: Other options in `ChatClientConfig.Logging` will not take affect if this is changed.
     public static var destinations: [LogDestination] = {
-        let consoleLogDestination = ConsoleLogDestination(
-            level: level,
-            subsystems: subsystems,
-            showDate: showDate,
-            dateFormatter: dateFormatter,
-            formatters: formatters,
-            showLevel: showLevel,
-            showIdentifier: showIdentifier,
-            showThreadName: showThreadName,
-            showFileName: showFileName,
-            showLineNumber: showLineNumber,
-            showFunctionName: showFunctionName
-        )
-        return [consoleLogDestination]
+        destinationTypes.map {
+            $0.init(
+                identifier: identifier,
+                level: level,
+                subsystems: subsystems,
+                showDate: showDate,
+                dateFormatter: dateFormatter,
+                formatters: formatters,
+                showLevel: showLevel,
+                showIdentifier: showIdentifier,
+                showThreadName: showThreadName,
+                showFileName: showFileName,
+                showLineNumber: showLineNumber,
+                showFunctionName: showFunctionName
+            )
+        }
     }() {
         didSet {
             invalidateLogger()

--- a/StreamChatSample/LogStore.swift
+++ b/StreamChatSample/LogStore.swift
@@ -8,10 +8,42 @@ import StreamChat
 class LogStore: BaseLogDestination {
     @Atomic var logs = ""
     
-    static let shared = LogStore()
+    static var shared: LogStore!
+    
+    required init(
+        identifier: String,
+        level: LogLevel,
+        subsystems: LogSubsystem,
+        showDate: Bool,
+        dateFormatter: DateFormatter,
+        formatters: [LogFormatter],
+        showLevel: Bool,
+        showIdentifier: Bool,
+        showThreadName: Bool,
+        showFileName: Bool,
+        showLineNumber: Bool,
+        showFunctionName: Bool
+    ) {
+        super.init(
+            identifier: identifier,
+            level: level,
+            subsystems: subsystems,
+            showDate: showDate,
+            dateFormatter: dateFormatter,
+            formatters: formatters,
+            showLevel: showLevel,
+            showIdentifier: showIdentifier,
+            showThreadName: showThreadName,
+            showFileName: showFileName,
+            showLineNumber: showLineNumber,
+            showFunctionName: showFunctionName
+        )
+        
+        Self.shared = self
+    }
     
     static func registerShared() {
-        log.destinations.append(LogStore.shared)
+        LogConfig.destinationTypes.append(LogStore.self)
     }
     
     override func write(message: String) {


### PR DESCRIPTION
### 🎯 Goal

Our Logger is flexible and one can add new destinations easily, using `LogConfig.destinations`. But there's a limitation: adding a new destination using existing LogConfig parameters is hard. Consider the scenario, where you create a new destination:
```swift
class CoolLogDestination: BaseLogDestination {
    override func write(message: String) {
        // CoolLoggingSystem.log(message)
    }
}
```
and you want to use this destination. You do:
```swift
LogConfig.destinations = [CoolLogDestination()]
```
then the new destination gets initialized with default params of `BaseLogDestination`, which is not what we want, we want it to get initialized with `LogConfig` parameters, which we can customize.

The other way is to initialize it by passing all params:
```swift
LogConfig.destinations = [CoolLogDestination(identifier: "", showLevel: false, showDate: true.......)]
```
which is just too many params, and we already have defaults in `LogConfig`

### 🛠 Implementation

I introduce a new property in `LogConfig`, which is `destinationTypes`. This works like our `Components`: you assign types instead of objects, and LogConfig initializes the types by using its own parameters.

The default params in `BaseLogDestination.init` are removed since they can cause confusion.

```swift
LogConfig.destinationTypes = [CoolLogDestination.self]
```
then you're sure `LogConfig` params will be used.

`LogConfig.destinations` are not deprecated so users can use it too if they desire.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
