### PR TITLE
[CIS-1720] UI Scenarios for Message Delivery Status

### DIFF
--- a/DemoApp/DemoAppCoordinator.swift
+++ b/DemoApp/DemoAppCoordinator.swift
@@ -396,7 +396,7 @@ class CustomMessageContentView: ChatMessageContentView {
             }
         }
 
-        guard let authorNameLabel = authorNameLabel, authorNameLabel.text != "" else {
+        guard let authorNameLabel = authorNameLabel, authorNameLabel.text?.isEmpty == true else {
             return
         }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCell.swift
@@ -34,7 +34,6 @@ public final class ChatMessageCell: _TableViewCell, ComponentsProvider {
     
     override public func setUp() {
         super.setUp()
-        
         selectionStyle = .none
     }
     

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageDeliveryStatusView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageDeliveryStatusView.swift
@@ -48,6 +48,11 @@ open class ChatMessageDeliveryStatusView: _Control, ThemeProvider {
         
         stackView.isUserInteractionEnabled = false
         isUserInteractionEnabled = false
+        accessibilityElements = [
+            messageReadСountsLabel,
+            messageDeliveryChekmarkView,
+            stackView
+        ]
     }
     
     override open func setUpAppearance() {

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -855,6 +855,10 @@
 		A3698DD62821504C00814143 /* ws_events_member.json in Resources */ = {isa = PBXBuildFile; fileRef = A3698DD52821504C00814143 /* ws_events_member.json */; };
 		A3698DD828215E2F00814143 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3698DD728215E2F00814143 /* Settings.swift */; };
 		A36F997A2818459C0078260D /* InternetConnectionMonitor_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A36F99792818459C0078260D /* InternetConnectionMonitor_Mock.swift */; };
+		A3813B48282525280076E838 /* ws_events_user.json in Resources */ = {isa = PBXBuildFile; fileRef = A3813B47282525280076E838 /* ws_events_user.json */; };
+		A3813B4A282595960076E838 /* ChannelConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3813B49282595960076E838 /* ChannelConfig.swift */; };
+		A3813B4C2825C8030076E838 /* CustomChatMessageListRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3813B4B2825C8030076E838 /* CustomChatMessageListRouter.swift */; };
+		A3813B4E2825C8A30076E838 /* ThreadVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3813B4D2825C8A30076E838 /* ThreadVC.swift */; };
 		A382131E2805C8AC0068D30E /* TestsEnvironmentSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A382131D2805C8AC0068D30E /* TestsEnvironmentSetup.swift */; };
 		A3960E0B27DA587B003AB2B0 /* RetryStrategy_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3960E0A27DA587B003AB2B0 /* RetryStrategy_Tests.swift */; };
 		A3960E0D27DA5973003AB2B0 /* ConnectionRecoveryHandler_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3960E0C27DA5973003AB2B0 /* ConnectionRecoveryHandler_Tests.swift */; };
@@ -863,7 +867,10 @@
 		A39B040B27F196F200D6B18A /* StreamChatUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39B040A27F196F200D6B18A /* StreamChatUITests.swift */; };
 		A3A52B6627EB61FC00311DFC /* EventPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794927F0249E3DE6009D7EB7 /* EventPayload_Tests.swift */; };
 		A3A644B327BF99D400F92494 /* ChannelTruncateRequestPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3A644B227BF99D400F92494 /* ChannelTruncateRequestPayload_Tests.swift */; };
+		A3AFEAA72816F1A200A79A6A /* MessageDeliveryStatus_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3AFEAA62816F1A200A79A6A /* MessageDeliveryStatus_Tests.swift */; };
 		A3B0CFA227BBF52600F352F9 /* ChannelTruncateRequestPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B0CFA127BBF52600F352F9 /* ChannelTruncateRequestPayload.swift */; };
+		A3B78F18282A675700348AD1 /* MessageDeliveryStatus+ChannelList_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B78F17282A675700348AD1 /* MessageDeliveryStatus+ChannelList_Tests.swift */; };
+		A3B78F1A282A6A8F00348AD1 /* UserRobot+Asserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B78F19282A6A8F00348AD1 /* UserRobot+Asserts.swift */; };
 		A3BB3FFF261DA74D00365496 /* ContainerStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BB3FFE261DA74D00365496 /* ContainerStackView.swift */; };
 		A3BD4815281A941B0090D511 /* AutomaticSettings in Frameworks */ = {isa = PBXBuildFile; productRef = A3BD4814281A941B0090D511 /* AutomaticSettings */; };
 		A3BD4818281A984C0090D511 /* DispatchQueue+AsyncAfter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BD4817281A984C0090D511 /* DispatchQueue+AsyncAfter.swift */; };
@@ -3048,6 +3055,10 @@
 		A3698DD52821504C00814143 /* ws_events_member.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ws_events_member.json; sourceTree = "<group>"; };
 		A3698DD728215E2F00814143 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		A36F99792818459C0078260D /* InternetConnectionMonitor_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetConnectionMonitor_Mock.swift; sourceTree = "<group>"; };
+		A3813B47282525280076E838 /* ws_events_user.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ws_events_user.json; sourceTree = "<group>"; };
+		A3813B49282595960076E838 /* ChannelConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelConfig.swift; sourceTree = "<group>"; };
+		A3813B4B2825C8030076E838 /* CustomChatMessageListRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomChatMessageListRouter.swift; sourceTree = "<group>"; };
+		A3813B4D2825C8A30076E838 /* ThreadVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadVC.swift; sourceTree = "<group>"; };
 		A382131D2805C8AC0068D30E /* TestsEnvironmentSetup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestsEnvironmentSetup.swift; sourceTree = "<group>"; };
 		A3960E0A27DA587B003AB2B0 /* RetryStrategy_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryStrategy_Tests.swift; sourceTree = "<group>"; };
 		A3960E0C27DA5973003AB2B0 /* ConnectionRecoveryHandler_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConnectionRecoveryHandler_Tests.swift; sourceTree = "<group>"; };
@@ -3055,8 +3066,11 @@
 		A39A8AE6263825F4003453D9 /* ChatMessageLayoutOptionsResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageLayoutOptionsResolver.swift; sourceTree = "<group>"; };
 		A39B040A27F196F200D6B18A /* StreamChatUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamChatUITests.swift; sourceTree = "<group>"; };
 		A3A644B227BF99D400F92494 /* ChannelTruncateRequestPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTruncateRequestPayload_Tests.swift; sourceTree = "<group>"; };
+		A3AFEAA62816F1A200A79A6A /* MessageDeliveryStatus_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDeliveryStatus_Tests.swift; sourceTree = "<group>"; };
 		A3B0CFA127BBF52600F352F9 /* ChannelTruncateRequestPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTruncateRequestPayload.swift; sourceTree = "<group>"; };
 		A3B0CFA327BCF66A00F352F9 /* ChannelTruncated_with_message.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ChannelTruncated_with_message.json; sourceTree = "<group>"; };
+		A3B78F17282A675700348AD1 /* MessageDeliveryStatus+ChannelList_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessageDeliveryStatus+ChannelList_Tests.swift"; sourceTree = "<group>"; };
+		A3B78F19282A6A8F00348AD1 /* UserRobot+Asserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserRobot+Asserts.swift"; sourceTree = "<group>"; };
 		A3BB3FFE261DA74D00365496 /* ContainerStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerStackView.swift; sourceTree = "<group>"; };
 		A3BD4817281A984C0090D511 /* DispatchQueue+AsyncAfter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+AsyncAfter.swift"; sourceTree = "<group>"; };
 		A3BD484D281ABB620090D511 /* CustomChannelListRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomChannelListRouter.swift; sourceTree = "<group>"; };
@@ -4946,6 +4960,7 @@
 				82CED1CD27DF60AC006E967A /* http_reaction.json */,
 				A3698DD1282147A200814143 /* ws_events_channel.json */,
 				A3698DD52821504C00814143 /* ws_events_member.json */,
+				A3813B47282525280076E838 /* ws_events_user.json */,
 				825A32C727DBA243000402A9 /* ws_events.json */,
 				82E4CBD927F232EA0013B02D /* ws_health_check.json */,
 				822F268B27DA447F00E454FB /* ws_message.json */,
@@ -4977,6 +4992,7 @@
 				82D2E81E27D10F4300169ADA /* StreamMockServer.swift */,
 				82E4CBDF27F322EA0013B02D /* User.swift */,
 				82E4CBDB27F240C60013B02D /* WebsocketResponses.swift */,
+				A3813B49282595960076E838 /* ChannelConfig.swift */,
 			);
 			path = MockServer;
 			sourceTree = "<group>";
@@ -4993,11 +5009,12 @@
 		82AD02B627D8E3D4000611B7 /* Robots */ = {
 			isa = PBXGroup;
 			children = (
+				A3698DCD28212C8400814143 /* BackendRobot.swift */,
 				82AD02B827D8E416000611B7 /* DeviceRobot.swift */,
 				822F268D27DA460800E454FB /* ParticipantRobot.swift */,
 				82BA52F027E1F36B00951B87 /* Robot+CustomAssertions.swift */,
 				8298C8E827D22C3E004082D3 /* UserRobot.swift */,
-				A3698DCD28212C8400814143 /* BackendRobot.swift */,
+				A3B78F19282A6A8F00348AD1 /* UserRobot+Asserts.swift */,
 			);
 			path = Robots;
 			sourceTree = "<group>";
@@ -5016,6 +5033,7 @@
 		82AD02BE27D8E453000611B7 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				A3B78F16282A670600348AD1 /* Message Delivery Status */,
 				82BA52EE27E1EF7B00951B87 /* MessageList_Tests.swift */,
 				82A6F5BF27E2031000F4A2F6 /* Reactions_Tests.swift */,
 				82AD02BC27D8E44B000611B7 /* StreamTestCase.swift */,
@@ -5585,12 +5603,14 @@
 		A34407FA27D8C8AB0044F150 /* StreamChat */ = {
 			isa = PBXGroup;
 			children = (
-				A34407F627D8C8A70044F150 /* ChatClient+shared.swift */,
-				A34407F527D8C8A70044F150 /* User.swift */,
-				A34407FB27D8C9040044F150 /* StreamChatWrapper.swift */,
 				8210AA2727FC916B005F0B32 /* ChannelList.swift */,
-				A3BD484D281ABB620090D511 /* CustomChannelListRouter.swift */,
 				A3BD484F281AC16C0090D511 /* ChannelVC.swift */,
+				A34407F627D8C8A70044F150 /* ChatClient+shared.swift */,
+				A3BD484D281ABB620090D511 /* CustomChannelListRouter.swift */,
+				A3813B4B2825C8030076E838 /* CustomChatMessageListRouter.swift */,
+				A34407FB27D8C9040044F150 /* StreamChatWrapper.swift */,
+				A34407F527D8C8A70044F150 /* User.swift */,
+				A3813B4D2825C8A30076E838 /* ThreadVC.swift */,
 			);
 			path = StreamChat;
 			sourceTree = "<group>";
@@ -6519,6 +6539,15 @@
 				849AE661270CB00000423A20 /* VideoLoader_Mock.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		A3B78F16282A670600348AD1 /* Message Delivery Status */ = {
+			isa = PBXGroup;
+			children = (
+				A3AFEAA62816F1A200A79A6A /* MessageDeliveryStatus_Tests.swift */,
+				A3B78F17282A675700348AD1 /* MessageDeliveryStatus+ChannelList_Tests.swift */,
+			);
+			path = "Message Delivery Status";
 			sourceTree = "<group>";
 		};
 		A3BD4816281A97750090D511 /* Extensions */ = {
@@ -8333,6 +8362,7 @@
 			files = (
 				82E4CBD627F22EC50013B02D /* http_channels.json in Resources */,
 				82CED1CE27DF60AC006E967A /* http_reaction.json in Resources */,
+				A3813B48282525280076E838 /* ws_events_user.json in Resources */,
 				82E4CBDA27F232EA0013B02D /* ws_health_check.json in Resources */,
 				822F268027DA3F7700E454FB /* http_events.json in Resources */,
 				A3698DCA2820325900814143 /* http_member.json in Resources */,
@@ -9611,6 +9641,7 @@
 				A3BD4818281A984C0090D511 /* DispatchQueue+AsyncAfter.swift in Sources */,
 				A3BD484E281ABB620090D511 /* CustomChannelListRouter.swift in Sources */,
 				A3698DD828215E2F00814143 /* Settings.swift in Sources */,
+				A3813B4C2825C8030076E838 /* CustomChatMessageListRouter.swift in Sources */,
 				A3698D802820187200814143 /* DebugMenu.swift in Sources */,
 				A34407C127D8C33F0044F150 /* ViewController.swift in Sources */,
 				A3BD4850281AC16C0090D511 /* ChannelVC.swift in Sources */,
@@ -9619,6 +9650,7 @@
 				A34407F827D8C8A70044F150 /* User.swift in Sources */,
 				A34407F927D8C8A70044F150 /* ChatClient+shared.swift in Sources */,
 				A34407FC27D8C9040044F150 /* StreamChatWrapper.swift in Sources */,
+				A3813B4E2825C8A30076E838 /* ThreadVC.swift in Sources */,
 				8210AA2827FC916B005F0B32 /* ChannelList.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -9644,17 +9676,21 @@
 				825A32AC27DA5462000402A9 /* Dictionary.swift in Sources */,
 				82E4CBDC27F240C60013B02D /* WebsocketResponses.swift in Sources */,
 				828C584927F72B090003EAD9 /* (null) in Sources */,
+				A3AFEAA72816F1A200A79A6A /* MessageDeliveryStatus_Tests.swift in Sources */,
 				822F265727D8F75D00E454FB /* UserRobot.swift in Sources */,
+				A3B78F1A282A6A8F00348AD1 /* UserRobot+Asserts.swift in Sources */,
 				822F265527D8F75600E454FB /* String.swift in Sources */,
 				825A32CD27DBB46F000402A9 /* ChannelListPage.swift in Sources */,
 				822F265C27D8F79100E454FB /* StreamMockServer.swift in Sources */,
 				A3698DCE28212C8400814143 /* BackendRobot.swift in Sources */,
 				82B350FB27EA298800FEB6A0 /* ReactionResponses.swift in Sources */,
 				822F268E27DA460800E454FB /* ParticipantRobot.swift in Sources */,
+				A3B78F18282A675700348AD1 /* MessageDeliveryStatus+ChannelList_Tests.swift in Sources */,
 				825A32CB27DBB463000402A9 /* MessageListPage.swift in Sources */,
 				8224FD86280EC09800B32D43 /* HttpServer.swift in Sources */,
 				82E4CBE027F322EA0013B02D /* User.swift in Sources */,
 				822F265B27D8F76800E454FB /* LaunchArgument.swift in Sources */,
+				A3813B4A282595960076E838 /* ChannelConfig.swift in Sources */,
 				824445AB27EA364300DB2FD8 /* ChannelResponses.swift in Sources */,
 				822F265227D8F74700E454FB /* StreamTestCase.swift in Sources */,
 				822F266227D9FE5E00E454FB /* RequestRecorderURLProtocol_Mock.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -12482,7 +12482,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift-test-helpers.git";
 			requirement = {
 				kind = revision;
-				revision = 3c5b3ebc3b65a671b2bf890f2745190872a1fabd;
+				revision = 246845edb41de52325b249165f68e045fd30d955;
 			};
 		};
 		AD472EF625C425FB00A96E70 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -7870,6 +7870,7 @@
 				A34407B627D8C33F0044F150 /* Sources */,
 				A34407B727D8C33F0044F150 /* Frameworks */,
 				A34407B827D8C33F0044F150 /* Resources */,
+				A3B78F1B282AB07100348AD1 /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -8441,6 +8442,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which mint >/dev/null && mint which swiftgen; then\n  xcrun --sdk macosx mint run swiftgen config run --config ./Sources/StreamChatUI/.swiftgen.yml\nelse\n  echo \"Warning: Bootstrap not run, please run ./bootstrap.sh\"\nfi\n";
+		};
+		A3B78F1B282AB07100348AD1 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Adds support for Apple Silicon brew directory\nexport PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which mint; then\n  echo \"Runnning SwiftLint\"\n    mint run swiftlint\nelse\n  echo \"Warning: Mint not installed\"\nfi\n";
 		};
 		E3FBB83E27F737F10067608A /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/StreamChatUITestsApp/DebugMenu.swift
+++ b/StreamChatUITestsApp/DebugMenu.swift
@@ -59,7 +59,8 @@ final class DebugMenu {
                               handler: { [unowned self] _ in
                                   self.presentAlert(in: viewController,
                                                     title: "Members",
-                                                    message: channelController.channel?.lastActiveMembers.map(\.name).debugDescription, actions: []
+                                                    message: channelController.channel?.lastActiveMembers.map(\.name).debugDescription,
+                                                    actions: []
                                   )
                         })
                      ])

