### PR TITLE
[CIS-1764] Fix connection recovery issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix support for multiple active channel lists at the same time [#1879](https://github.com/GetStream/stream-chat-swift/pull/1879)
 - Fix channels linked to the channel list not being watched [#1924](https://github.com/GetStream/stream-chat-swift/pull/1924)
+- Fix connection recovery flow being triggered after the first connection [#1925](https://github.com/GetStream/stream-chat-swift/pull/1925)
+- Fix connection recovery flow not being cancelled on disconnect [#1925](https://github.com/GetStream/stream-chat-swift/pull/1925)
+- Fix cooldown being applied to /sync endpoint in connection recovery flow [#1925](https://github.com/GetStream/stream-chat-swift/pull/1925)
+- Fix active components not being reset when another user is connected [#1925](https://github.com/GetStream/stream-chat-swift/pull/1925)
 
 ## StreamChatUI
 ### 💥 Removed

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -352,7 +352,6 @@ public class ChatClient {
     public func disconnect() {
         clientUpdater.disconnect()
         userConnectionProvider = nil
-        apiClient.flushRequestsQueue()
     }
 
     func fetchCurrentUserIdFromDatabase() -> UserId? {

--- a/Sources/StreamChat/Repositories/SyncOperations.swift
+++ b/Sources/StreamChat/Repositories/SyncOperations.swift
@@ -6,10 +6,15 @@ import Foundation
 
 /// A final class that holds the context for the ongoing operations during the sync process
 final class SyncContext {
+    let lastSyncAt: Date
     var localChannelIds: [ChannelId] = []
     var synchedChannelIds: Set<ChannelId> = Set()
     var watchedAndSynchedChannelIds: Set<ChannelId> = Set()
     var unwantedChannelIds: Set<ChannelId> = Set()
+    
+    init(lastSyncAt: Date) {
+        self.lastSyncAt = lastSyncAt
+    }
 }
 
 private let syncOperationsMaximumRetries = 2
@@ -43,6 +48,7 @@ final class SyncEventsOperation: AsyncOperation {
 
             syncRepository?.syncChannelsEvents(
                 channelIds: context.localChannelIds,
+                lastSyncAt: context.lastSyncAt,
                 isRecovery: true
             ) { result in
                 switch result {

--- a/Sources/StreamChat/Repositories/SyncOperations.swift
+++ b/Sources/StreamChat/Repositories/SyncOperations.swift
@@ -102,23 +102,25 @@ final class RefetchChannelListQueryOperation: AsyncOperation {
                 done(.continue)
                 return
             }
+            
+            let query = controller.query
 
             log.info("3 & 4. Refetching channel lists queries & Cleaning up local message history", subsystems: .offlineSupport)
             channelRepository.resetChannelsQuery(
-                for: controller.query,
+                for: query,
                 watchedChannelIds: context.watchedAndSynchedChannelIds,
                 synchedChannelIds: context.synchedChannelIds
             ) { result in
                 switch result {
                 case let .success((watchedChannels, unwantedCids)):
-                    log.info("Successfully refetched query for \(controller.query.debugDescription)", subsystems: .offlineSupport)
+                    log.info("Successfully refetched query for \(query.debugDescription)", subsystems: .offlineSupport)
                     let queryChannelIds = watchedChannels.map(\.cid)
                     context.watchedAndSynchedChannelIds = context.watchedAndSynchedChannelIds.union(queryChannelIds)
                     context.unwantedChannelIds = context.unwantedChannelIds.union(unwantedCids)
                     done(.continue)
                 case let .failure(error):
                     log.error(
-                        "Failed refetching query for \(controller.query.debugDescription): \(error)",
+                        "Failed refetching query for \(query.debugDescription): \(error)",
                         subsystems: .offlineSupport
                     )
                     done(.retry)

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -64,9 +64,13 @@ class SyncRepository {
         self.apiClient = apiClient
     }
     
+    deinit {
+        cancelRecoveryFlow()
+    }
+    
     func syncLocalState(completion: @escaping () -> Void) {
-        operationQueue.cancelAllOperations()
-                
+        cancelRecoveryFlow()
+        
         getUser { [weak self] in
             guard let currentUser = $0 else {
                 log.error("Current user must exist", subsystems: .offlineSupport)
@@ -176,6 +180,10 @@ class SyncRepository {
                 )
             }
         }
+    }
+    
+    func cancelRecoveryFlow() {
+        operationQueue.cancelAllOperations()
     }
 
     private func getChannelIds(completion: @escaping ([ChannelId]) -> Void) {

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -184,6 +184,7 @@ class SyncRepository {
     
     func cancelRecoveryFlow() {
         operationQueue.cancelAllOperations()
+        apiClient.exitRecoveryMode()
     }
 
     private func getChannelIds(completion: @escaping ([ChannelId]) -> Void) {

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -5,7 +5,6 @@
 import Foundation
 
 enum SyncError: Error {
-    case localStorageDisabled
     case noNeedToSync
     case tooManyEvents(Error)
     case syncEndpointFailed(Error)
@@ -14,7 +13,7 @@ enum SyncError: Error {
 
     var shouldRetry: Bool {
         switch self {
-        case .localStorageDisabled, .noNeedToSync, .tooManyEvents, .couldNotUpdateUserValue:
+        case .noNeedToSync, .tooManyEvents, .couldNotUpdateUserValue:
             return false
         case .syncEndpointFailed, .failedFetchingChannels:
             return true

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -194,7 +194,9 @@ class SyncRepository {
         isRecovery: Bool,
         completion: @escaping (Result<[ChannelId], SyncError>) -> Void
     ) {
-        guard Date().timeIntervalSince(lastSyncAt) > syncCooldown else {
+        // In recovery mode, `/sync` should always be called.
+        // Otherwise, the cooldown is checked.
+        guard isRecovery || Date().timeIntervalSince(lastSyncAt) > syncCooldown else {
             completion(.failure(.noNeedToSync))
             return
         }

--- a/Sources/StreamChat/Workers/ChatClientUpdater.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater.swift
@@ -45,7 +45,7 @@ class ChatClientUpdater {
             client.currentToken = newToken
 
             // Disconnect from web-socket.
-            disconnect(source: .systemInitiated)
+            disconnect(source: .userInitiated)
             
             // Update web-socket endpoint.
             client.webSocketClient?.connectEndpoint = .webSocketConnect(

--- a/Sources/StreamChat/Workers/ChatClientUpdater.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater.swift
@@ -161,6 +161,8 @@ class ChatClientUpdater {
     /// Disconnects the chat client the controller represents from the chat servers. No further updates from the servers
     /// are received.
     func disconnect(source: WebSocketConnectionState.DisconnectionSource = .userInitiated) {
+        client.apiClient.flushRequestsQueue()
+        
         // Disconnecting is not possible in connectionless mode (duh)
         guard client.config.isClientInActiveMode else {
             log.error(ClientError.ClientIsNotInActiveMode().localizedDescription)

--- a/Sources/StreamChat/Workers/ChatClientUpdater.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater.swift
@@ -54,7 +54,11 @@ class ChatClientUpdater {
 
             // Re-create backgroundWorker's since they are related to the previous user.
             client.createBackgroundWorkers()
-
+            
+            // Stop tracking active components
+            client.activeChannelControllers.removeAllObjects()
+            client.activeChannelListControllers.removeAllObjects()
+            
             // Reset all existing local data.
             return try client.databaseContainer.removeAllData(force: true)
         }

--- a/Sources/StreamChat/Workers/ChatClientUpdater.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater.swift
@@ -162,6 +162,7 @@ class ChatClientUpdater {
     /// are received.
     func disconnect(source: WebSocketConnectionState.DisconnectionSource = .userInitiated) {
         client.apiClient.flushRequestsQueue()
+        client.syncRepository.cancelRecoveryFlow()
         
         // Disconnecting is not possible in connectionless mode (duh)
         guard client.config.isClientInActiveMode else {

--- a/Tests/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
+++ b/Tests/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
@@ -163,6 +163,18 @@ extension ChatClient {
     var mockDatabaseContainer: DatabaseContainer_Spy {
         databaseContainer as! DatabaseContainer_Spy
     }
+    
+    var mockSyncRepository: SyncRepository_Spy {
+        syncRepository as! SyncRepository_Spy
+    }
+    
+    var mockMessageRepository: MessageRepository_Spy {
+        messageRepository as! MessageRepository_Spy
+    }
+    
+    var mockOfflineRequestsRepository: OfflineRequestsRepository_Spy {
+        offlineRequestsRepository as! OfflineRequestsRepository_Spy
+    }
 
     func simulateProvidedConnectionId(connectionId: ConnectionId?) {
         guard let connectionId = connectionId else {
@@ -207,7 +219,10 @@ extension ChatClient.Environment {
             requestDecoderBuilder: DefaultRequestDecoder.init,
             eventDecoderBuilder: EventDecoder.init,
             notificationCenterBuilder: EventNotificationCenter.init,
-            clientUpdaterBuilder: ChatClientUpdater_Mock.init
+            clientUpdaterBuilder: ChatClientUpdater_Mock.init,
+            syncRepositoryBuilder: SyncRepository_Spy.init,
+            messageRepositoryBuilder: MessageRepository_Spy.init,
+            offlineRequestsRepositoryBuilder: OfflineRequestsRepository_Spy.init
         )
     }
 

--- a/Tests/StreamChatTestTools/SpyPattern/Spy/SyncRepository_Spy.swift
+++ b/Tests/StreamChatTestTools/SpyPattern/Spy/SyncRepository_Spy.swift
@@ -16,6 +16,10 @@ final class SyncRepository_Spy: SyncRepository, Spy {
     override func syncExistingChannelsEvents(completion: @escaping (Result<[ChannelId], SyncError>) -> Void) {
         record()
     }
+    
+    override func cancelRecoveryFlow() {
+        record()
+    }
 
     override func syncChannelsEvents(
         channelIds: [ChannelId],

--- a/Tests/StreamChatTestTools/SpyPattern/Spy/SyncRepository_Spy.swift
+++ b/Tests/StreamChatTestTools/SpyPattern/Spy/SyncRepository_Spy.swift
@@ -8,32 +8,6 @@ import Foundation
 final class SyncRepository_Spy: SyncRepository, Spy {
     var recordedFunctions: [String] = []
     var syncMissingEventsResult: Result<[ChannelId], SyncError>?
-    var _activeChannelControllers = NSHashTable<ChatChannelController>.weakObjects()
-    var _activeChannelListControllers = NSHashTable<ChatChannelListController>.weakObjects()
-
-    init(client: ChatClient) {
-        let _activeChannelControllers = NSHashTable<ChatChannelController>.weakObjects()
-        let _activeChannelListControllers = NSHashTable<ChatChannelListController>.weakObjects()
-        let channelRepository = ChannelListUpdater(database: client.databaseContainer, apiClient: client.apiClient)
-        let messageRepository = MessageRepository(database: client.databaseContainer, apiClient: client.apiClient)
-        let offlineRepository = OfflineRequestsRepository_Spy(
-            messageRepository: messageRepository,
-            database: client.databaseContainer,
-            apiClient: client.apiClient
-        )
-        super.init(
-            config: client.config,
-            activeChannelControllers: _activeChannelControllers,
-            activeChannelListControllers: _activeChannelListControllers,
-            channelRepository: channelRepository,
-            offlineRequestsRepository: offlineRepository,
-            eventNotificationCenter: client.eventNotificationCenter,
-            database: client.databaseContainer,
-            apiClient: client.apiClient
-        )
-        self._activeChannelControllers = _activeChannelControllers
-        self._activeChannelListControllers = _activeChannelListControllers
-    }
 
     override func syncLocalState(completion: @escaping () -> Void) {
         record()

--- a/Tests/StreamChatTestTools/SpyPattern/Spy/SyncRepository_Spy.swift
+++ b/Tests/StreamChatTestTools/SpyPattern/Spy/SyncRepository_Spy.swift
@@ -19,6 +19,7 @@ final class SyncRepository_Spy: SyncRepository, Spy {
 
     override func syncChannelsEvents(
         channelIds: [ChannelId],
+        lastSyncAt: Date,
         isRecovery: Bool,
         completion: @escaping (Result<[ChannelId], SyncError>) -> Void
     ) {

--- a/Tests/StreamChatTests/Repositories/SyncOperations_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncOperations_Tests.swift
@@ -17,7 +17,7 @@ final class SyncOperations_Tests: XCTestCase {
         client = ChatClient_Mock(config: ChatClientConfig(apiKeyString: .unique))
         channelRepository = ChannelListUpdater_Spy(database: client.databaseContainer, apiClient: client.apiClient)
         database = client.mockDatabaseContainer
-        syncRepository = SyncRepository_Spy(client: client)
+        syncRepository = client.mockSyncRepository
     }
 
     override func tearDown() {

--- a/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
@@ -85,7 +85,6 @@ final class SyncRepository_Tests: XCTestCase {
         let lastSyncAt = try XCTUnwrap(lastSyncAtValue)
         XCTAssertTrue(Calendar.current.isDateInToday(lastSyncAt))
         XCTAssertNotCall("enterRecoveryMode()", on: apiClient)
-        XCTAssertNotCall("exitRecoveryMode()", on: apiClient)
     }
     
     func test_syncLocalState_localStorageDisabled_firstSession() throws {
@@ -118,7 +117,6 @@ final class SyncRepository_Tests: XCTestCase {
         let lastSyncAt = try XCTUnwrap(lastSyncAtValue)
         XCTAssertTrue(Calendar.current.isDateInToday(lastSyncAt))
         XCTAssertNotCall("enterRecoveryMode()", on: apiClient)
-        XCTAssertNotCall("exitRecoveryMode()", on: apiClient)
     }
 
     // MARK: - Sync local state
@@ -528,6 +526,17 @@ final class SyncRepository_Tests: XCTestCase {
     
     // MARL: - cancelRecoveryFlow
     
+    func test_cancelRecoveryFlow_existsRecoveryMode() throws {
+        // GIVEN
+        XCTAssertNotCall("exitRecoveryMode()", on: apiClient)
+        
+        // WHEN
+        repository.cancelRecoveryFlow()
+        
+        // THEN
+        XCTAssertCall("exitRecoveryMode()", on: apiClient, times: 1)
+    }
+    
     func test_syncLocalState_cancelsRecoveryFlow() throws {
         // GIVEN
         let mock = CancelRecoveryFlowTracker(
@@ -624,7 +633,6 @@ final class SyncRepository_Tests: XCTestCase {
         // Assert left operations are not executed
         AssertAsync {
             Assert.staysTrue(self.channelRepository.recordedFunctions.isEmpty)
-            Assert.staysTrue("exitRecoveryMode()".wasNotCalled(on: self.apiClient))
             Assert.staysFalse(completionCalled)
         }
     }
@@ -688,7 +696,7 @@ extension SyncRepository_Tests {
         }
 
         waitForExpectations(timeout: 0.1, handler: nil)
-        XCTAssertCall("exitRecoveryMode()", on: apiClient, times: 1)
+        XCTAssertCall("exitRecoveryMode()", on: apiClient)
     }
     
     private class CancelRecoveryFlowTracker: SyncRepository {

--- a/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
@@ -575,9 +575,10 @@ final class ChatClient_Tests: XCTestCase {
         // Disconnect chat client
         client.disconnect()
         
-        // Assert `flushRequestsQueue` is triggered, client is not recreated
+        // Assert client is not recreated
         XCTAssertTrue(testEnv.apiClient! === client.apiClient)
-        XCTAssertCall("flushRequestsQueue()", on: testEnv.apiClient!, times: 1)
+        // Assert `disconnect` on updater is triggered
+        XCTAssertTrue(testEnv.clientUpdater!.disconnect_called)
     }
     
     // MARK: - Background workers tests

--- a/Tests/StreamChatTests/Workers/ChatClientUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChatClientUpdater_Tests.swift
@@ -9,7 +9,7 @@ import XCTest
 final class ChatClientUpdater_Tests: XCTestCase {
     // MARK: Disconnect
 
-    func test_disconnect_doesNothing_ifClientIsPassive() {
+    func test_disconnect_whenClientIsPassive() {
         // Create a passive client with user session.
         let client = mockClientWithUserSession(isActive: false)
 
@@ -21,6 +21,9 @@ final class ChatClientUpdater_Tests: XCTestCase {
 
         // Assert `disconnect` was not called on `webSocketClient`.
         XCTAssertEqual(client.mockWebSocketClient.disconnect_calledCounter, 0)
+        
+        // Assert `flushRequestsQueue` is called on API client.
+        XCTAssertCall("flushRequestsQueue()", on: client.mockAPIClient, times: 1)
     }
 
     func test_disconnect_closesTheConnection_ifClientIsActive() {
@@ -40,9 +43,11 @@ final class ChatClientUpdater_Tests: XCTestCase {
         // Assert all requests waiting for the connection-id were canceled.
         XCTAssertTrue(client.completeConnectionIdWaiters_called)
         XCTAssertNil(client.completeConnectionIdWaiters_connectionId)
+        // Assert `flushRequestsQueue` is called on API client.
+        XCTAssertCall("flushRequestsQueue()", on: client.mockAPIClient, times: 1)
     }
 
-    func test_disconnect_doesNothing_ifThereIsNoConnection() throws {
+    func test_disconnect_whenWebSocketIsNotConnected() throws {
         // Create an active client with user session.
         let client = mockClientWithUserSession()
 
@@ -54,12 +59,17 @@ final class ChatClientUpdater_Tests: XCTestCase {
 
         // Reset disconnect counter.
         client.mockWebSocketClient.disconnect_calledCounter = 0
+        
+        // Reset API client
+        client.mockAPIClient.recordedFunctions.removeAll()
 
         // Simulate `disconnect` one more time.
         updater.disconnect()
 
         // Assert `connect` was not called on `webSocketClient`.
         XCTAssertEqual(client.mockWebSocketClient.disconnect_calledCounter, 0)
+        // Assert `flushRequestsQueue` is called on API client.
+        XCTAssertCall("flushRequestsQueue()", on: client.mockAPIClient, times: 1)
     }
 
     // MARK: Connect

--- a/Tests/StreamChatTests/Workers/ChatClientUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChatClientUpdater_Tests.swift
@@ -24,6 +24,8 @@ final class ChatClientUpdater_Tests: XCTestCase {
         
         // Assert `flushRequestsQueue` is called on API client.
         XCTAssertCall("flushRequestsQueue()", on: client.mockAPIClient, times: 1)
+        // Assert recovery flow is cancelled.
+        XCTAssertCall("cancelRecoveryFlow()", on: client.mockSyncRepository, times: 1)
     }
 
     func test_disconnect_closesTheConnection_ifClientIsActive() {
@@ -45,6 +47,8 @@ final class ChatClientUpdater_Tests: XCTestCase {
         XCTAssertNil(client.completeConnectionIdWaiters_connectionId)
         // Assert `flushRequestsQueue` is called on API client.
         XCTAssertCall("flushRequestsQueue()", on: client.mockAPIClient, times: 1)
+        // Assert recovery flow is cancelled.
+        XCTAssertCall("cancelRecoveryFlow()", on: client.mockSyncRepository, times: 1)
     }
 
     func test_disconnect_whenWebSocketIsNotConnected() throws {
@@ -57,11 +61,10 @@ final class ChatClientUpdater_Tests: XCTestCase {
         // Simulate `disconnect` call.
         updater.disconnect()
 
-        // Reset disconnect counter.
+        // Reset state.
         client.mockWebSocketClient.disconnect_calledCounter = 0
-        
-        // Reset API client
         client.mockAPIClient.recordedFunctions.removeAll()
+        client.mockSyncRepository.recordedFunctions.removeAll()
 
         // Simulate `disconnect` one more time.
         updater.disconnect()
@@ -70,6 +73,8 @@ final class ChatClientUpdater_Tests: XCTestCase {
         XCTAssertEqual(client.mockWebSocketClient.disconnect_calledCounter, 0)
         // Assert `flushRequestsQueue` is called on API client.
         XCTAssertCall("flushRequestsQueue()", on: client.mockAPIClient, times: 1)
+        // Assert recovery flow is cancelled.
+        XCTAssertCall("cancelRecoveryFlow()", on: client.mockSyncRepository, times: 1)
     }
 
     // MARK: Connect

--- a/Tests/StreamChatTests/Workers/ChatClientUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChatClientUpdater_Tests.swift
@@ -362,6 +362,7 @@ final class ChatClientUpdater_Tests: XCTestCase {
         XCTAssertEqual(client.currentToken, updatedToken)
         // Assert web-socket is disconnected
         XCTAssertEqual(client.mockWebSocketClient.disconnect_calledCounter, 1)
+        XCTAssertEqual(client.mockWebSocketClient.disconnect_source, .userInitiated)
         // Assert web-socket endpoint is valid.
         XCTAssertEqual(
             client.webSocketClient?.connectEndpoint.map(AnyEndpoint.init),

--- a/Tests/StreamChatTests/Workers/ChatClientUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChatClientUpdater_Tests.swift
@@ -240,6 +240,21 @@ final class ChatClientUpdater_Tests: XCTestCase {
         // Create an active client with user session.
         let client = mockClientWithUserSession(token: initialToken)
         
+        // Create and track channel controller
+        let channelController = ChatChannelController(
+            channelQuery: .init(cid: .unique),
+            channelListQuery: nil,
+            client: client
+        )
+        client.trackChannelController(channelController)
+        
+        // Create and track channel list controller
+        let channelListController = ChatChannelListController(
+            query: .init(filter: .exists(.cid)),
+            client: client
+        )
+        client.trackChannelListController(channelListController)
+        
         // Create an updater.
         let updater = ChatClientUpdater(client: client)
         
@@ -275,6 +290,9 @@ final class ChatClientUpdater_Tests: XCTestCase {
         XCTAssertEqual(client.testBackgroundWorkerId, oldWorkerIDs)
         // Assert database is not flushed.
         XCTAssertFalse(client.mockDatabaseContainer.removeAllData_called)
+        // Assert active components are preserved
+        XCTAssertTrue(client.activeChannelControllers.contains(channelController))
+        XCTAssertTrue(client.activeChannelListControllers.contains(channelListController))
         
         // Assert web-socket `connect` is called.
         XCTAssertEqual(client.mockWebSocketClient.connect_calledCounter, 0)
@@ -306,6 +324,21 @@ final class ChatClientUpdater_Tests: XCTestCase {
         
         // Create an active client with user session.
         let client = mockClientWithUserSession(token: initialToken)
+        
+        // Create and track channel controller
+        let channelController = ChatChannelController(
+            channelQuery: .init(cid: .unique),
+            channelListQuery: nil,
+            client: client
+        )
+        client.trackChannelController(channelController)
+        
+        // Create and track channel list controller
+        let channelListController = ChatChannelListController(
+            query: .init(filter: .exists(.cid)),
+            client: client
+        )
+        client.trackChannelListController(channelListController)
         
         // Create an updater.
         let updater = ChatClientUpdater(client: client)
@@ -348,6 +381,10 @@ final class ChatClientUpdater_Tests: XCTestCase {
         XCTAssertNotEqual(client.testBackgroundWorkerId, oldWorkerIDs)
         // Assert database was flushed.
         XCTAssertTrue(client.mockDatabaseContainer.removeAllData_called)
+        // Assert active components from previous user are no longer tracked.
+        XCTAssertTrue(client.activeChannelControllers.allObjects.isEmpty)
+        XCTAssertTrue(client.activeChannelListControllers.allObjects.isEmpty)
+        
         // Assert completion hasn't been called yet.
         XCTAssertFalse(reloadUserIfNeededCompletionCalled)
         


### PR DESCRIPTION
### 🔗 Issue Link

CIS-1764

### 🎯 Goal

Fix connection recovery issues, mainly:
- recovery flow is triggered on the first login
- recovery flow is not canceled when `ChatClient` is deallocated
- recovery flow is not canceled on disconnect 
- active components are not untracked when chat client is connected with another user
- `/sync` cooldown is applied to connection recovery flow

### 🛠 Implementation

Update `SyncRepository` to run recovery flow only for further connections. If it's the 1st connection, the `lastSyncedAt` is set to the current timestamp and will be used as a reference date for `/sync` endpoint when the web socket is reconnected.

### 📝 Changes

N/A

### 🎨 UI Changes

N/A

### 🧪 Testing

Use `LogConfig.level = .debug; LogConfig.subsystems = [.offlineSupport]` in DemoApp
Run `DemoApp` on the device

**Recovery flow is not triggered for the 1st session:**
1. Sign in as any user
1. Check the logs, make sure connection recovery flow is **not triggered**
1. Send app to background
1. Wait for web-socket to be disconnected
1. Send app to foreground
1. Check the logs, make sure connection recovery flow is **triggered**

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎉 GIF

![](https://media.giphy.com/media/FuSJ5C7SSHlZCxjC6q/giphy-downsized.gif)