### PR TITLE
[CIS-1525] Crashfix for hanging DispatchWorkItem reference in WebSocketClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Add custom modal transition for message list [#1760](https://github.com/GetStream/stream-chat-swift/pull/1760)
 - Fix composer not showing any files when >3 files are selected in bulk [#1768](https://github.com/GetStream/stream-chat-swift/issues/1768)
+- Crashfix for hanging `DispatchWorkItem` reference in `WebSocketClient`[#1766](https://github.com/GetStream/stream-chat-swift/issues/1766)
 
 # [4.9.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.9.0)
 _January 18, 2022_

--- a/Sources/StreamChat/Utils/Timers.swift
+++ b/Sources/StreamChat/Utils/Timers.swift
@@ -84,17 +84,17 @@ private class RepeatingTimer: RepeatingTimerControl {
     }
     
     private var state: State = .suspended
-    private var timer: DispatchSourceTimer?
+    private let timer: DispatchSourceTimer
     
     init(timeInterval: TimeInterval, queue: DispatchQueue, onFire: @escaping () -> Void) {
         timer = DispatchSource.makeTimerSource(queue: queue)
-        timer?.schedule(deadline: .now() + .milliseconds(Int(timeInterval)), repeating: timeInterval, leeway: .seconds(1))
-        timer?.setEventHandler(handler: onFire)
+        timer.schedule(deadline: .now() + .milliseconds(Int(timeInterval)), repeating: timeInterval, leeway: .seconds(1))
+        timer.setEventHandler(handler: onFire)
     }
     
     deinit {
-        timer?.setEventHandler {}
-        timer?.cancel()
+        timer.setEventHandler {}
+        timer.cancel()
         // If the timer is suspended, calling cancel without resuming
         // triggers a crash. This is documented here https://forums.developer.apple.com/thread/15902
         resume()
@@ -106,7 +106,7 @@ private class RepeatingTimer: RepeatingTimerControl {
         }
         
         state = .resumed
-        timer?.resume()
+        timer.resume()
     }
     
     func suspend() {
@@ -115,6 +115,6 @@ private class RepeatingTimer: RepeatingTimerControl {
         }
         
         state = .suspended
-        timer?.suspend()
+        timer.suspend()
     }
 }

--- a/Sources/StreamChat/Utils/Timers.swift
+++ b/Sources/StreamChat/Utils/Timers.swift
@@ -51,8 +51,6 @@ protocol RepeatingTimerControl {
 protocol TimerControl {
     /// Cancels the timer.
     func cancel()
-    
-    var isCancelled: Bool { get }
 }
 
 extension DispatchWorkItem: TimerControl {}
@@ -86,17 +84,17 @@ private class RepeatingTimer: RepeatingTimerControl {
     }
     
     private var state: State = .suspended
-    private let timer: DispatchSourceTimer
+    private var timer: DispatchSourceTimer?
     
     init(timeInterval: TimeInterval, queue: DispatchQueue, onFire: @escaping () -> Void) {
         timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: .now() + .milliseconds(Int(timeInterval)), repeating: timeInterval, leeway: .seconds(1))
-        timer.setEventHandler(handler: onFire)
+        timer?.schedule(deadline: .now() + .milliseconds(Int(timeInterval)), repeating: timeInterval, leeway: .seconds(1))
+        timer?.setEventHandler(handler: onFire)
     }
     
     deinit {
-        timer.setEventHandler {}
-        timer.cancel()
+        timer?.setEventHandler {}
+        timer?.cancel()
         // If the timer is suspended, calling cancel without resuming
         // triggers a crash. This is documented here https://forums.developer.apple.com/thread/15902
         resume()
@@ -108,7 +106,7 @@ private class RepeatingTimer: RepeatingTimerControl {
         }
         
         state = .resumed
-        timer.resume()
+        timer?.resume()
     }
     
     func suspend() {
@@ -117,6 +115,6 @@ private class RepeatingTimer: RepeatingTimerControl {
         }
         
         state = .suspended
-        timer.suspend()
+        timer?.suspend()
     }
 }

--- a/Sources/StreamChat/Utils/Timers.swift
+++ b/Sources/StreamChat/Utils/Timers.swift
@@ -51,6 +51,8 @@ protocol RepeatingTimerControl {
 protocol TimerControl {
     /// Cancels the timer.
     func cancel()
+    
+    var isCancelled: Bool { get }
 }
 
 extension DispatchWorkItem: TimerControl {}

--- a/Sources/StreamChat/WebSocketClient/Engine/URLSessionWebSocketEngine.swift
+++ b/Sources/StreamChat/WebSocketClient/Engine/URLSessionWebSocketEngine.swift
@@ -54,7 +54,9 @@ class URLSessionWebSocketEngine: NSObject, WebSocketEngine, URLSessionDataDelega
             switch result {
             case let .success(message):
                 if case let .string(string) = message {
-                    self.delegate?.webSocketDidReceiveMessage(string)
+                    self.callbackQueue.async { [weak self] in
+                        self?.delegate?.webSocketDidReceiveMessage(string)
+                    }
                 }
                 self.doRead()
                 
@@ -69,7 +71,9 @@ class URLSessionWebSocketEngine: NSObject, WebSocketEngine, URLSessionDataDelega
         webSocketTask: URLSessionWebSocketTask,
         didOpenWithProtocol protocol: String?
     ) {
-        delegate?.webSocketDidConnect()
+        callbackQueue.async { [weak self] in
+            self?.delegate?.webSocketDidConnect()
+        }
     }
     
     func urlSession(
@@ -88,7 +92,9 @@ class URLSessionWebSocketEngine: NSObject, WebSocketEngine, URLSessionDataDelega
             )
         }
         
-        delegate?.webSocketDidDisconnect(error: error)
+        callbackQueue.async { [weak self] in
+            self?.delegate?.webSocketDidDisconnect(error: error)
+        }
     }
     
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
@@ -97,6 +103,8 @@ class URLSessionWebSocketEngine: NSObject, WebSocketEngine, URLSessionDataDelega
         // Delegate is already informed with `didCloseWith` callback,
         // so we don't need to call delegate again.
         guard let error = error else { return }
