### PR TITLE
[CIS-1549] Make `ChannelId.rawValue` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### ✅ Added
-- Make Date Formatters Configurable [#1742](https://github.com/GetStream/stream-chat-swift/pull/1742)
-- Add quoted video support [#1765](https://github.com/GetStream/stream-chat-swift/pull/1765)
-
-### 🔄 Changed
-- In case you are presenting the `ChatChannelVC` in a modal, you should now be using the `StreamModalTransitioningDelegate`. The workaround to fix the message list being dismissed when scrolling to the bottom has been removed in favor of the custom modal transition. Please check the following PR description to see how to use it: [#1760](https://github.com/GetStream/stream-chat-swift/pull/1760)
-
 ### 🐞 Fixed
-- Add custom modal transition for message list [#1760](https://github.com/GetStream/stream-chat-swift/pull/1760)
-- Fix composer not showing any files when >3 files are selected in bulk [#1768](https://github.com/GetStream/stream-chat-swift/issues/1768)
-- Crashfix for hanging `DispatchWorkItem` reference in `WebSocketClient`[#1766](https://github.com/GetStream/stream-chat-swift/issues/1766)
+- Make ChannelId.rawValue public [#1780](https://github.com/GetStream/stream-chat-swift/pull/1780)
 
 # [4.10.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.10.0)
 _February 01, 2022_

--- a/Sources/StreamChat/Models/ChannelId.swift
+++ b/Sources/StreamChat/Models/ChannelId.swift
@@ -11,7 +11,7 @@ import Foundation
 public struct ChannelId: Hashable, CustomStringConvertible {
     private static let separator: Character = ":"
     
-    let rawValue: String
+    public let rawValue: String
     
     /// Creates a new `ChannelId` value.
     ///


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1549

### 🎯 Goal

Simple one-liner, just to fix the `ChannelId.rawValue` access control. 

### 🛠 Implementation

Change `ChannelId.rawValue` access control to public. 

### 🎨 Changes
N/A

### 🧪 Testing
N/A

### ☑️ Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes