### PR TITLE
[CIS-1624] Fix not watching channel when added as a member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Local Storage is enabled by default. You can read more [here](https://getstream.io/chat/docs/sdk/ios/guides/offline-support) [#1890](https://github.com/GetStream/stream-chat-swift/pull/1890)
 
 ### 🐞 Fixed
-- Fixed support for multiple active channel lists at the same time [#1879](https://github.com/GetStream/stream-chat-swift/pull/1879)
+- Fix support for multiple active channel lists at the same time [#1879](https://github.com/GetStream/stream-chat-swift/pull/1879)
+- Fix channels linked to the channel list not being watched [#1924](https://github.com/GetStream/stream-chat-swift/pull/1924)
 
 ## StreamChatUI
 ### 💥 Removed

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -259,6 +259,15 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
                 }
                 queryDTO.channels.insert(channelDTO)
             }
+        } completion: { [weak self] _ in
+            let cids = channels.map(\.cid)
+            self?.worker.startWatchingChannels(withIds: cids) {
+                guard let error = $0 else { return }
+                
+                log.warning(
+                    "Failed to start watching linked channels: \(cids), error: \(error.localizedDescription)"
+                )
+            }
         }
     }
     

--- a/Tests/StreamChatTestTools/SpyPattern/Spy/ChannelListUpdater_Spy.swift
+++ b/Tests/StreamChatTestTools/SpyPattern/Spy/ChannelListUpdater_Spy.swift
@@ -18,6 +18,9 @@ final class ChannelListUpdater_Spy: ChannelListUpdater, Spy {
     var resetChannelsQueryResult: Result<(synchedAndWatched: [ChatChannel], unwanted: Set<ChannelId>), Error>?
     
     @Atomic var markAllRead_completion: ((Error?) -> Void)?
+
+    @Atomic var startWatchingChannels_cids: [ChannelId] = []
+    @Atomic var startWatchingChannels_completion: ((Error?) -> Void)?
     
     func cleanUp() {
         update_queries.removeAll()
@@ -27,6 +30,9 @@ final class ChannelListUpdater_Spy: ChannelListUpdater, Spy {
         fetch_completion = nil
         
         markAllRead_completion = nil
+        
+        startWatchingChannels_cids.removeAll()
+        startWatchingChannels_completion = nil
     }
     
     override func update(
@@ -57,5 +63,10 @@ final class ChannelListUpdater_Spy: ChannelListUpdater, Spy {
     ) {
         record()
         resetChannelsQueryResult.map(completion)
+    }
+
+    override func startWatchingChannels(withIds ids: [ChannelId], completion: ((Error?) -> Void)?) {
+        startWatchingChannels_cids = ids
+        startWatchingChannels_completion = completion
     }
 }

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -566,7 +566,7 @@ final class ChannelListController_Tests: XCTestCase {
 
     // MARK: - Change propagation tests with filter block
 
-    func test_addingANewChannelThatMatchesFilter_shouldLinkItToQuery() throws {
+    func test_addingANewChannelThatMatchesFilter_shouldLinkItToQuery_shouldWatchIt() throws {
         let userId = UserId.unique
         var filterCalls = 0
         prepareControllerWithOwnerFilter(userId: userId, onFilterCall: { filterCalls += 1 })
@@ -597,6 +597,8 @@ final class ChannelListController_Tests: XCTestCase {
 
         // Two channels were added to the DB, both were evaluated, only one was added to the list
         XCTAssertEqual(filterCalls, 2)
+        // Watches channel that was added to the list
+        XCTAssertEqual(env.channelListUpdater?.startWatchingChannels_cids, [ownedCid])
     }
 
     func test_updatingAChannelThatIsLinkedToTheQuery_shouldUnlinkIt() throws {


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1624

### 🎯 Goal
Fix a channel not receiving new messages and unread count updates, when a user is added as a member and the user is in the channel list.

### 🛠 Implementation
When a new channel is inserted into the channel list we now make sure that not only do we link the channel but also start watching it.

### 🧪 Testing
1. Log in to two different accounts (e.g.: Leia on one device and C-3PO on another one)
2. Create a new channel using one of those accounts inviting another one
3. Send a message on the new channel

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)