### PR TITLE
[CIS-1367] Remove unnecessary API calls from `ChannelVC` and `ChannelListVC `

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix multiple pagination requests being fired from `ChatChannelVC` and `ChatChannelListVC` [#1706](https://github.com/GetStream/stream-chat-swift/issues/1706)
 
 # [4.6.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.6.0)
 _December 20, 2021_

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -64,7 +64,7 @@ open class ChatChannelVC:
         messageListVC.listView.isLastCellFullyVisible
     }
 
-    private var loadingPreviousMessages: Bool = false
+    private var isLoadingPreviousMessages: Bool = false
 
     override open func setUp() {
         super.setUp()
@@ -168,18 +168,22 @@ open class ChatChannelVC:
             return
         }
 
+        guard messageListVC.listView.isTrackingOrDecelerating else {
+            return
+        }
+
         if indexPath.row < channelController.messages.count - 10 {
             return
         }
 
-        guard !loadingPreviousMessages else {
+        guard !isLoadingPreviousMessages else {
             return
         }
-        loadingPreviousMessages = true
+        isLoadingPreviousMessages = true
 
-        channelController.loadPreviousMessages(completion: { [weak self] _ in
-            self?.loadingPreviousMessages = false
-        })
+        channelController.loadPreviousMessages { [weak self] _ in
+            self?.isLoadingPreviousMessages = false
+        }
     }
 
     open func chatMessageListVC(

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -17,7 +17,7 @@ open class ChatChannelListVC: _ViewController,
     /// The `ChatChannelListController` instance that provides channels data.
     public var controller: ChatChannelListController!
 
-    private var loadingPreviousMessages: Bool = false
+    private var isPaginatingChannels: Bool = false
 
     open private(set) lazy var loadingIndicator: UIActivityIndicatorView = {
         if #available(iOS 13.0, *) {
@@ -85,8 +85,7 @@ open class ChatChannelListVC: _ViewController,
         
         // Set the Controller on the ViewController
         chatChannelListVC.controller = controller
-        chatChannelListVC.setUp()
-        
+
         // Return the newly created ChatChannelListVC
         return chatChannelListVC
     }
@@ -121,6 +120,10 @@ open class ChatChannelListVC: _ViewController,
         forItemAt indexPath: IndexPath
     ) {
         if controller.state != .remoteDataFetched {
+            return
+        }
+
+        guard collectionView.isTrackingOrDecelerating else {
             return
         }
 
@@ -221,14 +224,14 @@ open class ChatChannelListVC: _ViewController,
     }
 
     open func loadMoreChannels() {
-        guard !loadingPreviousMessages else {
+        guard !isPaginatingChannels else {
             return
         }
-        loadingPreviousMessages = true
+        isPaginatingChannels = true
 
-        controller.loadNextChannels(completion: { [weak self] _ in
-            self?.loadingPreviousMessages = false
-        })
+        controller.loadNextChannels { [weak self] _ in
+            self?.isPaginatingChannels = false
+        }
     }
 
     open func swipeableViewWillShowActionViews(for indexPath: IndexPath) {

--- a/Sources/StreamChatUI/Utils/UIScrollView+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/UIScrollView+Extensions.swift
@@ -1,0 +1,11 @@
+//
+// Copyright © 2021 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+extension UIScrollView {
+    var isTrackingOrDecelerating: Bool {
+        isTracking || isDecelerating
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -534,6 +534,7 @@
 		847E946E269C687300E31D0C /* EventsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847E946D269C687300E31D0C /* EventsController.swift */; };
 		847F3CEA2689FDEB00D240E0 /* ChatMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847F3CE92689FDEB00D240E0 /* ChatMessageCell.swift */; };
 		8486CAF926FA51EE00A9AD96 /* EventDTOConverterMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8486CAF826FA51EE00A9AD96 /* EventDTOConverterMiddleware_Tests.swift */; };
+		849980F1277246DB00ABA58B /* UIScrollView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849980F0277246DB00ABA58B /* UIScrollView+Extensions.swift */; };
 		849AE662270CB00000423A20 /* VideoLoading_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849AE661270CB00000423A20 /* VideoLoading_Mock.swift */; };
 		849AE664270CB14000423A20 /* VideoAttachmentComposerPreview_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849AE663270CB14000423A20 /* VideoAttachmentComposerPreview_Tests.swift */; };
 		849AE666270CB55F00423A20 /* VideoAttachmentGalleryCell_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849AE665270CB55F00423A20 /* VideoAttachmentGalleryCell_Tests.swift */; };
@@ -2498,6 +2499,7 @@
 		847E946D269C687300E31D0C /* EventsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsController.swift; sourceTree = "<group>"; };
 		847F3CE92689FDEB00D240E0 /* ChatMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageCell.swift; sourceTree = "<group>"; };
 		8486CAF826FA51EE00A9AD96 /* EventDTOConverterMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDTOConverterMiddleware_Tests.swift; sourceTree = "<group>"; };
+		849980F0277246DB00ABA58B /* UIScrollView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIScrollView+Extensions.swift"; sourceTree = "<group>"; };
 		849AE661270CB00000423A20 /* VideoLoading_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoLoading_Mock.swift; sourceTree = "<group>"; };
 		849AE663270CB14000423A20 /* VideoAttachmentComposerPreview_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentComposerPreview_Tests.swift; sourceTree = "<group>"; };
 		849AE665270CB55F00423A20 /* VideoAttachmentGalleryCell_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentGalleryCell_Tests.swift; sourceTree = "<group>"; };
@@ -4827,6 +4829,7 @@
 		888123D0255D42F000070D5A /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				849980F0277246DB00ABA58B /* UIScrollView+Extensions.swift */,
 				ACA3C98426CA23F300EB8B07 /* DateUtils_Tests.swift */,
 				ACA3C98526CA23F300EB8B07 /* DateUtils.swift */,
 				ACF73D7726CFE07900372DC0 /* Cancellable.swift */,
@@ -6811,6 +6814,7 @@
 				F80BCA1E26304FEE00F2107B /* CloseButton.swift in Sources */,
 				22ADD682256C40410098EFEB /* ComposerView.swift in Sources */,
 				E7A37B8425ADA66E0055458F /* ChatSuggestionsHeaderView.swift in Sources */,
+				849980F1277246DB00ABA58B /* UIScrollView+Extensions.swift in Sources */,
 				8850FE91256558B200C8D534 /* NavigationRouter.swift in Sources */,
 				883051C82630579D0069D731 /* ChatThreadArrowView.swift in Sources */,
 				E798D6D325FF69120002C3B9 /* SwipeableView.swift in Sources */,


### PR DESCRIPTION
### 🔗 Issue Link

CIS-1367

### 🎯 Goal

Fix sending multiple unnecessary pagination requests when `ChannelListVC` and `ChannelVC` are shown.
This PR makes sure that only 1 API call is made to load both `ChannelListVC` and `ChannelVC`

### 🎨 Changes

Before this PR `ChannelListVC` was calling the Query Channels endpoint 3 times!

**ChannelListVC**
- Pagination was incorrectly firing the request to load another page 
- The `make` method was calling the `setUp` method (which calls `synchronize`)

**ChannelVC**
- Pagination was incorrectly firing the request to load another page 

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)