### PR TITLE
[CIS-1911] Return Sonar Analysis on push

### DIFF
--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -1,6 +1,11 @@
 name: Smoke Checks
 
 on:
+  push:
+    branches:
+      - main
+      - develop
+
   pull_request:
     branches:
       - '**'
@@ -22,6 +27,7 @@ jobs:
   automated-code-review:
     name: Automated Code Review
     runs-on: macos-12
+    if: ${{ github.event_name != 'push' }}
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/bootstrap
@@ -79,6 +85,7 @@ jobs:
   build-and-test-ui-debug:
     name: Test UI (Debug)
     runs-on: macos-12
+    if: ${{ github.event_name != 'push' }}
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/bootstrap
@@ -97,20 +104,11 @@ jobs:
       with:
         paths: fastlane/test_output/report.junit
       if: failure()
-    - uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        text: "You shall not pass!"
-        job_name: "Test UI (Debug)"
-        fields: message,commit,author,action,workflow,job,took
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        MATRIX_CONTEXT: ${{ toJson(matrix) }}
-      if: ${{ github.event_name == 'push' && failure() }}
 
   build-and-test-e2e-debug:
     name: Test E2E UI (Debug)
     runs-on: macos-12
+    if: ${{ github.event_name != 'push' }}
     needs: allure_testops_launch
     env:
       LAUNCH_ID: ${{ needs.allure_testops_launch.outputs.launch_id }}
@@ -142,20 +140,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ALLURE_TOKEN: ${{ secrets.ALLURE_TOKEN }}
-    - uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        text: "You shall not pass!"
-        job_name: "Test UI (Debug)"
-        fields: message,commit,author,action,workflow,job,took
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        MATRIX_CONTEXT: ${{ toJson(matrix) }}
-      if: ${{ github.event_name == 'push' && failure() }}
 
   allure_testops_launch:
     name: Launch Allure TestOps
     runs-on: macos-12
+    if: ${{ github.event_name != 'push' }}
     outputs:
       launch_id: ${{ steps.get_launch_id.outputs.launch_id }}
     steps:
@@ -176,6 +165,7 @@ jobs:
   build-xcode12:
     name: Build LLC + UI (Xcode 12)
     runs-on: macos-11
+    if: ${{ github.event_name != 'push' }}
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/bootstrap
@@ -191,20 +181,11 @@ jobs:
         XCODE_VERSION: "12.5.1"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_EVENT: ${{ toJson(github.event) }}
-    - uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        text: "You shall not pass!"
-        job_name: "Build LLC + UI (Xcode 12)"
-        fields: message,commit,author,action,workflow,job,took
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        MATRIX_CONTEXT: ${{ toJson(matrix) }}
-      if: ${{ github.event_name == 'push' && failure() }}
 
   build-apps:
     name: Build Sample + Demo Apps
     runs-on: macos-12
+    if: ${{ github.event_name != 'push' }}
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/bootstrap
@@ -220,70 +201,33 @@ jobs:
       run: bundle exec fastlane build_messenger_clone
     - name: Build YouTubeClone App
       run: bundle exec fastlane build_youtube_clone
-    - uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        text: "You shall not pass!"
-        job_name: "Build Sample + Demo Apps"
-        fields: message,commit,author,action,workflow,job,took
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        MATRIX_CONTEXT: ${{ toJson(matrix) }}
-      if: ${{ github.event_name == 'push' && failure() }}
 
   # build-docs-snippets:
   #   name: Build Docs Snippets
   #   runs-on: macos-12
+  #   if: ${{ github.event_name != 'push' }}
   #   steps:
   #   - uses: actions/checkout@v1
   #   - uses: ./.github/actions/bootstrap
   #   - name: Build Docs Snippets
   #     run: bundle exec fastlane build_docs_snippets
-  #   - uses: 8398a7/action-slack@v3
-  #     with:
-  #       status: ${{ job.status }}
-  #       text: "You shall not pass!"
-  #       job_name: "Build Docs Snippets"
-  #       fields: message,commit,author,action,workflow,job,took
-  #     env:
-  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #       MATRIX_CONTEXT: ${{ toJson(matrix) }}
-  #     if: ${{ github.event_name == 'push' && failure() }}
 
   spm-integration:
     name: Test Integration (SPM)
     runs-on: macos-12
+    if: ${{ github.event_name != 'push' }}
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/bootstrap
     - name: Build Test Project
       run: bundle exec fastlane spm_integration
-    - uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        text: "You shall not pass!"
-        job_name: "Test Integration (SPM)"
-        fields: message,commit,author,action,workflow,job,took
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        MATRIX_CONTEXT: ${{ toJson(matrix) }}
-      if: ${{ github.event_name == 'push' && failure() }}
 
   cocoapods-integration:
     name: Test Integration (CocoaPods)
     runs-on: macos-12
+    if: ${{ github.event_name != 'push' }}
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/bootstrap
     - name: Build Test Project
       run: bundle exec fastlane cocoapods_integration
-    - uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        text: "You shall not pass!"
-        job_name: "Test Integration (CocoaPods)"
-        fields: message,commit,author,action,workflow,job,took
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        MATRIX_CONTEXT: ${{ toJson(matrix) }}
-      if: ${{ github.event_name == 'push' && failure() }}


### PR DESCRIPTION
### 🔗 Issue Links

- https://stream-io.atlassian.net/browse/CIS-1911
- https://github.com/GetStream/stream-chat-swift/pull/2033

### 🎯 Goal

- To run Sonar Analysis on `push` to `main` and `develop`

### 📝 Summary

- Return Sonar Analysis on push
- Remove slack actions that had a condition to fire on `push`

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

