### PR TITLE
[CIS-1491] Add custom modal transition for message list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Add custom modal transition for message list [#1760](https://github.com/GetStream/stream-chat-swift/pull/1760)
 
 # [4.9.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.9.0)
 _January 18, 2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### 🔄 Changed
+- In case you are presenting the `ChatChannelVC` in a modal, you should now be using the `StreamModalTransitioningDelegate`. The workaround to fix the message list being dismissed when scrolling to the bottom has been removed in favor of the custom modal transition. Please check the following PR description to see how to use it: [#1760](https://github.com/GetStream/stream-chat-swift/pull/1760)
+
 ### 🐞 Fixed
 - Add custom modal transition for message list [#1760](https://github.com/GetStream/stream-chat-swift/pull/1760)
 

--- a/DemoApp/ChatPresenter.swift
+++ b/DemoApp/ChatPresenter.swift
@@ -15,7 +15,7 @@ class DemoChatChannelListRouter: ChatChannelListRouter {
 
     var channelPresentingStyle: ChannelPresentingStyle = .push
 
-    let streamModalTransitioningDelegate = StreamModalTransitioningDelegate()
+    lazy var streamModalTransitioningDelegate = StreamModalTransitioningDelegate()
 
     func showCreateNewChannelFlow() {
         let storyboard = UIStoryboard(name: "Main", bundle: .main)

--- a/DemoApp/ChatPresenter.swift
+++ b/DemoApp/ChatPresenter.swift
@@ -15,6 +15,8 @@ class DemoChatChannelListRouter: ChatChannelListRouter {
 
     var channelPresentingStyle: ChannelPresentingStyle = .push
 
+    let streamModalTransitioningDelegate = StreamModalTransitioningDelegate()
+
     func showCreateNewChannelFlow() {
         let storyboard = UIStoryboard(name: "Main", bundle: .main)
         
@@ -53,7 +55,8 @@ class DemoChatChannelListRouter: ChatChannelListRouter {
             let vc = components.channelVC.init()
             vc.channelController = rootViewController.controller.client.channelController(for: cid)
             let navVc = UINavigationController(rootViewController: vc)
-            navVc.isModalInPresentation = false
+            navVc.transitioningDelegate = streamModalTransitioningDelegate
+            navVc.modalPresentationStyle = .custom
             rootNavigationController?.present(navVc, animated: true, completion: nil)
 
         case .embeddedInTabBar:

--- a/DemoApp/ChatPresenter.swift
+++ b/DemoApp/ChatPresenter.swift
@@ -52,7 +52,9 @@ class DemoChatChannelListRouter: ChatChannelListRouter {
         case .modally:
             let vc = components.channelVC.init()
             vc.channelController = rootViewController.controller.client.channelController(for: cid)
-            rootNavigationController?.present(vc, animated: true, completion: nil)
+            let navVc = UINavigationController(rootViewController: vc)
+            navVc.isModalInPresentation = false
+            rootNavigationController?.present(navVc, animated: true, completion: nil)
 
         case .embeddedInTabBar:
             let vc = components.channelVC.init()

--- a/Sources/StreamChatUI/ChatChannel/StreamModalTransitioningDelegate.swift
+++ b/Sources/StreamChatUI/ChatChannel/StreamModalTransitioningDelegate.swift
@@ -1,0 +1,166 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import UIKit
+
+/// Stream's custom transitioning delegate to handle a modal presentation.
+///
+/// This should be used if you are presenting the ``ChatChannelVC`` in a modal.
+/// The reason this custom transition should be used instead of the native one is because we use an inverted
+/// `UITableView` for the message list component which it doesn't play well with the native modal transition.
+open class StreamModalTransitioningDelegate: NSObject, UIViewControllerTransitioningDelegate {
+    public func presentationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController?,
+        source: UIViewController
+    ) -> UIPresentationController? {
+        StreamModalPresentationController(presentedViewController: presented, presenting: presenting)
+    }
+}
+
+/// Stream's custom `UIPresentationController` to handle a modal presentation.
+open class StreamModalPresentationController: UIPresentationController {
+    /// The overlay view that is rendered between the presenting and presented view.
+    open var overlayView: UIView = UIView()
+
+    /// The overlay opacity value when the presented view is shown.
+    open var overlayViewAlpha: CGFloat = 0.7
+
+    /// The corner radius of the presented view when it is shown.
+    open var cornerRadius: CGFloat = 22
+
+    /// The presented view height scale.
+    open var presentedViewHeightScale: CGFloat = 0.94
+
+    /// The presenting view height scale when the presented view is shown.
+    open var presentingViewHeightScale: CGFloat = 0.9
+
+    override public init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?) {
+        super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
+        setup()
+    }
+
+    /// Setup the overlay view and gesture recognizers of the `UIPresentationController`.
+    open func setup() {
+        overlayView.backgroundColor = UIColor.black
+        overlayView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        overlayView.isUserInteractionEnabled = true
+
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissController))
+        overlayView.addGestureRecognizer(tapGestureRecognizer)
+
+        let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePan))
+        presentedViewController.view.addGestureRecognizer(panGestureRecognizer)
+    }
+
+    override open var frameOfPresentedViewInContainerView: CGRect {
+        guard let containerView = self.containerView else {
+            return .zero
+        }
+        return CGRect(
+            origin: CGPoint(x: 0, y: containerView.frame.height * (1 - presentedViewHeightScale)),
+            size: CGSize(
+                width: containerView.frame.width,
+                height: containerView.frame.height * presentedViewHeightScale
+            )
+        )
+    }
+
+    override open func presentationTransitionWillBegin() {
+        overlayView.alpha = 0
+        containerView?.addSubview(overlayView)
+
+        presentedViewController.transitionCoordinator?.animate(alongsideTransition: { _ in
+            self.showPresentedView()
+        })
+    }
+
+    override open func dismissalTransitionWillBegin() {
+        presentedViewController.transitionCoordinator?.animate(alongsideTransition: { _ in
+            self.dismissPresentedView()
+        }, completion: { (_) in
+            self.overlayView.removeFromSuperview()
+        })
+    }
+
+    override open func containerViewDidLayoutSubviews() {
+        super.containerViewDidLayoutSubviews()
+
+        presentedView?.frame = frameOfPresentedViewInContainerView
+        overlayView.frame = containerView?.bounds ?? .zero
+    }
+
+    @objc open func handlePan(_ gestureRecognizer: UIPanGestureRecognizer) {
+        guard let presentedView = self.presentedView else { return }
+        guard let containerView = self.containerView else { return }
+
+        let translationY = gestureRecognizer.translation(in: presentedView).y
+        guard translationY >= 0 else { return }
+
+        animateInteractiveTransition(translationY)
+
+        if gestureRecognizer.state == .ended {
+            // In case the user drags the view too fast or below half of the screen, dismiss the controller
+            let dragVelocity = gestureRecognizer.velocity(in: presentedView)
+            if dragVelocity.y >= 1000 || translationY > containerView.frame.height * 0.5 {
+                dismissController()
+                return
+            }
+
+            // Otherwise, cancel the dismissal (which means, show the presented view again)
+            UIView.animate(withDuration: 0.3) {
+                self.showPresentedView()
+            }
+        }
+    }
+
+    @objc open func dismissController() {
+        presentedViewController.dismiss(animated: true, completion: nil)
+    }
+
+    /// Animates the interactive transition based on the translation of the `UIPanGestureRecognizer`.
+    /// - Parameter translationY: The translation in the Y axis of pan gesture.
+    open func animateInteractiveTransition(_ translationY: CGFloat) {
+        guard let presentedView = self.presentedView else { return }
+        guard let containerView = self.containerView else { return }
+
+        let translationPercentage = translationY / containerView.frame.height
+
+        let newCornerRadius = cornerRadius - (cornerRadius * translationPercentage)
+        presentedView.layer.cornerRadius = newCornerRadius
+
+        var newFrame = frameOfPresentedViewInContainerView
+        newFrame.origin.y += translationY
+        presentedView.frame = newFrame
+
+        let newOverlayAlpha = overlayViewAlpha - (overlayViewAlpha * translationPercentage)
+        overlayView.alpha = newOverlayAlpha
+
+        let newPresentingViewHeightScale = (1 - presentingViewHeightScale) * translationPercentage
+        presentingViewController.view.transform = CGAffineTransform(
+            scaleX: presentingViewHeightScale + newPresentingViewHeightScale,
+            y: presentingViewHeightScale + newPresentingViewHeightScale
+        )
+    }
+
+    /// Shows the presented view.
+    open func showPresentedView() {
+        overlayView.alpha = overlayViewAlpha
+        presentedView?.layer.cornerRadius = cornerRadius
+        presentedView?.frame = frameOfPresentedViewInContainerView
+        presentingViewController.view.layer.cornerRadius = cornerRadius
+        presentingViewController.view.transform = .init(
+            scaleX: presentingViewHeightScale,
+            y: presentingViewHeightScale
+        )
+    }
+
+    /// Dismisses the presented view.
+    open func dismissPresentedView() {
+        overlayView.alpha = 0
+        presentedView?.layer.cornerRadius = 0
+        presentingViewController.view.transform = .init(scaleX: 1, y: 1)
+        presentingViewController.view.layer.cornerRadius = 0
+    }
+}

--- a/Sources/StreamChatUI/ChatChannel/StreamModalTransitioningDelegate.swift
+++ b/Sources/StreamChatUI/ChatChannel/StreamModalTransitioningDelegate.swift
@@ -45,7 +45,6 @@ open class StreamModalPresentationController: UIPresentationController {
     open func setup() {
         overlayView.backgroundColor = UIColor.black
         overlayView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        overlayView.isUserInteractionEnabled = true
 
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissController))
         overlayView.addGestureRecognizer(tapGestureRecognizer)

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -19,8 +19,7 @@ open class ChatMessageListVC:
     LinkPreviewViewDelegate,
     UITableViewDataSource,
     UITableViewDelegate,
-    UIGestureRecognizerDelegate,
-    UIAdaptivePresentationControllerDelegate {
+    UIGestureRecognizerDelegate {
     /// The object that acts as the data source of the message list.
     public weak var dataSource: ChatMessageListVCDataSource? {
         didSet {
@@ -107,8 +106,6 @@ open class ChatMessageListVC:
         tapOnList.delegate = self
         listView.addGestureRecognizer(tapOnList)
 
-        navigationController?.presentationController?.delegate = self
-        
         scrollToLatestMessageButton.addTarget(self, action: #selector(scrollToLatestMessage), for: .touchUpInside)
     }
     
@@ -534,13 +531,5 @@ open class ChatMessageListVC:
     ) -> Bool {
         // To prevent the gesture recognizer consuming up the events from UIControls, we receive touch only when the view isn't a UIControl.
         !(touch.view is UIControl)
-    }
-
-    // MARK: - UIAdaptivePresentationControllerDelegate
-
-    public func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
-        // A workaround is required because we are using an inverted UITableView for the message list.
-        // More details on the issue: https://github.com/GetStream/stream-chat-swift/issues/1307
-        !listView.isDragging
     }
 }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -891,6 +891,8 @@
 		ADC4AAAE2788ACFE0004BB35 /* MessageDeletedHard.json in Resources */ = {isa = PBXBuildFile; fileRef = ADC4AAAD2788ACFE0004BB35 /* MessageDeletedHard.json */; };
 		ADCBBFD526D66A560023FCB2 /* iMessageChatMessageListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCBBFD426D66A560023FCB2 /* iMessageChatMessageListViewController.swift */; };
 		ADCBBFD726D66ADC0023FCB2 /* SlackChatMessageListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCBBFD626D66ADC0023FCB2 /* SlackChatMessageListViewController.swift */; };
+		ADCD5E4327987EFE00E66911 /* StreamModalTransitioningDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCD5E4227987EFE00E66911 /* StreamModalTransitioningDelegate.swift */; };
+		ADCD5E4427987EFE00E66911 /* StreamModalTransitioningDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCD5E4227987EFE00E66911 /* StreamModalTransitioningDelegate.swift */; };
 		ADCDDCC525AE1293004E15FB /* UserUpdateResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = ADCDDCC425AE1293004E15FB /* UserUpdateResponse.json */; };
 		ADCDDD0025AE2784004E15FB /* UserUpdateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCDDCEC25AE2214004E15FB /* UserUpdateViewController.swift */; };
 		ADCDDD0825AE2F4A004E15FB /* InputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCDDD0725AE2F4A004E15FB /* InputViewController.swift */; };
