### PR TITLE
[CIS-1263, CIS-1376] Fix message list jumping when message updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix multiple pagination requests being fired from `ChatChannelVC` and `ChatChannelListVC` [#1706](https://github.com/GetStream/stream-chat-swift/issues/1706)
 - Fix rendering unavailable reactions on `ChatMessageReactionAuthorsVC` [#1719](https://github.com/GetStream/stream-chat-swift/issues/1719)
 - Fix quoted messages not updated after edit [#1703](https://github.com/GetStream/stream-chat-swift/pull/1703)
+- Fix message list jumping when message updated [#1723](https://github.com/GetStream/stream-chat-swift/pull/1723)
 
 # [4.6.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.6.0)
 _December 20, 2021_

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -46,7 +46,6 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
     open func setUp() {
         keyboardDismissMode = .onDrag
         rowHeight = UITableView.automaticDimension
-        estimatedRowHeight = 150
         separatorStyle = .none
         transform = .mirrorY
     }


### PR DESCRIPTION
### 🔗 Issue Link
None

### 🎯 Goal
Fix message list jumping when editing a message.

### 🛠 Implementation
Remove the `estimatedRowHeight` of the table view. 

### 🎨 Changes
| Before | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/12814114/147157888-b3cbfa2c-4f5f-4ee6-9a25-522fe8025689.mp4"/> | <video src="https://user-images.githubusercontent.com/12814114/147157934-d5ab58b2-b718-423a-90d7-15ecfceddc52.mp4"/> |

### 🧪 Testing
Check the videos above :)

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
