### PR TITLE
[CIS-1555] Fix crash when changing users within an active chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix cooldown being applied to /sync endpoint in connection recovery flow [#1925](https://github.com/GetStream/stream-chat-swift/pull/1925)
 - Fix active components not being reset when another user is connected [#1925](https://github.com/GetStream/stream-chat-swift/pull/1925)
 - Fix unusable firebase push provider [#1934](https://github.com/GetStream/stream-chat-swift/pull/1934)
+- Fix DB errors happening when logging in after a logout / user switch [#1926](https://github.com/GetStream/stream-chat-swift/issues/1926)
 
 ## StreamChatUI
 ### 💥 Removed

--- a/DemoApp/ChatPresenter.swift
+++ b/DemoApp/ChatPresenter.swift
@@ -29,19 +29,25 @@ class DemoChatChannelListRouter: ChatChannelListRouter {
     
     override func showCurrentUserProfile() {
         rootViewController.presentAlert(title: nil, actions: [
+            .init(title: "Switch User", style: .default, handler: { [unowned self] _ in
+                let actions = UserCredentials.builtInUsers.map { user in
+                    UIAlertAction(title: user.name, style: .default) { _ in
+                        ChatClient.shared.connectUser(
+                            userInfo: user.userInfo,
+                            token: Token(stringLiteral: user.token)
+                        )
+                    }
+                }
+                self.rootViewController.presentAlert(
+                    title: "Select a user",
+                    message: "Channel list won't be correct until you logout and login again.",
+                    actions: actions,
+                    cancelHandler: nil
+                )
+            }),
             .init(title: "Logout", style: .destructive, handler: { _ in
                 let window = self.rootViewController.view.window!
-                guard let navigationController = UIStoryboard(name: "Main", bundle: Bundle.main)
-                    .instantiateInitialViewController() as? UINavigationController else {
-                    return
-                }
-                guard let sceneDelegate = window.windowScene?.delegate as? SceneDelegate else {
-                    return
-                }
-                sceneDelegate.coordinator = DemoAppCoordinator(navigationController: navigationController)
-                UIView.transition(with: window, duration: 0.3, options: .transitionFlipFromLeft, animations: {
-                    window.rootViewController = navigationController
-                })
+                DemoAppCoordinator.logout(window: window)
             })
         ])
     }
@@ -77,6 +83,25 @@ class DemoChatChannelListRouter: ChatChannelListRouter {
     override func didTapMoreButton(for cid: ChannelId) {
         let channelController = rootViewController.controller.client.channelController(for: cid)
         rootViewController.presentAlert(title: "Select an action", actions: [
+            .init(title: "Switch User", style: .default, handler: { [unowned self] _ in
+                let channelUsers = UserCredentials.builtInUsers.filter { user in
+                    channelController.channel?.lastActiveMembers.contains(where: { $0.id == user.id }) ?? false
+                }
+                let actions = channelUsers.map { user in
+                    UIAlertAction(title: user.name, style: .default) { _ in
+                        ChatClient.shared.connectUser(
+                            userInfo: user.userInfo,
+                            token: Token(stringLiteral: user.token)
+                        )
+                    }
+                }
+                self.rootViewController.presentAlert(
+                    title: "Select a user",
+                    message: "Channel list won't be correct until you logout and login again.",
+                    actions: actions,
+                    cancelHandler: nil
+                )
+            }),
             .init(title: "Change nav bar translucency", style: .default, handler: { [unowned self] _ in
                 self.rootViewController.presentAlert(
                     title: "Change nav bar translucency",

--- a/DemoApp/DemoAppCoordinator.swift
+++ b/DemoApp/DemoAppCoordinator.swift
@@ -53,7 +53,7 @@ final class DemoAppCoordinator: NSObject, UNUserNotificationCenterDelegate {
         
         if let userId = UserDefaults(suiteName: applicationGroupIdentifier)?.string(forKey: currentUserIdRegisteredForPush),
            let userCredentials = UserCredentials.builtInUsersByID(id: userId) {
-            presentChat(userCredentials: userCredentials, channelID: cid)
+            presentChat(userType: .credentials(userCredentials), channelID: cid)
         }
     }
 
@@ -68,13 +68,8 @@ final class DemoAppCoordinator: NSObject, UNUserNotificationCenterDelegate {
                 }
             }
     }
-
-    func presentChat(userCredentials: UserCredentials, channelID: ChannelId? = nil) {
-        // Create a token
-        guard let token = try? Token(rawValue: userCredentials.token) else {
-            fatalError("There has been a problem getting the token, please check Stream API status")
-        }
-        
+    
+    func setUpChat() {
         // Set the log level
         LogConfig.level = .warning
         LogConfig.formatters = [
@@ -87,19 +82,9 @@ final class DemoAppCoordinator: NSObject, UNUserNotificationCenterDelegate {
         } else {
             Atlantis.stop()
         }
-
-        // Connect the User
+        
+        // Create Client
         ChatClient.shared = ChatClient(config: AppConfig.shared.chatClientConfig)
-        ChatClient.shared.connectUser(
-            userInfo: .init(id: userCredentials.id, name: userCredentials.name, imageURL: userCredentials.avatarURL),
-            token: token
-        ) { [weak self] error in
-            if let error = error {
-                log.error("connecting the user failed \(error)")
-                return
-            }
-            self?.setupRemoteNotifications()
-        }
         
         // Config
         Components.default.channelListRouter = DemoChatChannelListRouter.self
@@ -120,14 +105,66 @@ final class DemoAppCoordinator: NSObject, UNUserNotificationCenterDelegate {
                 ? Bundle.main.localizedString(forKey: key, value: nil, table: table)
                 : localizedString
         }
-
-        // Channels with the current user
-        let controller = ChatClient.shared
-            .channelListController(query: .init(filter: .containMembers(userIds: [userCredentials.id])))
-        let chatList = DemoChannelListVC.make(with: controller)
         
+        // Setup connection observer
         connectionController = ChatClient.shared.connectionController()
         connectionController?.delegate = connectionDelegate
+    }
+
+    func presentChat(userType: DemoUserType, channelID: ChannelId? = nil) {
+        if ChatClient.shared == nil {
+            setUpChat()
+        }
+        
+        let controller: ChatChannelListController
+        
+        let connectCompletion: (Error?) -> Void = { [weak self] error in
+            if let error = error {
+                log.error("connecting the user failed \(error)")
+                if let self = self {
+                    DispatchQueue.main.async {
+                        self.navigationController.presentAlert(
+                            title: "Connecting failed",
+                            message: "Error: \(error)",
+                            okHandler: {
+                                DemoAppCoordinator.logout(window: self.navigationController.view.window!)
+                            }
+                        )
+                    }
+                }
+                return
+            }
+            self?.setupRemoteNotifications()
+        }
+        
+        switch userType {
+        case let .credentials(userCredentials):
+            // Create a token
+            guard let token = try? Token(rawValue: userCredentials.token) else {
+                fatalError("There has been a problem getting the token, please check Stream API status")
+            }
+            
+            // Connect the User
+            ChatClient.shared.connectUser(
+                userInfo: userCredentials.userInfo,
+                token: token,
+                completion: connectCompletion
+            )
+            
+            // Channels with the current user
+            controller = ChatClient.shared
+                .channelListController(query: .init(filter: .containMembers(userIds: [userCredentials.id])))
+        case .anonymous:
+            ChatClient.shared.connectAnonymousUser(completion: connectCompletion)
+            controller = ChatClient.shared
+                .channelListController(query: .init(filter: .equal(.type, to: .messaging)))
+        case let .guest(userId):
+            ChatClient.shared.connectGuestUser(userInfo: .init(id: userId), completion: connectCompletion)
+            controller = ChatClient.shared
+                .channelListController(query: .init(filter: .equal(.type, to: .messaging)))
+        }
+        
+        let chatList = DemoChannelListVC.make(with: controller)
 
         navigationController.viewControllers = [chatList]
         navigationController.isNavigationBarHidden = false
@@ -153,7 +190,7 @@ final class DemoAppCoordinator: NSObject, UNUserNotificationCenterDelegate {
     private func injectActions() {
         if let loginViewController = navigationController.topViewController as? LoginViewController {
             loginViewController.didRequestChatPresentation = { [weak self] in
-                self?.presentChat(userCredentials: $0)
+                self?.presentChat(userType: $0)
             }
         }
     }
@@ -178,6 +215,21 @@ final class DemoAppCoordinator: NSObject, UNUserNotificationCenterDelegate {
         }
 
         return splitController
+    }
+    
+    static func logout(window: UIWindow) {
+        ChatClient.shared.disconnect()
+        guard let navigationController = UIStoryboard(name: "Main", bundle: Bundle.main)
+            .instantiateInitialViewController() as? UINavigationController else {
+            return
+        }
+        guard let sceneDelegate = window.windowScene?.delegate as? SceneDelegate else {
+            return
+        }
+        sceneDelegate.coordinator = DemoAppCoordinator(navigationController: navigationController)
+        UIView.transition(with: window, duration: 0.3, options: .transitionFlipFromLeft, animations: {
+            window.rootViewController = navigationController
+        })
     }
 }
 

--- a/DemoApp/DemoUsers.swift
+++ b/DemoApp/DemoUsers.swift
@@ -3,10 +3,17 @@
 //
 
 import Foundation
+import StreamChat
 
 public let apiKeyString = "8br4watad788"
 public let applicationGroupIdentifier = "group.io.getstream.iOS.ChatDemoApp"
 public let currentUserIdRegisteredForPush = "currentUserIdRegisteredForPush"
+
+enum DemoUserType {
+    case credentials(UserCredentials)
+    case anonymous
+    case guest(String)
+}
 
 public struct UserCredentials {
     let id: String
@@ -17,6 +24,15 @@ public struct UserCredentials {
 }
 
 public extension UserCredentials {
+    var userInfo: UserInfo {
+        .init(
+            id: id,
+            name: name,
+            imageURL: avatarURL,
+            extraData: [ChatUser.birthLandFieldName: .string(birthLand)]
+        )
+    }
+    
     static func builtInUsersByID(id: String) -> UserCredentials? {
         builtInUsers.filter { $0.id == id }.first
     }

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -164,7 +164,7 @@ public class ChatClient {
                 )
                 
                 let dbFileURL = storeURL.appendingPathComponent(config.apiKey.apiKeyString)
-                return try environment.databaseContainerBuilder(
+                return environment.databaseContainerBuilder(
                     .onDisk(databaseFileURL: dbFileURL),
                     config.shouldFlushLocalStorageOnStart,
                     config.isClientInActiveMode, // Only reset Ephemeral values in active mode
@@ -178,21 +178,17 @@ public class ChatClient {
             log.assertionFailure("The URL provided in ChatClientConfig can't be `nil`. Falling back to the in-memory option.")
             
         } catch {
-            log.error("Failed to initalized the local storage with error: \(error). Falling back to the in-memory option.")
+            log.error("Failed to initialize the local storage with error: \(error). Falling back to the in-memory option.")
         }
         
-        do {
-            return try environment.databaseContainerBuilder(
-                .inMemory,
-                config.shouldFlushLocalStorageOnStart,
-                config.isClientInActiveMode, // Only reset Ephemeral values in active mode
-                config.localCaching,
-                config.deletedMessagesVisibility,
-                config.shouldShowShadowedMessages
-            )
-        } catch {
-            fatalError("Failed to initialize the in-memory storage with error: \(error). This is a non-recoverable error.")
-        }
+        return environment.databaseContainerBuilder(
+            .inMemory,
+            config.shouldFlushLocalStorageOnStart,
+            config.isClientInActiveMode, // Only reset Ephemeral values in active mode
+            config.localCaching,
+            config.deletedMessagesVisibility,
+            config.shouldShowShadowedMessages
+        )
     }()
     
     private(set) lazy var clientUpdater = environment.clientUpdaterBuilder(self)
@@ -459,8 +455,8 @@ extension ChatClient {
             _ localCachingSettings: ChatClientConfig.LocalCaching?,
             _ deletedMessageVisibility: ChatClientConfig.DeletedMessageVisibility?,
             _ shouldShowShadowedMessages: Bool?
-        ) throws -> DatabaseContainer = {
-            try DatabaseContainer(
+        ) -> DatabaseContainer = {
+            DatabaseContainer(
                 kind: $0,
                 shouldFlushOnStart: $1,
                 shouldResetEphemeralValuesOnStart: $2,

--- a/Sources/StreamChat/Workers/ChatClientUpdater.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater.swift
@@ -13,7 +13,8 @@ class ChatClientUpdater {
 
     func prepareEnvironment(
         userInfo: UserInfo?,
-        newToken: Token
+        newToken: Token,
+        completion: @escaping (Error?) -> Void
     ) throws {
         guard let currentUserId = client.currentUserId else {
             // Set the current user id
@@ -26,6 +27,7 @@ class ChatClientUpdater {
             client.createBackgroundWorkers()
             // Provide the token to pending API requests
             client.completeTokenWaiters(token: newToken)
+            completion(nil)
             return
         }
         
@@ -60,7 +62,7 @@ class ChatClientUpdater {
             client.activeChannelListControllers.removeAllObjects()
             
             // Reset all existing local data.
-            return try client.databaseContainer.removeAllData(force: true)
+            return client.databaseContainer.removeAllData(force: true, completion: completion)
         }
 
         // Set the web-socket endpoint
@@ -68,7 +70,10 @@ class ChatClientUpdater {
             client.webSocketClient?.connectEndpoint = .webSocketConnect(userInfo: userInfo ?? .init(id: newToken.userId))
         }
 
-        guard newToken != client.currentToken else { return }
+        guard newToken != client.currentToken else {
+            completion(nil)
+            return
+        }
 
         client.currentToken = newToken
 
@@ -81,6 +86,8 @@ class ChatClientUpdater {
         if client.backgroundWorkers.isEmpty {
             client.createBackgroundWorkers()
         }
+        
+        completion(nil)
     }
 
     func reloadUserIfNeeded(
@@ -100,19 +107,30 @@ class ChatClientUpdater {
                     try self.prepareEnvironment(
                         userInfo: userInfo,
                         newToken: newToken
-                    )
-
-                    // We manually change the `connectionStatus` for passive client
-                    // to `disconnected` when environment was prepared correctly
-                    // (e.g. current user session is successfully restored).
-                    if !self.client.config.isClientInActiveMode {
-                        self.client.connectionStatus = .disconnected(error: nil)
+                    ) { [weak self] error in
+                        // Errors thrown during `prepareEnvironment` cannot be recovered
+                        if let error = error {
+                            completion?(error)
+                            return
+                        }
+                        
+                        guard let self = self else {
+                            completion?(nil)
+                            return
+                        }
+                        
+                        // We manually change the `connectionStatus` for passive client
+                        // to `disconnected` when environment was prepared correctly
+                        // (e.g. current user session is successfully restored).
+                        if !self.client.config.isClientInActiveMode {
+                            self.client.connectionStatus = .disconnected(error: nil)
+                        }
+                        
+                        self.connect(
+                            userInfo: userInfo,
+                            completion: completion
+                        )
                     }
-
-                    self.connect(
-                        userInfo: userInfo,
-                        completion: completion
-                    )
                 } catch {
                     completion?(error)
                 }

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -319,7 +319,10 @@ open class ChatChannelListVC: _ViewController,
             completion: { _ in
                 // Move changes from NSFetchController also can mean an update of the content.
                 // Since a `moveItem` in collections do not update the content of the cell, we need to reload those cells.
-                self.collectionView.reloadItems(at: Array(indices.move.map(\.toIndex)))
+                let moveIndexes = Array(indices.move.map(\.toIndex))
+                if !moveIndexes.isEmpty {
+                    self.collectionView.reloadItems(at: moveIndexes)
+                }
             }
         )
     }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -259,6 +259,7 @@
 		79A0E9B02498C09900E9BD50 /* ConnectionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C750BD2490D0130023F0B7 /* ConnectionStatus.swift */; };
 		79A0E9BB2498C31300E9BD50 /* TypingStartCleanupMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9B92498C31300E9BD50 /* TypingStartCleanupMiddleware.swift */; };
 		79A0E9BE2498C33100E9BD50 /* TypingEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0E9BD2498C33100E9BD50 /* TypingEvent.swift */; };
+		79A5097127FF31DE00A0C568 /* ChatUser+CustomFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43016E1526B734410054E805 /* ChatUser+CustomFields.swift */; };
 		79A9EB4D2625793000F2A72D /* CoreDataLazy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9EB4C2625793000F2A72D /* CoreDataLazy.swift */; };
 		79A9EB572625798000F2A72D /* CoreDataLazy_StressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9EB562625798000F2A72D /* CoreDataLazy_StressTests.swift */; };
 		79AF43B42632AF1C00E75CDA /* ChannelVisibilityEventMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79AF43B32632AF1B00E75CDA /* ChannelVisibilityEventMiddleware.swift */; };
@@ -8315,6 +8316,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				79A5097127FF31DE00A0C568 /* ChatUser+CustomFields.swift in Sources */,
 				437FCA0726D67BE40000223C /* NotificationService.swift in Sources */,
 				43C68D9126DD37B700622533 /* DemoUsers.swift in Sources */,
 			);

--- a/Tests/StreamChatTestTools/Mocks/StreamChat/ChatClientUpdater_Mock.swift
+++ b/Tests/StreamChatTestTools/Mocks/StreamChat/ChatClientUpdater_Mock.swift
@@ -30,7 +30,8 @@ final class ChatClientUpdater_Mock: ChatClientUpdater {
 
     override func prepareEnvironment(
         userInfo: UserInfo?,
-        newToken: Token
+        newToken: Token,
+        completion: ((Error?) -> Void)? = nil
     ) throws {
         prepareEnvironment_newToken = newToken
     }

--- a/Tests/StreamChatTestTools/Mocks/StreamChat/ChatClientUpdater_Mock.swift
+++ b/Tests/StreamChatTestTools/Mocks/StreamChat/ChatClientUpdater_Mock.swift
@@ -32,7 +32,7 @@ final class ChatClientUpdater_Mock: ChatClientUpdater {
         userInfo: UserInfo?,
         newToken: Token,
         completion: ((Error?) -> Void)? = nil
-    ) throws {
+    ) {
         prepareEnvironment_newToken = newToken
     }
 

--- a/Tests/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
+++ b/Tests/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
@@ -129,7 +129,7 @@ extension ChatClient {
                     )
                 },
                 databaseContainerBuilder: {
-                    try DatabaseContainer_Spy(
+                    DatabaseContainer_Spy(
                         kind: $0,
                         shouldFlushOnStart: $1,
                         shouldResetEphemeralValuesOnStart: $2,
@@ -201,19 +201,14 @@ extension ChatClient.Environment {
                 )
             },
             databaseContainerBuilder: {
-                do {
-                    return try DatabaseContainer_Spy(
-                        kind: .onDisk(databaseFileURL: .newTemporaryFileURL()),
-                        shouldFlushOnStart: $1,
-                        shouldResetEphemeralValuesOnStart: $2,
-                        localCachingSettings: $3,
-                        deletedMessagesVisibility: $4,
-                        shouldShowShadowedMessages: $5
-                    )
-                } catch {
-                    XCTFail("Unable to initialize DatabaseContainer_Spy \(error)")
-                    fatalError("Unable to initialize DatabaseContainer_Spy \(error)")
-                }
+                DatabaseContainer_Spy(
+                    kind: .onDisk(databaseFileURL: .newTemporaryFileURL()),
+                    shouldFlushOnStart: $1,
+                    shouldResetEphemeralValuesOnStart: $2,
+                    localCachingSettings: $3,
+                    deletedMessagesVisibility: $4,
+                    shouldShowShadowedMessages: $5
+                )
             },
             requestEncoderBuilder: DefaultRequestEncoder.init,
             requestDecoderBuilder: DefaultRequestDecoder.init,

--- a/Tests/StreamChatTestTools/SpyPattern/Spy/DatabaseContainer_Spy.swift
+++ b/Tests/StreamChatTestTools/SpyPattern/Spy/DatabaseContainer_Spy.swift
@@ -29,7 +29,7 @@ final class DatabaseContainer_Spy: DatabaseContainer, Spy {
     var shouldCleanUpTempDBFiles = false
     
     convenience init(localCachingSettings: ChatClientConfig.LocalCaching? = nil) {
-        try! self.init(kind: .onDisk(databaseFileURL: .newTemporaryFileURL()), localCachingSettings: localCachingSettings)
+        self.init(kind: .onDisk(databaseFileURL: .newTemporaryFileURL()), localCachingSettings: localCachingSettings)
         shouldCleanUpTempDBFiles = true
     }
     
@@ -42,9 +42,9 @@ final class DatabaseContainer_Spy: DatabaseContainer, Spy {
         localCachingSettings: ChatClientConfig.LocalCaching? = nil,
         deletedMessagesVisibility: ChatClientConfig.DeletedMessageVisibility? = nil,
         shouldShowShadowedMessages: Bool? = nil
-    ) throws {
+    ) {
         init_kind = kind
-        try super.init(
+        super.init(
             kind: kind,
             shouldFlushOnStart: shouldFlushOnStart,
             shouldResetEphemeralValuesOnStart: shouldResetEphemeralValuesOnStart,
@@ -82,14 +82,15 @@ final class DatabaseContainer_Spy: DatabaseContainer, Spy {
         super.removeAllData(force: force, completion: completion)
     }
     
-    override func recreatePersistentStore(completion: ((Error?) -> Void)? = nil) throws {
+    override func recreatePersistentStore(completion: ((Error?) -> Void)? = nil) {
         recreatePersistentStore_called = true
         
         if let error = recreatePersistentStore_errorResponse {
-            throw error
+            completion?(error)
+            return
         }
         
-        try super.recreatePersistentStore(completion: completion)
+        super.recreatePersistentStore(completion: completion)
     }
     
     override func write(_ actions: @escaping (DatabaseSession) throws -> Void, completion: @escaping (Error?) -> Void) {

--- a/Tests/StreamChatTestTools/SpyPattern/Spy/DatabaseContainer_Spy.swift
+++ b/Tests/StreamChatTestTools/SpyPattern/Spy/DatabaseContainer_Spy.swift
@@ -71,24 +71,25 @@ final class DatabaseContainer_Spy: DatabaseContainer, Spy {
         }
     }
     
-    override func removeAllData(force: Bool = true) throws {
+    override func removeAllData(force: Bool = true, completion: ((Error?) -> Void)? = nil) {
         removeAllData_called = true
 
         if let error = removeAllData_errorResponse {
-            throw error
+            completion?(error)
+            return
         }
 
-        try super.removeAllData(force: force)
+        super.removeAllData(force: force, completion: completion)
     }
     
-    override func recreatePersistentStore() throws {
+    override func recreatePersistentStore(completion: ((Error?) -> Void)? = nil) throws {
         recreatePersistentStore_called = true
         
         if let error = recreatePersistentStore_errorResponse {
             throw error
         }
         
-        try super.recreatePersistentStore()
+        try super.recreatePersistentStore(completion: completion)
     }
     
     override func write(_ actions: @escaping (DatabaseSession) throws -> Void, completion: @escaping (Error?) -> Void) {

--- a/Tests/StreamChatTests/Controllers/ChannelWatcherListController/ChatChannelWatcherListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelWatcherListController/ChatChannelWatcherListController_Tests.swift
@@ -394,7 +394,14 @@ final class ChatChannelWatcherListController_Tests: XCTestCase {
         }
 
         // Simulate database flush
-        try client.databaseContainer.removeAllData()
+        let exp = expectation(description: "removeAllData called")
+        client.databaseContainer.removeAllData { error in
+            if let error = error {
+                XCTFail("removeAllData failed with \(error)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 0.1)
 
         // Assert `remove` entity changes are received by the delegate.
         AssertAsync {

--- a/Tests/StreamChatTests/Controllers/MemberController/MemberController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MemberController/MemberController_Tests.swift
@@ -304,7 +304,14 @@ final class MemberController_Tests: XCTestCase {
         }
         
         // Simulate database flush
-        try client.databaseContainer.removeAllData()
+        let exp = expectation(description: "removeAllData called")
+        client.databaseContainer.removeAllData { error in
+            if let error = error {
+                XCTFail("removeAllData failed with \(error)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 0.1)
         
         // Assert `remove` entity change is received by the delegate
         AssertAsync {

--- a/Tests/StreamChatTests/Controllers/MemberListController/MemberListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MemberListController/MemberListController_Tests.swift
@@ -373,7 +373,14 @@ final class MemberListController_Tests: XCTestCase {
         }
         
         // Simulate database flush
-        try client.databaseContainer.removeAllData()
+        let exp = expectation(description: "removeAllData called")
+        client.databaseContainer.removeAllData { error in
+            if let error = error {
+                XCTFail("removeAllData failed with \(error)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 0.1)
 
         // Assert `remove` entity changes are received by the delegate.
         AssertAsync {

--- a/Tests/StreamChatTests/Database/DTOs/CurrentUserDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/CurrentUserDTO_Tests.swift
@@ -205,8 +205,15 @@ final class CurrentUserModelDTO_Tests: XCTestCase {
         
         XCTAssertNotNil(database.viewContext.currentUser)
         
-        try database.removeAllData()
+        let expectation = expectation(description: "removeAllData completion")
+        database.removeAllData { error in
+            if let error = error {
+                XCTFail("removeAllData failed with \(error)")
+            }
+            expectation.fulfill()
+        }
         
+        wait(for: [expectation], timeout: 0.1)
         XCTAssertNil(database.viewContext.currentUser)
     }
     
@@ -233,7 +240,15 @@ final class CurrentUserModelDTO_Tests: XCTestCase {
             XCTAssertNotNil(context.currentUser)
         }
         
-        try database.removeAllData()
+        let expectation = expectation(description: "removeAllData completion")
+        database.removeAllData { error in
+            if let error = error {
+                XCTFail("removeAllData failed with \(error)")
+            }
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 0.1)
         
         context.performAndWait {
             XCTAssertNil(context.currentUser)

--- a/Tests/StreamChatTests/Database/DatabaseContainer_Tests.swift
+++ b/Tests/StreamChatTests/Database/DatabaseContainer_Tests.swift
@@ -18,7 +18,7 @@ final class DatabaseContainer_Tests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: dbURL.path))
     }
     
-    func test_databaseContainer_propagatesError_wnenInitializedWithIncorrectURL() {
+    func test_databaseContainer_propagatesError_whenInitializedWithIncorrectURL() {
         let dbURL = URL(fileURLWithPath: "/") // This URL is not writable
         XCTAssertThrowsError(try DatabaseContainer(kind: .onDisk(databaseFileURL: dbURL)))
     }

--- a/Tests/StreamChatTests/Database/DatabaseContainer_Tests.swift
+++ b/Tests/StreamChatTests/Database/DatabaseContainer_Tests.swift
@@ -9,22 +9,28 @@ import XCTest
 
 final class DatabaseContainer_Tests: XCTestCase {
     func test_databaseContainer_isInitialized_withInMemoryPreset() {
-        XCTAssertNoThrow(try DatabaseContainer(kind: .inMemory))
+        _ = DatabaseContainer(kind: .inMemory)
     }
     
     func test_databaseContainer_isInitialized_withOnDiskPreset() {
         let dbURL = URL.newTemporaryFileURL()
-        XCTAssertNoThrow(try DatabaseContainer(kind: .onDisk(databaseFileURL: dbURL)))
+        _ = DatabaseContainer(kind: .onDisk(databaseFileURL: dbURL))
         XCTAssertTrue(FileManager.default.fileExists(atPath: dbURL.path))
     }
     
-    func test_databaseContainer_propagatesError_whenInitializedWithIncorrectURL() {
+    func test_databaseContainer_switchesToInMemory_whenInitializedWithIncorrectURL() {
         let dbURL = URL(fileURLWithPath: "/") // This URL is not writable
-        XCTAssertThrowsError(try DatabaseContainer(kind: .onDisk(databaseFileURL: dbURL)))
+        let db = DatabaseContainer(kind: .onDisk(databaseFileURL: dbURL))
+        // Assert that we've switched to in-memory type
+        if #available(iOS 13, *) {
+            XCTAssertEqual(db.persistentStoreDescriptions.first?.url, URL(fileURLWithPath: "/dev/null"))
+        } else {
+            XCTAssertEqual(db.persistentStoreDescriptions.first?.type, NSInMemoryStoreType)
+        }
     }
     
     func test_writeCompletionBlockIsCalled() throws {
-        let container = try DatabaseContainer(kind: .inMemory)
+        let container = DatabaseContainer(kind: .inMemory)
         let goldenPathExpectation = expectation(description: "gold")
 
         // Write a valid entity to DB and wait for the completion block to be called
@@ -67,7 +73,7 @@ final class DatabaseContainer_Tests: XCTestCase {
         
         try containerTypes.forEach { containerType in
             
-            let container = try DatabaseContainer(kind: containerType)
+            let container = DatabaseContainer(kind: containerType)
             
             // Add some random objects and for completion block
             try container.writeSynchronously { session in
@@ -77,7 +83,15 @@ final class DatabaseContainer_Tests: XCTestCase {
             }
             
             // Delete the data
-            try container.removeAllData()
+            let expectation = expectation(description: "removeAllData completion")
+            container.removeAllData { error in
+                if let error = error {
+                    XCTFail("removeAllData failed with \(error)")
+                }
+                expectation.fulfill()
+            }
+            
+            wait(for: [expectation], timeout: 0.1)
             
             // Assert the DB is empty by trying to fetch all possible entities
             try container.managedObjectModel.entities.forEach { entityDescription in
@@ -89,7 +103,7 @@ final class DatabaseContainer_Tests: XCTestCase {
     }
 
     func test_removingAllData_generatesRemoveAllDataNotifications() throws {
-        let container = try DatabaseContainer(kind: .inMemory)
+        let container = DatabaseContainer(kind: .inMemory)
         
         // Set up notification expectations for all contexts
         let contexts = [container.viewContext, container.backgroundReadOnlyContext, container.writableContext]
@@ -99,7 +113,15 @@ final class DatabaseContainer_Tests: XCTestCase {
         }
 
         // Delete the data
-        try container.removeAllData(force: true)
+        let exp = expectation(description: "removeAllData completion")
+        container.removeAllData { error in
+            if let error = error {
+                XCTFail("removeAllData failed with \(error)")
+            }
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 0.1)
         
         // All expectations should be fulfilled by now
         waitForExpectations(timeout: 0)
@@ -108,7 +130,7 @@ final class DatabaseContainer_Tests: XCTestCase {
     func test_databaseContainer_callsResetEphemeralValues_onAllEphemeralValuesContainerEntities() throws {
         // Create a new on-disc database with the test data model
         let dbURL = URL.newTemporaryFileURL()
-        var database: DatabaseContainer_Spy? = try DatabaseContainer_Spy(
+        var database: DatabaseContainer_Spy? = DatabaseContainer_Spy(
             kind: .onDisk(databaseFileURL: dbURL),
             modelName: "TestDataModel",
             bundle: .testTools
@@ -127,7 +149,7 @@ final class DatabaseContainer_Tests: XCTestCase {
         AssertAsync.canBeReleased(&database)
         
         // Create a new database with the same underlying SQLite store
-        var newDatabase: DatabaseContainer! = try DatabaseContainer_Spy(
+        var newDatabase: DatabaseContainer! = DatabaseContainer_Spy(
             kind: .onDisk(databaseFileURL: dbURL),
             modelName: "TestDataModel",
             bundle: .testTools
@@ -140,16 +162,16 @@ final class DatabaseContainer_Tests: XCTestCase {
             .fetch(NSFetchRequest<TestManagedObject>(entityName: "TestManagedObject"))
             .first
         
-        AssertAsync.willBeEqual(testObject2?.resetEphemeralValuesCalled, true)
+        AssertAsync.willBeTrue(testObject2?.resetEphemeralValuesCalled)
         
         // Wait for the new DB instance to be released
         AssertAsync.canBeReleased(&newDatabase)
     }
     
-    func test_databaseContainer_doesntCallsResetEphemeralValues_whenFlagIsSetToFalse() throws {
+    func test_databaseContainer_doesntCallsResetEphemeralValues_whenFlagIsSetToFalse() {
         // Create a new on-disc database with the test data model
         let dbURL = URL.newTemporaryFileURL()
-        let database = try DatabaseContainer_Spy(
+        let database = DatabaseContainer_Spy(
             kind: .onDisk(databaseFileURL: dbURL),
             shouldResetEphemeralValuesOnStart: false,
             modelName: "TestDataModel",
@@ -163,7 +185,7 @@ final class DatabaseContainer_Tests: XCTestCase {
     func test_databaseContainer_removesAllData_whenShouldFlushOnStartIsTrue() throws {
         // Create a new on-disc database with the test data model
         let dbURL = URL.newTemporaryFileURL()
-        var database: DatabaseContainer_Spy? = try DatabaseContainer_Spy(
+        var database: DatabaseContainer_Spy? = DatabaseContainer_Spy(
             kind: .onDisk(databaseFileURL: dbURL),
             modelName: "TestDataModel",
             bundle: .testTools
@@ -179,7 +201,7 @@ final class DatabaseContainer_Tests: XCTestCase {
         XCTAssertNotNil(testObject)
                 
         // Create a new database with the same underlying SQLite store and shouldFlushOnStart config
-        database = try DatabaseContainer_Spy(
+        database = DatabaseContainer_Spy(
             kind: .onDisk(databaseFileURL: dbURL),
             shouldFlushOnStart: true,
             modelName: "TestDataModel",
@@ -193,7 +215,7 @@ final class DatabaseContainer_Tests: XCTestCase {
     func test_databaseContainer_createsNewDatabase_whenPersistentStoreFailsToLoad() throws {
         // Create a new on-disc database with the test data model
         let dbURL = URL.newTemporaryFileURL()
-        _ = try DatabaseContainer_Spy(
+        _ = DatabaseContainer_Spy(
             kind: .onDisk(databaseFileURL: dbURL),
             modelName: "TestDataModel",
             bundle: .testTools
@@ -201,33 +223,29 @@ final class DatabaseContainer_Tests: XCTestCase {
                 
         // Create a new database with the same url but totally different models
         // Should re-create the database
-        XCTAssertNoThrow(
-            try DatabaseContainer_Spy(
-                kind: .onDisk(databaseFileURL: dbURL),
-                modelName: "TestDataModel2",
-                bundle: .testTools
-            )
+        _ = DatabaseContainer_Spy(
+            kind: .onDisk(databaseFileURL: dbURL),
+            modelName: "TestDataModel2",
+            bundle: .testTools
         )
     }
     
     func test_databaseContainer_hasDefinedBehaviorForInMemoryStore_whenShouldFlushOnStartIsTrue() throws {
         // Create a new in-memory database that should flush on start and assert no error is thrown
-        XCTAssertNoThrow(
-            try DatabaseContainer_Spy(
-                kind: .inMemory,
-                shouldFlushOnStart: true,
-                modelName: "TestDataModel",
-                bundle: .testTools
-            )
+        _ = DatabaseContainer_Spy(
+            kind: .inMemory,
+            shouldFlushOnStart: true,
+            modelName: "TestDataModel",
+            bundle: .testTools
         )
     }
     
-    func test_channelConfig_isStoredInAllContexts() throws {
+    func test_channelConfig_isStoredInAllContexts() {
         var cachingSettings = ChatClientConfig.LocalCaching()
         cachingSettings.chatChannel.lastActiveMembersLimit = .unique
         cachingSettings.chatChannel.lastActiveWatchersLimit = .unique
         
-        let database = try DatabaseContainer_Spy(kind: .inMemory, localCachingSettings: cachingSettings)
+        let database = DatabaseContainer_Spy(kind: .inMemory, localCachingSettings: cachingSettings)
         
         XCTAssertEqual(database.viewContext.localCachingSettings, cachingSettings)
         
@@ -240,10 +258,10 @@ final class DatabaseContainer_Tests: XCTestCase {
         }
     }
 
-    func test_deletedMessagesVisibility_isStoredInAllContexts() throws {
+    func test_deletedMessagesVisibility_isStoredInAllContexts() {
         let visibility = ChatClientConfig.DeletedMessageVisibility.alwaysVisible
 
-        let database = try DatabaseContainer_Spy(kind: .inMemory, deletedMessagesVisibility: visibility)
+        let database = DatabaseContainer_Spy(kind: .inMemory, deletedMessagesVisibility: visibility)
 
         XCTAssertEqual(database.viewContext.deletedMessagesVisibility, visibility)
 
@@ -256,10 +274,10 @@ final class DatabaseContainer_Tests: XCTestCase {
         }
     }
     
-    func test_shouldShowShadowedMessages_isStoredInAllContexts() throws {
+    func test_shouldShowShadowedMessages_isStoredInAllContexts() {
         let shouldShowShadowedMessages = Bool.random()
         
-        let database = try DatabaseContainer_Spy(kind: .inMemory, shouldShowShadowedMessages: shouldShowShadowedMessages)
+        let database = DatabaseContainer_Spy(kind: .inMemory, shouldShowShadowedMessages: shouldShowShadowedMessages)
         
         XCTAssertEqual(database.viewContext.shouldShowShadowedMessages, shouldShowShadowedMessages)
         

--- a/Tests/StreamChatTests/EntityDatabaseObserver_Tests.swift
+++ b/Tests/StreamChatTests/EntityDatabaseObserver_Tests.swift
@@ -17,7 +17,7 @@ final class EntityDatabaseObserver_Tests: XCTestCase {
         
         fetchRequest = NSFetchRequest(entityName: "TestManagedObject")
         fetchRequest.sortDescriptors = [.init(keyPath: \TestManagedObject.testId, ascending: true)]
-        database = try! DatabaseContainer_Spy(
+        database = DatabaseContainer_Spy(
             kind: .onDisk(databaseFileURL: .newTemporaryFileURL()),
             modelName: "TestDataModel",
             bundle: .testTools
@@ -228,7 +228,14 @@ final class EntityDatabaseObserver_Tests: XCTestCase {
         try observer.startObserving()
 
         // Call `removeAllData` on the database container
-        try database.removeAllData()
+        let expectation = expectation(description: "removeAllData completion")
+        database.removeAllData { error in
+            if let error = error {
+                XCTFail("removeAllData failed with \(error)")
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.1)
         
         XCTAssertEqual(listener, [.remove(testItem)])
     }

--- a/Tests/StreamChatTests/ListDatabaseObserver_Tests.swift
+++ b/Tests/StreamChatTests/ListDatabaseObserver_Tests.swift
@@ -19,7 +19,7 @@ final class ListDatabaseObserver_Tests: XCTestCase {
         
         fetchRequest = NSFetchRequest(entityName: "TestManagedObject")
         fetchRequest.sortDescriptors = [.init(key: "testId", ascending: true)]
-        database = try! DatabaseContainer_Spy(
+        database = DatabaseContainer_Spy(
             kind: .onDisk(databaseFileURL: .newTemporaryFileURL()),
             modelName: "TestDataModel",
             bundle: .testTools
@@ -36,6 +36,7 @@ final class ListDatabaseObserver_Tests: XCTestCase {
     override func tearDown() {
         observer.releaseNotificationObservers?()
         fetchRequest = nil
+        observer = nil
 
         AssertAsync {
             Assert.canBeReleased(&observer)

--- a/Tests/StreamChatTests/Query/ChannelMemberListQuery_Tests.swift
+++ b/Tests/StreamChatTests/Query/ChannelMemberListQuery_Tests.swift
@@ -121,7 +121,7 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
         )
         
         // Create database container
-        let database = try DatabaseContainer_Spy(kind: .inMemory)
+        let database = DatabaseContainer_Spy(kind: .inMemory)
         
         try database.writeSynchronously { session in
             // Save channel to database
@@ -169,7 +169,7 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
         )
         
         // Create database container
-        let database = try DatabaseContainer_Spy(kind: .inMemory)
+        let database = DatabaseContainer_Spy(kind: .inMemory)
         
         try database.writeSynchronously { session in
             // Save channel to database
@@ -217,7 +217,7 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
         )
         
         // Create database container
-        let database = try DatabaseContainer_Spy(kind: .inMemory)
+        let database = DatabaseContainer_Spy(kind: .inMemory)
         
         try database.writeSynchronously { session in
             // Save channel to database
@@ -275,7 +275,7 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
         )
         
         // Create database container
-        let database = try DatabaseContainer_Spy(kind: .inMemory)
+        let database = DatabaseContainer_Spy(kind: .inMemory)
         
         try database.writeSynchronously { session in
             // Save channel to database
@@ -339,7 +339,7 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
         )
         
         // Create database container
-        let database = try DatabaseContainer_Spy(kind: .inMemory)
+        let database = DatabaseContainer_Spy(kind: .inMemory)
         
         try database.writeSynchronously { session in
             // Save channel to database

--- a/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
@@ -142,29 +142,18 @@ final class ChatClient_Tests: XCTestCase {
     /// When the initialization of a local DB fails for some reason (i.e. incorrect URL),
     /// use a DB in the in-memory configuration
     func test_clientDatabaseStackInitialization_useInMemoryWhenOnDiskFails() {
-        // Prepare a config with the local storage
-        let storeFolderURL = URL.newTemporaryDirectoryURL()
+        // Prepare a config with nil local storage
         var config = ChatClientConfig()
         config.isLocalStorageEnabled = true
-        config.localStorageFolderURL = storeFolderURL
+        config.localStorageFolderURL = nil
         
         var usedDatabaseKinds: [DatabaseContainer.Kind] = []
-        
-        // Prepare a queue with errors the db builder should return. We want to return an error only the first time
-        // when we expect the DB is created with the local DB option and we want it to fail.
-        var errorsToReturn = Queue<Error>()
-        errorsToReturn.push(TestError())
 
         // Create env object and store all `kinds it's called with.
         var env = ChatClient.Environment()
         env.clientUpdaterBuilder = ChatClientUpdater_Mock.init
         env.databaseContainerBuilder = { kind, _, _, _, _, _ in
             usedDatabaseKinds.append(kind)
-            // Return error for the first time
-            if let error = errorsToReturn.pop() {
-                throw error
-            }
-            // Return a new container the second time
             return DatabaseContainer_Spy()
         }
         
@@ -177,7 +166,7 @@ final class ChatClient_Tests: XCTestCase {
         
         XCTAssertEqual(
             usedDatabaseKinds,
-            [.onDisk(databaseFileURL: storeFolderURL.appendingPathComponent(config.apiKey.apiKeyString)), .inMemory]
+            [.inMemory]
         )
     }
     
@@ -889,7 +878,7 @@ private class TestEnvironment {
                 return self.webSocketClient!
             },
             databaseContainerBuilder: {
-                self.databaseContainer = try! DatabaseContainer_Spy(
+                self.databaseContainer = DatabaseContainer_Spy(
                     kind: $0,
                     shouldFlushOnStart: $1,
                     shouldResetEphemeralValuesOnStart: $2,

--- a/Tests/StreamChatTests/StreamChatIntegrationTests/MessageEvents_IntegrationTests.swift
+++ b/Tests/StreamChatTests/StreamChatIntegrationTests/MessageEvents_IntegrationTests.swift
@@ -130,7 +130,7 @@ final class MessageEvents_IntegrationTests: XCTestCase {
 
     func test_messageNewEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
 
         // Create event payload
         let cid: ChannelId = .unique
@@ -169,7 +169,7 @@ final class MessageEvents_IntegrationTests: XCTestCase {
 
     func test_messageUpdatedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
 
         // Create event payload
         let cid: ChannelId = .unique
@@ -204,7 +204,7 @@ final class MessageEvents_IntegrationTests: XCTestCase {
 
     func test_messageDeletedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
 
         // Create event payload
         let cid: ChannelId = .unique
@@ -239,7 +239,7 @@ final class MessageEvents_IntegrationTests: XCTestCase {
 
     func test_messageReadEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
 
         // Create event payload
         let eventPayload = EventPayload(

--- a/Tests/StreamChatTests/StreamChatIntegrationTests/ReactionEvents_IntegrationTests.swift
+++ b/Tests/StreamChatTests/StreamChatIntegrationTests/ReactionEvents_IntegrationTests.swift
@@ -140,7 +140,7 @@ final class ReactionEvents_IntegrationTests: XCTestCase {
 
     func test_reactionNewEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
 
         // Create event payload
         let channel: ChannelDetailPayload = .dummy(cid: .unique)
@@ -182,7 +182,7 @@ final class ReactionEvents_IntegrationTests: XCTestCase {
 
     func test_reactionUpdatedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
 
         // Create event payload
         let channel: ChannelDetailPayload = .dummy(cid: .unique)
@@ -224,7 +224,7 @@ final class ReactionEvents_IntegrationTests: XCTestCase {
 
     func test_reactionDeletedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
 
         // Create event payload
         let channel: ChannelDetailPayload = .dummy(cid: .unique)

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/EventDTOConverterMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/EventDTOConverterMiddleware_Tests.swift
@@ -13,7 +13,7 @@ final class EventDTOConverterMiddleware_Tests: XCTestCase {
 
     override func setUp() {
         middleware = .init()
-        database = try! DatabaseContainer_Spy(kind: .inMemory)
+        database = DatabaseContainer_Spy(kind: .inMemory)
         super.setUp()
     }
     

--- a/Tests/StreamChatTests/WebSocketClient/Events/ChannelEvents_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/Events/ChannelEvents_Tests.swift
@@ -98,7 +98,7 @@ final class ChannelEvents_Tests: XCTestCase {
     
     func test_channelUpdatedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let cid: ChannelId = .unique
@@ -132,7 +132,7 @@ final class ChannelEvents_Tests: XCTestCase {
     
     func test_channelDeletedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -161,7 +161,7 @@ final class ChannelEvents_Tests: XCTestCase {
     
     func test_channelTruncatedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -190,7 +190,7 @@ final class ChannelEvents_Tests: XCTestCase {
     
     func test_channelVisibleEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -218,7 +218,7 @@ final class ChannelEvents_Tests: XCTestCase {
     
     func test_channelHiddenEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(

--- a/Tests/StreamChatTests/WebSocketClient/Events/MemberEvents_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/Events/MemberEvents_Tests.swift
@@ -44,7 +44,7 @@ final class MemberEvents_Tests: XCTestCase {
     
     func test_memberAddedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -80,7 +80,7 @@ final class MemberEvents_Tests: XCTestCase {
     
     func test_memberUpdatedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -116,7 +116,7 @@ final class MemberEvents_Tests: XCTestCase {
     
     func test_memberRemovedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(

--- a/Tests/StreamChatTests/WebSocketClient/Events/NotificationEvents_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/Events/NotificationEvents_Tests.swift
@@ -110,7 +110,7 @@ final class NotificationsEvents_Tests: XCTestCase {
     
     func test_notificationMessageNewEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let cid: ChannelId = .unique
@@ -145,7 +145,7 @@ final class NotificationsEvents_Tests: XCTestCase {
     
     func test_notificationMarkAllReadEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -173,7 +173,7 @@ final class NotificationsEvents_Tests: XCTestCase {
     
     func test_notificationMarkReadEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -203,7 +203,7 @@ final class NotificationsEvents_Tests: XCTestCase {
     
     func test_notificationMutesUpdatedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -229,7 +229,7 @@ final class NotificationsEvents_Tests: XCTestCase {
     
     func test_notificationAddedToChannelEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -259,7 +259,7 @@ final class NotificationsEvents_Tests: XCTestCase {
     
     func test_notificationRemovedFromChannelEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -293,7 +293,7 @@ final class NotificationsEvents_Tests: XCTestCase {
     
     func test_notificationChannelMutesUpdatedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -319,7 +319,7 @@ final class NotificationsEvents_Tests: XCTestCase {
     
     func test_notificationInvitedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -353,7 +353,7 @@ final class NotificationsEvents_Tests: XCTestCase {
     
     func test_notificationInviteAcceptedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -388,7 +388,7 @@ final class NotificationsEvents_Tests: XCTestCase {
     
     func test_notificationInviteRejectedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -423,7 +423,7 @@ final class NotificationsEvents_Tests: XCTestCase {
     
     func test_notificationChannelDeletedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(

--- a/Tests/StreamChatTests/WebSocketClient/Events/TypingEvent_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/Events/TypingEvent_Tests.swift
@@ -72,7 +72,7 @@ final class TypingEvent_Tests: XCTestCase {
     
     func test_startTypingEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -104,7 +104,7 @@ final class TypingEvent_Tests: XCTestCase {
     
     func test_stopTypingEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(

--- a/Tests/StreamChatTests/WebSocketClient/Events/UserEvents_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/Events/UserEvents_Tests.swift
@@ -63,7 +63,7 @@ final class UserEvents_Tests: XCTestCase {
     
     func test_userPresenceChangedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -89,7 +89,7 @@ final class UserEvents_Tests: XCTestCase {
     
     func test_userUpdatedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -115,7 +115,7 @@ final class UserEvents_Tests: XCTestCase {
     
     func test_userStartWatchingEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -146,7 +146,7 @@ final class UserEvents_Tests: XCTestCase {
     
     func test_userStopWatchingEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -176,7 +176,7 @@ final class UserEvents_Tests: XCTestCase {
     
     func test_userBannedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -210,7 +210,7 @@ final class UserEvents_Tests: XCTestCase {
     
     func test_userUnbannedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -238,7 +238,7 @@ final class UserEvents_Tests: XCTestCase {
     
     func test_userGloballyBannedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(
@@ -264,7 +264,7 @@ final class UserEvents_Tests: XCTestCase {
     
     func test_userGloballyUnbannedEventDTO_toDomainEvent() throws {
         // Create database session
-        let session = try DatabaseContainer_Spy(kind: .inMemory).viewContext
+        let session = DatabaseContainer_Spy(kind: .inMemory).viewContext
         
         // Create event payload
         let eventPayload = EventPayload(

--- a/Tests/StreamChatTests/Workers/ChatClientUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChatClientUpdater_Tests.swift
@@ -390,7 +390,7 @@ final class ChatClientUpdater_Tests: XCTestCase {
         XCTAssertFalse(reloadUserIfNeededCompletionCalled)
         
         // Assert web-socket `connect` is called.
-        XCTAssertEqual(client.mockWebSocketClient.connect_calledCounter, 1)
+        AssertAsync.willBeEqual(client.mockWebSocketClient.connect_calledCounter, 1)
         
         // Simulate established connection and provide `connectionId` to waiters.
         let connectionId: String = .unique

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -92,7 +92,14 @@ final class MessageUpdater_Tests: XCTestCase {
             let updatedText: String = .unique
 
             // Flush the database
-            try database.removeAllData()
+            let exp = expectation(description: "removeAllData completion")
+            database.removeAllData { error in
+                if let error = error {
+                    XCTFail("removeAllData failed with \(error)")
+                }
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 0.1)
 
             // Create current user is the database
             try database.createCurrentUser(id: currentUserId)
@@ -143,7 +150,14 @@ final class MessageUpdater_Tests: XCTestCase {
             let updatedText: String = .unique
             
             // Flush the database
-            try database.removeAllData()
+            let exp = expectation(description: "removeAllData completion")
+            database.removeAllData { error in
+                if let error = error {
+                    XCTFail("removeAllData failed with \(error)")
+                }
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 0.1)
             
             // Create current user is the database
             try database.createCurrentUser(id: currentUserId)
@@ -346,7 +360,14 @@ final class MessageUpdater_Tests: XCTestCase {
             let messageId: MessageId = .unique
 
             // Flush the database
-            try database.removeAllData()
+            let exp = expectation(description: "removeAllData completion")
+            database.removeAllData { error in
+                if let error = error {
+                    XCTFail("removeAllData failed with \(error)")
+                }
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 0.1)
             
             // Create current user in the database
             try database.createCurrentUser(id: currentUserId)
@@ -378,7 +399,14 @@ final class MessageUpdater_Tests: XCTestCase {
             let messageId: MessageId = .unique
 
             // Flush the database
-            try database.removeAllData()
+            let exp = expectation(description: "removeAllData completion")
+            database.removeAllData { error in
+                if let error = error {
+                    XCTFail("removeAllData failed with \(error)")
+                }
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 0.1)
             messageRepository.clear()
 
             // Create current user in the database
@@ -422,7 +450,14 @@ final class MessageUpdater_Tests: XCTestCase {
             messageRepository.clear()
 
             // Flush the database
-            try database.removeAllData()
+            let exp = expectation(description: "removeAllData completion")
+            database.removeAllData { error in
+                if let error = error {
+                    XCTFail("removeAllData failed with \(error)")
+                }
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 0.1)
             
             // Create current user in the database
             try database.createCurrentUser(id: currentUserId)
@@ -456,7 +491,14 @@ final class MessageUpdater_Tests: XCTestCase {
         let messageId: MessageId = .unique
 
         // Flush the database
-        try database.removeAllData()
+        let exp = expectation(description: "removeAllData completion")
+        database.removeAllData { error in
+            if let error = error {
+                XCTFail("removeAllData failed with \(error)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 0.1)
 
         // Create current user in the database
         try database.createCurrentUser(id: currentUserId)
@@ -491,7 +533,14 @@ final class MessageUpdater_Tests: XCTestCase {
         let messageId: MessageId = .unique
 
         // Flush the database
-        try database.removeAllData()
+        let exp = expectation(description: "removeAllData completion")
+        database.removeAllData { error in
+            if let error = error {
+                XCTFail("removeAllData failed with \(error)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 0.1)
 
         // Create current user in the database
         try database.createCurrentUser(id: currentUserId)
@@ -1541,7 +1590,14 @@ final class MessageUpdater_Tests: XCTestCase {
             let pin = MessagePinning(expirationDate: .unique)
 
             // Flush the database
-            try database.removeAllData()
+            let exp = expectation(description: "removeAllData completion")
+            database.removeAllData { error in
+                if let error = error {
+                    XCTFail("removeAllData failed with \(error)")
+                }
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 0.1)
 
             // Create current user is the database
             try database.createCurrentUser(id: currentUserId)
@@ -1578,7 +1634,14 @@ final class MessageUpdater_Tests: XCTestCase {
             let initialText: String = .unique
 
             // Flush the database
-            try database.removeAllData()
+            let exp = expectation(description: "removeAllData completion")
+            database.removeAllData { error in
+                if let error = error {
+                    XCTFail("removeAllData failed with \(error)")
+                }
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 0.1)
 
             // Create current user is the database
             try database.createCurrentUser(id: currentUserId)
@@ -1625,7 +1688,14 @@ final class MessageUpdater_Tests: XCTestCase {
             let messageId: MessageId = .unique
 
             // Flush the database
-            try database.removeAllData()
+            let exp = expectation(description: "removeAllData completion")
+            database.removeAllData { error in
+                if let error = error {
+                    XCTFail("removeAllData failed with \(error)")
+                }
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 0.1)
 
             // Create current user is the database
             try database.createCurrentUser(id: currentUserId)
@@ -1669,7 +1739,14 @@ final class MessageUpdater_Tests: XCTestCase {
             let messageId: MessageId = .unique
 
             // Flush the database
-            try database.removeAllData()
+            let exp = expectation(description: "removeAllData completion")
+            database.removeAllData { error in
+                if let error = error {
+                    XCTFail("removeAllData failed with \(error)")
+                }
+                exp.fulfill()
+            }
+            wait(for: [exp], timeout: 0.1)
 
             // Create current user is the database
             try database.createCurrentUser(id: currentUserId)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,9 +10,8 @@ stress_tests_cycles = 50
 before_all do
   if is_ci
     setup_ci()
+    xcversion(version: "~> #{xcode_version}")
   end
-
-  xcversion(version: "~> #{xcode_version}")
 end
 
 desc "Build .xcframeworks"


### PR DESCRIPTION
### 🔗 Issue Link
CIS-1555 (see the zendesk ticket related to this)
CIS-1743
CIS-1741

### 🎯 Goal

One of the usecases we support is: app opens with guest/anonymous user, which can send/read messages. At one point, user can login and become a signed in user, without reloading the chat screen

Another usecase: at any point, user can logout and login with the same / another user credential.

### 🛠 Implementation

Let's understand our DB cleanup mechanism first.
When a new user logs in, we call `databaseContainer.removeAllData(force: true)` non-force clean is not implemented, and it's not clear what it'll be. Perhaps it'll only remove user-related data (such as removing only `CurrentUserDTO` but keeping channels/messages intact). Anyways, it's not the point of this PR.

`removeAllData` rips out the underlying DB file. In this case, none of the DB observers will get `object deleted` notification, because we don't play by the CoreData rules. We "workaround" this by sending our own "willDelete" and "didDelete" notifications.

`willDelete` prepares `delete` events for all the objects we're currently aware of (in the context of observer)
`didDelete` notification is sent _after_ the DB file is removed. This causes the `delete` events to be published to the observing object.

This is where it gets fun. Whenever an update is published from observers (`EntityChangeObserver` or `ListChangeObserver`), we call `asModel` on the DTO, lazily. Since the DTO is deleted, all fields are reset: strings are "", numbers are 0. `Date`s are different: if we try to get the `Date` from an erased object, we get
```swift
Date._unconditionallyBridgeFromObjectiveC(_:)
```
our beloved crash.

The solution is to publish the changes _before_ the underlying DTOs are deleted, so calling `asModel` on them succeeds. The DTOs are removed immediately after the changes are published.

Another problem was that we were sending `didDelete` notification _before_ the actual DB file was removed, so observers were re-subscribing to DB, receiving further updates.

Another problem was that removing the DB file was an async operation but we treated as sync. User connection cannot be completed before DB wipe is completed. This caused crashes, too.

### 🧪 Testing

First, checkout the first commit of this repo. It adds the possibility of logging in as `anonymous` and `guest` users.
Due to our app configuration, anonymous users don't see any channels. So:
1. Login as guest user. ID doesn't matter, leave it empty, defaults to `guest`
1. Open the first channel you see
1. Tap the debug icon in the navigation bar.
1. Tap "switch user"
1. Select any member
You'll see the `Date` crash.

Now, checkout the final commit, and follow the same steps. The chat screen will remove all messages and load them again, without any crash.

### 🥸 Known Issues 

For some reason, it takes ~10 secs for the ChannelListController to dealloc. If one swaps users too quickly (logout/login), there'll be 2 ChatClient instances alive for ~10 secs. This causes a race condition, and sometimes a crash. This shouldn't be a problem in production, since switching users within 10 seconds of logging in is too rare, and it's not caused by this PR, so the investigation will continue without blocking this PR.

The DB errors when launching are not properly handled. Again, not related to the PR. It's a bit hard to resolve, since `init` is sync but errors come async. Investigation will continue without blocking the PR.

### 🎉 GIF

![Simulator Screen Recording - iPhone 13 Pro - 2022-04-07 at 17 40 36](https://user-images.githubusercontent.com/770464/162238881-70cfb58e-bdb2-477a-abd2-f4fb23080d11.gif)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)
