### PR TITLE
[CIS-1475] Fix wrong image resolution when images are being quoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### 🐞 Fixed
+- Fix wrong image resolution when images are being quoted [#1747](https://github.com/GetStream/stream-chat-swift/pull/1747)
+
 # [4.8.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.8.0)
 _January 4, 2022_
 

--- a/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.swift
+++ b/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.swift
@@ -234,7 +234,8 @@ open class QuotedChatMessageView: _View, ThemeProvider, SwiftUIRepresentable {
         components.imageLoader.loadImage(
             into: attachmentPreviewView,
             url: url,
-            imageCDN: components.imageCDN
+            imageCDN: components.imageCDN,
+            preferredSize: attachmentPreviewSize
         )
     }
 

--- a/Sources/StreamChatUI/Utils/ImageCDN.swift
+++ b/Sources/StreamChatUI/Utils/ImageCDN.swift
@@ -67,14 +67,26 @@ open class StreamImageCDN: ImageCDN {
         else { return originalURL }
 
         let scale = UIScreen.main.scale
-        components.queryItems = components.queryItems ?? []
-        components.queryItems?.append(contentsOf: [
-            URLQueryItem(name: "w", value: String(format: "%.0f", preferredSize.width * scale)),
-            URLQueryItem(name: "h", value: String(format: "%.0f", preferredSize.height * scale)),
-            URLQueryItem(name: "crop", value: "center"),
-            URLQueryItem(name: "resize", value: "fill"),
-            URLQueryItem(name: "ro", value: "0") // Required parameter.
-        ])
+        let queryItems: [String: String] = [
+            "w": preferredSize.width == 0 ? "*" : String(format: "%.0f", preferredSize.width * scale),
+            "h": preferredSize.height == 0 ? "*" : String(format: "%.0f", preferredSize.height * scale),
+            "crop": "center",
+            "resize": "fill",
+            "ro": "0" // Required parameter.
+        ]
+
+        var items = components.queryItems ?? []
+
+        for (key, value) in queryItems {
+            if let index = items.firstIndex(where: { $0.name == key }) {
+                items[index].value = value
+            } else {
+                let item = URLQueryItem(name: key, value: value)
+                items += [item]
+            }
+        }
+
+        components.queryItems = items
         return components.url ?? originalURL
     }
 }

--- a/Sources/StreamChatUI/Utils/ImageCDN_Tests.swift
+++ b/Sources/StreamChatUI/Utils/ImageCDN_Tests.swift
@@ -70,7 +70,7 @@ class ImageCDN_Tests: XCTestCase {
             preferredSize: CGSize(width: 40, height: 40)
         )
         
-        XCTAssertEqual(processedURL, thumbnailUrl)
+        assertEqualURL(processedURL, thumbnailUrl)
     }
     
     func test_thumbnail_validStreamUrl_withParameters() {
@@ -85,7 +85,7 @@ class ImageCDN_Tests: XCTestCase {
             preferredSize: CGSize(width: 40, height: 40)
         )
         
-        XCTAssertEqual(processedURL, thumbnailUrl)
+        assertEqualURL(processedURL, thumbnailUrl)
     }
     
     func test_thumbnail_validURL_unchanged() {
@@ -98,5 +98,34 @@ class ImageCDN_Tests: XCTestCase {
         )
         
         XCTAssertEqual(processedURL, url)
+    }
+
+    private func assertEqualURL(_ lhs: URL, _ rhs: URL) {
+        guard var lhsComponents = URLComponents(url: lhs, resolvingAgainstBaseURL: true),
+              var rhsComponents = URLComponents(url: rhs, resolvingAgainstBaseURL: true) else {
+            XCTFail("Unexpected url")
+            return
+        }
+
+        // Because query paramters can be placed in a different order, we need to check it key by key.
+        var lhsParameters: [String: String] = [:]
+        lhsComponents.queryItems?.forEach {
+            lhsParameters[$0.name] = $0.value
+        }
+
+        var rhsParameters: [String: String] = [:]
+        rhsComponents.queryItems?.forEach {
+            rhsParameters[$0.name] = $0.value
+        }
+
+        XCTAssertEqual(lhsParameters.count, rhsParameters.count)
+
+        lhsParameters.forEach { key, lValue in
+            XCTAssertEqual(lValue, rhsParameters[key])
+        }
+
+        lhsComponents.query = nil
+        rhsComponents.query = nil
+        XCTAssertEqual(lhsComponents.url, rhsComponents.url)
     }
 }

