### PR TITLE
[CIS-1729] Call read endpoint when only silent messages/thread replies are posted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - `quotesEnabled` property is added to the `ChannelConfig` [#1891](https://github.com/GetStream/stream-chat-swift/issues/1891)
 - Expose `readBy/readByCount` on `ChatMessage` containing info about users who has seen this message. These fields are populated only for messages sent by the current user. [#1887](https://github.com/GetStream/stream-chat-swift/issues/1887)
+- Expose number of unread silent messages and thread replies on `ChatChannel` [#1904](https://github.com/GetStream/stream-chat-swift/issues/1904)
 ### 🔄 Changed
 - Assertions are no longer thrown by default. Check `StreamRuntimeCheck` to enable them [#1885](https://github.com/GetStream/stream-chat-swift/pull/1885)
 - Local Storage is enabled by default. You can read more [here](https://getstream.io/chat/docs/sdk/ios/guides/offline-support) [#1890](https://github.com/GetStream/stream-chat-swift/pull/1890)
+### 🐞 Fixed
+- Channel not being marked as read by the current user when it's only thread replies or silent messages sent after the last read [#1904](https://github.com/GetStream/stream-chat-swift/issues/1904)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -325,10 +325,8 @@ extension ChatChannel {
         let unreadCount: () -> ChannelUnreadCount = {
             guard let currentUser = context.currentUser else { return .noUnread }
             
-            let currentUserRead = reads.first(where: { $0.user.id == currentUser.user.id })
-            
-            let allUnreadMessages = currentUserRead?.unreadMessagesCount ?? 0
-            
+            let currentUserRead = dto.reads.first(where: { $0.user.id == currentUser.user.id })
+                        
             // Fetch count of all mentioned messages after last read
             // (this is not 100% accurate but it's the best we have)
             let mentionedUnreadMessagesRequest = NSFetchRequest<MessageDTO>(entityName: MessageDTO.entityName)
@@ -344,8 +342,10 @@ extension ChatChannel {
             
             do {
                 return ChannelUnreadCount(
-                    messages: allUnreadMessages,
-                    mentioningMessages: try context.count(for: mentionedUnreadMessagesRequest)
+                    messages: Int(currentUserRead?.unreadMessageCount ?? 0),
+                    mentioningMessages: try context.count(for: mentionedUnreadMessagesRequest),
+                    silentMessages: Int(currentUserRead?.unreadSilentMessagesCount ?? 0),
+                    threadReplies: Int(currentUserRead?.unreadThreadRepliesCount ?? 0)
                 )
             } catch {
                 log.error("Failed to fetch unread counts for channel `\(cid)`. Error: \(error)")

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -345,7 +345,7 @@ extension ChatChannel {
             do {
                 return ChannelUnreadCount(
                     messages: allUnreadMessages,
-                    mentionedMessages: try context.count(for: mentionedUnreadMessagesRequest)
+                    mentioningMessages: try context.count(for: mentionedUnreadMessagesRequest)
                 )
             } catch {
                 log.error("Failed to fetch unread counts for channel `\(cid)`. Error: \(error)")

--- a/Sources/StreamChat/Database/DTOs/ChannelReadDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelReadDTO.swift
@@ -9,7 +9,9 @@ import Foundation
 class ChannelReadDTO: NSManagedObject {
     @NSManaged var lastReadAt: Date
     @NSManaged var unreadMessageCount: Int32
-    
+    @NSManaged var unreadSilentMessagesCount: Int32
+    @NSManaged var unreadThreadRepliesCount: Int32
+
     // MARK: - Relationships
     
     @NSManaged var channel: ChannelDTO

--- a/Sources/StreamChat/Database/DTOs/ChannelReadDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelReadDTO.swift
@@ -75,6 +75,8 @@ extension NSManagedObjectContext {
         
         dto.lastReadAt = payload.lastReadAt
         dto.unreadMessageCount = Int32(payload.unreadMessagesCount)
+        dto.unreadSilentMessagesCount = dto.user.currentUser == nil ? 0 : dto.unreadSilentMessagesCount
+        dto.unreadThreadRepliesCount = dto.user.currentUser == nil ? 0 : dto.unreadThreadRepliesCount
         
         return dto
     }

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -98,6 +98,8 @@
     <entity name="ChannelReadDTO" representedClassName="ChannelReadDTO" syncable="YES">
         <attribute name="lastReadAt" attributeType="Date" defaultDateTimeInterval="0" usesScalarValueType="NO"/>
         <attribute name="unreadMessageCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="unreadSilentMessagesCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="unreadThreadRepliesCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="reads" inverseEntity="ChannelDTO"/>
         <relationship name="readMessagesFromCurrentUser" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="reads" inverseEntity="MessageDTO"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="channelReads" inverseEntity="UserDTO"/>

--- a/Sources/StreamChat/Deprecations.swift
+++ b/Sources/StreamChat/Deprecations.swift
@@ -213,3 +213,8 @@ public typealias NotificationInviteAccepted = NotificationInviteAcceptedEvent
 
 @available(*, deprecated, renamed: "UnknownChannelEvent")
 public typealias UnknownEvent = UnknownChannelEvent
+
+public extension ChannelUnreadCount {
+    @available(*, deprecated, renamed: "mentioningMessages")
+    var mentionedMessages: Int { mentioningMessages }
+}

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -228,7 +228,7 @@ extension ChatChannel {
     public var isDirectMessageChannel: Bool { cid.id.hasPrefix("!members") }
     
     /// returns `true` if the channel has one or more unread messages for the current user.
-    public var isUnread: Bool { unreadCount.messages > 0 }
+    public var isUnread: Bool { unreadCount != .noUnread }
 }
 
 /// A type-erased version of `ChannelModel<CustomData>`. Not intended to be used directly.

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -248,11 +248,11 @@ extension ChatChannel: Hashable {
 /// A struct describing unread counts for a channel.
 public struct ChannelUnreadCount: Decodable, Equatable {
     /// The default value representing no unread messages.
-    public static let noUnread = ChannelUnreadCount(messages: 0, mentionedMessages: 0)
+    public static let noUnread = ChannelUnreadCount(messages: 0, mentioningMessages: 0)
     
     /// The total number of unread messages in the channel.
     public let messages: Int
     
     /// The number of unread messages that mention the current user.
-    public let mentionedMessages: Int
+    public let mentioningMessages: Int
 }

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -251,8 +251,8 @@ public struct ChannelUnreadCount: Decodable, Equatable {
     public static let noUnread = ChannelUnreadCount(messages: 0, mentionedMessages: 0)
     
     /// The total number of unread messages in the channel.
-    public internal(set) var messages: Int
+    public let messages: Int
     
     /// The number of unread messages that mention the current user.
-    public internal(set) var mentionedMessages: Int
+    public let mentionedMessages: Int
 }

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -248,11 +248,22 @@ extension ChatChannel: Hashable {
 /// A struct describing unread counts for a channel.
 public struct ChannelUnreadCount: Decodable, Equatable {
     /// The default value representing no unread messages.
-    public static let noUnread = ChannelUnreadCount(messages: 0, mentioningMessages: 0)
+    public static let noUnread = ChannelUnreadCount(
+        messages: 0,
+        mentioningMessages: 0,
+        silentMessages: 0,
+        threadReplies: 0
+    )
     
     /// The total number of unread messages in the channel.
     public let messages: Int
     
-    /// The number of unread messages that mention the current user.
+    /// The number of unread messages mentioning the current user in the channel.
     public let mentioningMessages: Int
+    
+    /// The number of unread silent messages in the channel.
+    public let silentMessages: Int
+    
+    /// The number of unread thread replies (not sent to the channel).
+    public let threadReplies: Int
 }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -542,6 +542,7 @@
 		84EB4E76276A012900E47E73 /* ClientError_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EB4E75276A012900E47E73 /* ClientError_Tests.swift */; };
 		84EB4E78276A03DE00E47E73 /* ErrorPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EB4E77276A03DE00E47E73 /* ErrorPayload_Tests.swift */; };
 		84F61270268B415C00DDF6EE /* ChatClientConfig_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F6126F268B415C00DDF6EE /* ChatClientConfig_Tests.swift */; };
+		84FD350827FD8BE300D68D85 /* ChatChannel_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FD350727FD8BE300D68D85 /* ChatChannel_Tests.swift */; };
 		8800A26F258A04D5006D64C4 /* ChatMessageAttachmentPreviewVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8800A26E258A04D5006D64C4 /* ChatMessageAttachmentPreviewVC.swift */; };
 		8800A28C258A1924006D64C4 /* ChatMessageFileAttachmentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8800A28B258A1924006D64C4 /* ChatMessageFileAttachmentListView.swift */; };
 		8802F9EF25AF3D4200475159 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8802F9EE25AF3D4200475159 /* HTTPHeader.swift */; };
@@ -2749,6 +2750,7 @@
 		84EB4E75276A012900E47E73 /* ClientError_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientError_Tests.swift; sourceTree = "<group>"; };
 		84EB4E77276A03DE00E47E73 /* ErrorPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorPayload_Tests.swift; sourceTree = "<group>"; };
 		84F6126F268B415C00DDF6EE /* ChatClientConfig_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatClientConfig_Tests.swift; sourceTree = "<group>"; };
+		84FD350727FD8BE300D68D85 /* ChatChannel_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannel_Tests.swift; sourceTree = "<group>"; };
 		8800A26E258A04D5006D64C4 /* ChatMessageAttachmentPreviewVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageAttachmentPreviewVC.swift; sourceTree = "<group>"; };
 		8800A28B258A1924006D64C4 /* ChatMessageFileAttachmentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageFileAttachmentListView.swift; sourceTree = "<group>"; };
 		8802F9BC25AF1DE200475159 /* WebSocketClient_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient_Mock.swift; sourceTree = "<group>"; };
@@ -5845,6 +5847,7 @@
 			isa = PBXGroup;
 			children = (
 				8A5D3EF824AF749200E2FE35 /* ChannelId_Tests.swift */,
+				84FD350727FD8BE300D68D85 /* ChatChannel_Tests.swift */,
 				64C80614262EDA9600B1F7AD /* ChatMessage_Tests.swift */,
 				796CBC6425FBAD12003299B0 /* Member_Tests.swift */,
 				88EA9AFB25472269007EE76B /* MessageReactionType_Tests.swift */,
@@ -9183,6 +9186,7 @@
 				84A1D2F426AB221E00014712 /* ChannelEventsController_Tests.swift in Sources */,
 				88381E6E258259310047A6A3 /* FileUploadPayload_Tests.swift in Sources */,
 				64F70D4B26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift in Sources */,
+				84FD350827FD8BE300D68D85 /* ChatChannel_Tests.swift in Sources */,
 				F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */,
 				22CAFA7625CAE278005935D9 /* RawJSON_Tests.swift in Sources */,
 				79342EEC2632C7770018F0F7 /* ChannelVisibilityEventMiddleware_Tests.swift in Sources */,

--- a/Tests/StreamChatTestTools/Mocks/Models + Extensions/ChannelUnreadCount_Mock.swift
+++ b/Tests/StreamChatTestTools/Mocks/Models + Extensions/ChannelUnreadCount_Mock.swift
@@ -6,7 +6,17 @@ import Foundation
 @testable import StreamChat
 
 public extension ChannelUnreadCount {
-    static func mock(messages: Int, mentioningMessages: Int = 0) -> Self {
-        .init(messages: messages, mentioningMessages: mentioningMessages)
+    static func mock(
+        messages: Int,
+        mentioningMessages: Int = 0,
+        silentMessages: Int = 0,
+        threadReplies: Int = 0
+    ) -> Self {
+        .init(
+            messages: messages,
+            mentioningMessages: mentioningMessages,
+            silentMessages: silentMessages,
+            threadReplies: threadReplies
+        )
     }
 }

--- a/Tests/StreamChatTestTools/Mocks/Models + Extensions/ChannelUnreadCount_Mock.swift
+++ b/Tests/StreamChatTestTools/Mocks/Models + Extensions/ChannelUnreadCount_Mock.swift
@@ -6,7 +6,7 @@ import Foundation
 @testable import StreamChat
 
 public extension ChannelUnreadCount {
-    static func mock(messages: Int, mentionedMessages: Int = 0) -> Self {
-        .init(messages: messages, mentionedMessages: mentionedMessages)
+    static func mock(messages: Int, mentioningMessages: Int = 0) -> Self {
+        .init(messages: messages, mentioningMessages: mentioningMessages)
     }
 }

--- a/Tests/StreamChatTestTools/TestData/DummyData/MessagePayload.swift
+++ b/Tests/StreamChatTestTools/TestData/DummyData/MessagePayload.swift
@@ -42,7 +42,8 @@ extension MessagePayload {
         isShadowed: Bool = false,
         reactionScores: [MessageReactionType: Int] = ["like": 1],
         reactionCounts: [MessageReactionType: Int] = ["like": 1],
-        translations: [TranslationLanguage: String]? = nil
+        translations: [TranslationLanguage: String]? = nil,
+        mentionedUsers: [UserPayload] = [.dummy(userId: .unique)]
     ) -> MessagePayload {
         .init(
             id: messageId,
@@ -60,7 +61,7 @@ extension MessagePayload {
             showReplyInChannel: showReplyInChannel,
             quotedMessageId: quotedMessageId,
             quotedMessage: quotedMessage,
-            mentionedUsers: [UserPayload.dummy(userId: .unique)],
+            mentionedUsers: mentionedUsers,
             threadParticipants: threadParticipants,
             replyCount: .random(in: 0...1000),
             extraData: extraData,

--- a/Tests/StreamChatTests/Database/DTOs/ChannelReadDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/ChannelReadDTO_Tests.swift
@@ -22,6 +22,158 @@ final class ChannelReadDTO_Tests: XCTestCase {
         super.tearDown()
     }
     
+    // MARK: - saveChannelRead
+    
+    func test_saveChannelRead_whenReadDoesNotExist_createsIt() throws {
+        // GIVEN
+        let readPayload = ChannelReadPayload(
+            user: .dummy(userId: .unique),
+            lastReadAt: .init(),
+            unreadMessagesCount: 10
+        )
+        
+        let channelPayload: ChannelPayload = .dummy(
+            members: [.dummy(user: readPayload.user)],
+            channelReads: []
+        )
+                
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: channelPayload)
+            
+            // WHEN
+            try session.saveChannelRead(
+                payload: readPayload,
+                for: channelPayload.channel.cid
+            )
+        }
+        
+        // THEN
+        let readDTO = try XCTUnwrap(
+            ChannelReadDTO.load(
+                cid: channelPayload.channel.cid,
+                userId: readPayload.user.id,
+                context: database.viewContext
+            )
+        )
+        XCTAssertEqual(readDTO.lastReadAt, readPayload.lastReadAt)
+        XCTAssertEqual(Int(readDTO.unreadMessageCount), readPayload.unreadMessagesCount)
+        XCTAssertEqual(readDTO.unreadThreadRepliesCount, 0)
+        XCTAssertEqual(readDTO.unreadSilentMessagesCount, 0)
+    }
+    
+    func test_saveChannelRead_whenAnotherUserReadExists_updatesIt() throws {
+        // GIVEN
+        let userPayload: UserPayload = .dummy(userId: .unique)
+        
+        let readPayload = ChannelReadPayload(
+            user: userPayload,
+            lastReadAt: .init(),
+            unreadMessagesCount: 10
+        )
+        
+        let newReadPayload = ChannelReadPayload(
+            user: userPayload,
+            lastReadAt: readPayload.lastReadAt.addingTimeInterval(10),
+            unreadMessagesCount: 5
+        )
+        
+        let channelPayload: ChannelPayload = .dummy(
+            members: [.dummy(user: userPayload)],
+            channelReads: [readPayload]
+        )
+                
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: channelPayload)
+            
+            let readDTO = try XCTUnwrap(
+                session.loadChannelRead(
+                    cid: channelPayload.channel.cid,
+                    userId: userPayload.id
+                )
+            )
+            readDTO.unreadThreadRepliesCount = 3
+            readDTO.unreadSilentMessagesCount = 2
+            
+            // WHEN
+            try session.saveChannelRead(
+                payload: newReadPayload,
+                for: channelPayload.channel.cid
+            )
+        }
+        
+        // THEN
+        let readDTO = try XCTUnwrap(
+            ChannelReadDTO.load(
+                cid: channelPayload.channel.cid,
+                userId: userPayload.id,
+                context: database.viewContext
+            )
+        )
+        XCTAssertEqual(readDTO.lastReadAt, newReadPayload.lastReadAt)
+        XCTAssertEqual(Int(readDTO.unreadMessageCount), newReadPayload.unreadMessagesCount)
+        XCTAssertEqual(readDTO.unreadThreadRepliesCount, 0)
+        XCTAssertEqual(readDTO.unreadSilentMessagesCount, 0)
+    }
+    
+    func test_saveChannelRead_whenCurrenUserReadExists_updatesIt() throws {
+        // GIVEN
+        let currentUserPayload: CurrentUserPayload = .dummy(userId: .unique, role: .user)
+    
+        let readPayload = ChannelReadPayload(
+            user: currentUserPayload,
+            lastReadAt: .init(),
+            unreadMessagesCount: 10
+        )
+        
+        let newReadPayload = ChannelReadPayload(
+            user: currentUserPayload,
+            lastReadAt: readPayload.lastReadAt.addingTimeInterval(10),
+            unreadMessagesCount: 5
+        )
+        
+        let channelPayload: ChannelPayload = .dummy(
+            members: [.dummy(user: currentUserPayload)],
+            channelReads: [readPayload]
+        )
+                
+        let unreadThreadRepliesCount: Int32 = 3
+        let unreadSilentMessagesCount: Int32 = 2
+        
+        try database.writeSynchronously { session in
+            try session.saveCurrentUser(payload: currentUserPayload)
+            
+            try session.saveChannel(payload: channelPayload)
+            
+            let readDTO = try XCTUnwrap(
+                session.loadChannelRead(
+                    cid: channelPayload.channel.cid,
+                    userId: currentUserPayload.id
+                )
+            )
+            readDTO.unreadThreadRepliesCount = unreadThreadRepliesCount
+            readDTO.unreadSilentMessagesCount = unreadSilentMessagesCount
+            
+            // WHEN
+            try session.saveChannelRead(
+                payload: newReadPayload,
+                for: channelPayload.channel.cid
+            )
+        }
+        
+        // THEN
+        let readDTO = try XCTUnwrap(
+            ChannelReadDTO.load(
+                cid: channelPayload.channel.cid,
+                userId: currentUserPayload.id,
+                context: database.viewContext
+            )
+        )
+        XCTAssertEqual(readDTO.lastReadAt, newReadPayload.lastReadAt)
+        XCTAssertEqual(Int(readDTO.unreadMessageCount), newReadPayload.unreadMessagesCount)
+        XCTAssertEqual(readDTO.unreadThreadRepliesCount, unreadThreadRepliesCount)
+        XCTAssertEqual(readDTO.unreadSilentMessagesCount, unreadSilentMessagesCount)
+    }
+    
     // MARK: - markChannelAsRead
     
     func test_markChannelAsRead_whenReadExists_isIsUpdated() throws {

--- a/Tests/StreamChatTests/Database/DTOs/ChannelReadDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/ChannelReadDTO_Tests.swift
@@ -190,7 +190,11 @@ final class ChannelReadDTO_Tests: XCTestCase {
         )
                 
         try database.writeSynchronously { session in
-            try session.saveChannel(payload: channel)
+            let channelDTO = try session.saveChannel(payload: channel)
+            
+            let readDTO = try XCTUnwrap(channelDTO.reads.first(where: { $0.user.id == read.user.id }))
+            readDTO.unreadThreadRepliesCount = 3
+            readDTO.unreadSilentMessagesCount = 2
         }
             
         // WHEN
@@ -206,6 +210,8 @@ final class ChannelReadDTO_Tests: XCTestCase {
             ChannelReadDTO.load(cid: channel.channel.cid, userId: read.user.id, context: database.viewContext)
         )
         XCTAssertEqual(readDTO.lastReadAt, newLastReadAt)
+        XCTAssertEqual(readDTO.unreadThreadRepliesCount, 0)
+        XCTAssertEqual(readDTO.unreadSilentMessagesCount, 0)
         XCTAssertEqual(readDTO.unreadMessageCount, 0)
     }
     
@@ -235,6 +241,8 @@ final class ChannelReadDTO_Tests: XCTestCase {
         )
         XCTAssertEqual(createdReadDTO.lastReadAt, readAt)
         XCTAssertEqual(createdReadDTO.unreadMessageCount, 0)
+        XCTAssertEqual(createdReadDTO.unreadThreadRepliesCount, 0)
+        XCTAssertEqual(createdReadDTO.unreadSilentMessagesCount, 0)
     }
     
     func test_markChannelAsRead_whenReadDoesNotExistAndCanNotBeCreated_doesNothing() throws {

--- a/Tests/StreamChatTests/Models/ChatChannel_Tests.swift
+++ b/Tests/StreamChatTests/Models/ChatChannel_Tests.swift
@@ -1,0 +1,56 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class ChatChannel_Tests: XCTestCase {
+    func test_isUnread_whenUnreadCountIsNotZero_returnsTrue() {
+        let counts: [ChannelUnreadCount] = [
+            .init(
+                messages: 1,
+                mentioningMessages: 0,
+                silentMessages: 0,
+                threadReplies: 0
+            ),
+            .init(
+                messages: 0,
+                mentioningMessages: 1,
+                silentMessages: 0,
+                threadReplies: 0
+            ),
+            .init(
+                messages: 0,
+                mentioningMessages: 0,
+                silentMessages: 1,
+                threadReplies: 0
+            ),
+            .init(
+                messages: 0,
+                mentioningMessages: 0,
+                silentMessages: 0,
+                threadReplies: 1
+            )
+        ]
+        
+        for unreadCount in counts {
+            let channel: ChatChannel = .mock(
+                cid: .unique,
+                unreadCount: unreadCount
+            )
+            
+            XCTAssertTrue(channel.isUnread)
+        }
+    }
+    
+    func test_isUnread_whenUnreadCountIsZero_returnsFalse() {
+        let channel: ChatChannel = .mock(
+            cid: .unique,
+            unreadCount: .noUnread
+        )
+        
+        XCTAssertFalse(channel.isUnread)
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Link
[CIS-1729](https://stream-io.atlassian.net/browse/CIS-1722)

⚠️ The PR is targeting the feature branch for message delivery status ⚠️

### 🎯 Goal

Fix the bug when silent messages/thread replies stay **unread** until the message that increments unread counts is posted to the channel.

### 🛠 Implementation

Keep track of unread silent messages/thread replies and call `channels/***/read` endpoint if there's at least 1 unread message.

### 📝 Changes

- Update `ChannelReadUpdaterMiddleware` to account silent message/thread replies
- Update `ChatChannel.isUnread` to check all kind of unread messages, not only messages that increment unread badge
- Expose `silentMessage/threadReplies` on `ChannelUnreadCounts`
- Rename `mentionedMessages` to `mentioningMessages` in `ChannelUnreadCounts` 

### 🎨 UI Changes

**Before:**
![](https://user-images.githubusercontent.com/12818985/162002086-a36f3add-8c6e-4d3f-80c4-b07cc9e993e5.mov) 

**After:**
![](https://user-images.githubusercontent.com/12818985/162002234-deb8abc4-5e44-4d07-b08a-e08c36f2721a.mov)

### 🧪 Testing

**GIVEN** I'm in the channel
**AND** I long-press the message
**AND** I choose Thread reply action
**AND** I successfully send the new thread reply
**WHEN** Channel member opens the channel
**THEN** Thread reply get's read by this member

Unit tests are updated to cover the updates.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎉 GIF

![](https://media.giphy.com/media/Y4aoabH2SF4Z6BJS9F/giphy.gif)