### PR TITLE
[CIS-1219] - Allowing StackView to use it's Content Size

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
@@ -599,6 +599,7 @@ open class ChatMessageContentView: _View, ThemeProvider {
             textView?.dataDetectorTypes = .link
             textView?.isScrollEnabled = false
             textView?.backgroundColor = .clear
+            textView?.textContainer.lineBreakMode = .byTruncatingTail
             textView?.adjustsFontForContentSizeCategory = true
             textView?.textContainerInset = .init(top: 0, left: 8, bottom: 0, right: 8)
             textView?.textContainer.lineFragmentPadding = 0

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.swift
@@ -121,9 +121,9 @@ open class ChatMessagePopupVC: _ViewController, ComponentsProvider {
         }
 
         messageContainerStackView.addArrangedSubview(messageContentContainerView)
+
         constraints += [
-            messageContentContainerView.widthAnchor.pin(equalToConstant: messageViewFrame.width),
-            messageContentContainerView.heightAnchor.pin(equalToConstant: messageViewFrame.height)
+            messageContentContainerView.widthAnchor.pin(equalToConstant: messageViewFrame.width)
         ]
 
         if let actionsController = actionsController {

--- a/Sources/StreamChatUI/MessageActionsPopup/MessageActionsTransitionController.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/MessageActionsTransitionController.swift
@@ -150,10 +150,8 @@ open class ChatMessageActionsTransitionController: NSObject, UIViewControllerTra
             options: [.curveEaseInOut],
             animations: {
                 messageView.transform = .identity
-                messageView.frame = toVC.messageContentContainerView.superview?.convert(
-                    toVC.messageContentContainerView.frame,
-                    to: nil
-                ) ?? .zero
+                
+                actionsSnapshot?.frame = self.selectedMessageContentViewFrame ?? .zero
                 
                 showSnapshot(actionsSnapshot)
                 showSnapshot(reactionsSnapshot)


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1219

### 🎯 Goal

We're not currently utilising the height of the StackView so the MessageContentView is pushing the ActionsController further down on larger messages which creates the bug seen in the ticket.

### 🛠 Implementation

The implementation is to remove the fixed height on the StackView, and allow the message to be truncated on larger messages.

### 🎨 UI Changes

The main change in the UI is that on larger messages you now see ellipses at the tail of the message.

### 🧪 Testing

1. Launch the Demo App
2. Create a large message that covers the whole screen
3. Tap and Hold on to that message to show the actions
4. The message is truncated and you can see all the reactions & actions.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎉 GIF

![RocketSim_Recording_iPhone_13_2022-03-23_17 47 27](https://user-images.githubusercontent.com/1519998/159763555-375fb528-e329-4663-a63f-551a3f33d8de.gif)