--- a/StreamChatUITestsApp/StreamChat/CustomChatMessageListRouter.swift
+++ b/StreamChatUITestsApp/StreamChat/CustomChatMessageListRouter.swift
@@ -1,0 +1,29 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamChatUI
+import StreamChat
+
+final class CustomMessageListRouter: ChatMessageListRouter {
+
+    var onThreadViewWillAppear: ((ThreadVC) -> Void)?
+
+    override func showThread(messageId: MessageId, cid: ChannelId, client: ChatClient) {
+        let threadVC = components.threadVC.init()
+        threadVC.channelController = client.channelController(for: cid)
+        threadVC.messageController = client.messageController(
+            cid: cid,
+            messageId: messageId
+        )
+
+        if let vc = threadVC as? ThreadVC {
+            vc.onViewWillAppear = { [weak self] _ in
+                self?.onThreadViewWillAppear?(vc)
+            }
+        }
+        rootNavigationController?.show(threadVC, sender: self)
+    }
+
+}

--- a/StreamChatUITestsApp/StreamChat/StreamChatWrapper.swift
+++ b/StreamChatUITestsApp/StreamChat/StreamChatWrapper.swift
@@ -25,11 +25,15 @@ final class StreamChatWrapper {
         config.isLocalStorageEnabled = false
 
         // Customization
-        Components.default.channelListRouter = CustomChannelListRouter.self
-        Components.default.channelVC = ChannelVC.self
+        var components = Components.default
+        components.channelListRouter = CustomChannelListRouter.self
+        components.messageListRouter = CustomMessageListRouter.self
+        components.channelVC = ChannelVC.self
+        components.threadVC = ThreadVC.self
+        Components.default = components
 
         // create an instance of ChatClient and share it using the singleton
-        let environment: ChatClient.Environment = ChatClient.Environment()
+        let environment = ChatClient.Environment()
         ChatClient.shared = ChatClient(config: config, environment: environment)
 
         // connect to chat

--- a/StreamChatUITestsApp/StreamChat/ThreadVC.swift
+++ b/StreamChatUITestsApp/StreamChat/ThreadVC.swift
@@ -1,0 +1,18 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import StreamChatUI
+
+final class ThreadVC: ChatThreadVC {
+
+    var onViewWillAppear: ((ChatThreadVC) -> Void)?
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        onViewWillAppear?(self)
+    }
+    
+}

