### PR TITLE
Fix Release creation/automation issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@ all_artifacts:
 	echo "🏁 Finished creating dynamic libraries at $$(date +%T)"
 	make static_libraries
 	echo "🏁 Finished creating static libraries at $$(date +%T)"
-	make clean
-	make swiftpm_checksum
 	open ./Products
 	echo "🏁 Ended at $$(date +%T)"
 
@@ -18,15 +16,19 @@ frameworks: clean
 	echo "👉 Creating dynamic libraries. Will take a while... Logs available: DerivedData/fastlane.log"
 	bundle exec fastlane build_xcframeworks > DerivedData/fastlane.log
 	echo "👉 Creating compressed archives"
+	cp ./LICENSE ./Products/LICENSE
 	make zip_artifacts name="StreamChat-All" pattern=./*.xcframework
-	make zip_artifacts name="StreamChat" pattern=./StreamChat.xcframework
-	make zip_artifacts name="StreamChatUI" pattern=./StreamChatUI.xcframework
+	make zip_artifacts name="StreamChat" pattern="./StreamChat.xcframework ./LICENSE"
+	make zip_artifacts name="StreamChatUI" pattern="./StreamChatUI.xcframework ./LICENSE"
+	make swiftpm_checksum
+	make clean
 
 static_libraries: clean
 	echo "👉 Creating static libraries"
 	./Scripts/buildStaticLibraries.sh
 	echo "👉 Creating compressed archive"
 	make zip_artifacts name="StreamChat-All-Static" pattern='./*.xcframework ./*.bundle'
+	make clean
 
 clean:
 	echo "♻️  Cleaning ./Products & ./DerivedData"
@@ -36,6 +38,7 @@ clean:
 	rm -rf Products/*.bundle
 	rm -rf Products/*.BCSymbolMaps
 	rm -rf Products/*.dSYMs
+	rm Products/LICENSE
 
 zip_artifacts:
 	@if [ "$(name)" = "" ]; then\

--- a/StreamChat-XCFramework.podspec
+++ b/StreamChat-XCFramework.podspec
@@ -11,7 +11,6 @@ Pod::Spec.new do |spec|
 
   spec.swift_version = "5.5"
   spec.ios.deployment_target  = '11.0'
-  spec.osx.deployment_target  = '10.15'
   spec.requires_arc = true
 
   spec.framework = "Foundation"

--- a/docusaurus/docs/iOS/basics/integration.md
+++ b/docusaurus/docs/iOS/basics/integration.md
@@ -127,6 +127,11 @@ In your project's `Cartfile`, add one of these options
 Our SwiftUI components library is not yet available using Carthage, please use Swift Package Manager or CocoaPods.
 :::
 
+Now that we’ve modified our Cartfile, let’s go ahead and install the project dependencies via the terminal with one simple command:
+
+```bash
+carthage update --use-xcframeworks --no-use-binaries --platform iOS
+```
 
 <details><summary>➤ Do you want to use <b>XCFrameworks</b>? (Click to read more)</summary>
 <p>
@@ -142,14 +147,14 @@ You can learn more about [our Module Stable XCFrameworks here](#xcframeworks)
 - For the UIKit components (**StreamChatUI**, which depends on **StreamChat**) use:
   - `binary "https://raw.githubusercontent.com/GetStream/stream-chat-swift/main/StreamChatArtifacts.json" ~> 4.6`
 
-</p>
-</details>
-
 Now that we’ve modified our Cartfile, let’s go ahead and install the project dependencies via the terminal with one simple command:
 
 ```bash
 carthage update --use-xcframeworks
 ```
+
+</p>
+</details>
 
 This command will create pre-built XCFrameworks built from our source code. You now need to add those to your project.
 

--- a/docusaurus/docs/iOS/basics/integration.md
+++ b/docusaurus/docs/iOS/basics/integration.md
@@ -116,24 +116,13 @@ _More information about CocoaPods [can be found here](https://cocoapods.org/)._
 
 ### Carthage
 
-In your project's `Cartfile`, add one of these options
-
-- For the LLC (**StreamChat**) use:
-  - `github "getstream/stream-chat-swift" ~> 4.6.0`
-- For the UIKit components (**StreamChatUI**, which depends on **StreamChat**) use:
-  - `github "getstream/stream-chat-swift" ~> 4.6.0`
+If you are using **Swift 5.5 / Xcode 13** or above, the recommended method for Carthage is to use **pre-built XCFrameworks**.
 
 :::note
 Our SwiftUI components library is not yet available using Carthage, please use Swift Package Manager or CocoaPods.
 :::
 
-Now that we’ve modified our Cartfile, let’s go ahead and install the project dependencies via the terminal with one simple command:
-
-```bash
-carthage update --use-xcframeworks --no-use-binaries --platform iOS
-```
-
-<details><summary>➤ Do you want to use <b>XCFrameworks</b>? (Click to read more)</summary>
+<details><summary>➤ Using pre-built <b>XCFrameworks</b></summary>
 <p>
 
 :::caution
@@ -153,10 +142,31 @@ Now that we’ve modified our Cartfile, let’s go ahead and install the project
 carthage update --use-xcframeworks
 ```
 
+The previous command will download pre-built XCFrameworks. You now need to add those to your project. Keep reading.
+
 </p>
 </details>
 
-This command will create pre-built XCFrameworks built from our source code. You now need to add those to your project.
+<details><summary>➤ Building from source <b>(OSS)</b></summary>
+<p>
+
+In your project's `Cartfile`, add one of these options
+
+- For the LLC (**StreamChat**) use:
+  - `github "getstream/stream-chat-swift" ~> 4.6.0`
+- For the UIKit components (**StreamChatUI**, which depends on **StreamChat**) use:
+  - `github "getstream/stream-chat-swift" ~> 4.6.0`
+
+Now that we’ve modified our Cartfile, let’s go ahead and install the project dependencies via the terminal with one simple command:
+
+```bash
+carthage update --use-xcframeworks --no-use-binaries --platform iOS
+```
+
+The previous command will create pre-built XCFrameworks built from our source code (This might take a while ⏱). You now need to add those to your project. Keep reading.
+
+</p>
+</details>
 
 Open the `Carthage/Build` folder that has been created in the root of your project, and drag and drop the frameworks you want to use. Those should be added to the "Frameworks, Libraries, and Embedded Content" section under General settings:
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -113,22 +113,19 @@ lane :publish_release do |options|
   # Update Frameworks (WIP)
   # update_frameworks
 
+  changes = touch_changelog(release_version: version)
+
   # Create Github Release
   github_release = set_github_release(
                      repository_name: "GetStream/stream-chat-swift",
                      api_token: ENV["GITHUB_TOKEN"],
                      name: version,
                      tag_name: version,
+                     commitish: "main",
                      description: changes
                      # upload_assets: ["Products/StreamChat.zip", "Products/StreamChatUI.zip", "Products/StreamChat-All.zip"]
                    )
   push_pods(sync: options[:sync])
-
-  # Set tag
-  sh("git tag #{version}")
-
-  # Push tag to remote
-  push_to_git_remote(tags: true)
 
   UI.success("Github release was created, please visit #{github_release["url"]} to see it")
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -125,7 +125,8 @@ lane :publish_release do |options|
                      description: changes
                      # upload_assets: ["Products/StreamChat.zip", "Products/StreamChatUI.zip", "Products/StreamChat-All.zip"]
                    )
-  push_pods(sync: options[:sync])
+  # Firing this lane is done manually at the moment.
+  #push_pods(sync: options[:sync])
 
   UI.success("Github release was created, please visit #{github_release["url"]} to see it")
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -209,14 +209,13 @@ lane :push_pods do |options|
   # that won't cause pod_push action to fire.
   dry = options[:dry] == 1
 
-  ["StreamChat.podspec", "StreamChatUI.podspec"].each do |podspec|
+  ["StreamChat.podspec", "StreamChat-XCFramework.podspec"].each do |podspec|
     release_pod(sync: sync, podspec: podspec, dry: dry)
   end
 
-  ["StreamChat-XCFramework.podspec", "StreamChatUI-XCFramework.podspec"].each do |podspec|
+  ["StreamChatUI.podspec", "StreamChatUI-XCFramework.podspec"].each do |podspec|
     release_pod(sync: sync, podspec: podspec, dry: dry)
   end
-
 end
 
 lane :set_SDK_version do |options|


### PR DESCRIPTION
### 🔗 Issue Link
None

### 🎯 Goal

While I was doing the release for 4.6.0, I spotted some deficiencies in our automated processes. This PR intends to fix those

### 🎨 Changes

- Make sure LICENSE is present in the zipped artifacts for CocoaPods not to complain
- Update Carthage OSS integration documentation to require --no-use-binaries
- Fix release's changelog and target branch
- Remove redundant tag creation executions in Fastfile's publish_release
- Improve order of podspecs publishing to avoid waiting too long
- Remove macOS references in StreamChat-XCFramework for CocoaPods not to fail because of missing macOS slice in the binary. This will be addressed in https://stream-io.atlassian.net/browse/CIS-1433
- Outline XCFrameworks as preferred integration method for Carthage

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
