### PR TITLE
Use IndexPath's item instead of row for macOS compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Use IndexPath's item instead of row for macOS compatibility [#1859](https://github.com/GetStream/stream-chat-swift/pull/1859)
 
 # [4.12.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.12.0)
 _March 16, 2022_

--- a/Sources/StreamChat/Controllers/SearchControllers/UserSearchController/UserSearchController.swift
+++ b/Sources/StreamChat/Controllers/SearchControllers/UserSearchController/UserSearchController.swift
@@ -185,17 +185,17 @@ private extension ChatUserSearchController {
         switch updatePolicy {
         case .replace:
             let deletions = userArray.enumerated().reversed().map { (index, user) in
-                ListChange.remove(user, index: .init(row: index, section: 0))
+                ListChange.remove(user, index: .init(item: index, section: 0))
             }
             
             let insertions = loadedPage.enumerated().map { (index, user) in
-                ListChange.insert(user, index: .init(row: index, section: 0))
+                ListChange.insert(user, index: .init(item: index, section: 0))
             }
             
             return deletions + insertions
         case .merge:
             let insertions = loadedPage.enumerated().map { (index, user) in
-                ListChange.insert(user, index: .init(row: index + userArray.count, section: 0))
+                ListChange.insert(user, index: .init(item: index + userArray.count, section: 0))
             }
             
             return insertions
@@ -213,9 +213,9 @@ private extension ChatUserSearchController {
         for change in changes {
             switch change {
             case let .insert(user, indexPath):
-                users.insert(user, at: indexPath.row)
+                users.insert(user, at: indexPath.item)
             case let .remove(_, indexPath):
-                users.remove(at: indexPath.row)
+                users.remove(at: indexPath.item)
             default:
                 log.assertionFailure("Unsupported list change observed: \(change)")
             }

--- a/Tests/StreamChatTests/Controllers/SearchControllers/UserSearchController/UserSearchController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/SearchControllers/UserSearchController/UserSearchController_Tests.swift
@@ -123,8 +123,8 @@ class UserSearchController_Tests: XCTestCase {
         XCTAssertEqual(controller.state, .remoteDataFetched)
         // Assert correct list changes are reported
         XCTAssertEqual(delegate.didChangeUsers_changes, [
-            .insert(user1, index: .init(row: 0, section: 0)),
-            .insert(user2, index: .init(row: 1, section: 0))
+            .insert(user1, index: .init(item: 0, section: 0)),
+            .insert(user2, index: .init(item: 1, section: 0))
         ])
         
         // Clean up the state for 2nd query call
@@ -160,12 +160,12 @@ class UserSearchController_Tests: XCTestCase {
         // Assert correct list changes are reported
         XCTAssertEqual(delegate.didChangeUsers_changes, [
             // Assert deletions for 1st query are reported in reverse order
-            .remove(user2, index: .init(row: 1, section: 0)),
-            .remove(user1, index: .init(row: 0, section: 0)),
+            .remove(user2, index: .init(item: 1, section: 0)),
+            .remove(user1, index: .init(item: 0, section: 0)),
             
             // Assert insertions for 2nd query are reported in normal order
-            .insert(user3, index: .init(row: 0, section: 0)),
-            .insert(user4, index: .init(row: 1, section: 0))
+            .insert(user3, index: .init(item: 0, section: 0)),
+            .insert(user4, index: .init(item: 1, section: 0))
         ])
     }
     
@@ -204,8 +204,8 @@ class UserSearchController_Tests: XCTestCase {
         XCTAssertEqual(controller.state, .remoteDataFetched)
         // Assert correct list changes are reported
         XCTAssertEqual(delegate.didChangeUsers_changes, [
-            .insert(user1, index: .init(row: 0, section: 0)),
-            .insert(user2, index: .init(row: 1, section: 0))
+            .insert(user1, index: .init(item: 0, section: 0)),
+            .insert(user2, index: .init(item: 1, section: 0))
         ])
         
         // Save controller's state
@@ -325,8 +325,8 @@ class UserSearchController_Tests: XCTestCase {
         XCTAssertEqual(controller.state, .remoteDataFetched)
         // Assert correct list changes are reported
         XCTAssertEqual(delegate.didChangeUsers_changes, [
-            .insert(user1, index: .init(row: 0, section: 0)),
-            .insert(user2, index: .init(row: 1, section: 0))
+            .insert(user1, index: .init(item: 0, section: 0)),
+            .insert(user2, index: .init(item: 1, section: 0))
         ])
         
         // Clean up the state for 2nd query call
@@ -362,12 +362,12 @@ class UserSearchController_Tests: XCTestCase {
         // Assert correct list changes are reported
         XCTAssertEqual(delegate.didChangeUsers_changes, [
             // Assert deletions for 1st query are reported in reverse order
-            .remove(user2, index: .init(row: 1, section: 0)),
-            .remove(user1, index: .init(row: 0, section: 0)),
+            .remove(user2, index: .init(item: 1, section: 0)),
+            .remove(user1, index: .init(item: 0, section: 0)),
             
             // Assert insertions for 2nd query are reported in normal order
-            .insert(user3, index: .init(row: 0, section: 0)),
-            .insert(user4, index: .init(row: 1, section: 0))
+            .insert(user3, index: .init(item: 0, section: 0)),
+            .insert(user4, index: .init(item: 1, section: 0))
         ])
     }
     
@@ -405,8 +405,8 @@ class UserSearchController_Tests: XCTestCase {
         XCTAssertEqual(controller.state, .remoteDataFetched)
         // Assert correct list changes are reported
         XCTAssertEqual(delegate.didChangeUsers_changes, [
-            .insert(user1, index: .init(row: 0, section: 0)),
-            .insert(user2, index: .init(row: 1, section: 0))
+            .insert(user1, index: .init(item: 0, section: 0)),
+            .insert(user2, index: .init(item: 1, section: 0))
         ])
         
         // Save controller's state
@@ -560,8 +560,8 @@ class UserSearchController_Tests: XCTestCase {
         XCTAssertEqual(controller.state, .remoteDataFetched)
         // Assert correct list changes are reported
         XCTAssertEqual(delegate.didChangeUsers_changes, [
-            .insert(user2, index: .init(row: 1, section: 0)),
-            .insert(user3, index: .init(row: 2, section: 0))
+            .insert(user2, index: .init(item: 1, section: 0)),
+            .insert(user3, index: .init(item: 2, section: 0))
         ])
     }
     


### PR DESCRIPTION
### 🎯 Goal
Use IndexPath's item instead of row for macOS compatibility

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
