### PR TITLE
[CIS-1554] Make `SendButton` animation overridable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### ✅ Added
-- Make Date Formatters Configurable [#1742](https://github.com/GetStream/stream-chat-swift/pull/1742)
-- Add quoted video support [#1765](https://github.com/GetStream/stream-chat-swift/pull/1765)
-
-### 🔄 Changed
-- In case you are presenting the `ChatChannelVC` in a modal, you should now be using the `StreamModalTransitioningDelegate`. The workaround to fix the message list being dismissed when scrolling to the bottom has been removed in favor of the custom modal transition. Please check the following PR description to see how to use it: [#1760](https://github.com/GetStream/stream-chat-swift/pull/1760)
-
 ### 🐞 Fixed
-- Add custom modal transition for message list [#1760](https://github.com/GetStream/stream-chat-swift/pull/1760)
-- Fix composer not showing any files when >3 files are selected in bulk [#1768](https://github.com/GetStream/stream-chat-swift/issues/1768)
-- Crashfix for hanging `DispatchWorkItem` reference in `WebSocketClient`[#1766](https://github.com/GetStream/stream-chat-swift/issues/1766)
+- Make SendButton animation overridable [#1781](https://github.com/GetStream/stream-chat-swift/issues/1781)
 
 # [4.10.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.10.0)
 _February 01, 2022_

--- a/Sources/StreamChatUI/CommonViews/SendButton/SendButton.swift
+++ b/Sources/StreamChatUI/CommonViews/SendButton/SendButton.swift
@@ -10,7 +10,7 @@ open class SendButton: _Button, AppearanceProvider {
     /// Override this variable to enable custom behavior upon button enabled.
     override open var isEnabled: Bool {
         didSet {
-            isEnabledChangeAnimation()
+            isEnabledChangeAnimation(isEnabled)
         }
     }
 
@@ -26,9 +26,9 @@ open class SendButton: _Button, AppearanceProvider {
     }
 
     /// The animation when the `isEnabled` state changes.
-    open func isEnabledChangeAnimation() {
+    open func isEnabledChangeAnimation(_ isEnabled: Bool) {
         Animate {
-            self.transform = self.isEnabled
+            self.transform = isEnabled
                 ? CGAffineTransform(rotationAngle: -CGFloat.pi / 2.0)
                 : .identity
         }

--- a/Sources/StreamChatUI/CommonViews/SendButton/SendButton.swift
+++ b/Sources/StreamChatUI/CommonViews/SendButton/SendButton.swift
@@ -10,11 +10,7 @@ open class SendButton: _Button, AppearanceProvider {
     /// Override this variable to enable custom behavior upon button enabled.
     override open var isEnabled: Bool {
         didSet {
-            Animate {
-                self.transform = self.isEnabled
-                    ? CGAffineTransform(rotationAngle: -CGFloat.pi / 2.0)
-                    : .identity
-            }
+            isEnabledChangeAnimation()
         }
     }
 
@@ -27,5 +23,14 @@ open class SendButton: _Button, AppearanceProvider {
         let buttonColor: UIColor = appearance.colorPalette.alternativeInactiveTint
         let disabledStateImage = appearance.images.sendArrow.tinted(with: buttonColor)
         setImage(disabledStateImage, for: .disabled)
+    }
+
+    /// The animation when the `isEnabled` state changes.
+    open func isEnabledChangeAnimation() {
+        Animate {
+            self.transform = self.isEnabled
+                ? CGAffineTransform(rotationAngle: -CGFloat.pi / 2.0)
+                : .identity
+        }
     }
 }


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1554

### 🎯 Goal
Currently, the animation of SendButton is done on the didSet observer of the `SendButton.isEnabled`, the problem with this is that the `didSet` implementation is not overridable. We need to extract the animation to a different function so that the customer can override it.

### 🛠 Implementation
Extract the animation to a different function so that the customer can override it.

### 🎨 Changes
N/A

### 🧪 Testing
N/A

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
