### PR TITLE
[CIS-1679] Fix payload for reaction when using enforce_unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix payload for reaction when using `enforce_unique` [#1861](https://github.com/GetStream/stream-chat-swift/issues/1861)
 
 # [4.12.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.12.0)
 _March 16, 2022_

--- a/Sources/StreamChat/APIClient/Endpoints/MessageEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/MessageEndpoints.swift
@@ -64,19 +64,20 @@ extension Endpoint {
         extraData: [String: RawJSON],
         messageId: MessageId
     ) -> Endpoint<EmptyResponse> {
-        .init(
+        let body = MessageReactionRequestPayload(
+            enforceUnique: enforceUnique,
+            reaction: ReactionRequestPayload(
+                type: type,
+                score: score,
+                extraData: extraData
+            )
+        )
+        return .init(
             path: .addReaction(messageId),
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
-            body: [
-                "reaction": MessageReactionRequestPayload(
-                    type: type,
-                    score: score,
-                    enforceUnique: enforceUnique,
-                    extraData: extraData
-                )
-            ]
+            body: body
         )
     }
     

--- a/Sources/StreamChat/APIClient/Endpoints/Requests/MessageReactionRequestPayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Requests/MessageReactionRequestPayload.swift
@@ -7,21 +7,34 @@ import Foundation
 /// The type describes the outgoing JSON to `message/[message_id]/reaction` endpoint
 struct MessageReactionRequestPayload: Encodable {
     private enum CodingKeys: String, CodingKey {
-        case type
-        case score
         case enforceUnique = "enforce_unique"
+        case reaction
     }
     
+    let enforceUnique: Bool
+    let reaction: ReactionRequestPayload
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(enforceUnique, forKey: .enforceUnique)
+        try container.encode(reaction, forKey: .reaction)
+    }
+}
+
+struct ReactionRequestPayload: Encodable {
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case score
+    }
+
     let type: MessageReactionType
     let score: Int
-    let enforceUnique: Bool
     let extraData: [String: RawJSON]
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(type, forKey: .type)
         try container.encode(score, forKey: .score)
-        try container.encode(enforceUnique, forKey: .enforceUnique)
         try extraData.encode(to: encoder)
     }
 }

--- a/Tests/StreamChatTests/APIClient/Endpoints/MessageEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/MessageEndpoints_Tests.swift
@@ -138,14 +138,10 @@ final class MessageEndpoints_Tests: XCTestCase {
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
-            body: [
-                "reaction": MessageReactionRequestPayload(
-                    type: reaction,
-                    score: score,
-                    enforceUnique: false,
-                    extraData: extraData
-                )
-            ]
+            body: MessageReactionRequestPayload(
+                enforceUnique: false,
+                reaction: ReactionRequestPayload(type: reaction, score: score, extraData: extraData)
+            )
         )
         
         // Build endpoint.

--- a/Tests/StreamChatTests/APIClient/Endpoints/Requests/MessageReactionRequestPayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Requests/MessageReactionRequestPayload_Tests.swift
@@ -9,21 +9,21 @@ final class MessageReactionRequestPayload_Tests: XCTestCase {
     func test_payload_isBuiltAndEncodedCorrectly() throws {
         // Build the payload.
         let payload = MessageReactionRequestPayload(
-            type: "like",
-            score: 10,
             enforceUnique: false,
-            extraData: ["mood": .string("good one")]
+            reaction: ReactionRequestPayload(type: "like", score: 10, extraData: ["mood": .string("good one")])
         )
-        
+
         // Encode the payload.
         let json = try JSONEncoder.default.encode(payload)
         
         // Assert encoding is correct.
         AssertJSONEqual(json, [
-            "type": payload.type.rawValue,
-            "score": payload.score,
             "enforce_unique": payload.enforceUnique,
-            "mood": "good one"
+            "reaction": [
+                "type": payload.reaction.type.rawValue,
+                "score": payload.reaction.score,
+                "mood": "good one"
+            ]
         ])
     }
 }


### PR DESCRIPTION
### 🔗 Issue Link
https://stream-io.atlassian.net/browse/CIS-1679

Reported here: https://github.com/GetStream/stream-chat-swift/issues/1856

### 🎯 Goal

Using `enforce_unique` when adding a reaction was not producing the expected results.
This was basically due to the fact that the value was wrongly sent in the body

### 🛠 Implementation

Move `enforce_unique` to be at the top level of the body

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎉 GIF

![](https://media.giphy.com/media/H9uW3dmi53JYrhrsk3/giphy.gif)
