### PR TITLE
[CIS-1794] Link UI tests to TestOps scenarios

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -12271,7 +12271,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift-test-helpers.git";
 			requirement = {
 				kind = revision;
-				revision = 81c9e470ebf07b624bcec84b336f9494c77a1717;
+				revision = 3c5b3ebc3b65a671b2bf890f2745190872a1fabd;
 			};
 		};
 		AD472EF625C425FB00A96E70 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/StreamChatUITestsAppUITests/MockServer/MessageResponses.swift
+++ b/StreamChatUITestsAppUITests/MockServer/MessageResponses.swift
@@ -323,15 +323,13 @@ extension StreamMockServer {
         let user = setUpUser(source: message, details: UserDetails.lukeSkywalker)
         let mockedMessage = mockDeletedMessage(message, user: user)
         
-        websocketDelay {
-            self.websocketMessage(
-                channelId: channelId,
-                messageId: messageId,
-                timestamp: timestamp,
-                eventType: .messageDeleted,
-                user: user
-            )
-        }
+        websocketMessage(
+            channelId: channelId,
+            messageId: messageId,
+            timestamp: timestamp,
+            eventType: .messageDeleted,
+            user: user
+        )
         
         json[TopLevelKey.message] = mockedMessage
         return .ok(.json(json))

--- a/StreamChatUITestsAppUITests/MockServer/WebsocketResponses.swift
+++ b/StreamChatUITestsAppUITests/MockServer/WebsocketResponses.swift
@@ -13,7 +13,7 @@ extension StreamMockServer {
     /// - Parameters: Void
     /// - Returns: Self
     func websocketDelay(closure: @escaping () -> Void) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             closure()
         }
     }

