### PR TITLE
Fix possible deadlock in `CurrentChatUser` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `channel.hidden` event failing to decode on launch/reconnection [#2056](https://github.com/GetStream/stream-chat-swift/issues/2056)
 - Fix messages in hidden channels with `clearHistory` re-appearing [#2056](https://github.com/GetStream/stream-chat-swift/issues/2056)
 - Fix last message of hidden channel with `clearHistory` visible in channel list [#2056](https://github.com/GetStream/stream-chat-swift/issues/2056)
+- Fix possible deadlock in `CurrentUserController` functions being called from background threads [#2074](https://github.com/GetStream/stream-chat-swift/issues/2074)
 ### 🔄 Changed
 - Changing the decoding of `role` to `channel_role` as `role` is now deprecated on the backend. This allows for custom roles defined within your V2 permissions [#2028](https://github.com/GetStream/stream-chat-swift/issues/2028)
 

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -162,7 +162,7 @@ public extension CurrentChatUserController {
         userExtraData: [String: RawJSON] = [:],
         completion: ((Error?) -> Void)? = nil
     ) {
-        guard let currentUserId = currentUser?.id else {
+        guard let currentUserId = client.currentUserId else {
             completion?(ClientError.CurrentUserDoesNotExist())
             return
         }
@@ -182,7 +182,7 @@ public extension CurrentChatUserController {
     /// Fetches the most updated devices and syncs with the local database.
     /// - Parameter completion: Called when the devices are synced successfully, or with error.
     func synchronizeDevices(completion: ((Error?) -> Void)? = nil) {
-        guard let currentUserId = currentUser?.id else {
+        guard let currentUserId = client.currentUserId else {
             completion?(ClientError.CurrentUserDoesNotExist())
             return
         }
@@ -197,7 +197,7 @@ public extension CurrentChatUserController {
     ///   - pushDevice: The device information required for the desired push provider.
     ///   - completion: Callback when device is successfully registered, or failed with error.
     func addDevice(_ pushDevice: PushDevice, completion: ((Error?) -> Void)? = nil) {
-        guard let currentUserId = currentUser?.id else {
+        guard let currentUserId = client.currentUserId else {
             completion?(ClientError.CurrentUserDoesNotExist())
             return
         }
@@ -220,7 +220,7 @@ public extension CurrentChatUserController {
     ///   If `currentUser.devices` is not up-to-date, please make an `synchronize` call.
     ///   - completion: Called when device is successfully deregistered, or with error.
     func removeDevice(id: DeviceId, completion: ((Error?) -> Void)? = nil) {
-        guard let currentUserId = currentUser?.id else {
+        guard let currentUserId = client.currentUserId else {
             completion?(ClientError.CurrentUserDoesNotExist())
             return
         }


### PR DESCRIPTION
### 🔗 Issue Links

https://getstream.slack.com/archives/CRB9P6L03/p1654667559058219

### 🎯 Goal

A customer has reported that calling `addDevice` causes a deadlock

### 📝 Summary

Calling `addDevice` twice, once from background queue and once from main queue causes deadlock:
background queue -> acquires the lock (semaphore), waits on main queue because of performAndWait
main queue -> waits on the lock, cannot perform any work

### 🛠 Implementation

`EntityDatabaseObserver` uses `viewContext` for its DB operations, both in tests and production code. This is because it needs to be performant.

When you try to access `EntityDatabaseObserver.item` from background queue, since it's an `Atomic`, it acquires the lock & calls `viewContext.performAndWait` (to convert DTO to Model) which waits for main queue to complete some work

If you try to access `EntityDatabaseObserver.item` from main queue, it'll wait on the lock... which is held by background queue, which is waiting on main queue (because of `performAndWait`), which is waiting on background queue to release the lock, which is waiting on main queue to complete the work, which is waiting on background queue to release the lock......

We cannot "fix" the bug in `EntityDatabaseObserver` right away, it's complicated. But the bug happens because we access `currentUser`, which is `currentUserObserver.item` in the `CurrentUserController`. This causes DB operations, which is not required, we already have O(1) access to `currentUserId`, which is all we need.

The patch in this PR will mitigate this issue for now.

### 🧪 Manual Testing Notes

Paste this in `EntityDatabaseObserver_Tests`
```swift
func test_deadlock() throws {
        let testId: String = .unique
        fetchRequest.predicate = NSPredicate(format: "testId == %@", testId)
        
        // Insert the item matching the predicate
        try database.writeSynchronously {
            let context = $0 as! NSManagedObjectContext
            let new = NSEntityDescription.insertNewObject(forEntityName: "TestManagedObject", into: context) as! TestManagedObject
            new.testId = testId
            new.testValue = .unique
        }
        
        try observer.startObserving()
        
        // Read item.value from background queue
        DispatchQueue.global().async {
            XCTAssertEqual(self.observer.item?.id, testId)
        }
        
        // Sleep main thread for a little time
        // to make sure background thread acquires lock
        // if we don't sleep, main thread acquires lock first & no deadlock occurs
        sleep(1)
        
        // Read item.value from main queue
        XCTAssertEqual(self.observer.item?.id, testId)
    }
```

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)