--- a/StreamChatUITestsApp/ViewController.swift
+++ b/StreamChatUITestsApp/ViewController.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 import StreamChat
+import StreamChatUI
 
 final class ViewController: UIViewController {
 
@@ -12,6 +13,7 @@ final class ViewController: UIViewController {
 
     var channelController: ChatChannelController?
     var router: CustomChannelListRouter?
+    var messageListRouter: CustomMessageListRouter?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -44,6 +46,8 @@ final class ViewController: UIViewController {
         router?.onChannelViewWillAppear = { [weak self] channelVC in
             guard let self = self else { return }
             self.channelController = channelVC.channelController
+
+            // show connection switch if needed
             let switchControl = self.createIsConnectedSwitchIfNeeded()
             if let switchControl = switchControl {
                 channelVC.navigationItem.titleView = switchControl
@@ -51,6 +55,9 @@ final class ViewController: UIViewController {
 
             // Show debug button on the right side
             channelVC.navigationItem.rightBarButtonItems?.append(self.createDebugButton())
+
+            // Hook on mesage list router
+            self.configureMessageListRouter(router: channelVC.messageListVC.router)
         }
 
         // Settings
@@ -62,6 +69,19 @@ final class ViewController: UIViewController {
         // pops when tapped on user icon
         router?.onLeave = { [weak self] in
             self?.navigationController?.popViewController(animated: true)
+        }
+    }
+
+    private func configureMessageListRouter(router: ChatMessageListRouter) {
+        guard let router = router as? CustomMessageListRouter else {
+            return
+        }
+
+        self.messageListRouter = router
+        messageListRouter?.onThreadViewWillAppear = { [weak self] threadVC in
+            guard let self = self else { return }
+            threadVC.navigationItem.rightBarButtonItem = self.createDebugButton()
+            threadVC.navigationItem.titleView = self.createIsConnectedSwitchIfNeeded()
         }
     }
 

--- a/StreamChatUITestsAppUITests/MockResponses/http_channels.json
+++ b/StreamChatUITestsAppUITests/MockResponses/http_channels.json
@@ -104,7 +104,7 @@
       },
       "messages": [],
       "pinned_messages": [],
-      "watcher_count": 1,
+      "watcher_count": 3,
       "read": [],
       "members": [
         {

--- a/StreamChatUITestsAppUITests/MockResponses/ws_events_user.json
+++ b/StreamChatUITestsAppUITests/MockResponses/ws_events_user.json
@@ -1,0 +1,18 @@
+{
+  "user": {
+    "id": "han_solo",
+    "role": "user",
+    "created_at": "2020-12-07T11:37:34.230369Z",
+    "updated_at": "2022-03-21T15:23:04.466699Z",
+    "last_active": "2022-03-28T17:49:21.522571744Z",
+    "banned": false,
+    "online": true,
+    "name": "Han Solo",
+    "image": "https://vignette.wikia.nocookie.net/starwars/images/e/e2/TFAHanSolo.png",
+    "birthland": "Corellia",
+    "extraData": {},
+    "image_url": "https://vignette.wikia.nocookie.net/starwars/images/e/e2/TFAHanSolo.png"
+  },
+  "type": "user.presence.changed",
+  "created_at": "2022-05-06T09:41:39.052596002Z"
+}

--- a/StreamChatUITestsAppUITests/MockServer/ChannelConfig.swift
+++ b/StreamChatUITestsAppUITests/MockServer/ChannelConfig.swift
@@ -17,12 +17,14 @@ struct ChannelConfigs {
     func updateChannel(channel: inout [String: Any], withId id: String) {
         guard
             let config = configs[id],
-            var configJson = channel[JSONKey.config] as? [String: Any]
+            var innerChannel = channel[JSONKey.channel] as? [String: Any],
+            var configJson = innerChannel[JSONKey.config] as? [String: Any]
         else {
             return
         }
         config.update(json: &configJson)
-        channel[JSONKey.config] = configJson
+        innerChannel[JSONKey.config] = configJson
+        channel[JSONKey.channel] = innerChannel
     }
 
     mutating func updateConfig(config: ChannelConfig_Mock,
@@ -32,17 +34,14 @@ struct ChannelConfigs {
         guard
             var channels = json[JSONKey.channels] as? [[String: Any]],
             let channelIndex = server.channelIndex(withId: id),
-            var channel = server.channel(withId: id),
-            var innerChannel = channel[JSONKey.channel] as? [String: Any]
+            var channel = server.channel(withId: id)
         else {
             return
         }
 
         configs[id] = config
 
-        updateChannel(channel: &innerChannel, withId: id)
-
-        channel[JSONKey.channel] = innerChannel
+        updateChannel(channel: &channel, withId: id)
         channels[channelIndex] = channel
         json[JSONKey.channels] = channels
         server.channelList = json

--- a/StreamChatUITestsAppUITests/MockServer/ChannelConfig.swift
+++ b/StreamChatUITestsAppUITests/MockServer/ChannelConfig.swift
@@ -1,0 +1,132 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+@testable import StreamChat
+import Swifter
+import XCTest
+
+// MARK: - Config
+
+struct ChannelConfigs {
+
+    private var configs: [String: ChannelConfig_Mock] = [:]
+
+    func updateChannel(channel: inout [String: Any], withId id: String) {
+        guard
+            let config = configs[id],
+            var configJson = channel[JSONKey.config] as? [String: Any]
+        else {
+            return
+        }
+        config.update(json: &configJson)
+        channel[JSONKey.config] = configJson
+    }
+
+    mutating func updateConfig(config: ChannelConfig_Mock,
+                               forChannelWithId id: String,
+                               server: StreamMockServer) {
+        var json = server.channelList
+        guard
+            var channels = json[JSONKey.channels] as? [[String: Any]],
+            let channelIndex = server.channelIndex(withId: id),
+            var channel = server.channel(withId: id),
+            var innerChannel = channel[JSONKey.channel] as? [String: Any]
+        else {
+            return
+        }
+
+        configs[id] = config
+
+        updateChannel(channel: &innerChannel, withId: id)
+
+        channel[JSONKey.channel] = innerChannel
+        channels[channelIndex] = channel
+        json[JSONKey.channels] = channels
+        server.channelList = json
+    }
+
+    mutating func config(forChannelId id: String,
+                         server: StreamMockServer) -> ChannelConfig_Mock? {
+        if let config = configs[id] { return config }
+
+        let config = loadConfig(forChannelId: id, server: server)
+        configs[id] = config
+        return config
+    }
+
+    private func loadConfig(forChannelId id: String,
+                            server: StreamMockServer) -> ChannelConfig_Mock? {
+        guard
+            let channel = server.channel(withId: id),
+            let innerChannel = channel[JSONKey.channel] as? [String: Any],
+            let configJson = (innerChannel[JSONKey.config] as? [String: Any])?.jsonToString()
+        else {
+            return nil
+        }
+
+        return try? ChannelConfig_Mock(configJson)
+    }
+
+}
+
+struct ChannelConfig_Mock: Codable {
+    var typingEvents: Bool
+    var readEvents: Bool
+    var connectEvents: Bool
+    var search: Bool
+    var reactions: Bool
+    var replies: Bool
+    var quotes: Bool
+    var mutes: Bool
+    var uploads: Bool
+    var urlEnrichment: Bool
+    var customEvents: Bool
+    var pushNotifications: Bool
+    var reminders: Bool
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case typingEvents = "typing_events"
+        case readEvents = "read_events"
+        case connectEvents = "connect_events"
+        case search = "search"
+        case reactions = "reactions"
+        case replies = "replies"
+        case quotes = "quotes"
+        case mutes = "mutes"
+        case uploads = "uploads"
+        case urlEnrichment = "url_enrichment"
+        case customEvents = "custom_events"
+        case pushNotifications = "push_notifications"
+        case reminders = "reminders"
+    }
+
+    func update(json: inout [String: Any]) {
+        json[CodingKeys.typingEvents.rawValue] = typingEvents
+        json[CodingKeys.readEvents.rawValue] = readEvents
+        json[CodingKeys.connectEvents.rawValue] = connectEvents
+        json[CodingKeys.search.rawValue] = search
+        json[CodingKeys.reactions.rawValue] = reactions
+        json[CodingKeys.replies.rawValue] = replies
+        json[CodingKeys.quotes.rawValue] = quotes
+        json[CodingKeys.mutes.rawValue] = mutes
+        json[CodingKeys.uploads.rawValue] = uploads
+        json[CodingKeys.urlEnrichment.rawValue] = urlEnrichment
+        json[CodingKeys.customEvents.rawValue] = customEvents
+        json[CodingKeys.pushNotifications.rawValue] = pushNotifications
+        json[CodingKeys.reminders.rawValue] = reminders
+    }
+
+    init(data: Data) throws {
+        self = try JSONDecoder().decode(ChannelConfig_Mock.self, from: data)
+    }
+
+    init(_ json: String, using encoding: String.Encoding = .utf8) throws {
+        guard let data = json.data(using: encoding) else {
+            throw NSError(domain: "JSONDecoding", code: 0, userInfo: nil)
+        }
+        try self.init(data: data)
+    }
+}

--- a/StreamChatUITestsAppUITests/MockServer/ChannelResponses.swift
+++ b/StreamChatUITestsAppUITests/MockServer/ChannelResponses.swift
@@ -169,7 +169,10 @@ extension StreamMockServer {
         case .memberAdded:
             members.append(contentsOf: membersWithIds)
         case .memberRemoved:
-            members.removeAll(where: { ids.contains($0[JSONKey.userId] as! String) })
+            members.removeAll(where: {
+                let memberId = $0[JSONKey.userId] as? String
+                return ids.contains(memberId ?? "")
+            })
         default:
             return .badRequest(nil)
         }
@@ -178,8 +181,6 @@ extension StreamMockServer {
         channel[JSONKey.channel] = innerChannel
         channels[channelIndex] = channel
         json[JSONKey.channels] = channels
-
-        channelList = json
 
         if let channelId = (channel[JSONKey.channel] as? [String: Any])?[JSONKey.id] as? String {
             // Send web socket event with given event type
@@ -190,6 +191,8 @@ extension StreamMockServer {
             // Send channel update web socket event
             websocketChannelUpdated(with: members, channelId: channelId)
         }
+
+        channelList = json
 
         return .ok(.json(json))
     }

--- a/StreamChatUITestsAppUITests/MockServer/MessageResponses.swift
+++ b/StreamChatUITestsAppUITests/MockServer/MessageResponses.swift
@@ -211,15 +211,15 @@ extension StreamMockServer {
         let responseMessage = responseJson[JSONKey.message] as? [String: Any]
         let timestamp: String = TestData.currentDate
         let user = setUpUser(source: responseMessage, details: UserDetails.lukeSkywalker)
-        let parrentMessage = findMessageById(parentId)
+        let parentMessage = findMessageById(parentId)
         
         websocketMessage(
-            parrentMessage?[MessagePayloadsCodingKeys.text.rawValue] as? String,
+            parentMessage?[MessagePayloadsCodingKeys.text.rawValue] as? String,
             channelId: channelId,
             messageId: parentId,
-            timestamp: parrentMessage?[MessagePayloadsCodingKeys.createdAt.rawValue] as? String,
+            timestamp: parentMessage?[MessagePayloadsCodingKeys.createdAt.rawValue] as? String,
             eventType: .messageUpdated,
-            user: user
+            user: parentMessage?[JSONKey.user] as? [String: Any]
         ) { message in
             message?[MessagePayloadsCodingKeys.threadParticipants.rawValue] = [user]
             return message
@@ -320,7 +320,7 @@ extension StreamMockServer {
         var json = TestData.toJson(.httpMessage)
         let message = findMessageById(messageId)
         let timestamp: String = TestData.currentDate
-        let user = setUpUser(source: message, details: UserDetails.lukeSkywalker)
+        let user = message?[JSONKey.user] as? [String: Any]
         let mockedMessage = mockDeletedMessage(message, user: user)
         
         websocketMessage(

--- a/StreamChatUITestsAppUITests/MockServer/MockServerAttributes.swift
+++ b/StreamChatUITestsAppUITests/MockServer/MockServerAttributes.swift
@@ -14,12 +14,13 @@ enum MockFile: String {
     case wsChatEvent = "ws_events"
     case wsChannelEvent = "ws_events_channel"
     case wsMemberEvent = "ws_events_member"
+    case wsUserEvent = "ws_events_user"
     case wsReaction = "ws_reaction"
     case wsHealthCheck = "ws_health_check"
     case httpChannels = "http_channels"
 }
 
-struct MockEndpoint {
+enum MockEndpoint {
     static let connect = "/connect"
     
     static let messageUpdate = "/messages/\(EndpointQuery.messageId)"
@@ -46,7 +47,7 @@ enum MessageType: String {
     case deleted
 }
 
-struct JSONKey {
+enum JSONKey {
     static let messages = "messages"
     static let message = "message"
     static let reaction = "reaction"
@@ -58,21 +59,22 @@ struct JSONKey {
     static let channel = "channel"
     static let channelId = "channel_id"
     static let channelType = "channel_type"
+    static let config = "config"
     static let createdAt = "created_at"
     static let eventType = "type"
     static let members = "members"
     static let member = "member"
     static let id = "id"
 
-    struct Channel {
+    enum Channel {
         static let addMembers = "add_members"
         static let removeMembers = "remove_members"
     }
 }
 
-struct UserDetails {
+enum UserDetails {
 
-    static var users: [[String: Any]] {
+    static var users: [[String: String]] {
         [
             hanSolo,
             lukeSkywalker,
@@ -127,12 +129,16 @@ struct UserDetails {
         UserPayloadsCodingKeys.imageURL.rawValue: "https://vignette.wikia.nocookie.net/starwars/images/e/eb/ArtooTFA2-Fathead.png"
     ]
 
-    static func unknownUser(withUserId userId: String) -> [String: Any] {
+    static func unknownUser(withUserId userId: String) -> [String: String] {
         [
             UserPayloadsCodingKeys.id.rawValue: userId,
             UserPayloadsCodingKeys.name.rawValue: userName(for: userId),
             UserPayloadsCodingKeys.imageURL.rawValue: "https://vignette.wikia.nocookie.net/starwars/images/f/fc/Leia_Organa_TLJ.png"
         ]
+    }
+
+    static func userId(for user: [String: String]) -> String {
+        user[UserPayloadsCodingKeys.id.rawValue] ?? leiaOrganaId
     }
 
     static func userName(for id: String) -> String {
@@ -142,17 +148,19 @@ struct UserDetails {
             .joined(separator: " ")
     }
 
-    static func user(withUserId userId: String) -> (id: String, name: String, url: String) {
-        var user = UserDetails.users.first(where: { ($0[UserPayloadsCodingKeys.id.rawValue] as? String) == userId })
-
-        if user == nil {
-            user = UserDetails.unknownUser(withUserId: userId)
-        }
-
+    static func userTuple(withUserId userId: String) -> (id: String, name: String, url: String) {
+        let user = user(withUserId: userId)
         return (
-            (user?[UserPayloadsCodingKeys.id.rawValue] as? String) ?? leiaOrganaId,
-            (user?[UserPayloadsCodingKeys.name.rawValue] as? String) ?? "Leia Organa",
-            (user?[UserPayloadsCodingKeys.imageURL.rawValue] as? String) ?? "https://vignette.wikia.nocookie.net/starwars/images/f/fc/Leia_Organa_TLJ.png"
+            user[UserPayloadsCodingKeys.id.rawValue] ?? leiaOrganaId,
+            user[UserPayloadsCodingKeys.name.rawValue] ?? "Leia Organa",
+            user[UserPayloadsCodingKeys.imageURL.rawValue] ?? "https://vignette.wikia.nocookie.net/starwars/images/f/fc/Leia_Organa_TLJ.png"
         )
+    }
+
+    static func user(withUserId userId: String) -> [String: String] {
+        guard let user = UserDetails.users.first(where: { $0[UserPayloadsCodingKeys.id.rawValue] == userId }) else {
+            return UserDetails.unknownUser(withUserId: userId)
+        }
+        return user
     }
 }

--- a/StreamChatUITestsAppUITests/MockServer/StreamMockServer.swift
+++ b/StreamChatUITestsAppUITests/MockServer/StreamMockServer.swift
@@ -19,8 +19,9 @@ final class StreamMockServer {
     private var _messageList: [[String: Any]] = []
     private var _channelList = TestData.toJson(.httpChannels)
     private var _currentChannelId: String = ""
+    private var channelConfigs = ChannelConfigs()
     
-    public var messageList: [[String: Any]] {
+    var messageList: [[String: Any]] {
         get {
             return self._messageList
         }
@@ -29,7 +30,7 @@ final class StreamMockServer {
         }
     }
     
-    public var channelList: [String: Any] {
+    var channelList: [String: Any] {
         get {
             return self._channelList
         }
@@ -38,7 +39,7 @@ final class StreamMockServer {
         }
     }
     
-    public var currentChannelId: String {
+    var currentChannelId: String {
         get {
             return self._currentChannelId
         }
@@ -46,7 +47,7 @@ final class StreamMockServer {
             self._currentChannelId = newValue
         }
     }
-    
+
     func start(port: UInt16) {
         do {
             try server.start(port)
@@ -84,5 +85,22 @@ final class StreamMockServer {
     
     private func healthCheck() {
         writeText(TestData.getMockResponse(fromFile: .wsHealthCheck))
+    }
+}
+
+// MARK: Config
+
+extension StreamMockServer {
+
+    func config(forChannelId id: String) -> ChannelConfig_Mock? {
+        channelConfigs.config(forChannelId: id, server: self)
+    }
+
+    func updateConfig(config: ChannelConfig_Mock, forChannelWithId id: String) {
+        channelConfigs.updateConfig(config: config, forChannelWithId: id, server: self)
+    }
+
+    func updateConfig(in channel: inout [String: Any], withId id: String) {
+        channelConfigs.updateChannel(channel: &channel, withId: id)
     }
 }

--- a/StreamChatUITestsAppUITests/MockServer/User.swift
+++ b/StreamChatUITestsAppUITests/MockServer/User.swift
@@ -21,7 +21,7 @@ extension StreamMockServer {
 
     func memberJSONs(for ids: [String]) -> [[String: Any]] {
         ids.map {
-            let user = UserDetails.user(withUserId: $0)
+            let user = UserDetails.userTuple(withUserId: $0)
             var member = TestData.toJson(.httpMember)
             member[JSONKey.userId] = user.id
             member[UserPayloadsCodingKeys.id.rawValue] = user.name

--- a/StreamChatUITestsAppUITests/MockServer/WebsocketResponses.swift
+++ b/StreamChatUITestsAppUITests/MockServer/WebsocketResponses.swift
@@ -17,7 +17,7 @@ extension StreamMockServer {
             closure()
         }
     }
-    
+
     /// Sends an event over a websocket connection
     ///
     /// - Parameters:
@@ -30,6 +30,12 @@ extension StreamMockServer {
         user: [String: Any]?,
         channelId: String
     ) -> Self {
+        let json = websocketEventJSON(eventType, user: user, channelId: channelId)
+        writeText(json.jsonToString())
+        return self
+    }
+
+    private func websocketEventJSON(_ eventType: EventType, user: [String: Any]?, channelId: String) -> [String: Any] {
         var json = TestData.getMockResponse(fromFile: .wsChatEvent).json
         json[EventPayload.CodingKeys.user.rawValue] = user
         json[EventPayload.CodingKeys.createdAt.rawValue] = TestData.currentDate
@@ -37,9 +43,7 @@ extension StreamMockServer {
         json[EventPayload.CodingKeys.channelId.rawValue] = channelId
         json[EventPayload.CodingKeys.channelType.rawValue] = ChannelType.messaging.rawValue
         json[EventPayload.CodingKeys.cid.rawValue] = "\(ChannelType.messaging.rawValue):\(channelId)"
-        
-        writeText(json.jsonToString())
-        return self
+        return json
     }
     
     /// Manages the lifecycle of the messages over a websocket connection
@@ -188,6 +192,10 @@ extension StreamMockServer {
         timestamp: String? = TestData.currentDate
     ) -> Self {
         var json = TestData.getMockResponse(fromFile: .wsChannelEvent).json
+
+        // updated config with current values
+        updateConfig(in: &json, withId: channelId)
+        
         json[JSONKey.channelId] = channelId
         json[JSONKey.cid] = "\(ChannelType.messaging.rawValue):\(channelId)"
         json[JSONKey.channelType] = ChannelType.messaging.rawValue

--- a/StreamChatUITestsAppUITests/Pages/ChannelListPage.swift
+++ b/StreamChatUITestsAppUITests/Pages/ChannelListPage.swift
@@ -31,12 +31,16 @@ enum ChannelListPage {
             cell.otherElements["ChatAvatarView"].images.firstMatch
         }
 
-        static func readCount(messageCell: XCUIElement) -> XCUIElement {
-            messageCell.staticTexts["unreadCountLabel"]
+        static func readCount(in cell: XCUIElement) -> XCUIElement {
+            cell.staticTexts["unreadCountLabel"]
         }
 
-        static func statusCheckmark(for status: MessageDeliveryStatus, with messageCell: XCUIElement) -> XCUIElement {
-            messageCell.images["imageView_\(status.rawValue)"]
+        static func statusCheckmark(for status: MessageDeliveryStatus?, in cell: XCUIElement) -> XCUIElement {
+            var identifier = "imageView"
+            if let status = status {
+                identifier = "\(identifier)_\(status.rawValue)"
+            }
+            return cell.images[identifier]
         }
     }
 

--- a/StreamChatUITestsAppUITests/Pages/ChannelListPage.swift
+++ b/StreamChatUITestsAppUITests/Pages/ChannelListPage.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import XCTest
+import StreamChat
 
 enum ChannelListPage {
     
@@ -14,20 +15,28 @@ enum ChannelListPage {
     }
     
     enum Attributes {
-        static func name(channelCell: XCUIElement) -> XCUIElement {
-            channelCell.staticTexts["titleLabel"]
+        static func name(in cell: XCUIElement) -> XCUIElement {
+            cell.staticTexts["titleLabel"]
         }
         
-        static func lastMessageTime(channelCell: XCUIElement) -> XCUIElement {
-            channelCell.staticTexts["timestampLabel"]
+        static func lastMessageTime(in cell: XCUIElement) -> XCUIElement {
+            cell.staticTexts["timestampLabel"]
         }
         
-        static func lastMessage(channelCell: XCUIElement) -> XCUIElement {
-            channelCell.staticTexts["subtitleLabel"]
+        static func lastMessage(in cell: XCUIElement) -> XCUIElement {
+            cell.staticTexts["subtitleLabel"]
         }
         
-        static func avatar(channelCell: XCUIElement) -> XCUIElement {
-            channelCell.otherElements["ChatAvatarView"].images.firstMatch
+        static func avatar(in cell: XCUIElement) -> XCUIElement {
+            cell.otherElements["ChatAvatarView"].images.firstMatch
+        }
+
+        static func readCount(messageCell: XCUIElement) -> XCUIElement {
+            messageCell.staticTexts["unreadCountLabel"]
+        }
+
+        static func statusCheckmark(for status: MessageDeliveryStatus, with messageCell: XCUIElement) -> XCUIElement {
+            messageCell.images["imageView_\(status.rawValue)"]
         }
     }
 

--- a/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
+++ b/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import XCTest
+import StreamChat
 
 // swiftlint:disable convenience_type
 
@@ -52,7 +53,6 @@ class MessageListPage {
             static var showMemberInfo: XCUIElement { alert.buttons["Show Members"] }
             static var dismissMemberInfo: XCUIElement { app.alerts["Members"].buttons["Cancel"] }
         }
-
     }
     
     enum Composer {
@@ -81,18 +81,59 @@ class MessageListPage {
     }
     
     enum ContextMenu {
-        static var reactionsView: XCUIElement { app.otherElements["ChatReactionPickerReactionsView"] }
-        static var reply: XCUIElement { app.otherElements["InlineReplyActionItem"] }
-        static var threadReply: XCUIElement { app.otherElements["ThreadReplyActionItem"] }
-        static var copy: XCUIElement { app.otherElements["CopyActionItem"] }
-        static var flag: XCUIElement { app.otherElements["FlagActionItem"] }
-        static var mute: XCUIElement { app.otherElements["MuteUserActionItem"] }
-        static var unmute: XCUIElement { app.otherElements["UnmuteUserActionItem"] }
-        static var edit: XCUIElement { app.otherElements["EditActionItem"] }
-        static var delete: XCUIElement { app.otherElements["DeleteActionItem"] }
-        static var resend: XCUIElement { app.otherElements["ResendActionItem"] }
-        static var block: XCUIElement { app.otherElements["BlockUserActionItem"] }
-        static var unblock: XCUIElement { app.otherElements["UnblockUserActionItem"] }
+        case reactions
+        case reply
+        case threadReply
+        case copy
+        case flag
+        case mute
+        case edit
+        case delete
+        case resend
+        case block
+        case unblock
+
+        var element: XCUIElement {
+            switch self {
+            case .reactions:
+                return Element.reactionsView
+            case .reply:
+                return Element.reply
+            case .threadReply:
+                return Element.threadReply
+            case .copy:
+                return Element.copy
+            case .flag:
+                return Element.flag
+            case .mute:
+                return Element.mute
+            case .edit:
+                return Element.edit
+            case .delete:
+                return Element.delete
+            case .resend:
+                return Element.resend
+            case .block:
+                return Element.block
+            case .unblock:
+                return Element.unblock
+            }
+        }
+
+        struct Element {
+            static var reactionsView: XCUIElement { app.otherElements["ChatReactionPickerReactionsView"] }
+            static var reply: XCUIElement { app.otherElements["InlineReplyActionItem"] }
+            static var threadReply: XCUIElement { app.otherElements["ThreadReplyActionItem"] }
+            static var copy: XCUIElement { app.otherElements["CopyActionItem"] }
+            static var flag: XCUIElement { app.otherElements["FlagActionItem"] }
+            static var mute: XCUIElement { app.otherElements["MuteUserActionItem"] }
+            static var unmute: XCUIElement { app.otherElements["UnmuteUserActionItem"] }
+            static var edit: XCUIElement { app.otherElements["EditActionItem"] }
+            static var delete: XCUIElement { app.otherElements["DeleteActionItem"] }
+            static var resend: XCUIElement { app.otherElements["ResendActionItem"] }
+            static var block: XCUIElement { app.otherElements["BlockUserActionItem"] }
+            static var unblock: XCUIElement { app.otherElements["UnblockUserActionItem"] }
+        }
     }
     
     enum Attributes {
@@ -132,6 +173,13 @@ class MessageListPage {
             messageCell.buttons["error indicator"]
         }
 
+        static func readCount(messageCell: XCUIElement) -> XCUIElement {
+            messageCell.staticTexts["messageReadСountsLabel"]
+        }
+
+        static func statusCheckmark(for status: MessageDeliveryStatus, with messageCell: XCUIElement) -> XCUIElement {
+            messageCell.images["imageView_\(status.rawValue)"]
+        }
     }
     
     enum PopUpButtons {

--- a/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
+++ b/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
@@ -137,15 +137,15 @@ class MessageListPage {
     }
     
     enum Attributes {
-        static func reactionButton(messageCell: XCUIElement) -> XCUIElement {
+        static func reactionButton(in messageCell: XCUIElement) -> XCUIElement {
             messageCell.buttons["ChatMessageReactionItemView"]
         }
         
-        static func threadButton(messageCell: XCUIElement) -> XCUIElement {
+        static func threadButton(in messageCell: XCUIElement) -> XCUIElement {
             messageCell.buttons["threadReplyCountButton"]
         }
         
-        static func time(messageCell: XCUIElement) -> XCUIElement {
+        static func time(in messageCell: XCUIElement) -> XCUIElement {
             messageCell.staticTexts["timestampLabel"]
         }
         
@@ -153,32 +153,36 @@ class MessageListPage {
             messageCell.staticTexts["authorNameLabel"]
         }
         
-        static func text(messageCell: XCUIElement) -> XCUIElement {
+        static func text(in messageCell: XCUIElement) -> XCUIElement {
             messageCell.textViews["textView"]
         }
         
-        static func quotedText(_ text: String, messageCell: XCUIElement) -> XCUIElement {
+        static func quotedText(_ text: String, in messageCell: XCUIElement) -> XCUIElement {
             messageCell.textViews.matching(NSPredicate(format: "value LIKE '\(text)'")).firstMatch
         }
         
-        static func deletedIcon(messageCell: XCUIElement) -> XCUIElement {
+        static func deletedIcon(in messageCell: XCUIElement) -> XCUIElement {
             messageCell.images["onlyVisibleToYouImageView"]
         }
         
-        static func deletedLabel(messageCell: XCUIElement) -> XCUIElement {
+        static func deletedLabel(in messageCell: XCUIElement) -> XCUIElement {
             messageCell.staticTexts["onlyVisibleToYouLabel"]
         }
 
-        static func errorButton(messageCell: XCUIElement) -> XCUIElement {
+        static func errorButton(in messageCell: XCUIElement) -> XCUIElement {
             messageCell.buttons["error indicator"]
         }
 
-        static func readCount(messageCell: XCUIElement) -> XCUIElement {
+        static func readCount(in messageCell: XCUIElement) -> XCUIElement {
             messageCell.staticTexts["messageReadСountsLabel"]
         }
 
-        static func statusCheckmark(for status: MessageDeliveryStatus, with messageCell: XCUIElement) -> XCUIElement {
-            messageCell.images["imageView_\(status.rawValue)"]
+        static func statusCheckmark(for status: MessageDeliveryStatus?, in messageCell: XCUIElement) -> XCUIElement {
+            var identifier = "imageView"
+            if let status = status {
+                identifier = "\(identifier)_\(status.rawValue)"
+            }
+            return messageCell.images[identifier]
         }
     }
     

--- a/StreamChatUITestsAppUITests/Robots/BackendRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/BackendRobot.swift
@@ -13,9 +13,26 @@ final class BackendRobot: Robot {
         var element: XCUIElement { app.switches[rawValue] }
     }
 
+    private var server: StreamMockServer
+
+    init(_ server: StreamMockServer) {
+        self.server = server
+    }
+
     @discardableResult
     func delayServerResponse(byTimeInterval timeInterval: TimeInterval) -> Self {
         StreamMockServer.httpResponseDelay = timeInterval
+        return self
+    }
+
+    @discardableResult
+    func setReadEvents(to value: Bool) -> Self {
+        let id = server.currentChannelId.isEmpty ? "general" : server.currentChannelId
+        guard var config = server.config(forChannelId: id) else {
+            return self
+        }
+        config.readEvents = value
+        server.updateConfig(config: config, forChannelWithId: id)
         return self
     }
 }

--- a/StreamChatUITestsAppUITests/Robots/ParticipantRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/ParticipantRobot.swift
@@ -168,8 +168,10 @@ final class ParticipantRobot: Robot {
     
     private func participant() -> [String: Any]? {
         let json = TestData.toJson(.wsMessage)
-        let message = json[JSONKey.message] as! [String: Any]
-        let user = server.setUpUser(source: message, details: _user)
-        return user
+        guard let message = json[JSONKey.message] as? [String: Any] else {
+            return nil
+        }
+
+        return server.setUpUser(source: message, details: _user)
     }
 }

--- a/StreamChatUITestsAppUITests/Robots/ParticipantRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/ParticipantRobot.swift
@@ -16,7 +16,11 @@ final class ParticipantRobot: Robot {
     init(_ server: StreamMockServer) {
         self.server = server
     }
-    
+
+    var currentUserId: String {
+        UserDetails.userId(for: user)
+    }
+
     var user: [String: String] {
         get {
             return self._user
@@ -165,7 +169,7 @@ final class ParticipantRobot: Robot {
     private func participant() -> [String: Any]? {
         let json = TestData.toJson(.wsMessage)
         let message = json[JSONKey.message] as! [String: Any]
-        let user = server.setUpUser(source: message, details: user)
+        let user = server.setUpUser(source: message, details: _user)
         return user
     }
 }

--- a/StreamChatUITestsAppUITests/Robots/Robot+CustomAssertions.swift
+++ b/StreamChatUITestsAppUITests/Robots/Robot+CustomAssertions.swift
@@ -23,7 +23,9 @@ extension Robot {
             XCTAssertGreaterThanOrEqual(
                 cells.count,
                 minExpectedCount,
-                "Message cell is not found at index #\(index)"
+                "Message cell is not found at index #\(index)",
+                file: file,
+                line: line
             )
             messageCell = cells.element(boundBy: index)
         } else {
@@ -40,7 +42,7 @@ extension Robot {
         line: UInt = #line
     ) -> Self {
         let messageCell = mesageCell(withIndex: messageCellIndex, file: file, line: line)
-        let message = attributes.text(messageCell: messageCell)
+        let message = attributes.text(in: messageCell)
         let actualText = message.waitForText(text).text
         XCTAssertEqual(text, actualText, file: file, line: line)
         return self
@@ -53,7 +55,7 @@ extension Robot {
         line: UInt = #line
     ) -> Self {
         let messageCell = mesageCell(withIndex: messageCellIndex, file: file, line: line)
-        let message = attributes.text(messageCell: messageCell)
+        let message = attributes.text(in: messageCell)
         let expectedMessage = L10n.Message.deletedMessagePlaceholder
         let actualMessage = message.waitForText(expectedMessage).text
         XCTAssertEqual(expectedMessage, actualMessage, "Text is wrong", file: file, line: line)
@@ -83,7 +85,7 @@ extension Robot {
                            file: StaticString = #filePath,
                            line: UInt = #line) -> Self {
         let cell = mesageCell(withIndex: messageCellIndex, file: file, line: line).wait()
-        let textView = attributes.text(messageCell: cell)
+        let textView = attributes.text(in: cell)
         _ = textView.waitForText(text)
         return self
     }
@@ -120,7 +122,7 @@ extension Robot {
     ) -> Self {
         assertMessage(replyText, file: file, line: line)
         let messageCell = mesageCell(withIndex: messageCellIndex, file: file, line: line)
-        let quotedMessage = attributes.quotedText(quotedText, messageCell: messageCell)
+        let quotedMessage = attributes.quotedText(quotedText, in: messageCell)
         XCTAssertTrue(quotedMessage.exists, "Quoted message was not showed", file: file, line: line)
         XCTAssertFalse(quotedMessage.isEnabled, "Quoted message should be disabled", file: file, line: line)
         return self
@@ -137,7 +139,7 @@ extension Robot {
         line: UInt = #line
     ) -> Self {
         let messageCell = mesageCell(withIndex: messageCellIndex, file: file, line: line)
-        let reaction = attributes.reactionButton(messageCell: messageCell)
+        let reaction = attributes.reactionButton(in: messageCell)
         let errMessage = isPresent ? "There are no reactions" : "Reaction is presented"
         _ = isPresent ? reaction.wait() : reaction.waitForLoss()
         XCTAssertEqual(isPresent, reaction.exists, errMessage, file: file, line: line)
@@ -152,7 +154,7 @@ extension Robot {
                             file: StaticString = #filePath,
                             line: UInt = #line) -> Self {
         let cell = mesageCell(withIndex: messageCellIndex, file: file, line: line).wait()
-        let reaction = attributes.reactionButton(messageCell: cell)
+        let reaction = attributes.reactionButton(in: cell)
         reaction.wait()
         return self
     }

--- a/StreamChatUITestsAppUITests/Robots/Robot+CustomAssertions.swift
+++ b/StreamChatUITestsAppUITests/Robots/Robot+CustomAssertions.swift
@@ -3,82 +3,72 @@
 //
 
 @testable import StreamChatUI
+@testable import StreamChat
 import XCTest
 
-// MARK: Messages
+let attributes = MessageListPage.Attributes.self
+let cells = MessageListPage.cells
+
+// MARK: Message List
 extension Robot {
+
+    @discardableResult
+    func mesageCell(withIndex index: Int? = nil,
+                    file: StaticString = #filePath,
+                    line: UInt = #line) -> XCUIElement {
+        let messageCell: XCUIElement
+        if let index = index {
+            let minExpectedCount = index + 1
+            let cells = cells.waitCount(index)
+            XCTAssertGreaterThanOrEqual(
+                cells.count,
+                minExpectedCount,
+                "Message cell is not found at index #\(index)"
+            )
+            messageCell = cells.element(boundBy: index)
+        } else {
+            messageCell = cells.firstMatch
+        }
+        return messageCell
+    }
 
     @discardableResult
     func assertMessage(
         _ text: String,
+        at messageCellIndex: Int? = nil,
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> Self {
-        let messageCell = MessageListPage.cells.firstMatch
-        let message = MessageListPage.Attributes.text(messageCell: messageCell)
+        let messageCell = mesageCell(withIndex: messageCellIndex, file: file, line: line)
+        let message = attributes.text(messageCell: messageCell)
         let actualText = message.waitForText(text).text
         XCTAssertEqual(text, actualText, file: file, line: line)
         return self
     }
 
     @discardableResult
-    func assertMessageFailedToBeSent(
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) -> Self {
-        let messageCell = MessageListPage.cells.firstMatch
-        let checkmark = MessageListPage.Attributes.errorButton(messageCell: messageCell).wait()
-        XCTAssertTrue(checkmark.exists)
-        return self
-    }
-    
-    @discardableResult
-    func assertThreadReply(
-        _ text: String,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) -> Self {
-        let isThreadPageOpen = ThreadPage.alsoSendInChannelCheckbox.exists
-        XCTAssertTrue(isThreadPageOpen, file: file, line: line)
-        return assertMessage(text, file: file, line: line)
-    }
-    
-    @discardableResult
-    func assertQuotedMessage(
-        replyText: String,
-        quotedText: String,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) -> Self {
-        assertMessage(replyText, file: file, line: line)
-        let messageCell = MessageListPage.cells.firstMatch
-        let quotedMessage = MessageListPage.Attributes.quotedText(quotedText, messageCell: messageCell)
-        XCTAssertTrue(quotedMessage.exists, "Quoted message was not showed", file: file, line: line)
-        XCTAssertFalse(quotedMessage.isEnabled, "Quoted message should be disabled", file: file, line: line)
-        return self
-    }
-    
-    @discardableResult
     func assertDeletedMessage(
+        at messageCellIndex: Int? = nil,
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> Self {
-        let messageCell = MessageListPage.cells.firstMatch
-        let message = MessageListPage.Attributes.text(messageCell: messageCell)
+        let messageCell = mesageCell(withIndex: messageCellIndex, file: file, line: line)
+        let message = attributes.text(messageCell: messageCell)
         let expectedMessage = L10n.Message.deletedMessagePlaceholder
         let actualMessage = message.waitForText(expectedMessage).text
         XCTAssertEqual(expectedMessage, actualMessage, "Text is wrong", file: file, line: line)
         return self
     }
-    
+
     @discardableResult
     func assertMessageAuthor(
         _ author: String,
+        at messageCellIndex: Int? = nil,
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> Self {
-        let messageCell = MessageListPage.cells.firstMatch
-        let textView = MessageListPage.Attributes.author(messageCell: messageCell)
+        let messageCell = mesageCell(withIndex: messageCellIndex, file: file, line: line)
+        let textView = attributes.author(messageCell: messageCell)
         let actualAuthor = textView.waitForText(author).text
         XCTAssertEqual(author, actualAuthor, file: file, line: line)
         return self
@@ -88,10 +78,51 @@ extension Robot {
     ///
     /// - Returns: Self
     @discardableResult
-    func waitForNewMessage(withText text: String) -> Self {
-        let cell = MessageListPage.cells.firstMatch.wait()
-        let textView = MessageListPage.Attributes.text(messageCell: cell)
+    func waitForNewMessage(withText text: String,
+                           at messageCellIndex: Int? = nil,
+                           file: StaticString = #filePath,
+                           line: UInt = #line) -> Self {
+        let cell = mesageCell(withIndex: messageCellIndex, file: file, line: line).wait()
+        let textView = attributes.text(messageCell: cell)
         _ = textView.waitForText(text)
+        return self
+    }
+}
+
+// MARK: Thread Replies
+extension Robot {
+
+    @discardableResult
+    func assertThreadReply(
+        _ text: String,
+        at messageCellIndex: Int? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        let isThreadPageOpen = ThreadPage.alsoSendInChannelCheckbox.exists
+        XCTAssertTrue(isThreadPageOpen, file: file, line: line)
+        return assertMessage(text,
+                             at: messageCellIndex,
+                             file: file,
+                             line: line)
+    }
+}
+
+// MARK: Quoted Messages
+extension Robot {
+    @discardableResult
+    func assertQuotedMessage(
+        replyText: String,
+        quotedText: String,
+        at messageCellIndex: Int? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        assertMessage(replyText, file: file, line: line)
+        let messageCell = mesageCell(withIndex: messageCellIndex, file: file, line: line)
+        let quotedMessage = attributes.quotedText(quotedText, messageCell: messageCell)
+        XCTAssertTrue(quotedMessage.exists, "Quoted message was not showed", file: file, line: line)
+        XCTAssertFalse(quotedMessage.isEnabled, "Quoted message should be disabled", file: file, line: line)
         return self
     }
 }
@@ -101,11 +132,12 @@ extension Robot {
     @discardableResult
     func assertReaction(
         isPresent: Bool,
+        at messageCellIndex: Int? = nil,
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> Self {
-        let messageCell = MessageListPage.cells.firstMatch
-        let reaction = MessageListPage.Attributes.reactionButton(messageCell: messageCell)
+        let messageCell = mesageCell(withIndex: messageCellIndex, file: file, line: line)
+        let reaction = attributes.reactionButton(messageCell: messageCell)
         let errMessage = isPresent ? "There are no reactions" : "Reaction is presented"
         _ = isPresent ? reaction.wait() : reaction.waitForLoss()
         XCTAssertEqual(isPresent, reaction.exists, errMessage, file: file, line: line)
@@ -116,13 +148,14 @@ extension Robot {
     ///
     /// - Returns: Self
     @discardableResult
-    func waitForNewReaction() -> Self {
-        let cell = MessageListPage.cells.firstMatch.wait()
-        let reaction = MessageListPage.Attributes.reactionButton(messageCell: cell)
+    func waitForNewReaction(at messageCellIndex: Int? = nil,
+                            file: StaticString = #filePath,
+                            line: UInt = #line) -> Self {
+        let cell = mesageCell(withIndex: messageCellIndex, file: file, line: line).wait()
+        let reaction = attributes.reactionButton(messageCell: cell)
         reaction.wait()
         return self
     }
-    
 }
 
 // MARK: Keyboard

--- a/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
@@ -1,0 +1,180 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import StreamChat
+
+let channelAttributes = ChannelListPage.Attributes.self
+let channelCells = ChannelListPage.cells
+
+// MARK: Channel List
+extension UserRobot {
+
+    @discardableResult
+    func channelCell(withIndex index: Int? = nil,
+                     file: StaticString = #filePath,
+                     line: UInt = #line) -> XCUIElement {
+        let channelCell: XCUIElement
+        if let index = index {
+            let minExpectedCount = index + 1
+            let cells = cells.waitCount(index)
+            XCTAssertGreaterThanOrEqual(
+                cells.count,
+                minExpectedCount,
+                "Message cell is not found at index #\(index)"
+            )
+            channelCell = channelCells.element(boundBy: index)
+        } else {
+            channelCell = channelCells.firstMatch
+        }
+        return channelCell
+    }
+
+    @discardableResult
+    func assertLastMessageInChannelPreview(
+        _ text: String,
+        at cellIndex: Int? = nil,
+        authoredByUser: Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        let cell = channelCell(withIndex: cellIndex, file: file, line: line)
+        let message = channelAttributes.lastMessage(in: cell)
+        let preview = "You: \(text)"
+        let actualText = message.waitForText(preview).text
+        XCTAssertEqual(preview, actualText, file: file, line: line)
+        return self
+    }
+
+    @discardableResult
+    func assertMessageDeliveryStatusInChannelPreview(
+        _ deliveryStatus: MessageDeliveryStatus,
+        at cellIndex: Int? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        let messageCell = channelCell(withIndex: cellIndex, file: file, line: line)
+        let checkmark = channelAttributes.statusCheckmark(for: deliveryStatus, with: messageCell)
+        XCTAssertEqual(checkmark.wait().exists, true)
+
+        return self
+    }
+
+    @discardableResult
+    func assertMessageReadCountInChannelPreview(
+        readBy: Int,
+        at cellIndex: Int? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        let messageCell = channelCell(withIndex: cellIndex, file: file, line: line)
+        let readByCount = channelAttributes.readCount(messageCell: messageCell)
+        if readBy == 0 {
+            XCTAssertFalse(readByCount.isHittable)
+        } else {
+            XCTAssertEqual(readByCount.wait().text, "\(readBy)")
+        }
+        return self
+    }
+
+}
+
+// MARK: Message List
+extension UserRobot {
+
+    @discardableResult
+    func assertContextMenuOptionNotAvailable(option: MessageListPage.ContextMenu, forMessageAtIndex index: Int = 0) -> Self {
+        openContextMenu(messageCellIndex: index)
+        XCTAssertFalse(option.element.exists)
+        return self
+    }
+
+    @discardableResult
+    func assertMessageFailedToBeSent(
+        at messageCellIndex: Int? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        let messageCell = mesageCell(withIndex: messageCellIndex, file: file, line: line)
+        let errorButton = attributes.errorButton(messageCell: messageCell).wait()
+        XCTAssertTrue(errorButton.exists, file: file, line: line)
+        return self
+    }
+
+    @discardableResult
+    func assertMessageDeliveryStatus(
+        _ deliveryStatus: MessageDeliveryStatus,
+        at messageCellIndex: Int? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        let messageCell = mesageCell(withIndex: messageCellIndex, file: file, line: line)
+        let checkmark = attributes.statusCheckmark(for: deliveryStatus, with: messageCell)
+        if deliveryStatus == .failed {
+            XCTAssertEqual(checkmark.exists, false)
+        } else {
+            XCTAssertEqual(checkmark.wait().exists, true)
+        }
+
+        return self
+    }
+
+    @discardableResult
+    func assertMessageReadCount(
+        readBy: Int,
+        at messageCellIndex: Int? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        let messageCell = mesageCell(withIndex: messageCellIndex, file: file, line: line)
+        let readByCount = attributes.readCount(messageCell: messageCell)
+        if readBy == 0 {
+            XCTAssertFalse(readByCount.isHittable)
+        } else {
+            XCTAssertEqual(readByCount.wait().text, "\(readBy)")
+        }
+        return self
+    }
+}
+
+// MARK: Thread Replies
+
+extension UserRobot {
+
+    @discardableResult
+    func assertThreadReplyReadCount(
+        readBy: Int,
+        at messageCellIndex: Int? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        let isThreadPageOpen = ThreadPage.alsoSendInChannelCheckbox.exists
+        XCTAssertTrue(isThreadPageOpen, file: file, line: line)
+        return assertMessageReadCount(readBy: readBy, at: messageCellIndex)
+    }
+
+    @discardableResult
+    func assertThreadReplyDeliveryStatus(
+        _ deliveryStatus: MessageDeliveryStatus,
+        at messageCellIndex: Int? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        let isThreadPageOpen = ThreadPage.alsoSendInChannelCheckbox.exists
+        XCTAssertTrue(isThreadPageOpen, file: file, line: line)
+        return assertMessageDeliveryStatus(deliveryStatus, at: messageCellIndex)
+    }
+
+    @discardableResult
+    func assertThreadReplyFailedToBeSent(
+        at messageCellIndex: Int? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        let isThreadPageOpen = ThreadPage.alsoSendInChannelCheckbox.exists
+        XCTAssertTrue(isThreadPageOpen, file: file, line: line)
+        return assertMessageFailedToBeSent(at: messageCellIndex)
+    }
+}

--- a/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
@@ -42,7 +42,7 @@ extension UserRobot {
     ) -> Self {
         let cell = channelCell(withIndex: cellIndex, file: file, line: line)
         let message = channelAttributes.lastMessage(in: cell)
-        let actualText = message.waitForText(text).text
+        let actualText = message.waitForText(text, mustBeEqual: false).text
         XCTAssertTrue(actualText.contains(text), file: file, line: line)
         return self
     }

--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -182,6 +182,13 @@ extension UserRobot {
         app.back()
         return self
     }
+
+    @discardableResult
+    func moveToChannelListFromThreadReplies() -> Self {
+        tapOnBackButton()
+        tapOnBackButton()
+        return self
+    }
 }
 
 // MARK: Debug menu

--- a/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus+ChannelList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus+ChannelList_Tests.swift
@@ -165,7 +165,7 @@ final class MessageDeliveryStatus_ChannelList_Tests: StreamTestCase {
 
 extension MessageDeliveryStatus_ChannelList_Tests {
 
-    func test_singleCheckmarkShownForMessageInPreview_whenThreadReplyIsSent() {
+    func test_noCheckmarkShownForMessageInPreview_whenThreadReplyIsSent() {
         linkToScenario(withId: 172)
 
         GIVEN("user opens chat") {
@@ -185,7 +185,7 @@ extension MessageDeliveryStatus_ChannelList_Tests {
         THEN("delivery status is hidden") {
             userRobot
                 .assertLastMessageInChannelPreview(message)
-                .assertMessageDeliveryStatusInChannelPreview(.sent)
+                .assertMessageDeliveryStatusInChannelPreview(nil)
                 .assertMessageReadCountInChannelPreview(readBy: 0)
         }
     }
@@ -219,7 +219,7 @@ extension MessageDeliveryStatus_ChannelList_Tests {
         }
     }
 
-    func test_doubleCheckmarkShownForMessageInPreview_whenThreadReplyReadByParticipant() {
+    func test_noCheckmarkShownForMessageInPreview_whenThreadReplyReadByParticipant() {
         linkToScenario(withId: 174)
 
         GIVEN("user opens the channel") {
@@ -242,7 +242,7 @@ extension MessageDeliveryStatus_ChannelList_Tests {
         THEN("user spots double checkmark next to the message") {
             userRobot
                 .assertLastMessageInChannelPreview(message)
-                .assertMessageDeliveryStatusInChannelPreview(.read)
+                .assertMessageDeliveryStatusInChannelPreview(nil)
         }
         AND("read count is hidden") {
             userRobot.assertMessageReadCountInChannelPreview(readBy: 0)

--- a/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus+ChannelList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus+ChannelList_Tests.swift
@@ -1,0 +1,307 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import XCTest
+
+final class MessageDeliveryStatus_ChannelList_Tests: StreamTestCase {
+
+    let message = "message"
+    var failedMessage: String { "failed \(message)" }
+
+    let threadReply = "thread reply"
+    var pendingThreadReply: String { "pending \(threadReply)" }
+    var failedThreadReply: String { "failed \(threadReply)" }
+
+    func test_deliveryStatusClocksShownInPreview_whenTheLastMessageIsInPendingState() {
+        linkToScenario(withId: 166)
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+            backendRobot.delayServerResponse(byTimeInterval: 10.0)
+        }
+        AND("user sends new message") {
+            userRobot.sendMessage(message)
+        }
+        WHEN("user retuns to the channel list before the message is sent") {
+            userRobot.tapOnBackButton()
+        }
+        THEN("last message delivery status in the channel preview shows clocks on the left") {
+            userRobot
+                .assertLastMessageInChannelPreview(message, authoredByUser: true)
+                .assertMessageReadCountInChannelPreview(readBy: 0)
+                .assertMessageDeliveryStatusInChannelPreview(.pending)
+        }
+    }
+
+    func test_singleCheckmarkShownInPreview_whenTheLastMessageIsSent() {
+        linkToScenario(withId: 167)
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+            backendRobot.delayServerResponse(byTimeInterval: 10.0)
+        }
+        AND("user sends new message") {
+            userRobot.sendMessage(message)
+        }
+        AND("message is succesfully sent") {
+            userRobot.waitForNewMessage(withText: message)
+        }
+        WHEN("user retuns to the channel list") {
+            userRobot.tapOnBackButton()
+        }
+        THEN("last message delivery status in the channel preview shows clocks on the left") {
+            userRobot
+                .assertLastMessageInChannelPreview(message, authoredByUser: true)
+                .assertMessageReadCountInChannelPreview(readBy: 0)
+                .assertMessageDeliveryStatusInChannelPreview(.pending)
+
+        }
+    }
+
+    func test_errorIndicatorShownInPreview_whenMessageFailedToBeSent() {
+        linkToScenario(withId: 168)
+
+        GIVEN("user opens the channel") {
+            deviceRobot.setConnectivitySwitchVisibility(to: .on)
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user's message is not sent") {
+            deviceRobot.setConnectivity(to: .off)
+            userRobot
+                .sendMessage(failedMessage)
+                .assertMessageFailedToBeSent()
+        }
+        WHEN("user retuns to the channel list") {
+            userRobot.tapOnBackButton()
+        }
+        THEN("error indicator is shown for the failed message") {
+            userRobot
+            .assertMessageDeliveryStatus(.failed)
+            .assertMessageReadCount(readBy: 0)
+        }
+    }
+
+    func test_doubleCheckmarkShownInPreview_whenMessageReadByParticipant() {
+        linkToScenario(withId: 169)
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user succesfully sends new message") {
+            userRobot
+                .sendMessage(message)
+                .waitForNewMessage(withText: message)
+        }
+        AND("user retuns to the channel list") {
+            userRobot.tapOnBackButton()
+        }
+        WHEN("participant reads the user's message") {
+            participantRobot.readMessage()
+        }
+        THEN("user spots double checkmark next to the message") {
+            userRobot.assertMessageDeliveryStatusInChannelPreview(.read)
+        }
+        AND("read count is hidden") {
+            userRobot.assertMessageReadCountInChannelPreview(readBy: 0)
+        }
+    }
+
+    func test_deliveryStatusHiddenInPreview_whenMessageIsSentAndReadEventsIsDisabled() {
+        linkToScenario(withId: 170)
+
+        GIVEN("user opens chat") {
+            backendRobot.setReadEvents(to: false)
+            userRobot.login()
+            userRobot.openChannel()
+        }
+        AND("user sends a new message") {
+            userRobot.sendMessage(message)
+        }
+        AND("message is succesfully sent") {
+            userRobot.waitForNewMessage(withText: message)
+        }
+        WHEN("user retuns to the channel list") {
+            userRobot.tapOnBackButton()
+        }
+        THEN("delivery status is hidden") {
+            userRobot
+                .assertMessageDeliveryStatus(.failed)
+                .assertMessageReadCount(readBy: 0)
+        }
+    }
+
+    func test_deliveryStatusHiddenInPreview_whenMessageIsSentByParticipant() {
+        linkToScenario(withId: 171)
+
+        GIVEN("user opens chat") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        WHEN("participant sends a new message") {
+            participantRobot
+                .sendMessage(message)
+                .waitForNewMessage(withText: message)
+        }
+        AND("user retuns to the channel list") {
+            userRobot.tapOnBackButton()
+        }
+        THEN("delivery status is hidden") {
+            userRobot
+                .assertMessageDeliveryStatus(.failed)
+                .assertMessageReadCount(readBy: 0)
+        }
+    }
+}
+
+// MARK: Thread Reply
+
+extension MessageDeliveryStatus_ChannelList_Tests {
+
+    func test_singleCheckmarkShownInPreview_whenThreadReplyIsSent() {
+        linkToScenario(withId: 172)
+
+        GIVEN("user opens chat") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("participant sends a new message") {
+            participantRobot.sendMessage(message)
+        }
+        AND("user replies to the message in thread") {
+            userRobot.replyToMessageInThread(threadReply)
+        }
+        WHEN("user retuns to the channel list") {
+            userRobot
+                .tapOnBackButton()
+                .tapOnBackButton()
+        }
+        THEN("delivery status is hidden") {
+            userRobot
+                .assertMessageDeliveryStatusInChannelPreview(.sent)
+                .assertMessageReadCountInChannelPreview(readBy: 0)
+        }
+    }
+
+    func test_errorIndicatorShownInPreview_whenThreadReplyFailedToBeSent() {
+        linkToScenario(withId: 173)
+
+        GIVEN("user opens the channel") {
+            deviceRobot.setConnectivitySwitchVisibility(to: .on)
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user sends a new message") {
+            userRobot.sendMessage(message)
+        }
+        AND("user becomes offline") {
+            deviceRobot.setConnectivity(to: .off)
+        }
+        AND("user replies to message in thread") {
+            userRobot.replyToMessageInThread(failedThreadReply)
+        }
+        WHEN("user retuns to the channel list") {
+            userRobot
+                .tapOnBackButton()
+                .tapOnBackButton()
+        }
+        THEN("delivery status is hidden") {
+            userRobot
+                .assertMessageDeliveryStatusInChannelPreview(.failed)
+                .assertMessageReadCountInChannelPreview(readBy: 0)
+        }
+    }
+
+    func test_doubleCheckmarkShownInPreview_whenThreadReplyReadByParticipant() {
+        linkToScenario(withId: 174)
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("participant sends a new message") {
+            participantRobot.sendMessage(message)
+        }
+        AND("user replies to message in thread") {
+            userRobot.replyToMessageInThread(threadReply)
+        }
+        AND("participant reads the user's thread reply") {
+            participantRobot.readMessage()
+        }
+        WHEN("user retuns to the channel list") {
+            userRobot
+                .tapOnBackButton()
+                .tapOnBackButton()
+        }
+        THEN("user spots double checkmark next to the message") {
+            userRobot.assertMessageDeliveryStatusInChannelPreview(.read)
+        }
+        AND("read count is hidden") {
+            userRobot.assertMessageReadCountInChannelPreview(readBy: 0)
+        }
+    }
+
+    func test_deliveryStatusHiddenInPreview_whenThreadReplyIsSentAndReadEventsIsDisabled() {
+        linkToScenario(withId: 176)
+
+        GIVEN("user opens chat") {
+            backendRobot.setReadEvents(to: false)
+            userRobot.login()
+            userRobot.openChannel()
+        }
+        AND("participant sends a new message") {
+            participantRobot.sendMessage(message)
+        }
+        AND("user replies to message in thread") {
+            userRobot.replyToMessageInThread(threadReply)
+        }
+        WHEN("user retuns to the channel list") {
+            userRobot
+                .tapOnBackButton()
+                .tapOnBackButton()
+        }
+        THEN("delivery status is hidden") {
+            userRobot
+                .assertMessageDeliveryStatus(.failed)
+                .assertMessageReadCount(readBy: 0)
+        }
+    }
+
+    func test_deliveryStatusHiddenInPreview_whenThreadReplyIsSentByParticipant() {
+        linkToScenario(withId: 177)
+
+        GIVEN("user opens chat") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user sends a new message") {
+            participantRobot.sendMessage(message)
+        }
+        AND("participant replies to message in thread") {
+            participantRobot.replyToMessageInThread(threadReply)
+        }
+        WHEN("user retuns to the channel list") {
+            userRobot
+                .tapOnBackButton()
+                .tapOnBackButton()
+        }
+        THEN("delivery status is hidden") {
+            userRobot
+                .assertMessageDeliveryStatus(.failed)
+                .assertMessageReadCount(readBy: 0)
+        }
+    }
+}

--- a/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus_Tests.swift
@@ -1,0 +1,713 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import XCTest
+
+final class MessageDeliveryStatus_Tests: StreamTestCase {
+
+    let message = "message"
+    var pendingMessage: String { "pending \(message)" }
+    var failedMessage: String { "failed \(message)" }
+
+    let threadReply = "thread reply"
+    var pendingThreadReply: String { "pending \(threadReply)" }
+    var failedThreadReply: String { "failed \(threadReply)" }
+
+    // MARK: Message List
+    func test_singleCheckmarkShown_whenMessageIsSent() {
+        linkToScenario(withId: 129)
+
+        GIVEN("user opens chat") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        WHEN("user sends a new message") {
+            userRobot.sendMessage(message)
+        }
+        AND("message is succesfully sent") {
+            userRobot.waitForNewMessage(withText: message)
+        }
+        THEN("user spots single checkmark below the message") {
+            userRobot
+                .assertMessageDeliveryStatus(.sent)
+                .assertMessageReadCount(readBy: 0)
+        }
+    }
+
+    func test_deliveryStatusShowsClocks_whenMessageIsInPendingState() {
+        linkToScenario(withId: 140)
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        WHEN("user sends a new message") {
+            backendRobot.delayServerResponse(byTimeInterval: 5.0)
+            userRobot.sendMessage(pendingMessage)
+        }
+        THEN("message delivery status shows clocks") {
+            userRobot.assertMessageDeliveryStatus(.pending)
+        }
+    }
+
+    func test_errorIndicatorShown_whenMessageFailedToBeSent() {
+        linkToScenario(withId: 141)
+
+        GIVEN("user opens the channel") {
+            deviceRobot.setConnectivitySwitchVisibility(to: .on)
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user becomes offline") {
+            deviceRobot.setConnectivity(to: .off)
+        }
+        WHEN("user sends a new message") {
+            userRobot.sendMessage(failedMessage)
+        }
+        THEN("error indicator is shown for the message") {
+            userRobot
+                .assertMessageFailedToBeSent()
+        }
+        AND("delivery status is hidden") {
+            userRobot
+            .assertMessageDeliveryStatus(.failed)
+            .assertMessageReadCount(readBy: 0)
+        }
+    }
+
+    func test_doubleCheckmarkShown_whenMessageReadByParticipant() {
+        linkToScenario(withId: 142)
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user succesfully sends new message") {
+            userRobot
+                .sendMessage(message)
+                .waitForNewMessage(withText: message)
+        }
+        WHEN("participant reads the user's message") {
+            participantRobot.readMessage()
+        }
+        THEN("user spots double checkmark below the message") {
+            userRobot.assertMessageDeliveryStatus(.read)
+        }
+        AND("user spots read by 1 number below the message") {
+            userRobot.assertMessageReadCount(readBy: 1)
+        }
+    }
+
+    func test_doubleCheckmarkShown_whenNewParticipantAdded() {
+        linkToScenario(withId: 143)
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user succesfully sends new message") {
+            userRobot
+                .sendMessage(message)
+                .waitForNewMessage(withText: message)
+        }
+        AND("message is read by more than 1 participant") {
+            participantRobot.readMessage()
+            userRobot
+                .assertMessageDeliveryStatus(.read)
+                .assertMessageReadCount(readBy: 1)
+        }
+        WHEN("new participant is added to the channel") {
+            userRobot
+                .tapOnDebugMenu()
+                .addParticipant()
+        }
+        THEN("user spots double checkmark below the message") {
+            userRobot.assertMessageDeliveryStatus(.read)
+        }
+        AND("user see read count 2 below the message") {
+            userRobot.assertMessageReadCount(readBy: 2)
+        }
+    }
+
+    func test_readByDecremented_whenParticipantIsRemoved() {
+        linkToScenario(withId: 145)
+    
+        let participantOne = participantRobot.currentUserId
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user succesfully sends new message") {
+            userRobot
+                .sendMessage(message)
+                .waitForNewMessage(withText: message)
+        }
+        AND("is read by participant") {
+            participantRobot
+                .readMessage()
+            userRobot
+                .assertMessageDeliveryStatus(.read)
+                .assertMessageReadCount(readBy: 1)
+        }
+        WHEN("participant is removed from the channel") {
+            userRobot
+                .tapOnDebugMenu()
+                .removeParticipant(withUserId: participantOne)
+        }
+        THEN("user spots single checkmark below the message") {
+            userRobot.assertMessageDeliveryStatus(.sent)
+        }
+    }
+
+    func test_deliveryStatusShownForTheLastMessageInGroup() {
+        linkToScenario(withId: 146)
+        let secondMessage = "second message"
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user succesfully sends new message") {
+            userRobot.sendMessage(message)
+        }
+        AND("delivery status shows single checkmark") {
+            userRobot.assertMessageDeliveryStatus(.sent)
+        }
+        WHEN("user sends another message") {
+            userRobot.sendMessage(secondMessage)
+        }
+        THEN("delivery status for the previous message is hidden") {
+            // indexes are reverted
+            userRobot
+                .assertMessageDeliveryStatus(.failed, at: 1)
+                .assertMessageDeliveryStatus(.sent, at: 0)
+        }
+    }
+
+    func test_deliveryStatusHidden_whenMessageIsDeleted() {
+        linkToScenario(withId: 147)
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user succesfully sends new message") {
+            userRobot
+                .sendMessage(message)
+                .waitForNewMessage(withText: message)
+        }
+        AND("delivery status shows single checkmark") {
+            userRobot.assertMessageDeliveryStatus(.sent)
+        }
+        WHEN("user removes the message") {
+            userRobot.deleteMessage()
+        }
+        THEN("delivery status is hidden") {
+            userRobot
+                .assertMessageDeliveryStatus(.failed)
+                .assertMessageReadCount(readBy: 0)
+        }
+    }
+}
+
+// MARK: Thread Reply
+
+extension MessageDeliveryStatus_Tests {
+
+    // MARK: Thread Previews
+    func test_singleCheckmarkShown_whenMessageIsSent_andPreviewedInThread() {
+        linkToScenario(withId: 148)
+
+        GIVEN("user opens chat") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user succesfully sends a new message") {
+            userRobot
+                .sendMessage(message)
+                .waitForNewMessage(withText: message)
+        }
+        WHEN("user previews thread for message: \(message)") {
+            userRobot.showThread()
+        }
+        THEN("user spots single checkmark below the message") {
+            userRobot
+                .assertMessageDeliveryStatus(.sent)
+                .assertMessageReadCount(readBy: 0)
+        }
+    }
+
+    func test_errorIndicatorShown_whenMessageFailedToBeSent_andCantBePreviewedInThread() {
+        linkToScenario(withId: 149)
+
+        GIVEN("user opens the channel") {
+            deviceRobot.setConnectivitySwitchVisibility(to: .on)
+            userRobot
+                .login()
+                .openChannel()
+        }
+        WHEN("user becomes offline") {
+            deviceRobot.setConnectivity(to: .off)
+        }
+        AND("user sends a new message") {
+            userRobot.sendMessage(failedMessage)
+        }
+        THEN("error indicator is shown for the message") {
+            userRobot.assertMessageFailedToBeSent()
+        }
+        AND("delivery status is not shown") {
+            userRobot
+            .assertMessageDeliveryStatus(.failed)
+            .assertMessageReadCount(readBy: 0)
+        }
+        AND("user can't preview this message in thread") {
+            userRobot.assertContextMenuOptionNotAvailable(option: .threadReply)
+        }
+    }
+
+    func test_doubleCheckmarkShown_whenMessageReadByParticipant_andPreviewedInThread() {
+        linkToScenario(withId: 150)
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user succesfully sends new message") {
+            userRobot
+                .sendMessage(message)
+                .waitForNewMessage(withText: message)
+        }
+        AND("the message is read by participant") {
+            participantRobot.readMessage()
+        }
+        WHEN("user previews thread for read message: \(message)") {
+            userRobot.showThread()
+        }
+        THEN("user spots double checkmark below the message") {
+            userRobot.assertMessageDeliveryStatus(.read)
+        }
+        AND("user spots read by 1 number below the message") {
+            userRobot.assertMessageReadCount(readBy: 1)
+        }
+    }
+
+    // MARK: Thread Replies
+
+    func test_singleCheckmarkShown_whenThreadReplyIsSent() {
+        linkToScenario(withId: 151)
+
+        GIVEN("user opens chat") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        WHEN("participant sends a new message") {
+            participantRobot.sendMessage(message)
+        }
+        AND("user replies to the message in thread") {
+            userRobot.replyToMessageInThread(threadReply)
+        }
+        THEN("user spots single checkmark below the thread reply") {
+            userRobot
+                .assertThreadReplyDeliveryStatus(.sent)
+                .assertMessageReadCount(readBy: 0)
+        }
+    }
+
+    func test_errorIndicatorShown_whenThreadReplyFailedToBeSent() {
+        linkToScenario(withId: 152)
+
+        GIVEN("user opens the channel") {
+            deviceRobot.setConnectivitySwitchVisibility(to: .on)
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user sends a new message") {
+            userRobot.sendMessage(message)
+        }
+        WHEN("user becomes offline") {
+            deviceRobot.setConnectivity(to: .off)
+        }
+        AND("user replies to message in thread") {
+            userRobot.replyToMessageInThread(failedThreadReply)
+        }
+        THEN("error indicator is shown for the thread reply") {
+            userRobot.assertThreadReplyFailedToBeSent()
+        }
+        AND("delivery status is not shown") {
+            userRobot
+                .assertThreadReplyDeliveryStatus(.failed)
+                .assertThreadReplyReadCount(readBy: 0)
+        }
+    }
+
+    func test_doubleCheckmarkShown_whenThreadReplyReadByParticipant() {
+        linkToScenario(withId: 153)
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("participant sends a new message") {
+            participantRobot.sendMessage(message)
+        }
+        WHEN("user replies to message in thread") {
+            userRobot.replyToMessageInThread(threadReply)
+        }
+        AND("participant reads the user's thread reply") {
+            participantRobot.readMessage()
+        }
+        THEN("user spots double checkmark below the message") {
+            userRobot.assertMessageDeliveryStatus(.read)
+        }
+        AND("user spots read by 1 number below the message") {
+            userRobot.assertMessageReadCount(readBy: 1)
+        }
+    }
+
+    func test_doubleCheckmarkShownInThreadReply_whenNewParticipantAdded() {
+        linkToScenario(withId: 154)
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("participant sends a new message") {
+            participantRobot.sendMessage(message)
+        }
+        AND("user replies to message in thread") {
+            userRobot.replyToMessageInThread(threadReply)
+        }
+        WHEN("new participant is added to the channel") {
+            userRobot
+                .tapOnDebugMenu()
+                .addParticipant()
+        }
+        THEN("user spots double checkmark below the thread reply") {
+            userRobot.assertMessageDeliveryStatus(.read)
+        }
+        AND("user see read count 2 below the message") {
+            userRobot.assertMessageReadCount(readBy: 1)
+        }
+    }
+
+    func test_readByDecrementedInThreadReply_whenParticipantIsRemoved() {
+        linkToScenario(withId: 155)
+
+        let participantOne = participantRobot.currentUserId
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("participant sends a new message") {
+            participantRobot.sendMessage(message)
+        }
+        AND("user replies to message in thread") {
+            userRobot.replyToMessageInThread(threadReply)
+        }
+        AND("thread reply is read by participant") {
+            participantRobot
+                .readMessage()
+            userRobot
+                .assertMessageDeliveryStatus(.read)
+                .assertMessageReadCount(readBy: 1)
+        }
+        WHEN("participant is removed from the channel") {
+            userRobot
+                .tapOnDebugMenu()
+                .removeParticipant(withUserId: participantOne)
+        }
+        THEN("user spots single checkmark below the message") {
+            userRobot.assertMessageDeliveryStatus(.sent)
+        }
+    }
+
+    func test_deliveryStatusShownForTheLastThreadReplyInGroup() {
+        linkToScenario(withId: 156)
+        let secondMessage = "second message"
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("participant sends a new message") {
+            participantRobot.sendMessage(message)
+        }
+        AND("user replies to message in thread") {
+            userRobot.replyToMessageInThread(threadReply)
+        }
+        AND("delivery status shows single checkmark") {
+            userRobot.assertMessageDeliveryStatus(.sent)
+        }
+        WHEN("user sends another message") {
+            userRobot.sendMessage(secondMessage)
+        }
+        THEN("delivery status for the previous message is hidden") {
+            // indexes are reverted
+            userRobot
+                .assertMessageDeliveryStatus(.failed, at: 1)
+                .assertMessageDeliveryStatus(.sent, at: 0)
+        }
+    }
+
+    func test_deliveryStatusHidden_whenThreadReplyIsDeleted() {
+        linkToScenario(withId: 157)
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("participant sends a new message") {
+            participantRobot.sendMessage(message)
+        }
+        AND("user replies to message in thread") {
+            userRobot.replyToMessageInThread(threadReply)
+        }
+        AND("delivery status shows single checkmark") {
+            userRobot.assertMessageDeliveryStatus(.sent)
+        }
+        WHEN("user removes the message") {
+            userRobot.deleteMessage()
+        }
+        THEN("delivery status is hidden") {
+            userRobot
+                .assertMessageDeliveryStatus(.failed)
+                .assertMessageReadCount(readBy: 0)
+        }
+    }
+}
+
+// MARK: Disabled Read Events feature
+
+extension MessageDeliveryStatus_Tests {
+
+    // MARK: Messages
+
+    func test_deliveryStatusHidden_whenMessageIsSentAndReadEventsIsDisabled() {
+        linkToScenario(withId: 158)
+
+        GIVEN("user opens chat") {
+            backendRobot.setReadEvents(to: false)
+            userRobot
+                .login()
+                .openChannel()
+        }
+        WHEN("user sends a new message") {
+            userRobot.sendMessage(message)
+        }
+        AND("message is succesfully sent") {
+            userRobot.waitForNewMessage(withText: message)
+        }
+        THEN("delivery status is hidden") {
+            userRobot
+                .assertMessageDeliveryStatus(.failed)
+                .assertMessageReadCount(readBy: 0)
+        }
+    }
+
+    func test_deliveryStatusShowsClocks_whenMessageIsInPendingStateAndReadEventsIsDisabled() {
+        linkToScenario(withId: 159)
+
+        GIVEN("user opens the channel") {
+            backendRobot.setReadEvents(to: false)
+            userRobot
+                .login()
+                .openChannel()
+        }
+        WHEN("user sends a new message") {
+            backendRobot.delayServerResponse(byTimeInterval: 5.0)
+            userRobot.sendMessage(pendingMessage)
+        }
+        THEN("message delivery status shows clocks") {
+            userRobot
+                .assertMessageDeliveryStatus(.pending)
+                .assertMessageReadCount(readBy: 0)
+        }
+    }
+
+    func test_errorIndicatorShown_whenMessageFailedToBeSentAndReadEventsIsDisabled() {
+        linkToScenario(withId: 160)
+
+        GIVEN("user opens the channel") {
+            backendRobot.setReadEvents(to: false)
+            deviceRobot.setConnectivitySwitchVisibility(to: .on)
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user becomes offline") {
+            deviceRobot.setConnectivity(to: .off)
+        }
+        WHEN("user sends a new message") {
+            userRobot.sendMessage(failedMessage)
+        }
+        THEN("error indicator is shown for the message") {
+            userRobot
+                .assertMessageFailedToBeSent()
+        }
+        AND("delivery status is hidden") {
+            userRobot
+            .assertMessageDeliveryStatus(.failed)
+            .assertMessageReadCount(readBy: 0)
+        }
+    }
+
+    func test_deliveryStatusHidden_whenMessageReadByParticipantAndReadEventsIsDisabled() {
+        linkToScenario(withId: 161)
+
+        GIVEN("user opens the channel") {
+            backendRobot.setReadEvents(to: false)
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user succesfully sends new message") {
+            userRobot
+                .sendMessage(message)
+                .waitForNewMessage(withText: message)
+        }
+        WHEN("participant reads the user's message") {
+            participantRobot.readMessage()
+        }
+        THEN("delivery status is hidden") {
+            userRobot
+                .assertMessageDeliveryStatus(.failed)
+                .assertMessageReadCount(readBy: 0)
+        }
+    }
+
+    func test_deliveryStatusHidden_whenNewParticipantAddedAndReadEventsIsDisabled() {
+        linkToScenario(withId: 162)
+
+        GIVEN("user opens the channel") {
+            backendRobot.setReadEvents(to: false)
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user succesfully sends new message") {
+            userRobot
+                .sendMessage(message)
+                .waitForNewMessage(withText: message)
+        }
+        AND("message is read by more than 1 participant") {
+            participantRobot.readMessage()
+        }
+        WHEN("new participant is added to the channel") {
+            userRobot
+                .tapOnDebugMenu()
+                .addParticipant()
+        }
+        THEN("delivery status is hidden") {
+            userRobot
+                .assertMessageDeliveryStatus(.failed)
+                .assertMessageReadCount(readBy: 0)
+        }
+    }
+
+    func test_deliveryStatusHidden_whenParticipantIsRemovedAndReadEventsIsDisabled() {
+        linkToScenario(withId: 163)
+
+        let participantOne = participantRobot.currentUserId
+
+        GIVEN("user opens the channel") {
+            backendRobot.setReadEvents(to: false)
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user succesfully sends new message") {
+            userRobot
+                .sendMessage(message)
+                .waitForNewMessage(withText: message)
+        }
+        AND("is read by participant") {
+            participantRobot
+                .readMessage()
+        }
+        WHEN("participant is removed from the channel") {
+            userRobot
+                .tapOnDebugMenu()
+                .removeParticipant(withUserId: participantOne)
+        }
+        AND("delivery status is hidden") {
+            userRobot.assertMessageDeliveryStatus(.failed)
+        }
+        AND("user doesn't see read count") {
+            userRobot.assertMessageReadCount(readBy: 0)
+        }
+    }
+
+    func test_deliveryStatusHiddenForMessagesInGroup_whenReadEventsIsDisabled() {
+        linkToScenario(withId: 164)
+        let secondMessage = "second message"
+
+        GIVEN("user opens the channel") {
+            backendRobot.setReadEvents(to: false)
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user succesfully sends new message") {
+            userRobot.sendMessage(message)
+        }
+        AND("delivery status is hidden") {
+            userRobot.assertMessageDeliveryStatus(.failed)
+        }
+        WHEN("user sends another message") {
+            userRobot.sendMessage(secondMessage)
+        }
+        THEN("delivery status is hidden for all messages") {
+            // indexes are reverted
+            userRobot
+                .assertMessageDeliveryStatus(.failed, at: 1)
+                .assertMessageDeliveryStatus(.failed, at: 0)
+        }
+    }
+
+    func test_deliveryStatusHidden_whenMessageIsDeletedAndReadEventsIsDisabled() {
+        linkToScenario(withId: 165)
+
+        GIVEN("user opens the channel") {
+            backendRobot.setReadEvents(to: false)
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user succesfully sends new message") {
+            userRobot
+                .sendMessage(message)
+                .waitForNewMessage(withText: message)
+        }
+        AND("delivery status is hidden") {
+            userRobot.assertMessageDeliveryStatus(.failed)
+        }
+        WHEN("user removes the message") {
+            userRobot.deleteMessage()
+        }
+        THEN("delivery status stays hidden") {
+            userRobot
+                .assertMessageDeliveryStatus(.failed)
+                .assertMessageReadCount(readBy: 0)
+        }
+    }
+}

--- a/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus_Tests.swift
@@ -74,8 +74,8 @@ final class MessageDeliveryStatus_Tests: StreamTestCase {
         }
         AND("delivery status is hidden") {
             userRobot
-            .assertMessageDeliveryStatus(.failed)
-            .assertMessageReadCount(readBy: 0)
+                .assertMessageDeliveryStatus(nil)
+                .assertMessageReadCount(readBy: 0)
         }
     }
 
@@ -188,7 +188,7 @@ final class MessageDeliveryStatus_Tests: StreamTestCase {
         THEN("delivery status for the previous message is hidden") {
             // indexes are reverted
             userRobot
-                .assertMessageDeliveryStatus(.failed, at: 1)
+                .assertMessageDeliveryStatus(nil, at: 1)
                 .assertMessageDeliveryStatus(.sent, at: 0)
         }
     }
@@ -214,7 +214,7 @@ final class MessageDeliveryStatus_Tests: StreamTestCase {
         }
         THEN("delivery status is hidden") {
             userRobot
-                .assertMessageDeliveryStatus(.failed)
+                .assertMessageDeliveryStatus(nil)
                 .assertMessageReadCount(readBy: 0)
         }
     }
@@ -268,7 +268,7 @@ extension MessageDeliveryStatus_Tests {
         }
         AND("delivery status is not shown") {
             userRobot
-            .assertMessageDeliveryStatus(.failed)
+            .assertMessageDeliveryStatus(nil)
             .assertMessageReadCount(readBy: 0)
         }
         AND("user can't preview this message in thread") {
@@ -349,7 +349,7 @@ extension MessageDeliveryStatus_Tests {
         }
         AND("delivery status is not shown") {
             userRobot
-                .assertThreadReplyDeliveryStatus(.failed)
+                .assertThreadReplyDeliveryStatus(nil)
                 .assertThreadReplyReadCount(readBy: 0)
         }
     }
@@ -463,7 +463,7 @@ extension MessageDeliveryStatus_Tests {
         THEN("delivery status for the previous message is hidden") {
             // indexes are reverted
             userRobot
-                .assertMessageDeliveryStatus(.failed, at: 1)
+                .assertMessageDeliveryStatus(nil, at: 1)
                 .assertMessageDeliveryStatus(.sent, at: 0)
         }
     }
@@ -490,7 +490,7 @@ extension MessageDeliveryStatus_Tests {
         }
         THEN("delivery status is hidden") {
             userRobot
-                .assertMessageDeliveryStatus(.failed)
+                .assertMessageDeliveryStatus(nil)
                 .assertMessageReadCount(readBy: 0)
         }
     }
@@ -519,7 +519,7 @@ extension MessageDeliveryStatus_Tests {
         }
         THEN("delivery status is hidden") {
             userRobot
-                .assertMessageDeliveryStatus(.failed)
+                .assertMessageDeliveryStatus(nil)
                 .assertMessageReadCount(readBy: 0)
         }
     }
@@ -566,7 +566,7 @@ extension MessageDeliveryStatus_Tests {
         }
         AND("delivery status is hidden") {
             userRobot
-            .assertMessageDeliveryStatus(.failed)
+            .assertMessageDeliveryStatus(nil)
             .assertMessageReadCount(readBy: 0)
         }
     }
@@ -590,7 +590,7 @@ extension MessageDeliveryStatus_Tests {
         }
         THEN("delivery status is hidden") {
             userRobot
-                .assertMessageDeliveryStatus(.failed)
+                .assertMessageDeliveryStatus(nil)
                 .assertMessageReadCount(readBy: 0)
         }
     }
@@ -619,7 +619,7 @@ extension MessageDeliveryStatus_Tests {
         }
         THEN("delivery status is hidden") {
             userRobot
-                .assertMessageDeliveryStatus(.failed)
+                .assertMessageDeliveryStatus(nil)
                 .assertMessageReadCount(readBy: 0)
         }
     }
@@ -650,7 +650,7 @@ extension MessageDeliveryStatus_Tests {
                 .removeParticipant(withUserId: participantOne)
         }
         AND("delivery status is hidden") {
-            userRobot.assertMessageDeliveryStatus(.failed)
+            userRobot.assertMessageDeliveryStatus(nil)
         }
         AND("user doesn't see read count") {
             userRobot.assertMessageReadCount(readBy: 0)
@@ -671,7 +671,7 @@ extension MessageDeliveryStatus_Tests {
             userRobot.sendMessage(message)
         }
         AND("delivery status is hidden") {
-            userRobot.assertMessageDeliveryStatus(.failed)
+            userRobot.assertMessageDeliveryStatus(nil)
         }
         WHEN("user sends another message") {
             userRobot.sendMessage(secondMessage)
@@ -679,8 +679,8 @@ extension MessageDeliveryStatus_Tests {
         THEN("delivery status is hidden for all messages") {
             // indexes are reverted
             userRobot
-                .assertMessageDeliveryStatus(.failed, at: 1)
-                .assertMessageDeliveryStatus(.failed, at: 0)
+                .assertMessageDeliveryStatus(nil, at: 1)
+                .assertMessageDeliveryStatus(nil, at: 0)
         }
     }
 
@@ -699,14 +699,14 @@ extension MessageDeliveryStatus_Tests {
                 .waitForNewMessage(withText: message)
         }
         AND("delivery status is hidden") {
-            userRobot.assertMessageDeliveryStatus(.failed)
+            userRobot.assertMessageDeliveryStatus(nil)
         }
         WHEN("user removes the message") {
             userRobot.deleteMessage()
         }
         THEN("delivery status stays hidden") {
             userRobot
-                .assertMessageDeliveryStatus(.failed)
+                .assertMessageDeliveryStatus(nil)
                 .assertMessageReadCount(readBy: 0)
         }
     }

--- a/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
@@ -56,7 +56,9 @@ final class MessageList_Tests: StreamTestCase {
             userRobot.login().openChannel()
         }
         WHEN("user sends the message: '\(message)'") {
-            userRobot.sendMessage(message)
+            userRobot
+                .sendMessage(message)
+                .waitForNewMessage(withText: message)
         }
         AND("user deletes the message: '\(message)'") {
             userRobot.deleteMessage()

--- a/StreamChatUITestsAppUITests/Tests/StreamTestCase.swift
+++ b/StreamChatUITestsAppUITests/Tests/StreamTestCase.swift
@@ -10,8 +10,8 @@ let app = XCUIApplication()
 class StreamTestCase: XCTestCase {
 
     let deviceRobot = DeviceRobot()
-    let backendRobot = BackendRobot()
-    var userRobot = UserRobot()
+    let userRobot = UserRobot()
+    var backendRobot: BackendRobot!
     var participantRobot: ParticipantRobot!
     var server: StreamMockServer!
 
@@ -21,6 +21,7 @@ class StreamTestCase: XCTestCase {
         server.configure()
         server.start(port: in_port_t(MockServerConfiguration.port))
         participantRobot = ParticipantRobot(server)
+        backendRobot = BackendRobot(server)
 
         try super.setUpWithError()
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -13,6 +13,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 # Available Actions
 
+### sonar_upload
+
+```sh
+[bundle exec] fastlane sonar_upload
+```
+
+Get code coverage report and run complexity analysis for Sonar
+
 ### allure_upload
 
 ```sh
@@ -21,18 +29,18 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 Upload test results to Allure TestOps
 
-### allure_testcase
+### allure_create_testcase
 
 ```sh
-[bundle exec] fastlane allure_testcase
+[bundle exec] fastlane allure_create_testcase
 ```
 
 Create test-case in Allure TestOps and get its id
 
-### allure_regression
+### allure_start_regression
 
 ```sh
-[bundle exec] fastlane allure_regression
+[bundle exec] fastlane allure_start_regression
 ```
 
 Sync and run regression test-plan on Allure TestOps
@@ -269,14 +277,6 @@ Test CocoaPods Integration
 ```
 
 Build and upload DemoApp to Emerge
-
-### sonar_upload
-
-```sh
-[bundle exec] fastlane sonar_upload
-```
-
-Get code coverage report and run complexity analysis for Sonar
 
 ----
 


### PR DESCRIPTION
### 🔗 Issue Links

CIS-1720

### 🎯 Goal

Automate `To Be Automated` scenarios for Message Delivery Status.

### 📝 Summary

This work brings UI tests for `Message Receipts` feature.

Here's the list of automated scenarios

# Group Channel

## Messages

#### Channel List Preview
* Delivery status shows clocks when the last message is from the current user and it’s in the pending send state
* Delivery status shows error when sending fails for the last message from the current user
* Delivery status shows a single checkmark when the last message is from the current user and it is sent
* Delivery status shows double checkmark when the last message is from the current user and it is seen by a channel member
* Delivery status is hidden for own channel preview messages when reads are disabled
* Delivery status is hidden if the preview message is from another user

#### Message List
* Clocks are shown for local message in pending send state
* The error indicator is shown for message that failed to be sent
* A single checkmark is shown for sent message when reads enabled
* A double checkmark is shown for sent message when member opens channel 
* A double checkmark is shown for sent message when new member is added
* A single checkmark is shown for message when the only member who’s seen it is removed
* Reads counter is decremented when one of the members who have seen the message is removed
* Reads counter is incremented for a seen message when the new member is added
* Read counter is shown on seen messages in group channel
* Delivery status is hidden for messages when reads are disabled no matter what (message sent, delivered, failed, etc)
* Delivery status is shown for the last message in a group
* Delivery status is hidden for the deleted message

## Thread Replies

#### Channel List Preview
* Delivery status matches the sent message when thread reply is pending, sent, read, errored

#### Message List
* Clocks are shown for local thread reply in pending send state
* The error indicator is shown for thread reply that failed to be sent
* A single checkmark is shown for sent thread reply when reads enabled
* A double checkmark is shown for sent thread reply when member opens channel 
* A double checkmark is shown for sent thread reply when new member is added
* A single checkmark is shown for thread reply when the only member who’s seen it is removed
* Reads counter is decremented when one of the members who have seen the message is removed
* Reads counter is incremented for a seen message when the new member is added
* Read counter is shown on seen thread replies in group channel
* Delivery status is hidden for thread replies when reads are disabled no matter what
* Delivery status is shown for the last thread reply in a group
* Delivery status is hidden for the deleted thread reply

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
