### PR TITLE
[Docs] Move UI Kit Customizing Components doc to main level

### DIFF
--- a/docusaurus/docs/iOS/common-content/components-note.md
+++ b/docusaurus/docs/iOS/common-content/components-note.md
@@ -1,3 +1,3 @@
 :::note
-You can find more information on how the components configuration works [here](../uikit/components/custom-components.md).
+You can find more information on how the components configuration works [here](../uikit/custom-components.md).
 :::

--- a/docusaurus/docs/iOS/uikit/custom-components.md
+++ b/docusaurus/docs/iOS/uikit/custom-components.md
@@ -2,7 +2,7 @@
 title: Customizing Components
 ---
 
-The Stream SDK UI components are fully customizable and interchangeable through the `Components` configuration type that holds all the reusable views of the SDK. You can customize these views by subclassing them and replacing them in the configuration with your subclass. Just like the `Appearance` configuration mentioned in the [Theming](../theming.md) page, you should modify the values of the `Components` configuration from `Components.default` as early as possible in your application life-cycle.
+The Stream SDK UI components are fully customizable and interchangeable through the `Components` configuration type that holds all the reusable views of the SDK. You can customize these views by subclassing them and replacing them in the configuration with your subclass. Just like the `Appearance` configuration mentioned in the [Theming](theming.md) page, you should modify the values of the `Components` configuration from `Components.default` as early as possible in your application life-cycle.
 
 ## Customizing Components
 
@@ -36,7 +36,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 }
 ```
 
-The full list of customizations exposed by `Components` is available [here](../../common-content/reference-docs/stream-chat-ui/components.md#properties).
+The full list of customizations exposed by `Components` is available [here](../common-content/reference-docs/stream-chat-ui/components.md#properties).
 
 ## Components Lifecycle Methods
 
@@ -98,7 +98,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 | Before  | After |
 | ------------- | ------------- |
-| ![Default Avatars](../../assets/default-avatars.png)  | ![Rect Avatars](../../assets/rect-avatars.png)  |
+| ![Default Avatars](../assets/default-avatars.png)  | ![Rect Avatars](../assets/rect-avatars.png)  |
 
 And that's it 🎉 as you can see all avatars across the UI are now rectangular.
 
@@ -108,7 +108,7 @@ Now, to show an example on how to use to other lifecycle methods, let's try to c
 
 | Default style  | Custom "iMessage" Style |
 | ------------- | ------------- |
-| ![Default unread count](../../assets/default-unread-count.png)  | ![iMessage unread count](../../assets/custom-unread-count.png)  |
+| ![Default unread count](../assets/default-unread-count.png)  | ![iMessage unread count](../assets/custom-unread-count.png)  |
 
 First, we need to create a custom subclass of `ChatChannelListItemView`, which is the component responsible for showing the channel summary in the channel list. Because the iMessage-style unread indicator is just a blue dot, rather then trying to modify the existing unread indicator, it's easier to create a brand new view for it:
 

--- a/docusaurus/sidebars-ios.json
+++ b/docusaurus/sidebars-ios.json
@@ -14,6 +14,7 @@
         "uikit/getting-started",
         "uikit/localization",
         "uikit/theming",
+        "uikit/custom-components",
         "uikit/data-formatting",
         {
             "Controllers and Delegates": [
@@ -31,8 +32,7 @@
               "uikit/components/channel",
               "uikit/components/thread",
               "uikit/components/message",
-              "uikit/components/message-composer",
-              "uikit/components/custom-components"
+              "uikit/components/message-composer"
             ]
           },
          {


### PR DESCRIPTION
### 🔗 Issue Link
None

### 🎯 Goal
Currently, this documentation was hidden in a subsection of "CoreComponents". This documentation is very important and should be at the main level. 

### 🎨 UI Changes
<img width="286" alt="image" src="https://user-images.githubusercontent.com/12814114/160607148-d64ab416-f5b1-4366-8d32-2bb06848d703.png">

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)