### PR TITLE
[CIS-1557] Fix channel not removed from channel list when user leaves the channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### 🔄 Changed
+- `ChannelListVC` now keeps track of channels where user is a member only instead of all channels loaded in the SDK. [#1785](https://github.com/GetStream/stream-chat-swift/pull/1785)
+
 ### 🐞 Fixed
 - Make SendButton animation overridable [#1781](https://github.com/GetStream/stream-chat-swift/issues/1781)
 - Make ChannelId.rawValue public [#1780](https://github.com/GetStream/stream-chat-swift/pull/1780)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Make SendButton animation overridable [#1781](https://github.com/GetStream/stream-chat-swift/issues/1781)
 - Make ChannelId.rawValue public [#1780](https://github.com/GetStream/stream-chat-swift/pull/1780)
+- Fix channel not removed from channel list when user leaves the channel [#1785](https://github.com/GetStream/stream-chat-swift/pull/1785)
 
 # [4.10.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.10.0)
 _February 01, 2022_

--- a/DemoApp/DemoAppCoordinator.swift
+++ b/DemoApp/DemoAppCoordinator.swift
@@ -242,14 +242,6 @@ class DemoChannelListVC: ChatChannelListVC {
         navigationController?.pushViewController(channelListVC, animated: true)
     }
 
-    override func controller(_ controller: ChatChannelListController, shouldListUpdatedChannel channel: ChatChannel) -> Bool {
-        channel.membership != nil
-    }
-
-    override func controller(_ controller: ChatChannelListController, shouldAddNewChannelToList channel: ChatChannel) -> Bool {
-        channel.membership != nil
-    }
-
     var isPad: Bool { UIDevice.current.userInterfaceIdiom == .pad }
 
     var didSelectChannel: ((ChatChannel) -> Void)?

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -317,11 +317,11 @@ open class ChatChannelListVC: _ViewController,
     }
     
     open func controller(_ controller: ChatChannelListController, shouldAddNewChannelToList channel: ChatChannel) -> Bool {
-        true
+        channel.membership != nil
     }
     
     open func controller(_ controller: ChatChannelListController, shouldListUpdatedChannel channel: ChatChannel) -> Bool {
-        true
+        channel.membership != nil
     }
     
     // MARK: - DataControllerStateDelegate

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC_Tests.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC_Tests.swift
@@ -312,6 +312,38 @@ extension ChatChannelListVC_Tests {
         XCTAssertEqual(channelListVC.mockedCollectionView.reloadDataCallCount, 1)
     }
 
+    func test_shouldAddNewChannelToList_whenCurrentUserIsMember_shouldReturnTrue() {
+        let channelListVC = FakeChatChannelListVC()
+        channelListVC.controller = mockedChannelListController
+
+        let channel = ChatChannel.mock(cid: .unique, membership: .mock(id: .unique))
+        XCTAssertTrue(channelListVC.controller(mockedChannelListController, shouldAddNewChannelToList: channel))
+    }
+
+    func test_shouldAddNewChannelToList_whenCurrentUserIsNotMember_shouldReturnFalse() {
+        let channelListVC = FakeChatChannelListVC()
+        channelListVC.controller = mockedChannelListController
+
+        let channel = ChatChannel.mock(cid: .unique, membership: nil)
+        XCTAssertFalse(channelListVC.controller(mockedChannelListController, shouldAddNewChannelToList: channel))
+    }
+
+    func test_shouldListUpdatedChannel_whenCurrentUserIsMember_shouldReturnTrue() {
+        let channelListVC = FakeChatChannelListVC()
+        channelListVC.controller = mockedChannelListController
+
+        let channel = ChatChannel.mock(cid: .unique, membership: .mock(id: .unique))
+        XCTAssertTrue(channelListVC.controller(mockedChannelListController, shouldListUpdatedChannel: channel))
+    }
+
+    func test_shouldListUpdatedChannel_whenCurrentUserIsNotMember_shouldReturnFalse() {
+        let channelListVC = FakeChatChannelListVC()
+        channelListVC.controller = mockedChannelListController
+
+        let channel = ChatChannel.mock(cid: .unique, membership: nil)
+        XCTAssertFalse(channelListVC.controller(mockedChannelListController, shouldListUpdatedChannel: channel))
+    }
+
     private class FakeChatChannelListVC: ChatChannelListVC {
         var mockedCollectionView: MockCollectionView = MockCollectionView()
         override var collectionView: UICollectionView {


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1557

### 🎯 Goal
Change the default logic of `shouldAddNewChannelToList` and `shoudListUpdatedChannel`. Currently, whenever a user removes itself from the channel, the channel is still present in the channel list. This shouldn't be the default use case, because most customers want the opposite to happen. This will reduce the customer support tickets we are having.

### 🛠 Implementation
Move the `DemoApp` implementation to be the default one.

### 🎨 Changes
N/A

### 🧪 Testing
- Go to a channel
- Click on the Debug icon
- Remove yourself from the members
- Channel list should remove the channel

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
