### PR TITLE
[CIS-1635] Make it possible to customize the message view only in the popup actions

### DIFF
--- a/Sources/StreamChatUI/MessageActionsPopup/MessageActionsTransitionController.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/MessageActionsTransitionController.swift
@@ -85,18 +85,11 @@ open class ChatMessageActionsTransitionController: NSObject, UIViewControllerTra
         else { return }
         
         selectedMessageId = originalMessageContentView.content?.id
-        
+
+        let messageView = makeMessageContentView(fromOriginalView: originalMessageContentView)
         let messageViewFrame = selectedMessageContentViewFrame ?? .zero
-        let messageViewType = type(of: originalMessageContentView)
-        let messageAttachmentInjectorType = originalMessageContentView.attachmentViewInjector.map { type(of: $0) }
-        let messageLayoutOptions = originalMessageContentView.layoutOptions?.subtracting([.reactions]) ?? []
-        let message = originalMessageContentView.content
-        
-        let messageView = messageViewType.init()
-        messageView.setUpLayoutIfNeeded(options: messageLayoutOptions, attachmentViewInjectorType: messageAttachmentInjectorType)
         messageView.frame = messageViewFrame
-        messageView.content = message
-        
+
         transitionContext.containerView.addSubview(toVC.view)
         toVC.view.isHidden = true
         toVC.messageContentView = messageView
@@ -251,5 +244,19 @@ open class ChatMessageActionsTransitionController: NSObject, UIViewControllerTra
                 self.selectedMessageId = nil
             }
         )
+    }
+
+    /// Responsible to create the message view from the original one in the message list.
+    open func makeMessageContentView(fromOriginalView originalView: ChatMessageContentView) -> ChatMessageContentView {
+        let messageViewType = type(of: originalView)
+        let messageAttachmentInjectorType = originalView.attachmentViewInjector.map { type(of: $0) }
+        let messageLayoutOptions = originalView.layoutOptions?.subtracting([.reactions]) ?? []
+        let message = originalView.content
+
+        let messageView = messageViewType.init()
+        messageView.setUpLayoutIfNeeded(options: messageLayoutOptions, attachmentViewInjectorType: messageAttachmentInjectorType)
+        messageView.content = message
+
+        return messageView
     }
 }


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1635

### 🎯 Goal
Right now is not possible to provide customization to the message content view only in the context of the popup actions.

### 🛠 Implementation
We extract the logic to create the message content view copy to a separate function so that it can be easily changed.

### 🧪 Testing
One way to test this, is to provide a custom actions transition controller and for example remove the timestamp of the message content view:

```swift
class CustomMessageActionsTransitionController: ChatMessageActionsTransitionController {
    override func makeMessageContentView(fromOriginalView originalView: ChatMessageContentView) -> ChatMessageContentView {
        let messageContentView = super.makeMessageContentView(fromOriginalView: originalView)
        messageContentView.layoutOptions?.remove(.timestamp)
        return messageContentView
    }
}

Components.default.messageActionsTransitionController = CustomMessageActionsTransitionController.self
```

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)