### PR TITLE
[CIS-1592] Fix file mime-types and attachment type 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix payload for reaction when using `enforce_unique` [#1861](https://github.com/GetStream/stream-chat-swift/issues/1861)
 - Use IndexPath's item instead of row for macOS compatibility [#1859](https://github.com/GetStream/stream-chat-swift/pull/1859)
+- Fix attachment file mime-types [#1873](https://github.com/GetStream/stream-chat-swift/pull/1873)
+## StreamChatUI
+### 🐞 Fixed
+- Resolve attachment file type when importing from file picker [#1873](https://github.com/GetStream/stream-chat-swift/pull/1873)
 
 # [4.12.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.12.0)
 _March 16, 2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix attachment file mime-types [#1873](https://github.com/GetStream/stream-chat-swift/pull/1873)
 ## StreamChatUI
 ### 🐞 Fixed
-- Resolve attachment type when importing from file picker [#1873](https://github.com/GetStream/stream-chat-swift/pull/1873)
+- Resolve attachment type when importing file from file picker [#1873](https://github.com/GetStream/stream-chat-swift/pull/1873)
 
 # [4.12.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.12.0)
 _March 16, 2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix attachment file mime-types [#1873](https://github.com/GetStream/stream-chat-swift/pull/1873)
 ## StreamChatUI
 ### 🐞 Fixed
-- Resolve attachment file type when importing from file picker [#1873](https://github.com/GetStream/stream-chat-swift/pull/1873)
+- Resolve attachment type when importing from file picker [#1873](https://github.com/GetStream/stream-chat-swift/pull/1873)
 
 # [4.12.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.12.0)
 _March 16, 2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix payload for reaction when using `enforce_unique` [#1861](https://github.com/GetStream/stream-chat-swift/issues/1861)
 - Use IndexPath's item instead of row for macOS compatibility [#1859](https://github.com/GetStream/stream-chat-swift/pull/1859)
-- Fix attachment file mime-types [#1873](https://github.com/GetStream/stream-chat-swift/pull/1873)
+- Fix mime-type for file attachments [#1873](https://github.com/GetStream/stream-chat-swift/pull/1873)
 ## StreamChatUI
 ### 🐞 Fixed
 - Resolve attachment type when importing file from file picker [#1873](https://github.com/GetStream/stream-chat-swift/pull/1873)

--- a/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
+++ b/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
@@ -103,10 +103,7 @@ public struct AttachmentType: RawRepresentable, Codable, Hashable, ExpressibleBy
     /// the attachment type through its extension/mime-type.
     public init(fileExtension: String) {
         let attachmentFileType = AttachmentFileType(ext: fileExtension)
-        guard let mainMimeType = attachmentFileType.mimeType.split(separator: "/").first else {
-            self = .file
-            return
-        }
+        let mainMimeType = attachmentFileType.mimeType.split(separator: "/").first
         switch mainMimeType {
         case "image":
             self = .image
@@ -114,8 +111,6 @@ public struct AttachmentType: RawRepresentable, Codable, Hashable, ExpressibleBy
             self = .video
         case "audio":
             self = .audio
-        case "text", "application":
-            self = .file
         default:
             self = .file
         }

--- a/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
+++ b/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
@@ -187,25 +187,50 @@ public struct AttachmentFile: Codable, Hashable {
 
 /// An attachment file type.
 public enum AttachmentFileType: String, Codable, Equatable, CaseIterable {
-    /// A file attachment type.
-    case generic, csv, doc, pdf, ppt, tar, xls, zip, mp3, mp4, mov, jpeg, png, gif
-    
+    /// File
+    case generic, doc, docx, pdf, ppt, pptx, tar, xls, zip, x7z, xz, ods, odt, xlsx
+    /// Text
+    case csv, rtf, txt
+    /// Audio
+    case mp3, mp4, wav, ogg, m4a
+    /// Video
+    case mov, avi, wmv, webm
+    /// Image
+    case jpeg, png, gif, bmp, webp
+
     private static let mimeTypes: [String: AttachmentFileType] = [
         "application/octet-stream": .generic,
-        "text/csv": .csv,
         "application/msword": .doc,
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document": .docx,
         "application/pdf": .pdf,
         "application/vnd.ms-powerpoint": .ppt,
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation": .pptx,
         "application/x-tar": .tar,
         "application/vnd.ms-excel": .xls,
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": .xlsx,
         "application/zip": .zip,
+        "application/x-7z-compressed": .x7z,
+        "application/x-xz": .xz,
+        "application/vnd.oasis.opendocument.spreadsheet": .ods,
+        "application/vnd.oasis.opendocument.text": .odt,
+        "text/csv": .csv,
+        "text/rtf": .rtf,
+        "text/plain": .txt,
         "audio/mp3": .mp3,
+        "audio/mp4": .m4a,
+        "audio/wav": .wav,
+        "audio/ogg": .ogg,
         "video/mp4": .mp4,
         "video/quicktime": .mov,
+        "video/x-msvideo": .avi,
+        "video/x-ms-wmv": .wmv,
+        "video/webm": .webm,
         "image/jpeg": .jpeg,
         "image/jpg": .jpeg,
         "image/png": .png,
-        "image/gif": .gif
+        "image/gif": .gif,
+        "image/bmp": .bmp,
+        "image/webp": .webp
     ]
     
     /// Init an attachment file type by mime type.
@@ -223,11 +248,17 @@ public enum AttachmentFileType: String, Codable, Equatable, CaseIterable {
         // which breaks our file type detection code.
         // We lowercase it for extra safety
         let ext = ext.lowercased()
+
         if ext == "jpg" {
             self = .jpeg
             return
         }
-        
+
+        if ext == "7z" {
+            self = .x7z
+            return
+        }
+
         self = AttachmentFileType(rawValue: ext) ?? .generic
     }
     
@@ -236,8 +267,10 @@ public enum AttachmentFileType: String, Codable, Equatable, CaseIterable {
         if self == .jpeg {
             return "image/jpeg"
         }
-        
-        return AttachmentFileType.mimeTypes.first(where: { $1 == self })?.key ?? "application/octet-stream"
+
+        return AttachmentFileType.mimeTypes
+            .first(where: { $1 == self })?
+            .key ?? "application/octet-stream"
     }
 }
 

--- a/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
+++ b/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
@@ -96,6 +96,30 @@ public struct AttachmentType: RawRepresentable, Codable, Hashable, ExpressibleBy
     public init(stringLiteral value: String) {
         self.init(rawValue: value)
     }
+
+    /// Create an `AttachmentType` from a file extension.
+    ///
+    /// If we know the extension of a file, it is possible to resolve
+    /// the attachment type through its extension/mime-type.
+    public init(fileExtension: String) {
+        let attachmentFileType = AttachmentFileType(ext: fileExtension)
+        guard let mainMimeType = attachmentFileType.mimeType.split(separator: "/").first else {
+            self = .file
+            return
+        }
+        switch mainMimeType {
+        case "image":
+            self = .image
+        case "video":
+            self = .video
+        case "audio":
+            self = .audio
+        case "text", "application":
+            self = .file
+        default:
+            self = .file
+        }
+    }
 }
 
 public extension AttachmentType {

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -860,15 +860,14 @@ open class ComposerVC: _ViewController,
     // MARK: - UIDocumentPickerViewControllerDelegate
     
     open func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
-        let type: AttachmentType = .file
-        
         for fileURL in urls {
+            let attachmentType = AttachmentType(fileExtension: fileURL.pathExtension)
             do {
-                try addAttachmentToContent(from: fileURL, type: type)
+                try addAttachmentToContent(from: fileURL, type: attachmentType)
             } catch {
                 handleAddAttachmentError(
                     attachmentURL: fileURL,
-                    attachmentType: type,
+                    attachmentType: attachmentType,
                     error: error
                 )
                 break

--- a/Tests/StreamChatTests/Models/Attachments/AttachmentTypes_Tests.swift
+++ b/Tests/StreamChatTests/Models/Attachments/AttachmentTypes_Tests.swift
@@ -107,4 +107,13 @@ class AttachmentTypes_Tests: XCTestCase {
         XCTAssertEqual(AttachmentFileType(ext: "jpeg"), .jpeg)
         XCTAssertEqual(AttachmentFileType(ext: "7z"), .x7z)
     }
+
+    func test_attachmentType_initWithFileExtension() {
+        XCTAssertEqual(AttachmentType(fileExtension: "jpg"), .image)
+        XCTAssertEqual(AttachmentType(fileExtension: "mp4"), .video)
+        XCTAssertEqual(AttachmentType(fileExtension: "wav"), .audio)
+        XCTAssertEqual(AttachmentType(fileExtension: "txt"), .file)
+        XCTAssertEqual(AttachmentType(fileExtension: "zip"), .file)
+        XCTAssertEqual(AttachmentType(fileExtension: "unknown"), .file)
+    }
 }

--- a/Tests/StreamChatTests/Models/Attachments/AttachmentTypes_Tests.swift
+++ b/Tests/StreamChatTests/Models/Attachments/AttachmentTypes_Tests.swift
@@ -101,4 +101,10 @@ class AttachmentTypes_Tests: XCTestCase {
         // Assert object encoded and decoded correctly
         XCTAssertEqual(file, decoded)
     }
+
+    func test_attachmentFileType_initWithExtension_edgeCases() {
+        XCTAssertEqual(AttachmentFileType(ext: "jpg"), .jpeg)
+        XCTAssertEqual(AttachmentFileType(ext: "jpeg"), .jpeg)
+        XCTAssertEqual(AttachmentFileType(ext: "7z"), .x7z)
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1592

### 🎯 Goal
- Align the file mime-types with the other SDKs
- When adding a file from the File Picker, resolve the correct attachment type

### 🛠 Implementation
- Fix the incorrect mime-type and add missing ones
- When adding a file in the composer, resolve the attachment type through the file extension

### 🎨 UI Changes
**Adding an image through the file picker:**

https://user-images.githubusercontent.com/12814114/159786027-e060d590-7330-476b-9b3e-ca9e357dcbac.mp4


### 🧪 Testing
**Scenario 1**:
1. Open a chat
2. Add a file attachment with extension `.rtf`
3. Check the HTTP Request - mime-type should be `text/rtf`

**Scenario 2**:
1. Open a chat
2. Add an image from the File Picker (Instead of Photo & Video Picker)
3. Composer should preview the image
4. Image should be added to the message list successfully

**Note:** When importing audio files from the File Picker, nothing will render 
since we currently don't support audio files in the iOS SDK

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)