### PR TITLE
[CIS-1827] Expose `actions` on image attachment payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
+## StreamChat
+### ✅ Added
+- Expose `actions` on image attachment [#1979](https://github.com/GetStream/stream-chat-swift/issues/1979)
 
 ## StreamChatUI
 ### 🔄 Changed

--- a/Sources/StreamChat/Models/Attachments/ChatMessageImageAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageImageAttachment.swift
@@ -22,6 +22,8 @@ public struct ImageAttachmentPayload: AttachmentPayload {
     public var imageURL: URL
     /// A link to the image preview.
     public var imagePreviewURL: URL
+    /// Attachment actions.
+    public var actions: [AttachmentAction]
     /// An extra data.
     public var extraData: [String: RawJSON]?
     
@@ -37,10 +39,17 @@ public struct ImageAttachmentPayload: AttachmentPayload {
     /// Creates `ImageAttachmentPayload` instance.
     ///
     /// Use this initializer if the attachment is already uploaded and you have the remote URLs.
-    public init(title: String?, imageRemoteURL: URL, imagePreviewRemoteURL: URL? = nil, extraData: [String: RawJSON]?) {
+    public init(
+        title: String?,
+        imageRemoteURL: URL,
+        imagePreviewRemoteURL: URL? = nil,
+        actions: [AttachmentAction] = [],
+        extraData: [String: RawJSON]? = nil
+    ) {
         self.title = title
         imageURL = imageRemoteURL
         imagePreviewURL = imagePreviewRemoteURL ?? imageRemoteURL
+        self.actions = actions
         self.extraData = extraData
     }
 }
@@ -51,9 +60,13 @@ extension ImageAttachmentPayload: Hashable {}
 
 extension ImageAttachmentPayload: Encodable {
     public func encode(to encoder: Encoder) throws {
+        let actionsData = try JSONEncoder.default.encode(actions)
+        let actions = try JSONDecoder.default.decode([RawJSON].self, from: actionsData)
+        
         var values = extraData ?? [:]
         values[AttachmentCodingKeys.title.rawValue] = title.map { .string($0) }
         values[AttachmentCodingKeys.imageURL.rawValue] = .string(imageURL.absoluteString)
+        values[AttachmentCodingKeys.actions.rawValue] = .array(actions)
         try values.encode(to: encoder)
     }
 }
@@ -80,6 +93,8 @@ extension ImageAttachmentPayload: Decodable {
             imageRemoteURL: imageURL,
             imagePreviewRemoteURL: try container
                 .decodeIfPresent(URL.self, forKey: .thumbURL) ?? imageURL,
+            actions: try container
+                .decodeIfPresent([AttachmentAction].self, forKey: .actions) ?? [],
             extraData: try Self.decodeExtraData(from: decoder)
         )
     }

--- a/Tests/StreamChatTests/Models/Attachments/ImageAttachmentPayload_Tests.swift
+++ b/Tests/StreamChatTests/Models/Attachments/ImageAttachmentPayload_Tests.swift
@@ -7,41 +7,20 @@
 import XCTest
 
 final class ImageAttachmentPayload_Tests: XCTestCase {
-    func test_decodingDefaultValues() throws {
-        // Create attachment field values.
-        let title: String = .unique
-        let imageURL: URL = .unique()
-        let thumbURL: URL = .unique()
-        
-        // Create JSON with the given values.
-        let json = """
-        {
-            "title": "\(title)",
-            "image_url": "\(imageURL.absoluteString)",
-            "thumb_url": "\(thumbURL.absoluteString)"
-        }
-        """.data(using: .utf8)!
-        
-        // Decode attachment from JSON.
-        let payload = try JSONDecoder.stream.decode(ImageAttachmentPayload.self, from: json)
-        
-        // Assert values are decoded correctly.
-        XCTAssertEqual(payload.title, title)
-        XCTAssertEqual(payload.imageURL, imageURL)
-        XCTAssertEqual(payload.imagePreviewURL, thumbURL)
-        XCTAssertNil(payload.extraData)
-    }
-    
-    func test_decodingExtraData() throws {
-        struct ExtraData: Codable {
-            let comment: String
-        }
-        
+    func test_decode() throws {
         // Create attachment field values.
         let title: String = .unique
         let imageURL: URL = .unique()
         let thumbURL: URL = .unique()
         let comment: String = .unique
+        
+        let action = AttachmentAction(
+            name: .unique,
+            value: .unique,
+            style: .default,
+            type: .button,
+            text: .unique
+        )
         
         // Create JSON with the given values.
         let json = """
@@ -49,7 +28,16 @@ final class ImageAttachmentPayload_Tests: XCTestCase {
             "title": "\(title)",
             "image_url": "\(imageURL.absoluteString)",
             "thumb_url": "\(thumbURL.absoluteString)",
-            "comment": "\(comment)"
+            "comment": "\(comment)",
+            "actions": [
+                {
+                    "name": "\(action.name)",
+                    "value": "\(action.value)",
+                    "style": "\(action.style.rawValue)",
+                    "type": "\(action.type.rawValue)",
+                    "text": "\(action.text)"
+                }
+            ]
         }
         """.data(using: .utf8)!
         
@@ -60,9 +48,52 @@ final class ImageAttachmentPayload_Tests: XCTestCase {
         XCTAssertEqual(payload.title, title)
         XCTAssertEqual(payload.imageURL, imageURL)
         XCTAssertEqual(payload.imagePreviewURL, thumbURL)
-        
+        XCTAssertEqual(payload.actions, [action])
+
         // Assert extra data can be decoded.
         let extraData = try XCTUnwrap(payload.extraData(ofType: ExtraData.self))
         XCTAssertEqual(extraData.comment, comment)
     }
+    
+    func test_encode() throws {
+        let extraData = ExtraData(comment: .unique)
+        
+        let payload = ImageAttachmentPayload(
+            title: .unique,
+            imageRemoteURL: .unique(),
+            actions: [
+                .init(
+                    name: .unique,
+                    value: .unique,
+                    style: .default,
+                    type: .button,
+                    text: .unique
+                )
+            ],
+            extraData: [
+                "comment": .string(extraData.comment)
+            ]
+        )
+
+        let serialized = try JSONEncoder.stream.encode(payload)
+        let expected: [String: Any] = [
+            "title": payload.title!,
+            "image_url": payload.imageURL.absoluteString,
+            "actions": NSArray(array: payload.actions.map {
+                [
+                    "name": $0.name,
+                    "value": $0.value,
+                    "style": $0.style.rawValue,
+                    "type": $0.type.rawValue,
+                    "text": $0.text
+                ]
+            }),
+            "comment": extraData.comment
+        ]
+        AssertJSONEqual(serialized, expected)
+    }
+}
+
+private struct ExtraData: Codable {
+    let comment: String
 }


### PR DESCRIPTION
### 🔗 Issue Links

CIS-1827

### 🎯 Goal

Make it possible to attach/handle actions on `image` attachments.

### 📝 Summary

Expose `actions` on `ImageAttachmentPayload`.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/3oz8xDOdpO1XqE21mU/giphy.gif)