### PR TITLE
[CIS-1288] Fix Message List NSInternalInconsistencyException Crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix wrong image resolution when images are being quoted [#1747](https://github.com/GetStream/stream-chat-swift/pull/1747)
+- Fix message list NSInternalInconsistencyException crash [#1752](https://github.com/GetStream/stream-chat-swift/pull/1752)
 
 # [4.8.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.8.0)
 _January 4, 2022_

--- a/DemoApp/DemoAppCoordinator.swift
+++ b/DemoApp/DemoAppCoordinator.swift
@@ -164,7 +164,6 @@ final class DemoAppCoordinator: NSObject, UNUserNotificationCenterDelegate {
 
         channelListVC.didSelectChannel = { channel in
             channelVC.channelController = makeChannelController(channel.cid.id)
-            channelVC.messageListVC.listView.reloadData()
             channelVC.setUp()
         }
 

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC_Tests.swift
@@ -206,6 +206,7 @@ final class ChatChannelVC_Tests: XCTestCase {
         components.messageListView = TestMessageListView.self
         components.messageComposerView = TestComposerView.self
         vc.components = components
+        vc.messageListVC.components = components
         
         // Simulate view loading
         _ = vc.view

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -22,7 +22,11 @@ open class ChatMessageListVC:
     UIGestureRecognizerDelegate,
     UIAdaptivePresentationControllerDelegate {
     /// The object that acts as the data source of the message list.
-    public weak var dataSource: ChatMessageListVCDataSource?
+    public weak var dataSource: ChatMessageListVCDataSource? {
+        didSet {
+            listView.reloadData()
+        }
+    }
 
     /// The object that acts as the delegate of the message list.
     public weak var delegate: ChatMessageListVCDelegate?

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC_Tests.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC_Tests.swift
@@ -83,6 +83,7 @@ final class ChatThreadVC_Tests: XCTestCase {
         components.messageListView = TestMessageListView.self
         components.messageComposerView = TestComposerView.self
         vc.components = components
+        vc.messageListVC.components = components
         
         // Simulate view loading
         _ = vc.view


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1288

### 🎯 Goal
Fix a crash that happened when switching channels very quickly, and when the messages were not prefetched from a channel list.

### 🛠 Implementation
Call `reloadData()` when the data source of the message list is changed. When switching channels in quick succession it could happen that there were conflicts in the message list with the old data.

### 🎨 Changes
N/A

### 🧪 Testing
Steps to reproduce this:
1. Apply this patch: [dontSaveChannelListMessages.patch.zip](https://github.com/GetStream/stream-chat-swift/files/7841000/dontSaveChannelListMessages.patch.zip)
2. Open the demo app with an iPad (Easier to quickly switch channels)
3. Quickly switch channels
4. Observe there are no crashes.

In order to reproduce the crash, make sure to revert this PR and delete the `reloadData()` from here: [DemoAppCoordinatior.swift#L167](https://github.com/GetStream/stream-chat-swift/pull/1752/files#diff-55ec0ba42c0fa93f6c625aa3f8b251ebbe2d462a043f460d84ed7635df61bb46L167) (This is why it was really hard to reproduce this issue because we were fixing it on the demo app).


### ☑️ Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
