### PR TITLE
Fix crash when participant hard deletes message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _June 06, 2022_
 - Fix `Date._unconditionallyBridgeFromObjectiveC(NSDate?)` crash [#2027](https://github.com/GetStream/stream-chat-swift/pull/2027)
 - Fix `NSHashTable` count underflow crash [#2032](https://github.com/GetStream/stream-chat-swift/pull/2032)
 - Fix Message List using incorrect indexPath for message updates [#2044](https://github.com/GetStream/stream-chat-swift/pull/2044)
+- Fix crash when participant hard deletes a message [2075](https://github.com/GetStream/stream-chat-swift/pull/2075)
 ### 🔄 Changed
 - Changing the decoding of `role` to `channel_role` as `role` is now deprecated on the backend. This allows for custom roles defined within your V2 permissions [#2028](https://github.com/GetStream/stream-chat-swift/issues/2028)
 

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -422,7 +422,9 @@ extension DatabaseSession {
         )
 
         if payload.eventType == .messageDeleted && payload.hardDelete {
-            delete(message: savedMessage)
+            // We should in fact delete it from the DB, but right now this produces a crash
+            // This should be fixed in this ticket: https://stream-io.atlassian.net/browse/CIS-1963
+            savedMessage.isHardDeleted = true
             return
         }
 

--- a/Tests/StreamChatTests/Database/DatabaseSession_Tests.swift
+++ b/Tests/StreamChatTests/Database/DatabaseSession_Tests.swift
@@ -384,7 +384,8 @@ final class DatabaseSession_Tests: XCTestCase {
 
         let messageAfterEvent = database.viewContext.message(id: messageId)
 
-        XCTAssertNil(messageAfterEvent)
+        // XCTAssertNil(messageAfterEvent) This should be uncommented out after: https://stream-io.atlassian.net/browse/CIS-1963
+        XCTAssertTrue(messageAfterEvent?.isHardDeleted == true)
     }
 
     func test_saveEvent_whenMessageDelete_whenNotHardDeleted_shouldNotHardDeleteMessageFromDatabase() throws {


### PR DESCRIPTION
### 🔗 Issue Links
None. Issue found in QA.

### 🎯 Goal
Fix a crash when the participant of a message list, hard deletes a message.

### 📝 Summary
Change the hard deleting of a message from an event to just switch the `isHardDelete = true` instead of actually deleting the message from the database. This has some data privacy concerns, so this should be addressed properly in another ticket:  https://stream-io.atlassian.net/browse/CIS-1963

### 🧪 Manual Testing Notes

1. Open a Channel with messages
2. Send a message to user A
3. Send a message wth user B
4. User B hard deletes a message
5. 💣 

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)