### PR TITLE
[CIS-1444] Support passing the extra data along with the message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - `ChannelListQuery.membersLimit` param for controlling the number of members returned for each channel [#1721](https://github.com/GetStream/stream-chat-swift/issues/1721)
+- Adds support to pass extra data for message from `ComposerVC` [#1722](https://github.com/GetStream/stream-chat-swift/pull/1722)
 
 ### 🐞 Fixed
 - Fix multiple pagination requests being fired from `ChatChannelVC` and `ChatChannelListVC` [#1706](https://github.com/GetStream/stream-chat-swift/issues/1706)

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
@@ -7,6 +7,7 @@ import Foundation
 /// Coding keys for message-related JSON payloads
 enum MessagePayloadsCodingKeys: String, CodingKey, CaseIterable {
     case id
+    case cid
     case type
     case user
     case createdAt = "created_at"

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -194,11 +194,12 @@ public extension ChatMessageController {
     ///
     /// - Parameters:
     ///   - text: The updated message text.
+    ///   - extraData: Custom extra data. When `nil` is passed the message custom fields stay the same. Equals `nil` by default.
     ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
     ///                 If request fails, the completion will be called with an error.
     ///
-    func editMessage(text: String, completion: ((Error?) -> Void)? = nil) {
-        messageUpdater.editMessage(messageId: messageId, text: text) { error in
+    func editMessage(text: String, extraData: [String: RawJSON]? = nil, completion: ((Error?) -> Void)? = nil) {
+        messageUpdater.editMessage(messageId: messageId, text: text, extraData: extraData) { error in
             self.callback {
                 completion?(error)
             }

--- a/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController_Tests.swift
@@ -802,6 +802,18 @@ final class MessageController_Tests: XCTestCase {
         XCTAssertEqual(env.messageUpdater.editMessage_messageId, controller.messageId)
         XCTAssertEqual(env.messageUpdater.editMessage_text, updatedText)
     }
+
+    func test_editMessage_callsMessageUpdater_withCorrectExtraDataValues() {
+        let updatedText: String = .unique
+        let extraData: [String: RawJSON] = ["myKey": .string("myValue")]
+
+        // Simulate `editMessage` call and catch the completion
+        controller.editMessage(text: updatedText, extraData: extraData)
+
+        // Assert message updater is called with correct `messageId` and `text`
+        XCTAssertEqual(env.messageUpdater.editMessage_text, updatedText)
+        XCTAssertEqual(env.messageUpdater.editMessage_extraData, extraData)
+    }
     
     // MARK: - Flag message
     

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -87,10 +87,18 @@ class MessageUpdater: Worker {
     ///  - Parameters:
     ///   - messageId: The message identifier.
     ///   - text: The updated message text.
+    ///   - extraData: Extra Data for the message.
     ///   - completion: The completion. Will be called with an error if smth goes wrong, otherwise - will be called with `nil`.
-    func editMessage(messageId: MessageId, text: String, completion: ((Error?) -> Void)? = nil) {
+    func editMessage(
+        messageId: MessageId,
+        text: String,
+        extraData: [String: RawJSON]? = nil,
+        completion: ((Error?) -> Void)? = nil
+    ) {
         database.write({ session in
             let messageDTO = try session.messageEditableByCurrentUser(messageId)
+            
+            let encodedExtraData = extraData.map { try? JSONEncoder.default.encode($0) } ?? messageDTO.extraData
 
             let updateQuotingMessages = {
                 messageDTO.quotedBy.forEach { message in
@@ -101,10 +109,12 @@ class MessageUpdater: Worker {
             switch messageDTO.localMessageState {
             case nil, .pendingSync, .syncingFailed, .deletingFailed:
                 messageDTO.text = text
+                messageDTO.extraData = encodedExtraData
                 messageDTO.localMessageState = .pendingSync
                 updateQuotingMessages()
             case .pendingSend, .sendingFailed:
                 messageDTO.text = text
+                messageDTO.extraData = encodedExtraData
                 messageDTO.localMessageState = .pendingSend
                 updateQuotingMessages()
             case .sending, .syncing, .deleting:

--- a/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -17,6 +17,7 @@ final class MessageUpdaterMock: MessageUpdater {
     @Atomic var editMessage_messageId: MessageId?
     @Atomic var editMessage_text: String?
     @Atomic var editMessage_completion: ((Error?) -> Void)?
+    @Atomic var editMessage_extraData: [String: RawJSON]?
     
     @Atomic var createNewReply_cid: ChannelId?
     @Atomic var createNewReply_text: String?
@@ -157,10 +158,14 @@ final class MessageUpdaterMock: MessageUpdater {
         deleteMessage_messageId = messageId
         deleteMessage_completion = completion
     }
-    
-    override func editMessage(messageId: MessageId, text: String, completion: ((Error?) -> Void)? = nil) {
+
+    override func editMessage(messageId: MessageId,
+                              text: String,
+                              extraData: [String : RawJSON]? = nil,
+                              completion: ((Error?) -> Void)? = nil) {
         editMessage_messageId = messageId
         editMessage_text = text
+        editMessage_extraData = extraData
         editMessage_completion = completion
     }
 

--- a/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -159,10 +159,12 @@ final class MessageUpdaterMock: MessageUpdater {
         deleteMessage_completion = completion
     }
 
-    override func editMessage(messageId: MessageId,
-                              text: String,
-                              extraData: [String : RawJSON]? = nil,
-                              completion: ((Error?) -> Void)? = nil) {
+    override func editMessage(
+        messageId: MessageId,
+        text: String,
+        extraData: [String: RawJSON]? = nil,
+        completion: ((Error?) -> Void)? = nil
+    ) {
         editMessage_messageId = messageId
         editMessage_text = text
         editMessage_extraData = extraData

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -141,7 +141,10 @@ final class MessageUpdater_Tests: XCTestCase {
             
             // Load the message
             let message = try XCTUnwrap(database.viewContext.message(id: messageId))
-            let extraData = try XCTUnwrap(message.extraData.map { try? JSONDecoder.default.decode([String:RawJSON].self, from: $0)} )
+            let extraData = try XCTUnwrap(
+                message.extraData
+                    .map { try? JSONDecoder.default.decode([String: RawJSON].self, from: $0) }
+            )
             
             // Assert `MessageEditing` error is received
             XCTAssertTrue(completionError is ClientError.MessageEditing)
@@ -158,8 +161,8 @@ final class MessageUpdater_Tests: XCTestCase {
         let currentUserId: UserId = .unique
         let messageId: MessageId = .unique
         let updatedText: String = .unique
-        let extraData: [String: RawJSON] = ["custom" : .number(0)]
-        let updatedExtraData: [String: RawJSON] = ["custom" : .number(1)]
+        let extraData: [String: RawJSON] = ["custom": .number(0)]
+        let updatedExtraData: [String: RawJSON] = ["custom": .number(1)]
 
         // Create current user is the database
         try database.createCurrentUser(id: currentUserId)
@@ -168,7 +171,10 @@ final class MessageUpdater_Tests: XCTestCase {
         try database.createMessage(id: messageId, authorId: currentUserId, extraData: extraData)
         let createdMessage = try XCTUnwrap(database.viewContext.message(id: messageId))
 
-        let encodedCreatedExtraData = try XCTUnwrap(createdMessage.extraData.map { try? JSONDecoder.default.decode([String:RawJSON].self, from: $0)} )
+        let encodedCreatedExtraData = try XCTUnwrap(
+            createdMessage.extraData
+                .map { try? JSONDecoder.default.decode([String: RawJSON].self, from: $0) }
+        )
         // Assert message's extra data is updated
         XCTAssertEqual(encodedCreatedExtraData, extraData)
 
@@ -179,7 +185,10 @@ final class MessageUpdater_Tests: XCTestCase {
 
         // Load the message
         let message = try XCTUnwrap(database.viewContext.message(id: messageId))
-        let encodedExtraData = try XCTUnwrap(message.extraData.map { try? JSONDecoder.default.decode([String:RawJSON].self, from: $0)} )
+        let encodedExtraData = try XCTUnwrap(
+            message.extraData
+                .map { try? JSONDecoder.default.decode([String: RawJSON].self, from: $0) }
+        )
 
         // Assert completion is called without any error
         XCTAssertNil(completionError)
@@ -191,7 +200,7 @@ final class MessageUpdater_Tests: XCTestCase {
         let currentUserId: UserId = .unique
         let messageId: MessageId = .unique
         let updatedText: String = .unique
-        let extraData: [String: RawJSON] = ["custom" : .number(0)]
+        let extraData: [String: RawJSON] = ["custom": .number(0)]
 
         // Create current user is the database
         try database.createCurrentUser(id: currentUserId)
@@ -200,7 +209,10 @@ final class MessageUpdater_Tests: XCTestCase {
         try database.createMessage(id: messageId, authorId: currentUserId, extraData: extraData)
         let createdMessage = try XCTUnwrap(database.viewContext.message(id: messageId))
 
-        let encodedCreatedExtraData = try XCTUnwrap(createdMessage.extraData.map { try? JSONDecoder.default.decode([String:RawJSON].self, from: $0)} )
+        let encodedCreatedExtraData = try XCTUnwrap(
+            createdMessage.extraData
+                .map { try? JSONDecoder.default.decode([String: RawJSON].self, from: $0) }
+        )
         // Assert message's extra data is updated
         XCTAssertEqual(encodedCreatedExtraData, extraData)
 
@@ -211,7 +223,10 @@ final class MessageUpdater_Tests: XCTestCase {
 
         // Load the message
         let message = try XCTUnwrap(database.viewContext.message(id: messageId))
-        let encodedExtraData = try XCTUnwrap(message.extraData.map { try? JSONDecoder.default.decode([String:RawJSON].self, from: $0)} )
+        let encodedExtraData = try XCTUnwrap(
+            message.extraData
+                .map { try? JSONDecoder.default.decode([String: RawJSON].self, from: $0) }
+        )
 
         // Assert completion is called without any error
         XCTAssertNil(completionError)
@@ -254,7 +269,7 @@ final class MessageUpdater_Tests: XCTestCase {
         // Simulate API response with success
         let testError = TestError()
         apiClient.test_simulateResponse(Result<EmptyResponse, Error>.failure(testError))
-                
+
         // Assert completion is called without any error
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
     }
@@ -295,7 +310,7 @@ final class MessageUpdater_Tests: XCTestCase {
         
         // Simulate API response with success
         apiClient.test_simulateResponse(Result<EmptyResponse, Error>.success(.init()))
-                
+
         // Assert database error is propogated
         AssertAsync.willBeEqual(completionCalledError as? TestError, databaseError)
     }
@@ -310,7 +325,7 @@ final class MessageUpdater_Tests: XCTestCase {
             
             // Create current user in the database
             try database.createCurrentUser(id: currentUserId)
-                   
+
             // Create a new message in the database
             try database.createMessage(id: messageId, authorId: currentUserId, localState: state)
 
@@ -375,7 +390,7 @@ final class MessageUpdater_Tests: XCTestCase {
         
         // Simulate `getMessage(cid:, messageId:)` call
         messageUpdater.getMessage(cid: cid, messageId: messageId)
-                
+
         // Assert correct endpoint is called
         let expectedEndpoint: Endpoint<MessagePayload.Boxed> = .getMessage(messageId: messageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
@@ -391,7 +406,7 @@ final class MessageUpdater_Tests: XCTestCase {
         // Simulate API response with failure
         let error = TestError()
         apiClient.test_simulateResponse(Result<MessagePayload.Boxed, Error>.failure(error))
-                
+
         // Assert the completion is called with the error
         AssertAsync.willBeEqual(completionCalledError as? TestError, error)
     }
@@ -417,7 +432,7 @@ final class MessageUpdater_Tests: XCTestCase {
         
         // Simulate API response with success
         apiClient.test_simulateResponse(Result<MessagePayload.Boxed, Error>.success(messagePayload))
-                
+
         // Assert database error is propogated
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
     }

--- a/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater_Tests.swift
@@ -141,6 +141,7 @@ final class MessageUpdater_Tests: XCTestCase {
             
             // Load the message
             let message = try XCTUnwrap(database.viewContext.message(id: messageId))
+            let extraData = try XCTUnwrap(message.extraData.map { try? JSONDecoder.default.decode([String:RawJSON].self, from: $0)} )
             
             // Assert `MessageEditing` error is received
             XCTAssertTrue(completionError is ClientError.MessageEditing)
@@ -148,7 +149,74 @@ final class MessageUpdater_Tests: XCTestCase {
             XCTAssertEqual(message.localMessageState, state)
             // Assert message's text stays the same
             XCTAssertEqual(message.text, initialText)
+            // Assert message's extra data stays the same
+            XCTAssertEqual(extraData, [:])
         }
+    }
+
+    func test_editMessage_updatesLocalMessageCorrectlyWithExtraData() throws {
+        let currentUserId: UserId = .unique
+        let messageId: MessageId = .unique
+        let updatedText: String = .unique
+        let extraData: [String: RawJSON] = ["custom" : .number(0)]
+        let updatedExtraData: [String: RawJSON] = ["custom" : .number(1)]
+
+        // Create current user is the database
+        try database.createCurrentUser(id: currentUserId)
+
+        // Create a new message in the database
+        try database.createMessage(id: messageId, authorId: currentUserId, extraData: extraData)
+        let createdMessage = try XCTUnwrap(database.viewContext.message(id: messageId))
+
+        let encodedCreatedExtraData = try XCTUnwrap(createdMessage.extraData.map { try? JSONDecoder.default.decode([String:RawJSON].self, from: $0)} )
+        // Assert message's extra data is updated
+        XCTAssertEqual(encodedCreatedExtraData, extraData)
+
+        // Edit created message with new text
+        let completionError = try waitFor {
+            messageUpdater.editMessage(messageId: messageId, text: updatedText, extraData: updatedExtraData, completion: $0)
+        }
+
+        // Load the message
+        let message = try XCTUnwrap(database.viewContext.message(id: messageId))
+        let encodedExtraData = try XCTUnwrap(message.extraData.map { try? JSONDecoder.default.decode([String:RawJSON].self, from: $0)} )
+
+        // Assert completion is called without any error
+        XCTAssertNil(completionError)
+        // Assert message's extra data is updated
+        XCTAssertEqual(encodedExtraData, updatedExtraData)
+    }
+
+    func test_editMessage_doesntUpdatesLocalMessageIfExtraDataAreNil() throws {
+        let currentUserId: UserId = .unique
+        let messageId: MessageId = .unique
+        let updatedText: String = .unique
+        let extraData: [String: RawJSON] = ["custom" : .number(0)]
+
+        // Create current user is the database
+        try database.createCurrentUser(id: currentUserId)
+
+        // Create a new message in the database
+        try database.createMessage(id: messageId, authorId: currentUserId, extraData: extraData)
+        let createdMessage = try XCTUnwrap(database.viewContext.message(id: messageId))
+
+        let encodedCreatedExtraData = try XCTUnwrap(createdMessage.extraData.map { try? JSONDecoder.default.decode([String:RawJSON].self, from: $0)} )
+        // Assert message's extra data is updated
+        XCTAssertEqual(encodedCreatedExtraData, extraData)
+
+        // Edit created message with new text
+        let completionError = try waitFor {
+            messageUpdater.editMessage(messageId: messageId, text: updatedText, extraData: nil, completion: $0)
+        }
+
+        // Load the message
+        let message = try XCTUnwrap(database.viewContext.message(id: messageId))
+        let encodedExtraData = try XCTUnwrap(message.extraData.map { try? JSONDecoder.default.decode([String:RawJSON].self, from: $0)} )
+
+        // Assert completion is called without any error
+        XCTAssertNil(completionError)
+        // Assert message's extra data is updated
+        XCTAssertEqual(encodedExtraData, extraData)
     }
     
     // MARK: Delete message

--- a/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
@@ -209,7 +209,7 @@ extension DatabaseContainer {
         authorId: UserId = .unique,
         cid: ChannelId = .unique,
         text: String = .unique,
-        extraData: [String : RawJSON] = [:],
+        extraData: [String: RawJSON] = [:],
         pinned: Bool = false,
         pinnedByUserId: UserId? = nil,
         pinnedAt: Date? = nil,

--- a/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
@@ -209,6 +209,7 @@ extension DatabaseContainer {
         authorId: UserId = .unique,
         cid: ChannelId = .unique,
         text: String = .unique,
+        extraData: [String : RawJSON] = [:],
         pinned: Bool = false,
         pinnedByUserId: UserId? = nil,
         pinnedAt: Date? = nil,
@@ -234,6 +235,7 @@ extension DatabaseContainer {
                 attachments: attachments,
                 authorUserId: authorId,
                 text: text,
+                extraData: extraData,
                 latestReactions: latestReactions,
                 ownReactions: ownReactions,
                 updatedAt: updatedAt,
@@ -256,7 +258,8 @@ extension DatabaseContainer {
                     messageId: .unique,
                     parentId: id,
                     authorUserId: authorId,
-                    text: "Reply \(idx)"
+                    text: "Reply \(idx)",
+                    extraData: extraData
                 )
                 
                 let replyDTO = try session.saveMessage(payload: reply, for: cid, syncOwnReactions: true)!

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -240,7 +240,8 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
                 cellBeforeUpdateMessage?.type == cellAfterUpdateMessage?.type,
                 cellBeforeUpdateMessage?.deletedAt == cellAfterUpdateMessage?.deletedAt,
                 cellBeforeUpdateMessage?.text == cellAfterUpdateMessage?.text,
-                cellBeforeUpdateMessage?.quotedMessage?.text == cellAfterUpdateMessage?.quotedMessage?.text {
+                cellBeforeUpdateMessage?.quotedMessage?.text == cellAfterUpdateMessage?.quotedMessage?.text,
+                cellBeforeUpdateMessage?.extraData == cellAfterUpdateMessage?.extraData {
                 // If identifiers and messages match we can simply update the current cell with new content
                 cellBeforeUpdate?.messageContentView?.content = cellAfterUpdateMessage
             } else {

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -56,6 +56,8 @@ open class ComposerVC: _ViewController,
         public var mentionedUsers: Set<ChatUser>
         /// The command of the message.
         public let command: Command?
+        /// The extra data assigned to message.
+        public var extraData: [String: RawJSON]
 
         /// A boolean that checks if the message contains any content.
         public var isEmpty: Bool {
@@ -75,7 +77,8 @@ open class ComposerVC: _ViewController,
             threadMessage: ChatMessage?,
             attachments: [AnyAttachmentPayload],
             mentionedUsers: Set<ChatUser>,
-            command: Command?
+            command: Command?,
+            extraData: [String: RawJSON] = [:]
         ) {
             self.text = text
             self.state = state
@@ -85,6 +88,7 @@ open class ComposerVC: _ViewController,
             self.attachments = attachments
             self.mentionedUsers = mentionedUsers
             self.command = command
+            self.extraData = extraData
         }
 
         /// Creates a new content struct with all empty data.
@@ -97,7 +101,8 @@ open class ComposerVC: _ViewController,
                 threadMessage: nil,
                 attachments: [],
                 mentionedUsers: [],
-                command: nil
+                command: nil,
+                extraData: [:]
             )
         }
 
@@ -111,7 +116,8 @@ open class ComposerVC: _ViewController,
                 threadMessage: threadMessage,
                 attachments: [],
                 mentionedUsers: [],
-                command: nil
+                command: nil,
+                extraData: [:]
             )
         }
 
@@ -127,7 +133,8 @@ open class ComposerVC: _ViewController,
                 threadMessage: threadMessage,
                 attachments: attachments,
                 mentionedUsers: message.mentionedUsers,
-                command: command
+                command: command,
+                extraData: message.extraData
             )
         }
 
@@ -143,7 +150,8 @@ open class ComposerVC: _ViewController,
                 threadMessage: threadMessage,
                 attachments: attachments,
                 mentionedUsers: mentionedUsers,
-                command: command
+                command: command,
+                extraData: extraData
             )
         }
 
@@ -156,7 +164,8 @@ open class ComposerVC: _ViewController,
                 threadMessage: threadMessage,
                 attachments: [],
                 mentionedUsers: mentionedUsers,
-                command: command
+                command: command,
+                extraData: extraData
             )
         }
     }
@@ -517,7 +526,8 @@ open class ComposerVC: _ViewController,
                 attachments: content.attachments,
                 mentionedUserIds: content.mentionedUsers.map(\.id),
                 showReplyInChannel: composerView.checkboxControl.isSelected,
-                quotedMessageId: content.quotingMessage?.id
+                quotedMessageId: content.quotingMessage?.id,
+                extraData: content.extraData
             )
             return
         }
@@ -527,7 +537,8 @@ open class ComposerVC: _ViewController,
             pinning: nil,
             attachments: content.attachments,
             mentionedUserIds: content.mentionedUsers.map(\.id),
-            quotedMessageId: content.quotingMessage?.id
+            quotedMessageId: content.quotingMessage?.id,
+            extraData: content.extraData
         )
     }
 
@@ -543,7 +554,7 @@ open class ComposerVC: _ViewController,
         )
         // TODO: Adjust LLC to edit attachments also
         // TODO: Adjust LLC to edit mentions
-        messageController?.editMessage(text: newText)
+        messageController?.editMessage(text: newText, extraData: content.extraData)
     }
 
     /// Returns a potential user mention in case the user is currently typing a username.


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1444

### 🎯 Goal

Support passing `extra data` for messages & replies from `ComposerVC`.

### 🎨 Changes

* `ComposerVC`'s content is now extended with `extraData` field that is passed along down to `MessageUpdater`.
* Contains bugfix for `cid` key appearing in the `extraData` payload.
* TableView properly reloads edited messages when `extraData` changes.

### 🧪 Testing

Subclass `ComposerVC` and try to pass the extra data eg when editing the message.
```
import Foundation
import StreamChat
import UIKit

final class CustomComposerVC: ComposerVC {

    override func editMessage(withId id: MessageId, newText: String) {
        content.extraData["myKey"] = .string("myValue")
        
        super.editMessage(withId: id, newText: newText)
    }
}
```

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
