### PR TITLE
CIS-1339 Exclude deleted replies correctly

### DIFF
--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -148,7 +148,7 @@ class MessageDTO: NSManagedObject {
         )
 
         let messageTypePredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [
-            .init(format: "type != %@", MessageType.reply.rawValue),
+            .init(format: "type != %@ AND parentMessageId == nil", MessageType.reply.rawValue),
             .init(format: "type == %@ AND showReplyInChannel == 1", MessageType.reply.rawValue)
         ])
         


### PR DESCRIPTION
Change Fetch Request to exclude deleted thread replies from showing up in the main channel. When a reply message is deleted, its type changes from "reply" into "deleted", we can still use the `parent_message_id` field to determine if the. message is a reply or not.