### PR TITLE
Move unwanted deprecated functions from `ChatMessageLayoutOptions`

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptions.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptions.swift
@@ -16,6 +16,18 @@ extension ChatMessageLayoutOptions: Identifiable {
     }
 }
 
+public extension ChatMessageLayoutOptions {
+    /// Remove multiple message layout options.
+    mutating func remove(_ options: ChatMessageLayoutOptions) {
+        self = subtracting(options)
+    }
+
+    /// Insert multiple message layout options.
+    mutating func insert(_ options: ChatMessageLayoutOptions) {
+        options.forEach { self.insert($0) }
+    }
+}
+
 /// Each message layout option is used to define which views will be part of the message cell.
 /// A different combination of layout options will produce a different cell reuse identifier.
 public struct ChatMessageLayoutOption: RawRepresentable, Hashable, ExpressibleByStringLiteral {

--- a/Sources/StreamChatUI/Deprecations.swift
+++ b/Sources/StreamChatUI/Deprecations.swift
@@ -182,16 +182,6 @@ public extension ChatMessageLayoutOptions {
         id
     }
 
-    @available(*, deprecated, message: "use `remove(_ member: ChatMessageLayoutOption)` instead.")
-    mutating func remove(_ options: ChatMessageLayoutOptions) {
-        self = subtracting(options)
-    }
-
-    @available(*, deprecated, message: "use `insert(_ member: ChatMessageLayoutOption)` instead.")
-    mutating func insert(_ options: ChatMessageLayoutOptions) {
-        options.forEach { self.insert($0) }
-    }
-
     @available(*, deprecated, message: "use `subtracting(_ other: Sequence)` instead.")
     mutating func subtracting(_ option: ChatMessageLayoutOption) {
         self = subtracting([option])


### PR DESCRIPTION
Fix some bad conflict resolutions of `ChatMessageLayoutOptions`. These functions should not be deprecated. 
