### PR TITLE
[CIS-1770] Move slack url to smoke-checks workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -46,5 +46,4 @@ jobs:
         env:
           GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: bundle exec fastlane publish_release version:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -86,6 +86,7 @@ jobs:
     - name: Run Sonar analysis
       run: bundle exec fastlane sonar_upload
       env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         PR_NUMBER: ${{ github.event.number }}
     - uses: 8398a7/action-slack@v3


### PR DESCRIPTION
### 🔗 Issue Links

- https://stream-io.atlassian.net/browse/CIS-1770

### 📝 Summary

Fixing an issue when Sonar can't post Slack messages due to a lack of webhook url.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
