### PR TITLE
[BW] Fix paths to resources in StreamChatTestTools

### DIFF
--- a/TestTools/StreamChatTestTools/StreamChatTestTools.swift
+++ b/TestTools/StreamChatTestTools/StreamChatTestTools.swift
@@ -12,10 +12,8 @@ extension Bundle {
 
     static let bundleName = "StreamChat_StreamChatTestTools"
 
-    private static let fixtures = "Fixtures"
-    private static let JSONs = "\(fixtures)/JSONs/"
-    private static let images = "\(fixtures)/Images/"
-    private static let other = "\(fixtures)/Other/"
+    private static let JSONs = "JSONs/"
+    private static let other = "Other/"
 
     /// Returns the resource bundle associated with the current Swift module.
     static let testTools: Bundle = {
@@ -41,10 +39,6 @@ extension Bundle {
 
     var pathToJSONsFolder: String {
         Self.testTools.bundlePath.contains(Self.bundleName) ? Self.JSONs : ""
-    }
-
-    var pathToImagesFolder: String {
-        Self.testTools.bundlePath.contains(Self.bundleName) ? Self.images : ""
     }
 
     var pathToOtherFolder: String {

--- a/TestTools/StreamChatTestTools/XCTestCase+TestImages.swift
+++ b/TestTools/StreamChatTestTools/XCTestCase+TestImages.swift
@@ -24,7 +24,7 @@ public extension XCTestCase {
         }()
         
         private static func getImage(withName name: String, fileExtension: String = "jpg") -> (url: URL, image: UIImage) {
-            let imageURL = Bundle.testTools.url(forResource: "\(Bundle.testTools.pathToImagesFolder)\(name)", withExtension: fileExtension)!
+            let imageURL = Bundle.testTools.url(forResource: name, withExtension: fileExtension)!
             let image = UIImage(contentsOfFile: imageURL.path)!
             return (imageURL, image)
         }
@@ -33,7 +33,7 @@ public extension XCTestCase {
 
 public extension URL {
     static let localYodaImage = Bundle.testTools
-        .url(forResource: "\(Bundle.testTools.pathToImagesFolder)yoda", withExtension: "jpg")!
+        .url(forResource: "yoda", withExtension: "jpg")!
 
     static let localYodaQuote = Bundle.testTools
         .url(forResource: "\(Bundle.testTools.pathToOtherFolder)yoda", withExtension: "txt")!


### PR DESCRIPTION
### 🎯 Goal

Paths to images were broken in `StreamChatTestTools` package.

### ☑️ Contributor Checklist
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
