### PR TITLE
[CIS-1227] [CIS-1430] Channel.membership correct handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ _January 4, 2022_
 
 ### 🐞 Fixed
 - `notification.channel_deleted` events are now handled by the SDK [#1737](https://github.com/GetStream/stream-chat-swift/pull/1737)
+- `MemberListController` receives new members correctly [#1736](https://github.com/GetStream/stream-chat-swift/issues/1736)
+- `ChatChannel.membership` is correctly reflected in all cases [#1736](https://github.com/GetStream/stream-chat-swift/issues/1736)
 
 # [4.7.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.7.0)
 _December 28, 2021_

--- a/DemoApp/DemoAppCoordinator.swift
+++ b/DemoApp/DemoAppCoordinator.swift
@@ -241,11 +241,11 @@ class DemoChannelListVC: ChatChannelListVC {
     }
 
     override func controller(_ controller: ChatChannelListController, shouldListUpdatedChannel channel: ChatChannel) -> Bool {
-        channel.lastActiveMembers.contains(where: { $0.id == controller.client.currentUserId })
+        channel.membership != nil
     }
 
     override func controller(_ controller: ChatChannelListController, shouldAddNewChannelToList channel: ChatChannel) -> Bool {
-        channel.lastActiveMembers.contains(where: { $0.id == controller.client.currentUserId })
+        channel.membership != nil
     }
 
     var isPad: Bool { UIDevice.current.userInterfaceIdiom == .pad }

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -64,6 +64,7 @@ class ChannelDTO: NSManagedObject {
     @NSManaged var reads: Set<ChannelReadDTO>
     @NSManaged var attachments: Set<AttachmentDTO>
     @NSManaged var watchers: Set<UserDTO>
+    @NSManaged var memberListQueries: Set<ChannelMemberListQueryDTO>
 
     override func willSave() {
         super.willSave()

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware_Tests.swift
@@ -131,11 +131,6 @@ final class MemberEventMiddleware_Tests: XCTestCase {
             try session.saveMember(payload: existingMember, channelId: cid, query: memberListQuery)
         }
         
-        // Load the channel
-        var channel: ChatChannel? {
-            database.viewContext.channel(cid: cid)?.asModel()
-        }
-        
         // Load the MemberListQueryDTO
         var memberListQueryDTO: ChannelMemberListQueryDTO? {
             database.viewContext.channelMemberListQuery(queryHash: memberListQuery.queryHash)
@@ -546,11 +541,6 @@ final class MemberEventMiddleware_Tests: XCTestCase {
         try database.writeSynchronously { session in
             try session.saveChannel(payload: channelPayload)
             try session.saveMember(payload: existingMember, channelId: cid, query: memberListQuery)
-        }
-        
-        // Load the channel
-        var channel: ChatChannel? {
-            database.viewContext.channel(cid: cid)?.asModel()
         }
         
         // Load the MemberListQueryDTO

--- a/Sources/StreamChat/WebSocketClient/Events/MemberEvents_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/MemberEvents_Tests.swift
@@ -158,6 +158,12 @@ class MemberEventsIntegration_Tests: XCTestCase {
         let event = try eventDecoder.decode(from: json) as? MemberAddedEventDTO
         
         let unwrappedEvent = try XCTUnwrap(event)
+        
+        // Add a channel so member will be saved
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: self.dummyPayload(with: unwrappedEvent.cid))
+        }
+        
         client.eventNotificationCenter.process(unwrappedEvent)
         
         AssertAsync {

--- a/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
@@ -171,6 +171,9 @@ public struct NotificationAddedToChannelEvent: ChannelSpecificEvent, HasUnreadCo
     /// The unread counts of the current user.
     public let unreadCount: UnreadCount?
     
+    /// The membership information of the current user.
+    public let member: ChatChannelMember
+    
     /// The event timestamp.
     public let createdAt: Date
 }
@@ -178,22 +181,29 @@ public struct NotificationAddedToChannelEvent: ChannelSpecificEvent, HasUnreadCo
 class NotificationAddedToChannelEventDTO: EventDTO {
     let channel: ChannelDetailPayload
     let unreadCount: UnreadCount?
+    // This `member` field is equal to the `membership` field in channel query
+    let member: MemberPayload
     let createdAt: Date
     let payload: EventPayload
     
     init(from response: EventPayload) throws {
         channel = try response.value(at: \.channel)
         unreadCount = try? response.value(at: \.unreadCount)
+        member = try response.value(at: \.memberContainer?.member)
         createdAt = try response.value(at: \.createdAt)
         payload = response
     }
     
     func toDomainEvent(session: DatabaseSession) -> Event? {
-        guard let channelDTO = session.channel(cid: channel.cid) else { return nil }
+        guard
+            let channelDTO = session.channel(cid: channel.cid),
+            let memberDTO = session.member(userId: member.user.id, cid: channel.cid)
+        else { return nil }
 
         return NotificationAddedToChannelEvent(
             channel: channelDTO.asModel(),
             unreadCount: unreadCount,
+            member: memberDTO.asModel(),
             createdAt: createdAt
         )
     }
@@ -217,6 +227,7 @@ public struct NotificationRemovedFromChannelEvent: ChannelSpecificEvent {
 class NotificationRemovedFromChannelEventDTO: EventDTO {
     let cid: ChannelId
     let user: UserPayload
+    // This `member` field is equal to the `membership` field in channel query
     let member: MemberPayload
     let createdAt: Date
     let payload: EventPayload
@@ -292,6 +303,7 @@ public struct NotificationInvitedEvent: MemberEvent, ChannelSpecificEvent {
 class NotificationInvitedEventDTO: EventDTO {
     let user: UserPayload
     let cid: ChannelId
+    // This `member` field is equal to the `membership` field in channel query
     let member: MemberPayload
     let createdAt: Date
     let payload: EventPayload
@@ -340,6 +352,7 @@ public struct NotificationInviteAcceptedEvent: MemberEvent, ChannelSpecificEvent
 class NotificationInviteAcceptedEventDTO: EventDTO {
     let user: UserPayload
     let channel: ChannelDetailPayload
+    // This `member` field is equal to the `membership` field in channel query
     let member: MemberPayload
     let createdAt: Date
     let payload: EventPayload
@@ -389,6 +402,7 @@ public struct NotificationInviteRejectedEvent: MemberEvent, ChannelSpecificEvent
 class NotificationInviteRejectedEventDTO: EventDTO {
     let user: UserPayload
     let channel: ChannelDetailPayload
+    // This `member` field is equal to the `membership` field in channel query
     let member: MemberPayload
     let createdAt: Date
     let payload: EventPayload

--- a/Sources/StreamChat/WebSocketClient/Events/NotificationEvents_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/NotificationEvents_Tests.swift
@@ -224,6 +224,7 @@ class NotificationsEvents_Tests: XCTestCase {
         // Create event payload
         let eventPayload = EventPayload(
             eventType: .notificationAddedToChannel,
+            memberContainer: .dummy(userId: .unique),
             channel: .dummy(cid: .unique),
             unreadCount: .init(channels: 13, messages: 53),
             createdAt: .unique
@@ -237,6 +238,7 @@ class NotificationsEvents_Tests: XCTestCase {
         
         // Save event to database
         _ = try session.saveChannel(payload: eventPayload.channel!, query: nil)
+        _ = try session.saveMember(payload: eventPayload.memberContainer!.member!, channelId: eventPayload.channel!.cid, query: nil)
 
         // Assert event can be created and has correct fields
         let event = try XCTUnwrap(dto.toDomainEvent(session: session) as? NotificationAddedToChannelEvent)

--- a/Tests/StreamChatTests/MockEnpointResponses/Events/Notification/NotificationAddedToChannel+MissingFields.json
+++ b/Tests/StreamChatTests/MockEnpointResponses/Events/Notification/NotificationAddedToChannel+MissingFields.json
@@ -10,9 +10,6 @@
       "user" : {
           "id" : "general_grievous",
           "banned" : false,
-          "extraData" : {
-              
-          },
           "last_active" : "2021-12-21T15:50:18.579489557Z",
           "created_at" : "2020-12-07T11:37:39.918436Z",
           "image_url" : "https:\/\/vignette.wikia.nocookie.net\/starwars\/images\/d\/de\/Grievoushead.jpg",

--- a/Tests/StreamChatTests/MockEnpointResponses/Events/Notification/NotificationAddedToChannel+MissingFields.json
+++ b/Tests/StreamChatTests/MockEnpointResponses/Events/Notification/NotificationAddedToChannel+MissingFields.json
@@ -1,4 +1,29 @@
 {
+  "member" : {
+      "banned" : false,
+      "shadow_banned" : false,
+      "created_at" : "2021-12-21T15:51:42.125776Z",
+      "role" : "member",
+      "channel_role" : "channel_member",
+      "user_id" : "general_grievous",
+      "updated_at" : "2021-12-21T15:51:42.125776Z",
+      "user" : {
+          "id" : "general_grievous",
+          "banned" : false,
+          "extraData" : {
+              
+          },
+          "last_active" : "2021-12-21T15:50:18.579489557Z",
+          "created_at" : "2020-12-07T11:37:39.918436Z",
+          "image_url" : "https:\/\/vignette.wikia.nocookie.net\/starwars\/images\/d\/de\/Grievoushead.jpg",
+          "image" : "https:\/\/vignette.wikia.nocookie.net\/starwars\/images\/d\/de\/Grievoushead.jpg",
+          "updated_at" : "2021-08-27T05:38:15.102195Z",
+          "birthland" : "Qymaen jai Sheelal",
+          "role" : "user",
+          "online" : true,
+          "name" : "General Grievous"
+      }
+  },
   "channel" : {
     "created_by" : {
       "banned" : false,

--- a/Tests/StreamChatTests/MockEnpointResponses/Events/Notification/NotificationAddedToChannel.json
+++ b/Tests/StreamChatTests/MockEnpointResponses/Events/Notification/NotificationAddedToChannel.json
@@ -10,9 +10,6 @@
       "user" : {
           "id" : "general_grievous",
           "banned" : false,
-          "extraData" : {
-              
-          },
           "last_active" : "2021-12-21T15:50:18.579489557Z",
           "created_at" : "2020-12-07T11:37:39.918436Z",
           "image_url" : "https:\/\/vignette.wikia.nocookie.net\/starwars\/images\/d\/de\/Grievoushead.jpg",

--- a/Tests/StreamChatTests/MockEnpointResponses/Events/Notification/NotificationAddedToChannel.json
+++ b/Tests/StreamChatTests/MockEnpointResponses/Events/Notification/NotificationAddedToChannel.json
@@ -1,4 +1,29 @@
 {
+  "member" : {
+      "banned" : false,
+      "shadow_banned" : false,
+      "created_at" : "2021-12-21T15:51:42.125776Z",
+      "role" : "member",
+      "channel_role" : "channel_member",
+      "user_id" : "general_grievous",
+      "updated_at" : "2021-12-21T15:51:42.125776Z",
+      "user" : {
+          "id" : "general_grievous",
+          "banned" : false,
+          "extraData" : {
+              
+          },
+          "last_active" : "2021-12-21T15:50:18.579489557Z",
+          "created_at" : "2020-12-07T11:37:39.918436Z",
+          "image_url" : "https:\/\/vignette.wikia.nocookie.net\/starwars\/images\/d\/de\/Grievoushead.jpg",
+          "image" : "https:\/\/vignette.wikia.nocookie.net\/starwars\/images\/d\/de\/Grievoushead.jpg",
+          "updated_at" : "2021-08-27T05:38:15.102195Z",
+          "birthland" : "Qymaen jai Sheelal",
+          "role" : "user",
+          "online" : true,
+          "name" : "General Grievous"
+      }
+  },
   "channel" : {
     "created_by" : {
       "banned" : false,


### PR DESCRIPTION
### 🔗 Issue Link

CIS-1227
CIS-1430

### 🎯 Goal

CIS-1227 : 
`Channel.membership` was not parsed / removed in all cases. Some WS events were not handled correctly.
CIS-1430 :
`MemberListController` didn't report `member.added` and `notification.added_to_channel` events correctly.

### 🛠 Implementation

`MemberEventsMiddleware` now correctly handles all events.
We cannot add members to a `MemberListQuery` if the query has a filter, since we can't verify if the member matches the filter.

### 🧪 Testing

Unit tests are implemented.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