-        delegate?.webSocketDidDisconnect(error: WebSocketEngineError(error: error))
+        callbackQueue.async { [weak self] in
+            self?.delegate?.webSocketDidDisconnect(error: WebSocketEngineError(error: error))
+        }
     }
 }

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -257,8 +257,8 @@ extension WebSocketClient: WebSocketEngineDelegate {
 
 extension WebSocketClient: WebSocketPingControllerDelegate {
     func sendPing() {
-        engineQueue.async { [engine] in
-            engine?.sendPing()
+        engineQueue.async { [weak self] in
+            self?.engine?.sendPing()
         }
     }
     

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient_Tests.swift
@@ -336,16 +336,16 @@ class WebSocketClient_Tests: XCTestCase {
         AssertAsync.willBeEqual(engine!.sendPing_calledCount, 1)
     }
     
-    func test_pongReceived_callsPingController_pongRecieved() {
+    func test_pongReceived_callsPingController_pongReceived() {
         // Simulate connection to make sure web socket engine exists
         test_connectionFlow()
-        assert(pingController.pongRecievedCount == 1)
+        assert(pingController.pongReceivedCount == 1)
         
         // Simulate a health check (pong) event is received
         decoder.decodedEvent = .success(HealthCheckEvent(connectionId: connectionId))
         engine!.simulateMessageReceived()
         
-        AssertAsync.willBeEqual(pingController.pongRecievedCount, 2)
+        AssertAsync.willBeEqual(pingController.pongReceivedCount, 2)
     }
     
     func test_webSocketPingController_disconnectOnNoPongReceived_disconnectsEngine() {
@@ -617,15 +617,15 @@ class MockBackgroundTaskScheduler: BackgroundTaskScheduler {
 
 class WebSocketPingControllerMock: WebSocketPingController {
     var connectionStateDidChange_connectionStates: [WebSocketConnectionState] = []
-    var pongRecievedCount = 0
+    var pongReceivedCount = 0
     
     override func connectionStateDidChange(_ connectionState: WebSocketConnectionState) {
         connectionStateDidChange_connectionStates.append(connectionState)
         super.connectionStateDidChange(connectionState)
     }
     
-    override func pongRecieved() {
-        pongRecievedCount += 1
-        super.pongRecieved()
+    override func pongReceived() {
+        pongReceivedCount += 1
+        super.pongReceived()
     }
 }

--- a/Sources/StreamChat/WebSocketClient/WebSocketPingController.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketPingController.swift
@@ -6,10 +6,10 @@ import Foundation
 
 /// A delegate to control `WebSocketClient` connection by `WebSocketPingController`.
 protocol WebSocketPingControllerDelegate: AnyObject {
-    /// `WebSocketPingController` will call this func periodically to keep a connection alive.
+    /// `WebSocketPingController` will call this function periodically to keep a connection alive.
     func sendPing()
     
-    /// `WebSocketPingController` will call this func to force disconnect `WebSocketClient`.
+    /// `WebSocketPingController` will call this function to force disconnect `WebSocketClient`.
     func disconnectOnNoPongReceived()
 }
 
@@ -51,7 +51,7 @@ class WebSocketPingController {
         guard delegate != nil else { return }
         
         cancelPongTimeoutTimer()
-        createPingTimerIfNeeded()
+        schedulePingTimerIfNeeded()
         
         if connectionState.isConnected {
             log.info("Resume WebSocket Ping timer")
@@ -77,7 +77,7 @@ class WebSocketPingController {
     
     // MARK: Timers
     
-    private func createPingTimerIfNeeded() {
+    private func schedulePingTimerIfNeeded() {
         guard pingTimerControl == nil else { return }
         pingTimerControl = timerType.scheduleRepeating(timeInterval: Self.pingTimeInterval, queue: timerQueue) { [weak self] in
             self?.sendPing()

--- a/Sources/StreamChat/WebSocketClient/WebSocketPingController.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketPingController.swift
@@ -34,12 +34,14 @@ class WebSocketPingController {
     /// A delegate to control `WebSocketClient` connection by `WebSocketPingController`.
     weak var delegate: WebSocketPingControllerDelegate?
     
+    deinit {
+        cancelPongTimeoutTimer()
+    }
+    
     /// Creates a ping controller.
     /// - Parameters:
     ///   - timerType: a timer type.
     ///   - timerQueue: a timer dispatch queue.
-    ///   - ping: an action for `WebSocketClient` to send a ping.
-    ///   - forceReconnect: an action for `WebSocketClient` to force disconnect and reconnect.
     init(timerType: Timer.Type, timerQueue: DispatchQueue) {
         self.timerType = timerType
         self.timerQueue = timerQueue
@@ -78,7 +80,9 @@ class WebSocketPingController {
     }
     
     private func cancelPongTimeoutTimer() {
-        pongTimeoutTimer?.cancel()
+        if pongTimeoutTimer?.isCancelled == false {
+            pongTimeoutTimer?.cancel()
+        }
         pongTimeoutTimer = nil
     }
 }

--- a/Sources/StreamChat/WebSocketClient/WebSocketPingController.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketPingController.swift
@@ -17,9 +17,9 @@ protocol WebSocketPingControllerDelegate: AnyObject {
 /// After ping is sent, a pong waiting timer is started, and if pong does not come, a forced disconnect is called.
 class WebSocketPingController {
     /// The time interval to ping connection to keep it alive.
-    static let pingTimeInterval: TimeInterval = 0.1
+    static let pingTimeInterval: TimeInterval = 25
     /// The time interval for pong timeout.
-    static let pongTimeoutTimeInterval: TimeInterval = 0.1
+    static let pongTimeoutTimeInterval: TimeInterval = 3
     
     private let timerType: Timer.Type
     private let timerQueue: DispatchQueue

--- a/Sources/StreamChat/WebSocketClient/WebSocketPingController.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketPingController.swift
@@ -75,7 +75,6 @@ class WebSocketPingController {
         cancelPongTimeoutTimer()
     }
     
-    
     // MARK: Timers
     
     private func createPingTimerIfNeeded() {

--- a/Sources/StreamChat/WebSocketClient/WebSocketPingController_Tests.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketPingController_Tests.swift
@@ -20,6 +20,14 @@ class WebSocketPingController_Tests: XCTestCase {
         pingController.delegate = delegate
     }
     
+    override func tearDown() {
+        time = nil
+        VirtualTimeTimer.time = nil
+        pingController = nil
+        delegate = nil
+        super.tearDown()
+    }
+    
     func test_sendPing_called_whenTheConnectionIsConnected() throws {
         assert(delegate.sendPing_calledCount == 0)
         
@@ -54,7 +62,7 @@ class WebSocketPingController_Tests: XCTestCase {
         }
         
         // Simulate pong received
-        pingController.pongRecieved()
+        pingController.pongReceived()
         
         // Simulate time passed pongTimeoutTimeInterval + 1 and check disconnectOnNoPongReceived wasn't called
         assert(delegate.disconnectOnNoPongReceived_calledCount == 0)


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1525

### 🎯 Goal

_Describe why we are making this change._

### 🛠 Implementation

_Provide a description of the implementation._

### 🎨 Changes

* `WebSocketPingController` is run on specific engineQueue
* URL socket client calls delegate methods on dedicated `callbackQueue`
* Few renamings & doc updates

### 🧪 Testing

_Describe the steps how this change can be tested (or why it can't be tested)._

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
