### PR TITLE
[CIS-1558] Add increased logging for CoreData crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show Camera option on the ComposerVC [#1798](https://github.com/GetStream/stream-chat-swift/pull/1798)
 - `ChannelController`'s `truncateChannel` function now allows you to specify `systemMessage`, `hardDelete`, `skipPush` properties [#1799](https://github.com/GetStream/stream-chat-swift/pull/1799)
 - Added `truncatedAt` property to `ChatChannel`
+- Added increased logging for CoreData crashes caused by lingering models from previous sessions [#1814](https://github.com/GetStream/stream-chat-swift/issues/1814)
 
 ### 🐞 Fixed
 - Fix `ChatMentionSuggestionView` permanently hiding subviews [#1800](https://github.com/GetStream/stream-chat-swift/issues/1800)

--- a/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
+++ b/Sources/StreamChatTestTools/DatabaseContainer_Mock.swift
@@ -52,6 +52,10 @@ class DatabaseContainerMock: DatabaseContainer {
         // Remove the database file if the container requests that
         if shouldCleanUpTempDBFiles, case let .onDisk(databaseFileURL: url) = init_kind {
             do {
+                // Remove all loaded persistent stores first
+                try persistentStoreCoordinator.persistentStores.forEach { store in
+                    try persistentStoreCoordinator.remove(store)
+                }
                 try FileManager.default.removeItem(at: url)
             } catch {
                 fatalError("Failed to remove temp database file: \(error)")


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1558

### 🎯 Goal

Make it easier to debug the cryptic `Date._unconditionallyBridgeFromObjectiveC` crashes

### 🛠 Implementation

These crashes happen (not exclusively) when there's a model object belonging to an old user session. Since we evaluate models lazily (using our `CoreDataLazy` wrapper), when we keep a reference to a model, and then try to access a lazily evaluated property of that model, the DTO data is fully empty if the persistent store is recreated. This doesn't cause a crash for primitive types (Strings are "", numbers are 0), but for Date, it causes this crash.

### 📝 Changes

We print a big, fat error telling what happened. This should (hopefully) help the users debug their issues.

### 🧪 Testing

Open `DemoChatChannelListRouter` and add this property:
```swift
var someMessage: ChatMessage?
```

In the `showCurrentUserProfile` func, add this action to `rootViewController.presentAlert`:
```swift
.init(title: "Cause a CoreData crash", style: .default, handler: { _ in
                let newUser = UserCredentials.builtInUsers.filter({ $0.id != ChatClient.shared.currentUserId }).first!
                
                self.someMessage = ChatClient.shared.channelListController(query: .init(filter: .containMembers(userIds: [ChatClient.shared.currentUserId!]))).channels.first?.latestMessages.first
                
                ChatClient.shared.connectUser(
                    userInfo: .init(id: newUser.id, name: newUser.name, imageURL: newUser.avatarURL),
                    token: Token(stringLiteral: newUser.token)
                ) { error in
                    if let error = error {
                        log.error("connecting the user failed \(error)")
                        return
                    } else if let someMessage = self.someMessage {
                        print(someMessage.author)
                    }
                }
            }),
```

Now run the app, select any user. After you see the Channel List, tap the user avatar on top left, and tap "Cause a CoreData crash"

Without the changes in this PR, you'll see the exact same stack trace that was reported.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] This change follows zero ⚠️ policy (required)
