### PR TITLE
Disable Atlantis until Demo App Configuration is complete

### DIFF
--- a/DemoApp/AppDelegate.swift
+++ b/DemoApp/AppDelegate.swift
@@ -12,8 +12,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        // Override point for customization after application launch.
-        Atlantis.start()
+        // Uncomment this to be able to proxy WebSocket events from Proxyman.app
+        // Atlantis.start()
         return true
     }
 


### PR DESCRIPTION
Simply disable Atlantis until we have dynamic configuration in place
