### PR TITLE
[CIS-1849] Fix making new thread reply a channel preview

### DIFF
--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -462,8 +462,11 @@ extension NSManagedObjectContext: MessageDatabaseSession {
             parentMessageDTO.replyCount += 1
         }
         
-        // When the current user submits the new message for sending - make it a channel preview.
-        channelDTO.previewMessage = message
+        // When the current user submits the new message that will be shown
+        // in the channel for sending - make it a channel preview.
+        if parentMessageId == nil || showReplyInChannel {
+            channelDTO.previewMessage = message
+        }
         
         return message
     }


### PR DESCRIPTION
### 🔗 Issue Links

CIS-1849

### 🎯 Goal

Stop showing new thread reply in channel preview when it's submitted for sending.

### 🛠 Implementation

Check if the message is a thread reply before making it a channel preview.

### 🧪 Manual Testing Notes

**GIVEN** I'm in the channel with `read events` enabled
 **WHEN** I submit the new thread reply for sending
**AND** I go back to the channel list before it's sent
**THEN** The channel preview shows the last non-deleted message (not the newly submitted pending thread reply)

**GIVEN** I'm in the channel with `read events` enabled
 **WHEN** I submit the new thread reply for sending
**AND** Sending of thread reply fails
**AND** I go back to the channel list before it's sent
**THEN** The channel preview shows the last non-deleted message (not the submitted failed thread reply)

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)