### PR TITLE
Added docs for inline replies in the SwiftUI SDK

### DIFF
--- a/docusaurus/docs/iOS/swiftui/components/attachments.md
+++ b/docusaurus/docs/iOS/swiftui/components/attachments.md
@@ -57,11 +57,13 @@ class CustomFactory: ViewFactory {
     func makeMessageTextView(
         for message: ChatMessage,
         isFirst: Bool,
-        availableWidth: CGFloat
+        availableWidth: CGFloat,
+        scrolledId: Binding<String?>
     ) -> some View {
         CustomMessageTextView(
             message: message,
-            isFirst: isFirst
+            isFirst: isFirst,
+            scrolledId: scrolledId
         )
     }
 
@@ -146,7 +148,8 @@ Next, in our `CustomFactory`, we need to return the new view we have created abo
 func makeCustomAttachmentViewType(
     for message: ChatMessage,
     isFirst: Bool,
-    availableWidth: CGFloat
+    availableWidth: CGFloat,
+    scrolledId: Binding<String?>
 ) -> some View {
     CustomAttachmentView(
         message: message,

--- a/docusaurus/docs/iOS/swiftui/components/inline-replies.md
+++ b/docusaurus/docs/iOS/swiftui/components/inline-replies.md
@@ -1,0 +1,47 @@
+---
+title: Message inline replies
+---
+
+## Inline Replies Overview
+
+The SwiftUI SDK has support for inline message replies. These replies are invoked either by swiping left on a message, or via long pressing a message and selecting the "Reply" action. When a message is quoted, it appears in the message composer, as an indication which message the user is replying to.
+
+## Customizing the Quoted Message
+
+When a message appears as quoted in the composer, you can customize two parts. First, there's a header at the top of the composer, which by default has a title and a button to remove the quoted message from the composer. To swap this view with your own implementation, you need to implement the `makeQuotedMessageHeaderView` method in the `ViewFactory`, which passes a binding of the quoted chat message.
+
+```swift
+public func makeQuotedMessageHeaderView(
+        quotedMessage: Binding<ChatMessage?>
+) -> some View {
+    CustomQuotedMessageHeaderView(quotedMessage: quotedMessage)
+}
+```
+
+The second customization that can be done is to swap the preview of the message shown in the composer. The default implementation is able to present several different attachments, such as text, image, video, gifs, links and files. The UI consists of small image and either the message text (if present), or a description for the attachment.
+
+In order to swap this UI, you need to implement the `makeQuotedMessageComposerView` method in the `ViewFactory`. The method passes the quoted message as a parameter.
+
+```swift
+public func makeQuotedMessageComposerView(
+        quotedMessage: ChatMessage
+) -> some View {
+    QuotedMessageViewContainer(
+        quotedMessage: quotedMessage,
+        fillAvailableSpace: true,
+        forceLeftToRight: true,
+        scrolledId: .constant(nil)
+    )
+}
+```
+
+
+Finally, we need to inject the your `CustomFactory` in our view hierarchy.
+
+```swift
+var body: some Scene {
+    WindowGroup {
+        ChatChannelListView(viewFactory: CustomFactory.shared)
+    }
+}
+```

--- a/docusaurus/sidebars-ios.json
+++ b/docusaurus/sidebars-ios.json
@@ -64,7 +64,8 @@
             "swiftui/components/attachments",
             "swiftui/components/message-composer",
             "swiftui/components/message-reactions",
-            "swiftui/components/message-threads"
+            "swiftui/components/message-threads",
+            "swiftui/components/inline-replies"
           ]
         }
       ]


### PR DESCRIPTION
### 🔗 Issue Link
[JIRA](https://stream-io.atlassian.net/browse/SWUI-47?atlOrigin=eyJpIjoiYjlhNWNlNTQ0NTUzNDRiM2I1Nzk0Yjk4OWY4NTE4ODIiLCJwIjoiaiJ9)

### 🎯 Goal

Docs to reflect the new inline replies feature in the SwiftUI SDK.

### 🛠 Implementation

Updated the docs.

### 🎨 Changes

Only text changes.

### 🧪 Testing

Test locally on docusaurus.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
