### PR TITLE
[CIS-1431] Make only necessary API calls in threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix multiple pagination requests being fired from `ChatChannelVC` and `ChatChannelListVC` [#1706](https://github.com/GetStream/stream-chat-swift/issues/1706)
 - Fix rendering unavailable reactions on `ChatMessageReactionAuthorsVC` [#1719](https://github.com/GetStream/stream-chat-swift/issues/1719)
+- Fix unncessary API calls performed when loading threads [#1716](https://github.com/GetStream/stream-chat-swift/issues/1716)
 
 # [4.6.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.6.0)
 _December 20, 2021_

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -50,7 +50,7 @@ open class ChatThreadVC:
 
     public var messageComposerBottomConstraint: NSLayoutConstraint?
 
-    @Atomic private var loadingPreviousMessages: Bool = false
+    private var isLoadingPreviousMessages: Bool = false
 
     override open func setUp() {
         super.setUp()
@@ -66,20 +66,25 @@ open class ChatThreadVC:
         }
 
         messageController.delegate = self
-        let updateMessageControllerMessage: () -> Void = { [messageController, messageComposerVC] in
+
+        let completeSetup: (ChatMessage?) -> Void = { [messageController, messageComposerVC] message in
             if messageComposerVC.content.threadMessage == nil,
                let message = messageController?.message {
                 messageComposerVC.content.threadMessage = message
             }
-        }
-        channelController.synchronize { [messageController] _ in
-            messageController?.synchronize { _ in
-                updateMessageControllerMessage()
-                messageController?.loadPreviousReplies()
+            if let message = message, message.replyCount > 0 {
+                self.loadPreviousMessages()
             }
         }
 
-        userSuggestionSearchController.search(term: nil)
+        if let message = messageController.message {
+            completeSetup(message)
+            return
+        }
+
+        messageController.synchronize { [weak self] _ in
+            completeSetup(self?.messageController.message)
+        }
     }
 
     override open func setUpLayout() {
@@ -180,6 +185,17 @@ open class ChatThreadVC:
         return layoutOptions
     }
 
+    open func loadPreviousMessages() {
+        guard !isLoadingPreviousMessages else {
+            return
+        }
+        isLoadingPreviousMessages = true
+
+        messageController.loadPreviousReplies { [weak self] _ in
+            self?.isLoadingPreviousMessages = false
+        }
+    }
+
     // MARK: - ChatMessageListVCDelegate
 
     open func chatMessageListVC(
@@ -193,15 +209,8 @@ open class ChatThreadVC:
         if indexPath.row < replies.count - 10 {
             return
         }
-
-        if _loadingPreviousMessages.compareAndSwap(old: false, new: true) {
-            messageController.loadPreviousReplies(completion: { [weak self] _ in
-                guard let self = self else {
-                    return
-                }
-                self.loadingPreviousMessages = false
-            })
-        }
+        
+        loadPreviousMessages()
     }
 
     open func chatMessageListVC(

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -67,7 +67,7 @@ open class ChatThreadVC:
 
         messageController.delegate = self
 
-        let completeSetup: (ChatMessage?) -> Void = { [messageController, messageComposerVC] message in
+        let completeSetUp: (ChatMessage?) -> Void = { [messageController, messageComposerVC] message in
             if messageComposerVC.content.threadMessage == nil,
                let message = messageController?.message {
                 messageComposerVC.content.threadMessage = message
@@ -78,12 +78,12 @@ open class ChatThreadVC:
         }
 
         if let message = messageController.message {
-            completeSetup(message)
+            completeSetUp(message)
             return
         }
 
         messageController.synchronize { [weak self] _ in
-            completeSetup(self?.messageController.message)
+            completeSetUp(self?.messageController.message)
         }
     }
 

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -72,7 +72,9 @@ open class ChatThreadVC:
                let message = messageController?.message {
                 messageComposerVC.content.threadMessage = message
             }
-            if let message = message, message.replyCount > 0 {
+            // We only need to load the replies
+            // when we don't already have all the replies
+            if let message = message, message.latestReplies.count != message.replyCount {
                 self.loadPreviousMessages()
             }
         }


### PR DESCRIPTION
When you load a thread we perform 4 API calls:

- getMessage by ID (for the parent message)
- getReplies
- userSearch
- queryChannel

There are a number of issues here that this PR resolves:

- The getReplies is called even when the parent messages has `reply_count` == 0
- The userSearch call is call for no good reason (probably a leftover from previous version)
- The queryChannel API call comes from calling `channelController.synchronize` that seems to be also not necessary 
- In most cases `ChatThreadVC` already gets a `ChatMessage` 

End result (based on demo app):

- 0 API calls when you open a thread for the first time
- 1 API call when you open a thread that has > 0 replies