### PR TITLE
Offline Support - APIClient with OperationQueue

### DIFF
--- a/Sources/StreamChat/APIClient/APIClient.swift
+++ b/Sources/StreamChat/APIClient/APIClient.swift
@@ -159,13 +159,13 @@ class APIClient {
     }
 
     private func refreshToken(completion: @escaping () -> Void) {
-        // We stop the queue so no more operations are triggered
-        operationQueue.isSuspended = true
-
         guard _isRefreshingToken.compareAndSwap(old: false, new: true) else {
             completion()
             return
         }
+
+        // We stop the queue so no more operations are triggered
+        operationQueue.isSuspended = true
 
         // Increase the amount of consecutive failures
         _tokenRefreshConsecutiveFailures.mutate { $0 += 1 }
@@ -173,7 +173,7 @@ class APIClient {
         tokenRefresher { [weak self] in
             self?.isRefreshingToken = false
             // We restart the queue now that token refresh is completed
-            self?.operationQueue.isSuspended = true
+            self?.operationQueue.isSuspended = false
             completion()
         }
     }

--- a/Sources/StreamChat/APIClient/CDNClient_Mock.swift
+++ b/Sources/StreamChat/APIClient/CDNClient_Mock.swift
@@ -18,10 +18,14 @@ final class CDNClient_Mock: CDNClient, Spy {
         completion: @escaping (Result<URL, Error>) -> Void
     ) {
         record()
-        uploadAttachmentProgress.map { progress?($0) }
+        if let uploadAttachmentProgress = uploadAttachmentProgress {
+            progress?(uploadAttachmentProgress)
+        }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            self.uploadAttachmentResult.map(completion)
+        if let uploadAttachmentResult = uploadAttachmentResult {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                completion(uploadAttachmentResult)
+            }
         }
     }
 }

--- a/Sources/StreamChat/APIClient/CDNClient_Mock.swift
+++ b/Sources/StreamChat/APIClient/CDNClient_Mock.swift
@@ -5,21 +5,23 @@
 import StreamChat
 import StreamChatTestTools
 
-final class CDNClient_Mock: CDNClient {
+final class CDNClient_Mock: CDNClient, Spy {
+    var recordedFunctions: [String] = []
+
     static var maxAttachmentSize: Int64 { .max }
-    
-    lazy var uploadAttachmentMockFunc = MockFunc.mock(for: uploadAttachment)
+    var uploadAttachmentProgress: Double?
+    var uploadAttachmentResult: Result<URL, Error>?
+
     func uploadAttachment(
         _ attachment: AnyChatMessageAttachment,
         progress: ((Double) -> Void)?,
         completion: @escaping (Result<URL, Error>) -> Void
     ) {
-        uploadAttachmentMockFunc.callAndReturn(
-            (
-                attachment,
-                progress,
-                completion
-            )
-        )
+        record()
+        uploadAttachmentProgress.map { progress?($0) }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.uploadAttachmentResult.map(completion)
+        }
     }
 }

