### PR TITLE
Implement missing syntesized Codable methods for EndpointPath on Swift < 5.5

### DIFF
--- a/Sources/StreamChat/APIClient/APIClient_Tests.swift
+++ b/Sources/StreamChat/APIClient/APIClient_Tests.swift
@@ -341,7 +341,7 @@ class APIClient_Tests: XCTestCase {
                 result = $0
             }
         )
-        wait(for: [tokenRefreshIsCalled], timeout: 0.1)
+        wait(for: [tokenRefreshIsCalled], timeout: 0.5)
 
         let testUser = TestUser(name: "test")
         decoder.decodeRequestResponse = .success(testUser)

--- a/Sources/StreamChat/APIClient/Endpoints/EndpointPath.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/EndpointPath.swift
@@ -85,8 +85,7 @@ enum EndpointPath: Codable {
         }
     }
 
-    #if swift(>=5.5)
-    #else
+    #if swift(<5.5)
     // Only needed when compiling against 5.4 or lower
     enum CodingKeys: CodingKey {
         case connect, sync, users, guest, members, search, devices, channels, createChannel, updateChannel, deleteChannel,

--- a/Sources/StreamChat/APIClient/Endpoints/EndpointPath.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/EndpointPath.swift
@@ -84,4 +84,191 @@ enum EndpointPath: Codable {
         case let .muteUser(mute): return "moderation/\(mute ? "mute" : "unmute")"
         }
     }
