### PR TITLE
Revert ListChangeAggregator newIndexPath on Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ _June 06, 2022_
 - Fix not waiting for last batch of events to be processed when connecting as another user [#2016](https://github.com/GetStream/stream-chat-swift/issues/2016)
 - Fix `Date._unconditionallyBridgeFromObjectiveC(NSDate?)` crash [#2027](https://github.com/GetStream/stream-chat-swift/pull/2027)
 - Fix `NSHashTable` count underflow crash [#2032](https://github.com/GetStream/stream-chat-swift/pull/2032)
-- Fix Message List using incorrect indexPath for message updates [#2044](https://github.com/GetStream/stream-chat-swift/pull/2044)
 - Fix crash when participant hard deletes a message [2075](https://github.com/GetStream/stream-chat-swift/pull/2075)
 ### 🔄 Changed
 - Changing the decoding of `role` to `channel_role` as `role` is now deprecated on the backend. This allows for custom roles defined within your V2 permissions [#2028](https://github.com/GetStream/stream-chat-swift/issues/2028)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ _June 06, 2022_
 - Saving payloads to local database is now 50% faster. Initial launch and displaying channel list should be noticeably faster [#1973](https://github.com/GetStream/stream-chat-swift/issues/1973)
 - Fix not waiting for last batch of events to be processed when connecting as another user [#2016](https://github.com/GetStream/stream-chat-swift/issues/2016)
 - Fix `Date._unconditionallyBridgeFromObjectiveC(NSDate?)` crash [#2027](https://github.com/GetStream/stream-chat-swift/pull/2027)
-- Fix `NSHashTable` count underflow crash [#2032](https://github.com/GetStream/stream-chat-swift/pull/2032)
-- Fix Message List using incorrect indexPath for message updates [#2044](https://github.com/GetStream/stream-chat-swift/pull/2044)
+- Fix `NSHashTable` count underflow crash [#2032](https://github.com/GetStream/stream-chat-swift/pull/2032))
 ### 🔄 Changed
 - Changing the decoding of `role` to `channel_role` as `role` is now deprecated on the backend. This allows for custom roles defined within your V2 permissions [#2028](https://github.com/GetStream/stream-chat-swift/issues/2028)
 
@@ -28,7 +27,7 @@ _June 06, 2022_
 - Show channel screen as right detail when channel list is embedded by split view controller [#2011](https://github.com/GetStream/stream-chat-swift/pull/2011)
 ### 🐞 Fixed
 - Fix DM Channel with multiple members displaying only 1 user avatar [#2019](https://github.com/GetStream/stream-chat-swift/pull/2019)
-- Improve stability of Message List with Diffing disabled [#2006](https://github.com/GetStream/stream-chat-swift/pull/2006)
+- Improve stability of Message List with Diffing disabled [#2006](https://github.com/GetStream/stream-chat-swift/pull/2006) [#2076](https://github.com/GetStream/stream-chat-swift/pull/2076)
 - Fix quoted message extra spacing jump UI glitch [#2050](https://github.com/GetStream/stream-chat-swift/pull/2050)
 - Fix edge case where cell would be hidden after reacting to it [#2053](https://github.com/GetStream/stream-chat-swift/pull/2053)
 

--- a/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
@@ -340,7 +340,7 @@ class ListChangeAggregator<DTO: NSManagedObject, Item>: NSObject, NSFetchedResul
             currentChanges.append(.move(item, fromIndex: fromIndex, toIndex: toIndex))
             
         case .update:
-            guard let index = newIndexPath else {
+            guard let index = indexPath else {
                 log.warning("Skipping the update from DB because `indexPath` is missing for `.update` change.")
                 return
             }

--- a/Sources/StreamChat/WebSocketClient/Events/Event.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/Event.swift
@@ -7,6 +7,12 @@ import Foundation
 /// An `Event` object representing an event in the chat system.
 public protocol Event {}
 
+extension Event {
+    var name: String {
+        String(describing: Self.self).replacingOccurrences(of: "DTO", with: "")
+    }
+}
+
 /// An internal protocol marking the Events carrying the payload. This payload can be then used for additional work,
 /// i.e. for storing the data to the database.
 protocol EventDTO: Event {
@@ -23,10 +29,6 @@ protocol EventDTO: Event {
 
 extension EventDTO {
     func toDomainEvent(session: DatabaseSession) -> Event? { nil }
-
-    var name: String {
-        String(describing: Self.self).replacingOccurrences(of: "DTO", with: "")
-    }
 }
 
 /// A protocol for any `ChannelEvent` where it has a  `channel` payload.

--- a/Sources/StreamChat/Workers/EventNotificationCenter.swift
+++ b/Sources/StreamChat/Workers/EventNotificationCenter.swift
@@ -31,10 +31,10 @@ class EventNotificationCenter: NotificationCenter {
 
     func process(_ events: [Event], postNotifications: Bool = true, completion: (() -> Void)? = nil) {
         let processingEventsDebugMessage: () -> String = {
-            let eventNames = events.compactMap { ($0 as? EventDTO)?.name }
+            let eventNames = events.map(\.name)
             return "Processing Events: \(eventNames)"
         }
-        log.debug(processingEventsDebugMessage, subsystems: .webSocket)
+        log.debug(processingEventsDebugMessage(), subsystems: .webSocket)
 
         var eventsToPost = [Event]()
         database.write({ session in

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -245,22 +245,11 @@ open class ChatMessageListVC: _ViewController,
             // Because we use an inverted table view, we need to avoid animations since they look odd.
             UIView.performWithoutAnimation {
                 listView.updateMessages(with: changes) { [weak self] in
-                    guard let self = self else {
-                        completion?()
-                        return
-                    }
-
                     if let newMessageInserted = changes.first(where: { $0.isInsertion && $0.indexPath.row == 0 })?.item {
-                        if self.dataSource?.numberOfMessages(in: self) ?? 0 > 1 {
-                            let previousMessageIndexPath = IndexPath(row: 1, section: 0)
-                            self.listView.reloadRows(at: [previousMessageIndexPath], with: .none)
-                        }
-
                         if newMessageInserted.isSentByCurrentUser {
-                            self.listView.scrollToMostRecentMessage()
+                            self?.listView.scrollToMostRecentMessage()
                         }
                     }
-
                     completion?()
                 }
             }

--- a/Sources/StreamChatUI/Utils/ListChangeUpdater/ListChangeIndexPathResolver.swift
+++ b/Sources/StreamChatUI/Utils/ListChangeUpdater/ListChangeIndexPathResolver.swift
@@ -33,52 +33,63 @@ final class ListChangeIndexPathResolver {
     /// - Parameters:
     ///   - changes: changes
     /// - Returns: Returns the indices mapped to sets. Returns nil if there were conflicts.
-    func mapToSetsOfIndexPaths<Item>(
+    func resolve<Item>(
         changes: [ListChange<Item>]
     ) -> Indexes? {
-        var allIndexes = Set<IndexPath>()
+        var moveFromIndexes = Set<IndexPath>()
+        var moveToIndexes = Set<IndexPath>()
         var moveIndexes = Set<IndexPathMove>()
         var insertIndexes = Set<IndexPath>()
         var removeIndexes = Set<IndexPath>()
         var updateIndexes = Set<IndexPath>()
         
-        var hasConflicts = false
-        let verifyConflict = { (indexPath: IndexPath) in
-            let (inserted, _) = allIndexes.insert(indexPath)
-            hasConflicts = !inserted || hasConflicts
-        }
-        
         for change in changes {
-            if hasConflicts {
-                break
-            }
-            
             switch change {
             case let .insert(_, index):
-                verifyConflict(index)
                 insertIndexes.insert(index)
             case let .move(_, fromIndex, toIndex):
-                verifyConflict(fromIndex)
-                verifyConflict(toIndex)
                 moveIndexes.insert(IndexPathMove(fromIndex, toIndex))
+                moveFromIndexes.insert(fromIndex)
+                moveToIndexes.insert(toIndex)
             case let .remove(_, index):
-                verifyConflict(index)
                 removeIndexes.insert(index)
             case let .update(_, index):
-                verifyConflict(index)
                 updateIndexes.insert(index)
             }
         }
-        
-        if hasConflicts {
-            return nil
-        }
-        
-        return (
+
+        let indexes = Indexes(
             move: moveIndexes,
             insert: insertIndexes,
             remove: removeIndexes,
             update: updateIndexes
         )
+
+        // Check if there are conflicts between Inserts<->Moves<->Deletes or Updates<->Moves<->Deletes.
+        // We don't check for conflicts between Inserts<->Updates, since it is not a conflict.
+        let movesAndRemoves = [moveFromIndexes, moveToIndexes, removeIndexes]
+        let hasInsertConflicts = insertIndexes.containsDuplicates(between: movesAndRemoves)
+        let hasUpdateConflicts = updateIndexes.containsDuplicates(between: movesAndRemoves)
+        let hasConflicts = hasInsertConflicts || hasUpdateConflicts
+        if hasConflicts {
+            log.warning("ListChange conflicts found: \(indexes)")
+            return nil
+        }
+        
+        return indexes
+    }
+}
+
+private extension Set where Element == IndexPath {
+    // If the count of all elements before the sets are merged is different from the count of the elements
+    // after the sets are merged, then it means there are duplicates between the provided sets.
+    //
+    // Example of a conflict:
+    // ["1", "2", "3"] + ["4", "5", "6"] + ["1", "8", "9"] = 9
+    // ["1", "2", "3", "4", "5", "6", "8", "9"] = 8
+    func containsDuplicates(between sets: [Self]) -> Bool {
+        let allElements = sets.reduce(Array(self), +)
+        let mergedElements = Set(allElements)
+        return allElements.count != mergedElements.count
     }
 }

--- a/Sources/StreamChatUI/Utils/ListChangeUpdater/TableViewListChangeUpdater.swift
+++ b/Sources/StreamChatUI/Utils/ListChangeUpdater/TableViewListChangeUpdater.swift
@@ -22,7 +22,7 @@ final class TableViewListChangeUpdater: ListChangeUpdater {
     ///   - changes: The provided changes reported by a list controller.
     ///   - completion: A callback when the changes are fully executed.
     func performUpdate<Item>(with changes: [ListChange<Item>], completion: ((_ finished: Bool) -> Void)? = nil) {
-        guard let indices = listChangeIndexPathResolver.mapToSetsOfIndexPaths(
+        guard let indices = listChangeIndexPathResolver.resolve(
             changes: changes
         ) else {
             tableView?.reloadData()
@@ -30,31 +30,15 @@ final class TableViewListChangeUpdater: ListChangeUpdater {
             return
         }
 
-        if #available(iOS 15, *) {
-            tableView?.performBatchUpdates({
-                tableView?.deleteRows(at: Array(indices.remove), with: .none)
-                tableView?.insertRows(at: Array(indices.insert), with: .none)
-                tableView?.reloadRows(at: Array(indices.update), with: .none)
-                indices.move.forEach {
-                    tableView?.moveRow(at: $0.fromIndex, to: $0.toIndex)
-                }
-            }, completion: { finished in
-                completion?(finished)
-            })
-        } else {
-            // To fix a crash on iOS 14 below, we moved the reloads to the completion block.
-            tableView?.performBatchUpdates({
-                tableView?.deleteRows(at: Array(indices.remove), with: .none)
-                tableView?.insertRows(at: Array(indices.insert), with: .none)
-                indices.move.forEach {
-                    tableView?.moveRow(at: $0.fromIndex, to: $0.toIndex)
-                }
-            }, completion: { [weak self] finished in
-                UIView.performWithoutAnimation {
-                    self?.tableView?.reloadRows(at: Array(indices.update), with: .none)
-                    completion?(finished)
-                }
-            })
-        }
+        tableView?.performBatchUpdates({
+            tableView?.deleteRows(at: Array(indices.remove), with: .none)
+            tableView?.insertRows(at: Array(indices.insert), with: .none)
+            tableView?.reloadRows(at: Array(indices.update), with: .none)
+            indices.move.forEach {
+                tableView?.moveRow(at: $0.fromIndex, to: $0.toIndex)
+            }
+        }, completion: { finished in
+            completion?(finished)
+        })
     }
 }

--- a/Tests/StreamChatTests/ListChangeAggregator_Tests.swift
+++ b/Tests/StreamChatTests/ListChangeAggregator_Tests.swift
@@ -128,17 +128,17 @@ final class ListChangeAggregator_Tests: XCTestCase {
         aggregator.controller(
             fakeController,
             didChange: updatedObject1,
-            at: [0, 0],
+            at: [1, 0],
             for: .update,
-            newIndexPath: [1, 0] // Should use newIndexPath
+            newIndexPath: nil
         )
 
         aggregator.controller(
             fakeController,
             didChange: updatedObject2,
-            at: [3, 0],
+            at: [4, 0],
             for: .update,
-            newIndexPath: [4, 0] // Should use newIndexPath
+            newIndexPath: nil
         )
 
         // Simulate FRC finishes updating
@@ -227,9 +227,9 @@ final class ListChangeAggregator_Tests: XCTestCase {
         aggregator.controller(
             fakeController,
             didChange: updatedObject,
-            at: [1, 0],
+            at: [2, 0],
             for: .update,
-            newIndexPath: [2, 0]
+            newIndexPath: nil
         )
 
         // Simulate FRC finishes updating

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannelList/ChatChannelListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannelList/ChatChannelListVC_Tests.swift
@@ -252,7 +252,7 @@ extension ChatChannelListVC_Tests {
 
         let hasConflictChanges: [ListChange<ChatChannel>] = [
             .update(.mock(cid: .unique), index: .init(row: 1, section: 0)),
-            .update(.mock(cid: .unique), index: .init(row: 2, section: 0)),
+            .remove(.mock(cid: .unique), index: .init(row: 2, section: 0)),
             .insert(.mock(cid: .unique), index: .init(row: 3, section: 0)),
             .insert(.mock(cid: .unique), index: .init(row: 2, section: 0))
         ]
@@ -275,7 +275,7 @@ extension ChatChannelListVC_Tests {
             .update(.mock(cid: .unique), index: .init(row: 1, section: 0)),
             .update(.mock(cid: .unique), index: .init(row: 2, section: 0)),
             .insert(.mock(cid: .unique), index: .init(row: 3, section: 0)),
-            .update(.mock(cid: .unique), index: .init(row: 3, section: 0))
+            .remove(.mock(cid: .unique), index: .init(row: 3, section: 0))
         ]
 
         mockedChannelListController.simulate(

--- a/Tests/StreamChatUITests/Utils/ListChangeIndexPathResolver_Tests.swift
+++ b/Tests/StreamChatUITests/Utils/ListChangeIndexPathResolver_Tests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 final class ListChangeIndexPathResolver_Tests: XCTestCase {
     func test_resolve_whenHasNoConflicts_returnsIndices() {
-        let mapper = ListChangeIndexPathResolver()
+        let listChangeIndexPathResolver = ListChangeIndexPathResolver()
 
         let changes: [ListChange<Int>] = [
             .update(0, index: .init(row: 0, section: 0)),
@@ -21,7 +21,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
             .remove(0, index: .init(row: 3, section: 2))
         ]
 
-        let indices = mapper.resolve(
+        let indices = listChangeIndexPathResolver.resolve(
             changes: changes
         )
 
@@ -46,7 +46,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
     }
 
     func test_resolve_whenInsertAndUpdateWithSameIndex_hasNoConflicts_returnsIndices() {
-        let mapper = ListChangeIndexPathResolver()
+        let listChangeIndexPathResolver = ListChangeIndexPathResolver()
 
         let changes: [ListChange<Int>] = [
             .update(0, index: .init(row: 0, section: 0)),
@@ -59,7 +59,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
             .insert(0, index: .init(row: 0, section: 0))
         ]
 
-        let indices = mapper.resolve(
+        let indices = listChangeIndexPathResolver.resolve(
             changes: changes
         )
 
@@ -90,7 +90,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
     }
 
     func test_resolve_whenAllWithSameIndex_hasConflicts_returnsNil() {
-        let mapper = ListChangeIndexPathResolver()
+        let listChangeIndexPathResolver = ListChangeIndexPathResolver()
         
         let changes: [ListChange<Int>] = [
             .update(0, index: .init(row: 0, section: 0)),
@@ -103,7 +103,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
             .insert(0, index: .init(row: 0, section: 0))
         ]
 
-        let indices = mapper.resolve(
+        let indices = listChangeIndexPathResolver.resolve(
             changes: changes
         )
 
@@ -111,7 +111,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
     }
 
     func test_resolve_whenInsertAndRemoveWithSameIndex_hasConflicts_returnsNil() {
-        let mapper = ListChangeIndexPathResolver()
+        let listChangeIndexPathResolver = ListChangeIndexPathResolver()
 
         let changes: [ListChange<Int>] = [
             .update(0, index: .init(row: 5, section: 0)),
@@ -124,7 +124,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
             .insert(0, index: .init(row: 0, section: 0))
         ]
 
-        let indices = mapper.resolve(
+        let indices = listChangeIndexPathResolver.resolve(
             changes: changes
         )
 
@@ -132,7 +132,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
     }
 
     func test_resolve_whenInsertAndMoveFromWithSameIndex_hasConflicts_returnsNil() {
-        let mapper = ListChangeIndexPathResolver()
+        let listChangeIndexPathResolver = ListChangeIndexPathResolver()
 
         let changes: [ListChange<Int>] = [
             .update(0, index: .init(row: 5, section: 0)),
@@ -145,7 +145,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
             .insert(0, index: .init(row: 0, section: 0))
         ]
 
-        let indices = mapper.resolve(
+        let indices = listChangeIndexPathResolver.resolve(
             changes: changes
         )
 
@@ -153,7 +153,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
     }
 
     func test_resolve_whenInsertAndMoveToWithSameIndex_hasConflicts_returnsNil() {
-        let mapper = ListChangeIndexPathResolver()
+        let listChangeIndexPathResolver = ListChangeIndexPathResolver()
 
         let changes: [ListChange<Int>] = [
             .update(0, index: .init(row: 5, section: 0)),
@@ -166,7 +166,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
             .insert(0, index: .init(row: 0, section: 0))
         ]
 
-        let indices = mapper.resolve(
+        let indices = listChangeIndexPathResolver.resolve(
             changes: changes
         )
 
@@ -174,7 +174,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
     }
 
     func test_resolve_whenUpdateAndRemoveWithSameIndex_hasConflicts_returnsNil() {
-        let mapper = ListChangeIndexPathResolver()
+        let listChangeIndexPathResolver = ListChangeIndexPathResolver()
 
         let changes: [ListChange<Int>] = [
             .update(0, index: .init(row: 0, section: 0)),
@@ -187,7 +187,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
             .insert(0, index: .init(row: 5, section: 0))
         ]
 
-        let indices = mapper.resolve(
+        let indices = listChangeIndexPathResolver.resolve(
             changes: changes
         )
 
@@ -195,7 +195,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
     }
 
     func test_resolve_whenUpdateAndMoveFromWithSameIndex_hasConflicts_returnsNil() {
-        let mapper = ListChangeIndexPathResolver()
+        let listChangeIndexPathResolver = ListChangeIndexPathResolver()
 
         let changes: [ListChange<Int>] = [
             .update(0, index: .init(row: 0, section: 0)),
@@ -208,7 +208,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
             .insert(0, index: .init(row: 5, section: 0))
         ]
 
-        let indices = mapper.resolve(
+        let indices = listChangeIndexPathResolver.resolve(
             changes: changes
         )
 
@@ -216,7 +216,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
     }
 
     func test_resolve_whenUpdateAndMoveToWithSameIndex_hasConflicts_returnsNil() {
-        let mapper = ListChangeIndexPathResolver()
+        let listChangeIndexPathResolver = ListChangeIndexPathResolver()
 
         let changes: [ListChange<Int>] = [
             .update(0, index: .init(row: 0, section: 0)),
@@ -229,7 +229,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
             .insert(0, index: .init(row: 5, section: 0))
         ]
 
-        let indices = mapper.resolve(
+        let indices = listChangeIndexPathResolver.resolve(
             changes: changes
         )
 
@@ -237,7 +237,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
     }
 
     func test_resolve_whenRemoveAndMoveToWithSameIndex_hasConflicts_returnsNil() {
-        let mapper = ListChangeIndexPathResolver()
+        let listChangeIndexPathResolver = ListChangeIndexPathResolver()
 
         let changes: [ListChange<Int>] = [
             .update(0, index: .init(row: 2, section: 0)),
@@ -250,7 +250,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
             .insert(0, index: .init(row: 5, section: 0))
         ]
 
-        let indices = mapper.resolve(
+        let indices = listChangeIndexPathResolver.resolve(
             changes: changes
         )
 
@@ -258,7 +258,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
     }
 
     func test_resolve_whenRemoveAndMoveFromWithSameIndex_hasConflicts_returnsNil() {
-        let mapper = ListChangeIndexPathResolver()
+        let listChangeIndexPathResolver = ListChangeIndexPathResolver()
 
         let changes: [ListChange<Int>] = [
             .update(0, index: .init(row: 11, section: 0)),
@@ -271,7 +271,7 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
             .insert(0, index: .init(row: 5, section: 0))
         ]
 
-        let indices = mapper.resolve(
+        let indices = listChangeIndexPathResolver.resolve(
             changes: changes
         )
 

--- a/Tests/StreamChatUITests/Utils/ListChangeIndexPathResolver_Tests.swift
+++ b/Tests/StreamChatUITests/Utils/ListChangeIndexPathResolver_Tests.swift
@@ -8,30 +8,9 @@ import Foundation
 import XCTest
 
 final class ListChangeIndexPathResolver_Tests: XCTestCase {
-    func test_hasConflicts_returnsNil() {
+    func test_resolve_whenHasNoConflicts_returnsIndices() {
         let mapper = ListChangeIndexPathResolver()
-        
-        let changes: [ListChange<Int>] = [
-            .update(0, index: .init(row: 0, section: 0)),
-            .move(
-                0,
-                fromIndex: .init(row: 0, section: 0),
-                toIndex: .init(row: 1, section: 0)
-            ),
-            .remove(0, index: .init(row: 0, section: 0)),
-            .insert(0, index: .init(row: 0, section: 0))
-        ]
 
-        let indices = mapper.mapToSetsOfIndexPaths(
-            changes: changes
-        )
-
-        XCTAssertNil(indices)
-    }
-    
-    func test_hasNoConflicts_returnsIndices() {
-        let mapper = ListChangeIndexPathResolver()
-        
         let changes: [ListChange<Int>] = [
             .update(0, index: .init(row: 0, section: 0)),
             .move(
@@ -42,10 +21,10 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
             .remove(0, index: .init(row: 3, section: 2))
         ]
 
-        let indices = mapper.mapToSetsOfIndexPaths(
+        let indices = mapper.resolve(
             changes: changes
         )
-        
+
         XCTAssertEqual(
             indices?.update,
             [
@@ -64,5 +43,238 @@ final class ListChangeIndexPathResolver_Tests: XCTestCase {
                 .init(row: 3, section: 2)
             ]
         )
+    }
+
+    func test_resolve_whenInsertAndUpdateWithSameIndex_hasNoConflicts_returnsIndices() {
+        let mapper = ListChangeIndexPathResolver()
+
+        let changes: [ListChange<Int>] = [
+            .update(0, index: .init(row: 0, section: 0)),
+            .move(
+                0,
+                fromIndex: .init(row: 1, section: 1),
+                toIndex: .init(row: 2, section: 1)
+            ),
+            .remove(0, index: .init(row: 3, section: 2)),
+            .insert(0, index: .init(row: 0, section: 0))
+        ]
+
+        let indices = mapper.resolve(
+            changes: changes
+        )
+
+        XCTAssertEqual(
+            indices?.update,
+            [
+                .init(row: 0, section: 0)
+            ]
+        )
+        XCTAssertEqual(
+            indices?.move,
+            [
+                .init(.init(row: 1, section: 1), .init(row: 2, section: 1))
+            ]
+        )
+        XCTAssertEqual(
+            indices?.remove,
+            [
+                .init(row: 3, section: 2)
+            ]
+        )
+        XCTAssertEqual(
+            indices?.insert,
+            [
+                .init(row: 0, section: 0)
+            ]
+        )
+    }
+
+    func test_resolve_whenAllWithSameIndex_hasConflicts_returnsNil() {
+        let mapper = ListChangeIndexPathResolver()
+        
+        let changes: [ListChange<Int>] = [
+            .update(0, index: .init(row: 0, section: 0)),
+            .move(
+                0,
+                fromIndex: .init(row: 0, section: 0),
+                toIndex: .init(row: 1, section: 0)
+            ),
+            .remove(0, index: .init(row: 0, section: 0)),
+            .insert(0, index: .init(row: 0, section: 0))
+        ]
+
+        let indices = mapper.resolve(
+            changes: changes
+        )
+
+        XCTAssertNil(indices)
+    }
+
+    func test_resolve_whenInsertAndRemoveWithSameIndex_hasConflicts_returnsNil() {
+        let mapper = ListChangeIndexPathResolver()
+
+        let changes: [ListChange<Int>] = [
+            .update(0, index: .init(row: 5, section: 0)),
+            .move(
+                0,
+                fromIndex: .init(row: 6, section: 0),
+                toIndex: .init(row: 1, section: 0)
+            ),
+            .remove(0, index: .init(row: 0, section: 0)),
+            .insert(0, index: .init(row: 0, section: 0))
+        ]
+
+        let indices = mapper.resolve(
+            changes: changes
+        )
+
+        XCTAssertNil(indices)
+    }
+
+    func test_resolve_whenInsertAndMoveFromWithSameIndex_hasConflicts_returnsNil() {
+        let mapper = ListChangeIndexPathResolver()
+
+        let changes: [ListChange<Int>] = [
+            .update(0, index: .init(row: 5, section: 0)),
+            .move(
+                0,
+                fromIndex: .init(row: 0, section: 0),
+                toIndex: .init(row: 1, section: 0)
+            ),
+            .remove(0, index: .init(row: 8, section: 0)),
+            .insert(0, index: .init(row: 0, section: 0))
+        ]
+
+        let indices = mapper.resolve(
+            changes: changes
+        )
+
+        XCTAssertNil(indices)
+    }
+
+    func test_resolve_whenInsertAndMoveToWithSameIndex_hasConflicts_returnsNil() {
+        let mapper = ListChangeIndexPathResolver()
+
+        let changes: [ListChange<Int>] = [
+            .update(0, index: .init(row: 5, section: 0)),
+            .move(
+                0,
+                fromIndex: .init(row: 1, section: 0),
+                toIndex: .init(row: 0, section: 0)
+            ),
+            .remove(0, index: .init(row: 8, section: 0)),
+            .insert(0, index: .init(row: 0, section: 0))
+        ]
+
+        let indices = mapper.resolve(
+            changes: changes
+        )
+
+        XCTAssertNil(indices)
+    }
+
+    func test_resolve_whenUpdateAndRemoveWithSameIndex_hasConflicts_returnsNil() {
+        let mapper = ListChangeIndexPathResolver()
+
+        let changes: [ListChange<Int>] = [
+            .update(0, index: .init(row: 0, section: 0)),
+            .move(
+                0,
+                fromIndex: .init(row: 6, section: 0),
+                toIndex: .init(row: 1, section: 0)
+            ),
+            .remove(0, index: .init(row: 0, section: 0)),
+            .insert(0, index: .init(row: 5, section: 0))
+        ]
+
+        let indices = mapper.resolve(
+            changes: changes
+        )
+
+        XCTAssertNil(indices)
+    }
+
+    func test_resolve_whenUpdateAndMoveFromWithSameIndex_hasConflicts_returnsNil() {
+        let mapper = ListChangeIndexPathResolver()
+
+        let changes: [ListChange<Int>] = [
+            .update(0, index: .init(row: 0, section: 0)),
+            .move(
+                0,
+                fromIndex: .init(row: 0, section: 0),
+                toIndex: .init(row: 6, section: 0)
+            ),
+            .remove(0, index: .init(row: 10, section: 0)),
+            .insert(0, index: .init(row: 5, section: 0))
+        ]
+
+        let indices = mapper.resolve(
+            changes: changes
+        )
+
+        XCTAssertNil(indices)
+    }
+
+    func test_resolve_whenUpdateAndMoveToWithSameIndex_hasConflicts_returnsNil() {
+        let mapper = ListChangeIndexPathResolver()
+
+        let changes: [ListChange<Int>] = [
+            .update(0, index: .init(row: 0, section: 0)),
+            .move(
+                0,
+                fromIndex: .init(row: 6, section: 0),
+                toIndex: .init(row: 0, section: 0)
+            ),
+            .remove(0, index: .init(row: 10, section: 0)),
+            .insert(0, index: .init(row: 5, section: 0))
+        ]
+
+        let indices = mapper.resolve(
+            changes: changes
+        )
+
+        XCTAssertNil(indices)
+    }
+
+    func test_resolve_whenRemoveAndMoveToWithSameIndex_hasConflicts_returnsNil() {
+        let mapper = ListChangeIndexPathResolver()
+
+        let changes: [ListChange<Int>] = [
+            .update(0, index: .init(row: 2, section: 0)),
+            .move(
+                0,
+                fromIndex: .init(row: 6, section: 0),
+                toIndex: .init(row: 0, section: 0)
+            ),
+            .remove(0, index: .init(row: 0, section: 0)),
+            .insert(0, index: .init(row: 5, section: 0))
+        ]
+
+        let indices = mapper.resolve(
+            changes: changes
+        )
+
+        XCTAssertNil(indices)
+    }
+
+    func test_resolve_whenRemoveAndMoveFromWithSameIndex_hasConflicts_returnsNil() {
+        let mapper = ListChangeIndexPathResolver()
+
+        let changes: [ListChange<Int>] = [
+            .update(0, index: .init(row: 11, section: 0)),
+            .move(
+                0,
+                fromIndex: .init(row: 0, section: 0),
+                toIndex: .init(row: 3, section: 0)
+            ),
+            .remove(0, index: .init(row: 0, section: 0)),
+            .insert(0, index: .init(row: 5, section: 0))
+        ]
+
+        let indices = mapper.resolve(
+            changes: changes
+        )
+
+        XCTAssertNil(indices)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Switching the `ListChangeAggregator` to the `newIndexPath` caused multiple crashes. In Apple documentation, they use the `oldIndexPath`, so this PR reverts that change and also stops checking for conflicts between Inserts and Updates to avoid unnecessary reload data.

### 📝 Summary
- Reverts the ListChangeAggregator Update IndexPath. Switches back to the oldIndexPath.
- Don't treat Insert<->Updates has conflicts in `ListChangeIndexPathResolver`

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)