### PR TITLE
[CIS-1378] Safely access indexes of collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Reactions no longer cover the text in message bubble [#1666](https://github.com/GetStream/stream-chat-swift/pull/1666)
 - Fix `error` type messages rendered as user's messages and interactive [#1672](https://github.com/GetStream/stream-chat-swift/issues/1672)
 - Fix `ChannelListController` makes one redundant API call [#1687](https://github.com/GetStream/stream-chat-swift/issues/1687)
+- Safely access indexes of collections [#1692](https://github.com/GetStream/stream-chat-swift/pull/1692)
 
 ### ✅ Added
 - Add support for pre-built XCFrameworks [#1665](https://github.com/GetStream/stream-chat-swift/pull/1665)

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -142,7 +142,7 @@ open class ChatChannelVC:
 
     open func chatMessageListVC(_ vc: ChatMessageListVC, messageAt indexPath: IndexPath) -> ChatMessage? {
         guard indexPath.item < channelController.messages.count else { return nil }
-        return channelController.messages[indexPath.item]
+        return channelController.messages[safe: indexPath.item]
     }
 
     open func chatMessageListVC(

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -141,7 +141,7 @@ open class ChatChannelVC:
     }
 
     open func chatMessageListVC(_ vc: ChatMessageListVC, messageAt indexPath: IndexPath) -> ChatMessage? {
-        guard indexPath.item < channelController.messages.count else { return nil }
+        channelController.messages.assertIndexIsPresent(indexPath.item)
         return channelController.messages[safe: indexPath.item]
     }
 

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -168,12 +168,11 @@ open class ChatChannelListVC: _ViewController,
             withReuseIdentifier: collectionViewCellReuseIdentifier,
             for: indexPath
         ) as! ChatChannelListCollectionViewCell
-    
+
+        guard let channel = getChannel(at: indexPath) else { return UICollectionViewCell() }
+
         cell.components = components
-        cell.itemView.content = .init(
-            channel: controller.channels[indexPath.row],
-            currentUserId: controller.client.currentUserId
-        )
+        cell.itemView.content = .init(channel: channel, currentUserId: controller.client.currentUserId)
 
         cell.swipeableView.delegate = self
         cell.swipeableView.indexPath = { [weak cell, weak self] in
@@ -197,7 +196,7 @@ open class ChatChannelListVC: _ViewController,
     }
         
     open func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let channel = controller.channels[indexPath.row]
+        guard let channel = getChannel(at: indexPath) else { return }
         router.showChannel(for: channel.cid)
     }
         
@@ -265,13 +264,15 @@ open class ChatChannelListVC: _ViewController,
     /// This function is called when delete button is pressed from action items of a cell.
     /// - Parameter indexPath: IndexPath of given cell to fetch the content of it.
     open func deleteButtonPressedForCell(at indexPath: IndexPath) {
-        router.didTapDeleteButton(for: controller.channels[indexPath.row].cid)
+        guard let channel = getChannel(at: indexPath) else { return }
+        router.didTapDeleteButton(for: channel.cid)
     }
 
     /// This function is called when more button is pressed from action items of a cell.
     /// - Parameter indexPath: IndexPath of given cell to fetch the content of it.
     open func moreButtonPressedForCell(at indexPath: IndexPath) {
-        router.didTapMoreButton(for: controller.channels[indexPath.row].cid)
+        guard let channel = getChannel(at: indexPath) else { return }
+        router.didTapMoreButton(for: channel.cid)
     }
     
     // MARK: - ChatChannelListControllerDelegate
@@ -333,5 +334,11 @@ open class ChatChannelListVC: _ViewController,
         default:
             loadingIndicator.stopAnimating()
         }
+    }
+
+    private func getChannel(at indexPath: IndexPath) -> ChatChannel? {
+        let index = indexPath.row
+        controller.channels.assertIndexIsPresent(index)
+        return controller.channels[safe: index]
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
@@ -30,7 +30,7 @@ open class ChatMessageLayoutOptionsResolver {
     ) -> ChatMessageLayoutOptions {
         let messageIndex = messages.index(messages.startIndex, offsetBy: indexPath.item)
         guard let message = messages[safe: messageIndex] else {
-            log.warning("Accessing an index that is not present in the data source")
+            indexNotFoundAssertion()
             return []
         }
 
@@ -141,7 +141,7 @@ open class ChatMessageLayoutOptionsResolver {
     ) -> Bool {
         let messageIndex = messages.index(messages.startIndex, offsetBy: messageIndexPath.item)
         guard let message = messages[safe: messageIndex] else {
-            log.warning("Accessing an index that is not present in the data source")
+            indexNotFoundAssertion()
             return true
         }
 
@@ -150,7 +150,7 @@ open class ChatMessageLayoutOptionsResolver {
 
         let nextMessageIndex = messages.index(before: messageIndex)
         guard let nextMessage = messages[safe: nextMessageIndex] else {
-            log.warning("Accessing an index that is not present in the data source")
+            indexNotFoundAssertion()
             return true
         }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
@@ -29,7 +29,10 @@ open class ChatMessageLayoutOptionsResolver {
         appearance: Appearance
     ) -> ChatMessageLayoutOptions {
         let messageIndex = messages.index(messages.startIndex, offsetBy: indexPath.item)
-        let message = messages[messageIndex]
+        guard let message = messages[safe: messageIndex] else {
+            log.warning("Accessing an index that is not present in the data source")
+            return []
+        }
 
         let isLastInSequence = isMessageLastInSequence(
             messageIndexPath: indexPath,
@@ -137,13 +140,19 @@ open class ChatMessageLayoutOptionsResolver {
         messages: AnyRandomAccessCollection<ChatMessage>
     ) -> Bool {
         let messageIndex = messages.index(messages.startIndex, offsetBy: messageIndexPath.item)
-        let message = messages[messageIndex]
+        guard let message = messages[safe: messageIndex] else {
+            log.warning("Accessing an index that is not present in the data source")
+            return true
+        }
 
         // The current message is the last message so it's either a standalone or last in sequence.
         guard messageIndexPath.item > 0 else { return true }
 
         let nextMessageIndex = messages.index(before: messageIndex)
-        let nextMessage = messages[nextMessageIndex]
+        guard let nextMessage = messages[safe: nextMessageIndex] else {
+            log.warning("Accessing an index that is not present in the data source")
+            return true
+        }
 
         // The message after the current one has different author so the current message
         // is either a standalone or last in sequence.

--- a/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionAuthorsVC/ChatMessageReactionAuthorsVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionAuthorsVC/ChatMessageReactionAuthorsVC.swift
@@ -131,11 +131,8 @@ open class ChatMessageReactionAuthorsVC:
         ) as! ChatMessageReactionAuthorViewCell
 
         let reactions = messageController.reactions
-        if let currentUserId = messageController?.client.currentUserId {
-            cell.content = ChatMessageReactionAuthorViewCell.Content(
-                reaction: reactions[indexPath.item],
-                currentUserId: currentUserId
-            )
+        if let currentUserId = messageController?.client.currentUserId, let reaction = reactions[safe: indexPath.item] {
+            cell.content = ChatMessageReactionAuthorViewCell.Content(reaction: reaction, currentUserId: currentUserId)
         }
 
         return cell

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -153,7 +153,11 @@ open class ChatThreadVC:
 
     open func chatMessageListVC(_ vc: ChatMessageListVC, messageAt indexPath: IndexPath) -> ChatMessage? {
         guard indexPath.item < replies.count else { return nil }
-        return replies[indexPath.item]
+        guard let reply = replies[safe: indexPath.item] else {
+            indexNotFoundAssertion()
+            return nil
+        }
+        return reply
     }
 
     open func chatMessageListVC(

--- a/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.swift
+++ b/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.swift
@@ -183,9 +183,9 @@ open class ChatChannelAvatarView: _View, ThemeProvider, SwiftUIRepresentable {
                 orientation: .horizontal
             )
         } else if images.count == 3,
-                let firstImage = images[safe: 0],
-                let secondImage = images[safe: 1],
-                let thirdImage = images[safe: 2] {
+                  let firstImage = images[safe: 0],
+                  let secondImage = images[safe: 1],
+                  let thirdImage = images[safe: 2] {
             let leftImage = imageProcessor.crop(image: firstImage, to: halfContainerSize)
 
             let rightCollage = imageMerger.merge(
@@ -211,10 +211,10 @@ open class ChatChannelAvatarView: _View, ThemeProvider, SwiftUIRepresentable {
                 orientation: .horizontal
             )
         } else if images.count == 4,
-                let firstImage = images[safe: 0],
-                let secondImage = images[safe: 1],
-                let thirdImage = images[safe: 2],
-                let forthImage = images[safe: 3] {
+                  let firstImage = images[safe: 0],
+                  let secondImage = images[safe: 1],
+                  let thirdImage = images[safe: 2],
+                  let forthImage = images[safe: 3] {
             let leftCollage = imageMerger.merge(
                 images: [
                     firstImage,

--- a/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.swift
+++ b/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.swift
@@ -168,12 +168,12 @@ open class ChatChannelAvatarView: _View, ThemeProvider, SwiftUIRepresentable {
         // The half of the width of the avatar
         let halfContainerSize = CGSize(width: CGSize.avatarThumbnailSize.width / 2, height: CGSize.avatarThumbnailSize.height)
         
-        if images.count == 1 {
-            combinedImage = images[0]
-        } else if images.count == 2 {
-            let leftImage = imageProcessor.crop(image: images[0], to: halfContainerSize)
+        if images.count == 1, let image = images.first {
+            combinedImage = image
+        } else if images.count == 2, let firstImage = images.first, let secondImage = images.last {
+            let leftImage = imageProcessor.crop(image: firstImage, to: halfContainerSize)
                 ?? appearance.images.userAvatarPlaceholder1
-            let rightImage = imageProcessor.crop(image: images[1], to: halfContainerSize)
+            let rightImage = imageProcessor.crop(image: secondImage, to: halfContainerSize)
                 ?? appearance.images.userAvatarPlaceholder1
             combinedImage = imageMerger.merge(
                 images: [
@@ -182,13 +182,16 @@ open class ChatChannelAvatarView: _View, ThemeProvider, SwiftUIRepresentable {
                 ],
                 orientation: .horizontal
             )
-        } else if images.count == 3 {
-            let leftImage = imageProcessor.crop(image: images[0], to: halfContainerSize)
+        } else if images.count == 3,
+                let firstImage = images[safe: 0],
+                let secondImage = images[safe: 1],
+                let thirdImage = images[safe: 2] {
+            let leftImage = imageProcessor.crop(image: firstImage, to: halfContainerSize)
 
             let rightCollage = imageMerger.merge(
                 images: [
-                    images[1],
-                    images[2]
+                    secondImage,
+                    thirdImage
                 ],
                 orientation: .vertical
             )
@@ -207,11 +210,15 @@ open class ChatChannelAvatarView: _View, ThemeProvider, SwiftUIRepresentable {
                 ],
                 orientation: .horizontal
             )
-        } else if images.count == 4 {
+        } else if images.count == 4,
+                let firstImage = images[safe: 0],
+                let secondImage = images[safe: 1],
+                let thirdImage = images[safe: 2],
+                let forthImage = images[safe: 3] {
             let leftCollage = imageMerger.merge(
                 images: [
-                    images[0],
-                    images[2]
+                    firstImage,
+                    thirdImage
                 ],
                 orientation: .vertical
             )
@@ -224,8 +231,8 @@ open class ChatChannelAvatarView: _View, ThemeProvider, SwiftUIRepresentable {
             
             let rightCollage = imageMerger.merge(
                 images: [
-                    images[1],
-                    images[3]
+                    secondImage,
+                    forthImage
                 ],
                 orientation: .vertical
             )

--- a/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsVC.swift
+++ b/Sources/StreamChatUI/CommonViews/Suggestions/ChatSuggestionsVC.swift
@@ -180,7 +180,12 @@ open class ChatMessageComposerSuggestionsCommandDataSource: NSObject, UICollecti
         ) as! ChatCommandSuggestionCollectionViewCell
 
         cell.components = components
-        cell.commandView.content = commands[indexPath.row]
+        guard let command = commands[safe: indexPath.row] else {
+            indexNotFoundAssertion()
+            return UICollectionViewCell()
+        }
+
+        cell.commandView.content = command
 
         return cell
     }
@@ -248,7 +253,10 @@ open class ChatMessageComposerSuggestionsMentionDataSource: NSObject,
             for: indexPath
         ) as! ChatMentionSuggestionCollectionViewCell
 
-        let user = usersCache[indexPath.row]
+        guard let user = usersCache[safe: indexPath.row] else {
+            indexNotFoundAssertion()
+            return UICollectionViewCell()
+        }
         // We need to make sure we set the components before accessing the mentionView,
         // so the mentionView is created with the most up-to-dated components.
         cell.components = components

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -597,7 +597,12 @@ open class ComposerVC: _ViewController,
         )
         suggestionsVC.dataSource = dataSource
         suggestionsVC.didSelectItemAt = { [weak self] commandIndex in
-            self?.content.addCommand(commandHints[commandIndex])
+            guard let hintCommand = commandHints[safe: commandIndex] else {
+                indexNotFoundAssertion()
+                return
+            }
+
+            self?.content.addCommand(hintCommand)
 
             self?.dismissSuggestions()
         }
@@ -660,9 +665,12 @@ open class ComposerVC: _ViewController,
             guard dataSource.usersCache.count >= userIndex else {
                 return
             }
+            guard let user = dataSource.usersCache[safe: userIndex] else {
+                indexNotFoundAssertion()
+                return
+            }
 
             let textView = self.composerView.inputMessageView.textView
-            let user = dataSource.usersCache[userIndex]
             let text = textView.text as NSString
             let mentionText = self.mentionText(for: user)
             let newText = text.replacingCharacters(in: mentionRange, with: mentionText)

--- a/Sources/StreamChatUI/Gallery/GalleryVC.swift
+++ b/Sources/StreamChatUI/Gallery/GalleryVC.swift
@@ -341,8 +341,10 @@ open class GalleryVC:
             withReuseIdentifier: reuseIdentifier,
             for: indexPath
         ) as! GalleryCollectionViewCell
-        
-        cell.content = items[indexPath.item]
+
+        guard let item = getItem(at: indexPath) else { return UICollectionViewCell() }
+
+        cell.content = item
         
         cell.didTapOnce = { [weak self] in
             self?.handleSingleTapOnCell(at: indexPath)
@@ -389,14 +391,15 @@ open class GalleryVC:
     
     /// A currently visible gallery item.
     open var currentItem: AnyChatMessageAttachment {
-        items[currentItemIndexPath.item]
+        items.assertIndexIsPresent(currentItemIndexPath.item)
+        return items[currentItemIndexPath.item]
     }
     
     /// Returns a share item for the gallery item at given index path.
     /// - Parameter indexPath: An index path.
     /// - Returns: An item to share.
     open func shareItem(at indexPath: IndexPath) -> Any? {
-        let item = items[indexPath.item]
+        guard let item = getItem(at: indexPath) else { return nil }
         
         if let image = item.attachment(payloadType: ImageAttachmentPayload.self) {
             return image.imageURL
@@ -411,8 +414,8 @@ open class GalleryVC:
     /// - Parameter indexPath: An index path.
     /// - Returns: A cell reuse identifier.
     open func cellReuseIdentifierForItem(at indexPath: IndexPath) -> String? {
-        let item = items[indexPath.item]
-        
+        guard let item = getItem(at: indexPath) else { return nil }
+
         switch item.type {
         case .image:
             return components.imageAttachmentGalleryCell.reuseId
@@ -441,8 +444,9 @@ open class GalleryVC:
     /// Returns an image view to animate during interactive dismissing.
     open var imageViewToAnimateWhenDismissing: UIImageView? {
         let indexPath = currentItemIndexPath
-        
-        switch items[indexPath.item].type {
+        guard let item = getItem(at: indexPath) else { return nil }
+
+        switch item.type {
         case .image:
             let cell = attachmentsCollectionView
                 .cellForItem(at: indexPath) as? ImageAttachmentGalleryCell
@@ -454,5 +458,11 @@ open class GalleryVC:
         default:
             return nil
         }
+    }
+
+    private func getItem(at indexPath: IndexPath) -> AnyChatMessageAttachment? {
+        let index = indexPath.item
+        items.assertIndexIsPresent(index)
+        return items[safe: index]
     }
 }

--- a/Sources/StreamChatUI/Navigation/ChatMessageListRouter.swift
+++ b/Sources/StreamChatUI/Navigation/ChatMessageListRouter.swift
@@ -176,7 +176,10 @@ open class ChatMessageListRouter:
             galleryVC?.imageViewToAnimateWhenDismissing
         }
         zoomTransitionController.presentingImageView = {
-            let id = galleryVC.items[galleryVC.content.currentPage].id
+            guard let id = galleryVC.items[safe: galleryVC.content.currentPage]?.id else {
+                indexNotFoundAssertion()
+                return nil
+            }
             
             return previews.first(where: { $0.attachmentId == id })?.imageView ?? previews.last?.imageView
         }

--- a/Sources/StreamChatUI/Utils/Array+SafeSubscript.swift
+++ b/Sources/StreamChatUI/Utils/Array+SafeSubscript.swift
@@ -1,37 +1,38 @@
 //
-//  Array+SafeSubscript.swift
-//  StreamChat
-//
-//  Created by Pol Quintana on 14/12/21.
-//  Copyright © 2021 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation
 import StreamChat
 
 extension Collection {
-
     /// Returns the element at the specified index if it is within bounds, otherwise nil.
-    subscript (safe index: Index) -> Element? {
+    subscript(safe index: Index) -> Element? {
         indices.contains(index) ? self[index] : nil
     }
 
     /// Triggers indexNotFoundAssertion if the index is not present in the collection.
     /// Mostly used in places where returning optional would be a breaking change
-    func assertIndexIsPresent(_ index: Index,
-                              functionName: StaticString = #function,
-                              fileName: StaticString = #file,
-                              lineNumber: UInt = #line) {
+    func assertIndexIsPresent(
+        _ index: Index,
+        functionName: StaticString = #function,
+        fileName: StaticString = #file,
+        lineNumber: UInt = #line
+    ) {
         guard !indices.contains(index) else { return }
         indexNotFoundAssertion(functionName: functionName, fileName: fileName, lineNumber: lineNumber)
     }
 }
 
-func indexNotFoundAssertion(functionName: StaticString = #function,
-                            fileName: StaticString = #file,
-                            lineNumber: UInt = #line) {
-    log.assertionFailure("Accessing an index that is not present in the data source",
-                         functionName: functionName,
-                         fileName: fileName,
-                         lineNumber: lineNumber)
+func indexNotFoundAssertion(
+    functionName: StaticString = #function,
+    fileName: StaticString = #file,
+    lineNumber: UInt = #line
+) {
+    log.assertionFailure(
+        "Accessing an index that is not present in the data source",
+        functionName: functionName,
+        fileName: fileName,
+        lineNumber: lineNumber
+    )
 }

--- a/Sources/StreamChatUI/Utils/Array+SafeSubscript.swift
+++ b/Sources/StreamChatUI/Utils/Array+SafeSubscript.swift
@@ -1,0 +1,17 @@
+//
+//  Array+SafeSubscript.swift
+//  StreamChat
+//
+//  Created by Pol Quintana on 14/12/21.
+//  Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension Collection {
+
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
+    subscript (safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Sources/StreamChatUI/Utils/Array+SafeSubscript.swift
+++ b/Sources/StreamChatUI/Utils/Array+SafeSubscript.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import StreamChat
 
 extension Collection {
 
@@ -14,4 +15,23 @@ extension Collection {
     subscript (safe index: Index) -> Element? {
         return indices.contains(index) ? self[index] : nil
     }
+
+    /// Triggers indexNotFoundAssertion if the index is not present in the collection.
+    /// Mostly used in places where returning optional would be a breaking change
+    func assertIndexIsPresent(_ index: Index,
+                              functionName: StaticString = #function,
+                              fileName: StaticString = #file,
+                              lineNumber: UInt = #line) {
+        guard !indices.contains(index) else { return }
+        indexNotFoundAssertion(functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+    }
+}
+
+func indexNotFoundAssertion(functionName: StaticString = #function,
+                            fileName: StaticString = #file,
+                            lineNumber: UInt = #line) {
+    log.assertionFailure("Accessing an index that is not present in the data source",
+                         functionName: functionName,
+                         fileName: fileName,
+                         lineNumber: lineNumber)
 }

--- a/Sources/StreamChatUI/Utils/Array+SafeSubscript.swift
+++ b/Sources/StreamChatUI/Utils/Array+SafeSubscript.swift
@@ -13,7 +13,7 @@ extension Collection {
 
     /// Returns the element at the specified index if it is within bounds, otherwise nil.
     subscript (safe index: Index) -> Element? {
-        return indices.contains(index) ? self[index] : nil
+        indices.contains(index) ? self[index] : nil
     }
 
     /// Triggers indexNotFoundAssertion if the index is not present in the collection.

--- a/Sources/StreamChatUI/Utils/Array+SafeSubscript_Tests.swift
+++ b/Sources/StreamChatUI/Utils/Array+SafeSubscript_Tests.swift
@@ -1,0 +1,26 @@
+//
+//  Array+SafeSubscript_Tests.swift
+//  StreamChat
+//
+//  Created by Pol Quintana on 16/12/21.
+//  Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChatUI
+import XCTest
+
+final class Array_SafeSubscript_Tests: XCTestCase {
+    func test_safeSubscript_returnsObject_whenIndexIsPresent() {
+        let collection = (0..<3).map { "index\($0)" }
+        XCTAssertEqual(collection[safe: 0], "index0")
+        XCTAssertEqual(collection[safe: 1], "index1")
+        XCTAssertEqual(collection[safe: 2], "index2")
+    }
+
+    func test_safeSubscript_returnsNil_whenIndexNotPresent() {
+        let collection = (0..<3).map { "index\($0)" }
+        XCTAssertNil(collection[safe: 3])
+        XCTAssertNil(collection[safe: 84])
+    }
+}

--- a/Sources/StreamChatUI/Utils/Array+SafeSubscript_Tests.swift
+++ b/Sources/StreamChatUI/Utils/Array+SafeSubscript_Tests.swift
@@ -1,9 +1,5 @@
 //
-//  Array+SafeSubscript_Tests.swift
-//  StreamChat
-//
-//  Created by Pol Quintana on 16/12/21.
-//  Copyright © 2021 Stream.io Inc. All rights reserved.
+// Copyright © 2021 Stream.io Inc. All rights reserved.
 //
 
 import Foundation

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1384,6 +1384,7 @@
 		C121EC612746AC8C00023E4C /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; platformFilter = ios; };
 		C121EC622746AC8C00023E4C /* StreamChatUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C121EC662746AD0E00023E4C /* StreamChat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 799C941B247D2F80001F1104 /* StreamChat.framework */; };
+		C1320E0A276B2E0F00A06B35 /* Array+SafeSubscript_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1320E07276B2E0800A06B35 /* Array+SafeSubscript_Tests.swift */; };
 		C139335F275E7BD800225E7A /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = C139335E275E7BD800225E7A /* Nuke */; };
 		C1393361275F5D1E00225E7A /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = C1393360275F5D1E00225E7A /* Nuke */; };
 		C171041E2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */; };
@@ -2860,6 +2861,7 @@
 		BDEB9416268211EC00928AF1 /* ChatMessageListUnreadCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListUnreadCountView.swift; sourceTree = "<group>"; };
 		C121E758274543D000023E4C /* libStreamChat.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libStreamChat.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		C121EA2F2746A19400023E4C /* libStreamChatUI.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libStreamChatUI.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		C1320E07276B2E0800A06B35 /* Array+SafeSubscript_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeSubscript_Tests.swift"; sourceTree = "<group>"; };
 		C13C74D2273932D200F93B34 /* UIImageView+SwiftyGif.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImageView+SwiftyGif.swift"; sourceTree = "<group>"; };
 		C13C74D3273932D200F93B34 /* NSImage+SwiftyGif.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSImage+SwiftyGif.swift"; sourceTree = "<group>"; };
 		C13C74D4273932D200F93B34 /* UIImage+SwiftyGif.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+SwiftyGif.swift"; sourceTree = "<group>"; };
@@ -4859,6 +4861,7 @@
 				ACD502A826BC0C670029FB7D /* ImageMerger.swift */,
 				ACCA772D26C568D8007AE2ED /* NukeImageProcessor.swift */,
 				C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */,
+				C1320E07276B2E0800A06B35 /* Array+SafeSubscript_Tests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -7080,6 +7083,7 @@
 				ADFCCD7525C9D4D10024505D /* AssertSnapshot.swift in Sources */,
 				F838F6CE263713090025E1F5 /* GalleryVC_Tests.swift in Sources */,
 				8897305E265D046D00F83739 /* ChatMessageLayoutOptionsResolver_Tests.swift in Sources */,
+				C1320E0A276B2E0F00A06B35 /* Array+SafeSubscript_Tests.swift in Sources */,
 				F86615D9264940A80026814A /* ChatMessageGalleryView_Tests.swift in Sources */,
 				79B4F14A25D3F1120063FFB5 /* TemporaryData.swift in Sources */,
 				8893FF16265FC60B00DD62BE /* ChatMessageErrorIndicator_Tests.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1386,6 +1386,8 @@
 		C121EC662746AD0E00023E4C /* StreamChat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 799C941B247D2F80001F1104 /* StreamChat.framework */; };
 		C139335F275E7BD800225E7A /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = C139335E275E7BD800225E7A /* Nuke */; };
 		C1393361275F5D1E00225E7A /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = C1393360275F5D1E00225E7A /* Nuke */; };
+		C171041E2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */; };
+		C171041F2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */; };
 		C1BE72732732CA62006EB51E /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = C1BE72722732CA62006EB51E /* Nuke */; };
 		C1FC2F6727416E150062530F /* ResumableData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1BE728A2732CB7B006EB51E /* ResumableData.swift */; };
 		C1FC2F6827416E150062530F /* ImagePipelineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1BE72822732CB7B006EB51E /* ImagePipelineCache.swift */; };
@@ -2883,6 +2885,7 @@
 		C13C7508273936DA00F93B34 /* Engine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Engine.swift; sourceTree = "<group>"; };
 		C13C7509273936DA00F93B34 /* NativeEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeEngine.swift; sourceTree = "<group>"; };
 		C13C750A273936DA00F93B34 /* WSEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WSEngine.swift; sourceTree = "<group>"; };
+		C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeSubscript.swift"; sourceTree = "<group>"; };
 		C1BE72762732CB7B006EB51E /* ImageViewExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageViewExtensions.swift; sourceTree = "<group>"; };
 		C1BE72772732CB7B006EB51E /* FetchImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchImage.swift; sourceTree = "<group>"; };
 		C1BE72792732CB7B006EB51E /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
@@ -4855,6 +4858,7 @@
 				640FE0F526A57903006CE703 /* CollectionUpdatesMapper_Tests.swift */,
 				ACD502A826BC0C670029FB7D /* ImageMerger.swift */,
 				ACCA772D26C568D8007AE2ED /* NukeImageProcessor.swift */,
+				C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -6945,6 +6949,7 @@
 				AD447443263AC6A10030E583 /* ChatMentionSuggestionView.swift in Sources */,
 				E7166CBA25BED29200B03B07 /* Appearance+Fonts.swift in Sources */,
 				E7073A6325DD67B3003896B9 /* UILabel+Extensions.swift in Sources */,
+				C171041E2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */,
 				843F0BC526775D2D00B342CB /* VideoLoading.swift in Sources */,
 				88CABC4625933EE70061BB67 /* ChatReactionPickerBubbleView.swift in Sources */,
 				F838F6A92636D3C30025E1F5 /* ZoomTransitionController.swift in Sources */,
@@ -8264,6 +8269,7 @@
 				C121EBFB2746A1EB00023E4C /* ChatMessageListVCDataSource.swift in Sources */,
 				C121EBFC2746A1EB00023E4C /* ChatMessageListVCDelegate.swift in Sources */,
 				C121EBFD2746A1EB00023E4C /* ChatMessageListView.swift in Sources */,
+				C171041F2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */,
 				C121EBFE2746A1EB00023E4C /* ChatMessageListScrollOverlayView.swift in Sources */,
 				C121EBFF2746A1EB00023E4C /* ChatMessageListUnreadCountView.swift in Sources */,
 				C121EC002746A1EB00023E4C /* ScrollToLatestMessageButton.swift in Sources */,


### PR DESCRIPTION
### 🔗 Issue Link
https://stream-io.atlassian.net/browse/CIS-1378

### 🎯 Goal

Because of the nature of the core of our chat message list, we sometimes have crashes because we are accessing indexes of messages that are not present anymore. The purpose of this PR is not to fix the core nature of this edge cases, but instead make sure that we don't fail when this happens.
It also introduces a custom assertion, together with a log whenever this happens.

### 🛠 Implementation

A new extension over Collections will allow safe subscripts by checking whether the index is within the bounds of the collection. If it is not there, it would return nil, instead of crashing.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
