### PR TITLE
[BW] Allows UI customization via exposing references to views in GalleryVC & ChatMessagePopupVC

### DIFF
--- a/Sources/StreamChatUI/Gallery/GalleryVC.swift
+++ b/Sources/StreamChatUI/Gallery/GalleryVC.swift
@@ -63,45 +63,67 @@ open class GalleryVC:
     .withoutAutoresizingMaskConstraints
     
     /// Bar view displayed at the top.
-    open private(set) lazy var topBarView: UIView = UIView()
+    open private(set) lazy var topBarView = UIView()
         .withoutAutoresizingMaskConstraints
-    
+        .withAccessibilityIdentifier(identifier: "topBarView")
+
+    /// Stack view inside the `topBarView`'s view hierarchy
+    open private(set) lazy var topBarContainerStackView = ContainerStackView()
+        .withoutAutoresizingMaskConstraints
+        .withAccessibilityIdentifier(identifier: "topBarContainerStackView")
+
+    /// Stack view that displays user and date label.
+    open private(set) lazy var infoContainerStackView = ContainerStackView()
+        .withAccessibilityIdentifier(identifier: "infoContainerStackView")
+
     /// Label to show information about the user that sent the message.
-    open private(set) lazy var userLabel: UILabel = UILabel()
+    open private(set) lazy var userLabel = UILabel()
         .withoutAutoresizingMaskConstraints
         .withBidirectionalLanguagesSupport
         .withAdjustingFontForContentSizeCategory
+        .withAccessibilityIdentifier(identifier: "userLabel")
     
     /// Label to show information about the date the message was sent at.
-    open private(set) lazy var dateLabel: UILabel = UILabel()
+    open private(set) lazy var dateLabel = UILabel()
         .withoutAutoresizingMaskConstraints
         .withBidirectionalLanguagesSupport
         .withAdjustingFontForContentSizeCategory
+        .withAccessibilityIdentifier(identifier: "dateLabel")
     
     /// Bar view displayed at the bottom.
-    open private(set) lazy var bottomBarView: UIView = UIView()
+    open private(set) lazy var bottomBarView = UIView()
         .withoutAutoresizingMaskConstraints
+        .withAccessibilityIdentifier(identifier: "bottomBarView")
+
+    /// Stack view inside the `bottomBarView`'s view hierarchy
+    open private(set) lazy var bottomBarContainerStackView = ContainerStackView()
+        .withoutAutoresizingMaskConstraints
+        .withAccessibilityIdentifier(identifier: "bottomBarContainerStackView")
     
     /// Label to show which photo is currently being displayed.
-    open private(set) lazy var currentPhotoLabel: UILabel = UILabel()
+    open private(set) lazy var currentPhotoLabel = UILabel()
         .withoutAutoresizingMaskConstraints
         .withBidirectionalLanguagesSupport
         .withAdjustingFontForContentSizeCategory
+        .withAccessibilityIdentifier(identifier: "currentPhotoLabel")
     
     /// Button for closing this view controller.
-    open private(set) lazy var closeButton: UIButton = components
+    open private(set) lazy var closeButton = components
         .closeButton.init()
         .withoutAutoresizingMaskConstraints
+        .withAccessibilityIdentifier(identifier: "closeButton")
     
     /// View that controls the video player of currently visible cell.
     open private(set) lazy var videoPlaybackBar: VideoPlaybackControlView = components
         .videoPlaybackControlView.init()
         .withoutAutoresizingMaskConstraints
+        .withAccessibilityIdentifier(identifier: "videoPlaybackBar")
     
     /// Button for sharing content.
-    open private(set) lazy var shareButton: UIButton = components
+    open private(set) lazy var shareButton = components
         .shareButton.init()
         .withoutAutoresizingMaskConstraints
+        .withAccessibilityIdentifier(identifier: "shareButton")
     
     /// A constaint between `topBarView.topAnchor` and `view.topAnchor`.
     open private(set) var topBarTopConstraint: NSLayoutConstraint?
@@ -176,18 +198,13 @@ open class GalleryVC:
         topBarView.pin(anchors: [.leading, .trailing], to: view)
         topBarTopConstraint = topBarView.topAnchor.constraint(equalTo: view.topAnchor)
         topBarTopConstraint?.isActive = true
-        
-        let topBarContainerStackView = ContainerStackView()
-            .withoutAutoresizingMaskConstraints
-            .withAccessibilityIdentifier(identifier: "topBarContainerStackView")
+
         topBarView.embed(topBarContainerStackView)
         topBarContainerStackView.preservesSuperviewLayoutMargins = true
         topBarContainerStackView.isLayoutMarginsRelativeArrangement = true
         
         topBarContainerStackView.addArrangedSubview(closeButton)
-        
-        let infoContainerStackView = ContainerStackView()
-            .withAccessibilityIdentifier(identifier: "infoContainerStackView")
+
         infoContainerStackView.axis = .vertical
         infoContainerStackView.alignment = .center
         infoContainerStackView.spacing = 4
@@ -205,9 +222,7 @@ open class GalleryVC:
         bottomBarView.pin(anchors: [.leading, .trailing], to: view)
         bottomBarBottomConstraint = bottomBarView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         bottomBarBottomConstraint?.isActive = true
-        
-        let bottomBarContainerStackView = ContainerStackView()
-            .withoutAutoresizingMaskConstraints
+
         bottomBarContainerStackView.preservesSuperviewLayoutMargins = true
         bottomBarContainerStackView.isLayoutMarginsRelativeArrangement = true
         bottomBarView.embed(bottomBarContainerStackView)

