### PR TITLE
[Release Improvements] Push pods from CI

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -44,5 +44,6 @@ jobs:
       - name: "Fastlane - Publish Release"
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         env:
-            GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: bundle exec fastlane publish_release version:${{ env.RELEASE_VERSION }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -128,8 +128,7 @@ lane :publish_release do |options|
                    )
 
   spm_github_release_url = update_spm(version: version)
-  # Firing this lane is done manually at the moment.
-  # TODO: push_pods(sync: options[:sync])
+  push_pods(sync: options[:sync])
   # TODO: Update stream-chat-swift-integration-apps
 
   UI.success("🎉🎉🎉🎉🎉 Github releases successfully created:\n 👉 stream-chat-swift: #{github_release["html_url"]}\n👉 stream-chat-swift-spm: #{spm_github_release_url}")


### PR DESCRIPTION
### 🔗 Issue Link
This PR uses COCOAPODS_TRUNK_TOKEN to push pods updates in the name of Stream Chat Bot

This GHA shows how proper Trunk access has been given: https://github.com/GetStream/stream-chat-swift/actions/runs/1634183563

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
