### PR TITLE
[CIS-1699] Fix pasting long text into composer won't update input height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use IndexPath's item instead of row for macOS compatibility [#1859](https://github.com/GetStream/stream-chat-swift/pull/1859)
 - Fix commands without arguments cannot be sent without text [#1869](https://github.com/GetStream/stream-chat-swift/issues/1869)
 - Fix mime-type for file attachments [#1873](https://github.com/GetStream/stream-chat-swift/pull/1873)
+- Fix pasting long text into composer won't update input height [#1875](https://github.com/GetStream/stream-chat-swift/issues/1875)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
+++ b/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
@@ -168,6 +168,9 @@ open class InputTextView: UITextView, AppearanceProvider {
             clipboardAttachmentDelegate?.inputTextView(self, didPasteImage: pasteboardImage)
         } else {
             super.paste(sender)
+            // On text paste, textView height will not change automatically
+            // so we must call this function
+            setTextViewHeight()
         }
     }
 }


### PR DESCRIPTION
### 🔗 Issue Link
Fixes #1872
CiS-1699

### 🎯 Goal

Pasting a long text into composer should display maximum text size.

### 🛠 Implementation

Currently, pasting a long text does not call `setTextViewHeight` so text height is not correct.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Simulator Screen Recording - iPhone 13 Pro - 2022-03-24 at 15 17 36](https://user-images.githubusercontent.com/770464/159936408-b25c0202-4b70-4435-a88c-08da0dc5dbe4.gif) | ![Simulator Screen Recording - iPhone 13 Pro - 2022-03-24 at 15 16 41](https://user-images.githubusercontent.com/770464/159936379-aee1ff10-ef40-464a-878c-bee016724848.gif) |

### 🧪 Testing

Test with this text:

> Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message Really long message

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)
