### PR TITLE
[CIS-1185] Token provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 ## StreamChat
+### 💥 Removed
+- The `tokenProvider` property was removed from `ChatClient` [#2031](https://github.com/GetStream/stream-chat-swift/issues/2031)
+### ✅ Added
+- Make it possible to call `ChatClient.connect` with a `tokenProvider` [#2031](https://github.com/GetStream/stream-chat-swift/issues/2031)
 ### 🐞 Fixed
 - Saving payloads to local database is now 50% faster. Initial launch and displaying channel list should be noticeably faster [#1973](https://github.com/GetStream/stream-chat-swift/issues/1973)
 - Fix not waiting for last batch of events to be processed when connecting as another user [#2016](https://github.com/GetStream/stream-chat-swift/issues/2016)

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -227,10 +227,7 @@ public class ChatClient {
     
     /// The token of the current user. If the current user is anonymous, the token is `nil`.
     @Atomic var currentToken: Token?
-
-    /// In case of token expiration this property is used to obtain a new token
-    public var tokenProvider: TokenProvider?
-
+    
     /// Sets the user token to the client, this method is only needed to perform API calls
     /// without connecting as a user.
     /// You should only use this in special cases like a notification service or other background process
@@ -244,8 +241,7 @@ public class ChatClient {
     ///   - config: The config object for the `Client`. See `ChatClientConfig` for all configuration options.
     ///   - tokenProvider: In case of token expiration this closure is used to obtain a new token
     public convenience init(
-        config: ChatClientConfig,
-        tokenProvider: TokenProvider? = nil
+        config: ChatClientConfig
     ) {
         var environment = Environment()
         
@@ -255,7 +251,6 @@ public class ChatClient {
         
         self.init(
             config: config,
-            tokenProvider: tokenProvider,
             environment: environment
         )
     }
@@ -268,11 +263,9 @@ public class ChatClient {
     ///
     init(
         config: ChatClientConfig,
-        tokenProvider: TokenProvider? = nil,
         environment: Environment
     ) {
         self.config = config
-        self.tokenProvider = tokenProvider
         self.environment = environment
 
         setupConnectionRecoveryHandler(with: environment)
@@ -300,19 +293,44 @@ public class ChatClient {
         )
     }
     
-    /// Connects authorized user
+    /// Connects the client with the given user.
+    ///
+    /// - Parameters:
+    ///   - userInfo: The user info passed to `connect` endpoint.
+    ///   - tokenProvider: The closure used to retreive a token. Token provider will be used to establish the initial connection and also to obtain the new token when the previous one expires.
+    ///   - completion: The completion that will be called once the **first** user session for the given token is setup.
+    ///
+    /// - Note: Connect endpoint uses an upsert mechanism. If the user does not exist, it will be created with the given `userInfo`. If user already exists, it will get updated with non-nil fields from the `userInfo`.
+    public func connectUser(
+        userInfo: UserInfo,
+        tokenProvider: @escaping TokenProvider,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        setConnectionInfoAndConnect(
+            userInfo: userInfo,
+            userConnectionProvider: .init(tokenProvider: tokenProvider),
+            completion: completion
+        )
+    }
+    
+    /// Connects the client with the given user.
+    ///
     /// - Parameters:
     ///   - userInfo: User info that is passed to the `connect` endpoint for user creation
     ///   - token: Authorization token for the user.
     ///   - completion: The completion that will be called once the **first** user session for the given token is setup.
+    ///
+    /// - Note: Connect endpoint uses an upsert mechanism. If the user does not exist, it will be created with the given `userInfo`. If user already exists, it will get updated with non-nil fields from the `userInfo`.
+    ///
+    /// - Important: This method can only be used when `token` does not expire. If the token expores, the `connect` API with token provider has to be used.
     public func connectUser(
         userInfo: UserInfo,
         token: Token,
         completion: ((Error?) -> Void)? = nil
     ) {
-        setConnectionInfoAndConnect(
+        connectUser(
             userInfo: userInfo,
-            userConnectionProvider: .static(token),
+            tokenProvider: { $0(.success(token)) },
             completion: completion
         )
     }
@@ -329,6 +347,7 @@ public class ChatClient {
         setConnectionInfoAndConnect(
             userInfo: userInfo,
             userConnectionProvider: .guest(
+                client: self,
                 userId: userInfo.id,
                 name: userInfo.name,
                 imageURL: userInfo.imageURL,
@@ -663,7 +682,7 @@ extension ChatClient: ConnectionStateDelegate {
     private func refreshToken(
         completion: ((Error?) -> Void)?
     ) {
-        guard let tokenProvider = tokenProvider else {
+        guard let tokenProvider = userConnectionProvider?.tokenProvider else {
             return log.assertionFailure(
                 "In case if token expiration is enabled on backend you need to provide a way to reobtain it via `tokenProvider` on ChatClient"
             )
@@ -678,7 +697,7 @@ extension ChatClient: ConnectionStateDelegate {
                 queue: .main
             ) { [clientUpdater] in
                 clientUpdater.reloadUserIfNeeded(
-                    userConnectionProvider: .closure { _, completion in
+                    userConnectionProvider: .init { completion in
                         tokenProvider { result in
                             if case .success = result {
                                 self.tokenExpirationRetryStrategy.resetConsecutiveFailures()

--- a/Sources/StreamChat/Workers/ChatClientUpdater.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater.swift
@@ -108,7 +108,7 @@ class ChatClientUpdater {
             return
         }
         
-        userConnectionProvider.getToken(client) {
+        userConnectionProvider.tokenProvider {
             switch $0 {
             case let .success(newToken):
                 self.prepareEnvironment(

--- a/TestTools/StreamChatTestTools/Extensions/UserConnectionProvider+Invalid.swift
+++ b/TestTools/StreamChatTestTools/Extensions/UserConnectionProvider+Invalid.swift
@@ -7,8 +7,6 @@ import Foundation
 
 extension UserConnectionProvider {
     static func invalid(_ error: Error = TestError()) -> Self {
-        .closure {
-            $1(.failure(error))
-        }
+        .init { $0(.failure(error)) }
     }
 }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
@@ -8,7 +8,6 @@ import XCTest
 
 final class ChatClient_Mock: ChatClient {
     @Atomic var init_config: ChatClientConfig
-    @Atomic var init_tokenProvider: TokenProvider?
     @Atomic var init_environment: Environment
     @Atomic var init_completion: ((Error?) -> Void)?
 
@@ -32,17 +31,14 @@ final class ChatClient_Mock: ChatClient {
 
     init(
         config: ChatClientConfig,
-        tokenProvider: TokenProvider? = nil,
         workerBuilders: [WorkerBuilder] = [],
         environment: Environment = .mock
     ) {
         init_config = config
-        init_tokenProvider = tokenProvider
         init_environment = environment
 
         super.init(
             config: config,
-            tokenProvider: tokenProvider,
             environment: environment
         )
         if !workerBuilders.isEmpty {
@@ -101,7 +97,6 @@ final class ChatClient_Mock: ChatClient {
         completeTokenWaiters_token = nil
 
         _backgroundWorkers?.removeAll()
-        init_tokenProvider = nil
         init_completion = nil
     }
 }

--- a/Tests/StreamChatTests/Config/TokenProvider_Tests.swift
+++ b/Tests/StreamChatTests/Config/TokenProvider_Tests.swift
@@ -9,7 +9,7 @@ import XCTest
 final class TokenProvider_Tests: XCTestCase {
     func test_anonymousProvider_propagatesToken() throws {
         // Get token from `anonymous` provider.
-        let token = try waitFor { UserConnectionProvider.anonymous.getToken(.mock, $0) }.get()
+        let token = try waitFor { UserConnectionProvider.anonymous.tokenProvider($0) }.get()
 
         // Assert token is correct.
         XCTAssertEqual(token.rawValue, "")
@@ -22,7 +22,7 @@ final class TokenProvider_Tests: XCTestCase {
 
         // Get a token from `development` token provider.
         let token = try waitFor {
-            UserConnectionProvider.development(userId: userId).getToken(.mock, $0)
+            UserConnectionProvider.development(userId: userId).tokenProvider($0)
         }.get()
 
         // Assert token is correct.
@@ -38,43 +38,13 @@ final class TokenProvider_Tests: XCTestCase {
 
         // Get a token from `static` token provider.
         let receivedToken = try waitFor {
-            UserConnectionProvider.static(token).getToken(.mock, $0)
+            UserConnectionProvider.static(token).tokenProvider($0)
         }.get()
 
         // Assert token is propagated.
         XCTAssertEqual(receivedToken, token)
     }
-
-    func test_closureProvider_propagatesToken() throws {
-        // Create a token.
-        let token = Token.unique()
-
-        // Get a token from `closure` token provider.
-        let receivedToken = try waitFor {
-            UserConnectionProvider
-                .closure { $1(.success(token)) }
-                .getToken(.mock, $0)
-        }.get()
-
-        // Assert token is propagated.
-        XCTAssertEqual(receivedToken, token)
-    }
-
-    func test_closureProvider_propagatesError() throws {
-        // Create an error.
-        let error = TestError()
-
-        // Get a token from `closure` token provider.
-        let receivedError = try waitFor {
-            UserConnectionProvider
-                .closure { $1(.failure(error)) }
-                .getToken(.mock, $0)
-        }.error
-
-        // Assert error is propagated.
-        XCTAssertEqual(receivedError as! TestError, error)
-    }
-
+    
     func test_guestProvider_callsAPIClient_and_propagatesToken() throws {
         // Create guest user data.
         let userId: UserId = .unique
@@ -86,7 +56,8 @@ final class TokenProvider_Tests: XCTestCase {
         let client = ChatClient.mock
 
         // Create a `guest` token provider.
-        let tokenProvider = UserConnectionProvider.guest(
+        let provider = UserConnectionProvider.guest(
+            client: client,
             userId: userId,
             name: userName,
             imageURL: imageURL,
@@ -95,7 +66,7 @@ final class TokenProvider_Tests: XCTestCase {
 
         // Get token from provider and capture the result.
         var getTokenResult: Result<Token, Error>?
-        tokenProvider.getToken(client) {
+        provider.tokenProvider {
             getTokenResult = $0
         }
 
@@ -134,7 +105,8 @@ final class TokenProvider_Tests: XCTestCase {
         let client = ChatClient.mock
 
         // Create a `guest` token provider.
-        let tokenProvider = UserConnectionProvider.guest(
+        let provider = UserConnectionProvider.guest(
+            client: client,
             userId: userId,
             name: userName,
             imageURL: imageURL,
@@ -143,7 +115,7 @@ final class TokenProvider_Tests: XCTestCase {
 
         // Get token from provider and capture the result.
         var getTokenResult: Result<Token, Error>?
-        tokenProvider.getToken(client) {
+        provider.tokenProvider {
             getTokenResult = $0
         }
 

--- a/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
@@ -394,8 +394,8 @@ final class ChatClient_Tests: XCTestCase {
             environment: testEnv.environment
         )
         
-        client.connectAnonymousUser()
-        client.tokenProvider = { $0(.success(.unique())) }
+        let userId: UserId = .unique
+        client.connectUser(userInfo: .init(id: userId), tokenProvider: { $0(.success(.unique(userId: userId))) })
 
         // Simulate access to `webSocketClient` so it is initialized
         _ = client.webSocketClient
@@ -655,115 +655,147 @@ final class ChatClient_Tests: XCTestCase {
         }
     }
     
-    func test_reloadUserIfNeededIsCalled_whenClientIsInitialized_andErrorIsPropagated() {
+    // MARK: - Connect
+    
+    func test_reloadUserIfNeededIsCalled_whenClientIsInitialized_andErrorIsPropagated() throws {
         for error in [nil, TestError()] {
-            var clientInitCompletionCalled = false
-            var clientInitCompletionError: Error?
-
-            // Create a client, provide the completion and catch the result.
+            // GIVEN
             let client = ChatClient(
                 config: inMemoryStorageConfig,
                 environment: testEnv.environment
             )
-            client.connectAnonymousUser { error in
-                clientInitCompletionCalled = true
-                clientInitCompletionError = error
-            }
+            
+            // WHEN
+            let token = Token.unique()
+            var connectCompletionCalled = false
+            var connectCompletionError: Error?
+            client.connectUser(
+                userInfo: .init(id: .unique),
+                tokenProvider: { $0(.success(token)) },
+                completion: {
+                    connectCompletionCalled = true
+                    connectCompletionError = $0
+                }
+            )
+            
+            // THEN
+            var providedToken: Token?
+            client.userConnectionProvider?.tokenProvider { providedToken = try? $0.get() }
+            XCTAssertEqual(providedToken, token)
+            
+            XCTAssertEqual(testEnv.clientUpdater!.reloadUserIfNeeded_callsCount, 1)
 
-            // Assert `reloadUserIfNeeded` is called on `clientUpdater`.
-            XCTAssertTrue(testEnv.clientUpdater!.reloadUserIfNeeded_called)
-
-            // Simulate `reloadUserIfNeeded` completion result.
+            // WHEN
             testEnv.clientUpdater?.reloadUserIfNeeded_completion!(error)
-            // Wait for `ChatClient.init` completion called.
-            AssertAsync.willBeTrue(clientInitCompletionCalled)
-
-            // Assert error from `reloadUserIfNeeded` is propagated.
-            XCTAssertEqual(clientInitCompletionError as? TestError, error)
+            
+            // THEN
+            XCTAssertEqual(connectCompletionError as? TestError, error)
+            XCTAssertTrue(connectCompletionCalled)
         }
     }
     
-    func test_reloadUserIfNeededIsNotCalled_whenClientIsInitialized_andTokenProviderIsNil() {
-        _ = ChatClient(
-            config: inMemoryStorageConfig,
-            environment: testEnv.environment
-        )
-        
-        XCTAssert(testEnv.clientUpdater?.reloadUserIfNeeded_called != true)
-    }
-    
-    func test_connectUser_setsTokenProvider_andInitiatesConnection() {
-        let client = ChatClient(
-            config: inMemoryStorageConfig,
-            environment: testEnv.environment
-        )
-        let token = Token.unique()
-        XCTAssert(testEnv.clientUpdater?.reloadUserIfNeeded_called != true)
-
-        client.connectUser(
-            userInfo: .init(id: .unique, name: "John Doe", imageURL: .unique(), extraData: [:]),
-            token: token
-        )
-        XCTAssertTrue(testEnv.clientUpdater!.reloadUserIfNeeded_called)
-        
-        var providedToken: Token?
-        client.userConnectionProvider?.getToken(client) { providedToken = try! $0.get() }
-        AssertAsync.willBeEqual(token, providedToken)
+    func test_connectUserWithToken_setsTokenProvider_andInitiatesConnection() {
+        for error in [nil, TestError()] {
+            // GIVEN
+            let client = ChatClient(
+                config: inMemoryStorageConfig,
+                environment: testEnv.environment
+            )
+            
+            // WHEN
+            let token = Token.unique()
+            var connectCompletionCalled = false
+            var connectCompletionError: Error?
+            client.connectUser(
+                userInfo: .init(id: .unique),
+                token: token,
+                completion: {
+                    connectCompletionCalled = true
+                    connectCompletionError = $0
+                }
+            )
+            
+            // THEN
+            var providedToken: Token?
+            client.userConnectionProvider?.tokenProvider { providedToken = try? $0.get() }
+            XCTAssertEqual(providedToken, token)
+            
+            XCTAssertEqual(testEnv.clientUpdater!.reloadUserIfNeeded_callsCount, 1)
+            
+            // WHEN
+            testEnv.clientUpdater?.reloadUserIfNeeded_completion!(error)
+            
+            // THEN
+            XCTAssertEqual(connectCompletionError as? TestError, error)
+            XCTAssertTrue(connectCompletionCalled)
+        }
     }
     
     func test_connectGuestUser_setsTokenProvider_andInitiatesConnection() {
-        let client = ChatClient(
-            config: inMemoryStorageConfig,
-            environment: testEnv.environment
-        )
-        let token = Token.unique()
-        XCTAssert(testEnv.clientUpdater?.reloadUserIfNeeded_called != true)
-
-        let userId = UserId.unique
-        let name = "John Doe"
-        client.connectGuestUser(
-            userInfo: .init(
-                id: userId,
-                name: "John Doe",
+        for error in [nil, TestError()] {
+            // GIVEN
+            let client = ChatClient(
+                config: inMemoryStorageConfig,
+                environment: testEnv.environment
+            )
+            
+            // WHEN
+            let user = UserInfo(
+                id: .unique,
+                name: .unique,
                 imageURL: .localYodaImage,
                 extraData: [:]
             )
-        )
-        
-        XCTAssertTrue(testEnv.clientUpdater!.reloadUserIfNeeded_called)
-        
-        var providedToken: Token?
-        client.userConnectionProvider?.getToken(client) { providedToken = try! $0.get() }
-        
-        let expectedEndpoint: Endpoint<GuestUserTokenPayload> = .guestUserToken(
-            userId: userId,
-            name: name,
-            imageURL: .localYodaImage,
-            extraData: [:]
-        )
-        AssertAsync.willBeEqual(AnyEndpoint(expectedEndpoint), client.mockAPIClient.request_endpoint)
-        
-        let tokenResult: Result<GuestUserTokenPayload, Error> = .success(
-            .init(user: .dummy(userId: userId, role: .guest), token: token)
-        )
-        client.mockAPIClient.test_simulateResponse(tokenResult)
-
-        AssertAsync.willBeEqual(token, providedToken)
+            var connectCompletionCalled = false
+            var connectCompletionError: Error?
+            client.connectGuestUser(userInfo: user) {
+                connectCompletionCalled = true
+                connectCompletionError = $0
+            }
+            
+            // THEN
+            XCTAssertNotNil(client.userConnectionProvider)
+            XCTAssertEqual(testEnv.clientUpdater!.reloadUserIfNeeded_callsCount, 1)
+            
+            // WHEN
+            testEnv.clientUpdater?.reloadUserIfNeeded_completion!(error)
+            XCTAssertEqual(connectCompletionError as? TestError, error)
+            
+            // THEN
+            XCTAssertTrue(connectCompletionCalled)
+        }
     }
     
     func test_connectAnonymoususer_setsTokenProvider_andInitiatesConnection() {
-        let client = ChatClient(
-            config: inMemoryStorageConfig,
-            environment: testEnv.environment
-        )
-        XCTAssert(testEnv.clientUpdater?.reloadUserIfNeeded_called != true)
+        for error in [nil, TestError()] {
+            // GIVEN
+            let client = ChatClient(
+                config: inMemoryStorageConfig,
+                environment: testEnv.environment
+            )
+            
+            // WHEN
+            var connectCompletionCalled = false
+            var connectCompletionError: Error?
+            client.connectAnonymousUser {
+                connectCompletionCalled = true
+                connectCompletionError = $0
+            }
+            
+            // THEN
+            var providedToken: Token?
+            client.userConnectionProvider?.tokenProvider { providedToken = try? $0.get() }
+            XCTAssertEqual(providedToken?.userId.isAnonymousUser, true)
+            
+            XCTAssertEqual(testEnv.clientUpdater!.reloadUserIfNeeded_callsCount, 1)
 
-        client.connectAnonymousUser()
-        XCTAssertTrue(testEnv.clientUpdater!.reloadUserIfNeeded_called)
-        
-        var providedToken: Token?
-        client.userConnectionProvider?.getToken(client) { providedToken = try! $0.get() }
-        AssertAsync.willBeTrue(providedToken != nil)
+            // WHEN
+            testEnv.clientUpdater?.reloadUserIfNeeded_completion!(error)
+            
+            // THEN
+            XCTAssertEqual(connectCompletionError as? TestError, error)
+            XCTAssertTrue(connectCompletionCalled)
+        }
     }
 
     // MARK: - Passive (not active) Client tests

--- a/Tests/StreamChatTests/Workers/ChatClientUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChatClientUpdater_Tests.swift
@@ -539,8 +539,8 @@ final class ChatClientUpdater_Tests: XCTestCase {
         
         // Simulate `reloadUserIfNeeded` call.
         updater?.reloadUserIfNeeded(
-            userConnectionProvider: .closure {
-                tokenProviderCompletion = $1
+            userConnectionProvider: .init {
+                tokenProviderCompletion = $0
             }
         )
 


### PR DESCRIPTION
### 🔗 Issue Links

CIS-1185

### 🎯 Goal

Make it possible to pass a `tokenProvider` when connecting the chat-client.

### 📝 Summary

1. chat client has `connect` method that takes a token provider as an argument (the same as on other platforms)
1. chat client still has `connect` method that requires a token but with the note that a token must not expire
1. chat client no longer have `tokenProvider` exposed

⚠️ The **3rd** change is a **breaking** one but it might be OK to ship it: 
- customers who is using **non-expiring** tokens will not be affected by this change
- customers who is using **expiring** and a `tokenProvider` that was removed would be glad to hear that the whole flow is simplified:

**Before**:
```swift
// 1. Get a user
let user = 

// 2. Create a token provider
let tokenProvider: TokenProvider = { completion in
   authService.fetchToken(for: user, completion: completion)
}

// 3. Call the token provider to receive the 1st token
tokenProvider { tokenResult in
 guard case .success(let token) = tokenResult else { return }

 // 4. Create and connect the chat-client
 let chatClient: ChatClient = ...
 chatClient.tokenProvider = tokenProvider

 OR

 let chatClient = ChatClient(config, tokenProvider: tokenProvider)

 // 5. Connect the chat client with received token
 chatClient.connect(userInfo: user, token: token, completion: { /*handle connection error*/ })
}
```

**After**:
```swift
// 1. Get a user
let user: UserInfo = 

// 2. Create a token provider
let tokenProvider: TokenProvider = { completion in
   authService.fetchToken(for: user, completion: completion)
}

// 3. Create and connect chat-client with a token provider
let chatClient: ChatClient = ...
chatClient.connect(userInfo: user, tokenProvider: tokenProvider, completion: { /*handle connection error*/ })
```

### 🧪 Manual Testing Notes

Sign in to the `DemoApp` as a **normal/guest/anon** user and make sure the connection flow works as before.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme
![](https://media.giphy.com/media/9G1gmHBU29Wyk8zKi5/giphy-downsized.gif)