### PR TITLE
[BW] Workaround for flaky UI tests

### DIFF
--- a/StreamChatUITestsAppUITests/Robots/ParticipantRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/ParticipantRobot.swift
@@ -60,8 +60,13 @@ final class ParticipantRobot: Robot {
     }
     
     @discardableResult
-    func sendMessage(_ text: String) -> Self {
+    func sendMessage(_ text: String,
+                     at messageCellIndex: Int? = nil,
+                     waitForAppearance: Bool = true,
+                     file: StaticString = #filePath,
+                     line: UInt = #line) -> Self {
         waitForChannelQueryUpdate()
+        
         server.websocketMessage(
             text,
             channelId: server.currentChannelId,
@@ -69,6 +74,15 @@ final class ParticipantRobot: Robot {
             eventType: .messageNew,
             user: participant()
         )
+        
+        if waitForAppearance {
+            server.waitForWebsocketMessage(withText: text)
+            
+            let cell = messageCell(withIndex: messageCellIndex, file: file, line: line).wait()
+            let textView = attributes.text(in: cell)
+            _ = textView.waitForText(text)
+        }
+        
         return self
     }
 
@@ -81,7 +95,7 @@ final class ParticipantRobot: Robot {
         }
 
         texts.forEach {
-            sendMessage($0)
+            sendMessage($0, waitForAppearance: false)
             wait(0.5)
         }
         return self

--- a/StreamChatUITestsAppUITests/Robots/Robot+CustomAssertions.swift
+++ b/StreamChatUITestsAppUITests/Robots/Robot+CustomAssertions.swift
@@ -113,20 +113,6 @@ extension Robot {
         XCTAssertEqual(author, actualAuthor, file: file, line: line)
         return self
     }
-
-    /// Waits for a new message from the user or participant
-    ///
-    /// - Returns: Self
-    @discardableResult
-    func waitForNewMessage(withText text: String,
-                           at messageCellIndex: Int? = nil,
-                           file: StaticString = #filePath,
-                           line: UInt = #line) -> Self {
-        let cell = messageCell(withIndex: messageCellIndex, file: file, line: line).wait()
-        let textView = attributes.text(in: cell)
-        _ = textView.waitForText(text)
-        return self
-    }
     
     @discardableResult
     func assertTypingIndicatorShown(

--- a/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
@@ -77,7 +77,8 @@ extension UserRobot {
         if readBy == 0 {
             XCTAssertFalse(readByCount.isHittable, file: file, line: line)
         } else {
-            XCTAssertEqual(readByCount.wait().text, "\(readBy)", file: file, line: line)
+            let actualText = readByCount.waitForText("\(readBy)").text
+            XCTAssertEqual("\(readBy)", actualText, file: file, line: line)
         }
         return self
     }
@@ -139,7 +140,8 @@ extension UserRobot {
         if readBy == 0 {
             XCTAssertFalse(readByCount.isHittable, file: file, line: line)
         } else {
-            XCTAssertEqual(readByCount.wait().text, "\(readBy)", file: file, line: line)
+            let actualText = readByCount.waitForText("\(readBy)").text
+            XCTAssertEqual("\(readBy)", actualText, file: file, line: line)
         }
         return self
     }

--- a/StreamChatUITestsAppUITests/Tests/Base TestCase/StreamTestCase.swift
+++ b/StreamChatUITestsAppUITests/Tests/Base TestCase/StreamTestCase.swift
@@ -10,7 +10,7 @@ let app = XCUIApplication()
 class StreamTestCase: XCTestCase {
 
     let deviceRobot = DeviceRobot()
-    let userRobot = UserRobot()
+    var userRobot: UserRobot!
     var backendRobot: BackendRobot!
     var participantRobot: ParticipantRobot!
     var server: StreamMockServer!
@@ -22,6 +22,7 @@ class StreamTestCase: XCTestCase {
         server.start(port: in_port_t(MockServerConfiguration.port))
         participantRobot = ParticipantRobot(server)
         backendRobot = BackendRobot(server)
+        userRobot = UserRobot(server)
 
         try super.setUpWithError()
 

--- a/StreamChatUITestsAppUITests/Tests/ChannelList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/ChannelList_Tests.swift
@@ -22,9 +22,7 @@ final class ChannelList_Tests: StreamTestCase {
                 .openChannel()
         }
         WHEN("participant sends a new message") {
-            participantRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            participantRobot.sendMessage(message)
         }
         AND("user goes back to channel list") {
             userRobot.tapOnBackButton()
@@ -74,10 +72,7 @@ final class ChannelList_Tests: StreamTestCase {
         AND("user sends a message with invalid command") {
             userRobot
                 .sendMessage(message)
-                .sendMessage("/\(invalidCommand)")
-        }
-        AND("error message is shown") {
-            userRobot.waitForNewMessage(withText: Message.message(withInvalidCommand: invalidCommand))
+                .sendMessage("/\(invalidCommand)", waitForAppearance: false)
         }
         WHEN("user goes back to the channel list") {
             userRobot.tapOnBackButton()

--- a/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus+ChannelList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus+ChannelList_Tests.swift
@@ -28,9 +28,7 @@ final class MessageDeliveryStatus_ChannelList_Tests: StreamTestCase {
             backendRobot.delayServerResponse(byTimeInterval: 10.0)
         }
         AND("user sends new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message, waitForAppearance: false)
         }
         WHEN("user retuns to the channel list before the message is sent") {
             userRobot.tapOnBackButton()
@@ -52,9 +50,6 @@ final class MessageDeliveryStatus_ChannelList_Tests: StreamTestCase {
         }
         AND("user sends new message") {
             userRobot.sendMessage(message)
-        }
-        AND("message is succesfully sent") {
-            userRobot.waitForNewMessage(withText: message)
         }
         WHEN("user retuns to the channel list") {
             userRobot.tapOnBackButton()
@@ -79,7 +74,7 @@ final class MessageDeliveryStatus_ChannelList_Tests: StreamTestCase {
         AND("user's message is not sent") {
             deviceRobot.setConnectivity(to: .off)
             userRobot
-                .sendMessage(failedMessage)
+                .sendMessage(failedMessage, waitForAppearance: false)
                 .assertMessageFailedToBeSent()
         }
         WHEN("user retuns to the channel list") {
@@ -101,9 +96,7 @@ final class MessageDeliveryStatus_ChannelList_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("user succesfully sends new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("user retuns to the channel list") {
             userRobot.tapOnBackButton()
@@ -131,9 +124,6 @@ final class MessageDeliveryStatus_ChannelList_Tests: StreamTestCase {
         AND("user sends a new message") {
             userRobot.sendMessage(message)
         }
-        AND("message is succesfully sent") {
-            userRobot.waitForNewMessage(withText: message)
-        }
         WHEN("user retuns to the channel list") {
             userRobot.tapOnBackButton()
         }
@@ -153,9 +143,7 @@ final class MessageDeliveryStatus_ChannelList_Tests: StreamTestCase {
                 .openChannel()
         }
         WHEN("participant sends a new message") {
-            participantRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            participantRobot.sendMessage(message)
         }
         AND("user retuns to the channel list") {
             userRobot.tapOnBackButton()
@@ -184,9 +172,7 @@ extension MessageDeliveryStatus_ChannelList_Tests {
             participantRobot.sendMessage(message)
         }
         AND("user replies to the message in thread") {
-            userRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessageInThread(threadReply)
+            userRobot.replyToMessageInThread(threadReply)
         }
         WHEN("user retuns to the channel list") {
             userRobot.moveToChannelListFromThreadReplies()
@@ -209,15 +195,13 @@ extension MessageDeliveryStatus_ChannelList_Tests {
                 .openChannel()
         }
         AND("user sends a new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("user becomes offline") {
             deviceRobot.setConnectivity(to: .off)
         }
         AND("user replies to message in thread") {
-            userRobot.replyToMessageInThread(failedThreadReply)
+            userRobot.replyToMessageInThread(failedThreadReply, waitForAppearance: false)
         }
         WHEN("user retuns to the channel list") {
             userRobot.moveToChannelListFromThreadReplies()
@@ -239,9 +223,7 @@ extension MessageDeliveryStatus_ChannelList_Tests {
                 .openChannel()
         }
         AND("participant sends a new message") {
-            participantRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            participantRobot.sendMessage(message)
         }
         AND("user replies to message in thread") {
             userRobot.replyToMessageInThread(threadReply)
@@ -275,9 +257,7 @@ extension MessageDeliveryStatus_ChannelList_Tests {
             participantRobot.sendMessage(message)
         }
         AND("user replies to message in thread") {
-            userRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessageInThread(threadReply)
+            userRobot.replyToMessageInThread(threadReply)
         }
         WHEN("user retuns to the channel list") {
             userRobot.moveToChannelListFromThreadReplies()
@@ -302,9 +282,7 @@ extension MessageDeliveryStatus_ChannelList_Tests {
             participantRobot.sendMessage(message)
         }
         AND("participant replies to message in thread") {
-            participantRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessageInThread(threadReply)
+            participantRobot.replyToMessageInThread(threadReply)
         }
         WHEN("user retuns to the channel list") {
             userRobot.moveToChannelListFromThreadReplies()

--- a/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus_Tests.swift
@@ -31,9 +31,6 @@ final class MessageDeliveryStatus_Tests: StreamTestCase {
         WHEN("user sends a new message") {
             userRobot.sendMessage(message)
         }
-        AND("message is succesfully sent") {
-            userRobot.waitForNewMessage(withText: message)
-        }
         THEN("user spots single checkmark below the message") {
             userRobot
                 .assertMessageDeliveryStatus(.sent)
@@ -51,9 +48,7 @@ final class MessageDeliveryStatus_Tests: StreamTestCase {
         }
         WHEN("user sends a new message") {
             backendRobot.delayServerResponse(byTimeInterval: 5.0)
-            userRobot
-                .sendMessage(pendingMessage)
-                .waitForNewMessage(withText: pendingMessage)
+            userRobot.sendMessage(pendingMessage, waitForAppearance: false)
         }
         THEN("message delivery status shows clocks") {
             userRobot.assertMessageDeliveryStatus(.pending)
@@ -73,9 +68,7 @@ final class MessageDeliveryStatus_Tests: StreamTestCase {
             deviceRobot.setConnectivity(to: .off)
         }
         WHEN("user sends a new message") {
-            userRobot
-                .sendMessage(failedMessage)
-                .waitForNewMessage(withText: failedMessage)
+            userRobot.sendMessage(failedMessage, waitForAppearance: false)
         }
         THEN("error indicator is shown for the message") {
             userRobot
@@ -97,9 +90,7 @@ final class MessageDeliveryStatus_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("user succesfully sends new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         WHEN("participant reads the user's message") {
             participantRobot.readMessage()
@@ -121,9 +112,7 @@ final class MessageDeliveryStatus_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("user succesfully sends new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("message is read by more than 1 participant") {
             participantRobot.readMessage()
@@ -155,9 +144,7 @@ final class MessageDeliveryStatus_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("user succesfully sends new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("is read by participant") {
             participantRobot
@@ -186,9 +173,7 @@ final class MessageDeliveryStatus_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("user succesfully sends new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("delivery status shows single checkmark") {
             userRobot.assertMessageDeliveryStatus(.sent)
@@ -213,9 +198,7 @@ final class MessageDeliveryStatus_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("user succesfully sends new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("delivery status shows single checkmark") {
             userRobot.assertMessageDeliveryStatus(.sent)
@@ -245,9 +228,7 @@ extension MessageDeliveryStatus_Tests {
                 .openChannel()
         }
         AND("user succesfully sends a new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         WHEN("user previews thread for message: \(message)") {
             userRobot.showThread()
@@ -272,15 +253,15 @@ extension MessageDeliveryStatus_Tests {
             deviceRobot.setConnectivity(to: .off)
         }
         AND("user sends a new message") {
-            userRobot.sendMessage(failedMessage)
+            userRobot.sendMessage(failedMessage, waitForAppearance: false)
         }
         THEN("error indicator is shown for the message") {
             userRobot.assertMessageFailedToBeSent()
         }
         AND("delivery status is not shown") {
             userRobot
-            .assertMessageDeliveryStatus(nil)
-            .assertMessageReadCount(readBy: 0)
+                .assertMessageDeliveryStatus(nil)
+                .assertMessageReadCount(readBy: 0)
         }
         AND("user can't preview this message in thread") {
             userRobot.assertContextMenuOptionNotAvailable(option: .threadReply)
@@ -296,9 +277,7 @@ extension MessageDeliveryStatus_Tests {
                 .openChannel()
         }
         AND("user succesfully sends new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("the message is read by participant") {
             participantRobot.readMessage()
@@ -328,9 +307,7 @@ extension MessageDeliveryStatus_Tests {
             participantRobot.sendMessage(message)
         }
         AND("user replies to the message in thread") {
-            userRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessageInThread(threadReply)
+            userRobot.replyToMessageInThread(threadReply)
         }
         THEN("user spots single checkmark below the thread reply") {
             userRobot
@@ -349,9 +326,7 @@ extension MessageDeliveryStatus_Tests {
                 .openChannel()
         }
         AND("user sends a new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         WHEN("user becomes offline") {
             deviceRobot.setConnectivity(to: .off)
@@ -381,10 +356,7 @@ extension MessageDeliveryStatus_Tests {
             participantRobot.sendMessage(message)
         }
         WHEN("user replies to message in thread") {
-            userRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessageInThread(threadReply)
-                .waitForNewMessage(withText: threadReply)
+            userRobot.replyToMessageInThread(threadReply)
         }
         AND("participant reads the user's thread reply") {
             participantRobot.readMessage()
@@ -409,9 +381,7 @@ extension MessageDeliveryStatus_Tests {
             participantRobot.sendMessage(message)
         }
         AND("user replies to message in thread") {
-            userRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessageInThread(threadReply)
+            userRobot.replyToMessageInThread(threadReply)
         }
         WHEN("new participant is added to the channel") {
             userRobot
@@ -440,14 +410,10 @@ extension MessageDeliveryStatus_Tests {
             participantRobot.sendMessage(message)
         }
         AND("user replies to message in thread") {
-            userRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessageInThread(threadReply)
+            userRobot.replyToMessageInThread(threadReply)
         }
         AND("thread reply is read by participant") {
-            participantRobot
-                .waitForNewMessage(withText: threadReply)
-                .readMessage()
+            participantRobot.readMessage()
             userRobot
                 .assertMessageDeliveryStatus(.read)
                 .assertMessageReadCount(readBy: 1)
@@ -475,9 +441,7 @@ extension MessageDeliveryStatus_Tests {
             participantRobot.sendMessage(message)
         }
         AND("user replies to message in thread") {
-            userRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessageInThread(threadReply)
+            userRobot.replyToMessageInThread(threadReply)
         }
         AND("delivery status shows single checkmark") {
             userRobot.assertMessageDeliveryStatus(.sent)
@@ -505,9 +469,7 @@ extension MessageDeliveryStatus_Tests {
             participantRobot.sendMessage(message)
         }
         AND("user replies to message in thread") {
-            userRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessageInThread(threadReply)
+            userRobot.replyToMessageInThread(threadReply)
         }
         AND("delivery status shows single checkmark") {
             userRobot.assertMessageDeliveryStatus(.sent)
@@ -534,7 +496,7 @@ extension MessageDeliveryStatus_Tests {
             userRobot.sendMessage(message)
         }
         WHEN("user sends message with invalid command") {
-            userRobot.sendMessage("/command")
+            userRobot.sendMessage("/command", waitForAppearance: false)
         }
         THEN("delivery status is shown for \(message)") {
             userRobot
@@ -564,9 +526,6 @@ extension MessageDeliveryStatus_Tests {
         WHEN("user sends a new message") {
             userRobot.sendMessage(message)
         }
-        AND("message is succesfully sent") {
-            userRobot.waitForNewMessage(withText: message)
-        }
         THEN("delivery status is hidden") {
             userRobot
                 .assertMessageDeliveryStatus(nil)
@@ -585,9 +544,7 @@ extension MessageDeliveryStatus_Tests {
         }
         WHEN("user sends a new message") {
             backendRobot.delayServerResponse(byTimeInterval: 5.0)
-            userRobot
-                .sendMessage(pendingMessage)
-                .waitForNewMessage(withText: pendingMessage)
+            userRobot.sendMessage(pendingMessage, waitForAppearance: false)
         }
         THEN("message delivery status shows clocks") {
             userRobot
@@ -610,12 +567,10 @@ extension MessageDeliveryStatus_Tests {
             deviceRobot.setConnectivity(to: .off)
         }
         WHEN("user sends a new message") {
-            userRobot.sendMessage(failedMessage)
+            userRobot.sendMessage(failedMessage, waitForAppearance: false)
         }
         THEN("error indicator is shown for the message") {
-            userRobot
-                .waitForNewMessage(withText: failedMessage)
-                .assertMessageFailedToBeSent()
+            userRobot.assertMessageFailedToBeSent()
         }
         AND("delivery status is hidden") {
             userRobot
@@ -634,9 +589,7 @@ extension MessageDeliveryStatus_Tests {
                 .openChannel()
         }
         AND("user succesfully sends new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         WHEN("participant reads the user's message") {
             participantRobot.readMessage()
@@ -658,9 +611,7 @@ extension MessageDeliveryStatus_Tests {
                 .openChannel()
         }
         AND("user succesfully sends new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("message is read by more than 1 participant") {
             participantRobot.readMessage()
@@ -689,9 +640,7 @@ extension MessageDeliveryStatus_Tests {
                 .openChannel()
         }
         AND("user succesfully sends new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("is read by participant") {
             participantRobot
@@ -721,9 +670,7 @@ extension MessageDeliveryStatus_Tests {
                 .openChannel()
         }
         AND("user succesfully sends new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("delivery status is hidden") {
             userRobot.assertMessageDeliveryStatus(nil)
@@ -749,9 +696,7 @@ extension MessageDeliveryStatus_Tests {
                 .openChannel()
         }
         AND("user succesfully sends new message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("delivery status is hidden") {
             userRobot.assertMessageDeliveryStatus(nil)

--- a/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
@@ -111,9 +111,7 @@ final class MessageList_Tests: StreamTestCase {
             userRobot.login().openChannel()
         }
         WHEN("user sends the message: '\(message)'") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("user deletes the message: '\(message)'") {
             userRobot.deleteMessage()
@@ -139,9 +137,7 @@ final class MessageList_Tests: StreamTestCase {
                 .sendMessage(message)
         }
         THEN("the message is delivered") {
-            userRobot
-                .waitForNewMessage(withText: message)
-                .assertMessageAuthor(author)
+            userRobot.assertMessageAuthor(author)
         }
     }
     
@@ -154,9 +150,7 @@ final class MessageList_Tests: StreamTestCase {
             userRobot.login().openChannel()
         }
         WHEN("participant sends the message: '\(message)'") {
-            participantRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            participantRobot.sendMessage(message)
         }
         AND("participant deletes the message: '\(message)'") {
             participantRobot.deleteMessage()
@@ -182,9 +176,7 @@ final class MessageList_Tests: StreamTestCase {
                 .sendMessage(message)
         }
         AND("participant edits the message: '\(editedMessage)'") {
-            participantRobot
-                .waitForNewMessage(withText: message)
-                .editMessage(editedMessage)
+            participantRobot.editMessage(editedMessage)
         }
         THEN("the message is edited") {
             participantRobot.assertMessage(editedMessage)
@@ -202,9 +194,7 @@ final class MessageList_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("user sends \(oneLineMessage) message") {
-            userRobot
-                .sendMessage(oneLineMessage)
-                .waitForNewMessage(withText: oneLineMessage)
+            userRobot.sendMessage(oneLineMessage)
         }
         WHEN("user edits their message so that the length becomes two lines") {
             userRobot.editMessage(twoLinesMessage)
@@ -297,9 +287,7 @@ final class MessageList_Tests: StreamTestCase {
             userRobot.scrollMessageListUp()
         }
         AND("user sends a new message") {
-            userRobot
-                .sendMessage(newMessage)
-                .waitForNewMessage(withText: newMessage)
+            userRobot.sendMessage(newMessage)
         }
         THEN("message list is scrolled down") {
             userRobot.assertMessageIsVisible(newMessage)
@@ -311,7 +299,6 @@ final class MessageList_Tests: StreamTestCase {
 
         let count = 50
         let message = "message"
-        let lastMessage = "\(message)-\(count)"
         let newMessage = "New message"
 
         GIVEN("user opens the channel") {
@@ -320,14 +307,10 @@ final class MessageList_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("channel is scrollable") {
-            participantRobot
-                .sendMultipleMessages(repeatingText: message, count: count)
-                .waitForNewMessage(withText: lastMessage)
+            participantRobot.sendMultipleMessages(repeatingText: message, count: count)
         }
         WHEN("participant sends a message") {
-            participantRobot
-                .sendMessage(newMessage)
-                .waitForNewMessage(withText: newMessage)
+            participantRobot.sendMessage(newMessage)
         }
         THEN("message list is scrolled down") {
             userRobot.assertMessageIsVisible(newMessage)
@@ -379,9 +362,7 @@ extension MessageList_Tests {
             participantRobot.sendMessage(message)
         }
         WHEN("user adds a quoted reply to participant message") {
-            userRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessage(quotedMessage)
+            userRobot.replyToMessage(quotedMessage)
         }
         THEN("user observes the reply in message list") {
             userRobot.assertQuotedMessage(replyText: quotedMessage, quotedText: message)
@@ -403,9 +384,7 @@ extension MessageList_Tests {
             userRobot.sendMessage(message)
         }
         WHEN("participant adds a quoted reply to users message") {
-            participantRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessage(quotedMessage)
+            participantRobot.replyToMessage(quotedMessage)
         }
         THEN("user observes the reply in message list") {
             userRobot.assertQuotedMessage(replyText: quotedMessage, quotedText: message)
@@ -427,9 +406,7 @@ extension MessageList_Tests {
             userRobot.sendMessage(message)
         }
         AND("participant adds a quoted reply to users message") {
-            participantRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessage(quotedMessage)
+            participantRobot.replyToMessage(quotedMessage)
         }
         WHEN("participant deletes a quoted message") {
             participantRobot.deleteMessage()
@@ -454,9 +431,7 @@ extension MessageList_Tests {
             participantRobot.sendMessage(message)
         }
         AND("user adds a quoted reply to users message") {
-            userRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessage(quotedMessage)
+            userRobot.replyToMessage(quotedMessage)
         }
         WHEN("user deletes a quoted message") {
             userRobot.deleteMessage()
@@ -484,9 +459,7 @@ extension MessageList_Tests {
             participantRobot.sendMessage(message)
         }
         WHEN("user adds a thread reply to participant's message and sends it also to main channel") {
-            userRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessageInThread(threadReply, alsoSendInChannel: true)
+            userRobot.replyToMessageInThread(threadReply, alsoSendInChannel: true)
         }
         THEN("user observes the thread reply in thread") {
             userRobot.assertThreadReply(threadReply)
@@ -513,9 +486,7 @@ extension MessageList_Tests {
             userRobot.sendMessage(message)
         }
         AND("participant adds a thread reply to users's message and sends it also to main channel") {
-            participantRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessageInThread(threadReply, alsoSendInChannel: true)
+            participantRobot.replyToMessageInThread(threadReply, alsoSendInChannel: true)
         }
         WHEN("participant removes the thread reply from channel") {
             participantRobot.deleteMessage()
@@ -545,9 +516,7 @@ extension MessageList_Tests {
             participantRobot.sendMessage(message)
         }
         AND("user adds a thread reply to participant's message and sends it also to main channel") {
-            userRobot
-                .waitForNewMessage(withText: message)
-                .replyToMessageInThread(threadReply, alsoSendInChannel: true)
+            userRobot.replyToMessageInThread(threadReply, alsoSendInChannel: true)
         }
         WHEN("user removes thread reply from thread") {
             userRobot.deleteMessage()
@@ -574,9 +543,7 @@ extension MessageList_Tests {
                 .openChannel()
         }
         AND("participant sends a message") {
-            participantRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            participantRobot.sendMessage(message)
         }
         AND("user adds a thread reply to participant's message and sends it also to main channel") {
             userRobot.replyToMessageInThread(threadReply, alsoSendInChannel: true)

--- a/StreamChatUITestsAppUITests/Tests/Reactions_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Reactions_Tests.swift
@@ -70,7 +70,6 @@ final class Reactions_Tests: StreamTestCase {
         }
         AND("user adds the reaction") {
             userRobot
-                .waitForNewMessage(withText: message)
                 .addReaction(type: .love)
                 .waitForNewReaction()
         }
@@ -95,7 +94,6 @@ final class Reactions_Tests: StreamTestCase {
         }
         AND("user adds the reaction") {
             userRobot
-                .waitForNewMessage(withText: message)
                 .addReaction(type: .lol)
                 .waitForNewReaction()
         }
@@ -120,7 +118,6 @@ final class Reactions_Tests: StreamTestCase {
         }
         AND("participant adds the reaction") {
             participantRobot
-                .waitForNewMessage(withText: message)
                 .readMessage()
                 .addReaction(type: .like)
         }
@@ -142,7 +139,6 @@ final class Reactions_Tests: StreamTestCase {
         }
         AND("participant adds the reaction") {
             participantRobot
-                .waitForNewMessage(withText: message)
                 .readMessage()
                 .addReaction(type: .lol)
                 .waitForNewReaction()
@@ -164,9 +160,7 @@ final class Reactions_Tests: StreamTestCase {
             userRobot.login().openChannel()
         }
         WHEN("participant sends the message: '\(message)'") {
-            participantRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            participantRobot.sendMessage(message)
         }
         AND("participant adds the reaction") {
             participantRobot.addReaction(type: .wow)
@@ -189,7 +183,6 @@ final class Reactions_Tests: StreamTestCase {
         }
         AND("participant adds the reaction") {
             participantRobot
-                .waitForNewMessage(withText: message)
                 .addReaction(type: .sad)
                 .waitForNewReaction()
         }

--- a/StreamChatUITestsAppUITests/Tests/SlowMode_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/SlowMode_Tests.swift
@@ -27,9 +27,7 @@ final class SlowMode_Tests: StreamTestCase {
                 .openChannel()
         }
         WHEN("user sends a new text message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         THEN("slow mode is active and cooldown is shown") {
             userRobot.assertCooldownIsShown()
@@ -46,9 +44,7 @@ final class SlowMode_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("user sends a new text message") {
-            participantRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            participantRobot.sendMessage(message)
         }
         AND("user selects reply to a message from context menu") {
             userRobot.selectOptionFromContextMenu(option: .reply)
@@ -74,9 +70,7 @@ final class SlowMode_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("user sends a new text message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("slow mode is active and cooldown is shown") {
             userRobot.assertCooldownIsShown()
@@ -99,9 +93,7 @@ final class SlowMode_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("user sends a new text message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("user selects reply to a message from context menu") {
             userRobot.selectOptionFromContextMenu(option: .reply)
@@ -124,9 +116,7 @@ final class SlowMode_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("user sends a new text message") {
-            userRobot
-                .sendMessage(message)
-                .waitForNewMessage(withText: message)
+            userRobot.sendMessage(message)
         }
         AND("user selects thread to message from context menu") {
             userRobot.selectOptionFromContextMenu(option: .threadReply)

--- a/TestTools/StreamChatTestMockServer/MockServer/MessageList.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/MessageList.swift
@@ -92,4 +92,22 @@ public extension StreamMockServer {
         }
         return newMessageList.first
     }
+    
+    func waitForWebsocketMessage(withText text: String,
+                                 timeout: Double = XCUIElement.waitTimeout) {
+        let endTime = Date().timeIntervalSince1970 * 1000 + timeout * 1000
+        while latestWebsocketMessage != text
+                && endTime > Date().timeIntervalSince1970 * 1000 {
+            print("Waiting for websocket message with text: '\(text)'")
+        }
+    }
+    
+    func waitForHttpMessage(withText text: String,
+                            timeout: Double = XCUIElement.waitTimeout) {
+        let endTime = Date().timeIntervalSince1970 * 1000 + timeout * 1000
+        while latestHttpMessage != text
+                && endTime > Date().timeIntervalSince1970 * 1000 {
+            print("Waiting for http message with text: '\(text)'")
+        }
+    }
 }

--- a/TestTools/StreamChatTestMockServer/MockServer/MessageResponses.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/MessageResponses.swift
@@ -33,6 +33,14 @@ public extension StreamMockServer {
         }
     }
     
+    private func trackMessage(_ text: String,
+                              messageType: MessageType,
+                              eventType: EventType) {
+        if eventType == .messageNew && messageType != .ephemeral {
+            latestHttpMessage = text
+        }
+    }
+    
     func mockDeletedMessage(_ message: [String: Any]?, user: [String: Any]?) -> [String: Any]? {
         var mockedMessage = message
         mockedMessage?[messageKey.deletedAt.rawValue] = TestData.currentDate
@@ -229,6 +237,7 @@ public extension StreamMockServer {
         }
         
         responseJson[JSONKey.message] = mockedMessage
+        trackMessage(text, messageType: messageType, eventType: eventType)
         return .ok(.json(responseJson))
     }
     
@@ -277,6 +286,7 @@ public extension StreamMockServer {
         }
         
         responseJson[JSONKey.message] = mockedMessage
+        trackMessage(text, messageType: messageType, eventType: eventType)
         return .ok(.json(responseJson))
     }
 
@@ -326,6 +336,7 @@ public extension StreamMockServer {
         }
         
         responseJson[JSONKey.message] = mockedMessage
+        trackMessage(text, messageType: messageType, eventType: eventType)
         return .ok(.json(responseJson))
     }
     
@@ -380,6 +391,7 @@ public extension StreamMockServer {
         }
         
         responseJson[JSONKey.message] = mockedMessage
+        trackMessage(text, messageType: messageType, eventType: eventType)
         return .ok(.json(responseJson))
     }
     

--- a/TestTools/StreamChatTestMockServer/MockServer/StreamMockServer.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/StreamMockServer.swift
@@ -18,6 +18,8 @@ public final class StreamMockServer {
     public var channelList = TestData.toJson(.httpChannels)
     public var currentChannelId = ""
     public var channelQueryEndpointWasCalled = false
+    public var latestWebsocketMessage = ""
+    public var latestHttpMessage = ""
 
     public init() {}
 

--- a/TestTools/StreamChatTestMockServer/MockServer/WebsocketResponses.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/WebsocketResponses.swift
@@ -117,6 +117,7 @@ public extension StreamMockServer {
         json[MessagePayloadsCodingKeys.type.rawValue] = eventType.rawValue
         
         writeText(json.jsonToString())
+        if eventType == .messageNew { latestWebsocketMessage = text ?? "" }
         return self
     }
     


### PR DESCRIPTION
### 🔗 Issue Links

N/A

### 🎯 Goal

To make UI tests more stable

### 📝 Summary

From now on user and participant will wait for http request and websocket after sending a message:
-  `waitForHttpMessage()`
- `waitForWebsocketMessage()`

### 🎨 Showcase

<img width="1457" alt="Screen Shot 2022-06-01 at 2 36 27 PM" src="https://user-images.githubusercontent.com/20794991/171418273-16dab959-29ad-40b3-9889-a1baa5cf16c8.png">

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/gw3IWyGkC0rsazTi/giphy.gif)