--- a/Sources/StreamChatUI/Utils/ImageLoading/NukeImageLoader.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/NukeImageLoader.swift
@@ -101,12 +101,14 @@ open class NukeImageLoader: ImageLoading {
 
         let urlRequest = imageCDN.urlRequest(forImage: url)
         let size = preferredSize ?? imageView.bounds.size
+
         if resize && size != .zero {
             url = imageCDN.thumbnailURL(originalURL: url, preferredSize: size)
         }
+
         let cachingKey = imageCDN.cachingKey(forImage: url)
         let processors: [ImageProcessing] = resize
-            ? [ImageProcessors.LateResize(url: url, sizeProvider: { imageView.bounds.size })]
+            ? [ImageProcessors.LateResize(id: cachingKey, sizeProvider: { imageView.bounds.size })]
             : []
 
         let request = ImageRequest(

--- a/Sources/StreamChatUI/Utils/ImageLoading/NukeImageLoader.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/NukeImageLoader.swift
@@ -100,8 +100,7 @@ open class NukeImageLoader: ImageLoading {
         }
 
         let urlRequest = imageCDN.urlRequest(forImage: url)
-        let cachingKey = imageCDN.cachingKey(forImage: url)
-        
+
         let processors: [ImageProcessing] = resize
             ? [ImageProcessors.LateResize(sizeProvider: { imageView.bounds.size })]
             : []
@@ -110,7 +109,8 @@ open class NukeImageLoader: ImageLoading {
         if resize && size != .zero {
             url = imageCDN.thumbnailURL(originalURL: url, preferredSize: size)
         }
-        
+        let cachingKey = imageCDN.cachingKey(forImage: url)
+
         let request = ImageRequest(
             urlRequest: urlRequest,
             processors: processors,

--- a/Sources/StreamChatUI/Utils/ImageLoading/NukeImageLoader.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/NukeImageLoader.swift
@@ -93,30 +93,33 @@ open class NukeImageLoader: ImageLoading {
         completion: ((_ result: Result<UIImage, Error>) -> Void)? = nil
     ) -> Cancellable? {
         imageView.currentImageLoadingTask?.cancel()
-        
+
         guard var url = url else {
             imageView.image = placeholder
             return nil
         }
 
         let urlRequest = imageCDN.urlRequest(forImage: url)
-        let size = preferredSize ?? imageView.bounds.size
+        let size = preferredSize ?? .zero
+        let canResize = resize && size != .zero
 
-        if resize && size != .zero {
+        // If we don't have a valid size, we will not be able to resize using our CDN.
+        if canResize {
             url = imageCDN.thumbnailURL(originalURL: url, preferredSize: size)
         }
 
+        // At this point, if the image will be resized using our CDN, the url will contain the size values as
+        // parameters, and this will create a unique caching key for that url with this size. Only in this case we can
+        // successfully cache the resized image.
         let cachingKey = imageCDN.cachingKey(forImage: url)
-        let processors: [ImageProcessing] = resize
+
+        // If we don't have a size, we cannot properly create a 1:1 matching between a caching key and the resized image
+        // that LateResize will create. Therefore, we use/cache the original resolution image.
+        let processors: [ImageProcessing] = canResize
             ? [ImageProcessors.LateResize(id: cachingKey, sizeProvider: { imageView.bounds.size })]
             : []
 
-        let request = ImageRequest(
-            urlRequest: urlRequest,
-            processors: processors,
-            userInfo: [.imageIdKey: cachingKey]
-        )
-        
+        let request = ImageRequest(urlRequest: urlRequest, processors: processors, userInfo: [.imageIdKey: cachingKey])
         let options = ImageLoadingOptions(placeholder: placeholder)
         imageView.currentImageLoadingTask = StreamChatUI.loadImage(
             with: request,
@@ -130,7 +133,7 @@ open class NukeImageLoader: ImageLoading {
                 completion?(.failure(error))
             }
         }
-        
+
         return imageView.currentImageLoadingTask
     }
 }

--- a/Sources/StreamChatUI/Utils/ImageLoading/NukeImageLoader.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/NukeImageLoader.swift
@@ -100,16 +100,14 @@ open class NukeImageLoader: ImageLoading {
         }
 
         let urlRequest = imageCDN.urlRequest(forImage: url)
-
-        let processors: [ImageProcessing] = resize
-            ? [ImageProcessors.LateResize(sizeProvider: { imageView.bounds.size })]
-            : []
-        
         let size = preferredSize ?? imageView.bounds.size
         if resize && size != .zero {
             url = imageCDN.thumbnailURL(originalURL: url, preferredSize: size)
         }
         let cachingKey = imageCDN.cachingKey(forImage: url)
+        let processors: [ImageProcessing] = resize
+            ? [ImageProcessors.LateResize(url: url, sizeProvider: { imageView.bounds.size })]
+            : []
 
         let request = ImageRequest(
             urlRequest: urlRequest,

--- a/Sources/StreamChatUI/Utils/NukeImageProcessor.swift
+++ b/Sources/StreamChatUI/Utils/NukeImageProcessor.swift
@@ -63,13 +63,15 @@ extension ImageProcessors {
             return size
         }
 
-        private let url: URL
+        private let id: String
         private let sizeProvider: () -> CGSize
 
         /// Initializes the processor with size providing closure.
-        /// - Parameter sizeProvider: Closure to obtain size after the image is loaded.
-        public init(url: URL, sizeProvider: @escaping () -> CGSize) {
-            self.url = url
+        /// - Parameters:
+        ///   - id: Image identifier
+        ///   - sizeProvider: Closure to obtain size after the image is loaded.
+        public init(id: String, sizeProvider: @escaping () -> CGSize) {
+            self.id = id
             self.sizeProvider = sizeProvider
         }
 
@@ -86,7 +88,7 @@ extension ImageProcessors {
         }
 
         public var identifier: String {
-            "com.github.kean/nuke/lateResize?url=\(url.absoluteString)"
+            "com.github.kean/nuke/lateResize?id=\(id)"
         }
     }
 }

--- a/Sources/StreamChatUI/Utils/NukeImageProcessor.swift
+++ b/Sources/StreamChatUI/Utils/NukeImageProcessor.swift
@@ -67,8 +67,16 @@ extension ImageProcessors {
         private let sizeProvider: () -> CGSize
 
         /// Initializes the processor with size providing closure.
+        /// - Parameter sizeProvider: Closure to obtain size after the image is loaded.
+        @available(*, deprecated, message: "Use init(id:sizeProvider:) instead")
+        public init(sizeProvider: @escaping () -> CGSize) {
+            // Backwards compatible init
+            self.init(id: "", sizeProvider: sizeProvider)
+        }
+
+        /// Initializes the processor with size providing closure.
         /// - Parameters:
-        ///   - id: Image identifier
+        ///   - id: Image identifier.
         ///   - sizeProvider: Closure to obtain size after the image is loaded.
         public init(id: String, sizeProvider: @escaping () -> CGSize) {
             self.id = id

--- a/Sources/StreamChatUI/Utils/NukeImageProcessor.swift
+++ b/Sources/StreamChatUI/Utils/NukeImageProcessor.swift
@@ -63,11 +63,13 @@ extension ImageProcessors {
             return size
         }
 
+        private let url: URL
         private let sizeProvider: () -> CGSize
-        
+
         /// Initializes the processor with size providing closure.
         /// - Parameter sizeProvider: Closure to obtain size after the image is loaded.
-        public init(sizeProvider: @escaping () -> CGSize) {
+        public init(url: URL, sizeProvider: @escaping () -> CGSize) {
+            self.url = url
             self.sizeProvider = sizeProvider
         }
 
@@ -84,7 +86,7 @@ extension ImageProcessors {
         }
 
         public var identifier: String {
-            "com.github.kean/nuke/lateResize"
+            "com.github.kean/nuke/lateResize?url=\(url.absoluteString)"
         }
     }
 }


### PR DESCRIPTION
### 🔗 Issue Link
https://stream-io.atlassian.net/browse/CIS-1475

Fixes: https://github.com/GetStream/stream-chat-swift/issues/1541

### 🎯 Goal
It's been reported several times that we were randomly showing low resolution images. We recently discovered it was due to a combination of an image and a message quoting an image that this was reproducible. Our image cache was not properly distinguishing between the two, and in the event of the quoted message being downloaded before the full resolution image, it would use the cached quoted image in the full size version too.

### 🛠 Implementation
This PR changes the cacheKey to use the url with the size parameters, when possible. It will also keep the original image size if `preferredSize` is not passed, to make sure we don't have conflicting caching keys

### ☑️ Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
