### PR TITLE
[CIS-1737] Fix deadlock when accessing some properties from Events Delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
-
 # [4.13.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.13.1)
 _April 04, 2022_
 
-### 🔄 Changed
+### 🚨 Fixed
+- Fix deadlock when accessing some properties from Events Delegate [#1898](https://github.com/GetStream/stream-chat-swift/issues/1898)
 
 # [4.13.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.13.0)
 _March 29, 2022_

--- a/DemoApp/DemoAppCoordinator.swift
+++ b/DemoApp/DemoAppCoordinator.swift
@@ -197,7 +197,7 @@ class CustomChannelVC: ChatChannelVC {
     }
 }
 
-class DemoChannelListVC: ChatChannelListVC {
+class DemoChannelListVC: ChatChannelListVC, EventsControllerDelegate {
     /// The `UIButton` instance used for navigating to new channel screen creation.
     lazy var createChannelButton: UIButton = {
         let button = UIButton()
@@ -211,8 +211,12 @@ class DemoChannelListVC: ChatChannelListVC {
         return button
     }()
 
+    let eventsController = ChatClient.shared.eventsController()
+
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        eventsController.delegate = self
 
         navigationItem.rightBarButtonItems = [
             UIBarButtonItem(customView: hiddenChannelsButton),
@@ -289,6 +293,14 @@ class DemoChannelListVC: ChatChannelListVC {
             animated: false,
             scrollPosition: .centeredHorizontally
         )
+    }
+
+    func eventsController(_ controller: EventsController, didReceiveEvent event: Event) {
+        if let newMessageEvent = event as? MessageNewEvent {
+            // This is a DemoApp integration test to make sure there are no deadlocks when
+            // accessing CoreDataLazy properties from the EventsController.delegate
+            _ = newMessageEvent.message.author
+        }
     }
 }
 

--- a/Sources/StreamChat/Workers/EventNotificationCenter.swift
+++ b/Sources/StreamChat/Workers/EventNotificationCenter.swift
@@ -14,7 +14,7 @@ class EventNotificationCenter: NotificationCenter {
     // We post events on a queue different from database.writable context
     // queue to prevent a deadlock happening when @CoreDataLazy (with `context.performAndWait` inside)
     // model is accessed in event handlers.
-    var eventPostingQueue = DispatchQueue.main
+    var eventPostingQueue = DispatchQueue(label: "io.getstream.event-notification-center")
     
     init(database: DatabaseContainer) {
         self.database = database
@@ -42,7 +42,7 @@ class EventNotificationCenter: NotificationCenter {
                 return
             }
             
-            self.eventPostingQueue.sync {
+            self.eventPostingQueue.async {
                 eventsToPost.forEach { self.post(Notification(newEventReceived: $0, sender: self)) }
                 completion?()
             }


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1737

### 🎯 Goal
Fix deadlock when accessing CoreDataLazy properties from the Events Delegate.

### 🛠 Implementation
The current fix makes sure that the `EventNotificationCenter.postintEventQueue` is always called async to avoid any deadlock. Currently, there's no reason the call needs to be synchronous.

### 🧪 Testing
- Run the App
- Open a Channel
- Send a new message
- App should not be frozen

**Note:** An event handling and accessing `message.author` was introduced in the demo app so that we can test this often and there are no regressions.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎉 GIF
<img src="https://c.tenor.com/QySuxch-lLEAAAAC/frozen-freezing.gif"/>
