### PR TITLE
Offline Support - Closing bits

### DIFF
--- a/Sources/StreamChat/APIClient/APIClient_Mock.swift
+++ b/Sources/StreamChat/APIClient/APIClient_Mock.swift
@@ -117,6 +117,16 @@ class APIClientMock: APIClient, Spy {
         XCTWaiter().wait(for: [request_expectation], timeout: timeout)
         return request_endpoint
     }
+
+    override func enterRecoveryMode() {
+        record()
+        super.enterRecoveryMode()
+    }
+
+    override func exitRecoveryMode() {
+        record()
+        super.exitRecoveryMode()
+    }
 }
 
 extension APIClientMock {

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -585,7 +585,6 @@ extension ChatClient: ConnectionStateDelegate {
         case let .connected(connectionId: id):
             shouldNotifyConnectionIdWaiters = true
             connectionId = id
-            syncRepository.updateLastConnectionDate(with: Date())
         case let .disconnected(source):
             if let error = source.serverError,
                error.isInvalidTokenError {

--- a/Sources/StreamChat/ChatClient_Tests.swift
+++ b/Sources/StreamChat/ChatClient_Tests.swift
@@ -715,29 +715,6 @@ class ChatClient_Tests: XCTestCase {
         AssertAsync.willBeTrue(providedToken != nil)
     }
 
-    // MARK: - Last connection date
-
-    func test_lastConnectionDateIsPassedToSyncRepository() throws {
-        let client = ChatClient(
-            config: inMemoryStorageConfig,
-            environment: testEnv.environment
-        )
-        try client.databaseContainer.writeSynchronously { session in
-            try session.saveCurrentUser(payload: self.dummyCurrentUser)
-        }
-
-        let date = Date()
-        client.webSocketClient(client.webSocketClient!, didUpdateConnectionState: .connected(connectionId: "ConnectionId"))
-        try client.databaseContainer.writeSynchronously { session in
-            guard let pendingConnectionDate = session.currentUser?.lastPendingConnectionDate else {
-                XCTFail("Should have a pending connection date")
-                return
-            }
-
-            XCTAssertNearlySameDate(pendingConnectionDate, date)
-        }
-    }
-
     // MARK: - Passive (not active) Client tests
     
     func test_passiveClient_doesNotHaveWorkers() {

--- a/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
@@ -11,13 +11,8 @@ class CurrentUserDTO: NSManagedObject {
     @NSManaged var unreadMessagesCount: Int64
     
     /// Contains the timestamp when last sync process was finished.
-    /// The date later serves as reference date for `/sync` endpoint
-    @NSManaged var lastSyncAt: Date?
-
-    /// We save the last pending connection date from which we need to sync events
-    /// whenever we're recovering a connection. Only used for offline support.
-    /// See `SyncRepository` for more details.
-    @NSManaged var lastPendingConnectionDate: Date?
+    /// The date later serves as reference date for the last event synced using `/sync` endpoint
+    @NSManaged var lastSynchedEventDate: Date?
 
     @NSManaged var flaggedUsers: Set<UserDTO>
     @NSManaged var flaggedMessages: Set<MessageDTO>

--- a/Sources/StreamChat/Database/DatabaseSession_Tests.swift
+++ b/Sources/StreamChat/Database/DatabaseSession_Tests.swift
@@ -298,7 +298,7 @@ class DatabaseSession_Tests: XCTestCase {
         let currentUser = database.viewContext.currentUser
         
         // Assert `lastReceivedEventDate` is nil
-        XCTAssertNil(currentUser?.lastSyncAt)
+        XCTAssertNil(currentUser?.lastSynchedEventDate)
     }
 
     func test_saveEvent_whenMessageUpdated_shouldUpdateMessagesQuotingTheUpdatedMessage() throws {

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -102,8 +102,7 @@
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="channelReads" inverseEntity="UserDTO"/>
     </entity>
     <entity name="CurrentUserDTO" representedClassName="CurrentUserDTO" syncable="YES">
-        <attribute name="lastPendingConnectionDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="lastSyncAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastSynchedEventDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="uniquenessKey" attributeType="String" defaultValueString="this is an immmutable arbitrary key which makes sure we have only once instance of CurrentUserDTO in the db"/>
         <attribute name="unreadChannelsCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="unreadMessagesCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
@@ -307,7 +306,7 @@
         <element name="ChannelMemberListQueryDTO" positionX="9" positionY="153" width="128" height="88"/>
         <element name="ChannelMuteDTO" positionX="9" positionY="162" width="128" height="89"/>
         <element name="ChannelReadDTO" positionX="9" positionY="153" width="128" height="89"/>
-        <element name="CurrentUserDTO" positionX="0" positionY="0" width="128" height="194"/>
+        <element name="CurrentUserDTO" positionX="0" positionY="0" width="128" height="179"/>
         <element name="DeviceDTO" positionX="9" positionY="153" width="128" height="89"/>
         <element name="MemberDTO" positionX="0" positionY="0" width="128" height="239"/>
         <element name="MessageDTO" positionX="160" positionY="192" width="128" height="629"/>

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -78,10 +78,6 @@ class SyncRepository {
     ///
     /// - Parameter completion: A block that will get executed upon completion of the synchronization
     func syncLocalState(completion: @escaping () -> Void) {
-        guard config.isLocalStorageEnabled else {
-            completion()
-            return
-        }
         operationQueue.cancelAllOperations()
 
         log.info("Starting to recover offline state", subsystems: .offlineSupport)
@@ -118,7 +114,9 @@ class SyncRepository {
         operations.append(contentsOf: refetchChannelListQueryOperations)
 
         // 5. Run offline actions requests
-        operations.append(ExecutePendingOfflineActions(offlineRequestsRepository: offlineRequestsRepository))
+        if config.isLocalStorageEnabled {
+            operations.append(ExecutePendingOfflineActions(offlineRequestsRepository: offlineRequestsRepository))
+        }
 
         operations.append(BlockOperation(block: { [weak self] in
             log.info("Finished recovering offline state", subsystems: .offlineSupport)

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -75,7 +75,6 @@ class SyncRepository {
     /// 3. Refetch channel lists queries, link only what backend returns (the 1st page)
     /// 4. Clean up local message history for channels that are outdated/will get outdated
     /// 5. Run offline actions requests
-    /// 6. Bump the last sync timestamp
     ///
     /// - Parameter completion: A block that will get executed upon completion of the synchronization
     func syncLocalState(completion: @escaping () -> Void) {
@@ -87,7 +86,6 @@ class SyncRepository {
 
         log.info("Starting to recover offline state", subsystems: .offlineSupport)
         let context = SyncContext()
-        context.lastConnectionDate = lastConnection
         var operations: [Operation] = []
 
         // Enter recovery mode so no other requests are triggered.
@@ -95,11 +93,9 @@ class SyncRepository {
 
         // Get the existing channelIds
         operations.append(GetChannelIdsOperation(database: database, context: context))
-        // Get pending connection date
-        operations.append(GetPendingConnectionDateOperation(database: database, context: context))
 
         // 1. Call `/sync` endpoint and get missing events for all locally existed channels
-        operations.append(SyncEventsOperation(database: database, syncRepository: self, context: context))
+        operations.append(SyncEventsOperation(syncRepository: self, context: context))
 
         // 2. Start watching open channels.
         let watchChannelOperations: [AsyncOperation] = activeChannelControllers.allObjects.map { controller in
@@ -124,16 +120,6 @@ class SyncRepository {
         // 5. Run offline actions requests
         operations.append(ExecutePendingOfflineActions(offlineRequestsRepository: offlineRequestsRepository))
 
-        // 6. Bump the last sync timestamp
-        operations.append(AsyncOperation { [weak self] _, done in
-            log.info("6. Bump the last sync timestamp", subsystems: .offlineSupport)
-            self?.updateUserValue { user in
-                user?.lastSyncAt = Date()
-            } completion: { _ in
-                done(.continue)
-            }
-        })
-
         operations.append(BlockOperation(block: { [weak self] in
             log.info("Finished recovering offline state", subsystems: .offlineSupport)
             DispatchQueue.main.async {
@@ -154,63 +140,11 @@ class SyncRepository {
         operationQueue.addOperations(operations, waitUntilFinished: false)
     }
 
-    /// Receives a date when the connection has been stablished
-    /// It updates user's lastPendingConnectionDate if there's no other pending date. If there is another pending date, this date passed as parameter is stored in
-    /// memory for this class to use it when needed
-    /// - Parameter date: Date of the connection
-    func updateLastConnectionDate(with date: Date, completion: ((SyncError?) -> Void)? = nil) {
-        // We store the last connection date in memory.
-        lastConnection = date
-        updateUserValue({ user in
-            // If there's a pending connection date, it means there was an issue retrieving all the past events.
-            // If that's the case, we keep the existing one.
-            guard let user = user, user.lastPendingConnectionDate == nil else { return }
-            log.info("Updating last pending connection date", subsystems: .offlineSupport)
-            user.lastPendingConnectionDate = date
-        }, completion: completion)
-    }
-
     /// Syncs the events for the active chat channels using the last sync date.
     /// - Parameter completion: A block that will get executed upon completion of the synchronization
     func syncExistingChannelsEvents(completion: @escaping (Result<[ChannelId], SyncError>) -> Void) {
-        let syncCooldown = self.syncCooldown
-        getUser { [weak self] user in
-            guard let lastSyncAt = user?.lastSyncAt else {
-                // That's the first session of the current user. Bump `lastSyncAt` with current time and return.
-                self?.updateUserValue({
-                    $0?.lastSyncAt = Date()
-                }, completion: { _ in
-                    completion(.failure(.noNeedToSync))
-                })
-                return
-            }
-
-            guard Date().timeIntervalSince(lastSyncAt) > syncCooldown else {
-                completion(.failure(.noNeedToSync))
-                return
-            }
-
-            let request = ChannelDTO.allChannelsFetchRequest
-            request.fetchLimit = 1000
-            request.propertiesToFetch = ["cid"]
-
-            self?.getChannelIds { channelIds in
-                self?.syncMissingEvents(
-                    using: lastSyncAt,
-                    channelIds: channelIds,
-                    bumpLastSync: true,
-                    isRecoveryRequest: false,
-                    completion: completion
-                )
-            }
-        }
-    }
-
-    private func getUser(completion: @escaping (CurrentUserDTO?) -> Void) {
-        var user: CurrentUserDTO?
-        database.backgroundReadOnlyContext.perform {
-            user = self.database.backgroundReadOnlyContext.currentUser
-            completion(user)
+        getChannelIds { [weak self] channelIds in
+            self?.syncChannelsEvents(channelIds: channelIds, isRecovery: false, completion: completion)
         }
     }
 
@@ -224,46 +158,76 @@ class SyncRepository {
         }
     }
 
-    func syncMissingEvents(
-        using date: Date,
+    func syncChannelsEvents(
         channelIds: [ChannelId],
-        bumpLastSync: Bool,
-        isRecoveryRequest: Bool,
+        isRecovery: Bool,
         completion: @escaping (Result<[ChannelId], SyncError>) -> Void
     ) {
-        guard config.isLocalStorageEnabled else {
-            completion(.failure(.localStorageDisabled))
-            return
-        }
-
         guard !channelIds.isEmpty else {
             completion(.success([]))
             return
         }
 
+        let syncCooldown = self.syncCooldown
+        getUser { [weak self] user in
+            guard let lastSyncAt = user?.lastSynchedEventDate else {
+                // That's the first session of the current user. Bump `lastSyncAt` with current time and return.
+                self?.updateUserValue({
+                    $0?.lastSynchedEventDate = Date()
+                }, completion: { _ in
+                    completion(.failure(.noNeedToSync))
+                })
+                return
+            }
+
+            guard Date().timeIntervalSince(lastSyncAt) > syncCooldown else {
+                completion(.failure(.noNeedToSync))
+                return
+            }
+
+            self?.syncMissingEvents(
+                using: lastSyncAt,
+                channelIds: channelIds,
+                isRecoveryRequest: isRecovery,
+                completion: completion
+            )
+        }
+    }
+
+    private func getUser(completion: @escaping (CurrentUserDTO?) -> Void) {
+        var user: CurrentUserDTO?
+        database.backgroundReadOnlyContext.perform {
+            user = self.database.backgroundReadOnlyContext.currentUser
+            completion(user)
+        }
+    }
+
+    private func syncMissingEvents(
+        using date: Date,
+        channelIds: [ChannelId],
+        isRecoveryRequest: Bool,
+        completion: @escaping (Result<[ChannelId], SyncError>) -> Void
+    ) {
         log.info("Synching events for existing channels since \(date)", subsystems: .offlineSupport)
-        getMissingEvents(since: date, channelIds: channelIds, isRecoveryRequest: isRecoveryRequest) { [weak self] result in
+        let endpoint: Endpoint<MissingEventsPayload> = .missingEvents(since: date, cids: channelIds)
+        let requestCompletion: (Result<MissingEventsPayload, Error>) -> Void = { [weak self] result in
             switch result {
             case let .success(payload):
-                guard bumpLastSync else {
-                    log.info("Successfully synched events", subsystems: .offlineSupport)
-                    completion(.success(channelIds))
-                    return
-                }
-
-                log.info("Bumping last sync date", subsystems: .offlineSupport)
-                self?.updateUserValue({
-                    $0?.lastSyncAt = payload.eventPayloads.first?.createdAt ?? date
-                }) { error in
-                    if let error = error {
-                        completion(.failure(error))
-                    } else {
-                        completion(.success(channelIds))
+                log.info("Processing pending events. Count \(payload.eventPayloads.count)", subsystems: .offlineSupport)
+                self?.processMissingEventsPayload(payload) {
+                    #warning("Test first or last")
+                    self?.updateUserValue({ $0?.lastSynchedEventDate = payload.eventPayloads.first?.createdAt ?? date }) { error in
+                        if let error = error {
+                            completion(.failure(error))
+                        } else {
+                            completion(.success(channelIds))
+                        }
                     }
                 }
             case let .failure(error):
-                guard case .tooManyEvents = error else {
-                    completion(.failure(error))
+                log.error("Failed synching events: \(error).", subsystems: .offlineSupport)
+                guard error.isBackendErrorWith400StatusCode else {
+                    completion(.failure(.syncEndpointFailed(error)))
                     return
                 }
                 // Backend responds with 400 if there were more than 1000 events to return
@@ -272,43 +236,21 @@ class SyncRepository {
                 completion(.success([]))
             }
         }
-    }
-
-    private func getMissingEvents(
-        since lastSyncDate: Date,
-        channelIds: [ChannelId],
-        isRecoveryRequest: Bool,
-        completion: @escaping (Result<MissingEventsPayload, SyncError>) -> Void
-    ) {
-        let endpoint: Endpoint<MissingEventsPayload> = .missingEvents(since: lastSyncDate, cids: channelIds)
-        let requestCompletion: (Result<MissingEventsPayload, Error>) -> Void = { [weak self] result in
-            switch result {
-            case let .success(payload):
-                log.info("Processing pending events. Count \(payload.eventPayloads.count)", subsystems: .offlineSupport)
-                self?.eventNotificationCenter.process(
-                    payload.eventPayloads.asEvents(),
-                    postNotifications: false
-                ) {
-                    log.info(
-                        "Successfully processed pending events. Count \(payload.eventPayloads.count)",
-                        subsystems: .offlineSupport
-                    )
-                    completion(.success(payload))
-                }
-            case let .failure(error):
-                log.error("Failed synching events: \(error).", subsystems: .offlineSupport)
-                guard error.isBackendErrorWith400StatusCode else {
-                    completion(.failure(.syncEndpointFailed(error)))
-                    return
-                }
-                completion(.failure(.tooManyEvents(error)))
-            }
-        }
 
         if isRecoveryRequest {
             apiClient.recoveryRequest(endpoint: endpoint, completion: requestCompletion)
         } else {
             apiClient.request(endpoint: endpoint, completion: requestCompletion)
+        }
+    }
+
+    private func processMissingEventsPayload(_ payload: MissingEventsPayload, completion: @escaping () -> Void) {
+        eventNotificationCenter.process(payload.eventPayloads.asEvents(), postNotifications: false) {
+            log.info(
+                "Successfully processed pending events. Count \(payload.eventPayloads.count)",
+                subsystems: .offlineSupport
+            )
+            completion()
         }
     }
 

--- a/Sources/StreamChat/Repositories/SyncRepository_Mock.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository_Mock.swift
@@ -40,19 +40,13 @@ class SyncRepositoryMock: SyncRepository, Spy {
         record()
     }
 
-    override func updateLastConnectionDate(with date: Date, completion: ((SyncError?) -> Void)? = nil) {
-        record()
-    }
-
     override func syncExistingChannelsEvents(completion: @escaping (Result<[ChannelId], SyncError>) -> Void) {
         record()
     }
 
-    override func syncMissingEvents(
-        using date: Date,
+    override func syncChannelsEvents(
         channelIds: [ChannelId],
-        bumpLastSync: Bool,
-        isRecoveryRequest: Bool,
+        isRecovery: Bool,
         completion: @escaping (Result<[ChannelId], SyncError>) -> Void
     ) {
         record()

--- a/Sources/StreamChat/Repositories/SyncRepository_Tests.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository_Tests.swift
@@ -61,11 +61,7 @@ final class SyncRepository_Tests: XCTestCase {
             apiClient: apiClient
         )
 
-        let expectation = self.expectation(description: "syncLocalState completion")
-        repository.syncLocalState {
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 0.1, handler: nil)
+        waitForSyncLocalStateRun()
 
         XCTAssertNil(lastSyncAtValue)
         XCTAssertEqual(database.writeSessionCounter, 0)
@@ -73,12 +69,12 @@ final class SyncRepository_Tests: XCTestCase {
         XCTAssertEqual(repository.activeChannelListControllers.count, 0)
         XCTAssertEqual(apiClient.recoveryRequest_allRecordedCalls.count, 0)
         XCTAssertEqual(apiClient.request_allRecordedCalls.count, 0)
+        // When isLocalStorageEnabled is false, we don't need to run any offline requests related task
         XCTAssertNotCall("runQueuedRequests(completion:)", on: offlineRequestsRepository)
     }
 
     func test_syncLocalState_localStorageEnabled_noChannels() throws {
         try database.createCurrentUser()
-        database.writeSessionCounter = 0
 
         waitForSyncLocalStateRun()
 


### PR DESCRIPTION
### 🎯 Goal
This PR contains the last bits of Offline support:
- Make sure sync can be run when `isLocalStorageEnabled` is false
- Unify sync related dates under one single value
- Avoid non recovery requests to retry when in recovery mode

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎉 GIF

![](https://media.giphy.com/media/469ovwENmkTd9THhht/giphy.gif)