### PR TITLE
Adds a way to query for channels with no teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChat
 ### 🔄 Changed
-- Changes `.team` filter `FilterKey` to accept `nil` as a parameter
+- Changes `.team` filter `FilterKey` to accept `nil` as a parameter  [#1968](https://github.com/GetStream/stream-chat-swift/pull/1968)
 
 ## StreamChatUI
 ### ✅ Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Rename `mentionedMessages` to `mentions` in `ChannelUnreadCount` [#1978](https://github.com/GetStream/stream-chat-swift/issues/1978)
 
+## StreamChat
+### 🔄 Changed
+- Changes `.team` filter `FilterKey` to accept `nil` as a parameter
+
 ## StreamChatUI
 ### ✅ Added
 - Show delivery status indicator for messages sent by the current user. [#1887](https://github.com/GetStream/stream-chat-swift/issues/1887)

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -81,7 +81,7 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
     static var memberCount: FilterKey<Scope, Int> { "member_count" }
     
     /// A filter key for matching the `team` value.
-    static var team: FilterKey<Scope, TeamId> { "team" }
+    static var team: FilterKey<Scope, TeamId?> { "team" }
 }
 
 /// A query is used for querying specific channels from backend.

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -20,6 +20,11 @@ public extension Filter where Scope: AnyChannelListFilterScope {
     static var nonEmpty: Filter<Scope> {
         .greater(.lastMessageAt, than: Date(timeIntervalSince1970: 0))
     }
+    
+    /// Filter to match channels that are not related to any team.
+    static var noTeam: Filter<Scope> {
+        .equal(.team, to: nil)
+    }
 }
 
 extension Filter where Scope: AnyChannelListFilterScope {

--- a/Sources/StreamChat/Query/Filter.swift
+++ b/Sources/StreamChat/Query/Filter.swift
@@ -67,6 +67,7 @@ public protocol FilterValue: Encodable {}
 
 // Built-in `FilterValue` conformances for supported types
 
+extension Optional: FilterValue where Wrapped == String {}
 extension String: FilterValue {}
 extension Int: FilterValue {}
 extension Double: FilterValue {}

--- a/Sources/StreamChat/Query/Filter.swift
+++ b/Sources/StreamChat/Query/Filter.swift
@@ -67,7 +67,6 @@ public protocol FilterValue: Encodable {}
 
 // Built-in `FilterValue` conformances for supported types
 
-extension Optional: FilterValue where Wrapped == String {}
 extension String: FilterValue {}
 extension Int: FilterValue {}
 extension Double: FilterValue {}
@@ -83,6 +82,7 @@ extension ChannelId: FilterValue {}
 extension ChannelType: FilterValue {}
 extension UserRole: FilterValue {}
 extension AttachmentType: FilterValue {}
+extension Optional: FilterValue where Wrapped == TeamId {}
 
 /// Filter is used to specify the details about which elements should be returned from a specific query.
 ///

--- a/Tests/StreamChatTests/Query/ChannelListFilterScope_Tests.swift
+++ b/Tests/StreamChatTests/Query/ChannelListFilterScope_Tests.swift
@@ -80,4 +80,10 @@ final class ChannelListFilterScope_Tests: XCTestCase {
 
         XCTAssertEqual(query.debugDescription, "Filter: members IN [\"theid\"] | Sort: [cid:-1]")
     }
+    
+    func test_teamId_nilValue() {
+        let query = ChannelListQuery(filter: .equal(.team, to: nil))
+        
+        XCTAssertEqual(query.debugDescription, "Filter: team == nil | Sort: []")
+    }
 }

--- a/Tests/StreamChatTests/Query/ChannelListFilterScope_Tests.swift
+++ b/Tests/StreamChatTests/Query/ChannelListFilterScope_Tests.swift
@@ -32,6 +32,13 @@ final class ChannelListFilterScope_Tests: XCTestCase {
             Filter<ChannelListFilterScope>.in(.members, values: ids)
         )
     }
+    
+    func test_noTeam_helper() {
+        XCTAssertEqual(
+            Filter<ChannelListFilterScope>.noTeam,
+            Filter<ChannelListFilterScope>.equal(.team, to: nil)
+        )
+    }
 
     func test_safeSorting_added() {
         // Sortings without safe option
@@ -79,11 +86,5 @@ final class ChannelListFilterScope_Tests: XCTestCase {
         )
 
         XCTAssertEqual(query.debugDescription, "Filter: members IN [\"theid\"] | Sort: [cid:-1]")
-    }
-    
-    func test_teamId_nilValue() {
-        let query = ChannelListQuery(filter: .equal(.team, to: nil))
-        
-        XCTAssertEqual(query.debugDescription, "Filter: team == nil | Sort: []")
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Our web team uses these filters for one of the chats in our product:

```
{
   type: 'messaging',
   team: { $eq: null },
   members: {
     $in: [store.me?.id!]
   }
}
```

It is currently not possible to do this with the Swift SDK, as `.team` is a `FilterKey<Scope, TeamId>`and as such, can't take in `nil` as a parameter. This PR aims to change that behavior.

Another example of this use can be seen in [the docs](https://getstream.io/chat/docs/ios-swift/multi_tenant_chat/?language=javascript#query-channels)

### 📝 Summary

* Changes `.team` in `FilterKey`'s extension to `FilterKey<Scope, TeamId?>`
* Adds an extension to `Optional` to conform to `FilterValue` when its `Wrapped` is `TeamId`

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![giphy](https://user-images.githubusercontent.com/5796060/166327988-23258ad6-4281-4966-986a-8d8670cad082.gif)

