### PR TITLE
Update README to include SDK size badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
   <a href="https://sonarcloud.io/summary/new_code?id=GetStream_stream-chat-swift"><img src="https://sonarcloud.io/api/project_badges/measure?project=GetStream_stream-chat-swift&metric=coverage" /></a>
 </p>
 <p align="center">
-  <img alt="StreamChat" src="https://img.shields.io/endpoint?url=https://stream-sdks-size-badges.herokuapp.com/ios/stream-chat&cacheSeconds=1000"/>
-  <img alt="StreamChatUI" src="https://img.shields.io/endpoint?url=https://stream-sdks-size-badges.herokuapp.com/ios/stream-chat-ui&cacheSeconds=1000"/>
+  <img alt="StreamChat" src="https://img.shields.io/endpoint?url=https://stream-sdks-size-badges.herokuapp.com/ios/stream-chat&cacheSeconds=86400"/>
+  <img alt="StreamChatUI" src="https://img.shields.io/endpoint?url=https://stream-sdks-size-badges.herokuapp.com/ios/stream-chat-ui&cacheSeconds=86400"/>
 </p>
 
 This is the official iOS SDK for [Stream Chat](https://getstream.io/chat/sdk/ios/), a service for building chat and messaging applications. This library includes both a low-level SDK and a set of reusable UI components.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
   <a href="https://github.com/GetStream/stream-chat-swift/actions"><img src="https://github.com/GetStream/stream-chat-swift/actions/workflows/smoke-checks.yml/badge.svg" /></a>
   <a href="https://sonarcloud.io/summary/new_code?id=GetStream_stream-chat-swift"><img src="https://sonarcloud.io/api/project_badges/measure?project=GetStream_stream-chat-swift&metric=coverage" /></a>
 </p>
+<p align="center">
+  <img alt="StreamChat" src="https://img.shields.io/endpoint?url=https://stream-sdks-size-badges.herokuapp.com/ios/stream-chat&cacheSeconds=1000"/>
+  <img alt="StreamChatUI" src="https://img.shields.io/endpoint?url=https://stream-sdks-size-badges.herokuapp.com/ios/stream-chat-ui&cacheSeconds=1000"/>
+</p>
 
 This is the official iOS SDK for [Stream Chat](https://getstream.io/chat/sdk/ios/), a service for building chat and messaging applications. This library includes both a low-level SDK and a set of reusable UI components.
 


### PR DESCRIPTION
### 🔗 Issue Link
None

### 🎯 Goal
Dynamically display the current SDK sizes in the README. We often have customers asking for the size of each SDK, with this, it will be available just by reading our README 🙂 

### 🛠 Implementation
This is was a fun project, and the source of the implementation is here: https://github.com/GetStream/stream-sdks-size-badges

More details about the implementation are in the repo above, specifically [here](https://github.com/GetStream/stream-sdks-size-badges#implementation-details).

### 🎨 UI Changes
<img width="1138" alt="image" src="https://user-images.githubusercontent.com/12814114/164228640-611c3e26-dacb-48d4-b475-84297cfb52ab.png">

### 🧪 Testing
Just preview the README from this branch.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)