### PR TITLE
Pod trunk push all specs

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -170,9 +170,7 @@ lane :publish_release do |options|
                      description: changes,
                      upload_assets: ["Products/StreamChat.zip", "Products/StreamChatUI.zip", "Products/StreamChat-All.zip"]
                    )
-  # The & operator makes sure truthy values are converted to bool
-  # and falsy (false and nil) values are converted to bool false
-  push_pods(sync: options[:sync] & true)
+  push_pods(sync: options[:sync])
 
   # Set tag
   sh("git tag #{version}")
@@ -201,7 +199,14 @@ lane :push_pods do |options|
     end
   end
 
-  sync = options[:sync]
+  # The == 1 comparison makes sure truthy values are converted to bool
+  # and falsy (false and nil) values are converted to bool false
+
+  # When sync is false, pod trunk push is run asynchronously
+  sync = options[:sync] == 1
+
+  # When dry option is specified - `dry:1`, the lane is executed in test/safe mode
+  # that won't cause pod_push action to fire.
   dry = options[:dry] == 1
 
   ["StreamChat.podspec", "StreamChatUI.podspec"].each do |podspec|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -185,22 +185,33 @@ end
 
 desc "Pushes the StreamChat and StreamChatUI SDK podspecs to Cocoapods trunk"
 lane :push_pods do |options|
-  # First pod release will not have any problems
-  pod_push(path: "StreamChat.podspec", allow_warnings: true)
 
-  def release_ui(sync)
+  def release_pod(sync:, podspec:, dry:)
     begin
-      pod_push(path: "StreamChatUI.podspec", allow_warnings: true, synchronous: sync)
-    rescue
-      puts "pod_push failed. Waiting a minute until retry for trunk to get updated..."
+      UI.message "Starting to push podspec: #{podspec}"
+
+      if dry == false
+        pod_push(path: podspec, allow_warnings: true, synchronous: sync)
+      end
+    rescue => exception
+      UI.message exception
+      UI.message "pod_push failed for #{podspec}. Waiting a minute until retry for trunk to get updated..."
       sleep(60) # sleep for a minute, wait until trunk gets updates
-      release_ui(sync)
+      release_pod(sync: sync, podspec: podspec, dry: dry)
     end
   end
 
-  puts "Sleeping for 2 minutes for trunk to get updated..."
-  sleep(60 * 2)
-  release_ui(options[:sync])
+  sync = options[:sync]
+  dry = options[:dry] == 1
+
+  ["StreamChat.podspec", "StreamChatUI.podspec"].each do |podspec|
+    release_pod(sync: sync, podspec: podspec, dry: dry)
+  end
+
+  ["StreamChat-XCFramework.podspec", "StreamChatUI-XCFramework.podspec"].each do |podspec|
+    release_pod(sync: sync, podspec: podspec, dry: dry)
+  end
+
 end
 
 lane :set_SDK_version do |options|


### PR DESCRIPTION
### 🎯 Goal

Update lane to push all specs

### 🛠 Implementation

The new recursive function now includes the possibility to pass in `sync`, `podspec` and `dry` parameter.
The `push_pods` lane that wraps logic around pod trunk pushing all the specs now accetps `sync` and `dry` parameter.

If `dry` parameter is specified you can test the lane without firing the `pod trunk push` logic.

```
bundle exec fastlane push_pods sync:0 dry:1
```

### 🎨 Changes

`push_pods` now pushes all current podspecs - OSS + XCFramework counterparts.

### 🧪 Testing

Verify that running the below lane prints out all 4 podspecs without running the actual push.

`NOTE`:
Don't run the `bundle exec fastlane push_pods sync:0` without `dry:1` parameter specified.

```
bundle exec fastlane push_pods sync:0 dry:1
```

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
