### PR TITLE
[CIS-1689] Add support for multiple push providers

### DIFF
--- a/DemoApp/AppDelegate.swift
+++ b/DemoApp/AppDelegate.swift
@@ -28,7 +28,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 log.error("adding a device failed with an error \(error)")
                 return
             }
-            UserDefaults(suiteName: applicationGroupIdentifier)?.set(currentUserId, forKey: currentUserIdRegisteredForPush)
+            UserDefaults(suiteName: applicationGroupIdentifier)?
+                .set(currentUserId, forKey: currentUserIdRegisteredForPush)
         }
     }
 

--- a/Sources/StreamChat/APIClient/Endpoints/DeviceEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/DeviceEndpoints.swift
@@ -11,14 +11,23 @@ extension Endpoint {
     ///   - userId: UserId for adding the device.
     ///   - deviceId: DeviceId to be added. DeviceId is obtained via
     ///   `didRegisterForRemoteNotificationsWithDeviceToken` function in `AppDelegate`.
+    ///   - pushProvider: The push provider for this device.
     /// - Returns: The endpoint for adding a device.
-    static func addDevice(userId: UserId, deviceId: DeviceId) -> Endpoint<EmptyResponse> {
+    static func addDevice(
+        userId: UserId,
+        deviceId: DeviceId,
+        pushProvider: PushProvider
+    ) -> Endpoint<EmptyResponse> {
         .init(
             path: .devices,
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
-            body: ["user_id": userId, "id": deviceId, "push_provider": "apn"]
+            body: [
+                "user_id": userId,
+                "id": deviceId,
+                "push_provider": pushProvider.rawValue
+            ]
         )
     }
     

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -196,14 +196,19 @@ public extension CurrentChatUserController {
     /// `connectUser` must be called before calling this.
     /// - Parameters:
     ///   - token: Device token, obtained via `didRegisterForRemoteNotificationsWithDeviceToken` function in `AppDelegate`.
+    ///   - pushProvider: The push provider for this device. By default it is APN.
     ///   - completion: Called when device is successfully registered, or with error.
-    func addDevice(token: Data, completion: ((Error?) -> Void)? = nil) {
+    func addDevice(token: Data, pushProvider: PushProvider = .apn, completion: ((Error?) -> Void)? = nil) {
         guard let currentUserId = currentUser?.id else {
             completion?(ClientError.CurrentUserDoesNotExist())
             return
         }
 
-        currentUserUpdater.addDevice(token: token, currentUserId: currentUserId) { error in
+        currentUserUpdater.addDevice(
+            token: token,
+            currentUserId: currentUserId,
+            pushProvider: pushProvider
+        ) { error in
             self.callback {
                 completion?(error)
             }

--- a/Sources/StreamChat/Models/PushProvider.swift
+++ b/Sources/StreamChat/Models/PushProvider.swift
@@ -1,0 +1,20 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+public struct PushProvider: RawRepresentable, Hashable, ExpressibleByStringLiteral {
+    public static let firebase: Self = "firebase"
+    public static let apn: Self = "apn"
+
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(stringLiteral value: String) {
+        self.init(rawValue: value)
+    }
+}

--- a/Sources/StreamChat/Workers/CurrentUserUpdater.swift
+++ b/Sources/StreamChat/Workers/CurrentUserUpdater.swift
@@ -56,10 +56,12 @@ class CurrentUserUpdater: Worker {
     /// - Parameters:
     ///   - token: Device token, obtained via `didRegisterForRemoteNotificationsWithDeviceToken` function in `AppDelegate`.
     ///   - currentUserId: The current user identifier.
+    ///   - pushProvider: The push provider for this device.
     ///   - completion: Called when device is successfully registered, or with error.
     func addDevice(
         token: Data,
         currentUserId: UserId,
+        pushProvider: PushProvider,
         completion: ((Error?) -> Void)? = nil
     ) {
         let deviceId = token.deviceToken
@@ -80,7 +82,8 @@ class CurrentUserUpdater: Worker {
             .request(
                 endpoint: .addDevice(
                     userId: currentUserId,
-                    deviceId: deviceId
+                    deviceId: deviceId,
+                    pushProvider: pushProvider
                 ),
                 completion: { result in
                     if let error = result.error {

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -860,6 +860,8 @@
 		AD158B6526C1873000C104CD /* ChatThreadVC+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD158B6326C1872D00C104CD /* ChatThreadVC+SwiftUI.swift */; };
 		AD158B6626C1876800C104CD /* ChatChannelVC+SwiftUI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B059EC267116B40024CE90 /* ChatChannelVC+SwiftUI_Tests.swift */; };
 		AD158B6726C1876D00C104CD /* ChatChannelVC_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B8AC16266F86020092D5F6 /* ChatChannelVC_Tests.swift */; };
+		AD17CDF927E4DB2700E0D092 /* PushProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD17CDF827E4DB2700E0D092 /* PushProvider.swift */; };
+		AD17CDFA27E4DB2700E0D092 /* PushProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD17CDF827E4DB2700E0D092 /* PushProvider.swift */; };
 		AD1D7A8526A2131D00494CA5 /* ChatChannelVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1D7A8326A212D000494CA5 /* ChatChannelVC.swift */; };
 		AD25070D272C0C8D00BC14C4 /* ChatMessageReactionAuthorsVC_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD25070B272C0C8800BC14C4 /* ChatMessageReactionAuthorsVC_Tests.swift */; };
 		AD3D0CC026A8727800A6D813 /* SlackChatChannelHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3D0CBF26A8727800A6D813 /* SlackChatChannelHeaderView.swift */; };
@@ -2892,6 +2894,7 @@
 		AD050BA7265D600B006649A5 /* QuotedChatMessageView+SwiftUI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QuotedChatMessageView+SwiftUI_Tests.swift"; sourceTree = "<group>"; };
 		AD154C6C25DC3BA000850925 /* ChatCommandSuggestionView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCommandSuggestionView_Tests.swift; sourceTree = "<group>"; };
 		AD158B6326C1872D00C104CD /* ChatThreadVC+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatThreadVC+SwiftUI.swift"; sourceTree = "<group>"; };
+		AD17CDF827E4DB2700E0D092 /* PushProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushProvider.swift; sourceTree = "<group>"; };
 		AD1D7A8326A212D000494CA5 /* ChatChannelVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelVC.swift; sourceTree = "<group>"; };
 		AD25070B272C0C8800BC14C4 /* ChatMessageReactionAuthorsVC_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageReactionAuthorsVC_Tests.swift; sourceTree = "<group>"; };
 		AD3D0CBF26A8727800A6D813 /* SlackChatChannelHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlackChatChannelHeaderView.swift; sourceTree = "<group>"; };
@@ -4079,6 +4082,7 @@
 				799C9431247D2FB9001F1104 /* ChatMessage.swift */,
 				79877A052498E4BC00015F8B /* CurrentUser.swift */,
 				79877A022498E4BB00015F8B /* Device.swift */,
+				AD17CDF827E4DB2700E0D092 /* PushProvider.swift */,
 				79877A032498E4BB00015F8B /* Member.swift */,
 				AD7AC98B260A94C6004AADA5 /* MessagePinning.swift */,
 				8899BC52254318CC003CB98B /* MessageReaction.swift */,
@@ -8387,6 +8391,7 @@
 				C1B0B38327BFC08900C8207D /* EndpointPath+OfflineRequest.swift in Sources */,
 				DAFAD6A124DC476A0043ED06 /* Result+Extensions.swift in Sources */,
 				C1FC2F982742579D0062530F /* TCPTransport.swift in Sources */,
+				AD17CDF927E4DB2700E0D092 /* PushProvider.swift in Sources */,
 				AD7DFC3625D2FA8100DD9DA3 /* CurrentUserUpdater.swift in Sources */,
 				88206FC425B18C88009D086A /* ChatClientUpdater.swift in Sources */,
 				7991D83B24F5427E00D21BA3 /* EphemeralValuesContainer.swift in Sources */,
@@ -9005,6 +9010,7 @@
 				C121E89A274544B000023E4C /* MuteDetails.swift in Sources */,
 				C121E89B274544B000023E4C /* Controller.swift in Sources */,
 				C121E89C274544B000023E4C /* DataController.swift in Sources */,
+				AD17CDFA27E4DB2700E0D092 /* PushProvider.swift in Sources */,
 				C121E89D274544B000023E4C /* UserSearchController.swift in Sources */,
 				C121E89E274544B000023E4C /* MessageSearchController.swift in Sources */,
 				C121E89F274544B000023E4C /* MessageSearchController+Combine.swift in Sources */,

--- a/Tests/Shared/Mocks/StreamChat/Workers/CurrentUserUpdater_Mock.swift
+++ b/Tests/Shared/Mocks/StreamChat/Workers/CurrentUserUpdater_Mock.swift
@@ -15,6 +15,7 @@ final class CurrentUserUpdaterMock: CurrentUserUpdater {
     
     @Atomic var addDevice_token: Data?
     @Atomic var addDevice_currentUserId: UserId?
+    @Atomic var addDevice_pushProvider: PushProvider?
     @Atomic var addDevice_completion: ((Error?) -> Void)?
     
     @Atomic var removeDevice_id: String?
@@ -41,10 +42,12 @@ final class CurrentUserUpdaterMock: CurrentUserUpdater {
     override func addDevice(
         token: Data,
         currentUserId: UserId,
+        pushProvider: PushProvider,
         completion: ((Error?) -> Void)? = nil
     ) {
         addDevice_token = token
         addDevice_currentUserId = currentUserId
+        addDevice_pushProvider = pushProvider
         addDevice_completion = completion
     }
     

--- a/Tests/StreamChatTests/APIClient/Endpoints/DeviceEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/DeviceEndpoints_Tests.swift
@@ -6,10 +6,10 @@
 import XCTest
 
 final class DeviceEndpoints_Tests: XCTestCase {
-    func test_addDevice_buildsCorrectly() {
+    func test_addDevice_whenPushProviderIsAPN() {
         let userId: UserId = .unique
         let deviceId: String = .unique
-        
+
         let expectedEndpoint: Endpoint<EmptyResponse> = .init(
             path: .devices,
             method: .post,
@@ -17,10 +17,38 @@ final class DeviceEndpoints_Tests: XCTestCase {
             requiresConnectionId: false,
             body: ["user_id": userId, "id": deviceId, "push_provider": "apn"]
         )
-        
+
         // Build endpoint
-        let endpoint: Endpoint<EmptyResponse> = .addDevice(userId: userId, deviceId: deviceId)
-        
+        let endpoint: Endpoint<EmptyResponse> = .addDevice(
+            userId: userId,
+            deviceId: deviceId,
+            pushProvider: .apn
+        )
+
+        // Assert endpoint is built correctly
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        XCTAssertEqual("devices", endpoint.path.value)
+    }
+
+    func test_addDevice_whenPushProviderIsFirebase() {
+        let userId: UserId = .unique
+        let deviceId: String = .unique
+
+        let expectedEndpoint: Endpoint<EmptyResponse> = .init(
+            path: .devices,
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["user_id": userId, "id": deviceId, "push_provider": "firebase"]
+        )
+
+        // Build endpoint
+        let endpoint: Endpoint<EmptyResponse> = .addDevice(
+            userId: userId,
+            deviceId: deviceId,
+            pushProvider: .firebase
+        )
+
         // Assert endpoint is built correctly
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
         XCTAssertEqual("devices", endpoint.path.value)

--- a/Tests/StreamChatTests/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -414,7 +414,7 @@ final class CurrentUserController_Tests: XCTestCase {
     
     // MARK: addDevice
     
-    func test_addDevice_callCurrentUserUpdater_withCorrectValues() {
+    func test_addDevice_callsCurrentUserUpdaterWithCorrectValues() {
         // Simulate current user
         env.currentUserObserverItem = .mock(id: .unique)
         
@@ -424,6 +424,21 @@ final class CurrentUserController_Tests: XCTestCase {
         
         // Assert updater is called with correct data
         XCTAssertEqual(env.currentUserUpdater.addDevice_token, expectedToken)
+        XCTAssertEqual(env.currentUserUpdater.addDevice_pushProvider, PushProvider.apn)
+        XCTAssertNotNil(env.currentUserUpdater.addDevice_completion)
+    }
+
+    func test_addDevice_whenPushProviderIsFirebase_callsCurrentUserUpdaterWithCorrectValues() {
+        // Simulate current user
+        env.currentUserObserverItem = .mock(id: .unique)
+
+        let expectedToken = "test".data(using: .utf8)!
+
+        controller.addDevice(token: expectedToken, pushProvider: .firebase)
+
+        // Assert updater is called with correct data
+        XCTAssertEqual(env.currentUserUpdater.addDevice_token, expectedToken)
+        XCTAssertEqual(env.currentUserUpdater.addDevice_pushProvider, PushProvider.firebase)
         XCTAssertNotNil(env.currentUserUpdater.addDevice_completion)
     }
     

--- a/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/CurrentUserUpdater_Tests.swift
@@ -220,13 +220,21 @@ final class CurrentUserUpdater_Tests: XCTestCase {
         }
         
         // Call addDevice
-        currentUserUpdater.addDevice(token: .init(repeating: 1, count: 1), currentUserId: userPayload.id) {
+        currentUserUpdater.addDevice(
+            token: .init(repeating: 1, count: 1),
+            currentUserId: userPayload.id,
+            pushProvider: .apn
+        ) {
             // No error should be returned
             XCTAssertNil($0)
         }
         
         // Assert that request is made to the correct endpoint
-        let expectedEndpoint: Endpoint<EmptyResponse> = .addDevice(userId: userPayload.id, deviceId: "01")
+        let expectedEndpoint: Endpoint<EmptyResponse> = .addDevice(
+            userId: userPayload.id,
+            deviceId: "01",
+            pushProvider: .apn
+        )
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(expectedEndpoint))
     }
     
@@ -240,7 +248,7 @@ final class CurrentUserUpdater_Tests: XCTestCase {
         
         // Call addDevice
         var completionCalledError: Error?
-        currentUserUpdater.addDevice(token: .init(), currentUserId: .unique) {
+        currentUserUpdater.addDevice(token: .init(), currentUserId: .unique, pushProvider: .apn) {
             completionCalledError = $0
         }
 
@@ -267,7 +275,11 @@ final class CurrentUserUpdater_Tests: XCTestCase {
         
         // Call fetchDevices
         var completionCalledError: Error?
-        currentUserUpdater.addDevice(token: .init(repeating: 1, count: 1), currentUserId: .unique) {
+        currentUserUpdater.addDevice(
+            token: .init(repeating: 1, count: 1),
+            currentUserId: .unique,
+            pushProvider: .apn
+        ) {
             completionCalledError = $0
         }
         
@@ -297,7 +309,11 @@ final class CurrentUserUpdater_Tests: XCTestCase {
         assert(currentUser?.currentDevice == nil)
 
         // Call addDevice
-        currentUserUpdater.addDevice(token: .init(repeating: 1, count: 1), currentUserId: .unique) {
+        currentUserUpdater.addDevice(
+            token: .init(repeating: 1, count: 1),
+            currentUserId: .unique,
+            pushProvider: .apn
+        ) {
             // No error should be returned
             XCTAssertNil($0)
         }


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1689

### 🎯 Goal
Add support to select different push providers in the Device API.

### 🛠 Implementation
Add a new property (`pushProvider:`) to the `CurrentUserController.addDevice()`. The `PushProvider` currently has 2 providers options: `PushProvider.apn` and `PushProvider.firebase`.

### 📝 Changes
- New `pushProvider: PushProvider` property in `CurrentUserUpdater.addDevice()`
- New `pushProvider: PushProvider` property in `CurrentUserController.addDevice()`

### 🧪 Testing
No manual testing yet

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
