### PR TITLE
Install older versions of Xcode so we can support iOS 11+

### DIFF
--- a/.github/actions/prepare-ios-simulator/action.yml
+++ b/.github/actions/prepare-ios-simulator/action.yml
@@ -12,7 +12,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: |
+    - name: Set Xcode Version
+      env:
+        FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
+        FASTLANE_PASS: ${{ secrets.FASTLANE_PASS }}
+      run: |
         xcode_version=${{ inputs.xcode }}
         ios_version=${{ inputs.ios }}
         ios_version_dash=${ios_version//./-} # ex: 12.4 -> 12-4
@@ -30,4 +34,3 @@ runs:
         xcrun simctl create custom-test-device "${{ inputs.device }}" "com.apple.CoreSimulator.SimRuntime.iOS-$ios_version_dash"
         xcrun simctl list devices $ios_version
       shell: bash
-  

--- a/.github/actions/prepare-ios-simulator/action.yml
+++ b/.github/actions/prepare-ios-simulator/action.yml
@@ -14,8 +14,8 @@ runs:
   steps:
     - name: Set Xcode Version
       env:
-        XCODE_INSTALL_USER: ${{ secrets.FASTLANE_USER }}
-        XCODE_INSTALL_PASSWORD: ${{ secrets.FASTLANE_PASS }}
+        XCODE_INSTALL_USER: ${{ secrets.XCODE_INSTALL_USER }}
+        XCODE_INSTALL_PASSWORD: ${{ secrets.XCODE_INSTALL_PASSWORD }}
       run: |
         xcode_version=${{ inputs.xcode }}
         ios_version=${{ inputs.ios }}

--- a/.github/actions/prepare-ios-simulator/action.yml
+++ b/.github/actions/prepare-ios-simulator/action.yml
@@ -17,6 +17,11 @@ runs:
         ios_version=${{ inputs.ios }}
         ios_version_dash=${ios_version//./-} # ex: 12.4 -> 12-4
 
+        sudo gem install xcode-install
+        xcversion install $xcode_version
+
+        sudo xcode-select -switch /Applications/Xcode$xcode_version.app
+
         sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
 
         sudo ln -s /Applications/Xcode_$xcode_version.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ $ios_version.simruntime

--- a/.github/actions/prepare-ios-simulator/action.yml
+++ b/.github/actions/prepare-ios-simulator/action.yml
@@ -13,9 +13,6 @@ runs:
   using: "composite"
   steps:
     - name: Set Xcode Version
-      env:
-        XCODE_INSTALL_USER: ${{ secrets.XCODE_INSTALL_USER }}
-        XCODE_INSTALL_PASSWORD: ${{ secrets.XCODE_INSTALL_PASSWORD }}
       run: |
         xcode_version=${{ inputs.xcode }}
         ios_version=${{ inputs.ios }}

--- a/.github/actions/prepare-ios-simulator/action.yml
+++ b/.github/actions/prepare-ios-simulator/action.yml
@@ -14,8 +14,8 @@ runs:
   steps:
     - name: Set Xcode Version
       env:
-        FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
-        FASTLANE_PASS: ${{ secrets.FASTLANE_PASS }}
+        XCODE_INSTALL_USER: ${{ secrets.FASTLANE_USER }}
+        XCODE_INSTALL_PASSWORD: ${{ secrets.FASTLANE_PASS }}
       run: |
         xcode_version=${{ inputs.xcode }}
         ios_version=${{ inputs.ios }}

--- a/.github/workflows/full-checks.yml
+++ b/.github/workflows/full-checks.yml
@@ -156,6 +156,9 @@ jobs:
         device: "iPhone 11"
         ios: "12.4"
         xcode: "10.3"
+      env:
+        XCODE_INSTALL_USER: ${{ secrets.XCODE_INSTALL_USER }}
+        XCODE_INSTALL_PASSWORD: ${{ secrets.XCODE_INSTALL_PASSWORD }}
     - name: Run Stress Tests
       run: bundle exec fastlane stress_test_release device:"iPhone 11 (12.4)"
 


### PR DESCRIPTION
### 🎯 Goal

Our nightly build is failing because macOS 11 on Github Actions is no longer supporting iOS 11-13. We'd still like our tests to run on older supported iOS versions of the SDK.

### 🛠 Implementation

We're going to install the older versions of Xcode during the CI, this will for sure take longer but it's our nightly build.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