@@ -2864,6 +2866,7 @@
 		ADC4AAAD2788ACFE0004BB35 /* MessageDeletedHard.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MessageDeletedHard.json; sourceTree = "<group>"; };
 		ADCBBFD426D66A560023FCB2 /* iMessageChatMessageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iMessageChatMessageListViewController.swift; sourceTree = "<group>"; };
 		ADCBBFD626D66ADC0023FCB2 /* SlackChatMessageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlackChatMessageListViewController.swift; sourceTree = "<group>"; };
+		ADCD5E4227987EFE00E66911 /* StreamModalTransitioningDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamModalTransitioningDelegate.swift; sourceTree = "<group>"; };
 		ADCDDCC425AE1293004E15FB /* UserUpdateResponse.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = UserUpdateResponse.json; sourceTree = "<group>"; };
 		ADCDDCEC25AE2214004E15FB /* UserUpdateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdateViewController.swift; sourceTree = "<group>"; };
 		ADCDDD0725AE2F4A004E15FB /* InputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputViewController.swift; sourceTree = "<group>"; };
@@ -5539,6 +5542,7 @@
 				64B059E12670EFFE0024CE90 /* ChatChannelVC+SwiftUI.swift */,
 				64B059EC267116B40024CE90 /* ChatChannelVC+SwiftUI_Tests.swift */,
 				ADA3572D269C562A004AD8E9 /* ChatChannelHeaderView.swift */,
