### PR TITLE
[CIS-1558] Fix crash `unconditionallyBridgeFromObjectiveC` from CoreData DTOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - decrement when message is hard deleted
 - Fix paginated channels in channel list were left without messages when sync is executed [#1985](https://github.com/GetStream/stream-chat-swift/issues/1985)
 - Fix `deletedMessagesVisibility == .alwaysVisible` shows deleted ephemeral messages in message list [#1991](https://github.com/GetStream/stream-chat-swift/issues/1991)
+- Fix crash `unconditionallyBridgeFromObjectiveC` in `ChannelDTO.willSave()` [#2007](https://github.com/GetStream/stream-chat-swift/issues/2007)
 ### 🔄 Changed
 - Rename `mentionedMessages` to `mentions` in `ChannelUnreadCount` [#1978](https://github.com/GetStream/stream-chat-swift/issues/1978)
 - Changes `.team` filter `FilterKey` to accept `nil` as a parameter  [#1968](https://github.com/GetStream/stream-chat-swift/pull/1968)

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -79,8 +79,7 @@ class ChannelDTO: NSManagedObject {
         
         // Update the date for sorting every time new message in this channel arrive.
         // This will ensure that the channel list is updated/sorted when new message arrives.
-        let lastDate = lastMessageAt ?? createdAt
-        if lastDate != defaultSortingAt {
+        if let lastDate = lastMessageAt, lastDate != defaultSortingAt {
             defaultSortingAt = lastDate
         }
     }


### PR DESCRIPTION
### 🔗 Issue Links
CIS-1558

### 🎯 Goal
Fix crash  `unconditionallyBridgeFromObjectiveC` that happens when `CoreData` runtime attemps converting a `NSDate` to `Date?`.

### 🧪 Manual Testing Notes
A swiftlint rule will be added to avoid regressions.

### ☑️ Contributor Checklist
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)