### PR TITLE
Fix hidden cell content after popover transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix DM Channel with multiple members displaying only 1 user avatar [#2019](https://github.com/GetStream/stream-chat-swift/pull/2019)
 - Improve stability of Message List with Diffing disabled [#2006](https://github.com/GetStream/stream-chat-swift/pull/2006)
 - Fix quoted message extra spacing jump UI glitch [#2050](https://github.com/GetStream/stream-chat-swift/pull/2050)
+- Fix edge case where cell would be hidden after reacting to it [#2053](https://github.com/GetStream/stream-chat-swift/pull/2053)
 
 # [4.15.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.15.1)
 _June 01, 2022_

--- a/Sources/StreamChatUI/MessageActionsPopup/MessageActionsTransitionController.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/MessageActionsTransitionController.swift
@@ -210,7 +210,8 @@ open class ChatMessageActionsTransitionController: NSObject, UIViewControllerTra
 
         // We use alpha instead of isHidden, because messageContentView is embed
         // in a UIStackView, and so hiding it will change the layout of the message cell.
-        selectedMessageCell?.messageContentView?.alpha = 0.0
+        let messageContentView = selectedMessageCell?.messageContentView
+        messageContentView?.alpha = 0.0
 
         let hideView: (UIView?) -> Void = { view in
             view?.transform = CGAffineTransform(scaleX: 0.01, y: 0.01)
@@ -236,8 +237,8 @@ open class ChatMessageActionsTransitionController: NSObject, UIViewControllerTra
             },
             completion: { _ in
                 transitionSubviews.forEach { $0.removeFromSuperview() }
-                
-                self.selectedMessageCell?.messageContentView?.alpha = 1.0
+
+                messageContentView?.alpha = 1.0
 
                 transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
                 


### PR DESCRIPTION
### 🔗 Issue Links

Reported through Slack: https://getstream.slack.com/archives/C01FT5767AS/p1654165950668659

### 🎯 Goal

Fix hidden cell content after reacting to a message

### 📝 Summary

There was an edge case where, in ChatMessageActionsTransitionController, we would set the alpha of the cell content to 0 during an animation, and never reset it back to 1.

### 🛠 Implementation

The previous logic on the transition controller was looking for the cell both at the beginning of the animation and at the end of it. It was basically looking at the visible cells, and finding the first matching the cell content id.

In some cases, the cell content that was used at the beginning of the animation and the one that was used after were different references. That led to some cells staying with alpha 0.

This PR changes this logic by keeping a local reference to the cell content before the animation starts, to make sure the reference where we alter the alpha is always the same.

### 🎨 Showcase
Before:

https://user-images.githubusercontent.com/7887319/171851491-5e00be17-7f97-45c9-9739-607fd79d2316.mov

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/3orif9QyQQj2QylFL2/giphy.gif)
