### PR TITLE
Multiple fixes for channel hiding/appearing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `Date._unconditionallyBridgeFromObjectiveC(NSDate?)` crash [#2027](https://github.com/GetStream/stream-chat-swift/pull/2027)
 - Fix `NSHashTable` count underflow crash [#2032](https://github.com/GetStream/stream-chat-swift/pull/2032)
 - Fix Message List using incorrect indexPath for message updates [#2044](https://github.com/GetStream/stream-chat-swift/pull/2044)
+- Fix hidden channels not appearing on relaunch  [#2056](https://github.com/GetStream/stream-chat-swift/issues/2056)
+- Fix `channel.hidden` event failing to decode on launch/reconnection [#2056](https://github.com/GetStream/stream-chat-swift/issues/2056)
+- Fix messages in hidden channels with `clearHistory` re-appearing [#2056](https://github.com/GetStream/stream-chat-swift/issues/2056)
+- Fix last message of hidden channel with `clearHistory` visible in channel list [#2056](https://github.com/GetStream/stream-chat-swift/issues/2056)
 ### 🔄 Changed
 - Changing the decoding of `role` to `channel_role` as `role` is now deprecated on the backend. This allows for custom roles defined within your V2 permissions [#2028](https://github.com/GetStream/stream-chat-swift/issues/2028)
 

--- a/DemoApp/DemoChatChannelListRouter.swift
+++ b/DemoApp/DemoChatChannelListRouter.swift
@@ -244,11 +244,33 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
             (
                 channelController.channel?.isHidden == false ?
                     .init(title: "Hide channel", style: .default, handler: { [unowned self] _ in
-                        channelController.hideChannel { error in
-                            if let error = error {
-                                self.rootViewController.presentAlert(title: "Couldn't hide channel \(cid)", message: "\(error)")
-                            }
-                        }
+                        self.rootViewController.presentAlert(
+                            title: "Clear History?",
+                            message: nil,
+                            actions: [
+                                .init(title: "Clear History", style: .default, handler: { _ in
+                                    channelController.hideChannel(clearHistory: true) { error in
+                                        if let error = error {
+                                            self.rootViewController.presentAlert(
+                                                title: "Couldn't hide channel \(cid)",
+                                                message: "\(error)"
+                                            )
+                                        }
+                                    }
+                                }),
+                                .init(title: "Keep History", style: .default, handler: { _ in
+                                    channelController.hideChannel(clearHistory: false) { error in
+                                        if let error = error {
+                                            self.rootViewController.presentAlert(
+                                                title: "Couldn't hide channel \(cid)",
+                                                message: "\(error)"
+                                            )
+                                        }
+                                    }
+                                })
+                            ],
+                            cancelHandler: nil
+                        )
                     }) :
                     .init(title: "Show channel", style: .default, handler: { [unowned self] _ in
                         channelController.showChannel { error in

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -65,7 +65,7 @@ class ChannelDTO: NSManagedObject {
     override func willSave() {
         super.willSave()
 
-        // Change to the `trunctedAt` value have effect on messages, we need to mark them dirty manually
+        // Change to the `truncatedAt` value have effect on messages, we need to mark them dirty manually
         // to triggers related FRC updates
         if changedValues().keys.contains("truncatedAt") {
             messages
@@ -177,6 +177,14 @@ extension NSManagedObjectContext {
         dto.lastMessageAt = payload.lastMessageAt?.bridgeDate
         dto.memberCount = Int64(clamping: payload.memberCount)
         dto.truncatedAt = payload.truncatedAt?.bridgeDate
+        // We don't always set `truncatedAt` directly since we also use this property as `hiddenAt`
+        // when a channel is hidden with `clearHistory`
+        // Backend doesn't send `truncatedAt` for this case and we reset it, causing the hidden messages to re-appear
+        // It's not possible to set `truncatedAt` to `nil` once it's set on backend side
+        // so it's safe to keep client-side changes when backend sends `nil`
+        if payload.truncatedAt != nil {
+            dto.truncatedAt = payload.truncatedAt?.bridgeDate
+        }
 
         dto.isFrozen = payload.isFrozen
         

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -560,6 +560,12 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         if let pinnedByUser = payload.pinnedBy {
             dto.pinnedBy = try saveUser(payload: pinnedByUser)
         }
+        
+        if dto.pinned {
+            channelDTO.pinnedMessages.insert(dto)
+        } else {
+            channelDTO.pinnedMessages.remove(dto)
+        }
 
         if let quotedMessage = payload.quotedMessage {
             dto.quotedMessage = try saveMessage(payload: quotedMessage, channelDTO: channelDTO, syncOwnReactions: false)
@@ -591,12 +597,6 @@ extension NSManagedObjectContext: MessageDatabaseSession {
 
         channelDTO.lastMessageAt = max(channelDTO.lastMessageAt?.bridgeDate ?? payload.createdAt, payload.createdAt).bridgeDate
         
-        if dto.pinned {
-            channelDTO.pinnedMessages.insert(dto)
-        } else {
-            channelDTO.pinnedMessages.remove(dto)
-        }
-        
         dto.channel = channelDTO
 
         dto.latestReactions = payload
@@ -623,13 +623,6 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         if let parentMessageId = payload.parentId,
            let parentMessageDTO = MessageDTO.load(id: parentMessageId, context: self) {
             parentMessageDTO.replies.insert(dto)
-        }
-
-        dto.pinned = payload.pinned
-        dto.pinnedAt = payload.pinnedAt?.bridgeDate
-        dto.pinExpires = payload.pinExpires?.bridgeDate
-        if let pinnedBy = payload.pinnedBy {
-            dto.pinnedBy = try saveUser(payload: pinnedBy)
         }
         
         dto.translations = payload.translations?.mapKeys { $0.languageCode }

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -445,6 +445,9 @@ extension DatabaseSession {
         case .messageDeleted where channelDTO.previewMessage?.id == payload.message?.id:
             channelDTO.previewMessage = preview(for: cid)
             
+        case .channelHidden where payload.isChannelHistoryCleared == true:
+            channelDTO.previewMessage = preview(for: cid)
+            
         case .channelTruncated:
             // We're not using `preview(for: cid)` here because the channel
             // with updated `truncatedAt` is not saved to persistent store yet.

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelVisibilityEventMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelVisibilityEventMiddleware.swift
@@ -36,6 +36,15 @@ struct ChannelVisibilityEventMiddleware: EventMiddleware {
                 
                 channelDTO.isHidden = false
                 
+            // New Message will unhide the channel
+            // but we won't get `ChannelVisibleEvent` for this case
+            case let event as NotificationMessageNewEventDTO:
+                guard let channelDTO = session.channel(cid: event.channel.cid) else {
+                    throw ClientError.ChannelDoesNotExist(cid: event.channel.cid)
+                }
+                
+                channelDTO.isHidden = false
+                
             default:
                 break
             }

--- a/Sources/StreamChat/WebSocketClient/Events/ChannelEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/ChannelEvents.swift
@@ -203,7 +203,7 @@ class ChannelHiddenEventDTO: EventDTO {
         cid = try response.value(at: \.cid)
         createdAt = try response.value(at: \.createdAt)
         user = try response.value(at: \.user)
-        isHistoryCleared = try response.value(at: \.isChannelHistoryCleared)
+        isHistoryCleared = (try? response.value(at: \.isChannelHistoryCleared)) ?? false
         payload = response
     }
     

--- a/Sources/StreamChat/WebSocketClient/Events/EventPayload.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/EventPayload.swift
@@ -138,7 +138,7 @@ extension Array where Element == EventPayload {
             do {
                 return try $0.event()
             } catch {
-                log.error("Failed to decode event from event payload: \($0)")
+                log.error("Failed to decode event from event payload: \($0), error: \(error)")
                 return nil
             }
         }


### PR DESCRIPTION
### 🔗 Issue Links

#2039 

### 🎯 Goal

Channel hiding/appearing mechanism was broken with the introduction of offline caching

### 📝 Summary

This PR contains multiple fixes for multiple bugs.

1. DemoApp keeps a reference to last displayed ChannelVC
1. Duplicated pinned message saving in MessageDTO (performance)
1. channel.hidden event fails to decode
1. Locally saved hidden channels do not re-appear when they should
1. Hidden channel messages re-appear seemingly randomly
1. Hidden channel messages leak via channel list preview 
1. Querying a hidden channel makes the channel un-hide

### 🛠 Implementation

1. _DemoApp keeps a reference to last displayed ChannelVC_
We were always using splitVC, which keeps the ref to latest displayed VC, which keeps it alive. We should use the old logic and only use splitVC when we detect an iPad
Keeping a ref to ChannelVC causes the latest displayed channel to keep marking newly received messages as "read", which messes up the unread count

1. _Duplicated pinned message saving in MessageDTO (performance)_
This has a big performance implication since it included one `saveUser` call, effectively adding ~500 `saveUser` calls per channel list

1. _channel.hidden event fails to decode_
This only happens for channel.hidden events coming from sync endpoint. Backend explained that `clearHistory` is treated as custom data, and custom data is not sent on `/sync` call, so it's not sent. It's a bug that will be resolved by backend, but client needs a workaround meanwhile.
Also resolved that decoding errors are not printed to console.

1. _Locally saved hidden channels do not re-appear when they should_
When the client starts for the first time, the channels linked to the query will be watched. If a channel was hidden on a previous session, that channel will not be linked to the query, so will not be watched. We won't receive a `MessageNew` event for that channel (since it's not being watched) and we won't mark it as `hidden = false`, so it won't show up.
The visibility middleware should also act on `Notification` events and mark the channel accordingly. Then it can be linked to any query that's currently alive.

1. _Hidden channel messages re-appear seemingly randomly_
This happens because client uses `truncatedAt` as `hiddenAt`. Hiding channel with clearHistory flag sets truncatedAt, but backend is not aware so they send null for this value, and client uses null value to reset truncatedAt, effectively un-hiding the messages.
As per slack discussion (https://getstream.slack.com/archives/CE5N802GP/p1654094011610589?thread_ts=1654093897.531669&cid=CE5N802GP) it's not possible to un-truncate a channel by setting truncatedAt to null once it's set, so it's fine to only use non-nil truncatedAt values sent by backend

1. _Hidden channel messages leak via channel list preview_
We didn't re-set the `previewMessage` of a hidden channel so if `clearHistory == true`, last message was still set as `previewMessage` and leaked

1. _Querying a hidden channel makes the channel un-hide_
This was a backend issue, it was resolved & deployed, cannot be reproduced anymore

### 🧪 Manual Testing Notes

Reproduction videos for the bugs:

Points 5, 6, 7
https://user-images.githubusercontent.com/770464/171873446-dbbd5e9e-c6b5-42eb-9395-7f4ceb90cb92.mp4

Points 3 & 4
https://user-images.githubusercontent.com/770464/171873496-b59dd491-9a91-463b-9b13-3e519c1a2e18.mp4

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)

