### PR TITLE
Expose `QueryOptions` and `start/stopWatching`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ _December 15, 2021_
 - Added `LogConfig.destinationTypes` for ease of adding new destinations to logger [#1681](https://github.com/GetStream/stream-chat-swift/issues/1681)
 - Expose container embedding top & bottom containers by `ChatChannelListItemView` [#1670](https://github.com/GetStream/stream-chat-swift/issues/1670)
 - Add Static Message List Date Separators [#1686](https://github.com/GetStream/stream-chat-swift/issues/1686) (You can read this [doc](https://getstream.io/chat/docs/sdk/ios/uikit/components/message/#date-separators) to understand how to configure this feature)
+- `ChannelQuery.options` and `ChannelListQuery.options` are now public and mutable [#1696](https://github.com/GetStream/stream-chat-swift/issues/1696)
+- `ChannelController.startWatching` and `stopWatching` are now `public`. You can explicitly stop watching a channel [#1696](https://github.com/GetStream/stream-chat-swift/issues/1696)
 
 # [4.5.2](https://github.com/GetStream/stream-chat-swift/releases/tag/4.5.2)
 _December 10, 2021_

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1135,11 +1135,9 @@ public extension ChatChannelController {
     ///
     /// Please check [documentation](https://getstream.io/chat/docs/android/watch_channel/?language=swift) for more information.
     ///
-    /// We keep these functions internal since we're not sure how we should interface this behavior.
-    /// If you have suggestions, please open a ticket or send us an email at support@getstream.io
     ///
     /// - Parameter completion: Called when the API call is finished. Called with `Error` if the remote update fails.
-    internal func startWatching(completion: ((Error?) -> Void)? = nil) {
+    func startWatching(completion: ((Error?) -> Void)? = nil) {
         /// Perform action only if channel is already created on backend side and have a valid `cid`.
         guard let cid = cid, isChannelAlreadyCreated else {
             channelModificationFailed(completion)
@@ -1165,11 +1163,11 @@ public extension ChatChannelController {
     ///
     /// Please check [documentation](https://getstream.io/chat/docs/android/watch_channel/?language=swift) for more information.
     ///
-    /// We keep these functions internal since we're not sure how we should interface this behavior.
-    /// If you have suggestions, please open a ticket or send us an email at support@getstream.io
+    /// - Warning: If you're using `ChannelListController`, calling this function can disrupt `ChannelListController`'s functions,
+    /// such as updating channel data.
     ///
     /// - Parameter completion: Called when the API call is finished. Called with `Error` if the remote update fails.
-    internal func stopWatching(completion: ((Error?) -> Void)? = nil) {
+    func stopWatching(completion: ((Error?) -> Void)? = nil) {
         /// Perform action only if channel is already created on backend side and have a valid `cid`.
         guard let cid = cid, isChannelAlreadyCreated else {
             channelModificationFailed(completion)

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -102,7 +102,7 @@ public struct ChannelListQuery: Encodable {
     /// A number of messages inside each channel.
     public let messagesLimit: Int
     /// Query options.
-    var options: QueryOptions = [.watch]
+    public var options: QueryOptions = [.watch]
     
     /// Init a channels query.
     /// - Parameters:

--- a/Sources/StreamChat/Query/ChannelQuery.swift
+++ b/Sources/StreamChat/Query/ChannelQuery.swift
@@ -24,7 +24,7 @@ public struct ChannelQuery: Encodable {
     /// A number of watchers for the channel to be retrieved.
     public let watchersLimit: Int?
     /// A query options.
-    var options: QueryOptions = .all
+    public var options: QueryOptions = .all
     /// ChannelCreatePayload that is needed only when creating channel
     let channelPayload: ChannelEditDetailPayload?
     

--- a/Sources/StreamChat/Query/QueryOptions.swift
+++ b/Sources/StreamChat/Query/QueryOptions.swift
@@ -5,32 +5,32 @@
 import Foundation
 
 /// Query options.
-struct QueryOptions: OptionSet, Encodable {
+public struct QueryOptions: OptionSet, Encodable {
     private enum CodingKeys: String, CodingKey {
         case state
         case watch
         case presence
     }
     
-    let rawValue: Int
+    public let rawValue: Int
     
     /// A query will return a channel state, e.g. messages.
-    static let state = QueryOptions(rawValue: 1 << 0)
+    public static let state = QueryOptions(rawValue: 1 << 0)
     
     /// Listen for a channel changes in real time, e.g. a new message event.
-    static let watch = QueryOptions(rawValue: 1 << 1)
+    public static let watch = QueryOptions(rawValue: 1 << 1)
     
     /// Get updates when the user goes offline/online.
-    static let presence = QueryOptions(rawValue: 1 << 2)
+    public static let presence = QueryOptions(rawValue: 1 << 2)
     
     /// Includes all query options: state, watch and presence.
-    static let all: QueryOptions = [.state, .watch, .presence]
+    public static let all: QueryOptions = [.state, .watch, .presence]
     
-    init(rawValue: Int) {
+    public init(rawValue: Int) {
         self.rawValue = rawValue
     }
     
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         
         if contains(.state) {


### PR DESCRIPTION
### 🎯 Goal

Allowing users to explicitly start/stop watching a channel, and make Channel queries without `watch`ing.

### 🛠 Implementation

The functionality were there but hidden, now exposed.

### 🧪 Testing

Already tested in `ChannelController_Tests`

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
