### PR TITLE
[CIS-1734] Paginated channels are left without messages when sync is executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - respect muted channels
     - respect muted users
     - decrement when message is hard deleted
-- Fix paginated channels in channel list were left without channels when sync is executed [#1985](https://github.com/GetStream/stream-chat-swift/issues/1985)
+- Fix paginated channels in channel list were left without messages when sync is executed [#1985](https://github.com/GetStream/stream-chat-swift/issues/1985)
 ### 🔄 Changed
 - Rename `mentionedMessages` to `mentions` in `ChannelUnreadCount` [#1978](https://github.com/GetStream/stream-chat-swift/issues/1978)
 - Changes `.team` filter `FilterKey` to accept `nil` as a parameter  [#1968](https://github.com/GetStream/stream-chat-swift/pull/1968)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - respect muted channels
     - respect muted users
     - decrement when message is hard deleted
+- Fix paginated channels in channel list were left without channels when sync is executed [#1985](https://github.com/GetStream/stream-chat-swift/issues/1985)
 ### 🔄 Changed
 - Rename `mentionedMessages` to `mentions` in `ChannelUnreadCount` [#1978](https://github.com/GetStream/stream-chat-swift/issues/1978)
 

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -84,7 +84,6 @@ public class ChatClient {
             config,
             activeChannelControllers,
             activeChannelListControllers,
-            channelRepository,
             offlineRequestsRepository,
             eventNotificationCenter,
             databaseContainer,
@@ -539,7 +538,6 @@ extension ChatClient {
             _ config: ChatClientConfig,
             _ activeChannelControllers: NSHashTable<ChatChannelController>,
             _ activeChannelListControllers: NSHashTable<ChatChannelListController>,
-            _ channelRepository: ChannelListUpdater,
             _ offlineRequestsRepository: OfflineRequestsRepository,
             _ eventNotificationCenter: EventNotificationCenter,
             _ database: DatabaseContainer,
@@ -549,11 +547,10 @@ extension ChatClient {
                 config: $0,
                 activeChannelControllers: $1,
                 activeChannelListControllers: $2,
-                channelRepository: $3,
-                offlineRequestsRepository: $4,
-                eventNotificationCenter: $5,
-                database: $6,
-                apiClient: $7
+                offlineRequestsRepository: $3,
+                eventNotificationCenter: $4,
+                database: $5,
+                apiClient: $6
             )
         }
         

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -328,7 +328,7 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
         synchedChannelIds: Set<ChannelId>,
         completion: @escaping (Result<(synchedAndWatched: [ChatChannel], unwanted: Set<ChannelId>), Error>) -> Void
     ) {
-        let pageSize = Int.channelsPageSize
+        let pageSize = query.pagination.pageSize
         worker.resetChannelsQuery(
             for: query,
             pageSize: pageSize,

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -154,16 +154,18 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
     private func updateChannelList(
         _ completion: ((_ error: Error?) -> Void)? = nil
     ) {
+        let limit = query.pagination.pageSize
         worker.update(
             channelListQuery: query
-        ) { result in
+        ) { [weak self] result in
             switch result {
-            case .success:
-                self.state = .remoteDataFetched
-                self.callback { completion?(nil) }
+            case let .success(channels):
+                self?.state = .remoteDataFetched
+                self?.hasLoadedAllPreviousChannels = channels.count < limit
+                self?.callback { completion?(nil) }
             case let .failure(error):
-                self.state = .remoteDataFetchFailed(ClientError(with: error))
-                self.callback { completion?(error) }
+                self?.state = .remoteDataFetchFailed(ClientError(with: error))
+                self?.callback { completion?(error) }
             }
         }
     }

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -157,15 +157,15 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
         let limit = query.pagination.pageSize
         worker.update(
             channelListQuery: query
-        ) { [weak self] result in
+        ) { result in
             switch result {
             case let .success(channels):
-                self?.state = .remoteDataFetched
-                self?.hasLoadedAllPreviousChannels = channels.count < limit
-                self?.callback { completion?(nil) }
+                self.state = .remoteDataFetched
+                self.hasLoadedAllPreviousChannels = channels.count < limit
+                self.callback { completion?(nil) }
             case let .failure(error):
-                self?.state = .remoteDataFetchFailed(ClientError(with: error))
-                self?.callback { completion?(error) }
+                self.state = .remoteDataFetchFailed(ClientError(with: error))
+                self.callback { completion?(error) }
             }
         }
     }
@@ -312,13 +312,13 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
         let limit = limit ?? query.pagination.pageSize
         var updatedQuery = query
         updatedQuery.pagination = Pagination(pageSize: limit, offset: channels.count)
-        worker.update(channelListQuery: updatedQuery) { [weak self] result in
+        worker.update(channelListQuery: updatedQuery) { result in
             switch result {
             case let .success(channels):
-                self?.hasLoadedAllPreviousChannels = channels.count < limit
-                self?.callback { completion?(nil) }
+                self.hasLoadedAllPreviousChannels = channels.count < limit
+                self.callback { completion?(nil) }
             case let .failure(error):
-                self?.callback { completion?(error) }
+                self.callback { completion?(error) }
             }
         }
     }

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -283,6 +283,11 @@ extension NSManagedObjectContext {
             channelDTO.reads.removeAll()
         }
     }
+
+    func removeChannels(cids: Set<ChannelId>) {
+        let channels = ChannelDTO.load(cids: Array(cids), context: self)
+        channels.forEach(delete)
+    }
 }
 
 // To get the data from the DB

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -225,6 +225,9 @@ protocol ChannelDatabaseSession {
 
     /// Cleans a list of channels based on their id
     func cleanChannels(cids: Set<ChannelId>)
+
+    /// Removes a list of channels based on their id
+    func removeChannels(cids: Set<ChannelId>)
 }
 
 protocol ChannelReadDatabaseSession {

--- a/Sources/StreamChat/Repositories/SyncOperations.swift
+++ b/Sources/StreamChat/Repositories/SyncOperations.swift
@@ -129,7 +129,7 @@ final class RefetchChannelListQueryOperation: AsyncOperation {
     }
 }
 
-final class CleanUnwantedChannelsOperation: AsyncOperation {
+final class DeleteUnwantedChannelsOperation: AsyncOperation {
     init(database: DatabaseContainer, context: SyncContext) {
         super.init(maxRetries: syncOperationsMaximumRetries) { [weak database] _, done in
             log.info("4. Clean up unwanted channels", subsystems: .offlineSupport)

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -33,7 +33,6 @@ class SyncRepository {
     private let apiClient: APIClient
     let activeChannelControllers: NSHashTable<ChatChannelController>
     let activeChannelListControllers: NSHashTable<ChatChannelListController>
-    let channelRepository: ChannelListUpdater
     let offlineRequestsRepository: OfflineRequestsRepository
     let eventNotificationCenter: EventNotificationCenter
 
@@ -48,7 +47,6 @@ class SyncRepository {
         config: ChatClientConfig,
         activeChannelControllers: NSHashTable<ChatChannelController>,
         activeChannelListControllers: NSHashTable<ChatChannelListController>,
-        channelRepository: ChannelListUpdater,
         offlineRequestsRepository: OfflineRequestsRepository,
         eventNotificationCenter: EventNotificationCenter,
         database: DatabaseContainer,
@@ -57,7 +55,6 @@ class SyncRepository {
         self.config = config
         self.activeChannelControllers = activeChannelControllers
         self.activeChannelListControllers = activeChannelListControllers
-        self.channelRepository = channelRepository
         self.offlineRequestsRepository = offlineRequestsRepository
         self.eventNotificationCenter = eventNotificationCenter
         self.database = database
@@ -128,7 +125,6 @@ class SyncRepository {
             .map { controller in
                 RefetchChannelListQueryOperation(
                     controller: controller,
-                    channelRepository: channelRepository,
                     context: context
                 )
             }

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -131,7 +131,7 @@ class SyncRepository {
         operations.append(contentsOf: refetchChannelListQueryOperations)
 
         // 4. Clean up unwanted channels
-        operations.append(CleanUnwantedChannelsOperation(database: database, context: context))
+        operations.append(DeleteUnwantedChannelsOperation(database: database, context: context))
 
         // 5. Run offline actions requests
         if config.isLocalStorageEnabled {

--- a/Tests/StreamChatTestTools/Mocks/StreamChat/Controllers/Controllers/ChatChannelListController_Mock.swift
+++ b/Tests/StreamChatTestTools/Mocks/StreamChat/Controllers/Controllers/ChatChannelListController_Mock.swift
@@ -4,9 +4,12 @@
 
 import Foundation
 @testable import StreamChat
+import StreamChatTestHelpers
 
-public class ChatChannelListController_Mock: ChatChannelListController {
+public class ChatChannelListController_Mock: ChatChannelListController, Spy {
+    public var recordedFunctions: [String] = []
     public var loadNextChannelsIsCalled = false
+    public var resetChannelsQueryResult: Result<(synchedAndWatched: [ChatChannel], unwanted: Set<ChannelId>), Error>?
 
     /// Creates a new mock instance of `ChatChannelListController`.
     public static func mock() -> ChatChannelListController_Mock {
@@ -26,6 +29,15 @@ public class ChatChannelListController_Mock: ChatChannelListController {
 
     override public func loadNextChannels(limit: Int?, completion: ((Error?) -> Void)?) {
         loadNextChannelsIsCalled = true
+    }
+
+    override public func resetQuery(
+        watchedAndSynchedChannelIds: Set<ChannelId>,
+        synchedChannelIds: Set<ChannelId>,
+        completion: @escaping (Result<(synchedAndWatched: [ChatChannel], unwanted: Set<ChannelId>), Error>) -> Void
+    ) {
+        record()
+        resetChannelsQueryResult.map(completion)
     }
 }
 

--- a/Tests/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/Tests/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -94,6 +94,10 @@ extension DatabaseSession_Mock {
     func cleanChannels(cids: Set<ChannelId>) {
         underlyingSession.cleanChannels(cids: cids)
     }
+
+    func removeChannels(cids: Set<ChannelId>) {
+        underlyingSession.removeChannels(cids: cids)
+    }
     
     func saveCurrentUser(payload: CurrentUserPayload) throws -> CurrentUserDTO {
         try throwErrorIfNeeded()

--- a/Tests/StreamChatTestTools/SpyPattern/Spy/ChannelListUpdater_Spy.swift
+++ b/Tests/StreamChatTestTools/SpyPattern/Spy/ChannelListUpdater_Spy.swift
@@ -57,7 +57,8 @@ final class ChannelListUpdater_Spy: ChannelListUpdater, Spy {
 
     override func resetChannelsQuery(
         for query: ChannelListQuery,
-        watchedChannelIds: Set<ChannelId>,
+        pageSize: Int,
+        watchedAndSynchedChannelIds: Set<ChannelId>,
         synchedChannelIds: Set<ChannelId>,
         completion: @escaping (Result<(synchedAndWatched: [ChatChannel], unwanted: Set<ChannelId>), Error>) -> Void
     ) {

--- a/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
@@ -43,7 +43,6 @@ final class SyncRepository_Tests: XCTestCase {
             config: client.config,
             activeChannelControllers: _activeChannelControllers,
             activeChannelListControllers: _activeChannelListControllers,
-            channelRepository: channelRepository,
             offlineRequestsRepository: offlineRequestsRepository,
             eventNotificationCenter: client.eventNotificationCenter,
             database: database,
@@ -95,7 +94,6 @@ final class SyncRepository_Tests: XCTestCase {
             config: client.config,
             activeChannelControllers: _activeChannelControllers,
             activeChannelListControllers: _activeChannelListControllers,
-            channelRepository: channelRepository,
             offlineRequestsRepository: offlineRequestsRepository,
             eventNotificationCenter: repository.eventNotificationCenter,
             database: database,
@@ -129,7 +127,6 @@ final class SyncRepository_Tests: XCTestCase {
             config: client.config,
             activeChannelControllers: _activeChannelControllers,
             activeChannelListControllers: _activeChannelListControllers,
-            channelRepository: channelRepository,
             offlineRequestsRepository: offlineRequestsRepository,
             eventNotificationCenter: repository.eventNotificationCenter,
             database: database,
@@ -241,7 +238,8 @@ final class SyncRepository_Tests: XCTestCase {
         XCTAssertEqual(repository.activeChannelControllers.count, 0)
         XCTAssertEqual(repository.activeChannelListControllers.count, 1)
         XCTAssertCall(
-            "resetChannelsQuery(for:watchedChannelIds:synchedChannelIds:completion:)", on: channelRepository, times: 1
+            "resetChannelsQuery(for:pageSize:watchedAndSynchedChannelIds:synchedChannelIds:completion:)", on: channelRepository,
+            times: 1
         )
         XCTAssertEqual(apiClient.recoveryRequest_allRecordedCalls.count, 1)
         XCTAssertEqual(apiClient.request_allRecordedCalls.count, 0)
@@ -272,7 +270,8 @@ final class SyncRepository_Tests: XCTestCase {
         XCTAssertEqual(repository.activeChannelControllers.count, 0)
         XCTAssertEqual(repository.activeChannelListControllers.count, 1)
         XCTAssertCall(
-            "resetChannelsQuery(for:watchedChannelIds:synchedChannelIds:completion:)", on: channelRepository, times: 1
+            "resetChannelsQuery(for:pageSize:watchedAndSynchedChannelIds:synchedChannelIds:completion:)", on: channelRepository,
+            times: 1
         )
         XCTAssertEqual(apiClient.recoveryRequest_allRecordedCalls.count, 1)
         XCTAssertEqual(apiClient.request_allRecordedCalls.count, 0)
@@ -476,7 +475,6 @@ final class SyncRepository_Tests: XCTestCase {
             config: client.config,
             activeChannelControllers: _activeChannelControllers,
             activeChannelListControllers: _activeChannelListControllers,
-            channelRepository: channelRepository,
             offlineRequestsRepository: offlineRequestsRepository,
             eventNotificationCenter: repository.eventNotificationCenter,
             database: database,
@@ -504,7 +502,6 @@ final class SyncRepository_Tests: XCTestCase {
             config: client.config,
             activeChannelControllers: _activeChannelControllers,
             activeChannelListControllers: _activeChannelListControllers,
-            channelRepository: channelRepository,
             offlineRequestsRepository: offlineRequestsRepository,
             eventNotificationCenter: repository.eventNotificationCenter,
             database: database,
@@ -543,7 +540,6 @@ final class SyncRepository_Tests: XCTestCase {
             config: client.config,
             activeChannelControllers: _activeChannelControllers,
             activeChannelListControllers: _activeChannelListControllers,
-            channelRepository: channelRepository,
             offlineRequestsRepository: offlineRequestsRepository,
             eventNotificationCenter: repository.eventNotificationCenter,
             database: database,
@@ -568,7 +564,6 @@ final class SyncRepository_Tests: XCTestCase {
             config: client.config,
             activeChannelControllers: _activeChannelControllers,
             activeChannelListControllers: _activeChannelListControllers,
-            channelRepository: channelRepository,
             offlineRequestsRepository: offlineRequestsRepository,
             eventNotificationCenter: repository.eventNotificationCenter,
             database: database,

--- a/Tests/StreamChatTests/Workers/ChannelListUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelListUpdater_Tests.swift
@@ -131,7 +131,8 @@ final class ChannelListUpdater_Tests: XCTestCase {
         var receivedResult: Result<(synchedAndWatched: [ChatChannel], unwanted: Set<ChannelId>), Error>!
         listUpdater.resetChannelsQuery(
             for: query,
-            watchedChannelIds: Set<ChannelId>(),
+            pageSize: query.pagination.pageSize,
+            watchedAndSynchedChannelIds: Set<ChannelId>(),
             synchedChannelIds: Set<ChannelId>()
         ) { result in
             receivedResult = result
@@ -166,7 +167,8 @@ final class ChannelListUpdater_Tests: XCTestCase {
         var receivedResult: Result<(synchedAndWatched: [ChatChannel], unwanted: Set<ChannelId>), Error>!
         listUpdater.resetChannelsQuery(
             for: query,
-            watchedChannelIds: Set<ChannelId>(),
+            pageSize: query.pagination.pageSize,
+            watchedAndSynchedChannelIds: Set<ChannelId>(),
             synchedChannelIds: Set<ChannelId>()
         ) { result in
             receivedResult = result
@@ -225,7 +227,8 @@ final class ChannelListUpdater_Tests: XCTestCase {
         var receivedResult: Result<(synchedAndWatched: [ChatChannel], unwanted: Set<ChannelId>), Error>!
         listUpdater.resetChannelsQuery(
             for: query,
-            watchedChannelIds: watchedChannelIds,
+            pageSize: query.pagination.pageSize,
+            watchedAndSynchedChannelIds: watchedChannelIds,
             synchedChannelIds: synchedChannelIds
         ) { result in
             receivedResult = result


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-1734

### 🎯 Goal

When in a paginated channel list, if the sync was executed (eg. backgrounding the app and opening it), the channels were left in the list but showing "No messages".

### 🛠 Implementation

The issue described above was caused because we were only cleaning those channels, instead of deleting them.
Not we are properly deleting them.
While fixing this issue, other issues surfaced, which are tackled in #1984 

### 🧪 Manual Testing Notes

Pre-requisite: Make sure chat is disconnected when going to background

1. Open the DemoApp
2. Select a user
3. Scroll to paginate channels list
4. Background the app
5. Reopen the app

Expected result:
- Channels out of the first page should be deleted.

### ☑️ Contributor Checklist
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
