### PR TITLE
[BW] Test functions do follow test_ pattern across the whole test suite

### DIFF
--- a/StreamChatUITestsAppUITests/Tests/Messaging_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Messaging_Tests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 final class MessagingTests: StreamTestCase {
     
-    func testSendMessage() throws {
+    func test_sendsMessage() throws {
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -20,7 +20,7 @@ final class MessagingTests: StreamTestCase {
         }
     }
 
-    func testEditMessage() throws {
+    func test_editsMessage() throws {
         let message = "test message"
         let editedMessage = "hello"
         
@@ -38,7 +38,7 @@ final class MessagingTests: StreamTestCase {
         }
     }
     
-    func testDeleteMessage() throws {
+    func test_deletesMessage() throws {
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -55,7 +55,7 @@ final class MessagingTests: StreamTestCase {
         }
     }
     
-    func testReceiveMessage() throws {
+    func test_receivesMessage() throws {
         let message = "test message"
         let author = "Han Solo"
         
@@ -75,7 +75,7 @@ final class MessagingTests: StreamTestCase {
         }
     }
     
-    func testParticipantDeleteMessage() throws {
+    func test_messageDeleted_whenParticipantDeletesMessage() throws {
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -97,7 +97,7 @@ final class MessagingTests: StreamTestCase {
         }
     }
     
-    func testParticipantEditMessage() throws {
+    func test_messageIsEdited_whenParticipantEditsMessage() throws {
         let message = "test message"
         let editedMessage = "hello"
         

--- a/StreamChatUITestsAppUITests/Tests/Reactions_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Reactions_Tests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 final class ReactionsTests: StreamTestCase {
     
-    func testAddReaction() throws {
+    func test_addsReaction() throws {
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -23,7 +23,7 @@ final class ReactionsTests: StreamTestCase {
         }
     }
     
-    func testDeleteReaction() throws {
+    func test_deletesReaction() throws {
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -45,7 +45,7 @@ final class ReactionsTests: StreamTestCase {
         }
     }
     
-    func testAddReactionToParticipantsMessage() throws {
+    func test_reactionIsAdded_whenReactingToParticipantsMessage() throws {
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -68,7 +68,7 @@ final class ReactionsTests: StreamTestCase {
         }
     }
     
-    func testDeleteReactionToParticipantsMessage() throws {
+    func test_removesReaction_whenUnReactingToParticipantsMessage() throws {
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -94,7 +94,7 @@ final class ReactionsTests: StreamTestCase {
         }
     }
     
-    func testParticipantAddsReaction() throws {
+    func test_reactionIsAddedByParticipant_whenReactingToUsersMessage() throws {
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -113,7 +113,7 @@ final class ReactionsTests: StreamTestCase {
         }
     }
 
-    func testParticipantDeletesReaction() throws {
+    func test_reactionIsRemovedByParticipant_whenUnReactingToUsersMessage() throws {
         let message = "test message"
         
         GIVEN("user opens the channel") {

--- a/Tests/StreamChatTests/APIClient/ChatPushNotificationContent_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/ChatPushNotificationContent_Tests.swift
@@ -69,13 +69,13 @@ final class ChatPushNotificationContent_Tests: XCTestCase {
         super.tearDown()
     }
 
-    func testEmptyContentNotHandled() throws {
+    func test_notHandled_whenEmptyContent() throws {
         let content = UNNotificationContent()
         let handler = ChatRemoteNotificationHandler(client: clientWithOffline, content: content)
         XCTAssertFalse(handler.handleNotification(completion: { _ in }))
     }
 
-    func testContentWithoutCategoryNotHandled() throws {
+    func test_notHandled_whenContentWithoutCategory() throws {
         let content = UNMutableNotificationContent()
         let payload = [
             "type": "message.new",
@@ -87,7 +87,7 @@ final class ChatPushNotificationContent_Tests: XCTestCase {
         XCTAssertFalse(handler.handleNotification(completion: { _ in }))
     }
 
-    func testContentHandled() throws {
+    func test_contentHandled_whenCorrectPayload() throws {
         let content = UNMutableNotificationContent()
         let payload = [
             "type": "message.new",
@@ -100,7 +100,7 @@ final class ChatPushNotificationContent_Tests: XCTestCase {
         XCTAssertTrue(handler.handleNotification(completion: { _ in }))
     }
     
-    func testCompletion() throws {
+    func test_callsCompletion_whenHandled() throws {
         let handler = ChatRemoteNotificationHandler(client: clientWithOffline, content: exampleMessageNotificationContent)
         let expectation = XCTestExpectation(description: "Receive a message content")
 
@@ -117,7 +117,7 @@ final class ChatPushNotificationContent_Tests: XCTestCase {
         wait(for: [expectation], timeout: defaultTimeout)
     }
     
-    func testCompletion_withUnknownEvent() throws {
+    func test_callsCompletion_whenProcessingUnknownEvent() throws {
         let content = UNMutableNotificationContent()
         content.userInfo["stream"] = [
             "type": "message.deleted"

--- a/Tests/StreamChatTests/Query/FilterDecoding_Tests.swift
+++ b/Tests/StreamChatTests/Query/FilterDecoding_Tests.swift
@@ -9,36 +9,36 @@ import XCTest
 final class FilterDecoding_Tests: XCTestCase {
     // MARK: - Exception thrown tests
 
-    func testFilterDecodingThrowExceptionOnEmpty() {
+    func test_throwsException_whenFilterDecodesEmptyJSON() {
         checkDecodingFilterThrowException(json: "")
     }
 
-    func testFilterDecodingThrowExceptionOnInvalidJSON() {
+    func test_throwsException_whenFilterDecodesInvalidJSON() {
         checkDecodingFilterThrowException(json: "12345")
     }
 
-    func testFilterDecodingThrowExceptionOnInvalidKeylessJSON() {
+    func test_throwsException_whenFilterDecodesInvalidKeylessJSON() {
         checkDecodingFilterThrowException(json: #"{"value"}"#)
     }
 
-    func testFilterRightSideDecodingThrowExceptionWithMoreThanOneKey() {
+    func test_throwsException_whenFilterRightSideDecodesJSONWithMoreThanOneKey() {
         let filterJson = #"{"test_key":{"$eq":"test_value_1","$ne":"test_value_2"}}"#
         checkDecodingFilterThrowException(json: filterJson)
     }
 
-    func testFilterRightSideDecodingThrowExceptionWithoutOperationKey() {
+    func test_throwsException_whenFilterRightSideDecodesWithoutOperationKey() {
         let filterJson = #"{"test_key":{"eq":"test_value_1"}}"#
         checkDecodingFilterThrowException(json: filterJson)
     }
 
-    func testFilterRightSideDecodingThrowExceptionOnNonExistingOperation() {
+    func test_throwsException_whenFilterRightSideDecodesNonExistingOperation() {
         let filterJson = #"{"test_key":{"$myspecialOperation":"test_value_1"}}"#
         checkDecodingFilterThrowException(json: filterJson)
     }
 
     // MARK: - Correct decoded tests
 
-    func testFilterDecoding() {
+    func test_decodesFilter_whenCorrectJSONIsPassed() {
         // Given
         let testCases = FilterCodingTestPair.allCases
         for pair in testCases {

--- a/Tests/StreamChatTests/Query/FilterEncoding_Tests.swift
+++ b/Tests/StreamChatTests/Query/FilterEncoding_Tests.swift
@@ -7,7 +7,7 @@
 import XCTest
 
 final class FilterEncoding_Tests: XCTestCase {
-    func testFilterEncodingNotDoubles() {
+    func test_filterEncodes_whenNotDoubles() {
         // Given
         let testCases = FilterCodingTestPair.allCases
         for pair in testCases {

--- a/Tests/StreamChatTests/Query/Filter_Tests.swift
+++ b/Tests/StreamChatTests/Query/Filter_Tests.swift
@@ -102,7 +102,7 @@ final class Filter_Tests: XCTestCase {
         XCTAssertEqual(jsonString.deserializeFilter(), filter)
     }
 
-    func testEncodingAndDecodingOnAllCases() {
+    func test_encodesAndDecodes_forAllFilterCases() {
         // Given
         let testCases = FilterCodingTestPair.allCases
 

--- a/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
@@ -32,12 +32,12 @@ final class MessageRepositoryTests: XCTestCase {
 
     // MARK: sendMessage
 
-    func tests_sendMessage_notExistent() {
+    func test_sendMessage_notExistent() {
         let result = runSendMessageAndWait(id: .unique)
         XCTAssertEqual(result?.error, MessageRepositoryError.messageDoesNotExist)
     }
 
-    func tests_sendMessage_notPendingSent() throws {
+    func test_sendMessage_notPendingSent() throws {
         let id = MessageId.unique
         try createMessage(id: id, localState: .deleting)
 
@@ -45,7 +45,7 @@ final class MessageRepositoryTests: XCTestCase {
         XCTAssertEqual(result?.error, MessageRepositoryError.messageNotPendingSend)
     }
 
-    func tests_sendMessage_noChannel() throws {
+    func test_sendMessage_noChannel() throws {
         let id = MessageId.unique
         let message = try createMessage(id: id, localState: .pendingSend)
         try database.writeSynchronously { _ in
@@ -56,7 +56,7 @@ final class MessageRepositoryTests: XCTestCase {
         XCTAssertEqual(result?.error, MessageRepositoryError.messageDoesNotHaveValidChannel)
     }
 
-    func tests_sendMessage_preAPIRequest() throws {
+    func test_sendMessage_preAPIRequest() throws {
         let id = MessageId.unique
         try createMessage(id: id, localState: .pendingSend)
         repository.sendMessage(with: id) { _ in }
@@ -71,7 +71,7 @@ final class MessageRepositoryTests: XCTestCase {
         XCTAssertEqual(currentMessageState, .sending)
     }
 
-    func tests_sendMessage_APIFailure() throws {
+    func test_sendMessage_APIFailure() throws {
         let id = MessageId.unique
         try createMessage(id: id, localState: .pendingSend)
         let expectation = self.expectation(description: "Send Message completes")
@@ -97,7 +97,7 @@ final class MessageRepositoryTests: XCTestCase {
         XCTAssertEqual(result?.error, MessageRepositoryError.failedToSendMessage)
     }
 
-    func tests_sendMessage_APISuccess() throws {
+    func test_sendMessage_APISuccess() throws {
         let id = MessageId.unique
         try createMessage(id: id, localState: .pendingSend)
         let expectation = self.expectation(description: "Send Message completes")

--- a/Tests/StreamChatTests/Utils/JSONDecoder_Tests.swift
+++ b/Tests/StreamChatTests/Utils/JSONDecoder_Tests.swift
@@ -22,19 +22,19 @@ final class JSONDecoderTests: XCTestCase {
         super.tearDown()
     }
 
-    func testDecodingDateFromEmptyStringThrowException() {
+    func test_throwsException_whenDecodingDateFromEmptyString() {
         checkDecodingDateThrowException(dateString: "")
     }
 
-    func testDecodingDateFromInvalidStringThrowException() {
+    func test_throwsException_whenDecodingDateFromInvalidString() {
         checkDecodingDateThrowException(dateString: "123456")
     }
 
-    func testDecodingDateFromNonRFC3339DateThrowException() {
+    func test_throwsException_whenDecodingDateFromNonRFC3339Date() {
         checkDecodingDateThrowException(dateString: "2020-09-30T19:51:17")
     }
 
-    func testDecodingDateFromRFC3339DateWithMilliseconds() {
+    func test_decodes_whenDecodingDateFromRFC3339DateWithMilliseconds() {
         checkDateIsDecodingToComponents(
             dateString: "2020-08-24T17:28:04.123Z",
             year: 2020,
@@ -47,7 +47,7 @@ final class JSONDecoderTests: XCTestCase {
         )
     }
 
-    func testDecodingDateFromRFC3339DateWithEmptyMilliseconds() {
+    func test_decodes_whenDecodingDateFromRFC3339DateWithEmptyMilliseconds() {
         checkDateIsDecodingToComponents(
             dateString: "2002-12-02T15:11:12Z",
             year: 2002,
@@ -59,7 +59,7 @@ final class JSONDecoderTests: XCTestCase {
         )
     }
 
-    func testDecodingDateFromRFC3339DateWithMinusTimezone() {
+    func test_decodes_whenDecodingDateFromRFC3339DateWithMinusTimezone() {
         checkDateIsDecodingToComponents(
             dateString: "2002-10-02T07:12:13-03:00",
             year: 2002,
@@ -71,7 +71,7 @@ final class JSONDecoderTests: XCTestCase {
         )
     }
 
-    func testDecodingDateFromRFC3339DateWithPlusTimezone() {
+    func test_decodes_whenDecodingDateFromRFC3339DateWithPlusTimezone() {
         checkDateIsDecodingToComponents(
             dateString: "2002-10-02T10:12:13+02:00",
             year: 2002,
@@ -83,7 +83,7 @@ final class JSONDecoderTests: XCTestCase {
         )
     }
 
-    func testDecodingDateFromRFC3339DateWithPlusZeroTimezone() {
+    func test_decodes_whenDecodingDateFromRFC3339DateWithPlusZeroTimezone() {
         checkDateIsDecodingToComponents(
             dateString: "2002-10-02T10:12:13+00:00",
             year: 2002,
@@ -95,7 +95,7 @@ final class JSONDecoderTests: XCTestCase {
         )
     }
 
-    func testDecodingDateFromRFC3339DateWithMinusZeroTimezone() {
+    func test_decodes_whenDecodingDateFromRFC3339DateWithMinusZeroTimezone() {
         checkDateIsDecodingToComponents(
             dateString: "2002-10-02T10:12:13-00:00",
             year: 2002,
@@ -107,7 +107,7 @@ final class JSONDecoderTests: XCTestCase {
         )
     }
 
-    func testDecodingDateBefore1970() {
+    func test_decodes_whenDecodingDateBefore1970() {
         checkDateIsDecodingToComponents(
             dateString: "1936-10-02T10:12:13Z",
             year: 1936,

--- a/Tests/StreamChatTests/Utils/JSONEncoder_Tests.swift
+++ b/Tests/StreamChatTests/Utils/JSONEncoder_Tests.swift
@@ -39,7 +39,7 @@ final class JSONEncoderTests: XCTestCase {
         XCTAssertEqual(jsonString, "{\"created_at\":\"2020-04-14T10:10:00Z\"}")
     }
 
-    func testEncodingDateToRFC3339DateWithMilliseconds() {
+    func test_encodes_whenEncodingDateToRFC3339DateWithMilliseconds() {
         checkDateIsEncodingFromComponents(
             year: 2020,
             month: 10,
@@ -53,7 +53,7 @@ final class JSONEncoderTests: XCTestCase {
         )
     }
 
-    func testEncodingDateToRFC3339DateWithEmptyMilliseconds() {
+    func test_encodes_whenEncodingDateToRFC3339DateWithEmptyMilliseconds() {
         checkDateIsEncodingFromComponents(
             year: 2020,
             month: 11,
@@ -66,7 +66,7 @@ final class JSONEncoderTests: XCTestCase {
         )
     }
 
-    func testEncodingDateToRFC3339DateWithPlusTimezone() {
+    func test_encodes_whenEncodingDateToRFC3339DateWithPlusTimezone() {
         checkDateIsEncodingFromComponents(
             year: 2019,
             month: 8,
@@ -79,7 +79,7 @@ final class JSONEncoderTests: XCTestCase {
         )
     }
 
-    func testEncodingDateToRFC3339DateWithMinusTimezone() {
+    func test_encodes_whenEncodingDateToRFC3339DateWithMinusTimezone() {
         checkDateIsEncodingFromComponents(
             year: 2018,
             month: 7,
@@ -92,7 +92,7 @@ final class JSONEncoderTests: XCTestCase {
         )
     }
     
-    func testEncodingDateBefore1970() {
+    func test_encodes_whenEncodingDateBefore1970() {
         checkDateIsEncodingFromComponents(
             year: 1936,
             month: 10,

--- a/Tests/StreamChatTests/Utils/Operations/AsyncOperation_Tests.swift
+++ b/Tests/StreamChatTests/Utils/Operations/AsyncOperation_Tests.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 final class AsyncOperation_Tests: XCTestCase {
-    func testOperationCallsCompletion() {
+    func test_operationCallsCompletion_whenFinished() {
         let expectation = expectation(description: "operation concludes")
 
         let operation = AsyncOperation { _, completion in
@@ -23,7 +23,7 @@ final class AsyncOperation_Tests: XCTestCase {
         }
     }
 
-    func testOperationDoesNotRetryIfValueIsNotPassed() {
+    func test_operationDoesNotRetry_whenValueIsNotPassed() {
         var operationBlockCalls = 0
         let operation = AsyncOperation { _, completion in
             operationBlockCalls += 1
@@ -34,7 +34,7 @@ final class AsyncOperation_Tests: XCTestCase {
         XCTAssertEqual(operationBlockCalls, 1)
     }
 
-    func testOperationRetriesUpTillMaximumRetries() {
+    func test_operationRetriesUpTillMaximumRetries() {
         var operationBlockCalls = 0
         let operation = AsyncOperation(maxRetries: 2) { _, completion in
             operationBlockCalls += 1
@@ -45,7 +45,7 @@ final class AsyncOperation_Tests: XCTestCase {
         XCTAssertEqual(operationBlockCalls, 3)
     }
 
-    func testOperationRetriesUpTillSuccess() {
+    func test_operationRetriesUpTillSuccess() {
         var operationBlockCalls = 0
         let operation = AsyncOperation(maxRetries: 10) { _, completion in
             operationBlockCalls += 1
@@ -60,7 +60,7 @@ final class AsyncOperation_Tests: XCTestCase {
         XCTAssertEqual(operationBlockCalls, 2)
     }
 
-    func testOperationResetingRetriesShouldNotAccountPreviousRetries() {
+    func test_operationResetingRetriesShouldNotAccountPreviousRetries() {
         var operationBlockCalls = 0
         let operation = AsyncOperation(maxRetries: 10) { operation, completion in
             operationBlockCalls += 1
@@ -74,7 +74,7 @@ final class AsyncOperation_Tests: XCTestCase {
         XCTAssertEqual(operationBlockCalls, 12)
     }
 
-    func testOperationDoesNotRetryIfCancelled() {
+    func test_operationDoesNotRetry_whenCancelled() {
         var operationBlockCalls = 0
         let operation = AsyncOperation(maxRetries: 10) { _, completion in
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
@@ -104,7 +104,7 @@ final class AsyncOperation_Tests: XCTestCase {
         XCTAssertEqual(operationBlockCalls, 1)
     }
 
-    func testOperationShouldNotStartIfCancelled() {
+    func test_operationShouldNotStart_whenCancelled() {
         var operationBlockCalls = 0
         let operation = AsyncOperation(maxRetries: 10) { _, completion in
             operationBlockCalls += 1

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/ChannelTruncatedEventMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/ChannelTruncatedEventMiddleware_Tests.swift
@@ -27,7 +27,7 @@ final class ChannelTruncatedEventMiddleware_Tests: XCTestCase {
 
     // MARK: - Tests
 
-    func tests_middleware_forwardsOtherEvents() throws {
+    func test_middleware_forwardsOtherEvents() throws {
         let event = TestEvent()
 
         // Handle non-reaction event
@@ -37,7 +37,7 @@ final class ChannelTruncatedEventMiddleware_Tests: XCTestCase {
         XCTAssertEqual(forwardedEvent as! TestEvent, event)
     }
 
-    func tests_middleware_forwardsTheEvent_ifDatabaseWriteGeneratesError() throws {
+    func test_middleware_forwardsTheEvent_ifDatabaseWriteGeneratesError() throws {
         let eventPayload: EventPayload = .init(
             eventType: .channelTruncated,
             cid: .unique,
@@ -58,7 +58,7 @@ final class ChannelTruncatedEventMiddleware_Tests: XCTestCase {
         XCTAssertTrue(forwardedEvent is ChannelTruncatedEventDTO)
     }
 
-    func tests_middleware_handlesChannelTruncatedEventCorrectly() throws {
+    func test_middleware_handlesChannelTruncatedEventCorrectly() throws {
         let cid: ChannelId = .unique
         let date = Date()
         // Create channel truncate event

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/ChannelVisibilityEventMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/ChannelVisibilityEventMiddleware_Tests.swift
@@ -27,7 +27,7 @@ final class ChannelVisibilityEventMiddleware_Tests: XCTestCase {
 
     // MARK: - Tests
 
-    func tests_middleware_forwardsOtherEvents() throws {
+    func test_middleware_forwardsOtherEvents() throws {
         let event = TestEvent()
 
         // Handle non-reaction event
@@ -37,7 +37,7 @@ final class ChannelVisibilityEventMiddleware_Tests: XCTestCase {
         XCTAssertEqual(forwardedEvent as! TestEvent, event)
     }
 
-    func tests_middleware_forwardsTheEvent_ifDatabaseWriteGeneratesError() throws {
+    func test_middleware_forwardsTheEvent_ifDatabaseWriteGeneratesError() throws {
         // Set error to be thrown on write.
         let error = TestError()
         database.write_errorResponse = error

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/EventDataProcessorMiddleware_Tests.swift
@@ -51,7 +51,7 @@ final class EventDataProcessorMiddleware_Tests: XCTestCase {
         XCTAssertEqual(outputEvent?.asEquatable, testEvent.asEquatable)
     }
     
-    func tests_middleware_handlesReactionDeletedEvent() throws {
+    func test_middleware_handlesReactionDeletedEvent() throws {
         let cid: ChannelId = .unique
         let messageId: MessageId = .unique
 
@@ -100,7 +100,7 @@ final class EventDataProcessorMiddleware_Tests: XCTestCase {
         XCTAssertTrue(message.latestReactions.isEmpty)
     }
 
-    func tests_middleware_handlesReactionUpdated() throws {
+    func test_middleware_handlesReactionUpdated() throws {
         let cid: ChannelId = .unique
         let messageId: MessageId = .unique
         let messagePayload: MessagePayload = .dummy(messageId: messageId, authorUserId: .unique)
@@ -152,7 +152,7 @@ final class EventDataProcessorMiddleware_Tests: XCTestCase {
         XCTAssertEqual(message.asModel().latestReactions, [reaction])
     }
 
-    func tests_middleware_handlesReactionNewEvent() throws {
+    func test_middleware_handlesReactionNewEvent() throws {
         let cid: ChannelId = .unique
         let messageId: MessageId = .unique
         let messagePayload: MessagePayload = .dummy(messageId: messageId, authorUserId: .unique)

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/MemberEventMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/MemberEventMiddleware_Tests.swift
@@ -27,7 +27,7 @@ final class MemberEventMiddleware_Tests: XCTestCase {
     
     // MARK: - Tests
     
-    func tests_middleware_forwardsNonMemberEvents() throws {
+    func test_middleware_forwardsNonMemberEvents() throws {
         let event = TestEvent()
         
         // Handle non-member event
@@ -39,7 +39,7 @@ final class MemberEventMiddleware_Tests: XCTestCase {
     
     // MARK: - MemberAddedEvent
     
-    func tests_middleware_forwardsMemberAddedEvent_ifDatabaseWriteGeneratesError() throws {
+    func test_middleware_forwardsMemberAddedEvent_ifDatabaseWriteGeneratesError() throws {
         // Create MemberAddedEvent payload
         let eventPayload: EventPayload = .init(
             eventType: .memberAdded,
@@ -61,7 +61,7 @@ final class MemberEventMiddleware_Tests: XCTestCase {
         XCTAssertTrue(forwardedEvent is MemberAddedEventDTO)
     }
     
-    func tests_middleware_handlesMemberAddedEventCorrectly() throws {
+    func test_middleware_handlesMemberAddedEventCorrectly() throws {
         let cid = ChannelId.unique
         let memberId = UserId.unique
         let userId = UserId.unique
@@ -148,7 +148,7 @@ final class MemberEventMiddleware_Tests: XCTestCase {
     
     // MARK: - MemberRemovedEvent
     
-    func tests_middleware_forwardsMemberRemovedEvent_ifDatabaseWriteGeneratesError() throws {
+    func test_middleware_forwardsMemberRemovedEvent_ifDatabaseWriteGeneratesError() throws {
         // Create MemberAddedEvent payload
         let eventPayload: EventPayload = .init(
             eventType: .memberRemoved,
@@ -170,7 +170,7 @@ final class MemberEventMiddleware_Tests: XCTestCase {
         XCTAssertTrue(forwardedEvent is MemberRemovedEventDTO)
     }
     
-    func tests_middleware_handlesMemberRemovedEventCorrectly() throws {
+    func test_middleware_handlesMemberRemovedEventCorrectly() throws {
         let cid = ChannelId.unique
         
         // Create channel in the database.
@@ -253,7 +253,7 @@ final class MemberEventMiddleware_Tests: XCTestCase {
     
     // MARK: - MemberUpdatedEvent
     
-    func tests_middleware_forwardsMemberUpdatedEvent_ifDatabaseWriteGeneratesError() throws {
+    func test_middleware_forwardsMemberUpdatedEvent_ifDatabaseWriteGeneratesError() throws {
         // Create MemberAddedEvent payload
         let eventPayload: EventPayload = .init(
             eventType: .memberUpdated,
@@ -275,7 +275,7 @@ final class MemberEventMiddleware_Tests: XCTestCase {
         XCTAssertTrue(forwardedEvent is MemberUpdatedEventDTO)
     }
     
-    func tests_middleware_handlesMemberUpdatedEventCorrectly() throws {
+    func test_middleware_handlesMemberUpdatedEventCorrectly() throws {
         let cid = ChannelId.unique
         
         // Create channel in the database.
@@ -424,7 +424,7 @@ final class MemberEventMiddleware_Tests: XCTestCase {
     
     // MARK: - NotificationRemovedFromChannelEvent
     
-    func tests_middleware_handlesNotificationRemovedFromChannelEventCorrectly() throws {
+    func test_middleware_handlesNotificationRemovedFromChannelEventCorrectly() throws {
         let cid = ChannelId.unique
         
         // Create channel in the database.

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/UserChannelBanEventsMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/UserChannelBanEventsMiddleware_Tests.swift
@@ -27,7 +27,7 @@ final class UserChannelBanEventsMiddleware_Tests: XCTestCase {
 
     // MARK: - Tests
 
-    func tests_middleware_forwardsNonReactionEvents() throws {
+    func test_middleware_forwardsNonReactionEvents() throws {
         let event = TestEvent()
 
         // Handle non-banned event
@@ -37,7 +37,7 @@ final class UserChannelBanEventsMiddleware_Tests: XCTestCase {
         XCTAssertEqual(forwardedEvent as! TestEvent, event)
     }
 
-    func tests_middleware_forwardsBanEvent_ifDatabaseWriteGeneratesError() throws {
+    func test_middleware_forwardsBanEvent_ifDatabaseWriteGeneratesError() throws {
         let eventPayload: EventPayload = .init(
             eventType: .userBanned,
             cid: .unique,
@@ -59,7 +59,7 @@ final class UserChannelBanEventsMiddleware_Tests: XCTestCase {
         XCTAssertTrue(forwardedEvent is UserBannedEventDTO)
     }
 
-    func tests_middleware_forwardsUnbanEvent_ifDatabaseWriteGeneratesError() throws {
+    func test_middleware_forwardsUnbanEvent_ifDatabaseWriteGeneratesError() throws {
         let eventPayload: EventPayload = .init(
             eventType: .userUnbanned,
             cid: .unique,
@@ -79,7 +79,7 @@ final class UserChannelBanEventsMiddleware_Tests: XCTestCase {
         XCTAssertTrue(forwardedEvent is UserUnbannedEventDTO)
     }
 
-    func tests_middleware_handlesUserBannedEventCorrectly() throws {
+    func test_middleware_handlesUserBannedEventCorrectly() throws {
         // Create event payload
         let eventPayload: EventPayload = .init(
             eventType: .userBanned,
@@ -111,7 +111,7 @@ final class UserChannelBanEventsMiddleware_Tests: XCTestCase {
         XCTAssert(forwardedEvent is UserBannedEventDTO)
     }
 
-    func tests_middleware_handlesUserUnbannedEventCorrectly() throws {
+    func test_middleware_handlesUserUnbannedEventCorrectly() throws {
         // Create event payload
         let eventPayload: EventPayload = .init(
             eventType: .userUnbanned,

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/UserTypingStateUpdaterMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/UserTypingStateUpdaterMiddleware_Tests.swift
@@ -27,7 +27,7 @@ final class ChannelUserTypingStateUpdaterMiddleware_Tests: XCTestCase {
     
     // MARK: - Tests
     
-    func tests_middleware_forwardsNonTypingEvents() throws {
+    func test_middleware_forwardsNonTypingEvents() throws {
         let event = TestEvent()
         
         // Handle non-typing event
@@ -37,7 +37,7 @@ final class ChannelUserTypingStateUpdaterMiddleware_Tests: XCTestCase {
         XCTAssertEqual(forwardedEvent as! TestEvent, event)
     }
     
-    func tests_middleware_forwardsTypingEvent_ifDatabaseWriteGeneratesError() throws {
+    func test_middleware_forwardsTypingEvent_ifDatabaseWriteGeneratesError() throws {
         let cid: ChannelId = .unique
         let userId: UserId = .unique
         
@@ -59,7 +59,7 @@ final class ChannelUserTypingStateUpdaterMiddleware_Tests: XCTestCase {
         XCTAssertEqual(forwardedEvent as! TypingEventDTO, event)
     }
     
-    func tests_middleware_handlesTypingStartedEventCorrectly() throws {
+    func test_middleware_handlesTypingStartedEventCorrectly() throws {
         let cid: ChannelId = .unique
         let userId: UserId = .unique
         
@@ -88,7 +88,7 @@ final class ChannelUserTypingStateUpdaterMiddleware_Tests: XCTestCase {
         XCTAssertEqual(channel.currentlyTypingUsers.count, 1)
     }
     
-    func tests_middleware_handlesTypingFinishedEventCorrectly() throws {
+    func test_middleware_handlesTypingFinishedEventCorrectly() throws {
         let cid: ChannelId = .unique
         let userId: UserId = .unique
         
@@ -118,7 +118,7 @@ final class ChannelUserTypingStateUpdaterMiddleware_Tests: XCTestCase {
         XCTAssertTrue(channel.currentlyTypingUsers.isEmpty)
     }
     
-    func tests_middleware_handlesCleanUpTypingEventCorrectly() throws {
+    func test_middleware_handlesCleanUpTypingEventCorrectly() throws {
         let cid: ChannelId = .unique
         let userId: UserId = .unique
         

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/UserWatchingEventMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/UserWatchingEventMiddleware_Tests.swift
@@ -27,7 +27,7 @@ final class UserWatchingEventMiddleware_Tests: XCTestCase {
     
     // MARK: - Tests
     
-    func tests_middleware_forwardsOtherEvents() throws {
+    func test_middleware_forwardsOtherEvents() throws {
         let event = TestEvent()
         
         // Handle non-reaction event
@@ -37,7 +37,7 @@ final class UserWatchingEventMiddleware_Tests: XCTestCase {
         XCTAssertEqual(forwardedEvent as! TestEvent, event)
     }
     
-    func tests_middleware_forwardsTheEvent_ifDatabaseWriteGeneratesError() throws {
+    func test_middleware_forwardsTheEvent_ifDatabaseWriteGeneratesError() throws {
         let eventPayload: EventPayload = .init(
             eventType: .userStartWatching,
             cid: .unique,
@@ -59,7 +59,7 @@ final class UserWatchingEventMiddleware_Tests: XCTestCase {
         XCTAssertTrue(forwardedEvent is UserWatchingEventDTO)
     }
     
-    func tests_middleware_handlesUserStartWatchingEventCorrectly() throws {
+    func test_middleware_handlesUserStartWatchingEventCorrectly() throws {
         let cid: ChannelId = .unique
         let userId = UserId.unique
         let watcherCount = Int.random(in: 100...200)
@@ -91,7 +91,7 @@ final class UserWatchingEventMiddleware_Tests: XCTestCase {
         XCTAssert(forwardedEvent is UserWatchingEventDTO)
     }
     
-    func tests_middleware_handlesUserStopWatchingEventCorrectly() throws {
+    func test_middleware_handlesUserStopWatchingEventCorrectly() throws {
         let cid: ChannelId = .unique
         
         // Channel and user must exist for the middleware to work

--- a/Tests/StreamChatTests/WebSocketClient/WebSocketConnectPayload_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/WebSocketConnectPayload_Tests.swift
@@ -7,7 +7,7 @@
 import XCTest
 
 final class WebSocketConnectPayload_Tests: XCTestCase {
-    func testEncodeWebSocketConnectPayload() throws {
+    func test_encodesWebSocket_whenCorrectConnectPayloadIsPassed() throws {
         let custom: [String: RawJSON] = [
             "color": .string("blue")
         ]
@@ -37,7 +37,7 @@ final class WebSocketConnectPayload_Tests: XCTestCase {
         AssertJSONEqual(serialized, expected)
     }
     
-    func testEncodeWebSocketConnectPayloadNoImage() throws {
+    func test_EncodesWebSocket_whenConnectPayloadHasNoImage() throws {
         let custom: [String: RawJSON] = [
             "color": .string("blue")
         ]

--- a/Tests/StreamChatUITests/SnapshotTests/CommonViews/ContainerStackView_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/CommonViews/ContainerStackView_Tests.swift
@@ -41,7 +41,7 @@ final class ContainerStackView_Tests: XCTestCase {
         }
     }
 
-    func testAppearance_withOneViewOnly() {
+    func test_appearance_withOneViewOnly() {
         let views = [self.views.first!]
 
         let containerH = ContainerStackView(
@@ -59,7 +59,7 @@ final class ContainerStackView_Tests: XCTestCase {
         AssertSnapshot(containerV, variants: [.defaultLight], suffix: "vertical")
     }
     
-    func testAppearance_withTwoImageViews() {
+    func test_appearance_withTwoImageViews() {
         let containerH = ContainerStackView(
             axis: .horizontal,
             arrangedSubviews: [
@@ -79,7 +79,7 @@ final class ContainerStackView_Tests: XCTestCase {
         AssertSnapshot(containerH, variants: [.defaultLight])
     }
     
-    func testAppearance_withTwoImageViewsWhereOneIsHidden() {
+    func test_appearance_withTwoImageViewsWhereOneIsHidden() {
         let yodaImageView = UIImageView(
             image: TestImages.yoda.image
         )
@@ -102,7 +102,7 @@ final class ContainerStackView_Tests: XCTestCase {
         AssertSnapshot(containerH, variants: [.defaultLight])
     }
     
-    func testAppearance_withDoubleHiddenImageView() {
+    func test_appearance_withDoubleHiddenImageView() {
         let yodaImageView = UIImageView(
             image: TestImages.yoda.image
         )
@@ -134,7 +134,7 @@ final class ContainerStackView_Tests: XCTestCase {
         AssertSnapshot(containerV, variants: [.defaultLight])
     }
     
-    func testAppearance_withTwoContainerStackViews() {
+    func test_appearance_withTwoContainerStackViews() {
         let leftContainer = ContainerStackView(
             axis: .vertical,
             arrangedSubviews: [
@@ -172,7 +172,7 @@ final class ContainerStackView_Tests: XCTestCase {
         AssertSnapshot(containerH, variants: [.defaultLight])
     }
     
-    func testAppearance() {
+    func test_appearance() {
         let container = ContainerStackView(
             axis: .vertical,
             alignment: .fill,

--- a/Tests/StreamChatUITests/SnapshotTests/CommonViews/ContainerStackView_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/CommonViews/ContainerStackView_Tests.swift
@@ -41,7 +41,7 @@ final class ContainerStackView_Tests: XCTestCase {
         }
     }
 
-    func test_appearance_withOneViewOnly() {
+    func testAppearance_withOneViewOnly() {
         let views = [self.views.first!]
 
         let containerH = ContainerStackView(
@@ -59,7 +59,7 @@ final class ContainerStackView_Tests: XCTestCase {
         AssertSnapshot(containerV, variants: [.defaultLight], suffix: "vertical")
     }
     
-    func test_appearance_withTwoImageViews() {
+    func testAppearance_withTwoImageViews() {
         let containerH = ContainerStackView(
             axis: .horizontal,
             arrangedSubviews: [
@@ -79,7 +79,7 @@ final class ContainerStackView_Tests: XCTestCase {
         AssertSnapshot(containerH, variants: [.defaultLight])
     }
     
-    func test_appearance_withTwoImageViewsWhereOneIsHidden() {
+    func testAppearance_withTwoImageViewsWhereOneIsHidden() {
         let yodaImageView = UIImageView(
             image: TestImages.yoda.image
         )
@@ -102,7 +102,7 @@ final class ContainerStackView_Tests: XCTestCase {
         AssertSnapshot(containerH, variants: [.defaultLight])
     }
     
-    func test_appearance_withDoubleHiddenImageView() {
+    func testAppearance_withDoubleHiddenImageView() {
         let yodaImageView = UIImageView(
             image: TestImages.yoda.image
         )
@@ -134,7 +134,7 @@ final class ContainerStackView_Tests: XCTestCase {
         AssertSnapshot(containerV, variants: [.defaultLight])
     }
     
-    func test_appearance_withTwoContainerStackViews() {
+    func testAppearance_withTwoContainerStackViews() {
         let leftContainer = ContainerStackView(
             axis: .vertical,
             arrangedSubviews: [
@@ -172,7 +172,7 @@ final class ContainerStackView_Tests: XCTestCase {
         AssertSnapshot(containerH, variants: [.defaultLight])
     }
     
-    func test_appearance() {
+    func testAppearance() {
         let container = ContainerStackView(
             axis: .vertical,
             alignment: .fill,

--- a/Tests/StreamChatUITests/SnapshotTests/Composer/ComposerVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/Composer/ComposerVC_Tests.swift
@@ -209,7 +209,7 @@ final class ComposerVC_Tests: XCTestCase {
         AssertSnapshot(composerVC)
     }
     
-    func test_onlyChannelMembersAreShown_whenSuggestionsLookupIsLocal() {
+    func test_whenSuggestionsLookupIsLocal_onlyChannelMembersAreShown() {
         final class ComposerContainerVC: UIViewController {
             var composerVC: ComposerVC!
             var textWithMention = ""

--- a/Tests/StreamChatUITests/SnapshotTests/Composer/ComposerVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/Composer/ComposerVC_Tests.swift
@@ -8,7 +8,7 @@
 import XCTest
 
 final class ComposerVC_Tests: XCTestCase {
-    func testSearchByIDOrName() throws {
+    func test_userFound_whenSearchedByIDOrName() throws {
         let user1 = ChatUser.mock(id: "searchingThis")
         let user2 = ChatUser.mock(id: "x", name: "searchingThis")
 
@@ -16,7 +16,7 @@ final class ComposerVC_Tests: XCTestCase {
         XCTAssertEqual(searchUsers([user2], by: "sear"), [user2])
     }
 
-    func testMatchConsistentTieBreaker() throws {
+    func test_usersFound_whenSearchedWithTieBreaker() throws {
         let tommaso = ChatUser.mock(id: "tommaso", name: "Tommaso")
         let thierry = ChatUser.mock(id: "thierry", name: "Thierry")
         let users = [tommaso, thierry]
@@ -30,7 +30,7 @@ final class ComposerVC_Tests: XCTestCase {
         XCTAssertEqual(searchUsers(users, by: ""), [thierry, tommaso])
     }
 
-    func testMatchHappy() throws {
+    func test_userFound_whenTypingTheBeginningOfIDOrName() throws {
         let tommaso = ChatUser.mock(id: "tommaso", name: "Tommaso")
         let thierry = ChatUser.mock(id: "thierry", name: "Thierry")
         let users = [tommaso, thierry]
@@ -39,7 +39,7 @@ final class ComposerVC_Tests: XCTestCase {
         XCTAssertEqual(searchUsers(users, by: "thier"), [thierry])
     }
 
-    func testMatchHappyLowercased() throws {
+    func test_userFound_whenStartOfTheNameMatchesCase() throws {
         let tommaso = ChatUser.mock(id: "tommaso", name: "Tommaso")
         let thierry = ChatUser.mock(id: "thierry", name: "Thierry")
         let users = [tommaso, thierry]
@@ -48,7 +48,7 @@ final class ComposerVC_Tests: XCTestCase {
         XCTAssertEqual(searchUsers(users, by: "Thier"), [thierry])
     }
 
-    func testMatchHappyTranslitterated() throws {
+    func test_userFound_whenNameIsTranslitterated() throws {
         let tommaso = ChatUser.mock(id: "tommaso", name: "Tommaso")
         let thierry = ChatUser.mock(id: "thierry", name: "Thierry")
         let users = [tommaso, thierry]
@@ -57,7 +57,7 @@ final class ComposerVC_Tests: XCTestCase {
         XCTAssertEqual(searchUsers(users, by: "thíer"), [thierry])
     }
 
-    func testMatchHappySortedByDistance() throws {
+    func test_usersFoundAndSroted_whenSearchedByBeginningOfNameOrID() throws {
         let tommaso = ChatUser.mock(id: "tommaso", name: "tommaso")
         let tomas = ChatUser.mock(id: "tomas", name: "tomas")
         let users = [tommaso, tomas]
@@ -65,7 +65,7 @@ final class ComposerVC_Tests: XCTestCase {
         XCTAssertEqual(searchUsers(users, by: "tom"), [tomas, tommaso])
     }
 
-    func testMatchHappySortedByDistancePrefix() throws {
+    func test_userFound_whenHappySortedByDistancePrefix() throws {
         let tommaso = ChatUser.mock(id: "tommaso", name: "tommaso")
         let tommasi = ChatUser.mock(id: "tommasi", name: "tommasi")
         let users = [tommaso, tommasi]
@@ -79,7 +79,7 @@ final class ComposerVC_Tests: XCTestCase {
         XCTAssertEqual(searchUsers(users, by: "tommaso"), [tommaso])
     }
 
-    func testMatchHappySortedByDistancePrefix2() throws {
+    func test_userFound_whenHappySortedByDistancePrefix2() throws {
         let tommaso = ChatUser.mock(id: "tommaso", name: "tommaso")
         let tommasi = ChatUser.mock(id: "tommasi", name: "tommasi")
         let users = [tommasi, tommaso]
@@ -93,7 +93,7 @@ final class ComposerVC_Tests: XCTestCase {
         XCTAssertEqual(searchUsers(users, by: "tommaso"), [tommaso])
     }
 
-    func testMatchHappyCyrillic() throws {
+    func test_userFound_whenHappyCyrillic() throws {
         let petyo = ChatUser.mock(id: "42", name: "Петьо")
         let anastasia = ChatUser.mock(id: "13", name: "Анастасiя")
         let dmitriy = ChatUser.mock(id: "99", name: "Дмитрий")
@@ -106,7 +106,7 @@ final class ComposerVC_Tests: XCTestCase {
         XCTAssertEqual(searchUsers(users, by: "Дмитри"), [dmitriy])
     }
 
-    func testMatchHappyFrench() throws {
+    func test_userFound_whenHappyFrench() throws {
         let user = ChatUser.mock(id: "fra", name: "françois")
 
         XCTAssertEqual(searchUsers([user], by: "françois"), [user])
@@ -209,7 +209,7 @@ final class ComposerVC_Tests: XCTestCase {
         AssertSnapshot(composerVC)
     }
     
-    func test_whenSuggestionsLookupIsLocal_onlyChannelMembersAreShown() {
+    func test_onlyChannelMembersAreShown_whenSuggestionsLookupIsLocal() {
         final class ComposerContainerVC: UIViewController {
             var composerVC: ComposerVC!
             var textWithMention = ""

--- a/Tests/StreamChatUITests/Utils/String+Extensions_Tests.swift
+++ b/Tests/StreamChatUITests/Utils/String+Extensions_Tests.swift
@@ -44,7 +44,7 @@ final class String_Extensions_Tests: XCTestCase {
         XCTAssertFalse("#".containsEmoji)
     }
     
-    func testLevenshtein() throws {
+    func test_Levenshtein() throws {
         XCTAssertEqual("".levenshtein(""), "".levenshtein(""))
         XCTAssertEqual("".levenshtein(""), 0)
         XCTAssertEqual("a".levenshtein(""), 1)


### PR DESCRIPTION
### 🎯 Goal

Unify test function names across our test suite

### 📝 Changes

- tests funcs in our unit & UI test targets now leverages the `test_THEN_WHEN` pattern when applicable.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
