### PR TITLE
[CIS-1873] Wait for last events batch to be processed to disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Saving payloads to local database is now 50% faster. Initial launch and displaying channel list should be noticeably faster [#1973](https://github.com/GetStream/stream-chat-swift/issues/1973)
+- Fix not waiting for last batch of events to be processed when connecting as another user [#2016](https://github.com/GetStream/stream-chat-swift/issues/2016)
 
 # [4.15.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.15.0)
 _May 11, 2022_

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -611,6 +611,12 @@ extension ClientError {
             """
         }
     }
+    
+    public class ClientHasBeenDeallocated: ClientError {
+        override public var localizedDescription: String {
+            "ChatClient has beed deallocated, make sure to keep at least one strong reference to it."
+        }
+    }
 }
 
 /// `APIClient` listens for `WebSocketClient` connection updates so it can forward the current connection id to

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -351,7 +351,9 @@ public class ChatClient {
     /// Disconnects the chat client from the chat servers. No further updates from the servers
     /// are received.
     public func disconnect() {
-        clientUpdater.disconnect()
+        clientUpdater.disconnect(source: .userInitiated) {
+            log.info("The `ChatClient` has been disconnected.", subsystems: .webSocket)
+        }
         userConnectionProvider = nil
     }
 
@@ -614,7 +616,7 @@ extension ClientError {
     
     public class ClientHasBeenDeallocated: ClientError {
         override public var localizedDescription: String {
-            "ChatClient has beed deallocated, make sure to keep at least one strong reference to it."
+            "ChatClient has been deallocated, make sure to keep at least one strong reference to it."
         }
     }
 }

--- a/Sources/StreamChat/Controllers/ConnectionController/ConnectionController.swift
+++ b/Sources/StreamChat/Controllers/ConnectionController/ConnectionController.swift
@@ -96,7 +96,9 @@ public extension ChatConnectionController {
     /// Disconnects the chat client the controller represents from the chat servers.
     /// No further updates from the servers are received.
     func disconnect() {
-        chatClientUpdater.disconnect()
+        chatClientUpdater.disconnect(source: .userInitiated) {
+            log.info("The `ChatClient` has been disconnected.", subsystems: .webSocket)
+        }
     }
 }
 

--- a/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
+++ b/Sources/StreamChat/Workers/Background/ConnectionRecoveryHandler.swift
@@ -171,7 +171,9 @@ private extension DefaultConnectionRecoveryHandler {
     func disconnectIfNeeded() {
         guard canBeDisconnected else { return }
         
-        webSocketClient.disconnect(source: .systemInitiated)
+        webSocketClient.disconnect(source: .systemInitiated) {
+            log.debug("Did disconnect automatically", subsystems: .webSocket)
+        }
     }
     
     var canBeDisconnected: Bool {

--- a/Sources/StreamChat/Workers/ChatClientUpdater.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater.swift
@@ -48,22 +48,29 @@ class ChatClientUpdater {
             client.currentToken = newToken
 
             // Disconnect from web-socket.
-            disconnect(source: .userInitiated)
-            
-            // Update web-socket endpoint.
-            client.webSocketClient?.connectEndpoint = .webSocketConnect(
-                userInfo: userInfo ?? .init(id: newToken.userId)
-            )
+            disconnect(source: .userInitiated) { [weak client] in
+                guard let client = client else {
+                    completion(ClientError.ClientHasBeenDeallocated())
+                    return
+                }
+                
+                // Update web-socket endpoint.
+                client.webSocketClient?.connectEndpoint = .webSocketConnect(
+                    userInfo: userInfo ?? .init(id: newToken.userId)
+                )
 
-            // Re-create backgroundWorker's since they are related to the previous user.
-            client.createBackgroundWorkers()
+                // Re-create backgroundWorker's since they are related to the previous user.
+                client.createBackgroundWorkers()
+                
+                // Stop tracking active components
+                client.activeChannelControllers.removeAllObjects()
+                client.activeChannelListControllers.removeAllObjects()
+                
+                // Reset all existing local data.
+                client.databaseContainer.removeAllData(force: true, completion: completion)
+            }
             
-            // Stop tracking active components
-            client.activeChannelControllers.removeAllObjects()
-            client.activeChannelListControllers.removeAllObjects()
-            
-            // Reset all existing local data.
-            return client.databaseContainer.removeAllData(force: true, completion: completion)
+            return
         }
 
         // Set the web-socket endpoint
@@ -179,13 +186,17 @@ class ChatClientUpdater {
 
     /// Disconnects the chat client the controller represents from the chat servers. No further updates from the servers
     /// are received.
-    func disconnect(source: WebSocketConnectionState.DisconnectionSource = .userInitiated) {
+    func disconnect(
+        source: WebSocketConnectionState.DisconnectionSource = .userInitiated,
+        completion: @escaping () -> Void
+    ) {
         client.apiClient.flushRequestsQueue()
         client.syncRepository.cancelRecoveryFlow()
         
         // Disconnecting is not possible in connectionless mode (duh)
         guard client.config.isClientInActiveMode else {
             log.error(ClientError.ClientIsNotInActiveMode().localizedDescription)
+            completion()
             return
         }
 
@@ -193,17 +204,20 @@ class ChatClientUpdater {
             if source == .userInitiated {
                 log.warning("The client is already disconnected. Skipping the `disconnect` call.")
             }
+            completion()
             return
         }
 
         // Disconnect the web socket
-        client.webSocketClient?.disconnect(source: source)
+        client.webSocketClient?.disconnect(source: source) { [weak client] in
+            // Reset `connectionId`. This would happen asynchronously by the callback from WebSocketClient anyway, but it's
+            // safer to do it here synchronously to immediately stop all API calls.
+            client?.connectionId = nil
 
-        // Reset `connectionId`. This would happen asynchronously by the callback from WebSocketClient anyway, but it's
-        // safer to do it here synchronously to immediately stop all API calls.
-        client.connectionId = nil
-
-        // Remove all waiters for connectionId
-        client.completeConnectionIdWaiters(connectionId: nil)
+            // Remove all waiters for connectionId
+            client?.completeConnectionIdWaiters(connectionId: nil)
+            
+            completion()
+        }
     }
 }

--- a/StreamChatUITestsApp/StreamChat/StreamChatWrapper.swift
+++ b/StreamChatUITestsApp/StreamChat/StreamChatWrapper.swift
@@ -85,7 +85,7 @@ extension StreamChatWrapper {
             monitor.update(with: .unavailable)
 
             // Disconnect from websockets
-            client?.webSocketClient?.disconnect(source: .systemInitiated)
+            client?.webSocketClient?.disconnect(source: .systemInitiated) {}
 
         } else {
             HTTPStubs.removeAllStubs()

--- a/Tests/StreamChatTestTools/Mocks/StreamChat/ChatClientUpdater_Mock.swift
+++ b/Tests/StreamChatTestTools/Mocks/StreamChat/ChatClientUpdater_Mock.swift
@@ -23,8 +23,9 @@ final class ChatClientUpdater_Mock: ChatClientUpdater {
     @Atomic var connect_called = false
     @Atomic var connect_completion: ((Error?) -> Void)?
 
-    @Atomic var disconnect_called = false
+    var disconnect_called: Bool { disconnect_source != nil }
     @Atomic var disconnect_source: WebSocketConnectionState.DisconnectionSource?
+    @Atomic var disconnect_completion: (() -> Void)?
 
     // MARK: - Overrides
 
@@ -60,10 +61,13 @@ final class ChatClientUpdater_Mock: ChatClientUpdater {
         connect_called = true
         connect_completion = completion
     }
-
-    override func disconnect(source: WebSocketConnectionState.DisconnectionSource = .userInitiated) {
-        disconnect_called = true
+    
+    override func disconnect(
+        source: WebSocketConnectionState.DisconnectionSource = .userInitiated,
+        completion: @escaping () -> Void
+    ) {
         disconnect_source = source
+        disconnect_completion = completion
     }
 
     // MARK: - Clean Up
@@ -79,6 +83,7 @@ final class ChatClientUpdater_Mock: ChatClientUpdater {
         connect_called = false
         connect_completion = nil
 
-        disconnect_called = false
+        disconnect_source = nil
+        disconnect_completion = nil
     }
 }

--- a/Tests/StreamChatTestTools/Mocks/StreamChat/Utils/EventBatcher_Mock.swift
+++ b/Tests/StreamChatTestTools/Mocks/StreamChat/Utils/EventBatcher_Mock.swift
@@ -8,12 +8,12 @@ import Foundation
 final class EventBatcher_Mock: EventBatcher {
     var currentBatch: [Event] = []
     
-    let handler: ([Event]) -> Void
+    let handler: (_ batch: [Event], _ completion: @escaping () -> Void) -> Void
     
     init(
         period: TimeInterval = 0,
         timerType: StreamChat.Timer.Type = DefaultTimer.self,
-        handler: @escaping ([Event]) -> Void
+        handler: @escaping (_ batch: [Event], _ completion: @escaping () -> Void) -> Void
     ) {
         self.handler = handler
     }
@@ -23,12 +23,12 @@ final class EventBatcher_Mock: EventBatcher {
     func append(_ event: Event) {
         mock_append.call(with: (event))
         
-        handler([event])
+        handler([event]) {}
     }
     
     lazy var mock_processImmediately = MockFunc.mock(for: processImmediately)
     
-    func processImmediately() {
-        mock_processImmediately.call(with: ())
+    func processImmediately(completion: @escaping () -> Void) {
+        mock_processImmediately.call(with: (completion))
     }
 }

--- a/Tests/StreamChatTestTools/Mocks/StreamChat/WebSocketClient/WebSocketClient_Mock.swift
+++ b/Tests/StreamChatTestTools/Mocks/StreamChat/WebSocketClient/WebSocketClient_Mock.swift
@@ -19,6 +19,7 @@ final class WebSocketClient_Mock: WebSocketClient {
     @Atomic var disconnect_calledCounter = 0
     var disconnect_source: WebSocketConnectionState.DisconnectionSource?
     var disconnect_called: Bool { disconnect_calledCounter > 0 }
+    var disconnect_completion: (() -> Void)?
 
     override init(
         sessionConfiguration: URLSessionConfiguration,
@@ -46,9 +47,13 @@ final class WebSocketClient_Mock: WebSocketClient {
         _connect_calledCounter { $0 += 1 }
     }
 
-    override func disconnect(source: WebSocketConnectionState.DisconnectionSource = .userInitiated) {
+    override func disconnect(
+        source: WebSocketConnectionState.DisconnectionSource = .userInitiated,
+        completion: @escaping () -> Void
+    ) {
         _disconnect_calledCounter { $0 += 1 }
         disconnect_source = source
+        disconnect_completion = completion
     }
     
     var mockEventsBatcher: EventBatcher_Mock {

--- a/Tests/StreamChatTests/Controllers/ConnectionController/ConnectionController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ConnectionController/ConnectionController_Tests.swift
@@ -126,6 +126,7 @@ final class ChatConnectionController_Tests: XCTestCase {
         controller.disconnect()
 
         // Assert the `chatClientUpdater` is called.
+        XCTAssertEqual(env.chatClientUpdater.disconnect_source, .userInitiated)
         XCTAssertTrue(env.chatClientUpdater.disconnect_called)
     }
 }

--- a/Tests/StreamChatTests/Controllers/SearchControllers/UserSearchController/UserSearchController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/SearchControllers/UserSearchController/UserSearchController_Tests.swift
@@ -684,9 +684,3 @@ extension UserListQuery: Equatable {
             && lhs.shouldBeUpdatedInBackground == rhs.shouldBeUpdatedInBackground
     }
 }
-
-extension Sorting: Equatable where Key: Equatable {
-    public static func == (lhs: Sorting, rhs: Sorting) -> Bool {
-        lhs.key == rhs.key && lhs.direction == rhs.direction
-    }
-}

--- a/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
@@ -568,6 +568,8 @@ final class ChatClient_Tests: XCTestCase {
         XCTAssertTrue(testEnv.apiClient! === client.apiClient)
         // Assert `disconnect` on updater is triggered
         XCTAssertTrue(testEnv.clientUpdater!.disconnect_called)
+        // Assert source is user initiated
+        XCTAssertEqual(testEnv.clientUpdater!.disconnect_source, .userInitiated)
     }
     
     // MARK: - Background workers tests

--- a/Tests/StreamChatTests/Utils/EventBatcher_Tests.swift
+++ b/Tests/StreamChatTests/Utils/EventBatcher_Tests.swift
@@ -24,7 +24,7 @@ final class Batch_Tests: XCTestCase {
     func test_append() {
         // Create batcher for test events and keep track of handler calls
         var handlerCalls = [[TestEvent]]()
-        let batcher = Batcher<TestEvent>(period: 10, timerType: VirtualTimeTimer.self) { events in
+        let batcher = Batcher<TestEvent>(period: 10, timerType: VirtualTimeTimer.self) { events, _ in
             handlerCalls.append(events)
         }
 
@@ -72,8 +72,10 @@ final class Batch_Tests: XCTestCase {
     func test_processImmidiately() {
         // Create batcher with long period and keep track of handler calls
         var handlerCalls = [[TestEvent]]()
-        let batcher = Batcher<TestEvent>(period: 20, timerType: VirtualTimeTimer.self) { events in
+        var handlerCompletion: (() -> Void)?
+        let batcher = Batcher<TestEvent>(period: 20, timerType: VirtualTimeTimer.self) { events, completion in
             handlerCalls.append(events)
+            handlerCompletion = completion
         }
         
         // Prepare the event
@@ -83,15 +85,22 @@ final class Batch_Tests: XCTestCase {
         batcher.append(event)
         
         // Ask to process immidiately
-        batcher.processImmediately()
+        let expectation = expectation(description: "`processImmediately` completion")
+        batcher.processImmediately {
+            expectation.fulfill()
+        }
         
         // Wait for a small bit of time much less then a period
         time.run(numberOfSeconds: 0.1)
         
         // Assert handler is called sooner
         XCTAssertEqual(handlerCalls, [[event]])
+
+        // Complete batch processing
+        handlerCompletion?()
         
         // Assert current batch is empty
         XCTAssertEqual(batcher.currentBatch, [])
+        wait(for: [expectation], timeout: 0)
     }
 }

--- a/Tests/StreamChatTests/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/WebSocketClient_Tests.swift
@@ -99,7 +99,7 @@ final class WebSocketClient_Tests: XCTestCase {
         // Save currently existed engine.
         let oldEngine = webSocketClient.engine
         // Disconnect the client.
-        webSocketClient.disconnect()
+        webSocketClient.disconnect {}
 
         // Simulate connect to trigger engine creation or reuse.
         webSocketClient.connect()
@@ -117,7 +117,7 @@ final class WebSocketClient_Tests: XCTestCase {
         // Save currently existed engine.
         let oldEngine = webSocketClient.engine
         // Disconnect the client.
-        webSocketClient.disconnect()
+        webSocketClient.disconnect {}
 
         // Update request encode to provide different request.
         requestEncoder.encodeRequest = .success(.init(url: .unique()))
@@ -182,7 +182,7 @@ final class WebSocketClient_Tests: XCTestCase {
                 
         // Call `disconnect`, it should change connection state and call `disconnect` on the engine
         let source: WebSocketConnectionState.DisconnectionSource = .userInitiated
-        webSocketClient.disconnect(source: source)
+        webSocketClient.disconnect(source: source) {}
         
         // Assert disconnect is called
         AssertAsync.willBeEqual(engine!.disconnect_calledCount, 1)
@@ -227,7 +227,7 @@ final class WebSocketClient_Tests: XCTestCase {
             engine?.disconnect_calledCount = 0
             
             // Call `disconnect` with the given source
-            webSocketClient.disconnect(source: source)
+            webSocketClient.disconnect(source: source) {}
             
             // Assert connection state is changed to disconnecting respecting the source
             XCTAssertEqual(webSocketClient.connectionState, .disconnecting(source: source))
@@ -330,7 +330,7 @@ final class WebSocketClient_Tests: XCTestCase {
         
         // Disconnect
         assert(engine!.disconnect_calledCount == 0)
-        webSocketClient.disconnect()
+        webSocketClient.disconnect {}
         AssertAsync.willBeEqual(engine!.disconnect_calledCount, 1)
         
         // Reconnect again
@@ -487,9 +487,10 @@ final class WebSocketClient_Tests: XCTestCase {
         )
         
         // Assert incoming event get processed and posted
-        let (events, postNotifications, _) = try XCTUnwrap(eventNotificationCenter.mock_process.calls.first)
+        let (events, postNotifications, completion) = try XCTUnwrap(eventNotificationCenter.mock_process.calls.first)
         XCTAssertEqual(events.map(\.asEquatable), [incomingEvent.asEquatable])
         XCTAssertTrue(postNotifications)
+        XCTAssertNotNil(completion)
     }
     
     func test_whenDisconnectHappens_immidiateBatchedEventsProcessingIsTriggered() {
@@ -500,9 +501,18 @@ final class WebSocketClient_Tests: XCTestCase {
         XCTAssertFalse(eventsBatcher.mock_processImmediately.called)
         
         // Simulate disconnection
-        webSocketClient.disconnect()
+        let expectation = expectation(description: "disconnect completion")
+        webSocketClient.disconnect {
+            expectation.fulfill()
+        }
         
         // Assert `processImmediately` is triggered
         AssertAsync.willBeTrue(eventsBatcher.mock_processImmediately.called)
+        
+        // Simulate batch processing completion
+        eventsBatcher.mock_processImmediately.calls.last?()
+        
+        // Assert completion called
+        wait(for: [expectation], timeout: 0)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

CIS-1873

### 🎯 Goal

Fix crash happening when the chat client is connected with another user. The issue was connected to the last batch of events from the previous user posted **after** the new user is connected. The crash's root cause were models held by events that no longer exist after database removal.

### 🛠 Implementation

Add `completion` to disconnection methods called after processing the last batch of events.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/xT9KVmZwJl7fnigeAg/giphy.gif)