### PR TITLE
Fix reload rows out of bounds

### DIFF
--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -234,25 +234,20 @@ final class MessageUpdater_Tests: XCTestCase {
             // Create a new message in the database
             try database.createMessage(id: messageId, authorId: currentUserId, localState: state)
 
+            let expectation = expectation(description: "deleteMessage")
+
             // Simulate `deleteMessage(messageId:)` call
-            var completionCalled = false
             messageUpdater.deleteMessage(messageId: messageId) { error in
                 XCTAssertNil(error)
-                completionCalled = true
+                expectation.fulfill()
             }
-            
+
+            wait(for: [expectation], timeout: 0.1)
             let message = try XCTUnwrap(database.viewContext.message(id: messageId))
-            
-            AssertAsync {
-                // Assert completion is called
-                Assert.willBeTrue(completionCalled)
-                // Assert `deletedAt` is set for the message
-                Assert.willBeTrue(message.deletedAt != nil)
-                // Assert `type` is set to `.deleted`
-                Assert.willBeEqual(message.type, MessageType.deleted.rawValue)
-                // Assert API is not called
-                Assert.staysTrue(self.apiClient.request_endpoint == nil)
-            }
+
+            XCTAssertNotNil(message.deletedAt)
+            XCTAssertEqual(message.type, MessageType.deleted.rawValue)
+            XCTAssertNil(apiClient.request_endpoint)
         }
     }
     

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -141,8 +141,7 @@ open class ChatChannelVC:
     }
 
     open func chatMessageListVC(_ vc: ChatMessageListVC, messageAt indexPath: IndexPath) -> ChatMessage? {
-        channelController.messages.assertIndexIsPresent(indexPath.item)
-        return channelController.messages[safe: indexPath.item]
+        channelController.messages[safe: indexPath.item]
     }
 
     open func chatMessageListVC(

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -327,19 +327,22 @@ open class ChatMessageListVC:
         cell.messageContentView?.content = message
         cell.dateSeparatorView.isHidden = true
 
-        if isDateSeparatorEnabled, let currentMessage = message {
-            let currentDay = DateFormatter.messageListDateOverlay.string(from: currentMessage.createdAt)
-            cell.dateSeparatorView.content = currentDay
+        guard isDateSeparatorEnabled, let currentMessage = message else {
+            return cell
+        }
 
-            // Only the show the separator if the previous message has a different day
-            let previousIndexPath = IndexPath(row: indexPath.row + 1, section: indexPath.section)
-            if let previousMessage = dataSource?.chatMessageListVC(self, messageAt: previousIndexPath) {
-                let previousDay = DateFormatter.messageListDateOverlay.string(from: previousMessage.createdAt)
-                cell.dateSeparatorView.isHidden = previousDay == currentDay
-            } else {
-                // If previous message doesn't exist show the separator as well
-                cell.dateSeparatorView.isHidden = false
-            }
+        let currentDay = DateFormatter.messageListDateOverlay.string(from: currentMessage.createdAt)
+        cell.dateSeparatorView.content = currentDay
+
+        // Only show the separator if the previous message is from a different day
+        // TODO: simplify this and make it simpler to customize the logic (ie. extract this into a open `showDateSeparatorView` method)
+        let previousIndexPath = IndexPath(row: indexPath.row + 1, section: indexPath.section)
+        if let previousMessage = dataSource?.chatMessageListVC(self, messageAt: previousIndexPath) {
+            let previousDay = DateFormatter.messageListDateOverlay.string(from: previousMessage.createdAt)
+            cell.dateSeparatorView.isHidden = previousDay == currentDay
+        } else {
+            // If previous message doesn't exist show the separator as well
+            cell.dateSeparatorView.isHidden = false
         }
 
         return cell

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -194,7 +194,7 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
                     self.performBatchUpdates {
                         self.insertRows(at: [index], with: .none)
                     } completion: { _ in
-                        guard self.numberOfRows(inSection: index.section) > 1 else { return }
+                        guard self.numberOfRows(inSection: index.section) > index.row + 1 else { return }
                         // Update previous row to remove timestamp if needed
                         // +1 instead of -1 because the message list is inverted
                         let previousIndex = IndexPath(row: index.row + 1, section: index.section)

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -182,41 +182,39 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
             return
         }
 
-        if changes.count > 1 {
+        guard changes.count == 1, let change = changes.first else {
             reloadData()
             return
         }
 
-        changes.forEach {
-            switch $0 {
-            case let .insert(message, index: index):
-                UIView.performWithoutAnimation {
-                    self.performBatchUpdates {
-                        self.insertRows(at: [index], with: .none)
-                    } completion: { _ in
-                        guard self.numberOfRows(inSection: index.section) > index.row + 1 else { return }
-                        // Update previous row to remove timestamp if needed
-                        // +1 instead of -1 because the message list is inverted
-                        let previousIndex = IndexPath(row: index.row + 1, section: index.section)
-                        self.reloadRows(at: [previousIndex], with: .none)
-                    }
+        switch change {
+        case let .insert(message, index: index):
+            UIView.performWithoutAnimation {
+                self.performBatchUpdates {
+                    self.insertRows(at: [index], with: .none)
+                } completion: { _ in
+                    guard self.numberOfRows(inSection: index.section) > index.row + 1 else { return }
+                    // Update previous row to remove timestamp if needed
+                    // +1 instead of -1 because the message list is inverted
+                    let previousIndex = IndexPath(row: index.row + 1, section: index.section)
+                    self.reloadRows(at: [previousIndex], with: .none)
                 }
-
-                if message.isSentByCurrentUser, index == IndexPath(item: 0, section: 0) {
-                    self.scrollToBottomAction = .init { [weak self] in
-                        self?.scrollToMostRecentMessage()
-                    }
-                }
-
-            case let .move(_, fromIndex: fromIndex, toIndex: toIndex):
-                self.moveRow(at: fromIndex, to: toIndex)
-
-            case let .update(_, index: index):
-                self.reloadRows(at: [index], with: .automatic)
-
-            case .remove:
-                self.reloadData()
             }
+
+            if message.isSentByCurrentUser, index == IndexPath(item: 0, section: 0) {
+                scrollToBottomAction = .init { [weak self] in
+                    self?.scrollToMostRecentMessage()
+                }
+            }
+
+        case let .move(_, fromIndex: fromIndex, toIndex: toIndex):
+            moveRow(at: fromIndex, to: toIndex)
+
+        case let .update(_, index: index):
+            reloadRows(at: [index], with: .automatic)
+
+        case .remove:
+            reloadData()
         }
     }
 


### PR DESCRIPTION
This PR fixes an out of bound problem where we would reload a previous row that is not present in the message list

You could reproduce this on a channel with 26 messages 🙈