### PR TITLE
Fix feedback loop in ContainerStackView

### DIFF
--- a/Sources/StreamChatUI/CommonViews/ContainerStackView.swift
+++ b/Sources/StreamChatUI/CommonViews/ContainerStackView.swift
@@ -121,7 +121,6 @@ public class ContainerStackView: UIView {
     override public init(frame: CGRect) {
         super.init(frame: frame)
 
-        insetsLayoutMarginsFromSafeArea = false
         addLayoutGuide(sizeLayoutGuide)
     }
     

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionControl.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionControl.swift
@@ -33,13 +33,16 @@ open class ChatMessageActionControl: _Control, AppearanceProvider {
 
     override open func setUpAppearance() {
         super.setUpAppearance()
+
         titleLabel.font = appearance.fonts.body
         titleLabel.adjustsFontForContentSizeCategory = true
     }
 
     override open func setUp() {
         super.setUp()
+
         containerStackView.isUserInteractionEnabled = false
+        containerStackView.insetsLayoutMarginsFromSafeArea = false
         addTarget(self, action: #selector(touchUpInsideHandler(_:)), for: .touchUpInside)
     }
     

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
@@ -52,6 +52,7 @@ open class ChatMessageActionsVC: _ViewController, ThemeProvider {
         messageActionsContainerStackView.spacing = 1
 
         // Fix safe area layout issue when message actions go below scroll view
+        messageActionsContainerStackView.insetsLayoutMarginsFromSafeArea = false
         messageActionsContainerStackView.isLayoutMarginsRelativeArrangement = true
         messageActionsContainerStackView.layoutMargins = .zero
     }


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Fix feedback loop in `ContainerStackView` inside Thread Replies. 

### 📝 Summary
Applies `insetsLayoutMarginsFromSafeArea = false` only on the popup view, so that it doesn't influence other container stack views.

### 🧪 Manual Testing Notes
Create a thread reply, it shouldn't crash.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