--- a/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
@@ -6,13 +6,20 @@ import XCTest
 
 final class MessageList_Tests: StreamTestCase {
     
-    func test_sendsMessage() throws {
-        let message = "test message"
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        addTags([.general])
+    }
+    
+    func test_sendsMessageWithOneEmoji() throws {
+        linkToScenario(withId: 63)
+        
+        let message = "🍏"
         
         GIVEN("user opens the channel") {
             userRobot.login().openChannel()
         }
-        WHEN("user sends the message: '\(message)'") {
+        WHEN("user sends the emoji: '\(message)'") {
             userRobot.sendMessage(message)
         }
         THEN("the message is delivered") {
@@ -21,6 +28,8 @@ final class MessageList_Tests: StreamTestCase {
     }
 
     func test_editsMessage() throws {
+        linkToScenario(withId: 39)
+        
         let message = "test message"
         let editedMessage = "hello"
         
@@ -39,6 +48,8 @@ final class MessageList_Tests: StreamTestCase {
     }
     
     func test_deletesMessage() throws {
+        linkToScenario(withId: 37)
+        
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -56,13 +67,15 @@ final class MessageList_Tests: StreamTestCase {
     }
     
     func test_receivesMessage() throws {
-        let message = "test message"
+        linkToScenario(withId: 64)
+        
+        let message = "🚢"
         let author = "Han Solo"
         
         GIVEN("user opens the channel") {
             userRobot.login().openChannel()
         }
-        WHEN("participant sends the message: '\(message)'") {
+        WHEN("participant sends the emoji: '\(message)'") {
             participantRobot
                 .startTyping()
                 .stopTyping()
@@ -76,6 +89,8 @@ final class MessageList_Tests: StreamTestCase {
     }
     
     func test_messageDeleted_whenParticipantDeletesMessage() throws {
+        linkToScenario(withId: 38)
+        
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -98,6 +113,8 @@ final class MessageList_Tests: StreamTestCase {
     }
     
     func test_messageIsEdited_whenParticipantEditsMessage() throws {
+        linkToScenario(withId: 40)
+        
         let message = "test message"
         let editedMessage = "hello"
         

--- a/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
@@ -8,7 +8,7 @@ final class MessageList_Tests: StreamTestCase {
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        addTags([.general])
+        addTags([.coreFeatures])
     }
     
     func test_sendsMessageWithOneEmoji() throws {

--- a/StreamChatUITestsAppUITests/Tests/Reactions_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Reactions_Tests.swift
@@ -6,7 +6,14 @@ import XCTest
 
 final class Reactions_Tests: StreamTestCase {
     
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        addTags([.general])
+    }
+    
     func test_addsReaction() throws {
+        linkToScenario(withId: 41)
+        
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -24,6 +31,8 @@ final class Reactions_Tests: StreamTestCase {
     }
     
     func test_deletesReaction() throws {
+        linkToScenario(withId: 45)
+        
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -46,6 +55,8 @@ final class Reactions_Tests: StreamTestCase {
     }
     
     func test_reactionIsAdded_whenReactingToParticipantsMessage() throws {
+        linkToScenario(withId: 42)
+        
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -69,6 +80,8 @@ final class Reactions_Tests: StreamTestCase {
     }
     
     func test_removesReaction_whenUnReactingToParticipantsMessage() throws {
+        linkToScenario(withId: 46)
+        
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -95,6 +108,8 @@ final class Reactions_Tests: StreamTestCase {
     }
     
     func test_reactionIsAddedByParticipant_whenReactingToUsersMessage() throws {
+        linkToScenario(withId: 43)
+        
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -115,6 +130,8 @@ final class Reactions_Tests: StreamTestCase {
     }
 
     func test_reactionIsRemovedByParticipant_whenUnReactingToUsersMessage() throws {
+        linkToScenario(withId: 47)
+        
         let message = "test message"
         
         GIVEN("user opens the channel") {
@@ -125,12 +142,59 @@ final class Reactions_Tests: StreamTestCase {
         }
         AND("participant adds the reaction") {
             participantRobot
+                .waitForNewMessage(withText: message)
                 .readMessage()
                 .addReaction(type: .lol)
                 .waitForNewReaction()
         }
         AND("participant removes the reaction") {
             participantRobot.deleteReaction(type: .lol)
+        }
+        THEN("the reaction is removed") {
+            participantRobot.assertReaction(isPresent: false)
+        }
+    }
+    
+    func test_reactionIsAddedByParticipant_whenReactingToOwnMessage() throws {
+        linkToScenario(withId: 44)
+        
+        let message = "test message"
+        
+        GIVEN("user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        WHEN("participant sends the message: '\(message)'") {
+            participantRobot
+                .sendMessage(message)
+                .waitForNewMessage(withText: message)
+        }
+        AND("participant adds the reaction") {
+            participantRobot.addReaction(type: .wow)
+        }
+        THEN("the reaction is added") {
+            participantRobot.assertReaction(isPresent: true)
+        }
+    }
+    
+    func test_reactionIsRemovedByParticipant_whenUnReactingToOwnMessage() throws {
+        linkToScenario(withId: 48)
+        
+        let message = "test message"
+        
+        GIVEN("user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        WHEN("participant sends the message: '\(message)'") {
+            participantRobot.sendMessage(message)
+        }
+        AND("participant adds the reaction") {
+            participantRobot
+                .waitForNewMessage(withText: message)
+                .addReaction(type: .sad)
+                .waitForNewReaction()
+        }
+        AND("participant removes the reaction") {
+            participantRobot.deleteReaction(type: .sad)
         }
         THEN("the reaction is removed") {
             participantRobot.assertReaction(isPresent: false)

--- a/StreamChatUITestsAppUITests/Tests/Reactions_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Reactions_Tests.swift
@@ -8,7 +8,7 @@ final class Reactions_Tests: StreamTestCase {
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        addTags([.general])
+        addTags([.coreFeatures])
     }
     
     func test_addsReaction() throws {

--- a/StreamChatUITestsAppUITests/Tests/StreamTestCase.swift
+++ b/StreamChatUITestsAppUITests/Tests/StreamTestCase.swift
@@ -42,7 +42,7 @@ class StreamTestCase: XCTestCase {
 extension StreamTestCase {
     
     enum Tags: String {
-        case general
+        case coreFeatures = "Core Features"
         case offlineSupport = "Offline Support"
         case messageReceipts = "Message Receipts"
     }

--- a/StreamChatUITestsAppUITests/Tests/StreamTestCase.swift
+++ b/StreamChatUITestsAppUITests/Tests/StreamTestCase.swift
@@ -40,6 +40,16 @@ class StreamTestCase: XCTestCase {
 }
 
 extension StreamTestCase {
+    
+    enum Tags: String {
+        case general
+        case offlineSupport = "Offline Support"
+        case messageReceipts = "Message Receipts"
+    }
+    
+    func addTags(_ tags: [Tags]) {
+        addTagsToScenario(tags.map{ $0.rawValue })
+    }
 
     private func useMockServer() {
         // Leverage web socket server


### PR DESCRIPTION
### 🔗 Issue Links

- https://stream-io.atlassian.net/browse/CIS-1794

### 🎯 Goal

The goal is to link the tests in the source code to TestOps scenarios

### 📝 Summary

- Provided a way to add a TestOps `id` to the test:

```swift
    func test_sendsMessage() throws {
        linkToScenario(withId: 3)
        
        let message = "test message"
        
        GIVEN("user opens the channel") {
            userRobot.login().openChannel()
        }
        WHEN("user sends the message: '\(message)'") {
            userRobot.sendMessage(message)
        }
        THEN("the message is delivered") {
            userRobot.assertMessage(message)
        }
    }
```

- Provided a way to add the tags to any test suites or test cases:

```swift
    override func setUpWithError() throws {
        try super.setUpWithError()
        addTags([.messageReceipts])
    }
```

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/UIUaD8DbQm2NIFU771/giphy.gif)
