### PR TITLE
Fixed a typo in the `BaseLogDestination` documentation

### DIFF
--- a/Sources/StreamChat/Utils/Logger/Destination/BaseLogDestination.swift
+++ b/Sources/StreamChat/Utils/Logger/Destination/BaseLogDestination.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// Base class for log destinations. Already implements basic functionaly to allow easy destination implementation.
+/// Base class for log destinations. Already implements basic functionality to allow easy destination implementation.
 /// Extending this class, instead of implementing `LogDestination` is easier (and recommended) for creating new destinations.
 open class BaseLogDestination: LogDestination {
     open var identifier: String

--- a/docusaurus/docs/iOS/common-content/reference-docs/stream-chat/utils/logger/destination/base-log-destination.md
+++ b/docusaurus/docs/iOS/common-content/reference-docs/stream-chat/utils/logger/destination/base-log-destination.md
@@ -2,7 +2,7 @@
 title: BaseLogDestination
 ---
 
-Base class for log destinations. Already implements basic functionaly to allow easy destination implementation.
+Base class for log destinations. Already implements basic functionality to allow easy destination implementation.
 Extending this class, instead of implementing `LogDestination` is easier (and recommended) for creating new destinations.
 
 ``` swift


### PR DESCRIPTION
### 🎯 Goal

For there to be one less typo in the documentation. 😂

### 🛠 Implementation

1. Removed mistyped word.
2. Inserted correctly typed word.

### 🎨 Showcase

![Screenshot 2022-06-03 at 18 39 15](https://user-images.githubusercontent.com/5180/171917552-1c6dca23-5844-4b07-b5e8-a8751d2fd0b0.gif)

😂 

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

See GIF above 😂