+
+    #if swift(>=5.5)
+    #else
+    // Only needed when compiling against 5.4 or lower
+    enum CodingKeys: CodingKey {
+        case connect, sync, users, guest, members, search, devices, channels, createChannel, updateChannel, deleteChannel,
+             channelUpdate, muteChannel, showChannel, truncateChannel, markChannelRead, markAllChannelsRead, channelEvent,
+             stopWatchingChannel, pinnedMessages, uploadAttachment, sendMessage, message, editMessage, deleteMessage, replies,
+             reactions, addReaction, deleteReaction, messageAction, banMember, flagUser, flagMessage, muteUser
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        guard let key = container.allKeys.first else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription: "Unable to decode EndpointPath"
+                )
+            )
+        }
+
+        switch key {
+        case .connect:
+            self = .connect
+        case .sync:
+            self = .sync
+        case .users:
+            self = .users
+        case .guest:
+            self = .guest
+        case .members:
+            self = .members
+        case .search:
+            self = .search
+        case .devices:
+            self = .devices
+        case .channels:
+            self = .channels
+        case .createChannel:
+            self = try .createChannel(container.decode(String.self, forKey: key))
+        case .updateChannel:
+            self = try .updateChannel(container.decode(String.self, forKey: key))
+        case .deleteChannel:
+            self = try .deleteChannel(container.decode(String.self, forKey: key))
+        case .channelUpdate:
+            self = try .channelUpdate(container.decode(String.self, forKey: key))
+        case .muteChannel:
+            self = try .muteChannel(container.decode(Bool.self, forKey: key))
+        case .showChannel:
+            var nestedContainer = try container.nestedUnkeyedContainer(forKey: key)
+            self = try .showChannel(
+                nestedContainer.decode(String.self),
+                nestedContainer.decode(Bool.self)
+            )
+        case .truncateChannel:
+            self = try .truncateChannel(container.decode(String.self, forKey: key))
+        case .markChannelRead:
+            self = try .markChannelRead(container.decode(String.self, forKey: key))
+        case .markAllChannelsRead:
+            self = .markAllChannelsRead
+        case .channelEvent:
+            self = try .channelEvent(container.decode(String.self, forKey: key))
+        case .stopWatchingChannel:
+            self = try .stopWatchingChannel(container.decode(String.self, forKey: key))
+        case .pinnedMessages:
+            self = try .pinnedMessages(container.decode(String.self, forKey: key))
+        case .uploadAttachment:
+            var nestedContainer = try container.nestedUnkeyedContainer(forKey: key)
+            self = try .uploadAttachment(
+                channelId: nestedContainer.decode(String.self),
+                type: nestedContainer.decode(String.self)
+            )
+        case .sendMessage:
+            self = try .sendMessage(container.decode(ChannelId.self, forKey: key))
+        case .message:
+            self = try .message(container.decode(MessageId.self, forKey: key))
+        case .editMessage:
+            self = try .editMessage(container.decode(MessageId.self, forKey: key))
+        case .deleteMessage:
+            self = try .deleteMessage(container.decode(MessageId.self, forKey: key))
+        case .replies:
+            self = try .replies(container.decode(MessageId.self, forKey: key))
+        case .reactions:
+            self = try .reactions(container.decode(MessageId.self, forKey: key))
+        case .addReaction:
+            self = try .addReaction(container.decode(MessageId.self, forKey: key))
+        case .deleteReaction:
+            var nestedContainer = try container.nestedUnkeyedContainer(forKey: key)
+            self = try .deleteReaction(
+                nestedContainer.decode(MessageId.self),
+                nestedContainer.decode(MessageReactionType.self)
+            )
+        case .messageAction:
+            self = try .messageAction(container.decode(MessageId.self, forKey: key))
+        case .banMember:
+            self = .banMember
+        case .flagUser:
+            self = try .flagUser(container.decode(Bool.self, forKey: key))
+        case .flagMessage:
+            self = try .flagMessage(container.decode(Bool.self, forKey: key))
+        case .muteUser:
+            self = try .muteUser(container.decode(Bool.self, forKey: key))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .connect:
+            try container.encode(true, forKey: .connect)
+        case .sync:
+            try container.encode(true, forKey: .sync)
+        case .users:
+            try container.encode(true, forKey: .users)
+        case .guest:
+            try container.encode(true, forKey: .guest)
+        case .members:
+            try container.encode(true, forKey: .members)
+        case .search:
+            try container.encode(true, forKey: .search)
+        case .devices:
+            try container.encode(true, forKey: .devices)
+        case .channels:
+            try container.encode(true, forKey: .channels)
+        case let .createChannel(string):
+            try container.encode(string, forKey: .createChannel)
+        case let .updateChannel(string):
+            try container.encode(string, forKey: .updateChannel)
+        case let .deleteChannel(string):
+            try container.encode(string, forKey: .deleteChannel)
+        case let .channelUpdate(string):
+            try container.encode(string, forKey: .channelUpdate)
+        case let .muteChannel(bool):
+            try container.encode(bool, forKey: .muteChannel)
+        case let .showChannel(channelPath, show):
+            var nestedContainer = container.nestedUnkeyedContainer(forKey: .showChannel)
+            try nestedContainer.encode(channelPath)
+            try nestedContainer.encode(show)
+        case let .truncateChannel(string):
+            try container.encode(string, forKey: .truncateChannel)
+        case let .markChannelRead(string):
+            try container.encode(string, forKey: .markChannelRead)
+        case .markAllChannelsRead:
+            try container.encode(true, forKey: .markAllChannelsRead)
+        case let .channelEvent(string):
+            try container.encode(string, forKey: .channelEvent)
+        case let .stopWatchingChannel(string):
+            try container.encode(string, forKey: .stopWatchingChannel)
+        case let .pinnedMessages(string):
+            try container.encode(string, forKey: .pinnedMessages)
+        case let .uploadAttachment(channelId, type):
+            var nestedContainer = container.nestedUnkeyedContainer(forKey: .uploadAttachment)
+            try nestedContainer.encode(channelId)
+            try nestedContainer.encode(type)
+        case let .sendMessage(channelId):
+            try container.encode(channelId, forKey: .sendMessage)
+        case let .message(messageId):
+            try container.encode(messageId, forKey: .message)
+        case let .editMessage(messageId):
+            try container.encode(messageId, forKey: .editMessage)
+        case let .deleteMessage(messageId):
+            try container.encode(messageId, forKey: .deleteMessage)
+        case let .replies(messageId):
+            try container.encode(messageId, forKey: .replies)
+        case let .reactions(messageId):
+            try container.encode(messageId, forKey: .reactions)
+        case let .addReaction(messageId):
+            try container.encode(messageId, forKey: .addReaction)
+        case let .deleteReaction(messageId, reactionType):
+            var nestedContainer = container.nestedUnkeyedContainer(forKey: .deleteReaction)
+            try nestedContainer.encode(messageId)
+            try nestedContainer.encode(reactionType)
+        case let .messageAction(messageId):
+            try container.encode(messageId, forKey: .messageAction)
+        case .banMember:
+            try container.encode(true, forKey: .banMember)
+        case let .flagUser(bool):
+            try container.encode(bool, forKey: .flagUser)
+        case let .flagMessage(bool):
+            try container.encode(bool, forKey: .flagMessage)
+        case let .muteUser(bool):
+            try container.encode(bool, forKey: .muteUser)
+        }
+    }
+    #endif
 }

