### PR TITLE
[CIS-1446] Add `ChannelListQuery.membersLimit` param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- `ChannelListQuery.membersLimit` param for controlling the number of members returned for each channel [#1721](https://github.com/GetStream/stream-chat-swift/issues/1721)
+
 ### 🐞 Fixed
 - Fix multiple pagination requests being fired from `ChatChannelVC` and `ChatChannelListVC` [#1706](https://github.com/GetStream/stream-chat-swift/issues/1706)
 - Fix rendering unavailable reactions on `ChatMessageReactionAuthorsVC` [#1719](https://github.com/GetStream/stream-chat-swift/issues/1719)

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -91,6 +91,7 @@ public struct ChannelListQuery: Encodable {
         case presence
         case pagination
         case messagesLimit = "message_limit"
+        case membersLimit = "member_limit"
     }
     
     /// A filter for the query (see `Filter`).
@@ -101,6 +102,8 @@ public struct ChannelListQuery: Encodable {
     public var pagination: Pagination
     /// A number of messages inside each channel.
     public let messagesLimit: Int
+    /// Number of members inside each channel.
+    public let membersLimit: Int
     /// Query options.
     public var options: QueryOptions = [.watch]
     
@@ -114,12 +117,14 @@ public struct ChannelListQuery: Encodable {
         filter: Filter<ChannelListFilterScope>,
         sort: [Sorting<ChannelListSortingKey>] = [],
         pageSize: Int = .channelsPageSize,
-        messagesLimit: Int = .messagesPageSize
+        messagesLimit: Int = .messagesPageSize,
+        membersLimit: Int = .channelMembersPageSize
     ) {
         self.filter = filter
         self.sort = sort.appendingCidSortingKey()
         pagination = Pagination(pageSize: pageSize)
         self.messagesLimit = messagesLimit
+        self.membersLimit = membersLimit
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -131,6 +136,7 @@ public struct ChannelListQuery: Encodable {
         }
         
         try container.encode(messagesLimit, forKey: .messagesLimit)
+        try container.encode(membersLimit, forKey: .membersLimit)
         try options.encode(to: encoder)
         try pagination.encode(to: encoder)
     }

--- a/Sources/StreamChat/Query/ChannelListQuery_Tests.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery_Tests.swift
@@ -79,3 +79,39 @@ final class ChannelListFilterScope_Tests: XCTestCase {
         }
     }
 }
+
+final class ChannelListQuery_Tests: XCTestCase {
+    func test_channelListQuery_encodedCorrectly() throws {
+        let cid = ChannelId.unique
+        let filter = Filter<ChannelListFilterScope>.equal(.cid, to: cid)
+        let sort = Sorting<ChannelListSortingKey>.init(key: .cid)
+        let pageSize = Int.channelsPageSize
+        let messagesLimit = Int.messagesPageSize
+        let membersLimit = Int.channelMembersPageSize
+        
+        // Create ChannelListQuery
+        var query = ChannelListQuery(
+            filter: filter,
+            sort: [sort],
+            pageSize: pageSize,
+            messagesLimit: messagesLimit,
+            membersLimit: membersLimit
+        )
+        query.options = .watch
+        
+        let expectedData: [String: Any] = [
+            "limit": pageSize,
+            "message_limit": messagesLimit,
+            "member_limit": membersLimit,
+            "sort": [["field": "cid", "direction": -1]],
+            "filter_conditions": ["cid": ["$eq": cid.rawValue]],
+            "watch": true
+        ]
+        
+        let expectedJSON = try JSONSerialization.data(withJSONObject: expectedData, options: [])
+        let encodedJSON = try JSONEncoder.default.encode(query)
+        
+        // Assert ChannelListQuery encoded correctly
+        AssertJSONEqual(expectedJSON, encodedJSON)
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1446

### 🎯 Goal

`member_limit` was added to API some time ago but iOS SDK didn't include it.

### 🧪 Testing

Enable logs in DemoApp and use this controller:
```swift
// Channels with the current user
        let controller = ChatClient.shared
            .channelListController(query: .init(filter: .containMembers(userIds: [userCredentials.id]), messagesLimit: 0, membersLimit: 0))
```
you'll see that no messages or channels are returned.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
