### PR TITLE
Avoid compiler warnings in the `ChatChannelNamer` deprecation (#1774)

### DIFF
--- a/Sources/StreamChatUI/Utils/ChatChannelNamer.swift
+++ b/Sources/StreamChatUI/Utils/ChatChannelNamer.swift
@@ -39,11 +39,6 @@ public typealias ChatChannelNamer =
 ///   - separator: Separator of the members, defaults to `y`
 /// - Returns: A closure with 2 parameters carrying `channel` used for name generation and `currentUserId` to decide
 /// which members' names are going to be displayed
-@available(
-    *,
-    deprecated,
-    message: "Please use a `ChannelNameFormatter` instead"
-)
 public func DefaultChatChannelNamer(
     maxMemberNames: Int = 2,
     separator: String = ","


### PR DESCRIPTION
### 🎯 Goal

Avoid deprecation compiler warning in the `ChatChannelNamer`.

### 🧪 Testing

* There's no compiler warning emmited when project is built.

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
