### PR TITLE
[CIS-1724] Fix `only visible for you` badge not shown for ephemeral messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChatUI
 ### 🔄 Changed
+- Deprecate `ChatMessage.isOnlyVisibleForCurrentUser` as it does not account deleted messages visability setting [#1948](https://github.com/GetStream/stream-chat-swift/pull/1948)
+- Rename components related to message footnote content in `ChatMessageContentView` [#1948](https://github.com/GetStream/stream-chat-swift/pull/1948)
+### 🐞 Fixed
+- Fix `onlyVisibleForYouIndicator` not being shown for ephemeral messages [#1948](https://github.com/GetStream/stream-chat-swift/pull/1948)
 
 # [4.14.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.14.0)
-_April 20, 2022_
+_April 26, 2022_
 ## StreamChat
 ### ✅ Added
 - `quotesEnabled` property is added to the `ChannelConfig` [#1891](https://github.com/GetStream/stream-chat-swift/issues/1891)

--- a/Examples/SlackClone/SlackChatMessageContentView.swift
+++ b/Examples/SlackClone/SlackChatMessageContentView.swift
@@ -13,7 +13,7 @@ final class SlackChatMessageContentView: ChatMessageContentView {
         super.layout(options: options)
 
         mainContainer.alignment = .leading
-        bubbleThreadMetaContainer.changeOrdering()
+        bubbleThreadFootnoteContainer.changeOrdering()
         bubbleContentContainer.directionalLayoutMargins = .zero
     }
 

--- a/Examples/YouTubeClone/MessageOptionsResolver/YTMessageLayoutOptionsResolver.swift
+++ b/Examples/YouTubeClone/MessageOptionsResolver/YTMessageLayoutOptionsResolver.swift
@@ -25,7 +25,7 @@ final class YTMessageLayoutOptionsResolver: ChatMessageLayoutOptionsResolver {
             .authorName,
             .threadInfo,
             .reactions,
-            .onlyVisibleForYouIndicator,
+            .onlyVisibleToYouIndicator,
             .errorIndicator
         ])
         

--- a/Examples/YouTubeClone/YTChatMessageContentView.swift
+++ b/Examples/YouTubeClone/YTChatMessageContentView.swift
@@ -38,28 +38,28 @@ final class YTChatMessageContentView: ChatMessageContentView {
         super.layout(options: options)
         
         // Set the container's axis to horizontal to match the look of YouTube comments(default is vertical)
-        bubbleThreadMetaContainer.axis = .horizontal
+        bubbleThreadFootnoteContainer.axis = .horizontal
         
-        // Reverse the order of the subviews of the `bubbleThreadMetaContainer`
+        // Reverse the order of the subviews of the `bubbleThreadFootnoteContainer`
         // By default, the order is
         // |--- message---|
-        // |--metadataContainer---|
+        // |--footnoteContainer---|
         
         // By changing the axis to `horizontal` and reversing the order, now the arrangement looks like:
-        // |--- metadataContainer ---message ---|
-        let subviews = bubbleThreadMetaContainer.subviews
-        bubbleThreadMetaContainer.removeAllArrangedSubviews()
-        bubbleThreadMetaContainer.addArrangedSubviews(subviews.reversed())
+        // |--- footnoteContainer ---message ---|
+        let subviews = bubbleThreadFootnoteContainer.subviews
+        bubbleThreadFootnoteContainer.removeAllArrangedSubviews()
+        bubbleThreadFootnoteContainer.addArrangedSubviews(subviews.reversed())
         
-        // Reverse the order of the subviews in the `metadataContainer`
+        // Reverse the order of the subviews in the `footnoteContainer`
         // By default, the order is
         // |--- author --- time ---|
         
         // By changing reversing it, the arrangement looks like:
         // |---time --- author---|
-        let metadataSubviews = metadataContainer?.subviews
-        metadataContainer?.removeAllArrangedSubviews()
-        metadataContainer?.addArrangedSubviews((metadataSubviews?.reversed())!)
+        let metadataSubviews = footnoteContainer?.subviews
+        footnoteContainer?.removeAllArrangedSubviews()
+        footnoteContainer?.addArrangedSubviews((metadataSubviews?.reversed())!)
         
         // By default, there are directionalLayoutMargins with system value because of the bubble border option.
         // We need to disable them to get cleaner

--- a/Examples/iMessageClone/iMessageChatMessageContentView.swift
+++ b/Examples/iMessageClone/iMessageChatMessageContentView.swift
@@ -12,7 +12,7 @@ final class iMessageChatMessageContentView: ChatMessageContentView {
     override func layout(options: ChatMessageLayoutOptions) {
         super.layout(options: options)
 
-        metadataContainer?.alignment = .center
+        footnoteContainer?.alignment = .center
     }
 
     override func createTimestampLabel() -> UILabel {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
@@ -95,13 +95,13 @@ open class ChatMessageContentView: _View, ThemeProvider {
 
     /// Shows the icon part of the indicator saying the message is visible for current user only.
     /// Exists if `layout(options: MessageLayoutOptions)` was invoked with the options
-    /// containing `.onlyVisibleForYouIndicator`.
-    public private(set) var onlyVisibleForYouIconImageView: UIImageView?
+    /// containing `.onlyVisibleToYouIndicator`.
+    public private(set) var onlyVisibleToYouImageView: UIImageView?
 
     /// Shows the text part of the indicator saying the message is visible for current user only.
     /// Exists if `layout(options: MessageLayoutOptions)` was invoked with the options
-    /// containing `.onlyVisibleForYouIndicator`
-    public private(set) var onlyVisibleForYouLabel: UILabel?
+    /// containing `.onlyVisibleToYouIndicator`
+    public private(set) var onlyVisibleToYouLabel: UILabel?
 
     /// Shows error indicator.
     /// Exists if `layout(options: MessageLayoutOptions)` was invoked with the options containing `.errorIndicator`.
@@ -141,10 +141,10 @@ open class ChatMessageContentView: _View, ThemeProvider {
         .withoutAutoresizingMaskConstraints
         .withAccessibilityIdentifier(identifier: "mainContainer")
 
-    /// The container which holds `bubbleView` (or `bubbleContentContainer` directly), `threadInfoContainer`, and `metadataView`
-    public private(set) lazy var bubbleThreadMetaContainer = ContainerStackView(axis: .vertical, spacing: 4)
+    /// The container which holds `bubbleView` (or `bubbleContentContainer` directly), `threadInfoContainer`, and `footnoteContainer`
+    public private(set) lazy var bubbleThreadFootnoteContainer = ContainerStackView(axis: .vertical, spacing: 4)
         .withoutAutoresizingMaskConstraints
-        .withAccessibilityIdentifier(identifier: "bubbleThreadMetaContainer")
+        .withAccessibilityIdentifier(identifier: "bubbleThreadFootnoteContainer")
 
     /// The container which holds `quotedMessageView` and `textView`. It will be added as a subview to `bubbleView` if it exists
     /// otherwise it will be added to `bubbleThreadMetaContainer`.
@@ -155,13 +155,13 @@ open class ChatMessageContentView: _View, ThemeProvider {
     /// The container which holds `threadArrowView`, `threadAvatarView`, and `threadReplyCountButton`
     public private(set) var threadInfoContainer: ContainerStackView?
 
-    /// The container which holds `timestampLabel`, `authorNameLabel`, and `onlyVisibleForYouContainer`.
+    /// The container which holds `timestampLabel`, `authorNameLabel`, and `onlyVisibleToYouContainer`.
     /// Exists if `layout(options: MessageLayoutOptions)` was invoked with any of
-    /// `.timestamp/.authorName/.onlyVisibleForYouIndicator` options
-    public private(set) var metadataContainer: ContainerStackView?
+    /// `.timestamp/.authorName/.onlyVisibleToYouIndicator` options
+    public private(set) var footnoteContainer: ContainerStackView?
 
-    /// The container which holds `onlyVisibleForYouIconImageView` and `onlyVisibleForYouLabel`
-    public private(set) var onlyVisibleForYouContainer: ContainerStackView?
+    /// The container which holds `onlyVisibleToYouImageView` and `onlyVisibleToYouLabel`
+    public private(set) var onlyVisibleToYouContainer: ContainerStackView?
 
     /// The container which holds `errorIndicatorView`
     /// Exists if `layout(options: MessageLayoutOptions)` was invoked with the options containing `.errorIndicator`.
@@ -215,7 +215,7 @@ open class ChatMessageContentView: _View, ThemeProvider {
         }
 
         // Bubble - Thread - Metadata
-        bubbleThreadMetaContainer.alignment = attachmentViewInjector?.fillAllAvailableWidth == true
+        bubbleThreadFootnoteContainer.alignment = attachmentViewInjector?.fillAllAvailableWidth == true
             ? .fill
             : options.contains(.flipped) ? .trailing : .leading
 
@@ -228,15 +228,15 @@ open class ChatMessageContentView: _View, ThemeProvider {
                 mainContainer.layoutMargins.bottom = 0
             }
 
-            bubbleThreadMetaContainer.addArrangedSubview(bubbleView)
+            bubbleThreadFootnoteContainer.addArrangedSubview(bubbleView)
         } else {
-            bubbleThreadMetaContainer.addArrangedSubview(bubbleContentContainer)
+            bubbleThreadFootnoteContainer.addArrangedSubview(bubbleContentContainer)
         }
 
         // Thread info
         if options.contains(.threadInfo) {
             threadInfoContainer = ContainerStackView().withAccessibilityIdentifier(identifier: "threadInfoContainer")
-            bubbleThreadMetaContainer.addArrangedSubview(threadInfoContainer!)
+            bubbleThreadFootnoteContainer.addArrangedSubview(threadInfoContainer!)
 
             let arrowView = createThreadArrowView()
             let threadAvatarView = createThreadAvatarView()
@@ -270,30 +270,30 @@ open class ChatMessageContentView: _View, ThemeProvider {
         }
 
         // Metadata
-        if options.hasMetadata {
-            var metadataSubviews: [UIView] = []
+        if options.hasFootnoteOptions {
+            var footnoteSubviews: [UIView] = []
             
             if options.contains(.authorName) {
-                metadataSubviews.append(createAuthorNameLabel())
+                footnoteSubviews.append(createAuthorNameLabel())
             }
             if options.contains(.timestamp) {
-                metadataSubviews.append(createTimestampLabel())
+                footnoteSubviews.append(createTimestampLabel())
             }
-            if options.contains(.onlyVisibleForYouIndicator) {
-                onlyVisibleForYouContainer = ContainerStackView()
-                    .withAccessibilityIdentifier(identifier: "onlyVisibleForYouContainer")
-                onlyVisibleForYouContainer!.addArrangedSubview(createOnlyVisibleForYouIconImageView())
-                onlyVisibleForYouContainer!.addArrangedSubview(createOnlyVisibleForYouLabel())
-                metadataSubviews.append(onlyVisibleForYouContainer!)
+            if options.contains(.onlyVisibleToYouIndicator) {
+                onlyVisibleToYouContainer = ContainerStackView()
+                    .withAccessibilityIdentifier(identifier: "onlyVisibleToYouContainer")
+                onlyVisibleToYouContainer!.addArrangedSubview(createOnlyVisibleToYouImageView())
+                onlyVisibleToYouContainer!.addArrangedSubview(createOnlyVisibleToYouLabel())
+                footnoteSubviews.append(onlyVisibleToYouContainer!)
             }
             if attachmentViewInjector?.fillAllAvailableWidth == true {
-                metadataSubviews.append(.spacer(axis: .horizontal))
+                footnoteSubviews.append(.spacer(axis: .horizontal))
             }
 
-            metadataContainer = ContainerStackView(
-                arrangedSubviews: options.contains(.flipped) ? metadataSubviews.reversed() : metadataSubviews
-            ).withAccessibilityIdentifier(identifier: "metadataContainer")
-            bubbleThreadMetaContainer.addArrangedSubview(metadataContainer!)
+            footnoteContainer = ContainerStackView(
+                arrangedSubviews: options.contains(.flipped) ? footnoteSubviews.reversed() : footnoteSubviews
+            ).withAccessibilityIdentifier(identifier: "footnoteContainer")
+            bubbleThreadFootnoteContainer.addArrangedSubview(footnoteContainer!)
         }
 
         // Error
@@ -363,11 +363,11 @@ open class ChatMessageContentView: _View, ThemeProvider {
         let mainContainerSubviews = [
             authorAvatarView ?? authorAvatarSpacer,
             errorIndicatorContainer,
-            bubbleThreadMetaContainer
+            bubbleThreadFootnoteContainer
         ].compactMap { $0 }
 
         if options.contains(.centered) {
-            mainContainer.addArrangedSubviews([bubbleThreadMetaContainer])
+            mainContainer.addArrangedSubviews([bubbleThreadFootnoteContainer])
             
             constraintsToActivate += [
                 mainContainer.centerXAnchor
@@ -379,7 +379,7 @@ open class ChatMessageContentView: _View, ThemeProvider {
             if let errorIndicator = errorIndicatorView {
                 mainContainer.setCustomSpacing(
                     .init(-errorIndicator.intrinsicContentSize.width / 2),
-                    after: bubbleThreadMetaContainer
+                    after: bubbleThreadFootnoteContainer
                 )
             }
 
@@ -500,7 +500,7 @@ open class ChatMessageContentView: _View, ThemeProvider {
         }
 
         // Metadata
-        onlyVisibleForYouContainer?.isVisible = layoutOptions?.contains(.onlyVisibleForYouIndicator) == true
+        onlyVisibleToYouContainer?.isVisible = layoutOptions?.contains(.onlyVisibleToYouIndicator) == true
 
         authorNameLabel?.isVisible = layoutOptions?.contains(.authorName) == true
         authorNameLabel?.text = content?.author.name
@@ -786,36 +786,35 @@ open class ChatMessageContentView: _View, ThemeProvider {
         return authorNameLabel!
     }
 
-    /// Instantiates, configures and assigns `onlyVisibleForYouIconImageView` when called for the first time.
-    /// - Returns: The `onlyVisibleForYouIconImageView` subview.
-    open func createOnlyVisibleForYouIconImageView() -> UIImageView {
-        if onlyVisibleForYouIconImageView == nil {
-            onlyVisibleForYouIconImageView = UIImageView()
+    /// Instantiates, configures and assigns `onlyVisibleToYouImageView` when called for the first time.
+    /// - Returns: The `onlyVisibleToYouImageView` subview.
+    open func createOnlyVisibleToYouImageView() -> UIImageView {
+        if onlyVisibleToYouImageView == nil {
+            onlyVisibleToYouImageView = UIImageView()
                 .withoutAutoresizingMaskConstraints
-                .withAccessibilityIdentifier(identifier: "onlyVisibleForYouIconImageView")
-
-            onlyVisibleForYouIconImageView!.tintColor = appearance.colorPalette.subtitleText
-            onlyVisibleForYouIconImageView!.image = appearance.images.onlyVisibleToCurrentUser
-            onlyVisibleForYouIconImageView!.contentMode = .scaleAspectFit
+                .withAccessibilityIdentifier(identifier: "onlyVisibleToYouImageView")
+            onlyVisibleToYouImageView!.tintColor = appearance.colorPalette.subtitleText
+            onlyVisibleToYouImageView!.image = appearance.images.onlyVisibleToCurrentUser
+            onlyVisibleToYouImageView!.contentMode = .scaleAspectFit
         }
-        return onlyVisibleForYouIconImageView!
+        return onlyVisibleToYouImageView!
     }
 
-    /// Instantiates, configures and assigns `onlyVisibleForYouLabel` when called for the first time.
-    /// - Returns: The `onlyVisibleForYouLabel` subview.
-    open func createOnlyVisibleForYouLabel() -> UILabel {
-        if onlyVisibleForYouLabel == nil {
-            onlyVisibleForYouLabel = UILabel()
+    /// Instantiates, configures and assigns `onlyVisibleToYouLabel` when called for the first time.
+    /// - Returns: The `onlyVisibleToYouLabel` subview.
+    open func createOnlyVisibleToYouLabel() -> UILabel {
+        if onlyVisibleToYouLabel == nil {
+            onlyVisibleToYouLabel = UILabel()
                 .withAdjustingFontForContentSizeCategory
                 .withBidirectionalLanguagesSupport
                 .withoutAutoresizingMaskConstraints
-                .withAccessibilityIdentifier(identifier: "onlyVisibleForYouLabel")
+                .withAccessibilityIdentifier(identifier: "onlyVisibleToYouLabel")
 
-            onlyVisibleForYouLabel!.textColor = appearance.colorPalette.subtitleText
-            onlyVisibleForYouLabel!.text = L10n.Message.onlyVisibleToYou
-            onlyVisibleForYouLabel!.font = appearance.fonts.footnote
+            onlyVisibleToYouLabel!.textColor = appearance.colorPalette.subtitleText
+            onlyVisibleToYouLabel!.text = L10n.Message.onlyVisibleToYou
+            onlyVisibleToYouLabel!.font = appearance.fonts.footnote
         }
-        return onlyVisibleForYouLabel!
+        return onlyVisibleToYouLabel!
     }
 }
 
@@ -829,14 +828,14 @@ private extension ChatMessage {
 }
 
 private extension ChatMessageLayoutOptions {
-    static let metadata: Self = [
-        .onlyVisibleForYouIndicator,
+    static let footnote: Self = [
+        .onlyVisibleToYouIndicator,
         .authorName,
         .timestamp
     ]
     
-    var hasMetadata: Bool {
-        !intersection(.metadata).isEmpty
+    var hasFootnoteOptions: Bool {
+        !intersection(.footnote).isEmpty
     }
 }
 
@@ -849,5 +848,42 @@ extension ChatMessageLayoutOptions {
         } else {
             return CACornerMask.all.subtracting(.layerMinXMaxYCorner)
         }
+    }
+}
+
+extension ChatMessageContentView {
+    @available(*, deprecated, renamed: "onlyVisibleToYouImageView")
+    public var onlyVisibleForYouIconImageView: UIImageView? {
+        onlyVisibleToYouImageView
+    }
+    
+    @available(*, deprecated, renamed: "onlyVisibleToYouLabel")
+    public var onlyVisibleForYouLabel: UILabel? {
+        onlyVisibleToYouLabel
+    }
+    
+    @available(*, deprecated, renamed: "onlyVisibleToYouContainer")
+    public var onlyVisibleForYouContainer: ContainerStackView? {
+        onlyVisibleToYouContainer
+    }
+    
+    @available(*, deprecated, renamed: "footnoteContainer")
+    public var metadataContainer: ContainerStackView? {
+        footnoteContainer
+    }
+    
+    @available(*, deprecated, renamed: "bubbleThreadFootnoteContainer")
+    public var bubbleThreadMetaContainer: ContainerStackView? {
+        bubbleThreadFootnoteContainer
+    }
+    
+    @available(*, deprecated, renamed: "createOnlyVisibleToYouImageView")
+    open func createOnlyVisibleForYouIconImageView() -> UIImageView {
+        createOnlyVisibleToYouImageView()
+    }
+    
+    @available(*, deprecated, renamed: "createOnlyVisibleToYouLabel")
+    open func createOnlyVisibleForYouLabel() -> UILabel {
+        createOnlyVisibleToYouLabel()
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
@@ -500,7 +500,7 @@ open class ChatMessageContentView: _View, ThemeProvider {
         }
 
         // Metadata
-        onlyVisibleForYouContainer?.isVisible = content?.isOnlyVisibleForCurrentUser == true
+        onlyVisibleForYouContainer?.isVisible = layoutOptions?.contains(.onlyVisibleForYouIndicator) == true
 
         authorNameLabel?.isVisible = layoutOptions?.contains(.authorName) == true
         authorNameLabel?.text = content?.author.name

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptions.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptions.swift
@@ -80,12 +80,17 @@ public extension ChatMessageLayoutOption {
     /// If set the reactions added to the message will be shown.
     static let reactions: Self = "reactions"
 
-    /// If set the indicator saying that the message is visible for current user only will be shown.
-    static let onlyVisibleForYouIndicator: Self = "onlyVisibleForYouIndicator"
+    /// If set, the indicator saying that the message is visible to the current user only will be shown.
+    static let onlyVisibleToYouIndicator: Self = "onlyVisibleToYouIndicator"
     
     /// If set all the content will have centered alignment. By default, the system messages are centered.
     ///
     /// `flipped` and `centered` are mutually exclusive. Only one of these two should be used at a time.
     /// If both are specified in the options, `centered` is prioritized
     static let centered: Self = "centered"
+}
+
+public extension ChatMessageLayoutOption {
+    @available(*, deprecated, renamed: "onlyVisibleToYouIndicator")
+    static let onlyVisibleForYouIndicator: Self = onlyVisibleToYouIndicator
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
@@ -72,8 +72,8 @@ open class ChatMessageLayoutOptionsResolver {
         if isLastInSequence {
             options.insert(.timestamp)
         }
-        if showOnlyVisibleForYouIndicator(for: message) {
-            options.insert(.onlyVisibleForYouIndicator)
+        if showOnlyVisibleToYouIndicator(for: message) {
+            options.insert(.onlyVisibleToYouIndicator)
         }
         if message.textContent?.isEmpty == false {
             options.insert(.text)
@@ -179,10 +179,10 @@ open class ChatMessageLayoutOptionsResolver {
         return delay > maxTimeIntervalBetweenMessagesInGroup
     }
     
-    /// Determines whether to populate `onlyVisibleForYouIndicator` for the given message.
+    /// Determines whether to populate `onlyVisibleToYouIndicator` for the given message.
     /// - Parameter message: The message.
-    /// - Returns: `true` if `onlyVisibleForYouIndicator` layout option should be included for the given message.
-    open func showOnlyVisibleForYouIndicator(for message: ChatMessage) -> Bool {
+    /// - Returns: `true` if `onlyVisibleToYouIndicator` layout option should be included for the given message.
+    open func showOnlyVisibleToYouIndicator(for message: ChatMessage) -> Bool {
         guard message.isSentByCurrentUser else {
             return false
         }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
@@ -9,7 +9,11 @@ import StreamChat
 open class ChatMessageLayoutOptionsResolver {
     /// The maximum time interval between 2 consecutive messages sent by the same user to treat them as a single message group.
     public let maxTimeIntervalBetweenMessagesInGroup: TimeInterval
-
+    
+    // TODO: Propagate via `init` in v5, make it non-optional.
+    /// The config of the `ChatClient` used.
+    public internal(set) var config: ChatClientConfig?
+    
     /// Creates new `ChatMessageLayoutOptionsResolver`.
     ///
     /// - Parameter maxTimeIntervalBetweenMessagesInGroup: The maximum time interval between 2 consecutive messages sent by the same user to treat them as a single message group (`60 sec` by default).
@@ -68,7 +72,7 @@ open class ChatMessageLayoutOptionsResolver {
         if isLastInSequence {
             options.insert(.timestamp)
         }
-        if message.isOnlyVisibleForCurrentUser {
+        if showOnlyVisibleForYouIndicator(for: message) {
             options.insert(.onlyVisibleForYouIndicator)
         }
         if message.textContent?.isEmpty == false {
@@ -173,5 +177,28 @@ open class ChatMessageLayoutOptionsResolver {
         // If the message next to the current one is sent with delay > maxTimeIntervalBetweenMessagesInGroup,
         // the current message ends the sequence.
         return delay > maxTimeIntervalBetweenMessagesInGroup
+    }
+    
+    /// Determines whether to populate `onlyVisibleForYouIndicator` for the given message.
+    /// - Parameter message: The message.
+    /// - Returns: `true` if `onlyVisibleForYouIndicator` layout option should be included for the given message.
+    open func showOnlyVisibleForYouIndicator(for message: ChatMessage) -> Bool {
+        guard message.isSentByCurrentUser else {
+            return false
+        }
+        
+        switch message.type {
+        case .ephemeral:
+            return true
+        case .deleted:
+            guard let config = config else {
+                log.assertionFailure("The `config` property must be assiged at this point.")
+                return false
+            }
+            
+            return config.deletedMessagesVisibility == .visibleForCurrentUser
+        default:
+            return false
+        }
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -23,7 +23,7 @@ open class ChatMessageListVC:
     /// The object that acts as the data source of the message list.
     public weak var dataSource: ChatMessageListVCDataSource? {
         didSet {
-            updateContent()
+            updateContentIfNeeded()
         }
     }
 
@@ -119,6 +119,8 @@ open class ChatMessageListVC:
     override open func setUp() {
         super.setUp()
         
+        components.messageLayoutOptionsResolver.config = client.config
+        
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress))
         longPress.minimumPressDuration = 0.33
         listView.addGestureRecognizer(longPress)
@@ -196,19 +198,7 @@ open class ChatMessageListVC:
     /// By default there is one message with all possible layout and layout options
     /// determines which parts of the message are visible for the given message.
     open func cellLayoutOptionsForMessage(at indexPath: IndexPath) -> ChatMessageLayoutOptions {
-        guard let dataSource = self.dataSource else {
-            return ChatMessageLayoutOptions()
-        }
-
-        var options = dataSource.chatMessageListVC(self, messageLayoutOptionsAt: indexPath)
-
-        // Ideally this would be part of the `ChatMessageLayoutOptionsResolver`, but currently
-        // it is a bit odd to pass the `ChatClientConfig` to the resolver.
-        if client.config.deletedMessagesVisibility != .visibleForCurrentUser {
-            options.remove(.onlyVisibleForYouIndicator)
-        }
-
-        return options
+        dataSource?.chatMessageListVC(self, messageLayoutOptionsAt: indexPath) ?? .init()
     }
 
     /// Returns the content view class for the message at given `indexPath`

--- a/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
@@ -47,15 +47,6 @@ public extension ChatMessage {
         return isDeleted ? L10n.Message.deletedMessagePlaceholder : text
     }
 
-    /// A boolean value that checks if the message is visible for current user only.
-    var isOnlyVisibleForCurrentUser: Bool {
-        guard isSentByCurrentUser else {
-            return false
-        }
-
-        return isDeleted || type == .ephemeral
-    }
-
     /// Returns last active thread participant.
     var lastActiveThreadParticipant: ChatUser? {
         func sortingCriteriaDate(_ user: ChatUser) -> Date {
@@ -80,5 +71,21 @@ public extension ChatMessage {
     var shouldRenderAsJumbomoji: Bool {
         guard attachmentCounts.isEmpty, let textContent = textContent, !textContent.isEmpty else { return false }
         return textContent.count <= 3 && textContent.containsOnlyEmoji
+    }
+}
+
+public extension ChatMessage {
+    /// A boolean value that checks if the message is visible for current user only.
+    @available(
+        *,
+        deprecated,
+        message: "This property is deprecated because it does not take `deletedMessagesVisability` setting into account."
+    )
+    var isOnlyVisibleForCurrentUser: Bool {
+        guard isSentByCurrentUser else {
+            return false
+        }
+
+        return isDeleted || type == .ephemeral
     }
 }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -483,6 +483,7 @@
 		845CEE55270F1BDF002C7EBD /* SimpleChannelImageAttachmentsListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845CEE54270F1BDF002C7EBD /* SimpleChannelImageAttachmentsListController.swift */; };
 		845CEE57270F1D9C002C7EBD /* ImageAttachmentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845CEE56270F1D9C002C7EBD /* ImageAttachmentCell.swift */; };
 		845CEE5A270F2A06002C7EBD /* ChatReactionsBubbleView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845CEE59270F2A06002C7EBD /* ChatReactionsBubbleView_Tests.swift */; };
+		8479C7A92812FCC000FC8CFD /* ChatMessageListVC_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8479C7A82812FCC000FC8CFD /* ChatMessageListVC_Tests.swift */; };
 		847D60292679EDD300FB701D /* GalleryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847D60282679EDD300FB701D /* GalleryCollectionViewCell.swift */; };
 		847D602B2679EED400FB701D /* VideoAttachmentGalleryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847D602A2679EED400FB701D /* VideoAttachmentGalleryCell.swift */; };
 		847D602D2679EF8A00FB701D /* VideoPlaybackControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847D602C2679EF8A00FB701D /* VideoPlaybackControlView.swift */; };
@@ -2698,6 +2699,7 @@
 		845CEE59270F2A06002C7EBD /* ChatReactionsBubbleView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatReactionsBubbleView_Tests.swift; sourceTree = "<group>"; };
 		84698637274FE79200B22258 /* ConnectionRecoveryHandler_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionRecoveryHandler_Mock.swift; sourceTree = "<group>"; };
 		846C633B26FC834800F7518B /* MessageDeleted+MissingUser.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "MessageDeleted+MissingUser.json"; sourceTree = "<group>"; };
+		8479C7A82812FCC000FC8CFD /* ChatMessageListVC_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListVC_Tests.swift; sourceTree = "<group>"; };
 		847D60282679EDD300FB701D /* GalleryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryCollectionViewCell.swift; sourceTree = "<group>"; };
 		847D602A2679EED400FB701D /* VideoAttachmentGalleryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentGalleryCell.swift; sourceTree = "<group>"; };
 		847D602C2679EF8A00FB701D /* VideoPlaybackControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlaybackControlView.swift; sourceTree = "<group>"; };
@@ -6207,6 +6209,7 @@
 		A3960DED27DA2CF9003AB2B0 /* ChatMessageList */ = {
 			isa = PBXGroup;
 			children = (
+				8479C7A82812FCC000FC8CFD /* ChatMessageListVC_Tests.swift */,
 				E74DB0102655473300508D22 /* TypingIndicatorView_Tests.swift */,
 				A3960DEE27DA2D2F003AB2B0 /* Attachments */,
 				A3960DEF27DA2D4B003AB2B0 /* ChatMessage */,
@@ -8568,6 +8571,7 @@
 				2208241625DEE8070033544B /* ChatChannelListCollectionViewCell_Tests.swift in Sources */,
 				A3C0D774261CA25700A8A1A2 /* ContainerStackView_Tests.swift in Sources */,
 				CF8268B92800A54D00E300E7 /* ChatChannelHeaderView_Tests.swift in Sources */,
+				8479C7A92812FCC000FC8CFD /* ChatMessageListVC_Tests.swift in Sources */,
 				AD71130225F138BA00932AEE /* ChatChannelAvatarView_Tests.swift in Sources */,
 				BDDD1EA42632C66200BA007B /* Components+SwiftUI_Tests.swift in Sources */,
 				79567F2B266F5DB1007EADD3 /* TitleContainerView_Tests.swift in Sources */,

--- a/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
+++ b/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
@@ -94,11 +94,11 @@ class MessageListPage {
         }
         
         static func deletedIcon(messageCell: XCUIElement) -> XCUIElement {
-            messageCell.images["onlyVisibleForYouIconImageView"]
+            messageCell.images["onlyVisibleToYouImageView"]
         }
         
         static func deletedLabel(messageCell: XCUIElement) -> XCUIElement {
-            messageCell.staticTexts["onlyVisibleForYouLabel"]
+            messageCell.staticTexts["onlyVisibleToYouLabel"]
         }
         
     }

--- a/Tests/StreamChatUITests/ChatMessage_Tests.swift
+++ b/Tests/StreamChatUITests/ChatMessage_Tests.swift
@@ -351,62 +351,6 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertEqual(nonDeletedNonEphemeralMessage.textContent, nonDeletedNonEphemeralMessage.text)
     }
 
-    // MARK: - isOnlyVisibleForCurrentUser
-
-    func test_isOnlyVisibleForCurrentUser_whenMessageIsEphemeralAndSentByCurrentUser_returnsTrue() {
-        let ephemeralMessageFromCurrentUser: ChatMessage = .mock(
-            id: .unique,
-            cid: .unique,
-            text: .unique,
-            type: .ephemeral,
-            author: .mock(id: .unique),
-            isSentByCurrentUser: true
-        )
-
-        XCTAssertTrue(ephemeralMessageFromCurrentUser.isOnlyVisibleForCurrentUser)
-    }
-
-    func test_isOnlyVisibleForCurrentUser_whenMessageIsDeletedAndSentByCurrentUser_returnsTrue() {
-        let deletedMessageFromCurrentUser: ChatMessage = .mock(
-            id: .unique,
-            cid: .unique,
-            text: .unique,
-            author: .mock(id: .unique),
-            deletedAt: .unique,
-            isSentByCurrentUser: true
-        )
-
-        XCTAssertTrue(deletedMessageFromCurrentUser.isOnlyVisibleForCurrentUser)
-    }
-
-    func test_isOnlyVisibleForCurrentUser_whenMessageIsDeletedEphemeralAndSentByCurrentUser_returnsTrue() {
-        let deletedEphemeralMessageFromCurrentUser: ChatMessage = .mock(
-            id: .unique,
-            cid: .unique,
-            text: .unique,
-            type: .ephemeral,
-            author: .mock(id: .unique),
-            deletedAt: .unique,
-            isSentByCurrentUser: true
-        )
-
-        XCTAssertTrue(deletedEphemeralMessageFromCurrentUser.isOnlyVisibleForCurrentUser)
-    }
-
-    func test_isOnlyVisibleForCurrentUser_whenMessageIsSentNotByCurrentUser_returnsFalse() {
-        let deletedEphemeralMessageFromAnotherUser: ChatMessage = .mock(
-            id: .unique,
-            cid: .unique,
-            text: .unique,
-            type: .ephemeral,
-            author: .mock(id: .unique),
-            deletedAt: .unique,
-            isSentByCurrentUser: false
-        )
-
-        XCTAssertFalse(deletedEphemeralMessageFromAnotherUser.isOnlyVisibleForCurrentUser)
-    }
-
     // MARK: - isDeleted
 
     func test_isDeleted_whenMessageIsNotDeleted_returnsFalse() {

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
@@ -405,6 +405,7 @@ private extension ChatChannelVC_Tests {
             id: .unique,
             cid: .unique,
             text: text,
+            type: .deleted,
             author: .mock(id: .unique),
             deletedAt: Date(),
             isSentByCurrentUser: isSentByCurrentUser

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessage/ChatMessageContentView_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessage/ChatMessageContentView_Tests.swift
@@ -410,7 +410,7 @@ extension ChatMessage {
         if isLastInGroup {
             options.insert(.timestamp)
         }
-        if isLastInGroup && isOnlyVisibleForCurrentUser {
+        if isLastInGroup, isSentByCurrentUser, type == .deleted || type == .ephemeral {
             options.insert(.onlyVisibleForYouIndicator)
         }
         if textContent?.isEmpty == false {

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessage/ChatMessageContentView_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessage/ChatMessageContentView_Tests.swift
@@ -411,7 +411,7 @@ extension ChatMessage {
             options.insert(.timestamp)
         }
         if isLastInGroup, isSentByCurrentUser, type == .deleted || type == .ephemeral {
-            options.insert(.onlyVisibleForYouIndicator)
+            options.insert(.onlyVisibleToYouIndicator)
         }
         if textContent?.isEmpty == false {
             options.insert(.text)

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver_Tests.swift
@@ -346,7 +346,7 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
 
     // MARK: - Only visible for current user
 
-    func test_optionsForMessage_whenMessageIsNotSentByCurrentUser_doesNotIncludeOnlyVisibleForYouIndicator() {
+    func test_optionsForMessage_whenMessageIsNotSentByCurrentUser_doesNotIncludeOnlyVisibleToYouIndicator() {
         // Create ephemeral message sent by another user
         let messageSentByAnotherUser: ChatMessage = .mock(
             id: .unique,
@@ -364,11 +364,11 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
             appearance: appearance
         )
 
-        // Assert `.onlyVisibleForYouIndicator` is included
-        XCTAssertFalse(layoutOptions.contains(.onlyVisibleForYouIndicator))
+        // Assert `.onlyVisibleToYouIndicator` is included
+        XCTAssertFalse(layoutOptions.contains(.onlyVisibleToYouIndicator))
     }
 
-    func test_optionsForMessage_whenMessageSentByCurrentUserIsEphemeral_includesOnlyVisibleForYouIndicator() {
+    func test_optionsForMessage_whenMessageSentByCurrentUserIsEphemeral_includesOnlyVisibleToYouIndicator() {
         // Create ephemeral message sent by current user
         let ephemeralMessageSentByCurrentUser: ChatMessage = .mock(
             id: .unique,
@@ -387,11 +387,11 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
             appearance: appearance
         )
 
-        // Assert `.onlyVisibleForYouIndicator` is included
-        XCTAssertTrue(layoutOptions.contains(.onlyVisibleForYouIndicator))
+        // Assert `.onlyVisibleToYouIndicator` is included
+        XCTAssertTrue(layoutOptions.contains(.onlyVisibleToYouIndicator))
     }
     
-    func test_optionsForMessage_whenMessageSentByTheCurrentUserIsDeleted_includesOnlyVisibleForYouIndicator() {
+    func test_optionsForMessage_whenMessageSentByTheCurrentUserIsDeleted_includesOnlyVisibleToYouIndicator() {
         // Create ephemeral message sent by current user
         let deletedMessageSentByCurrentUser: ChatMessage = .mock(
             id: .unique,
@@ -416,11 +416,11 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
             appearance: appearance
         )
 
-        // Assert `.onlyVisibleForYouIndicator` is included
-        XCTAssertTrue(layoutOptions.contains(.onlyVisibleForYouIndicator))
+        // Assert `.onlyVisibleToYouIndicator` is included
+        XCTAssertTrue(layoutOptions.contains(.onlyVisibleToYouIndicator))
     }
     
-    func test_optionsForMessage_whenMessageSentByTheCurrentUserIsDeleted_doesNotIncludeOnlyVisibleForYouIndicator() {
+    func test_optionsForMessage_whenMessageSentByTheCurrentUserIsDeleted_doesNotIncludeOnlyVisibleToYouIndicator() {
         // Create ephemeral message sent by current user
         let deletedMessageSentByCurrentUser: ChatMessage = .mock(
             id: .unique,
@@ -446,8 +446,8 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
                 appearance: appearance
             )
 
-            // Assert `.onlyVisibleForYouIndicator` is not included
-            XCTAssertFalse(layoutOptions.contains(.onlyVisibleForYouIndicator))
+            // Assert `.onlyVisibleToYouIndicator` is not included
+            XCTAssertFalse(layoutOptions.contains(.onlyVisibleToYouIndicator))
         }
     }
 
@@ -1310,9 +1310,9 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
         )
     }
     
-    // MARK: - showOnlyVisibleForYouIndicator
+    // MARK: - showOnlyVisibleToYouIndicator
     
-    func test_showOnlyVisibleForYouIndicator_whenMessageIsSentByAnotherUser_returnsFalse() {
+    func test_showOnlyVisibleToYouIndicator_whenMessageIsSentByAnotherUser_returnsFalse() {
         let message: ChatMessage = .mock(
             id: .unique,
             cid: .unique,
@@ -1323,10 +1323,10 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
             isSentByCurrentUser: false
         )
 
-        XCTAssertFalse(optionsResolver.showOnlyVisibleForYouIndicator(for: message))
+        XCTAssertFalse(optionsResolver.showOnlyVisibleToYouIndicator(for: message))
     }
 
-    func test_showOnlyVisibleForYouIndicator_whenMessageIsEphemeralAndSentByCurrentUser_returnsTrue() {
+    func test_showOnlyVisibleToYouIndicator_whenMessageIsEphemeralAndSentByCurrentUser_returnsTrue() {
         let message: ChatMessage = .mock(
             id: .unique,
             cid: .unique,
@@ -1336,10 +1336,10 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
             isSentByCurrentUser: true
         )
 
-        XCTAssertTrue(optionsResolver.showOnlyVisibleForYouIndicator(for: message))
+        XCTAssertTrue(optionsResolver.showOnlyVisibleToYouIndicator(for: message))
     }
 
-    func test_showOnlyVisibleForYouIndicator_whenMessageIsDeletedAndSentByCurrentUser_returnsTrue() {
+    func test_showOnlyVisibleToYouIndicator_whenMessageIsDeletedAndSentByCurrentUser_returnsTrue() {
         let message: ChatMessage = .mock(
             id: .unique,
             cid: .unique,
@@ -1354,10 +1354,10 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
         config.deletedMessagesVisibility = .visibleForCurrentUser
         optionsResolver.config = config
 
-        XCTAssertTrue(optionsResolver.showOnlyVisibleForYouIndicator(for: message))
+        XCTAssertTrue(optionsResolver.showOnlyVisibleToYouIndicator(for: message))
     }
     
-    func test_showOnlyVisibleForYouIndicator_whenMessageIsDeletedAndSentByCurrentUser_returnsFalse() {
+    func test_showOnlyVisibleToYouIndicator_whenMessageIsDeletedAndSentByCurrentUser_returnsFalse() {
         let message: ChatMessage = .mock(
             id: .unique,
             cid: .unique,
@@ -1372,11 +1372,11 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
             config.deletedMessagesVisibility = deletedMessagesVisibility
             optionsResolver.config = config
             
-            XCTAssertFalse(optionsResolver.showOnlyVisibleForYouIndicator(for: message))
+            XCTAssertFalse(optionsResolver.showOnlyVisibleToYouIndicator(for: message))
         }
     }
     
-    func test_showOnlyVisibleForYouIndicator_whenMessageNotDeletedAndSentByCurrentUser_returnsFalse() {
+    func test_showOnlyVisibleToYouIndicator_whenMessageNotDeletedAndSentByCurrentUser_returnsFalse() {
         var config = ChatClientConfig(apiKey: .init(.unique))
         config.deletedMessagesVisibility = .visibleForCurrentUser
         optionsResolver.config = config
@@ -1392,7 +1392,7 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
                 isSentByCurrentUser: true
             )
                         
-            XCTAssertFalse(optionsResolver.showOnlyVisibleForYouIndicator(for: message))
+            XCTAssertFalse(optionsResolver.showOnlyVisibleToYouIndicator(for: message))
         }
     }
 }

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
@@ -1,0 +1,31 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+@testable import StreamChatTestTools
+@testable import StreamChatUI
+import XCTest
+
+final class ChatMessageListVC_Tests: XCTestCase {
+    func test_setUp_propagatesDeletedMessagesVisabilityToResolver() {
+        // GIVEN
+        var config = ChatClientConfig(apiKey: .init(.unique))
+        config.deletedMessagesVisibility = .alwaysHidden
+        
+        let sut = ChatMessageListVC()
+        sut.client = ChatClient(config: config)
+        sut.components = .mock
+        
+        XCTAssertNil(sut.components.messageLayoutOptionsResolver.config)
+        
+        // WHEN
+        sut.setUp()
+        
+        // THEN
+        XCTAssertEqual(
+            sut.components.messageLayoutOptionsResolver.config?.deletedMessagesVisibility,
+            config.deletedMessagesVisibility
+        )
+    }
+}

--- a/Tests/UISDKdocumentationTests/ChatMessageContentView_Documentation_Tests.swift
+++ b/Tests/UISDKdocumentationTests/ChatMessageContentView_Documentation_Tests.swift
@@ -69,9 +69,9 @@ class ChatMessageContentView_Documentation_Tests: XCTestCase {
                     .init(view: view.mainContainer, descriptionLabelPosition: .topLeft),
                     .init(view: view.authorAvatarView!, descriptionLabelPosition: .bottomLeft),
                     .init(view: view.reactionsBubbleView!, descriptionLabelPosition: .topRight),
-                    .init(view: view.bubbleThreadMetaContainer, descriptionLabelPosition: .bottomRight),
+                    .init(view: view.bubbleThreadFootnoteContainer, descriptionLabelPosition: .bottomRight),
                     .init(view: view.bubbleView!, lineColor: .systemTeal, descriptionLabelPosition: .top),
-                    .init(view: view.metadataContainer!, lineColor: .systemTeal, descriptionLabelPosition: .bottom),
+                    .init(view: view.footnoteContainer!, lineColor: .systemTeal, descriptionLabelPosition: .bottom),
                     .init(view: view.threadInfoContainer!, lineColor: .systemTeal, descriptionLabelPosition: .right)
                 ]
             },


### PR DESCRIPTION
### 🔗 Issue Links

Fixes: CIS-1724
Unblocks: CIS-1732

### 🎯 Goal

- Fix regression when `only visible for you` indicator is not shown for ephemeral messages
- Unblock CIS-1732. Handling deleted messages outside options resolver does not allow to write `ChatMessageContentView's` snapshot tests for deleted messages when visibility part is in `ChatMessageListVC`.

### 📝 Summary

- Fix `only visible for you` indicator missing for ephemeral message
- Fix `ChatMessageListVC's` lifecycle being triggered by assigning the delegate before it has a parent 
- `ChatMessage.isOnlyVisibleForCurrentUser` has been deprecated

### 🛠 Implementation

Move deleted message visibility check to `ChatMessageLayoutOptionsResolver`. Populate deleted messages setting on resolver from `chatClient.config` as the first thing on the message list.

### 🎨 Showcase

| Before | After |
| ------ | ----- |
| ![before](https://user-images.githubusercontent.com/12818985/164750704-a5409e83-a2ab-43f9-97d6-a83ef11717de.png) |  ![after 2](https://user-images.githubusercontent.com/12818985/164750898-e94bc867-efb1-48b4-bc83-3cce1eb3010a.png) |

### 🧪 Manual Testing Notes

**GIVEN** I'm in the channel 
**WHEN** I use `/giffy` command and send the message
**THEN** Ephemeral message with giffy picker appears in channel
**AND** Ephemeral message has `only visible to you` badge

**GIVEN** I'm in thread
**WHEN** I use `/giffy` command and send the thread reply
**THEN** Ephemeral reply with giffy picker appears in thread
**AND** Ephemeral reply has `only visible to you` badge

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/LSvPSsWLZnk6Aw29qw/giphy.gif)