### PR TITLE
Fixed sending device id when Firebase if used for sending push notification

### DIFF
--- a/Sources/StreamChat/APIClient/Endpoints/DeviceEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/DeviceEndpoints.swift
@@ -16,7 +16,7 @@ extension Endpoint {
     static func addDevice(
         userId: UserId,
         deviceId: DeviceId,
-        pushProvider: PushProvider
+        pushProviderId: PushProviderId
     ) -> Endpoint<EmptyResponse> {
         .init(
             path: .devices,
@@ -26,7 +26,7 @@ extension Endpoint {
             body: [
                 "user_id": userId,
                 "id": deviceId,
-                "push_provider": pushProvider.rawValue
+                "push_provider": pushProviderId
             ]
         )
     }

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -198,14 +198,13 @@ public extension CurrentChatUserController {
     ///   - token: Device token, obtained via `didRegisterForRemoteNotificationsWithDeviceToken` function in `AppDelegate`.
     ///   - pushProvider: The push provider for this device. By default, it is APN.
     ///   - completion: Called when device is successfully registered, or with error.
-    func addDevice(token: Data, pushProvider: PushProvider = .apn, completion: ((Error?) -> Void)? = nil) {
+    func addDevice(pushProvider: PushProvider, completion: ((Error?) -> Void)? = nil) {
         guard let currentUserId = currentUser?.id else {
             completion?(ClientError.CurrentUserDoesNotExist())
             return
         }
 
         currentUserUpdater.addDevice(
-            token: token,
             currentUserId: currentUserId,
             pushProvider: pushProvider
         ) { error in

--- a/Sources/StreamChat/Models/PushProvider.swift
+++ b/Sources/StreamChat/Models/PushProvider.swift
@@ -11,7 +11,10 @@ public typealias PushProviderId = String
 public enum PushProvider {
     case firebase(token: String)
     case apn(token: Data)
-    
+}
+
+extension PushProvider {
+    /// Push provider id, needed for device endpoind
     var pushProviderId: PushProviderId {
         switch self {
         case .firebase:
@@ -20,7 +23,7 @@ public enum PushProvider {
             return "apn"
         }
     }
-    
+    /// Device token id 
     var deviceToken: DeviceId {
         switch self {
         case .firebase(let token):

--- a/Sources/StreamChat/Models/PushProvider.swift
+++ b/Sources/StreamChat/Models/PushProvider.swift
@@ -4,18 +4,29 @@
 
 import Foundation
 
+/// A unique identifier of a push provider.
+public typealias PushProviderId = String
+
 /// A type that represents the supported push providers.
-public struct PushProvider: RawRepresentable, Hashable, ExpressibleByStringLiteral {
-    public static let firebase: Self = "firebase"
-    public static let apn: Self = "apn"
-
-    public let rawValue: String
-
-    public init(rawValue: String) {
-        self.rawValue = rawValue
+public enum PushProvider {
+    case firebase(token: String)
+    case apn(token: Data)
+    
+    var pushProviderId: PushProviderId {
+        switch self {
+        case .firebase:
+            return "firebase"
+        case .apn:
+            return "apn"
+        }
     }
-
-    public init(stringLiteral value: String) {
-        self.init(rawValue: value)
+    
+    var deviceToken: DeviceId {
+        switch self {
+        case .firebase(let token):
+            return token
+        case .apn(let token):
+            return token.deviceToken
+        }
     }
 }

--- a/Sources/StreamChat/Workers/CurrentUserUpdater.swift
+++ b/Sources/StreamChat/Workers/CurrentUserUpdater.swift
@@ -59,12 +59,11 @@ class CurrentUserUpdater: Worker {
     ///   - pushProvider: The push provider for this device.
     ///   - completion: Called when device is successfully registered, or with error.
     func addDevice(
-        token: Data,
         currentUserId: UserId,
         pushProvider: PushProvider,
         completion: ((Error?) -> Void)? = nil
     ) {
-        let deviceId = token.deviceToken
+        let deviceId = pushProvider.deviceToken
         
         func saveCurrentDevice(deviceId: String, completion: ((Error?) -> Void)?) {
             database.write({ (session) in
@@ -83,7 +82,7 @@ class CurrentUserUpdater: Worker {
                 endpoint: .addDevice(
                     userId: currentUserId,
                     deviceId: deviceId,
-                    pushProvider: pushProvider
+                    pushProviderId: pushProvider.pushProviderId
                 ),
                 completion: { result in
                     if let error = result.error {


### PR DESCRIPTION
### 🎯 Goal
- Make functions interface more simpler
- Remove complicated types dependencies for device endpoints
- Fix firebase notification support in iOS Applications

### 🛠 Implementation
- Replace PushProvider struct with PushProvider enum with nested objects for different providers type
- Add extension for provide `push provider id` and `device id` for endpoint as 'ready to use' data
- Change functions interface for use updated PushProvider type
 
### 📝 Changes
- replaced PushProvider struct with enum with nested objects (different types for different providers)
- changed functions interfaces


### 🧪 Testing
- Enable firebase notification support for application in the `Dashboard`
- call `addDevice(pushProvider: .firebase(token: "fcm-token"), completion: { _ in }`, token sent properly, and isn't got error in completion
- Push notifications start working

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