--- a/Sources/StreamChat/APIClient/Endpoints/EndpointPath_Tests.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/EndpointPath_Tests.swift
@@ -41,4 +41,103 @@ final class EndpointPathTests: XCTestCase {
     func banMember_shouldNOTBeQueuedOffline() {
         XCTAssertFalse(EndpointPath.banMember.shouldBeQueuedOffline)
     }
+
+    // MARK: - Codable
+
+    func test_isProperlyEncodedAndDecoded() throws {
+        assertResultEncodingAndDecoding(.connect)
+        assertResultEncodingAndDecoding(.sync)
+        assertResultEncodingAndDecoding(.users)
+        assertResultEncodingAndDecoding(.guest)
+        assertResultEncodingAndDecoding(.members)
+        assertResultEncodingAndDecoding(.search)
+        assertResultEncodingAndDecoding(.devices)
+
+        assertResultEncodingAndDecoding(.channels)
+        assertResultEncodingAndDecoding(.createChannel("channel_idc"))
+        assertResultEncodingAndDecoding(.updateChannel("channel_idu"))
+        assertResultEncodingAndDecoding(.deleteChannel("channel_idd"))
+        assertResultEncodingAndDecoding(.channelUpdate("channel_idq"))
+        assertResultEncodingAndDecoding(.muteChannel(false))
+        assertResultEncodingAndDecoding(.showChannel("channel_id", false))
+        assertResultEncodingAndDecoding(.truncateChannel("channel_idq"))
+        assertResultEncodingAndDecoding(.markChannelRead("channel_idq"))
+        assertResultEncodingAndDecoding(.markAllChannelsRead)
+        assertResultEncodingAndDecoding(.channelEvent("channel_idq"))
+        assertResultEncodingAndDecoding(.stopWatchingChannel("channel_idq"))
+        assertResultEncodingAndDecoding(.pinnedMessages("channel_idq"))
+        assertResultEncodingAndDecoding(.uploadAttachment(channelId: "channel_id", type: "file"))
+
+        assertResultEncodingAndDecoding(.sendMessage(ChannelId(type: .messaging, id: "the_id")))
+        assertResultEncodingAndDecoding(.message("message_idm"))
+        assertResultEncodingAndDecoding(.editMessage("message_ide"))
+        assertResultEncodingAndDecoding(.deleteMessage("message_idd"))
+        assertResultEncodingAndDecoding(.replies("message_idr"))
+        assertResultEncodingAndDecoding(.reactions("message_idre"))
+        assertResultEncodingAndDecoding(.addReaction("message_ida"))
+        assertResultEncodingAndDecoding(.deleteReaction("message_id", MessageReactionType(rawValue: "love")))
+        assertResultEncodingAndDecoding(.messageAction("message_ida"))
+
+        assertResultEncodingAndDecoding(.banMember)
+        assertResultEncodingAndDecoding(.flagUser(false))
+        assertResultEncodingAndDecoding(.flagMessage(false))
+        assertResultEncodingAndDecoding(.muteUser(false))
+    }
+
+    private func assertResultEncodingAndDecoding(_ value: EndpointPath, _ file: StaticString = #file, _ line: UInt = #line) {
+        do {
+            let encoded = try JSONEncoder.stream.encode(value)
+            let result = try JSONDecoder.stream.decode(EndpointPath.self, from: encoded)
+            XCTAssertEqual(result, value, file: file, line: line)
+        } catch {
+            XCTFail("Should not fail encoding/decoding", file: file, line: line)
+        }
+    }
+}
+
+extension EndpointPath: Equatable {}
+public func == (_ lhs: EndpointPath, _ rhs: EndpointPath) -> Bool {
+    switch (lhs, rhs) {
+    case (.connect, .connect): return true
+    case (.sync, .sync): return true
+    case (.users, .users): return true
+    case (.guest, .guest): return true
+    case (.members, .members): return true
+    case (.search, .search): return true
+    case (.devices, .devices): return true
+    case (.channels, .channels): return true
+    case let (.createChannel(string1), .createChannel(string2)): return string1 == string2
+    case let (.updateChannel(string1), .updateChannel(string2)): return string1 == string2
+    case let (.deleteChannel(string1), .deleteChannel(string2)): return string1 == string2
+    case let (.channelUpdate(string1), .channelUpdate(string2)): return string1 == string2
+    case let (.muteChannel(bool1), .muteChannel(bool2)): return bool1 == bool2
+    case let (.showChannel(string1, bool1), .showChannel(string2, bool2)): return string1 == string2 && bool1 == bool2
+    case let (.truncateChannel(string1), .truncateChannel(string2)): return string1 == string2
+    case let (.markChannelRead(string1), .markChannelRead(string2)): return string1 == string2
+    case (.markAllChannelsRead, .markAllChannelsRead): return true
+    case let (.channelEvent(string1), .channelEvent(string2)): return string1 == string2
+    case let (.stopWatchingChannel(string1), .stopWatchingChannel(string2)): return string1 == string2
+    case let (.pinnedMessages(string1), .pinnedMessages(string2)): return string1 == string2
+    case let (.uploadAttachment(channelId1, type1), .uploadAttachment(channelId2, type2)): return channelId1 == channelId2 &&
+        type1 ==
+        type2
+    case let (.sendMessage(channelId1), .sendMessage(channelId2)): return channelId1 == channelId2
+    case let (.message(messageId1), .message(messageId2)): return messageId1 == messageId2
+    case let (.editMessage(messageId1), .editMessage(messageId2)): return messageId1 == messageId2
+    case let (.deleteMessage(messageId1), .deleteMessage(messageId2)): return messageId1 == messageId2
+    case let (.replies(messageId1), .replies(messageId2)): return messageId1 == messageId2
+    case let (.reactions(messageId1), .reactions(messageId2)): return messageId1 == messageId2
+    case let (.addReaction(messageId1), .addReaction(messageId2)): return messageId1 == messageId2
+    case let (
+        .deleteReaction(messageId1, messageReactionType1),
+        .deleteReaction(messageId2, messageReactionType2)
+    ): return messageId1 == messageId2 && messageReactionType1 ==
+        messageReactionType2
+    case let (.messageAction(messageId1), .messageAction(messageId2)): return messageId1 == messageId2
+    case (.banMember, .banMember): return true
+    case let (.flagUser(bool1), .flagUser(bool2)): return bool1 == bool2
+    case let (.flagMessage(bool1), .flagMessage(bool2)): return bool1 == bool2
+    case let (.muteUser(bool1), .muteUser(bool2)): return bool1 == bool2
+    default: return false
+    }
 }


### PR DESCRIPTION
### 🎯 Goal

Offline Support's Head branch was failing on Xcode 12. This was due to the fact that before Swift 5.5 we did not have syntesized Codable implementations for enumerations with associated objects.

See proposal here: https://github.com/apple/swift-evolution/blob/main/proposals/0295-codable-synthesis-for-enums-with-associated-values.md

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎉 GIF

![](https://media.giphy.com/media/26gs6jWEXGu4pAYDK/giphy.gif)
