### PR TITLE
[CIS-1869] Fix launching DemoApp in offline state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
-## StreamChatUI
-### ✅ Added
-- Add Support for Slow Mode [#1953](https://github.com/GetStream/stream-chat-swift/pull/1953)
-### 🐞 Fixed
-- Fix DM Channel with multiple members displaying only 1 user avatar [#2019](https://github.com/GetStream/stream-chat-swift/pull/2019)
-
 ## StreamChat
 ### 🐞 Fixed
 - Saving payloads to local database is now 50% faster. Initial launch and displaying channel list should be noticeably faster [#1973](https://github.com/GetStream/stream-chat-swift/issues/1973)
 - Fix not waiting for last batch of events to be processed when connecting as another user [#2016](https://github.com/GetStream/stream-chat-swift/issues/2016)
+
+## StreamChatUI
+### ✅ Added
+- Add Support for Slow Mode [#1953](https://github.com/GetStream/stream-chat-swift/pull/1953)
+- Present channel screen modally when channel list in not embedded by navigation controller [#2011](https://github.com/GetStream/stream-chat-swift/pull/2011)
+- Show channel screen as right detail when channel list is embedded by split view controller [#2011](https://github.com/GetStream/stream-chat-swift/pull/2011)
+### 🐞 Fixed
+- Fix DM Channel with multiple members displaying only 1 user avatar [#2019](https://github.com/GetStream/stream-chat-swift/pull/2019)
 
 # [4.15.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.15.0)
 _May 11, 2022_

--- a/DemoApp/AppDelegate.swift
+++ b/DemoApp/AppDelegate.swift
@@ -26,18 +26,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
-        guard let currentUserId = ChatClient.shared.currentUserId else {
-            log.warning("cannot add the device without connecting as user first, did you call connectUser")
-            return
-        }
-
-        ChatClient.shared.currentUserController().addDevice(.apn(token: deviceToken)) { error in
-            if let error = error {
+        ChatClient.shared.currentUserController().addDevice(.apn(token: deviceToken)) {
+            if let error = $0 {
                 log.error("adding a device failed with an error \(error)")
-                return
             }
-            UserDefaults(suiteName: applicationGroupIdentifier)?
-                .set(currentUserId, forKey: currentUserIdRegisteredForPush)
         }
     }
 

--- a/DemoApp/DemoUsers.swift
+++ b/DemoApp/DemoUsers.swift
@@ -5,9 +5,8 @@
 import Foundation
 import StreamChat
 
-public let apiKeyString = "8br4watad788"
-public let applicationGroupIdentifier = "group.io.getstream.iOS.ChatDemoApp"
-public let currentUserIdRegisteredForPush = "currentUserIdRegisteredForPush"
+let apiKeyString = "8br4watad788"
+let applicationGroupIdentifier = "group.io.getstream.iOS.ChatDemoApp"
 
 enum DemoUserType {
     case credentials(UserCredentials)
@@ -15,15 +14,13 @@ enum DemoUserType {
     case guest(String)
 }
 
-public struct UserCredentials {
+struct UserCredentials {
     let id: String
     let name: String
     let avatarURL: URL
-    let token: String
+    let token: Token
     let birthLand: String
-}
-
-public extension UserCredentials {
+    
     var userInfo: UserInfo {
         .init(
             id: id,
@@ -32,126 +29,159 @@ public extension UserCredentials {
             extraData: [ChatUser.birthLandFieldName: .string(birthLand)]
         )
     }
+}
+
+// MARK: - Built-in users
+
+extension UserCredentials {
+    static let builtInUsers: [UserCredentials] = [
+        .luke,
+        .leia,
+        .hanSolo,
+        .lando,
+        .chewbacca,
+        .c3po,
+        .r2d2,
+        .anakin,
+        .obiwan,
+        .padme,
+        .quiGonJinn,
+        .maceWindu,
+        .jarJarBinks,
+        .darthMaul,
+        .countDooku,
+        .generalGrievous
+    ]
     
     static func builtInUsersByID(id: String) -> UserCredentials? {
         builtInUsers.first { $0.id == id }
     }
-
-    static let builtInUsers: [UserCredentials] = [
-        (
-            "luke_skywalker",
-            "Luke Skywalker",
-            "https://vignette.wikia.nocookie.net/starwars/images/2/20/LukeTLJ.jpg",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIifQ.kFSLHRB5X62t0Zlc7nwczWUfsQMwfkpylC6jCUZ6Mc0",
-            "Tatooine"
-        ),
-        (
-            "leia_organa",
-            "Leia Organa",
-            "https://vignette.wikia.nocookie.net/starwars/images/f/fc/Leia_Organa_TLJ.png",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibGVpYV9vcmdhbmEifQ.IzwBuaYwX5dRvnDDnJN2AyW3wwfYwgQm3w-1RD4BLPU",
-            "Polis Massa"
-        ),
-        (
-            "han_solo",
-            "Han Solo",
-            "https://vignette.wikia.nocookie.net/starwars/images/e/e2/TFAHanSolo.png",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiaGFuX3NvbG8ifQ.R6PkQeGPcusALmhvaST50lwroL_JkZnI3Q7hQ1Hvj3k",
-            "Corellia"
-        ),
-        (
-            "lando_calrissian",
-            "Lando Calrissian",
-            "https://vignette.wikia.nocookie.net/starwars/images/8/8f/Lando_ROTJ.png",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibGFuZG9fY2Fscmlzc2lhbiJ9.n_K7d-FroQzBUxETNcEQYqiW_U9CPjRHZHT1hyAjlAQ",
-            "Socorro"
-        ),
-        (
-            "chewbacca",
-            "Chewbacca",
-            "https://vignette.wikia.nocookie.net/starwars/images/4/48/Chewbacca_TLJ.png",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiY2hld2JhY2NhIn0.4nNFfO0dehvdLxDUGaMQPpMliSTGjHqh1C2Zo8wyaeM",
-            "Kashyyyk"
-        ),
-        (
-            "c-3po",
-            "C-3PO",
-            "https://vignette.wikia.nocookie.net/starwars/images/3/3f/C-3PO_TLJ_Card_Trader_Award_Card.png",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYy0zcG8ifQ.J4Xzu8rKP1XWQvSNV6wzWKW403qKd5N3FalpWXTDauw",
-            "Affa"
-        ),
-        (
-            "r2-d2",
-            "R2-D2",
-            "https://vignette.wikia.nocookie.net/starwars/images/e/eb/ArtooTFA2-Fathead.png",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicjItZDIifQ.UpSEW8jA2tYsUTPKbdFGMtHHnu9_AnEQqTK6TdT8L1g",
-            "Naboo"
-        ),
-        (
-            "anakin_skywalker",
-            "Anakin Skywalker",
-            "https://vignette.wikia.nocookie.net/starwars/images/6/6f/Anakin_Skywalker_RotS.png",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYW5ha2luX3NreXdhbGtlciJ9.oJkwakjdqw6gCA3-kaUaKqSVEcWO5ob5DJuyJCtnT6U",
-            "Tatooine"
-        ),
-        (
-            "obi-wan_kenobi",
-            "Obi-Wan Kenobi",
-            "https://vignette.wikia.nocookie.net/starwars/images/4/4e/ObiWanHS-SWE.jpg",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoib2JpLXdhbl9rZW5vYmkifQ.AVOtnXtMq9crXFwl68BrBRob335phYpYfPPq5i2agUM",
-            "Stewjon"
-        ),
-        (
-            "padme_amidala",
-            "Padmé Amidala",
-            "https://vignette.wikia.nocookie.net/starwars/images/b/b2/Padmegreenscrshot.jpg",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicGFkbWVfYW1pZGFsYSJ9.X8CwsnrWKvdrS6XchcUMZDLh_W0X4Gpx-oNyjGAdenI",
-            "Naboo"
-        ),
-        (
-            "qui-gon_jinn",
-            "Qui-Gon Jinn",
-            "https://vignette.wikia.nocookie.net/starwars/images/f/f6/Qui-Gon_Jinn_Headshot_TPM.jpg",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicXVpLWdvbl9qaW5uIn0.EDuyuTkyzG1OA3ROwa3sK8-K_U2MGREsY4Ic7flXvzw",
-            "Coruscant"
-        ),
-        (
-            "mace_windu",
-            "Mace Windu",
-            "https://vignette.wikia.nocookie.net/starwars/images/5/58/Mace_ROTS.png",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibWFjZV93aW5kdSJ9.x8xFcOQFr0XUDeA3BH0ISsR2VSmWSxmMgbnz8lprV58",
-            "Haruun Kal"
-        ),
-        (
-            "jar_jar_binks",
-            "Jar Jar Binks",
-            "https://vignette.wikia.nocookie.net/starwars/images/d/d2/Jar_Jar_aotc.jpg",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamFyX2phcl9iaW5rcyJ9.5-GhGE8sqlxKNUMyBGovrkoaxgkEQAUMJ3CZfcxyrZg",
-            "Naboo"
-        ),
-        (
-            "darth_maul",
-            "Darth Maul",
-            "https://vignette.wikia.nocookie.net/starwars/images/5/50/Darth_Maul_profile.png",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZGFydGhfbWF1bCJ9._cbBA2ThWpXcyxwvBV6gvqAwnw0lvzfHAlZ4stGqf2o",
-            "Dathomir"
-        ),
-        (
-            "count_dooku",
-            "Count Dooku",
-            "https://vignette.wikia.nocookie.net/starwars/images/b/b8/Dooku_Headshot.jpg",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiY291bnRfZG9va3UifQ.0sN_cPTKrXsxC23WUSIBUQK5IUZsdGijmqY50HJERQw",
-            "Serenno"
-        ),
-        (
-            "general_grievous",
-            "General Grievous",
-            "https://vignette.wikia.nocookie.net/starwars/images/d/de/Grievoushead.jpg",
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZ2VuZXJhbF9ncmlldm91cyJ9.FPRvRoeZdALErBA1bDybch4xY-c5CEinuc9qqEPzX4E",
-            "Qymaen jai Sheelal"
-        )
-
-    ].map {
-        UserCredentials(id: $0.0, name: $0.1, avatarURL: URL(string: $0.2)!, token: $0.3, birthLand: $0.4)
-    }
+    
+    static let luke = Self(
+        id: "luke_skywalker",
+        name: "Luke Skywalker",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/2/20/LukeTLJ.jpg")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIifQ.kFSLHRB5X62t0Zlc7nwczWUfsQMwfkpylC6jCUZ6Mc0",
+        birthLand: "Tatooine"
+    )
+    
+    static let leia = Self(
+        id: "leia_organa",
+        name: "Leia Organa",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/f/fc/Leia_Organa_TLJ.png")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibGVpYV9vcmdhbmEifQ.IzwBuaYwX5dRvnDDnJN2AyW3wwfYwgQm3w-1RD4BLPU",
+        birthLand: "Polis Massa"
+    )
+    
+    static let hanSolo = Self(
+        id: "han_solo",
+        name: "Han Solo",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/e/e2/TFAHanSolo.png")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiaGFuX3NvbG8ifQ.R6PkQeGPcusALmhvaST50lwroL_JkZnI3Q7hQ1Hvj3k",
+        birthLand: "Corellia"
+    )
+    
+    static let lando = Self(
+        id: "lando_calrissian",
+        name: "Lando Calrissian",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/8/8f/Lando_ROTJ.png")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibGFuZG9fY2Fscmlzc2lhbiJ9.n_K7d-FroQzBUxETNcEQYqiW_U9CPjRHZHT1hyAjlAQ",
+        birthLand: "Socorro"
+    )
+    
+    static let chewbacca = Self(
+        id: "chewbacca",
+        name: "Chewbacca",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/4/48/Chewbacca_TLJ.png")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiY2hld2JhY2NhIn0.4nNFfO0dehvdLxDUGaMQPpMliSTGjHqh1C2Zo8wyaeM",
+        birthLand: "Kashyyyk"
+    )
+    
+    static let c3po = Self(
+        id: "c-3po",
+        name: "C-3PO",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/3/3f/C-3PO_TLJ_Card_Trader_Award_Card.png")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYy0zcG8ifQ.J4Xzu8rKP1XWQvSNV6wzWKW403qKd5N3FalpWXTDauw",
+        birthLand: "Affa"
+    )
+    
+    static let r2d2 = Self(
+        id: "r2-d2",
+        name: "R2-D2",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/e/eb/ArtooTFA2-Fathead.png")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicjItZDIifQ.UpSEW8jA2tYsUTPKbdFGMtHHnu9_AnEQqTK6TdT8L1g",
+        birthLand: "Naboo"
+    )
+    
+    static let anakin = Self(
+        id: "anakin_skywalker",
+        name: "Anakin Skywalker",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/6/6f/Anakin_Skywalker_RotS.png")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYW5ha2luX3NreXdhbGtlciJ9.oJkwakjdqw6gCA3-kaUaKqSVEcWO5ob5DJuyJCtnT6U",
+        birthLand: "Tatooine"
+    )
+    
+    static let obiwan = Self(
+        id: "obi-wan_kenobi",
+        name: "Obi-Wan Kenobi",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/4/4e/ObiWanHS-SWE.jpg")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoib2JpLXdhbl9rZW5vYmkifQ.AVOtnXtMq9crXFwl68BrBRob335phYpYfPPq5i2agUM",
+        birthLand: "Stewjon"
+    )
+    
+    static let padme = Self(
+        id: "padme_amidala",
+        name: "Padmé Amidala",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/b/b2/Padmegreenscrshot.jpg")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicGFkbWVfYW1pZGFsYSJ9.X8CwsnrWKvdrS6XchcUMZDLh_W0X4Gpx-oNyjGAdenI",
+        birthLand: "Naboo"
+    )
+    
+    static let quiGonJinn = Self(
+        id: "qui-gon_jinn",
+        name: "Qui-Gon Jinn",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/f/f6/Qui-Gon_Jinn_Headshot_TPM.jpg")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicXVpLWdvbl9qaW5uIn0.EDuyuTkyzG1OA3ROwa3sK8-K_U2MGREsY4Ic7flXvzw",
+        birthLand: "Coruscant"
+    )
+    
+    static let maceWindu = Self(
+        id: "mace_windu",
+        name: "Mace Windu",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/5/58/Mace_ROTS.png")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibWFjZV93aW5kdSJ9.x8xFcOQFr0XUDeA3BH0ISsR2VSmWSxmMgbnz8lprV58",
+        birthLand: "Haruun Kal"
+    )
+    
+    static let jarJarBinks = Self(
+        id: "jar_jar_binks",
+        name: "Jar Jar Binks",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/d/d2/Jar_Jar_aotc.jpg")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamFyX2phcl9iaW5rcyJ9.5-GhGE8sqlxKNUMyBGovrkoaxgkEQAUMJ3CZfcxyrZg",
+        birthLand: "Naboo"
+    )
+    
+    static let darthMaul = Self(
+        id: "darth_maul",
+        name: "Darth Maul",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/5/50/Darth_Maul_profile.png")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZGFydGhfbWF1bCJ9._cbBA2ThWpXcyxwvBV6gvqAwnw0lvzfHAlZ4stGqf2o",
+        birthLand: "Dathomir"
+    )
+    
+    static let countDooku = Self(
+        id: "count_dooku",
+        name: "Count Dooku",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/b/b8/Dooku_Headshot.jpg")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiY291bnRfZG9va3UifQ.0sN_cPTKrXsxC23WUSIBUQK5IUZsdGijmqY50HJERQw",
+        birthLand: "Serenno"
+    )
+    
+    static let generalGrievous = Self(
+        id: "general_grievous",
+        name: "General Grievous",
+        avatarURL: URL(string: "https://vignette.wikia.nocookie.net/starwars/images/d/de/Grievoushead.jpg")!,
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZ2VuZXJhbF9ncmlldm91cyJ9.FPRvRoeZdALErBA1bDybch4xY-c5CEinuc9qqEPzX4E",
+        birthLand: "Qymaen jai Sheelal"
+    )
 }

--- a/DemoApp/LoginViewController.swift
+++ b/DemoApp/LoginViewController.swift
@@ -39,7 +39,7 @@ class UserCredentialsCell: UITableViewCell {
 
 class LoginViewController: UIViewController {
     @IBOutlet var tableView: UITableView!
-    var didRequestChatPresentation: ((DemoUserType) -> Void)!
+    var onUserSelection: ((DemoUserType) -> Void)!
     
     let users: [DemoUserType] = UserCredentials.builtInUsers.map { DemoUserType.credentials($0) } + [.guest("guest"), .anonymous]
     
@@ -54,11 +54,6 @@ class LoginViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
-        // Disconnect the current client
-        if ChatClient.shared != nil {
-            ChatClient.shared = nil
-        }
         
         navigationController?.isNavigationBarHidden = true
         if let selectedRow = tableView.indexPathForSelectedRow {
@@ -109,13 +104,13 @@ extension LoginViewController: UITableViewDelegate, UITableViewDataSource {
         
         switch user {
         case .credentials, .anonymous:
-            didRequestChatPresentation(user)
+            onUserSelection(user)
         case .guest:
             presentAlert(title: "Input a user id", message: nil, textFieldPlaceholder: "guest") { [weak self] userId in
                 if let userId = userId, !userId.isEmpty {
-                    self?.didRequestChatPresentation(.guest(userId))
+                    self?.onUserSelection(.guest(userId))
                 } else {
-                    self?.didRequestChatPresentation(.guest("guest"))
+                    self?.onUserSelection(.guest("guest"))
                 }
             }
         }

--- a/DemoApp/SceneDelegate.swift
+++ b/DemoApp/SceneDelegate.swift
@@ -14,26 +14,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let scene = scene as? UIWindowScene else { return }
-        let window = UIWindow(windowScene: scene)
         
-        guard let navigationController = UIStoryboard(
-            name: "Main",
-            bundle: nil
-        ).instantiateInitialViewController() as? UINavigationController else { return }
-        window.rootViewController = navigationController
-        coordinator = DemoAppCoordinator(navigationController: navigationController)
-
-        UNUserNotificationCenter.current().delegate = coordinator
-
-        if let notificationResponse = connectionOptions.notificationResponse {
-            print("debugging: \(notificationResponse)")
-            print("debugging: \(notificationResponse.actionIdentifier)")
-            print("debugging: \(notificationResponse.notification)")
-        }
+        let window = UIWindow(windowScene: scene)
+        window.tintColor = .streamBlue
+        
+        coordinator = DemoAppCoordinator(window: window)
+        coordinator.start()
+        
+        window.makeKeyAndVisible()
         
         self.window = window
-        window.makeKeyAndVisible()
-        scene.windows.forEach { $0.tintColor = .streamBlue }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {}

--- a/DemoApp/UserDefaults+Shared.swift
+++ b/DemoApp/UserDefaults+Shared.swift
@@ -1,0 +1,18 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension UserDefaults {
+    static let shared = UserDefaults(suiteName: applicationGroupIdentifier)!
+    
+    var currentUserId: String? {
+        get { string(forKey: #function) }
+        set { set(newValue, forKey: #function) }
+    }
+    
+    var currentUser: UserCredentials? {
+        currentUserId.flatMap { UserCredentials.builtInUsersByID(id: $0) }
+    }
+}

--- a/DemoAppPush/NotificationService.swift
+++ b/DemoAppPush/NotificationService.swift
@@ -76,8 +76,7 @@ class NotificationService: UNNotificationServiceExtension {
             return
         }
 
-        guard let userId = UserDefaults(suiteName: applicationGroupIdentifier)?.string(forKey: currentUserIdRegisteredForPush),
-              let userCredentials = UserCredentials.builtInUsersByID(id: userId) else {
+        guard let userCredentials = UserDefaults.shared.currentUser else {
             contentHandler(content)
             return
         }
@@ -87,7 +86,7 @@ class NotificationService: UNNotificationServiceExtension {
         config.applicationGroupIdentifier = applicationGroupIdentifier
 
         let client = ChatClient(config: config)
-        client.setToken(token: Token(stringLiteral: userCredentials.token))
+        client.setToken(token: Token(stringLiteral: userCredentials.token.rawValue))
 
         let chatHandler = ChatRemoteNotificationHandler(client: client, content: content)
 

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -131,7 +131,7 @@ class WebSocketClient {
         completion: @escaping () -> Void
     ) {
         connectionState = .disconnecting(source: source)
-        engineQueue.async { [weak engine, eventsBatcher] in
+        engineQueue.async { [engine, eventsBatcher] in
             engine?.disconnect()
             
             eventsBatcher.processImmediately(completion: completion)

--- a/Sources/StreamChatUI/Navigation/ChatChannelListRouter.swift
+++ b/Sources/StreamChatUI/Navigation/ChatChannelListRouter.swift
@@ -8,6 +8,8 @@ import UIKit
 /// A `NavigationRouter` subclass that handles navigation actions of `ChatChannelListVC`.
 @available(iOSApplicationExtension, unavailable)
 open class ChatChannelListRouter: NavigationRouter<ChatChannelListVC>, ComponentsProvider {
+    let modalTransitioningDelegate = StreamModalTransitioningDelegate()
+    
     /// Shows the view controller with the profile of the current user.
     open func showCurrentUserProfile() {
         log.error(
@@ -28,13 +30,17 @@ open class ChatChannelListRouter: NavigationRouter<ChatChannelListVC>, Component
             for: cid,
             channelListQuery: rootViewController.controller.query
         )
-
-        guard let navController = rootNavigationController else {
-            log.error("Can't push chat detail, no navigation controller available")
-            return
-        }
         
-        navController.show(vc, sender: self)
+        if let splitVC = rootViewController.splitViewController {
+            splitVC.showDetailViewController(UINavigationController(rootViewController: vc), sender: self)
+        } else if let navigationVC = rootViewController.navigationController {
+            navigationVC.show(vc, sender: self)
+        } else {
+            let navigationVC = UINavigationController(rootViewController: vc)
+            navigationVC.transitioningDelegate = modalTransitioningDelegate
+            navigationVC.modalPresentationStyle = .custom
+            rootViewController.show(navigationVC, sender: self)
+        }
     }
 
     /// Called when a user tapped `More` swipe action on a channel

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -155,7 +155,7 @@
 		7931818C24FD2660002F8C84 /* ChannelListController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7931818B24FD2660002F8C84 /* ChannelListController+Combine.swift */; };
 		7931818E24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7931818D24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift */; };
 		79330604256FEBE600FBB586 /* AdvancedOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79330603256FEBE600FBB586 /* AdvancedOptionsViewController.swift */; };
-		7933060B256FF94800FBB586 /* ChatPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7933060A256FF94800FBB586 /* ChatPresenter.swift */; };
+		7933060B256FF94800FBB586 /* DemoChatChannelListRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7933060A256FF94800FBB586 /* DemoChatChannelListRouter.swift */; };
 		7933064925712C8B00FBB586 /* DemoUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7933064825712C8B00FBB586 /* DemoUsers.swift */; };
 		79342EEC2632C7770018F0F7 /* ChannelVisibilityEventMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79342EEB2632C7770018F0F7 /* ChannelVisibilityEventMiddleware_Tests.swift */; };
 		7937282A2498FFD300E13FE5 /* MemberPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793728292498FFD300E13FE5 /* MemberPayload.swift */; };
@@ -495,6 +495,8 @@
 		849AE664270CB14000423A20 /* VideoAttachmentComposerPreview_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849AE663270CB14000423A20 /* VideoAttachmentComposerPreview_Tests.swift */; };
 		849AE666270CB55F00423A20 /* VideoAttachmentGalleryCell_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849AE665270CB55F00423A20 /* VideoAttachmentGalleryCell_Tests.swift */; };
 		849AE668270CB65F00423A20 /* VideoAttachmentGalleryPreview_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849AE667270CB65F00423A20 /* VideoAttachmentGalleryPreview_Tests.swift */; };
+		849C1B6A283686EE00F9DC42 /* UserDefaults+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849C1B69283686EE00F9DC42 /* UserDefaults+Shared.swift */; };
+		849C1B6B283686EE00F9DC42 /* UserDefaults+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849C1B69283686EE00F9DC42 /* UserDefaults+Shared.swift */; };
 		84A1D2E626AACDBE00014712 /* ChannelEventsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A1D2E526AACDBE00014712 /* ChannelEventsController.swift */; };
 		84A1D2E826AAEA3300014712 /* CustomEventRequestBody_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A1D2E726AAEA3300014712 /* CustomEventRequestBody_Tests.swift */; };
 		84A1D2EA26AAFB1D00014712 /* EventSender_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A1D2E926AAFB1D00014712 /* EventSender_Tests.swift */; };
@@ -2400,7 +2402,7 @@
 		7931818B24FD2660002F8C84 /* ChannelListController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelListController+Combine.swift"; sourceTree = "<group>"; };
 		7931818D24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelListController+Combine_Tests.swift"; sourceTree = "<group>"; };
 		79330603256FEBE600FBB586 /* AdvancedOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedOptionsViewController.swift; sourceTree = "<group>"; };
-		7933060A256FF94800FBB586 /* ChatPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPresenter.swift; sourceTree = "<group>"; };
+		7933060A256FF94800FBB586 /* DemoChatChannelListRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoChatChannelListRouter.swift; sourceTree = "<group>"; };
 		7933064825712C8B00FBB586 /* DemoUsers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoUsers.swift; sourceTree = "<group>"; };
 		79342EEB2632C7770018F0F7 /* ChannelVisibilityEventMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelVisibilityEventMiddleware_Tests.swift; sourceTree = "<group>"; };
 		793728292498FFD300E13FE5 /* MemberPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberPayload.swift; sourceTree = "<group>"; };
@@ -2760,6 +2762,7 @@
 		849AE663270CB14000423A20 /* VideoAttachmentComposerPreview_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentComposerPreview_Tests.swift; sourceTree = "<group>"; };
 		849AE665270CB55F00423A20 /* VideoAttachmentGalleryCell_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentGalleryCell_Tests.swift; sourceTree = "<group>"; };
 		849AE667270CB65F00423A20 /* VideoAttachmentGalleryPreview_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentGalleryPreview_Tests.swift; sourceTree = "<group>"; };
+		849C1B69283686EE00F9DC42 /* UserDefaults+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Shared.swift"; sourceTree = "<group>"; };
 		84A1D2E526AACDBE00014712 /* ChannelEventsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelEventsController.swift; sourceTree = "<group>"; };
 		84A1D2E726AAEA3300014712 /* CustomEventRequestBody_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEventRequestBody_Tests.swift; sourceTree = "<group>"; };
 		84A1D2E926AAFB1D00014712 /* EventSender_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSender_Tests.swift; sourceTree = "<group>"; };
@@ -4105,11 +4108,12 @@
 			children = (
 				437FC9E226D53F140000223C /* ChatSample.entitlements */,
 				792DDA67256FB69F001DB91B /* Info.plist */,
+				849C1B69283686EE00F9DC42 /* UserDefaults+Shared.swift */,
 				79330603256FEBE600FBB586 /* AdvancedOptionsViewController.swift */,
 				792DDA59256FB69E001DB91B /* AppDelegate.swift */,
 				6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */,
 				647F66D4261E22C200111B19 /* BannerView.swift */,
-				7933060A256FF94800FBB586 /* ChatPresenter.swift */,
+				7933060A256FF94800FBB586 /* DemoChatChannelListRouter.swift */,
 				43016E1526B734410054E805 /* ChatUser+CustomFields.swift */,
 				792DDAA025711AF2001DB91B /* CreateChatViewController.swift */,
 				792DDAA725753BEA001DB91B /* CreateGroupViewController.swift */,
@@ -8527,6 +8531,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				79A5097127FF31DE00A0C568 /* ChatUser+CustomFields.swift in Sources */,
+				849C1B6B283686EE00F9DC42 /* UserDefaults+Shared.swift in Sources */,
 				437FCA0726D67BE40000223C /* NotificationService.swift in Sources */,
 				43C68D9126DD37B700622533 /* DemoUsers.swift in Sources */,
 			);
@@ -8907,6 +8912,7 @@
 				647F66D5261E22C200111B19 /* BannerView.swift in Sources */,
 				AD75CB6B27886746005F5FF7 /* OptionsSelectorViewController.swift in Sources */,
 				648EC576261EF9D400B8F05F /* DemoAppCoordinator.swift in Sources */,
+				849C1B6A283686EE00F9DC42 /* UserDefaults+Shared.swift in Sources */,
 				792DDA5E256FB69E001DB91B /* LoginViewController.swift in Sources */,
 				792DDAA825753BEA001DB91B /* CreateGroupViewController.swift in Sources */,
 				7933064925712C8B00FBB586 /* DemoUsers.swift in Sources */,
@@ -8916,7 +8922,7 @@
 				792DDA5C256FB69E001DB91B /* SceneDelegate.swift in Sources */,
 				43016E1626B734410054E805 /* ChatUser+CustomFields.swift in Sources */,
 				794E20F52577DF4D00790DAB /* NameGroupViewController.swift in Sources */,
-				7933060B256FF94800FBB586 /* ChatPresenter.swift in Sources */,
+				7933060B256FF94800FBB586 /* DemoChatChannelListRouter.swift in Sources */,
 				79330604256FEBE600FBB586 /* AdvancedOptionsViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/docusaurus/docs/iOS/uikit/components/channel-list.md
+++ b/docusaurus/docs/iOS/uikit/components/channel-list.md
@@ -28,6 +28,7 @@ When the `ChatChannelListVC` instance is created, there are multiple ways of sho
 1. modally
 1. inside existed `UINavigationController`
 1. as a tab inside `UITabBarController`
+1. inside `UISplitViewController`
 1. as a child controller
 
 To present the channel list modally:
@@ -48,6 +49,18 @@ let navigationVC = UINavigationController(rootViewController: channelListVC)
 
 let tabBatVC = UITabBarController()
 tabBatVC.viewControllers = [..., navigationVC]
+```
+
+To show the channel list as a main screen in split view controller and the selected channel as a detail:
+```swift
+let channelListNVC = UINavigationController(rootViewController: channelListVC)
+
+let splitVC = UISplitViewController()
+splitVC.preferredDisplayMode = .oneBesideSecondary
+splitVC.viewControllers = [
+    channelListNVC, 
+    /*optionally provide a controller shown as a detail till user opens a channel*/
+]
 ```
 
 To show the channel list as a child:


### PR DESCRIPTION
### 🔗 Issue Links

CIS-1869
Discussion in slack: https://getstream.slack.com/archives/CRB9P6L03/p1652798185424229

### 🎯 Goal

1. When DemoApp is launched offline, the error alert is displayed and the only action logs out the user, making DemoApp unusable offline.
1. The alerts displayed are very ugly
1. DemoApp doesn't have login caching, requires user to "Login" on each app start.

### 📝 Summary

1. We decided to skip the alert if we know we're offline
1. The alerts should display the error message (or reason), not the whole error.
1. DemoApp already has login caching, used for push notification app starts. We can use the same mechanism to login on app start.

https://user-images.githubusercontent.com/12818985/170296163-c5f1c253-0623-404d-8a9e-09b8ca804ce8.mov

### 🧪 Manual Testing Notes

**GIVEN** user logs in as a `built-in` user
**AND** user kills the app
**WHEN** user launches the app offline
**THEN** user is navigated to the channel list
**AND** user observes the banner with the connection status

**GIVEN** user launches app offline
**AND** user tries to log in
**THEN** user is navigated to the channel list
**AND** user observes the banner with the connection status

**GIVEN** user logs in as a `built-in` user
**AND** user kills the app
**WHEN** user launches the app again
**THEN** user is logged in automatically
**AND** user is navigated to the channel list

**GIVEN** user logs in as a `guest/anonymous`
**AND** user kills the app
**WHEN** user launches the app again
**THEN** user is NOT logged in automatically
**AND** user is navigated to the login screen

**GIVEN** user logs in as a `built-in` user
**AND** user kills the app/sends app to background
**WHEN** the new message is posted to the channel
**AND** user receives a push notification
**AND** user taps on push notification
**THEN** user is navigated to the channel with the new message

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)
