### PR TITLE
[CIS-1763] Fix unread counts bumping logic 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### 🐞 Fixed
+- Fix unread messages count bumping logic [#1978](https://github.com/GetStream/stream-chat-swift/issues/1978)
+    - respect muted channels
+    - respect muted users
+    - decrement when message is hard deleted
+### 🔄 Changed
+- Rename `mentionedMessages` to `mentions` in `ChannelUnreadCount` [#1978](https://github.com/GetStream/stream-chat-swift/issues/1978)
+
 ## StreamChatUI
 ### 🔄 Changed
 - Deprecate `ChatMessage.isOnlyVisibleForCurrentUser` as it does not account deleted messages visability setting [#1948](https://github.com/GetStream/stream-chat-swift/pull/1948)

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1054,13 +1054,6 @@ public extension ChatChannelController {
             channelFeatureDisabled(feature: "read events", completion: completion)
             return
         }
-        
-        guard channel?.isUnread == true else {
-            callback {
-                completion?(nil)
-            }
-            return
-        }
 
         guard let currentUserId = client.currentUserId else {
             callback {

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -57,7 +57,10 @@ class ChannelDTO: NSManagedObject {
     @NSManaged var reads: Set<ChannelReadDTO>
     @NSManaged var watchers: Set<UserDTO>
     @NSManaged var memberListQueries: Set<ChannelMemberListQueryDTO>
-
+    
+    /// If the current channel is muted by the current user, `mute` contains details.
+    @NSManaged var mute: ChannelMuteDTO?
+    
     override func willSave() {
         super.willSave()
 
@@ -393,11 +396,8 @@ extension ChatChannel {
         }
 
         let fetchMuteDetails: () -> MuteDetails? = {
-            guard
-                let currentUser = context.currentUser,
-                let mute = ChannelMuteDTO.load(cid: cid, userId: currentUser.user.id, context: context)
-            else { return nil }
-
+            guard let mute = dto.mute else { return nil }
+            
             return .init(
                 createdAt: mute.createdAt,
                 updatedAt: mute.updatedAt

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -351,8 +351,8 @@ extension ChatChannel {
             
             // Fetch count of all mentioned messages after last read
             // (this is not 100% accurate but it's the best we have)
-            let mentionedUnreadMessagesRequest = NSFetchRequest<MessageDTO>(entityName: MessageDTO.entityName)
-            mentionedUnreadMessagesRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            let unreadMentionsRequest = NSFetchRequest<MessageDTO>(entityName: MessageDTO.entityName)
+            unreadMentionsRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
                 MessageDTO.channelMessagesPredicate(
                     for: dto.cid,
                     deletedMessagesVisibility: context.deletedMessagesVisibility ?? .visibleForCurrentUser,
@@ -365,7 +365,7 @@ extension ChatChannel {
             do {
                 return ChannelUnreadCount(
                     messages: allUnreadMessages,
-                    mentionedMessages: try context.count(for: mentionedUnreadMessagesRequest)
+                    mentions: try context.count(for: unreadMentionsRequest)
                 )
             } catch {
                 log.error("Failed to fetch unread counts for channel `\(cid)`. Error: \(error)")

--- a/Sources/StreamChat/Database/DTOs/ChannelMuteDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelMuteDTO.swift
@@ -8,7 +8,7 @@ import Foundation
 @objc(ChannelMuteDTO)
 final class ChannelMuteDTO: NSManagedObject {
     @NSManaged var createdAt: Date
-    @NSManaged var updatedAt: Date?
+    @NSManaged var updatedAt: Date
     @NSManaged var channel: ChannelDTO
     @NSManaged var user: UserDTO
 

--- a/Sources/StreamChat/Database/DTOs/ChannelMuteDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelMuteDTO.swift
@@ -11,71 +11,38 @@ final class ChannelMuteDTO: NSManagedObject {
     @NSManaged var updatedAt: Date
     @NSManaged var channel: ChannelDTO
     @NSManaged var currentUser: CurrentUserDTO
-
-    static func fetchRequest(userId: String) -> NSFetchRequest<ChannelMuteDTO> {
-        let request = NSFetchRequest<ChannelMuteDTO>(entityName: ChannelMuteDTO.entityName)
-        request.predicate = NSPredicate(format: "user.id == %@", userId)
-        return request
-    }
-
+    
     static func fetchRequest(for cid: ChannelId) -> NSFetchRequest<ChannelMuteDTO> {
         let request = NSFetchRequest<ChannelMuteDTO>(entityName: ChannelMuteDTO.entityName)
         request.predicate = NSPredicate(format: "channel.cid == %@", cid.rawValue)
         return request
     }
-
-    static func fetchRequest(for cid: ChannelId, userId: String) -> NSFetchRequest<ChannelMuteDTO> {
-        let request = NSFetchRequest<ChannelMuteDTO>(entityName: ChannelMuteDTO.entityName)
-        request.predicate = NSPredicate(format: "channel.cid == %@ && user.id == %@", cid.rawValue, userId)
-        return request
-    }
-
-    static func load(userId: String, context: NSManagedObjectContext) -> [ChannelMuteDTO] {
-        load(by: fetchRequest(userId: userId), context: context)
-    }
-
-    static func load(cid: ChannelId, context: NSManagedObjectContext) -> [ChannelMuteDTO] {
-        load(by: fetchRequest(for: cid), context: context)
-    }
-
-    static func load(cid: ChannelId, userId: String, context: NSManagedObjectContext) -> ChannelMuteDTO? {
-        load(by: fetchRequest(for: cid, userId: userId), context: context).first
-    }
-
-    static func loadOrCreate(cid: ChannelId, userId: String, context: NSManagedObjectContext) -> ChannelMuteDTO {
-        if let existing = load(cid: cid, userId: userId, context: context) {
-            return existing
-        }
-
-        let new = NSEntityDescription.insertNewObject(forEntityName: Self.entityName, into: context) as! ChannelMuteDTO
-        new.channel = ChannelDTO.loadOrCreate(cid: cid, context: context)
-        new.user = UserDTO.loadOrCreate(id: userId, context: context)
-        return new
+    
+    static func load(cid: ChannelId, context: NSManagedObjectContext) -> ChannelMuteDTO? {
+        load(by: fetchRequest(for: cid), context: context).first
     }
 }
 
 extension NSManagedObjectContext {
     @discardableResult
     func saveChannelMute(payload: MutedChannelPayload) throws -> ChannelMuteDTO {
-        let dto = ChannelMuteDTO.loadOrCreate(cid: payload.mutedChannel.cid, userId: payload.user.id, context: self)
-
-        dto.user = try saveUser(payload: payload.user)
-        dto.channel = try saveChannel(payload: payload.mutedChannel, query: nil)
+        guard let currentUser = currentUser else {
+            throw ClientError.CurrentUserDoesNotExist()
+        }
+        
+        let channel = try saveChannel(payload: payload.mutedChannel, query: nil)
+        
+        let dto: ChannelMuteDTO
+        if let existing = ChannelMuteDTO.load(cid: payload.mutedChannel.cid, context: self) {
+            dto = existing
+        } else {
+            dto = NSEntityDescription.insertNewObject(forEntityName: ChannelMuteDTO.entityName, into: self) as! ChannelMuteDTO
+        }
+        dto.channel = channel
+        dto.currentUser = currentUser
         dto.createdAt = payload.createdAt
         dto.updatedAt = payload.updatedAt
 
         return dto
-    }
-
-    func loadChannelMute(cid: ChannelId, userId: String) -> ChannelMuteDTO? {
-        ChannelMuteDTO.load(cid: cid, userId: userId, context: self)
-    }
-
-    func loadChannelMutes(for userId: UserId) -> [ChannelMuteDTO] {
-        ChannelMuteDTO.load(userId: userId, context: self)
-    }
-
-    func loadChannelMutes(for cid: ChannelId) -> [ChannelMuteDTO] {
-        ChannelMuteDTO.load(cid: cid, context: self)
     }
 }

--- a/Sources/StreamChat/Database/DTOs/ChannelMuteDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelMuteDTO.swift
@@ -10,7 +10,7 @@ final class ChannelMuteDTO: NSManagedObject {
     @NSManaged var createdAt: Date
     @NSManaged var updatedAt: Date
     @NSManaged var channel: ChannelDTO
-    @NSManaged var user: UserDTO
+    @NSManaged var currentUser: CurrentUserDTO
 
     static func fetchRequest(userId: String) -> NSFetchRequest<ChannelMuteDTO> {
         let request = NSFetchRequest<ChannelMuteDTO>(entityName: ChannelMuteDTO.entityName)

--- a/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
@@ -20,6 +20,7 @@ class CurrentUserDTO: NSManagedObject {
     @NSManaged var user: UserDTO
     @NSManaged var devices: Set<DeviceDTO>
     @NSManaged var currentDevice: DeviceDTO?
+    @NSManaged var channelMutes: Set<ChannelMuteDTO>
     
     /// Returns a default fetch request for the current user.
     static var defaultFetchRequest: NSFetchRequest<CurrentUserDTO> {
@@ -188,11 +189,7 @@ extension CurrentChatUser {
         let flaggedMessagesIDs: [MessageId] = dto.flaggedMessages.map(\.id)
 
         let fetchMutedChannels: () -> Set<ChatChannel> = {
-            Set(
-                ChannelMuteDTO
-                    .load(userId: user.id, context: context)
-                    .map { $0.channel.asModel() }
-            )
+            Set(dto.channelMutes.map { $0.channel.asModel() })
         }
 
         return CurrentChatUser(

--- a/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/CurrentUserDTO.swift
@@ -69,10 +69,11 @@ extension NSManagedObjectContext: CurrentUserDatabaseSession {
         let mutedUsers = try payload.mutedUsers.map { try saveUser(payload: $0.mutedUser) }
         dto.mutedUsers = Set(mutedUsers)
 
-        dto.user.channelMutes.forEach { delete($0) }
-        dto.user.channelMutes = Set(
+        let channelMutes = Set(
             try payload.mutedChannels.map { try saveChannelMute(payload: $0) }
         )
+        dto.channelMutes.subtracting(channelMutes).forEach { delete($0) }
+        dto.channelMutes = channelMutes
         
         if let unreadCount = payload.unreadCount {
             try saveCurrentUserUnreadCount(count: unreadCount)

--- a/Sources/StreamChat/Database/DTOs/UserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/UserDTO.swift
@@ -24,7 +24,6 @@ class UserDTO: NSManagedObject {
     @NSManaged var members: Set<MemberDTO>?
     @NSManaged var currentUser: CurrentUserDTO?
     @NSManaged var teams: [TeamId]
-    @NSManaged var channelMutes: Set<ChannelMuteDTO>
 
     /// Returns a fetch request for the dto with the provided `userId`.
     static func user(withID userId: UserId) -> NSFetchRequest<UserDTO> {

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -255,16 +255,6 @@ protocol ChannelMuteDatabaseSession {
     /// Creates a new `ChannelMuteDTO` object in the database. Throws an error if the `ChannelMuteDTO` fails to be created.
     @discardableResult
     func saveChannelMute(payload: MutedChannelPayload) throws -> ChannelMuteDTO
-
-    /// Fetches `ChannelMuteDTO` with the given `cid` and `userId` from the DB.
-    /// Returns `nil` if no `ChannelMuteDTO` matching the `cid` and `userId`  exists.
-    func loadChannelMute(cid: ChannelId, userId: String) -> ChannelMuteDTO?
-
-    /// Fetches `ChannelMuteDTO` entities for the given `userId` from the DB.
-    func loadChannelMutes(for userId: UserId) -> [ChannelMuteDTO]
-
-    /// Fetches `ChannelMuteDTO` entities for the given `cid` from the DB.
-    func loadChannelMutes(for cid: ChannelId) -> [ChannelMuteDTO]
 }
 
 protocol MemberDatabaseSession {

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -58,7 +58,7 @@
         <relationship name="members" toMany="YES" deletionRule="Nullify" destinationEntity="MemberDTO" inverseName="channel" inverseEntity="MemberDTO"/>
         <relationship name="membership" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MemberDTO" inverseName="membershipChannel" inverseEntity="MemberDTO"/>
         <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="channel" inverseEntity="MessageDTO"/>
-        <relationship name="mutes" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelMuteDTO" inverseName="channel" inverseEntity="ChannelMuteDTO"/>
+        <relationship name="mute" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelMuteDTO" inverseName="channel" inverseEntity="ChannelMuteDTO"/>
         <relationship name="pinnedMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="pinnedChannel" inverseEntity="MessageDTO"/>
         <relationship name="queries" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelListQueryDTO" inverseName="channels" inverseEntity="ChannelListQueryDTO"/>
         <relationship name="reads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelReadDTO" inverseName="channel" inverseEntity="ChannelReadDTO"/>
@@ -108,8 +108,8 @@
     <entity name="ChannelMuteDTO" representedClassName="ChannelMuteDTO" syncable="YES">
         <attribute name="createdAt" attributeType="Date" defaultDateTimeInterval="0" usesScalarValueType="NO"/>
         <attribute name="updatedAt" attributeType="Date" defaultDateTimeInterval="0" usesScalarValueType="NO"/>
-        <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="mutes" inverseEntity="ChannelDTO"/>
-        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="channelMutes" inverseEntity="UserDTO"/>
+        <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="mute" inverseEntity="ChannelDTO"/>
+        <relationship name="currentUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CurrentUserDTO" inverseName="channelMutes" inverseEntity="CurrentUserDTO"/>
     </entity>
     <entity name="ChannelReadDTO" representedClassName="ChannelReadDTO" syncable="YES">
         <attribute name="lastReadAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -129,6 +129,7 @@
         <attribute name="uniquenessKey" attributeType="String" defaultValueString="this is an immmutable arbitrary key which makes sure we have only once instance of CurrentUserDTO in the db"/>
         <attribute name="unreadChannelsCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="unreadMessagesCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="channelMutes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ChannelMuteDTO" inverseName="currentUser" inverseEntity="ChannelMuteDTO"/>
         <relationship name="currentDevice" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DeviceDTO" inverseName="relationship" inverseEntity="DeviceDTO"/>
         <relationship name="devices" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DeviceDTO" inverseName="user" inverseEntity="DeviceDTO"/>
         <relationship name="flaggedMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="flaggedBy" inverseEntity="MessageDTO"/>
@@ -285,7 +286,6 @@
         <attribute name="userCreatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="userRoleRaw" attributeType="String"/>
         <attribute name="userUpdatedAt" attributeType="Date" usesScalarValueType="NO"/>
-        <relationship name="channelMutes" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelMuteDTO" inverseName="user" inverseEntity="ChannelMuteDTO"/>
         <relationship name="channelReads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelReadDTO" inverseName="user" inverseEntity="ChannelReadDTO"/>
         <relationship name="createdChannels" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="createdBy" inverseEntity="ChannelDTO"/>
         <relationship name="currentUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CurrentUserDTO" inverseName="user" inverseEntity="CurrentUserDTO"/>

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21D49" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21A559" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
@@ -106,8 +106,8 @@
         </uniquenessConstraints>
     </entity>
     <entity name="ChannelMuteDTO" representedClassName="ChannelMuteDTO" syncable="YES">
-        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="createdAt" attributeType="Date" defaultDateTimeInterval="0" usesScalarValueType="NO"/>
+        <attribute name="updatedAt" attributeType="Date" defaultDateTimeInterval="0" usesScalarValueType="NO"/>
         <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChannelDTO" inverseName="mutes" inverseEntity="ChannelDTO"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserDTO" inverseName="channelMutes" inverseEntity="UserDTO"/>
     </entity>

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -251,8 +251,8 @@ public struct ChannelUnreadCount: Decodable, Equatable {
     public static let noUnread = ChannelUnreadCount(messages: 0, mentionedMessages: 0)
     
     /// The total number of unread messages in the channel.
-    public internal(set) var messages: Int
+    public let messages: Int
     
     /// The number of unread messages that mention the current user.
-    public internal(set) var mentionedMessages: Int
+    public let mentionedMessages: Int
 }

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -248,11 +248,16 @@ extension ChatChannel: Hashable {
 /// A struct describing unread counts for a channel.
 public struct ChannelUnreadCount: Decodable, Equatable {
     /// The default value representing no unread messages.
-    public static let noUnread = ChannelUnreadCount(messages: 0, mentionedMessages: 0)
+    public static let noUnread = ChannelUnreadCount(messages: 0, mentions: 0)
     
     /// The total number of unread messages in the channel.
     public let messages: Int
     
     /// The number of unread messages that mention the current user.
-    public let mentionedMessages: Int
+    public let mentions: Int
+}
+
+public extension ChannelUnreadCount {
+    @available(*, deprecated, renamed: "mentions")
+    var mentionedMessages: Int { mentions }
 }

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -227,8 +227,8 @@ extension ChatChannel {
     /// so backend creates a `cid` based on member's `id`s
     public var isDirectMessageChannel: Bool { cid.id.hasPrefix("!members") }
     
-    /// returns `true` if the channel has one or more unread messages for the current user.
-    public var isUnread: Bool { unreadCount.messages > 0 }
+    /// Returns `true` if the channel has one or more unread messages for the current user.
+    public var isUnread: Bool { unreadCount != .noUnread }
 }
 
 /// A type-erased version of `ChannelModel<CustomData>`. Not intended to be used directly.

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware.swift
@@ -9,16 +9,22 @@ struct ChannelReadUpdaterMiddleware: EventMiddleware {
     func handle(event: Event, session: DatabaseSession) -> Event? {
         switch event {
         case let event as MessageNewEventDTO:
-            increaseUnreadCountIfNeeded(
+            incrementUnreadCountIfNeeded(
                 for: event.cid,
                 message: event.message,
                 session: session
             )
 
         case let event as NotificationMessageNewEventDTO:
-            increaseUnreadCountIfNeeded(
+            incrementUnreadCountIfNeeded(
                 for: event.channel.cid,
                 message: event.message,
+                session: session
+            )
+        
+        case let event as MessageDeletedEventDTO:
+            decrementUnreadCountIfNeeded(
+                event: event,
                 session: session
             )
             
@@ -50,36 +56,136 @@ struct ChannelReadUpdaterMiddleware: EventMiddleware {
         session.markChannelAsRead(cid: cid, userId: userId, at: lastReadAt)
     }
     
-    private func increaseUnreadCountIfNeeded(
+    private func incrementUnreadCountIfNeeded(
         for cid: ChannelId,
         message: MessagePayload,
         session: DatabaseSession
     ) {
-        // Silent messages don't increase unread count
-        if message.isSilent {
-            return
+        guard let currentUser = session.currentUser else {
+            return log.error("Current user is missing", subsystems: .webSocket)
         }
-
-        // Thread replies don't increase unread count
-        if message.parentId != nil && !message.showReplyInChannel {
-            return
+        
+        guard let channelRead = session.loadChannelRead(cid: cid, userId: currentUser.user.id) else {
+            return log.error("Channel read is missing", subsystems: .webSocket)
         }
-
-        // Own messages don't increase unread count
-        guard let currentUserId = session.currentUser?.user.id, currentUserId != message.user.id else {
-            return
-        }
-
-        // Try to get the existing channel read for the current user
-        if let read = session.loadChannelRead(cid: cid, userId: currentUserId) {
-            if message.createdAt > read.lastReadAt ?? Date.distantPast {
-                read.unreadMessageCount += 1
-            }
-        } else {
-            log.info(
-                "Can't increase unread count for \(cid) because the `ChannelReadDTO` for " +
-                    "the current user doesn't exist."
+        
+        if let skipReason = unreadCountUpdateSkippingReason(
+            currentUser: currentUser,
+            channelRead: channelRead,
+            message: message
+        ) {
+            return log.debug(
+                "Message \(message.id) does not increment unread counts for channel \(cid): \(skipReason)",
+                subsystems: .webSocket
             )
+        }
+        
+        log.debug(
+            "Message \(message.id) increments unread counts for channel \(cid)",
+            subsystems: .webSocket
+        )
+        
+        channelRead.unreadMessageCount += 1
+    }
+    
+    private func decrementUnreadCountIfNeeded(
+        event: MessageDeletedEventDTO,
+        session: DatabaseSession
+    ) {
+        guard let currentUser = session.currentUser else {
+            return log.error("Current user is missing", subsystems: .webSocket)
+        }
+        
+        guard let channelRead = session.loadChannelRead(cid: event.cid, userId: currentUser.user.id) else {
+            return log.error("Channel read is missing", subsystems: .webSocket)
+        }
+        
+        if let skipReason = !event.hardDelete
+            ? .messageIsSoftDeleted
+            : unreadCountUpdateSkippingReason(
+                currentUser: currentUser,
+                channelRead: channelRead,
+                message: event.message
+            ) {
+            return log.debug(
+                "Message \(event.message.id) does not decrement unread coutns for \(event.message.user.id): \(skipReason)",
+                subsystems: .webSocket
+            )
+        }
+        
+        log.debug(
+            "Message \(event.message.id) decrements unread counts for channel \(event.cid)",
+            subsystems: .webSocket
+        )
+        
+        channelRead.unreadMessageCount = max(0, channelRead.unreadMessageCount - 1)
+    }
+        
+    private func unreadCountUpdateSkippingReason(
+        currentUser: CurrentUserDTO,
+        channelRead: ChannelReadDTO,
+        message: MessagePayload
+    ) -> UnreadSkippingReason? {
+        if channelRead.channel.mute != nil {
+            return .channelIsMuted
+        }
+        
+        if message.user.id == currentUser.user.id {
+            return .messageIsOwn
+        }
+
+        if currentUser.mutedUsers.contains(where: { message.user.id == $0.id }) {
+            return .authorIsMuted
+        }
+        
+        if message.isSilent {
+            return .messageIsSilent
+        }
+        
+        if message.parentId != nil && !message.showReplyInChannel {
+            return .messageIsThreadReply
+        }
+        
+        if message.type == .system {
+            return .messageIsSystem
+        }
+        
+        if message.createdAt <= (channelRead.lastReadAt ?? Date.distantPast) {
+            return .messageIsSeen
+        }
+        
+        return nil
+    }
+}
+
+private enum UnreadSkippingReason: CustomStringConvertible {
+    case channelIsMuted
+    case authorIsMuted
+    case messageIsOwn
+    case messageIsSilent
+    case messageIsThreadReply
+    case messageIsSystem
+    case messageIsSeen
+    case messageIsSoftDeleted
+
+    var description: String {
+        switch self {
+        case .channelIsMuted:
+            return "Channel is muted"
+        case .messageIsOwn:
+            return "Own messages do not affect unread counts"
+        case .authorIsMuted:
+            return "Message author is muted"
+        case .messageIsSilent:
+            return "Silent messages do not affect unread counts"
+        case .messageIsThreadReply:
+            return "Thread replies do not affect unread counts"
+        case .messageIsSystem:
+            return "System messages do not affect unread counts"
+        case .messageIsSeen:
+            return "Seen messages do not affect unread counts"
+        case .messageIsSoftDeleted:
+            return "Soft-deleted messages do not affect unread counts"
         }
     }
 }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -521,6 +521,7 @@
 		84EB4E76276A012900E47E73 /* ClientError_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EB4E75276A012900E47E73 /* ClientError_Tests.swift */; };
 		84EB4E78276A03DE00E47E73 /* ErrorPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EB4E77276A03DE00E47E73 /* ErrorPayload_Tests.swift */; };
 		84F61270268B415C00DDF6EE /* ChatClientConfig_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F6126F268B415C00DDF6EE /* ChatClientConfig_Tests.swift */; };
+		84FD350827FD8BE300D68D85 /* ChatChannel_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FD350727FD8BE300D68D85 /* ChatChannel_Tests.swift */; };
 		8800A26F258A04D5006D64C4 /* ChatMessageAttachmentPreviewVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8800A26E258A04D5006D64C4 /* ChatMessageAttachmentPreviewVC.swift */; };
 		8800A28C258A1924006D64C4 /* ChatMessageFileAttachmentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8800A28B258A1924006D64C4 /* ChatMessageFileAttachmentListView.swift */; };
 		8802F9EF25AF3D4200475159 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8802F9EE25AF3D4200475159 /* HTTPHeader.swift */; };
@@ -2755,6 +2756,7 @@
 		84EB4E75276A012900E47E73 /* ClientError_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientError_Tests.swift; sourceTree = "<group>"; };
 		84EB4E77276A03DE00E47E73 /* ErrorPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorPayload_Tests.swift; sourceTree = "<group>"; };
 		84F6126F268B415C00DDF6EE /* ChatClientConfig_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatClientConfig_Tests.swift; sourceTree = "<group>"; };
+		84FD350727FD8BE300D68D85 /* ChatChannel_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannel_Tests.swift; sourceTree = "<group>"; };
 		8800A26E258A04D5006D64C4 /* ChatMessageAttachmentPreviewVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageAttachmentPreviewVC.swift; sourceTree = "<group>"; };
 		8800A28B258A1924006D64C4 /* ChatMessageFileAttachmentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageFileAttachmentListView.swift; sourceTree = "<group>"; };
 		8802F9BC25AF1DE200475159 /* WebSocketClient_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient_Mock.swift; sourceTree = "<group>"; };
@@ -5889,6 +5891,7 @@
 			isa = PBXGroup;
 			children = (
 				8A5D3EF824AF749200E2FE35 /* ChannelId_Tests.swift */,
+				84FD350727FD8BE300D68D85 /* ChatChannel_Tests.swift */,
 				64C80614262EDA9600B1F7AD /* ChatMessage_Tests.swift */,
 				796CBC6425FBAD12003299B0 /* Member_Tests.swift */,
 				88EA9AFB25472269007EE76B /* MessageReactionType_Tests.swift */,
@@ -9263,6 +9266,7 @@
 				84A1D2F426AB221E00014712 /* ChannelEventsController_Tests.swift in Sources */,
 				88381E6E258259310047A6A3 /* FileUploadPayload_Tests.swift in Sources */,
 				64F70D4B26257FD400C9F979 /* Error+InternetNotAvailable_Tests.swift in Sources */,
+				84FD350827FD8BE300D68D85 /* ChatChannel_Tests.swift in Sources */,
 				F63CC37124E591990052844D /* EventObserver_Tests.swift in Sources */,
 				22CAFA7625CAE278005935D9 /* RawJSON_Tests.swift in Sources */,
 				79342EEC2632C7770018F0F7 /* ChannelVisibilityEventMiddleware_Tests.swift in Sources */,

--- a/Tests/StreamChatTestTools/Mocks/Models + Extensions/ChannelUnreadCount_Mock.swift
+++ b/Tests/StreamChatTestTools/Mocks/Models + Extensions/ChannelUnreadCount_Mock.swift
@@ -6,7 +6,7 @@ import Foundation
 @testable import StreamChat
 
 public extension ChannelUnreadCount {
-    static func mock(messages: Int, mentionedMessages: Int = 0) -> Self {
-        .init(messages: messages, mentionedMessages: mentionedMessages)
+    static func mock(messages: Int, mentions: Int = 0) -> Self {
+        .init(messages: messages, mentions: mentions)
     }
 }

--- a/Tests/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Tests/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -279,18 +279,6 @@ extension DatabaseSession_Mock {
         try throwErrorIfNeeded()
         return try underlyingSession.saveChannelMute(payload: payload)
     }
-
-    func loadChannelMutes(for cid: ChannelId) -> [ChannelMuteDTO] {
-        underlyingSession.loadChannelMutes(for: cid)
-    }
-
-    func loadChannelMutes(for userId: UserId) -> [ChannelMuteDTO] {
-        underlyingSession.loadChannelMutes(for: userId)
-    }
-
-    func loadChannelMute(cid: ChannelId, userId: String) -> ChannelMuteDTO? {
-        underlyingSession.loadChannelMute(cid: cid, userId: userId)
-    }
     
     func delete(query: ChannelListQuery) {
         underlyingSession.delete(query: query)

--- a/Tests/StreamChatTestTools/TestData/DummyData/MessagePayload.swift
+++ b/Tests/StreamChatTestTools/TestData/DummyData/MessagePayload.swift
@@ -42,7 +42,8 @@ extension MessagePayload {
         isShadowed: Bool = false,
         reactionScores: [MessageReactionType: Int] = ["like": 1],
         reactionCounts: [MessageReactionType: Int] = ["like": 1],
-        translations: [TranslationLanguage: String]? = nil
+        translations: [TranslationLanguage: String]? = nil,
+        mentionedUsers: [UserPayload] = [.dummy(userId: .unique)]
     ) -> MessagePayload {
         .init(
             id: messageId,
@@ -60,7 +61,7 @@ extension MessagePayload {
             showReplyInChannel: showReplyInChannel,
             quotedMessageId: quotedMessageId,
             quotedMessage: quotedMessage,
-            mentionedUsers: [UserPayload.dummy(userId: .unique)],
+            mentionedUsers: mentionedUsers,
             threadParticipants: threadParticipants,
             replyCount: .random(in: 0...1000),
             extraData: extraData,

--- a/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
@@ -625,7 +625,7 @@ final class ChannelDTO_Tests: XCTestCase {
         
         // THEN
         XCTAssertEqual(unreadCount.messages, unreadMessages)
-        XCTAssertEqual(unreadCount.mentionedMessages, 1)
+        XCTAssertEqual(unreadCount.mentions, 1)
     }
     
     func test_typingUsers_areCleared_onResetEphemeralValues() throws {

--- a/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
@@ -578,28 +578,54 @@ final class ChannelDTO_Tests: XCTestCase {
         XCTAssertTrue(loadedChannels.contains { $0.cid == visibleCid2.rawValue })
     }
     
-    func test_channelUnreadCount_calculatedCorrectly() {
-        // Create and save a current user, to be used for channel unread calculations
-        try! database.createCurrentUser(id: "dummyCurrentUser")
-        
-        let channelId: ChannelId = .unique
-        
-        let payload = dummyPayload(with: channelId)
-        
-        // Asynchronously save the payload to the db
-        database.write { session in
-            try! session.saveChannel(payload: payload)
+    func test_channelUnreadCount_calculatedCorrectly() throws {
+        // GIVEN
+        let currentUserPayload: CurrentUserPayload = .dummy(userId: .unique, role: .user)
+
+        let currentUserChannelReadPayload: ChannelReadPayload = .init(
+            user: currentUserPayload,
+            lastReadAt: .init(),
+            unreadMessagesCount: 0
+        )
+
+        let messageMentioningCurrentUser: MessagePayload = .dummy(
+            messageId: .unique,
+            authorUserId: .unique,
+            createdAt: currentUserChannelReadPayload.lastReadAt.addingTimeInterval(5),
+            mentionedUsers: [currentUserPayload]
+        )
+
+        let channelPayload = ChannelPayload(
+            channel: .dummy(cid: .unique),
+            watcherCount: 0,
+            watchers: [],
+            members: [.dummy(user: currentUserPayload)],
+            membership: .dummy(user: currentUserPayload),
+            messages: [messageMentioningCurrentUser],
+            pinnedMessages: [],
+            channelReads: [currentUserChannelReadPayload]
+        )
+
+        let unreadMessages = 5
+
+        try database.writeSynchronously { session in
+            try session.saveCurrentUser(payload: currentUserPayload)
+            try session.saveChannel(payload: channelPayload)
+
+            let read = try XCTUnwrap(
+                session.loadChannelRead(cid: channelPayload.channel.cid, userId: currentUserPayload.id)
+            )
+            read.unreadMessageCount = Int32(unreadMessages)
         }
+
+        // WHEN
+        let unreadCount = try XCTUnwrap(
+            database.viewContext.channel(cid: channelPayload.channel.cid)?.asModel().unreadCount
+        )
         
-        // Load the channel from the db and check the if fields are correct
-        var loadedChannel: ChatChannel? {
-            database.viewContext.channel(cid: channelId)?.asModel()
-        }
-        
-        AssertAsync {
-            Assert.willBeEqual(loadedChannel?.unreadCount.messages, self.dummyChannelRead.unreadMessagesCount)
-            Assert.willBeEqual(loadedChannel?.unreadCount.mentionedMessages, 1)
-        }
+        // THEN
+        XCTAssertEqual(unreadCount.messages, unreadMessages)
+        XCTAssertEqual(unreadCount.mentionedMessages, 1)
     }
     
     func test_typingUsers_areCleared_onResetEphemeralValues() throws {

--- a/Tests/StreamChatTests/Models/ChatChannel_Tests.swift
+++ b/Tests/StreamChatTests/Models/ChatChannel_Tests.swift
@@ -1,0 +1,40 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class ChatChannel_Tests: XCTestCase {
+    func test_isUnread_whenUnreadCountIsNotZero_returnsTrue() {
+        let counts: [ChannelUnreadCount] = [
+            .init(
+                messages: 1,
+                mentions: 0
+            ),
+            .init(
+                messages: 0,
+                mentions: 1
+            )
+        ]
+        
+        for unreadCount in counts {
+            let channel: ChatChannel = .mock(
+                cid: .unique,
+                unreadCount: unreadCount
+            )
+            
+            XCTAssertTrue(channel.isUnread)
+        }
+    }
+    
+    func test_isUnread_whenUnreadCountIsZero_returnsFalse() {
+        let channel: ChatChannel = .mock(
+            cid: .unique,
+            unreadCount: .noUnread
+        )
+        
+        XCTAssertFalse(channel.isUnread)
+    }
+}

--- a/Tests/StreamChatTests/StreamChatIntegrationTests/ChannelEvents_IntegrationTests.swift
+++ b/Tests/StreamChatTests/StreamChatIntegrationTests/ChannelEvents_IntegrationTests.swift
@@ -150,13 +150,13 @@ final class ChannelEventsIntegration_Tests: XCTestCase {
         }
 
         let unwrappedUser = try XCTUnwrap(client.databaseContainer.viewContext.currentUser)
-        XCTAssertFalse(unwrappedUser.user.channelMutes.isEmpty)
+        XCTAssertFalse(unwrappedUser.channelMutes.isEmpty)
 
         let unwrappedEvent = try XCTUnwrap(event)
         client.eventNotificationCenter.process(unwrappedEvent)
 
         AssertAsync {
-            Assert.willBeTrue(self.client.databaseContainer.viewContext.currentUser?.user.channelMutes.isEmpty ?? false)
+            Assert.willBeTrue(self.client.databaseContainer.viewContext.currentUser?.channelMutes.isEmpty ?? false)
         }
     }
 
@@ -167,13 +167,13 @@ final class ChannelEventsIntegration_Tests: XCTestCase {
         try client.databaseContainer.createCurrentUser(id: "luke_skywalker")
 
         let unwrappedUser = try XCTUnwrap(client.databaseContainer.viewContext.currentUser)
-        XCTAssertTrue(unwrappedUser.user.channelMutes.isEmpty)
+        XCTAssertTrue(unwrappedUser.channelMutes.isEmpty)
 
         let unwrappedEvent = try XCTUnwrap(event)
         client.eventNotificationCenter.process(unwrappedEvent)
 
         AssertAsync {
-            Assert.willBeFalse(self.client.databaseContainer.viewContext.currentUser?.user.channelMutes.isEmpty ?? true)
+            Assert.willBeFalse(self.client.databaseContainer.viewContext.currentUser?.channelMutes.isEmpty ?? true)
         }
     }
 

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
@@ -10,90 +10,664 @@ final class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
     var middleware: ChannelReadUpdaterMiddleware!
     fileprivate var database: DatabaseContainer_Spy!
     
+    var channelPayload: ChannelPayload!
+    var currentUserPayload: CurrentUserPayload!
+    var currentUserReadPayload: ChannelReadPayload!
+    var anotherUserPayload: UserPayload!
+    
+    var currentUserReadDTO: ChannelReadDTO? {
+        database.viewContext.loadChannelRead(
+            cid: channelPayload.channel.cid,
+            userId: currentUserPayload.id
+        )
+    }
+    
     override func setUp() {
         super.setUp()
         database = DatabaseContainer_Spy()
         middleware = ChannelReadUpdaterMiddleware()
+        
+        currentUserPayload = .dummy(userId: .unique, role: .user)
+        anotherUserPayload = .dummy(userId: .unique)
+
+        currentUserReadPayload = .init(
+            user: currentUserPayload,
+            lastReadAt: .init(),
+            unreadMessagesCount: 5
+        )
+        
+        channelPayload = ChannelPayload(
+            channel: .dummy(cid: .unique),
+            watcherCount: 0,
+            watchers: [],
+            members: [.dummy(user: currentUserPayload), .dummy(user: anotherUserPayload)],
+            membership: .dummy(user: currentUserPayload),
+            messages: [],
+            pinnedMessages: [],
+            channelReads: [currentUserReadPayload]
+        )
+        
+        try! database.writeSynchronously { session in
+            try! session.saveCurrentUser(payload: self.currentUserPayload)
+            try! session.saveChannel(payload: self.channelPayload)
+        }
     }
     
     override func tearDown() {
         AssertAsync.canBeReleased(&database)
         database = nil
+        currentUserPayload = nil
+        anotherUserPayload = nil
+        currentUserReadPayload = nil
+        channelPayload = nil
+        
         super.tearDown()
     }
-
-    func test_messageNewEvent_increasesChannelReadUnreadCount() throws {
-        // Save a channel with a channel read
-        let channelId = ChannelId.unique
-        let payload = dummyPayload(with: channelId)
+    
+    // MARK: - message.deleted
+    
+    func test_messageDeletedEvent_whenChannelIsMuted_doesNotDecrementUnreadCount() throws {
+        // GIVEN
+        let channelMute = MutedChannelPayload(
+            mutedChannel: channelPayload.channel,
+            user: currentUserPayload,
+            createdAt: .init(),
+            updatedAt: .init()
+        )
         
-        // Save dummy payload to database
-        try database.writeSynchronously {
-            try $0.saveCurrentUser(payload: self.dummyCurrentUser)
-            try $0.saveChannel(payload: payload)
+        try database.writeSynchronously { session in
+            try session.saveChannelMute(payload: channelMute)
         }
         
-        // Load the channel from the db and check the initial values
-        var loadedChannel: ChatChannel? {
-            database.viewContext.channel(cid: channelId)?.asModel()
-        }
-
-        let oldReadDate = try XCTUnwrap(loadedChannel?.reads.first?.lastReadAt)
+        // WHEN
+        let message: MessagePayload = .dummy(
+            type: .deleted,
+            messageId: .unique,
+            parentId: .unique,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1),
+            deletedAt: currentUserReadPayload.lastReadAt.addingTimeInterval(2)
+        )
         
-        XCTAssertEqual(loadedChannel?.reads.first?.unreadMessagesCount, 10)
-        XCTAssertEqual(oldReadDate, Date(timeIntervalSince1970: 1))
-        
-        try [
-            // 1. The current user message shouldn't increase the unread count
-            (user: dummyCurrentUser, expectedCount: 10),
-            // 2. Other user's message should increase the unread count
-            (user: dummyUser(id: .unique), expectedCount: 11)
-            
-        ].forEach { (user, expectedCount) in
-
-            // Create a MessageNewEvent with a `createdAt` date before `oldReadDate`
-            let eldEventPayload = EventPayload(
-                eventType: .messageNew,
-                cid: channelId,
-                user: user,
-                message: .dummy(messageId: .unique, authorUserId: user.id, createdAt: .unique(before: oldReadDate)),
-                createdAt: .unique(before: oldReadDate)
+        let event = try MessageDeletedEventDTO(
+            from: .init(
+                eventType: .messageDeleted,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: message,
+                createdAt: message.deletedAt!,
+                hardDelete: true
             )
-            let oldMessageNewEvent = try MessageNewEventDTO(from: eldEventPayload)
+        )
 
-            var handledEvent: Event?
-            try database.writeSynchronously { session in
-                // Let the middleware handle the event
-                // Middleware should mutate the loadedChannel's read
-                handledEvent = self.middleware.handle(event: oldMessageNewEvent, session: session)
-            }
-
-            XCTAssertEqual(handledEvent?.asEquatable, oldMessageNewEvent.asEquatable)
-
-            // Assert that the read event entity is NOT updated
-            XCTAssertEqual(loadedChannel?.reads.first?.unreadMessagesCount, 10)
-
-            // Create a MessageNewEvent with a `createdAt` date later than `oldReadDate`
-            let eventPayload = EventPayload(
-                eventType: .messageNew,
-                cid: channelId,
-                user: user,
-                message: .dummy(messageId: .unique, authorUserId: user.id, createdAt: .unique(after: oldReadDate)),
-                createdAt: .unique(after: oldReadDate)
-            )
-            let messageNewEvent = try MessageNewEventDTO(from: eventPayload)
-
-            try database.writeSynchronously { session in
-                // Let the middleware handle the event
-                // Middleware should mutate the loadedChannel's read
-                handledEvent = self.middleware.handle(event: messageNewEvent, session: session)
-            }
-
-            XCTAssertEqual(handledEvent?.asEquatable, messageNewEvent.asEquatable)
-
-            // Assert that the read event entity is updated
-            XCTAssertEqual(loadedChannel?.reads.first?.unreadMessagesCount, expectedCount)
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: event, session: session)
         }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+    
+    func test_messageDeletedEvent_whenMessageIsSentByCurrentUser_doesNotDecrementUnreadCount() throws {
+        // WHEN
+        let messageFromCurrentUser: MessagePayload = .dummy(
+            type: .deleted,
+            messageId: .unique,
+            parentId: nil,
+            authorUserId: currentUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1),
+            deletedAt: currentUserReadPayload.lastReadAt.addingTimeInterval(2)
+        )
+        
+        let event = try MessageDeletedEventDTO(
+            from: .init(
+                eventType: .messageDeleted,
+                cid: channelPayload.channel.cid,
+                user: currentUserPayload,
+                message: messageFromCurrentUser,
+                createdAt: messageFromCurrentUser.deletedAt!,
+                hardDelete: true
+            )
+        )
+        
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: event, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+
+    func test_messageDeletedEvent_whenDeletedMessageIsSentByMutedUser_doesNotDecrementUnreadCount() throws {
+        // GIVEN
+        try database.writeSynchronously { session in
+            let currentUser = try XCTUnwrap(session.currentUser)
+            let userToMute = try XCTUnwrap(session.user(id: self.anotherUserPayload.id))
+            currentUser.mutedUsers.insert(userToMute)
+        }
+        
+        // WHEN
+        let messageFromMutedUser: MessagePayload = .dummy(
+            type: .deleted,
+            messageId: .unique,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1),
+            deletedAt: currentUserReadPayload.lastReadAt.addingTimeInterval(2)
+        )
+        
+        let event = try MessageDeletedEventDTO(
+            from: .init(
+                eventType: .messageDeleted,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: messageFromMutedUser,
+                createdAt: messageFromMutedUser.deletedAt!,
+                hardDelete: true
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: event, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+    
+    func test_messageDeletedEvent_whenMessageIsSoftDeleted_doesNotDecrementUnreadCount() throws {
+        // WHEN
+        let softDeletedMessage: MessagePayload = .dummy(
+            type: .deleted,
+            messageId: .unique,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1),
+            deletedAt: currentUserReadPayload.lastReadAt.addingTimeInterval(2)
+        )
+        
+        let event = try MessageDeletedEventDTO(
+            from: .init(
+                eventType: .messageDeleted,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: softDeletedMessage,
+                createdAt: softDeletedMessage.deletedAt!,
+                hardDelete: false
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: event, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+    
+    func test_messageDeletedEvent_whenMessageIsSilent_doesNotDecrementUnreadCount() throws {
+        // WHEN
+        let silentMessage: MessagePayload = .dummy(
+            messageId: .unique,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1),
+            deletedAt: currentUserReadPayload.lastReadAt.addingTimeInterval(2),
+            isSilent: true
+        )
+        
+        let event = try MessageDeletedEventDTO(
+            from: .init(
+                eventType: .messageDeleted,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: silentMessage,
+                createdAt: silentMessage.deletedAt!,
+                hardDelete: true
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: event, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+    
+    func test_messageDeletedEvent_whenMessageIsThreadReply_doesNotDecrementUnreadCount() throws {
+        // WHEN
+        let threadReply: MessagePayload = .dummy(
+            type: .reply,
+            messageId: .unique,
+            parentId: .unique,
+            showReplyInChannel: false,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1),
+            deletedAt: currentUserReadPayload.lastReadAt.addingTimeInterval(2)
+        )
+        
+        let event = try MessageDeletedEventDTO(
+            from: .init(
+                eventType: .messageDeleted,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: threadReply,
+                createdAt: threadReply.deletedAt!,
+                hardDelete: true
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: event, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+
+    func test_messageDeletedEvent_whenMessageIsSystem_doesNotDecrementUnreadCount() throws {
+        // WHEN
+        let systemMessage: MessagePayload = .dummy(
+            type: .system,
+            messageId: .unique,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1),
+            deletedAt: currentUserReadPayload.lastReadAt.addingTimeInterval(2)
+        )
+        
+        let event = try MessageDeletedEventDTO(
+            from: .init(
+                eventType: .messageDeleted,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: systemMessage,
+                createdAt: systemMessage.deletedAt!,
+                hardDelete: true
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: event, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+    
+    func test_messageDeletedEvent_whenMessageIsRead_doesNotDecrementUnreadCount() throws {
+        // WHEN
+        let message: MessagePayload = .dummy(
+            messageId: .unique,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(-1),
+            deletedAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1)
+        )
+        
+        let event = try MessageDeletedEventDTO(
+            from: .init(
+                eventType: .messageDeleted,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: message,
+                createdAt: message.deletedAt!,
+                hardDelete: true
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: event, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+    
+    func test_messageDeletedEvent_whenMessageIsRegular_decrementsUnreadMessagesCount() throws {
+        // WHEN
+        let message: MessagePayload = .dummy(
+            type: .regular,
+            messageId: .unique,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1),
+            deletedAt: currentUserReadPayload.lastReadAt.addingTimeInterval(2)
+        )
+        
+        let event = try MessageDeletedEventDTO(
+            from: .init(
+                eventType: .messageDeleted,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: message,
+                createdAt: message.deletedAt!,
+                hardDelete: true
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: event, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount - 1)
+    }
+    
+    func test_messageDeletedEvent_whenMessageIsThreadReplySentToMainChannel_decrementsUnreadMessagesCount() throws {
+        // WHEN
+        let message: MessagePayload = .dummy(
+            type: .reply,
+            messageId: .unique,
+            parentId: .unique,
+            showReplyInChannel: true,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1),
+            deletedAt: currentUserReadPayload.lastReadAt.addingTimeInterval(2)
+        )
+        
+        let event = try MessageDeletedEventDTO(
+            from: .init(
+                eventType: .messageDeleted,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: message,
+                createdAt: message.deletedAt!,
+                hardDelete: true
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: event, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount - 1)
+    }
+    
+    // MARK: - message.new
+    
+    func test_messageNewEvent_whenChannelIsMuted_doesNotIncrementUnreadCount() throws {
+        // GIVEN
+        let channelMute = MutedChannelPayload(
+            mutedChannel: channelPayload.channel,
+            user: currentUserPayload,
+            createdAt: .init(),
+            updatedAt: .init()
+        )
+        
+        try database.writeSynchronously { session in
+            try session.saveChannelMute(payload: channelMute)
+        }
+        
+        // WHEN
+        let message: MessagePayload = .dummy(
+            type: .regular,
+            messageId: .unique,
+            parentId: .unique,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1)
+        )
+        
+        let messageNewEvent = try MessageNewEventDTO(
+            from: .init(
+                eventType: .messageNew,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: message,
+                createdAt: message.createdAt
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: messageNewEvent, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+    
+    func test_messageNewEvent_whenMessageIsSentByCurrentUser_doesNotIncrementUnreadCount() throws {
+        // WHEN
+        let messageFromCurrentUser: MessagePayload = .dummy(
+            messageId: .unique,
+            parentId: nil,
+            authorUserId: currentUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1),
+            isSilent: false
+        )
+        
+        let messageNewEvent = try MessageNewEventDTO(
+            from: .init(
+                eventType: .messageNew,
+                cid: channelPayload.channel.cid,
+                user: currentUserPayload,
+                message: messageFromCurrentUser,
+                createdAt: messageFromCurrentUser.createdAt
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: messageNewEvent, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+
+    func test_messageNewEvent_whenMessageIsSentByMutedUser_doesNotIncrementUnreadCount() throws {
+        // GIVEN
+        try database.writeSynchronously { session in
+            let currentUser = try XCTUnwrap(session.currentUser)
+            let userToMute = try XCTUnwrap(session.user(id: self.anotherUserPayload.id))
+            currentUser.mutedUsers.insert(userToMute)
+        }
+        
+        // WHEN
+        let messageFromMutedUser: MessagePayload = .dummy(
+            type: .regular,
+            messageId: .unique,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1)
+        )
+        
+        let messageNewEvent = try MessageNewEventDTO(
+            from: .init(
+                eventType: .messageNew,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: messageFromMutedUser,
+                createdAt: messageFromMutedUser.createdAt
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: messageNewEvent, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+    
+    func test_messageNewEvent_whenMessageIsSilent_doesNotIncrementUnreadCount() throws {
+        // WHEN
+        let silentMessage: MessagePayload = .dummy(
+            messageId: .unique,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1),
+            isSilent: true
+        )
+        
+        let messageNewEvent = try MessageNewEventDTO(
+            from: .init(
+                eventType: .messageNew,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: silentMessage,
+                createdAt: silentMessage.createdAt
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: messageNewEvent, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+    
+    func test_messageNewEvent_whenMessageIsThreadReply_doesNotIncrementUnreadCount() throws {
+        // WHEN
+        let threadReplyPayload: MessagePayload = .dummy(
+            type: .reply,
+            messageId: .unique,
+            parentId: .unique,
+            showReplyInChannel: false,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1)
+        )
+        
+        let messageNewEvent = try MessageNewEventDTO(
+            from: .init(
+                eventType: .messageNew,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: threadReplyPayload,
+                createdAt: threadReplyPayload.createdAt
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: messageNewEvent, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+
+    func test_messageNewEvent_whenMessageIsSystem_doesNotIncrementUnreadCount() throws {
+        // WHEN
+        let systemMessage: MessagePayload = .dummy(
+            type: .system,
+            messageId: .unique,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1)
+        )
+        
+        let messageNewEvent = try MessageNewEventDTO(
+            from: .init(
+                eventType: .messageNew,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: systemMessage,
+                createdAt: systemMessage.createdAt
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: messageNewEvent, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+    
+    func test_messageNewEvent_whenMessageIsRead_doesNotIncrementUnreadCount() throws {
+        // WHEN
+        let regularMessageEarlierThanLastRead: MessagePayload = .dummy(
+            messageId: .unique,
+            parentId: nil,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(-1)
+        )
+        
+        let messageNewEvent = try MessageNewEventDTO(
+            from: .init(
+                eventType: .messageNew,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: regularMessageEarlierThanLastRead,
+                createdAt: regularMessageEarlierThanLastRead.createdAt
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: messageNewEvent, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount)
+    }
+    
+    func test_messageNewEvent_whenMessageIsRegular_incrementsUnreadMessagesCount() throws {
+        // WHEN
+        let regularMessage: MessagePayload = .dummy(
+            messageId: .unique,
+            parentId: nil,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1),
+            isSilent: false
+        )
+        
+        let messageNewEvent = try MessageNewEventDTO(
+            from: .init(
+                eventType: .messageNew,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: regularMessage,
+                createdAt: regularMessage.createdAt
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: messageNewEvent, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount + 1)
+    }
+    
+    func test_messageNewEvent_whenMessageIsThreadReplySentToMainChannel_incrementsUnreadMessagesCount() throws {
+        // WHEN
+        let threadReplyPayload: MessagePayload = .dummy(
+            type: .reply,
+            messageId: .unique,
+            parentId: .unique,
+            showReplyInChannel: true,
+            authorUserId: anotherUserPayload.id,
+            createdAt: currentUserReadPayload.lastReadAt.addingTimeInterval(1)
+        )
+        
+        let messageNewEvent = try MessageNewEventDTO(
+            from: .init(
+                eventType: .messageNew,
+                cid: channelPayload.channel.cid,
+                user: anotherUserPayload,
+                message: threadReplyPayload,
+                createdAt: threadReplyPayload.createdAt
+            )
+        )
+
+        try database.writeSynchronously { session in
+            _ = self.middleware.handle(event: messageNewEvent, session: session)
+        }
+        
+        // THEN
+        let read = try XCTUnwrap(currentUserReadDTO)
+        XCTAssertEqual(Int(read.unreadMessageCount), currentUserReadPayload.unreadMessagesCount + 1)
     }
     
     func test_notificationMessageNewEvent_increasesChannelReadUnreadCount() throws {
@@ -170,52 +744,6 @@ final class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
             // Assert that the read event entity is updated
             XCTAssertEqual(loadedChannel?.reads.first?.unreadMessagesCount, expectedCount)
         }
-    }
-    
-    func test_messageNewEvent_doesntIncreasesChannelReadUnreadCount_forOwnMessages() throws {
-        // Save a channel with a channel read
-        let channelId = ChannelId.unique
-        let payload = dummyPayload(with: channelId)
-        
-        // Save dummy payload to database
-        try database.writeSynchronously {
-            try $0.saveCurrentUser(payload: self.dummyCurrentUser)
-            try $0.saveChannel(payload: payload)
-        }
-        
-        // Load the channel from the db and check the initial values
-        var loadedChannel: ChatChannel? {
-            database.viewContext.channel(cid: channelId)?.asModel()
-        }
-
-        let oldReadDate = try XCTUnwrap(loadedChannel?.reads.first?.lastReadAt)
-        
-        XCTAssertEqual(loadedChannel?.reads.first?.unreadMessagesCount, 10)
-        XCTAssertEqual(oldReadDate, Date(timeIntervalSince1970: 1))
-        
-        let user = dummyUser(id: .unique)
-
-        // Create a MessageNewEvent with a `createdAt` date later than `oldReadDate`
-        let eventPayload = EventPayload(
-            eventType: .messageNew,
-            cid: channelId,
-            user: user,
-            message: .dummy(messageId: .unique, authorUserId: user.id, createdAt: .unique(after: oldReadDate)),
-            createdAt: .unique(after: oldReadDate)
-        )
-        let messageNewEvent = try MessageNewEventDTO(from: eventPayload)
-
-        var handledEvent: Event?
-        try database.writeSynchronously { session in
-            // Let the middleware handle the event
-            // Middleware should mutate the loadedChannel's read
-            handledEvent = self.middleware.handle(event: messageNewEvent, session: session)
-        }
-
-        XCTAssertEqual(handledEvent?.asEquatable, messageNewEvent.asEquatable)
-
-        // Assert that the read event entity is updated
-        XCTAssertEqual(loadedChannel?.reads.first?.unreadMessagesCount, 11)
     }
 
     func test_messageReadEvent_resetsChannelReadUnreadCount() throws {


### PR DESCRIPTION
### 🔗 Issue Links

CIS-1763

### 🎯 Goal

- Fix local unread counts going out of sync with the remote
- Fix channel not being marked as read when it's muted OR when all messages after last read are thread replies/silent/from muted users

### 📝 Summary

Fix unread counts being **incremented** when:
- the channel is muted
- the message author is muted

Fix unread counts not being **decremented**:
- the message is hard deleted

### 🛠 Implementation

- Add handling of missing cases to `ChannelReadUpdaterMiddleware`
- Move channel mutes from `UserDTO` to `CurrentUserDTO`
- Rename `mentionedMessages` to `mentioningMessages` in channel unread counts
- Remove unused parts of `ChannelMuteDatabaseSession`

### 🧪 Manual Testing Notes

#### New message:

Message in muted channel does not increment unread counts:
**GIVEN** I'm on the channel list
**AND** The channel is muted
**WHEN** Channel member sends a new message to the muted channel
**THEN** unread messages count is not incremented

Message in unmuted channel from muted user does not increment unread counts:
**GIVEN** I'm on the channel list
**AND** The channel is unmuted
**AND** The channel has a muted member
**WHEN** Muted member sends a new message to the channel
**THEN** unread messages count is not incremented

The silent message in unmuted channel does not increment unread counts:
**GIVEN** I'm on the channel list
**AND** The channel is unmuted
**AND** The channel has unmuted member
**WHEN** Member sends a new `silent` message to the channel
**THEN** unread messages count is not incremented

The system message in unmuted channel does not increment unread counts:
**GIVEN** I'm on the channel list
**AND** The channel is unmuted
**AND** The channel has unmuted member
**WHEN** Member performs action that results in system message posted to the channel
**THEN** unread messages count is not incremented

Thread reply in unmuted channel does not increment unread counts:
**GIVEN** I'm on the channel list
**AND** The channel is unmuted
**AND** The channel has unmuted member
**WHEN** Member leaves a new thread reply in the channel
**THEN** unread messages count is not incremented

Own message in unmuted channel does not increment unread counts:
**GIVEN** I'm logged in using 2 devices as the same user
**AND** I'm on the channel list on device 1
**AND** I'm in the channel on device 2
**AND** The channel is unmuted
**WHEN** I send the new message to the channel on device 2
**THEN** unread messages count is not incremented on device 1

Regular message in unmuted channel from unmuted member increments from unread counts:
**GIVEN** I'm on the channel list
**AND** The channel is unmuted
**AND** The channel has unmuted member
**WHEN** Member sends a regular message to the channel
**THEN** unread messages count is incremented

Thread reply sent to main channel in unmuted channel from unmuted member increments from unread counts:
**GIVEN** I'm on the channel list
**AND** The channel is unmuted
**AND** The channel has unmuted member
**WHEN** Member leaves a new thread reply in the channel
**AND** Member selects `send also to main channel` checkmark
**THEN** unread messages count is incremented

#### Deleted message:

Hard delete of unseen message decrements unread counts:
**GIVEN** I'm on the channel list
**AND** The channel is unmuted
**AND** The channel has unmuted member
**AND** Member send the new message to the channel
**AND** unread messages count is incremented
**WHEN** Member performs hard deleted on his message 
**THEN** unread messages count is decremented

Soft delete of unseen message does not decrement unread counts:
**GIVEN** I'm on the channel list
**AND** The channel is unmuted
**AND** The channel has unmuted member
**AND** Member send the new message to the channel
**AND** unread messages count is incremented
**WHEN** Member performs soft deleted on his message 
**THEN** unread messages count is not decremented

Hard delete of seen message does not decrement unread counts:
**GIVEN** I'm on the channel list
**AND** The channel is unmuted
**AND** The channel has unmuted member
**AND** Member send the new message to the channel
**AND** unread messages count is incremented
**AND** I open the channel and go back to channel list
**AND** unread messages count become 0 
**WHEN** Member performs hard deleted on his message 
**THEN** unread messages is not decremented

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/xUOwGhauv1d6nceRbi/giphy-downsized.gif)