### PR TITLE
Fix mac-os version in release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     name: Publish new release
-    runs-on: macos-12
+    runs-on: macos-11
     if: github.event.pull_request.merged == true # only merged pull requests must trigger this job
     steps:
       - name: Install Bot SSH Key


### PR DESCRIPTION
### 🎯 Goal

Use `macos-11` in release workflow to get Xcode 13.0 used for xc-frameworks

### 📝 Summary

Use `macos-11` in release workflow to get Xcode 13.0 used for xc-frameworks

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)