+				ADCD5E4227987EFE00E66911 /* StreamModalTransitioningDelegate.swift */,
 			);
 			path = ChatChannel;
 			sourceTree = "<group>";
@@ -6953,6 +6957,7 @@
 				C1FC2F6827416E150062530F /* ImagePipelineCache.swift in Sources */,
 				792DD9D9256BC542001DB91B /* BaseViews.swift in Sources */,
 				ADA3572F269C807A004AD8E9 /* ChatChannelHeaderView.swift in Sources */,
+				ADCD5E4327987EFE00E66911 /* StreamModalTransitioningDelegate.swift in Sources */,
 				F80BCA1426304F7800F2107B /* ShareButton.swift in Sources */,
 				C1FC2F6F27416E150062530F /* ImagePipelineConfiguration.swift in Sources */,
 				F838F6B32636D42B0025E1F5 /* ZoomAnimator.swift in Sources */,
@@ -8396,6 +8401,7 @@
 				C121EC172746A1EC00023E4C /* ImagePipelineConfiguration.swift in Sources */,
 				C121EC182746A1EC00023E4C /* ImageEncoding.swift in Sources */,
 				C121EC192746A1EC00023E4C /* ImageRequest.swift in Sources */,
+				ADCD5E4427987EFE00E66911 /* StreamModalTransitioningDelegate.swift in Sources */,
 				C121EC1A2746A1EC00023E4C /* DataCache.swift in Sources */,
 				C121EC1B2746A1EC00023E4C /* ImageDecoding.swift in Sources */,
 				C121EC1C2746A1EC00023E4C /* ImagePipelineCache.swift in Sources */,


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1491
https://github.com/GetStream/stream-chat-swift/issues/1307

### 🎯 Goal
Introduces a custom modal transition to workaround the inverted table view on the message list. This custom transition should be used if you as a customer need to present the `ChatChannelVC` in a modal. 

#### Usage:
```swift
// Make sure to have a reference to the delegate or it will be instantly deallocated.
let streamModalTransitioningDelegate = StreamModalTransitioningDelegate()

func showChannelVC() {
    let vc = ChatChannelVC()
    vc.channelController = client.channelController(for: cid)
    let navVC = UINavigationController(rootViewController: vc)
    navVC.transitioningDelegate = streamModalTransitioningDelegate
    navVC.modalPresentationStyle = .custom
    navigationController?.present(navVC, animated: true, completion: nil)
}
```

### 🛠 Implementation
Adds a new `StreamModalTransitioningDelegate` that mimics the native's modal transition.

### 🎨 Changes
https://user-images.githubusercontent.com/12814114/150185171-85bda6ff-b8a8-4f5a-8b85-c5dd92b9e940.mp4


### 🧪 Testing
Check the video on how to test this in the demo app.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
