### PR TITLE
Add `nonEmpty` filter for channel list query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Rename components related to message footnote content in `ChatMessageContentView` [#1948](https://github.com/GetStream/stream-chat-swift/pull/1948)
 ### ✅ Added
 - Add support for custom reactions sorting [#1944](https://github.com/GetStream/stream-chat-swift/pull/1944)
+- Add `nonEmpty` filter for channel list query [#1960](https://github.com/GetStream/stream-chat-swift/pull/1960)
 ### 🐞 Fixed
 - Fix `onlyVisibleForYouIndicator` not being shown for ephemeral messages [#1948](https://github.com/GetStream/stream-chat-swift/pull/1948)
 

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -15,6 +15,11 @@ public extension Filter where Scope: AnyChannelListFilterScope {
     static func containMembers(userIds: [UserId]) -> Filter<Scope> {
         .in(.members, values: userIds)
     }
+    
+    /// Filter to match channels containing at least one message.
+    static var nonEmpty: Filter<Scope> {
+        .greater(.lastMessageAt, than: Date(timeIntervalSince1970: 0))
+    }
 }
 
 extension Filter where Scope: AnyChannelListFilterScope {


### PR DESCRIPTION
### 🎯 Goal

Provide a convenient way to exclude empty channels from the channel list query. 

### 📝 Summary

Add `nonEmpty` filter.

### 🧪 Manual Testing Notes

Update the controller creation code to be:
```
controller = ChatClient.shared.channelListController(
    query: .init(
        filter: .and([
            .containMembers(userIds: [userCredentials.id]),
            .nonEmpty
        ])
    ),
    filter: { channel in
        channel.membership != nil && channel.lastMessageAt != nil
    }
)
```

1. Apply the code snippet above to `DemoAppCoodrinator`
1. Run `DemoApp`
1. Sign in as any user 
1. Create an empty group channel

**Expected result:**
Created group channel does not appear in channel list as it's empty

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)