### PR TITLE
Add logging to failed parsed elements from an array

### DIFF
--- a/Sources/StreamChat/Utils/KeyedDecodingContainer+Array.swift
+++ b/Sources/StreamChat/Utils/KeyedDecodingContainer+Array.swift
@@ -6,14 +6,25 @@ import Foundation
 
 private struct ElementWrapper<T: Decodable>: Decodable {
     let value: T?
+    var error: Error?
     init(from decoder: Decoder) throws {
-        value = try? T(from: decoder)
+        do {
+            value = try T(from: decoder)
+        } catch {
+            value = nil
+            self.error = error
+        }
     }
 }
 
 extension KeyedDecodingContainer {
     func decodeArrayIgnoringFailures<T: Decodable>(_ type: [T].Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> [T] {
         let wrapper = try decode([ElementWrapper<T>].self, forKey: key)
+        let errors = wrapper.compactMap(\.error)
+        if !errors.isEmpty {
+            let errorsDescription = errors.map(String.init(describing:))
+            log.error("Failed decoding elements from array: \(errorsDescription)", subsystems: .httpRequests)
+        }
         return wrapper.compactMap(\.value)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Improve the error logging of failed parsed elements from an array. We were not logging any failed parsed events from the Missing Events Payload.

### 📝 Summary
Added a way to log errors from `decodeArrayIgnoringFailures`.

### 🎨 Showcase
```
🚨 2022-06-09 12:53:00.476 [ERROR] [com.apple.NSURLSession-delegate] [KeyedDecodingContainer+Array.swift:26] 
[decodeArrayIgnoringFailures(_:forKey:)] > Failed decoding elements from array:
["dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: \"events\", intValue: nil),
_JSONKey(stringValue: \"Index 0\", intValue: 0), CodingKeys(stringValue: \"message\", intValue: nil),
MessagePayloadsCodingKeys(stringValue: \"type\", intValue: nil)], debugDescription: \"Cannot initialize MessageType from
 invalid String value \", underlyingError: nil))", 
"dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: \"events\", intValue: nil),
_JSONKey(stringValue: \"Index 1\", intValue: 1), CodingKeys(stringValue: \"message\", intValue: nil), 
MessagePayloadsCodingKeys(stringValue: \"type\", intValue: nil)], debugDescription: \"Cannot initialize MessageType from
 invalid String value \", underlyingError: nil))"]
```

### 🧪 Manual Testing Notes
N/A