### PR TITLE
[CIS-1393] Fix crash on iOS 12 when local storage enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Make ChannelId.rawValue public [#1780](https://github.com/GetStream/stream-chat-swift/pull/1780)
 - Fix channel not removed from channel list when user leaves the channel [#1785](https://github.com/GetStream/stream-chat-swift/pull/1785)
 - Fix Message Input Accessibility for Large Text [#1787](https://github.com/GetStream/stream-chat-swift/pull/1787)
+- Fix crash on iOS 12 when local storage enabled [#1784](https://github.com/GetStream/stream-chat-swift/pull/1784)
 
 # [4.10.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.10.0)
 _February 01, 2022_

--- a/Examples/SlackClone/ChatClient.swift
+++ b/Examples/SlackClone/ChatClient.swift
@@ -27,7 +27,8 @@ extension ChatClient {
         Appearance.default = appearance
         Components.default = components
         
-        let config = ChatClientConfig(apiKey: APIKey("q95x9hkbyd6p"))
+        var config = ChatClientConfig(apiKey: APIKey("q95x9hkbyd6p"))
+        config.isLocalStorageEnabled = true
         let client = ChatClient(
             config: config
         )

--- a/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
@@ -206,7 +206,7 @@ extension CurrentChatUser {
             createdAt: user.userCreatedAt,
             updatedAt: user.userUpdatedAt,
             lastActiveAt: user.lastActivityAt,
-            teams: user.teams ?? [],
+            teams: Set(user.teams),
             extraData: extraData,
             devices: dto.devices.map { $0.asModel() },
             currentDevice: dto.currentDevice?.asModel(),

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -162,7 +162,7 @@ extension ChatChannelMember {
             userCreatedAt: dto.user.userCreatedAt,
             userUpdatedAt: dto.user.userUpdatedAt,
             lastActiveAt: dto.user.lastActivityAt,
-            teams: dto.user.teams ?? [],
+            teams: Set(dto.user.teams),
             extraData: extraData,
             memberRole: role,
             memberCreatedAt: dto.memberCreatedAt,

--- a/Sources/StreamChat/Database/DTOs/UserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/UserDTO.swift
@@ -23,7 +23,7 @@ class UserDTO: NSManagedObject {
 
     @NSManaged var members: Set<MemberDTO>?
     @NSManaged var currentUser: CurrentUserDTO?
-    @NSManaged var teams: Set<TeamId>?
+    @NSManaged var teams: [TeamId]
     @NSManaged var channelMutes: Set<ChannelMuteDTO>
 
     /// Returns a fetch request for the dto with the provided `userId`.
@@ -87,6 +87,7 @@ extension UserDTO {
         
         let new = NSEntityDescription.insertNewObject(forEntityName: Self.entityName, into: context) as! UserDTO
         new.id = id
+        new.teams = []
         return new
     }
     
@@ -132,7 +133,7 @@ extension NSManagedObjectContext: UserDatabaseSession {
             dto.extraData = Data()
         }
 
-        dto.teams = Set(payload.teams)
+        dto.teams = payload.teams
 
         // payloadHash doesn't cover the query
         if let query = query, let queryDTO = try saveQuery(query: query) {
@@ -217,7 +218,7 @@ extension ChatUser {
             createdAt: dto.userCreatedAt,
             updatedAt: dto.userUpdatedAt,
             lastActiveAt: dto.lastActivityAt,
-            teams: dto.teams ?? [],
+            teams: Set(dto.teams),
             extraData: extraData
         )
     }

--- a/Sources/StreamChat/Database/DTOs/UserDTO_Tests.swift
+++ b/Sources/StreamChat/Database/DTOs/UserDTO_Tests.swift
@@ -42,7 +42,7 @@ class UserDTO_Tests: XCTestCase {
             Assert.willBeEqual(payload.createdAt, loadedUserDTO.userCreatedAt)
             Assert.willBeEqual(payload.updatedAt, loadedUserDTO.userUpdatedAt)
             Assert.willBeEqual(payload.lastActiveAt, loadedUserDTO.lastActivityAt)
-            Assert.willBeEqual(payload.teams.sorted(), loadedUserDTO.teams?.sorted())
+            Assert.willBeEqual(payload.teams, loadedUserDTO.teams)
             Assert.willBeEqual(
                 payload.extraData,
                 try? JSONDecoder.default.decode([String: RawJSON].self, from: loadedUserDTO.extraData)

--- a/Sources/StreamChat/Database/DatabaseContainer_Tests.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer_Tests.swift
@@ -38,6 +38,7 @@ class DatabaseContainer_Tests: XCTestCase {
                 userDTO.userCreatedAt = .init()
                 userDTO.userUpdatedAt = .init()
                 userDTO.userRoleRaw = "user"
+                userDTO.teams = []
             }, completion: { error in
                 XCTAssertNil(error)
                 goldenPathExpectation.fulfill()

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21C52" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21A559" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
@@ -248,7 +248,7 @@
         <attribute name="isOnline" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="lastActivityAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
-        <attribute name="teams" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
+        <attribute name="teams" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
         <attribute name="userCreatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="userRoleRaw" attributeType="String"/>
         <attribute name="userUpdatedAt" attributeType="Date" usesScalarValueType="NO"/>

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -910,7 +910,6 @@
 		ADCDDCC525AE1293004E15FB /* UserUpdateResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = ADCDDCC425AE1293004E15FB /* UserUpdateResponse.json */; };
 		ADCDDD0025AE2784004E15FB /* UserUpdateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCDDCEC25AE2214004E15FB /* UserUpdateViewController.swift */; };
 		ADCDDD0825AE2F4A004E15FB /* InputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCDDD0725AE2F4A004E15FB /* InputViewController.swift */; };
-		ADDFDE292779EC67003B3B07 /* Atlantis in Frameworks */ = {isa = PBXBuildFile; productRef = ADDFDE282779EC67003B3B07 /* Atlantis */; };
 		ADDFDE2B2779EC8A003B3B07 /* Atlantis in Frameworks */ = {isa = PBXBuildFile; productRef = ADDFDE2A2779EC8A003B3B07 /* Atlantis */; };
 		ADEA7EB0261C88E200CA2289 /* CurrentChatUser_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEA7EAF261C88E200CA2289 /* CurrentChatUser_Mock.swift */; };
 		ADEA7F35261D302100CA2289 /* r2.jpg in Resources */ = {isa = PBXBuildFile; fileRef = ADEA7F22261D2F8C00CA2289 /* r2.jpg */; };
@@ -3280,7 +3279,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ADDFDE292779EC67003B3B07 /* Atlantis in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6351,7 +6349,6 @@
 			);
 			name = StreamChat;
 			packageProductDependencies = (
-				ADDFDE282779EC67003B3B07 /* Atlantis */,
 			);
 			productName = Sources;
 			productReference = 799C941B247D2F80001F1104 /* StreamChat.framework */;
@@ -10518,11 +10515,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AD472EF625C425FB00A96E70 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
 			productName = SnapshotTesting;
-		};
-		ADDFDE282779EC67003B3B07 /* Atlantis */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = ADDFDE272779EC67003B3B07 /* XCRemoteSwiftPackageReference "atlantis" */;
-			productName = Atlantis;
 		};
 		ADDFDE2A2779EC8A003B3B07 /* Atlantis */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -10171,7 +10171,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = Examples/SlackClone/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -10194,7 +10194,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = Examples/SlackClone/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -10215,7 +10215,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = EHV7XZLAHA;
 				INFOPLIST_FILE = Examples/SlackClone/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1393

### 🎯 Goal
Fix a crash on iOS 12 that whenever the app was launched, it would instantly crash.

### 🛠 Implementation

The crash was happening because of a mismatch between `UserDTO.teams` property marked as `[String]?` in db schema but being a `Set<String>?` in managed object subclass. Exactly what the error was saying: 
```
reason: 'Object of class Swift.__EmptySetSingleton is not among allowed top level class list (
  NSArray,
  NSDictionary,
  NSString,
  NSNumber,
  NSDate,
  NSData,
  NSURL,
  NSUUID,
  NSNull
)'
```
The `teams` property is updated to be an array, made non-optional, and ensured to exist at the moment the `UserDTO` is saved to the persistent store.

### 🎨 Changes
N/A

### 🧪 Testing
- Run Slack Clone App on iOS 12

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