--- a/Sources/StreamChatUI/Gallery/ZoomAnimator.swift
+++ b/Sources/StreamChatUI/Gallery/ZoomAnimator.swift
@@ -60,9 +60,11 @@ open class ZoomAnimator: NSObject, UIViewControllerAnimatedTransitioning {
         let duration = transitionDuration(using: transitionContext)
         
         UIView.animateKeyframes(withDuration: duration, delay: 0, animations: {
-            UIView.addKeyframe(withRelativeStartTime: 0.0, relativeDuration: 1.0, animations: {
-                self.transitionImageView?.frame = self.calculateZoomInImageFrame(image: fromImageView.image!, forView: toVC.view)
-                backgroundColorView.alpha = 1
+            UIView.addKeyframe(withRelativeStartTime: 0.0, relativeDuration: 1.0, animations: { [weak self] in
+                if let image = fromImageView.image {
+                    self?.transitionImageView?.frame = self?.calculateZoomInImageFrame(image: image, forView: toVC.view) ?? .zero
+                    backgroundColorView.alpha = 1
+                }
             })
             
             UIView.addKeyframe(withRelativeStartTime: 0.95, relativeDuration: 0.05, animations: {

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.swift
@@ -34,11 +34,11 @@ open class ChatMessagePopupVC: _ViewController, ComponentsProvider {
 
     /// Container that holds `reactionsController` that displays reactions
     open private(set) lazy var reactionsContainerView = ContainerStackView()
-                                                            .withAccessibilityIdentifier(identifier: "reactionsContainerView")
+        .withAccessibilityIdentifier(identifier: "reactionsContainerView")
 
     /// Container that holds actions
     open private(set) var actionsContainerStackView: ContainerStackView = ContainerStackView()
-                                                            .withAccessibilityIdentifier(identifier: "actionsContainerStackView")
+        .withAccessibilityIdentifier(identifier: "actionsContainerStackView")
 
     /// Insets for `messageContentView`'s bubble view.
     public var messageBubbleViewInsets: UIEdgeInsets = .zero

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessagePopupVC.swift
@@ -32,6 +32,14 @@ open class ChatMessagePopupVC: _ViewController, ComponentsProvider {
         .withoutAutoresizingMaskConstraints
         .withAccessibilityIdentifier(identifier: "messageContentContainerView")
 
+    /// Container that holds `reactionsController` that displays reactions
+    open private(set) lazy var reactionsContainerView = ContainerStackView()
+                                                            .withAccessibilityIdentifier(identifier: "reactionsContainerView")
+
+    /// Container that holds actions
+    open private(set) var actionsContainerStackView: ContainerStackView = ContainerStackView()
+                                                            .withAccessibilityIdentifier(identifier: "actionsContainerStackView")
+
     /// Insets for `messageContentView`'s bubble view.
     public var messageBubbleViewInsets: UIEdgeInsets = .zero
 
@@ -99,7 +107,6 @@ open class ChatMessagePopupVC: _ViewController, ComponentsProvider {
         ]
 
         if let reactionsController = reactionsController {
-            let reactionsContainerView = ContainerStackView().withAccessibilityIdentifier(identifier: "reactionsContainerView")
             messageContainerStackView.addArrangedSubview(reactionsContainerView)
             reactionsContainerView.addArrangedSubview(.spacer(axis: .horizontal))
             
@@ -134,8 +141,6 @@ open class ChatMessagePopupVC: _ViewController, ComponentsProvider {
                 actionsController.view.widthAnchor.pin(equalTo: view.widthAnchor, multiplier: actionsViewWidthMultiplier)
             )
 
-            let actionsContainerStackView = ContainerStackView()
-                .withAccessibilityIdentifier(identifier: "actionsContainerStackView")
             actionsContainerStackView.addArrangedSubview(.spacer(axis: .horizontal))
             messageContainerStackView.addArrangedSubview(actionsContainerStackView)
 


### PR DESCRIPTION
### 🔗 Issue Link
Request from customer.

### 🎯 Goal
Improve the ease of use of our APIs

### 📝 Changes

* Exposes references to our own declared `UIView`s in `GalleryVC` and `ChatMessagePopupVC`
* Adds missing accessibility labels
* Safely unwraps optional image in `ZoomTransitionAnimator`

### 🎨 UI Changes

Before:
```swift
class CustomGalleryVC: GalleryVC {

    override func setUpLayout() {
        super.setUpLayout()
        /// Gain access to reference of `bottomBarContainerStackView`
        if let bottomBarContainerStackView = shareButton.superview as? ContainerStackView {
            /// Removes shareButton from bottom bar
            bottomBarContainerStackView.removeArrangedSubview(shareButton)

            /// Gain access to reference of `topBarContainerStackView `
            if let topBarContainerStackView = topBarView.subviews.first as? ContainerStackView {
                /// Adds shareButton to top bar
                topBarContainerStackView.addArrangedSubview(shareButton)
            }
        }
    }
}

```

After:
```swift
class CustomGalleryVC: GalleryVC {

    override func setUpLayout() {
        super.setUpLayout()

        // Removes share button from bottom bar
        bottomBarContainerStackView.removeArrangedSubview(shareButton)

        // Adds share button to top bar
        topBarContainerStackView.addArrangedSubview(shareButton)
    }
}
```

![Simulator Screen Shot - iPhone 13 Pro Max - 2022-04-14 at 09 47 12](https://user-images.githubusercontent.com/4924709/163342151-7a99d81b-6160-4f63-a880-eb47e7598e99.png)


### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