--- a/Sources/StreamChat/APIClient/RequestDecoder.swift
+++ b/Sources/StreamChat/APIClient/RequestDecoder.swift
@@ -80,6 +80,7 @@ struct DefaultRequestDecoder: RequestDecoder {
 
 extension ClientError {
     class ExpiredToken: ClientError {}
+    class RefreshingToken: ClientError {}
     class TooManyTokenRefreshAttempts: ClientError {
         override var localizedDescription: String {
             "Authentication failed on expired tokens after too many refresh attempts, please check that your user tokens are created correctly."

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -531,8 +531,7 @@ class ChatClient_Tests: XCTestCase {
         
         // Assert `flushRequestsQueue` is triggered, client is not recreated
         XCTAssertTrue(testEnv.apiClient! === client.apiClient)
-        XCTAssertEqual(testEnv.apiClient!.flushRequestsQueue_timeout, 0)
-        XCTAssertNil(testEnv.apiClient!.flushRequestsQueue_itemAction)
+        XCTAssertTrue("flushRequestsQueue()".wasCalled(on: testEnv.apiClient!, times: 1))
     }
     
     // MARK: - Background workers tests

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -531,7 +531,7 @@ class ChatClient_Tests: XCTestCase {
         
         // Assert `flushRequestsQueue` is triggered, client is not recreated
         XCTAssertTrue(testEnv.apiClient! === client.apiClient)
-        XCTAssertTrue("flushRequestsQueue()".wasCalled(on: testEnv.apiClient!, times: 1))
+        XCTAssertCall("flushRequestsQueue()", on: testEnv.apiClient!, times: 1)
     }
     
     // MARK: - Background workers tests

--- a/Sources/StreamChat/Repositories/SyncOperations.swift
+++ b/Sources/StreamChat/Repositories/SyncOperations.swift
@@ -15,7 +15,7 @@ class SyncContext {
 
 class GetChannelIdsOperation: AsyncOperation {
     init(database: DatabaseContainer, context: SyncContext) {
-        super.init(maxRetries: 2) { [weak database] done in
+        super.init(maxRetries: 2) { [weak database] _, done in
             guard let database = database else {
                 done(.continue)
                 return
@@ -34,7 +34,7 @@ class GetChannelIdsOperation: AsyncOperation {
 
 class GetPendingConnectionDateOperation: AsyncOperation {
     init(database: DatabaseContainer, context: SyncContext) {
-        super.init(maxRetries: 2) { [weak database] done in
+        super.init(maxRetries: 2) { [weak database] _, done in
             database?.backgroundReadOnlyContext.perform {
                 context.lastPendingConnectionDate = database?.backgroundReadOnlyContext.currentUser?.lastPendingConnectionDate
                 done(.continue)
@@ -45,7 +45,7 @@ class GetPendingConnectionDateOperation: AsyncOperation {
 
 class SyncEventsOperation: AsyncOperation {
     init(database: DatabaseContainer, syncRepository: SyncRepository, context: SyncContext) {
-        super.init(maxRetries: 2) { [weak database, weak syncRepository] done in
+        super.init(maxRetries: 2) { [weak database, weak syncRepository] _, done in
             log.info(
                 "1. Call `/sync` endpoint and get missing events for all locally existed channels",
                 subsystems: .offlineSupport
@@ -78,7 +78,7 @@ class SyncEventsOperation: AsyncOperation {
 
 class WatchChannelOperation: AsyncOperation {
     init(controller: ChatChannelController, context: SyncContext) {
-        super.init(maxRetries: 2) { [weak controller] done in
+        super.init(maxRetries: 2) { [weak controller] _, done in
             guard let controller = controller, controller.isAvailableOnRemote else {
                 done(.continue)
                 return
@@ -109,7 +109,7 @@ class WatchChannelOperation: AsyncOperation {
 
 class RefetchChannelListQueryOperation: AsyncOperation {
     init(controller: ChatChannelListController, channelRepository: ChannelListUpdater, context: SyncContext) {
-        super.init(maxRetries: 2) { [weak controller] done in
+        super.init(maxRetries: 2) { [weak controller] _, done in
             guard let controller = controller, controller.isAvailableOnRemote else {
                 done(.continue)
                 return

--- a/Sources/StreamChat/Repositories/SyncOperations_Tests.swift
+++ b/Sources/StreamChat/Repositories/SyncOperations_Tests.swift
@@ -88,7 +88,7 @@ final class SyncOperations_Tests: XCTestCase {
         operation.startAndWaitForCompletion()
 
         XCTAssertEqual(context.synchedChannelIds.count, 0)
-        XCTAssertTrue("syncMissingEvents(using:channelIds:bumpLastSync:completion:)".wasNotCalled(on: syncRepository))
+        XCTAssertNotCall("syncMissingEvents(using:channelIds:bumpLastSync:completion:)", on: syncRepository)
     }
 
     func test_SyncEventsOperation_pendingDate_syncFailure_shouldRetry() throws {
@@ -103,7 +103,7 @@ final class SyncOperations_Tests: XCTestCase {
 
         XCTAssertEqual(context.synchedChannelIds.count, 0)
         XCTAssertNil(database.viewContext.currentUser?.lastPendingConnectionDate)
-        XCTAssertTrue("syncMissingEvents(using:channelIds:bumpLastSync:completion:)".wasCalled(on: syncRepository, times: 3))
+        XCTAssertCall("syncMissingEvents(using:channelIds:bumpLastSync:completion:)", on: syncRepository, times: 3)
     }
 
     func test_SyncEventsOperation_pendingDate_syncSuccess_shouldUpdateLastPendingConnectionDate() throws {
@@ -118,7 +118,7 @@ final class SyncOperations_Tests: XCTestCase {
 
         XCTAssertEqual(context.synchedChannelIds.count, 2)
         XCTAssertEqual(database.viewContext.currentUser?.lastPendingConnectionDate, context.lastConnectionDate)
-        XCTAssertTrue("syncMissingEvents(using:channelIds:bumpLastSync:completion:)".wasCalled(on: syncRepository, times: 1))
+        XCTAssertCall("syncMissingEvents(using:channelIds:bumpLastSync:completion:)", on: syncRepository, times: 1)
     }
 
     // MARK: - WatchChannelOperation
@@ -132,7 +132,7 @@ final class SyncOperations_Tests: XCTestCase {
         operation.startAndWaitForCompletion()
 
         XCTAssertEqual(context.watchedChannelIds.count, 0)
-        XCTAssertTrue("watchActiveChannel(completion:)".wasNotCalled(on: controller))
+        XCTAssertNotCall("watchActiveChannel(completion:)", on: controller)
     }
 
     func test_WatchChannelOperation_availableOnRemote_alreadySynched() {
@@ -146,7 +146,7 @@ final class SyncOperations_Tests: XCTestCase {
         operation.startAndWaitForCompletion()
 
         XCTAssertEqual(context.watchedChannelIds.count, 0)
-        XCTAssertTrue("watchActiveChannel(completion:)".wasNotCalled(on: controller))
+        XCTAssertNotCall("watchActiveChannel(completion:)", on: controller)
     }
 
     func test_WatchChannelOperation_availableOnRemote_notSynched_watchFailure_shouldRetry() {
@@ -160,7 +160,7 @@ final class SyncOperations_Tests: XCTestCase {
         operation.startAndWaitForCompletion()
 
         XCTAssertEqual(context.watchedChannelIds.count, 0)
-        XCTAssertTrue("watchActiveChannel(completion:)".wasCalled(on: controller, times: 3))
+        XCTAssertCall("watchActiveChannel(completion:)", on: controller, times: 3)
     }
 
     func test_WatchChannelOperation_availableOnRemote_notSynched_watchSuccess() {
@@ -174,7 +174,7 @@ final class SyncOperations_Tests: XCTestCase {
         operation.startAndWaitForCompletion()
 
         XCTAssertEqual(context.watchedChannelIds.count, 1)
-        XCTAssertTrue("watchActiveChannel(completion:)".wasCalled(on: controller, times: 1))
+        XCTAssertCall("watchActiveChannel(completion:)", on: controller, times: 1)
     }
 
     // MARK: - RefetchChannelListQueryOperation
@@ -192,7 +192,7 @@ final class SyncOperations_Tests: XCTestCase {
         operation.startAndWaitForCompletion()
 
         XCTAssertEqual(context.synchedChannelIds.count, 0)
-        XCTAssertTrue("resetChannelsQuery(for:watchedChannelIds:synchedChannelIds:completion:)".wasNotCalled(on: channelRepository))
+        XCTAssertNotCall("resetChannelsQuery(for:watchedChannelIds:synchedChannelIds:completion:)", on: channelRepository)
     }
 
     func test_RefetchChannelListQueryOperation_availableOnRemote_resetFailure_shouldRetry() {
@@ -209,9 +209,8 @@ final class SyncOperations_Tests: XCTestCase {
         operation.startAndWaitForCompletion()
 
         XCTAssertEqual(context.synchedChannelIds.count, 0)
-        XCTAssertTrue(
-            "resetChannelsQuery(for:watchedChannelIds:synchedChannelIds:completion:)"
-                .wasCalled(on: channelRepository, times: 3)
+        XCTAssertCall(
+            "resetChannelsQuery(for:watchedChannelIds:synchedChannelIds:completion:)", on: channelRepository, times: 3
         )
     }
 
@@ -236,9 +235,8 @@ final class SyncOperations_Tests: XCTestCase {
 
         XCTAssertEqual(context.synchedChannelIds.count, 1)
         XCTAssertEqual(context.synchedChannelIds.first?.id, channelId.id)
-        XCTAssertTrue(
-            "resetChannelsQuery(for:watchedChannelIds:synchedChannelIds:completion:)"
-                .wasCalled(on: channelRepository, times: 1)
+        XCTAssertCall(
+            "resetChannelsQuery(for:watchedChannelIds:synchedChannelIds:completion:)", on: channelRepository, times: 1
         )
     }
 }

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -115,7 +115,7 @@ class SyncRepository {
         operations.append(contentsOf: refetchChannelListQueryOperations)
 
         // 5. Bump the last sync timestamp
-        operations.append(AsyncOperation { [weak self] done in
+        operations.append(AsyncOperation { [weak self] _, done in
             log.info("5. Bump the last sync timestamp", subsystems: .offlineSupport)
             self?.updateUserValue { user in
                 user?.lastSyncAt = Date()

--- a/Sources/StreamChat/Repositories/SyncRepository_Tests.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository_Tests.swift
@@ -121,7 +121,7 @@ final class SyncRepository_Tests: XCTestCase {
         // Write: API Response, lastPendingConnectionDate, lastSyncAt
         XCTAssertEqual(database.writeSessionCounter, 3)
         XCTAssertEqual(repository.activeChannelControllers.count, 1)
-        XCTAssertTrue("watchActiveChannel(completion:)".wasCalled(on: chatController, times: 1))
+        XCTAssertCall("watchActiveChannel(completion:)", on: chatController, times: 1)
         XCTAssertEqual(repository.activeChannelListControllers.count, 0)
         XCTAssertEqual(apiClient.request_allRecordedCalls.count, 1)
     }
@@ -145,9 +145,8 @@ final class SyncRepository_Tests: XCTestCase {
         XCTAssertEqual(database.writeSessionCounter, 3)
         XCTAssertEqual(repository.activeChannelControllers.count, 0)
         XCTAssertEqual(repository.activeChannelListControllers.count, 1)
-        XCTAssertTrue(
-            "resetChannelsQuery(for:watchedChannelIds:synchedChannelIds:completion:)"
-                .wasCalled(on: channelRepository, times: 1)
+        XCTAssertCall(
+            "resetChannelsQuery(for:watchedChannelIds:synchedChannelIds:completion:)", on: channelRepository, times: 1
         )
         XCTAssertEqual(apiClient.request_allRecordedCalls.count, 1)
     }

--- a/Sources/StreamChat/Utils/Atomic.swift
+++ b/Sources/StreamChat/Utils/Atomic.swift
@@ -59,8 +59,11 @@ public class Atomic<T> {
 }
 
 public extension Atomic where T: Equatable {
-    /// Updates the value to `new` if the current value is `old`
-    /// if the swap happens true is returned
+    /// Updates the value to `new` if the current value is `old`.
+    /// - Parameters:
+    ///   - old: old value
+    ///   - new: new value
+    /// - Returns: true if the swap is successful
     func compareAndSwap(old: T, new: T) -> Bool {
         lock.lock()
         defer {

--- a/Sources/StreamChat/Utils/Operations/AsyncOperation_Tests.swift
+++ b/Sources/StreamChat/Utils/Operations/AsyncOperation_Tests.swift
@@ -9,7 +9,7 @@ final class AsyncOperation_Tests: XCTestCase {
     func testOperationCallsCompletion() {
         let expectation = expectation(description: "operation concludes")
 
-        let operation = AsyncOperation { completion in
+        let operation = AsyncOperation { _, completion in
             completion(.continue)
             expectation.fulfill()
         }
@@ -25,7 +25,7 @@ final class AsyncOperation_Tests: XCTestCase {
 
     func testOperationDoesNotRetryIfValueIsNotPassed() {
         var operationBlockCalls = 0
-        let operation = AsyncOperation { completion in
+        let operation = AsyncOperation { _, completion in
             operationBlockCalls += 1
             completion(.retry)
         }
@@ -36,7 +36,7 @@ final class AsyncOperation_Tests: XCTestCase {
 
     func testOperationRetriesUpTillMaximumRetries() {
         var operationBlockCalls = 0
-        let operation = AsyncOperation(maxRetries: 2) { completion in
+        let operation = AsyncOperation(maxRetries: 2) { _, completion in
             operationBlockCalls += 1
             completion(.retry)
         }
@@ -47,7 +47,7 @@ final class AsyncOperation_Tests: XCTestCase {
 
     func testOperationRetriesUpTillSuccess() {
         var operationBlockCalls = 0
-        let operation = AsyncOperation(maxRetries: 10) { completion in
+        let operation = AsyncOperation(maxRetries: 10) { _, completion in
             operationBlockCalls += 1
             if operationBlockCalls == 2 {
                 completion(.continue)
@@ -62,7 +62,7 @@ final class AsyncOperation_Tests: XCTestCase {
 
     func testOperationDoesNotRetryIfCancelled() {
         var operationBlockCalls = 0
-        let operation = AsyncOperation(maxRetries: 10) { completion in
+        let operation = AsyncOperation(maxRetries: 10) { _, completion in
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 operationBlockCalls += 1
                 completion(.retry)
@@ -92,7 +92,7 @@ final class AsyncOperation_Tests: XCTestCase {
 
     func testOperationShouldNotStartIfCancelled() {
         var operationBlockCalls = 0
-        let operation = AsyncOperation(maxRetries: 10) { completion in
+        let operation = AsyncOperation(maxRetries: 10) { _, completion in
             operationBlockCalls += 1
             completion(.retry)
         }

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler_Tests.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler_Tests.swift
@@ -489,7 +489,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         // Simulate connection update
         handler.webSocketClient(mockChatClient.mockWebSocketClient, didUpdateConnectionState: .connecting)
 
-        XCTAssertTrue("syncLocalState(completion:)".wasNotCalled(on: syncRepository))
+        XCTAssertNotCall("syncLocalState(completion:)", on: syncRepository)
     }
 
     func test_webSocketStateUpdate_connected() {
@@ -499,8 +499,8 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         // Simulate connection update
         handler.webSocketClient(mockChatClient.mockWebSocketClient, didUpdateConnectionState: .connected(connectionId: "124"))
 
-        XCTAssertTrue("resetConsecutiveFailures()".wasCalled(on: mockRetryStrategy, times: 1))
-        XCTAssertTrue("syncLocalState(completion:)".wasCalled(on: syncRepository, times: 1))
+        XCTAssertCall("resetConsecutiveFailures()", on: mockRetryStrategy, times: 1)
+        XCTAssertCall("syncLocalState(completion:)", on: syncRepository, times: 1)
     }
 
     func test_webSocketStateUpdate_disconnected_userInitiated() {
@@ -514,9 +514,9 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         handler.webSocketClient(mockChatClient.mockWebSocketClient, didUpdateConnectionState: status)
 
         // getDelayAfterTheFailure() calls nextRetryDelay() & incrementConsecutiveFailures() internally
-        XCTAssertTrue("nextRetryDelay()".wasNotCalled(on: mockRetryStrategy))
-        XCTAssertTrue("incrementConsecutiveFailures()".wasNotCalled(on: mockRetryStrategy))
-        XCTAssertTrue("syncLocalState(completion:)".wasNotCalled(on: syncRepository))
+        XCTAssertNotCall("nextRetryDelay()", on: mockRetryStrategy)
+        XCTAssertNotCall("incrementConsecutiveFailures()", on: mockRetryStrategy)
+        XCTAssertNotCall("syncLocalState(completion:)", on: syncRepository)
     }
 
     func test_webSocketStateUpdate_disconnected_systemInitiated() {
@@ -534,9 +534,9 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         handler.webSocketClient(mockChatClient.mockWebSocketClient, didUpdateConnectionState: status)
 
         // getDelayAfterTheFailure() calls nextRetryDelay() & incrementConsecutiveFailures() internally
-        XCTAssertTrue("nextRetryDelay()".wasCalled(on: mockRetryStrategy, times: 1))
-        XCTAssertTrue("incrementConsecutiveFailures()".wasCalled(on: mockRetryStrategy, times: 1))
-        XCTAssertTrue("syncLocalState(completion:)".wasNotCalled(on: syncRepository))
+        XCTAssertCall("nextRetryDelay()", on: mockRetryStrategy, times: 1)
+        XCTAssertCall("incrementConsecutiveFailures()", on: mockRetryStrategy, times: 1)
+        XCTAssertNotCall("syncLocalState(completion:)", on: syncRepository)
     }
 
     func test_webSocketStateUpdate_initialized() {
@@ -546,7 +546,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         // Simulate connection update
         handler.webSocketClient(mockChatClient.mockWebSocketClient, didUpdateConnectionState: .initialized)
 
-        XCTAssertTrue("syncLocalState(completion:)".wasNotCalled(on: syncRepository))
+        XCTAssertNotCall("syncLocalState(completion:)", on: syncRepository)
     }
 
     func test_webSocketStateUpdate_waitingForConnectionId() {
@@ -556,7 +556,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         // Simulate connection update
         handler.webSocketClient(mockChatClient.mockWebSocketClient, didUpdateConnectionState: .waitingForConnectionId)
 
-        XCTAssertTrue("syncLocalState(completion:)".wasNotCalled(on: syncRepository))
+        XCTAssertNotCall("syncLocalState(completion:)", on: syncRepository)
     }
 
     func test_webSocketStateUpdate_disconnecting() {
@@ -569,7 +569,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
             didUpdateConnectionState: .disconnecting(source: .systemInitiated)
         )
 
-        XCTAssertTrue("syncLocalState(completion:)".wasNotCalled(on: syncRepository))
+        XCTAssertNotCall("syncLocalState(completion:)", on: syncRepository)
     }
 }
 

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -7,8 +7,6 @@ import Foundation
 
 /// The type provides the API for getting/editing/deleting a message
 class MessageUpdater: Worker {
-    private var retryOptions: RetryOptions = .init()
-
     /// Fetches the message from the backend and saves it into the database
     /// - Parameters:
     ///   - cid: The channel identifier the message relates to.

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -352,7 +352,7 @@ class MessageUpdater: Worker {
                 reaction.version = version
             }
         } completion: { error in
-            self.apiClient.request(endpoint: endpoint, retryOptions: self.retryOptions) { result in
+            self.apiClient.request(endpoint: endpoint) { result in
                 if result.error == nil {
                     return
                 }
@@ -393,7 +393,7 @@ class MessageUpdater: Worker {
             reaction.localState = .pendingDelete
         } completion: { error in
             self.apiClient
-                .request(endpoint: .deleteReaction(type, messageId: messageId), retryOptions: self.retryOptions) { result in
+                .request(endpoint: .deleteReaction(type, messageId: messageId)) { result in
                     if result.error == nil {
                         return
                     }

--- a/Sources/StreamChatTestTools/ChatClient_Mock.swift
+++ b/Sources/StreamChatTestTools/ChatClient_Mock.swift
@@ -44,7 +44,6 @@ public extension ChatClient {
 class APIClient_Mock: APIClient {
     override func request<Response>(
         endpoint: Endpoint<Response>,
-        timeout: TimeInterval,
         completion: @escaping (Result<Response, Error>) -> Void
     ) where Response: Decodable {
         // Do nothing for now

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -864,7 +864,6 @@
 		AD71130225F138BA00932AEE /* ChatChannelAvatarView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E791E4D525D3E2DA00B0E076 /* ChatChannelAvatarView_Tests.swift */; };
 		AD71131225F138D500932AEE /* ChatUserAvatarView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD71131125F138D500932AEE /* ChatUserAvatarView_Tests.swift */; };
 		AD75CB6B27886746005F5FF7 /* OptionsSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD75CB6A27886746005F5FF7 /* OptionsSelectorViewController.swift */; };
-		AD77030225EFE24F004E2F10 /* DateFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7702F225EFE1D2004E2F10 /* DateFormatter+Extensions.swift */; };
 		AD793F49270B767500B05456 /* ChatMessageReactionAuthorsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD793F48270B767500B05456 /* ChatMessageReactionAuthorsVC.swift */; };
 		AD793F4B270B769E00B05456 /* ChatMessageReactionAuthorViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD793F4A270B769E00B05456 /* ChatMessageReactionAuthorViewCell.swift */; };
 		AD7AC99B260A9572004AADA5 /* MessagePinning.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7AC98B260A94C6004AADA5 /* MessagePinning.swift */; };
@@ -906,9 +905,9 @@
 		ADC40C3226E26E9F005B616C /* UserSearchController_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795297052583B52000435B2E /* UserSearchController_Tests.swift */; };
 		ADC40C3426E294EB005B616C /* MessageSearchController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC40C3326E294EB005B616C /* MessageSearchController+Combine.swift */; };
 		ADC40C3626E2980D005B616C /* MessageSearchController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC40C3526E2980D005B616C /* MessageSearchController+SwiftUI.swift */; };
+		ADC4AAAE2788ACFE0004BB35 /* MessageDeletedHard.json in Resources */ = {isa = PBXBuildFile; fileRef = ADC4AAAD2788ACFE0004BB35 /* MessageDeletedHard.json */; };
 		ADC4AAB02788C8850004BB35 /* Appearance+Formatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC4AAAF2788C8850004BB35 /* Appearance+Formatters.swift */; };
 		ADC4AAB12788C8850004BB35 /* Appearance+Formatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC4AAAF2788C8850004BB35 /* Appearance+Formatters.swift */; };
-		ADC4AAAE2788ACFE0004BB35 /* MessageDeletedHard.json in Resources */ = {isa = PBXBuildFile; fileRef = ADC4AAAD2788ACFE0004BB35 /* MessageDeletedHard.json */; };
 		ADCBBFD526D66A560023FCB2 /* iMessageChatMessageListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCBBFD426D66A560023FCB2 /* iMessageChatMessageListViewController.swift */; };
 		ADCBBFD726D66ADC0023FCB2 /* SlackChatMessageListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCBBFD626D66ADC0023FCB2 /* SlackChatMessageListViewController.swift */; };
 		ADCD5E4327987EFE00E66911 /* StreamModalTransitioningDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCD5E4227987EFE00E66911 /* StreamModalTransitioningDelegate.swift */; };
@@ -1429,6 +1428,7 @@
 		C1320E0A276B2E0F00A06B35 /* Array+SafeSubscript_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1320E07276B2E0800A06B35 /* Array+SafeSubscript_Tests.swift */; };
 		C139335F275E7BD800225E7A /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = C139335E275E7BD800225E7A /* Nuke */; };
 		C1393361275F5D1E00225E7A /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = C1393360275F5D1E00225E7A /* Nuke */; };
+		C147D78427B3D8BC00F8E7C5 /* WaitUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = C147D78327B3D8BC00F8E7C5 /* WaitUntil.swift */; };
 		C171041E2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */; };
 		C171041F2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */; };
 		C186BFA327A048690099CCA6 /* SyncRepository_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C186BFA227A048690099CCA6 /* SyncRepository_Mock.swift */; };
@@ -2906,8 +2906,8 @@
 		ADBBDA27279F0E9B00E47B1C /* ChannelNameFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelNameFormatter.swift; sourceTree = "<group>"; };
 		ADC40C3326E294EB005B616C /* MessageSearchController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessageSearchController+Combine.swift"; sourceTree = "<group>"; };
 		ADC40C3526E2980D005B616C /* MessageSearchController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessageSearchController+SwiftUI.swift"; sourceTree = "<group>"; };
-		ADC4AAAF2788C8850004BB35 /* Appearance+Formatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Appearance+Formatters.swift"; sourceTree = "<group>"; };
 		ADC4AAAD2788ACFE0004BB35 /* MessageDeletedHard.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MessageDeletedHard.json; sourceTree = "<group>"; };
+		ADC4AAAF2788C8850004BB35 /* Appearance+Formatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Appearance+Formatters.swift"; sourceTree = "<group>"; };
 		ADCBBFD426D66A560023FCB2 /* iMessageChatMessageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iMessageChatMessageListViewController.swift; sourceTree = "<group>"; };
 		ADCBBFD626D66ADC0023FCB2 /* SlackChatMessageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlackChatMessageListViewController.swift; sourceTree = "<group>"; };
 		ADCD5E4227987EFE00E66911 /* StreamModalTransitioningDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamModalTransitioningDelegate.swift; sourceTree = "<group>"; };
@@ -2971,6 +2971,7 @@
 		C13C7508273936DA00F93B34 /* Engine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Engine.swift; sourceTree = "<group>"; };
 		C13C7509273936DA00F93B34 /* NativeEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeEngine.swift; sourceTree = "<group>"; };
 		C13C750A273936DA00F93B34 /* WSEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WSEngine.swift; sourceTree = "<group>"; };
+		C147D78327B3D8BC00F8E7C5 /* WaitUntil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitUntil.swift; sourceTree = "<group>"; };
 		C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeSubscript.swift"; sourceTree = "<group>"; };
 		C186BFA227A048690099CCA6 /* SyncRepository_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncRepository_Mock.swift; sourceTree = "<group>"; };
 		C186BFA527A7F4E10099CCA6 /* AsyncOperation_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOperation_Tests.swift; sourceTree = "<group>"; };
@@ -3783,6 +3784,7 @@
 				799C9463247D7919001F1104 /* CustomAssertions */,
 				792A71E22578EF650082498D /* ChannelId.swift */,
 				799C9461247D78E2001F1104 /* WaitFor.swift */,
+				C147D78327B3D8BC00F8E7C5 /* WaitUntil.swift */,
 				791C0B6424EFBD260013CA2F /* UnwrapAsync.swift */,
 				7988F6B624D15F100004219B /* StressTestCase.swift */,
 				799C9474247D7D41001F1104 /* TemporaryData.swift */,
@@ -7704,6 +7706,7 @@
 				790A4C4E252E092E001F4A23 /* DevicePayloads_Tests.swift in Sources */,
 				79D6CE9D25F7D73300BE2EEC /* ChatChannelWatcherListController+SwiftUI_Tests.swift in Sources */,
 				84A2C56F275A50DE004749C0 /* EventNotificationCenter_Mock.swift in Sources */,
+				C147D78427B3D8BC00F8E7C5 /* WaitUntil.swift in Sources */,
 				F6CCA24F2512491B004C1859 /* UserTypingStateUpdaterMiddleware_Tests.swift in Sources */,
 				DA8407332526003D005A0F62 /* UserListUpdater_Tests.swift in Sources */,
 				F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */,

--- a/Tests/Shared/WaitUntil.swift
+++ b/Tests/Shared/WaitUntil.swift
@@ -1,0 +1,22 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+extension XCTestCase {
+    func waitUntil(timeout: TimeInterval = 0.1, _ action: (_ done: @escaping () -> Void) -> Void) {
+        let expectation = XCTestExpectation(description: "Action completed")
+        action {
+            if Thread.isMainThread {
+                expectation.fulfill()
+            } else {
+                DispatchQueue.main.async {
+                    expectation.fulfill()
+                }
+            }
+        }
+        wait(for: [expectation], timeout: timeout)
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Link
Part of https://stream-io.atlassian.net/browse/CIS-1484

### 🎯 Goal

The goal of this PR is to move the APIClient to use an OperationQueue to handle incoming requests

### 🛠 Implementation

Requests queue: Concurrent operations. Gives us the option to stop the queue and to easily queue a request.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
