### PR TITLE
[CIS-1845] Expose attachment `actions` as extra data, fix issue with deleted ephemeral messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - respect muted users
     - decrement when message is hard deleted
 - Fix paginated channels in channel list were left without messages when sync is executed [#1985](https://github.com/GetStream/stream-chat-swift/issues/1985)
-- Fix `deletedMessagesVisibility == .alwaysVisible` shows deleted ephemeral messages in mesage list [#1991](https://github.com/GetStream/stream-chat-swift/issues/1991)
+- Fix `deletedMessagesVisibility == .alwaysVisible` shows deleted ephemeral messages in message list [#1991](https://github.com/GetStream/stream-chat-swift/issues/1991)
 ### 🔄 Changed
 - Rename `mentionedMessages` to `mentions` in `ChannelUnreadCount` [#1978](https://github.com/GetStream/stream-chat-swift/issues/1978)
 - Changes `.team` filter `FilterKey` to accept `nil` as a parameter  [#1968](https://github.com/GetStream/stream-chat-swift/pull/1968)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 ## StreamChat
 ### ✅ Added
-- Expose `actions` on image attachment [#1979](https://github.com/GetStream/stream-chat-swift/issues/1979)
 - Expose `readBy/readByCount` on `ChatMessage` containing info about users who has seen this message. These fields are populated only for messages sent by the current user. [#1887](https://github.com/GetStream/stream-chat-swift/issues/1887)
 - Expose preview message on `ChatChannel` [#1935](https://github.com/GetStream/stream-chat-swift/issues/1935)
 ### 🐞 Fixed
@@ -13,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - respect muted users
     - decrement when message is hard deleted
 - Fix paginated channels in channel list were left without messages when sync is executed [#1985](https://github.com/GetStream/stream-chat-swift/issues/1985)
+- Fix `deletedMessagesVisibility == .alwaysVisible` shows deleted ephemeral messages in mesage list [#1991](https://github.com/GetStream/stream-chat-swift/issues/1991)
 ### 🔄 Changed
 - Rename `mentionedMessages` to `mentions` in `ChannelUnreadCount` [#1978](https://github.com/GetStream/stream-chat-swift/issues/1978)
 - Changes `.team` filter `FilterKey` to accept `nil` as a parameter  [#1968](https://github.com/GetStream/stream-chat-swift/pull/1968)

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -142,7 +142,12 @@ class MessageDTO: NSManagedObject {
         case .visibleForCurrentUser:
             deletedMessagesPredicate = onlyOwnDeletedMessagesPredicate()
         case .alwaysVisible:
-            deletedMessagesPredicate = NSPredicate(value: true) // an empty predicate to avoid optionals
+            deletedMessagesPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [
+                // Non-deleted messages
+                nonDeletedMessagesPredicate(),
+                // Deleted messages excluding ephemeral ones
+                NSPredicate(format: "deletedAt != nil AND type != %@", MessageType.ephemeral.rawValue)
+            ])
         }
 
         let ignoreHardDeletedMessagesPredicate = NSPredicate(

--- a/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
+++ b/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
@@ -18,7 +18,6 @@ enum AttachmentCodingKeys: String, CodingKey, CaseIterable {
     case imageURL = "image_url"
     case assetURL = "asset_url"
     case titleLink = "title_link"
-    case actions
 }
 
 /// A local state of the attachment. Applies only for attachments linked to the new messages sent from current device.

--- a/Sources/StreamChat/Models/Attachments/ChatMessageGiphyAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageGiphyAttachment.swift
@@ -25,6 +25,10 @@ public struct GiphyAttachmentPayload: AttachmentPayload {
 
 extension GiphyAttachmentPayload: Hashable {}
 
+enum GiphyAttachmentSpecificCodingKeys: String, CodingKey {
+    case actions
+}
+
 // MARK: - Encodable
 
 extension GiphyAttachmentPayload: Encodable {
@@ -33,7 +37,10 @@ extension GiphyAttachmentPayload: Encodable {
 
         try container.encode(title, forKey: .title)
         try container.encode(previewURL, forKey: .thumbURL)
-        try container.encode(actions, forKey: .actions)
+        
+        // Encode giphy attachment specific keys
+        var giphyAttachmentContainer = encoder.container(keyedBy: GiphyAttachmentSpecificCodingKeys.self)
+        try giphyAttachmentContainer.encode(actions, forKey: .actions)
     }
 }
 
@@ -42,11 +49,13 @@ extension GiphyAttachmentPayload: Encodable {
 extension GiphyAttachmentPayload: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: AttachmentCodingKeys.self)
+        // Used for decoding giphy attachment specific keys
+        let giphyAttachmentContainer = try decoder.container(keyedBy: GiphyAttachmentSpecificCodingKeys.self)
         
         self.init(
             title: try container.decode(String.self, forKey: .title),
             previewURL: try container.decode(URL.self, forKey: .thumbURL),
-            actions: try container.decodeIfPresent([AttachmentAction].self, forKey: .actions) ?? []
+            actions: try giphyAttachmentContainer.decodeIfPresent([AttachmentAction].self, forKey: .actions) ?? []
         )
     }
 }

--- a/Sources/StreamChat/Models/Attachments/ChatMessageImageAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageImageAttachment.swift
@@ -22,8 +22,6 @@ public struct ImageAttachmentPayload: AttachmentPayload {
     public var imageURL: URL
     /// A link to the image preview.
     public var imagePreviewURL: URL
-    /// Attachment actions.
-    public var actions: [AttachmentAction]
     /// An extra data.
     public var extraData: [String: RawJSON]?
     
@@ -39,17 +37,10 @@ public struct ImageAttachmentPayload: AttachmentPayload {
     /// Creates `ImageAttachmentPayload` instance.
     ///
     /// Use this initializer if the attachment is already uploaded and you have the remote URLs.
-    public init(
-        title: String?,
-        imageRemoteURL: URL,
-        imagePreviewRemoteURL: URL? = nil,
-        actions: [AttachmentAction] = [],
-        extraData: [String: RawJSON]? = nil
-    ) {
+    public init(title: String?, imageRemoteURL: URL, imagePreviewRemoteURL: URL? = nil, extraData: [String: RawJSON]?) {
         self.title = title
         imageURL = imageRemoteURL
         imagePreviewURL = imagePreviewRemoteURL ?? imageRemoteURL
-        self.actions = actions
         self.extraData = extraData
     }
 }
@@ -60,13 +51,9 @@ extension ImageAttachmentPayload: Hashable {}
 
 extension ImageAttachmentPayload: Encodable {
     public func encode(to encoder: Encoder) throws {
-        let actionsData = try JSONEncoder.default.encode(actions)
-        let actions = try JSONDecoder.default.decode([RawJSON].self, from: actionsData)
-        
         var values = extraData ?? [:]
         values[AttachmentCodingKeys.title.rawValue] = title.map { .string($0) }
         values[AttachmentCodingKeys.imageURL.rawValue] = .string(imageURL.absoluteString)
-        values[AttachmentCodingKeys.actions.rawValue] = .array(actions)
         try values.encode(to: encoder)
     }
 }
@@ -93,8 +80,6 @@ extension ImageAttachmentPayload: Decodable {
             imageRemoteURL: imageURL,
             imagePreviewRemoteURL: try container
                 .decodeIfPresent(URL.self, forKey: .thumbURL) ?? imageURL,
-            actions: try container
-                .decodeIfPresent([AttachmentAction].self, forKey: .actions) ?? [],
             extraData: try Self.decodeExtraData(from: decoder)
         )
     }

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -513,6 +513,7 @@ class MessageUpdater: Worker {
             guard action.isCancel == false else {
                 // For ephemeral messages we don't change `state` to `.deleted`
                 messageDTO.deletedAt = Date()
+                messageDTO.previewOfChannel?.previewMessage = session.preview(for: cid)
                 return
             }
 

--- a/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
@@ -2176,10 +2176,18 @@ final class MessageDTO_Tests: XCTestCase {
             channel: channel
         )
         
+        let deletedEphemeralMessage: MessagePayload = .dummy(
+            type: .ephemeral,
+            messageId: .unique,
+            authorUserId: .unique,
+            deletedAt: .unique,
+            channel: channel
+        )
+        
         try database.writeSynchronously { session in
             try session.saveCurrentUser(payload: currentUser)
             
-            for message in [deletedMessageFromCurrentUser, deletedMessageFromAnotherUser] {
+            for message in [deletedMessageFromCurrentUser, deletedMessageFromAnotherUser, deletedEphemeralMessage] {
                 try session.saveMessage(
                     payload: message,
                     for: channel.cid,

--- a/Tests/StreamChatTests/Models/Attachments/ImageAttachmentPayload_Tests.swift
+++ b/Tests/StreamChatTests/Models/Attachments/ImageAttachmentPayload_Tests.swift
@@ -7,37 +7,18 @@
 import XCTest
 
 final class ImageAttachmentPayload_Tests: XCTestCase {
-    func test_decode() throws {
+    func test_decodingDefaultValues() throws {
         // Create attachment field values.
         let title: String = .unique
         let imageURL: URL = .unique()
         let thumbURL: URL = .unique()
-        let comment: String = .unique
-        
-        let action = AttachmentAction(
-            name: .unique,
-            value: .unique,
-            style: .default,
-            type: .button,
-            text: .unique
-        )
         
         // Create JSON with the given values.
         let json = """
         {
             "title": "\(title)",
             "image_url": "\(imageURL.absoluteString)",
-            "thumb_url": "\(thumbURL.absoluteString)",
-            "comment": "\(comment)",
-            "actions": [
-                {
-                    "name": "\(action.name)",
-                    "value": "\(action.value)",
-                    "style": "\(action.style.rawValue)",
-                    "type": "\(action.type.rawValue)",
-                    "text": "\(action.text)"
-                }
-            ]
+            "thumb_url": "\(thumbURL.absoluteString)"
         }
         """.data(using: .utf8)!
         
@@ -48,52 +29,40 @@ final class ImageAttachmentPayload_Tests: XCTestCase {
         XCTAssertEqual(payload.title, title)
         XCTAssertEqual(payload.imageURL, imageURL)
         XCTAssertEqual(payload.imagePreviewURL, thumbURL)
-        XCTAssertEqual(payload.actions, [action])
-
+        XCTAssertNil(payload.extraData)
+    }
+    
+    func test_decodingExtraData() throws {
+        struct ExtraData: Codable {
+            let comment: String
+        }
+        
+        // Create attachment field values.
+        let title: String = .unique
+        let imageURL: URL = .unique()
+        let thumbURL: URL = .unique()
+        let comment: String = .unique
+        
+        // Create JSON with the given values.
+        let json = """
+        {
+            "title": "\(title)",
+            "image_url": "\(imageURL.absoluteString)",
+            "thumb_url": "\(thumbURL.absoluteString)",
+            "comment": "\(comment)"
+        }
+        """.data(using: .utf8)!
+        
+        // Decode attachment from JSON.
+        let payload = try JSONDecoder.stream.decode(ImageAttachmentPayload.self, from: json)
+        
+        // Assert values are decoded correctly.
+        XCTAssertEqual(payload.title, title)
+        XCTAssertEqual(payload.imageURL, imageURL)
+        XCTAssertEqual(payload.imagePreviewURL, thumbURL)
+        
         // Assert extra data can be decoded.
         let extraData = try XCTUnwrap(payload.extraData(ofType: ExtraData.self))
         XCTAssertEqual(extraData.comment, comment)
     }
-    
-    func test_encode() throws {
-        let extraData = ExtraData(comment: .unique)
-        
-        let payload = ImageAttachmentPayload(
-            title: .unique,
-            imageRemoteURL: .unique(),
-            actions: [
-                .init(
-                    name: .unique,
-                    value: .unique,
-                    style: .default,
-                    type: .button,
-                    text: .unique
-                )
-            ],
-            extraData: [
-                "comment": .string(extraData.comment)
-            ]
-        )
-
-        let serialized = try JSONEncoder.stream.encode(payload)
-        let expected: [String: Any] = [
-            "title": payload.title!,
-            "image_url": payload.imageURL.absoluteString,
-            "actions": NSArray(array: payload.actions.map {
-                [
-                    "name": $0.name,
-                    "value": $0.value,
-                    "style": $0.style.rawValue,
-                    "type": $0.type.rawValue,
-                    "text": $0.text
-                ]
-            }),
-            "comment": extraData.comment
-        ]
-        AssertJSONEqual(serialized, expected)
-    }
-}
-
-private struct ExtraData: Codable {
-    let comment: String
 }


### PR DESCRIPTION
### 🔗 Issue Links

CIS-1845

### 🎯 Goal

Make `actions` key usable as an extra data key in all attachments

### 📝 Summary

`actions` is a custom key, used in ephemeral messages (giphy attachments) for attachment actions. We considered it as built-in but didn't expose the key in other attachments, making the key unusable for other attachments.

### 🛠 Implementation

`actions` is only parsed for Giphy attachments.

### 🧪 Manual Testing Notes

Send giphys in channels

### Extra

The PR also fixes the previewMessage update issues introduced recently. No CHANGELOG is added for those fixes since the feature isn't released.
The PR fixes a long time bug where `alwaysVisible` visibility shows ephemeral messages in the Message List.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)