### PR TITLE
[CIS-1747] Fix audio files not rendering previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Assertions are no longer thrown by default. Check `StreamRuntimeCheck` to enable them [#1885](https://github.com/GetStream/stream-chat-swift/pull/1885)
 - Local Storage is enabled by default. You can read more [here](https://getstream.io/chat/docs/sdk/ios/guides/offline-support) [#1890](https://github.com/GetStream/stream-chat-swift/pull/1890)
 
-### 🚨 Fixed
+### 🐞 Fixed
 - Fixed support for multiple active channel lists at the same time [#1879](https://github.com/GetStream/stream-chat-swift/pull/1879)
 
 ## StreamChatUI
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix full screen live photos weird flicker when presented / dismissed to / from full screen [#1899](https://github.com/GetStream/stream-chat-swift/issues/1899)
 - Timestamp not being shown for the message when the next message is error [#1893](https://github.com/GetStream/stream-chat-swift/issues/1893)
 - Another user's avatar not being shown for deleted message last in a group [#1893](https://github.com/GetStream/stream-chat-swift/issues/1893)
+- Fix audio files not rendering previews [#1907](https://github.com/GetStream/stream-chat-swift/issues/1907)
 
 # [4.13.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.13.1)
 _April 04, 2022_

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -857,7 +857,12 @@ open class ComposerVC: _ViewController,
     
     open func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
         for fileURL in urls {
-            let attachmentType = AttachmentType(fileExtension: fileURL.pathExtension)
+            var attachmentType = AttachmentType(fileExtension: fileURL.pathExtension)
+            // Remove this condition when doing: https://stream-io.atlassian.net/browse/CIS-1740
+            // This is a fallback right now to treat audios as files until we don't support audios
+            if attachmentType == .audio {
+                attachmentType = .file
+            }
             do {
                 try addAttachmentToContent(from: fileURL, type: attachmentType)
             } catch {

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -859,7 +859,7 @@ open class ComposerVC: _ViewController,
         for fileURL in urls {
             var attachmentType = AttachmentType(fileExtension: fileURL.pathExtension)
             // Remove this condition when doing: https://stream-io.atlassian.net/browse/CIS-1740
-            // This is a fallback right now to treat audios as files until we don't support audios
+            // This is a fallback right now to treat audios as files until we actually support audios
             if attachmentType == .audio {
                 attachmentType = .file
             }


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1747
https://github.com/GetStream/stream-chat-swift/issues/1905

### 🎯 Goal
Fix audio files not rendering previews.

### 🛠 Implementation
Currently, we don't support audio files. And with the file-type fixes, now the audio files don't render any preview. So until we support audio files, we need to fall back the audio files to normal files.

### 🎨 UI Changes
| Before | After |
| --- | --- |
| <img width="335" alt="image" src="https://user-images.githubusercontent.com/12814114/162263040-8e807b61-c9ca-4a32-a80b-a8ae11b385f5.png"> | <img width="331" alt="image" src="https://user-images.githubusercontent.com/12814114/162262788-06eb635d-d613-474b-9631-f72246b49fa5.png"> |

### 🧪 Testing
- Open a Chat
- Tap on the attachment icon
- import an Audio File
- Audio File should render a preview

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)