### PR TITLE
[CIS-1489] Fix Image and Video sharing behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix wrong image resolution when images are being quoted [#1747](https://github.com/GetStream/stream-chat-swift/pull/1747)
 - Fix message list NSInternalInconsistencyException crash [#1752](https://github.com/GetStream/stream-chat-swift/pull/1752)
+- Fix Image and Video sharing behaviour [#1753](https://github.com/GetStream/stream-chat-swift/pull/1753)
 
 # [4.8.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.8.0)
 _January 4, 2022_

--- a/Sources/StreamChatUI/Gallery/GalleryVC.swift
+++ b/Sources/StreamChatUI/Gallery/GalleryVC.swift
@@ -412,8 +412,8 @@ open class GalleryVC:
                 return nil
             }
 
-            let fileName = itemAttachment.id.messageId.lowercased()
-            let filePath = NSTemporaryDirectory().appending("\(fileName).mov")
+            let fileName = itemAttachment.payload.title ?? itemAttachment.id.messageId.lowercased() + ".mp4"
+            let filePath = NSTemporaryDirectory().appending("\(fileName)")
             let url = URL(fileURLWithPath: filePath)
             do {
                 try urlData.write(to: url)

--- a/Sources/StreamChatUI/Gallery/GalleryVC.swift
+++ b/Sources/StreamChatUI/Gallery/GalleryVC.swift
@@ -400,12 +400,28 @@ open class GalleryVC:
     /// - Returns: An item to share.
     open func shareItem(at indexPath: IndexPath) -> Any? {
         guard let item = getItem(at: indexPath) else { return nil }
-        
-        if let image = item.attachment(payloadType: ImageAttachmentPayload.self) {
-            return image.imageURL
-        } else if let video = item.attachment(payloadType: VideoAttachmentPayload.self) {
-            return video.videoURL
-        } else {
+
+        switch item.type {
+        case .image:
+            let cell = attachmentsCollectionView
+                .cellForItem(at: indexPath) as? ImageAttachmentGalleryCell
+            return cell?.imageView.image
+        case .video:
+            guard let itemAttachment = item.attachment(payloadType: VideoAttachmentPayload.self),
+                  let urlData = try? Data(contentsOf: itemAttachment.videoURL) else {
+                return nil
+            }
+
+            let fileName = itemAttachment.id.messageId.lowercased()
+            let filePath = NSTemporaryDirectory().appending("\(fileName).mov")
+            let url = URL(fileURLWithPath: filePath)
+            do {
+                try urlData.write(to: url)
+                return url
+            } catch {
+                return nil
+            }
+        default:
             return nil
         }
     }


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1489

### 🎯 Goal
When sharing a video or image, it should not share an URL, but the asset itself.

### 🛠 Implementation
When it is an image, we share the actual `UIImage`. When it is a video, we share the actual video file.

### 🎨 Changes

https://user-images.githubusercontent.com/12814114/149010574-930e9d90-3eac-4235-ac04-1e257b279286.MP4

### 🧪 Testing
- Tap on a video/image
- Tap share
- Click on "mail"
- The video/image should appear on the content of the email instead of an URL

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
