### PR TITLE
Avoid compiler warnings in the `ChatChannelNamer` deprecation

### DIFF
--- a/Sources/StreamChatUI/Appearance+Formatters/ChannelNameFormatter.swift
+++ b/Sources/StreamChatUI/Appearance+Formatters/ChannelNameFormatter.swift
@@ -14,7 +14,13 @@ public protocol ChannelNameFormatter {
 open class DefaultChannelNameFormatter: ChannelNameFormatter {
     public init() {}
 
+    /// Internal static property to add backwards compatibility to `Components.channelNamer`
+    internal static var channelNamer: (
+        _ channel: ChatChannel,
+        _ currentUserId: UserId?
+    ) -> String? = DefaultChatChannelNamer()
+
     open func format(channel: ChatChannel, forCurrentUserId currentUserId: UserId?) -> String? {
-        Components.default.channelNamer(channel, currentUserId)
+        Self.channelNamer(channel, currentUserId)
     }
 }

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -265,7 +265,14 @@ public struct Components {
         deprecated,
         message: "Please use `Appearance.default.formatters.channelName` instead"
     )
-    public var channelNamer: ChatChannelNamer = DefaultChatChannelNamer()
+    public var channelNamer: ChatChannelNamer {
+        get {
+            DefaultChannelNameFormatter.channelNamer
+        }
+        set {
+            DefaultChannelNameFormatter.channelNamer = newValue
+        }
+    }
 
     /// The collection view layout of the channel list.
     public var channelListLayout: UICollectionViewLayout.Type = ListCollectionViewLayout.self

--- a/Sources/StreamChatUI/Utils/ChatChannelNamer.swift
+++ b/Sources/StreamChatUI/Utils/ChatChannelNamer.swift
@@ -39,15 +39,10 @@ public typealias ChatChannelNamer =
 ///   - separator: Separator of the members, defaults to `y`
 /// - Returns: A closure with 2 parameters carrying `channel` used for name generation and `currentUserId` to decide
 /// which members' names are going to be displayed
-@available(
-    *,
-    deprecated,
-    message: "Please use a `ChannelNameFormatter` instead"
-)
 public func DefaultChatChannelNamer(
     maxMemberNames: Int = 2,
     separator: String = ","
-) -> ChatChannelNamer {
+) -> (_ channel: ChatChannel, _ currentUserId: UserId?) -> String? {
     { channel, currentUserId in
         if let channelName = channel.name, !channelName.isEmpty {
             // If there's an assigned name and it's not empty, we use it


### PR DESCRIPTION
Fix compiler warnings of the `ChatChannelNamer` deprecation. 
