### PR TITLE
[CIS-1862] Fix not scrolling to bottom when inserting own message

### DIFF
--- a/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
@@ -37,7 +37,7 @@ extension ListChange: CustomStringConvertible {
 
 extension ListChange {
     /// Returns the underlaying item that was changed.
-    var item: Item {
+    public var item: Item {
         switch self {
         case let .insert(item, _):
             return item

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -157,90 +157,41 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
         with changes: [ListChange<ChatMessage>],
         completion: (() -> Void)? = nil
     ) {
-        defer {
-            let lastMessageInserted = changes.first(where: { $0.isInsertion && $0.indexPath.row == 0 })?.item
+        let lastMessageInserted = changes.first(where: { $0.isInsertion && $0.indexPath.row == 0 })?.item
+        let scrollToBottomIfNeeded = {
             if lastMessageInserted?.isSentByCurrentUser == true {
-                scrollToMostRecentMessage()
+                self.scrollToMostRecentMessage()
             }
+        }
 
+        guard let indices = collectionUpdatesMapper.mapToSetsOfIndexPaths(
+            changes: changes
+        ) else {
+            reloadData()
+            scrollToBottomIfNeeded()
             completion?()
-        }
-
-        let hasConflictUpdates = collectionUpdatesMapper.mapToSetsOfIndexPaths(changes: changes) == nil
-        if hasConflictUpdates {
-            reloadData()
             return
         }
 
-        guard changes.count == 1, let change = changes.first else {
-            reloadData()
-            return
-        }
-
-        switch change {
-        case let .insert(message, index: index):
-            UIView.performWithoutAnimation {
-                self.performBatchUpdates {
-                    self.insertRows(at: [index], with: .none)
-                } completion: { _ in
-                    guard self.numberOfRows(inSection: index.section) > index.row + 1 else { return }
-                    // Update previous row to remove timestamp if needed
-                    // +1 instead of -1 because the message list is inverted
-                    let previousIndex = IndexPath(row: index.row + 1, section: index.section)
-                    self.reloadRows(at: [previousIndex], with: .none)
+        UIView.performWithoutAnimation {
+            performBatchUpdates({
+                deleteRows(at: Array(indices.remove), with: .none)
+                insertRows(at: Array(indices.insert), with: .none)
+                reloadRows(at: Array(indices.update), with: .none)
+                indices.move.forEach {
+                    moveRow(at: $0.fromIndex, to: $0.toIndex)
                 }
-            }
+            }, completion: { _ in
+                // Move changes from NSFetchController also can mean an update of the content.
+                // Since a `moveItem` in collections do not update the content of the cell, we need to reload those cells.
+                let moveIndexes = Array(indices.move.map(\.toIndex))
+                if !moveIndexes.isEmpty {
+                    self.reloadRows(at: moveIndexes, with: .none)
+                }
 
-        case let .move(_, fromIndex: fromIndex, toIndex: toIndex):
-            moveRow(at: fromIndex, to: toIndex)
-            reloadRows(at: [fromIndex, toIndex], with: .automatic)
-
-        case let .update(_, index: index):
-            reloadRows(at: [index], with: .automatic)
-
-        case .remove:
-            reloadData()
-        }
-    }
-
-    override open func reloadRows(at indexPaths: [IndexPath], with animation: UITableView.RowAnimation) {
-        let visibleCells = getVisibleCells()
-
-        var indexPathToReload: [IndexPath] = []
-
-        indexPaths.forEach { indexPath in
-            // Get currently shown cell at index path
-            let cellBeforeUpdate = visibleCells[indexPath]
-            let cellBeforeUpdateReuseIdentifier = reuseIdentifier(for: cellBeforeUpdate)
-            let cellBeforeUpdateMessage = cellBeforeUpdate?.messageContentView?.content
-
-            // Get the cell that will be shown if reload happens
-            let cellAfterUpdate = dataSource?.tableView(self, cellForRowAt: indexPath) as? ChatMessageCell
-            let cellAfterUpdateReuseIdentifier = reuseIdentifier(for: cellAfterUpdate)
-            let cellAfterUpdateMessage = cellAfterUpdate?.messageContentView?.content
-
-            if
-                cellBeforeUpdateReuseIdentifier == cellAfterUpdateReuseIdentifier,
-                cellBeforeUpdateMessage?.id == cellAfterUpdateMessage?.id,
-                cellBeforeUpdateMessage?.type == cellAfterUpdateMessage?.type,
-                cellBeforeUpdateMessage?.deletedAt == cellAfterUpdateMessage?.deletedAt,
-                cellBeforeUpdateMessage?.text == cellAfterUpdateMessage?.text,
-                cellBeforeUpdateMessage?.quotedMessage?.text == cellAfterUpdateMessage?.quotedMessage?.text,
-                cellBeforeUpdateMessage?.extraData == cellAfterUpdateMessage?.extraData {
-                // If identifiers and messages match we can simply update the current cell with new content
-                cellBeforeUpdate?.messageContentView?.content = cellAfterUpdateMessage
-            } else {
-                // If identifiers do not match or the cell size will need to change, ex: Editing text
-                // we do a reload to let the table view dequeue another cell
-                // with the layout fitting the updated message.
-                indexPathToReload.append(indexPath)
-            }
-        }
-
-        if !indexPathToReload.isEmpty {
-            UIView.performWithoutAnimation {
-                super.reloadRows(at: indexPathToReload, with: animation)
-            }
+                scrollToBottomIfNeeded()
+                completion?()
+            })
         }
     }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -157,41 +157,90 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
         with changes: [ListChange<ChatMessage>],
         completion: (() -> Void)? = nil
     ) {
-        let lastMessageInserted = changes.first(where: { $0.isInsertion && $0.indexPath.row == 0 })?.item
-        let scrollToBottomIfNeeded = {
+        defer {
+            let lastMessageInserted = changes.first(where: { $0.isInsertion && $0.indexPath.row == 0 })?.item
             if lastMessageInserted?.isSentByCurrentUser == true {
-                self.scrollToMostRecentMessage()
+                scrollToMostRecentMessage()
             }
+
+            completion?()
         }
 
-        guard let indices = collectionUpdatesMapper.mapToSetsOfIndexPaths(
-            changes: changes
-        ) else {
+        let hasConflictUpdates = collectionUpdatesMapper.mapToSetsOfIndexPaths(changes: changes) == nil
+        if hasConflictUpdates {
             reloadData()
-            scrollToBottomIfNeeded()
-            completion?()
             return
         }
 
-        UIView.performWithoutAnimation {
-            performBatchUpdates({
-                deleteRows(at: Array(indices.remove), with: .none)
-                insertRows(at: Array(indices.insert), with: .none)
-                reloadRows(at: Array(indices.update), with: .none)
-                indices.move.forEach {
-                    moveRow(at: $0.fromIndex, to: $0.toIndex)
-                }
-            }, completion: { _ in
-                // Move changes from NSFetchController also can mean an update of the content.
-                // Since a `moveItem` in collections do not update the content of the cell, we need to reload those cells.
-                let moveIndexes = Array(indices.move.map(\.toIndex))
-                if !moveIndexes.isEmpty {
-                    self.reloadRows(at: moveIndexes, with: .none)
-                }
+        guard changes.count == 1, let change = changes.first else {
+            reloadData()
+            return
+        }
 
-                scrollToBottomIfNeeded()
-                completion?()
-            })
+        switch change {
+        case let .insert(message, index: index):
+            UIView.performWithoutAnimation {
+                self.performBatchUpdates {
+                    self.insertRows(at: [index], with: .none)
+                } completion: { _ in
+                    guard self.numberOfRows(inSection: index.section) > index.row + 1 else { return }
+                    // Update previous row to remove timestamp if needed
+                    // +1 instead of -1 because the message list is inverted
+                    let previousIndex = IndexPath(row: index.row + 1, section: index.section)
+                    self.reloadRows(at: [previousIndex], with: .none)
+                }
+            }
+
+        case let .move(_, fromIndex: fromIndex, toIndex: toIndex):
+            moveRow(at: fromIndex, to: toIndex)
+            reloadRows(at: [fromIndex, toIndex], with: .automatic)
+
+        case let .update(_, index: index):
+            reloadRows(at: [index], with: .automatic)
+
+        case .remove:
+            reloadData()
+        }
+    }
+
+    override open func reloadRows(at indexPaths: [IndexPath], with animation: UITableView.RowAnimation) {
+        let visibleCells = getVisibleCells()
+
+        var indexPathToReload: [IndexPath] = []
+
+        indexPaths.forEach { indexPath in
+            // Get currently shown cell at index path
+            let cellBeforeUpdate = visibleCells[indexPath]
+            let cellBeforeUpdateReuseIdentifier = reuseIdentifier(for: cellBeforeUpdate)
+            let cellBeforeUpdateMessage = cellBeforeUpdate?.messageContentView?.content
+
+            // Get the cell that will be shown if reload happens
+            let cellAfterUpdate = dataSource?.tableView(self, cellForRowAt: indexPath) as? ChatMessageCell
+            let cellAfterUpdateReuseIdentifier = reuseIdentifier(for: cellAfterUpdate)
+            let cellAfterUpdateMessage = cellAfterUpdate?.messageContentView?.content
+
+            if
+                cellBeforeUpdateReuseIdentifier == cellAfterUpdateReuseIdentifier,
+                cellBeforeUpdateMessage?.id == cellAfterUpdateMessage?.id,
+                cellBeforeUpdateMessage?.type == cellAfterUpdateMessage?.type,
+                cellBeforeUpdateMessage?.deletedAt == cellAfterUpdateMessage?.deletedAt,
+                cellBeforeUpdateMessage?.text == cellAfterUpdateMessage?.text,
+                cellBeforeUpdateMessage?.quotedMessage?.text == cellAfterUpdateMessage?.quotedMessage?.text,
+                cellBeforeUpdateMessage?.extraData == cellAfterUpdateMessage?.extraData {
+                // If identifiers and messages match we can simply update the current cell with new content
+                cellBeforeUpdate?.messageContentView?.content = cellAfterUpdateMessage
+            } else {
+                // If identifiers do not match or the cell size will need to change, ex: Editing text
+                // we do a reload to let the table view dequeue another cell
+                // with the layout fitting the updated message.
+                indexPathToReload.append(indexPath)
+            }
+        }
+
+        if !indexPathToReload.isEmpty {
+            UIView.performWithoutAnimation {
+                super.reloadRows(at: indexPathToReload, with: animation)
+            }
         }
     }
 

--- a/Sources/StreamChatUI/Utils/CollectionUpdatesMapper.swift
+++ b/Sources/StreamChatUI/Utils/CollectionUpdatesMapper.swift
@@ -55,9 +55,7 @@ final class CollectionUpdatesMapper {
             
             switch change {
             case let .insert(_, index):
-                if !updateIndexes.contains(index) {
-                    verifyConflict(index)
-                }
+                verifyConflict(index)
                 insertIndexes.insert(index)
             case let .move(_, fromIndex, toIndex):
                 verifyConflict(fromIndex)
@@ -67,10 +65,7 @@ final class CollectionUpdatesMapper {
                 verifyConflict(index)
                 removeIndexes.insert(index)
             case let .update(_, index):
-                // On updates, if there are conflicts in insertions, ignore them.
-                if !insertIndexes.contains(index) {
-                    verifyConflict(index)
-                }
+                verifyConflict(index)
                 updateIndexes.insert(index)
             }
         }

--- a/Sources/StreamChatUI/Utils/CollectionUpdatesMapper.swift
+++ b/Sources/StreamChatUI/Utils/CollectionUpdatesMapper.swift
@@ -55,7 +55,9 @@ final class CollectionUpdatesMapper {
             
             switch change {
             case let .insert(_, index):
-                verifyConflict(index)
+                if !updateIndexes.contains(index) {
+                    verifyConflict(index)
+                }
                 insertIndexes.insert(index)
             case let .move(_, fromIndex, toIndex):
                 verifyConflict(fromIndex)
@@ -65,7 +67,10 @@ final class CollectionUpdatesMapper {
                 verifyConflict(index)
                 removeIndexes.insert(index)
             case let .update(_, index):
-                verifyConflict(index)
+                // On updates, if there are conflicts in insertions, ignore them.
+                if !insertIndexes.contains(index) {
+                    verifyConflict(index)
+                }
                 updateIndexes.insert(index)
             }
         }


### PR DESCRIPTION
### 🔗 Issue Links
CIS-1862

### 🎯 Goal
Fix message list not scrolling to the bottom when a message from the current user was inserted (Only on non-diffing solution).

### 📝 Summary
- When a reloadData() happens, also scroll to bottom if a new message was inserted by the current user
- Refactor the `ChatMessageListView` and use performBatchUpdates to update the message list. 

### 🧪 Manual Testing Notes
- Open the Demo App (Not the StreamDevelopers Scheme)
- Select a user
- Open a channel
- Scroll up
- Send a message
- Should scroll to bottom


### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)