### PR TITLE
[CIS-425] Thread typing indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _June 10, 2022_
 - The `tokenProvider` property was removed from `ChatClient` [#2031](https://github.com/GetStream/stream-chat-swift/issues/2031)
 ### ✅ Added
 - Make it possible to call `ChatClient.connect` with a `tokenProvider` [#2031](https://github.com/GetStream/stream-chat-swift/issues/2031)
+- `parentMessageId` parameter for typing events [#2080](https://github.com/GetStream/stream-chat-swift/issues/2080)
 ### 🐞 Fixed
 - Saving payloads to local database is now 50% faster. Initial launch and displaying channel list should be noticeably faster [#1973](https://github.com/GetStream/stream-chat-swift/issues/1973)
 - Fix not waiting for last batch of events to be processed when connecting as another user [#2016](https://github.com/GetStream/stream-chat-swift/issues/2016)
@@ -37,7 +38,7 @@ _June 10, 2022_
 - Add Support for Slow Mode [#1953](https://github.com/GetStream/stream-chat-swift/pull/1953)
 - Present channel screen modally when channel list in not embedded by navigation controller [#2011](https://github.com/GetStream/stream-chat-swift/pull/2011)
 - Show channel screen as right detail when channel list is embedded by split view controller [#2011](https://github.com/GetStream/stream-chat-swift/pull/2011)
-- Show typing users within a thread [#2079](https://github.com/GetStream/stream-chat-swift/issues/2079)
+- Show typing users within a thread [#2080](https://github.com/GetStream/stream-chat-swift/issues/2080)
 ### 🐞 Fixed
 - Fix DM Channel with multiple members displaying only 1 user avatar [#2019](https://github.com/GetStream/stream-chat-swift/pull/2019)
 - Improve stability of Message List with Diffing disabled [#2006](https://github.com/GetStream/stream-chat-swift/pull/2006) [#2076](https://github.com/GetStream/stream-chat-swift/pull/2076)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ _June 10, 2022_
 - Add Support for Slow Mode [#1953](https://github.com/GetStream/stream-chat-swift/pull/1953)
 - Present channel screen modally when channel list in not embedded by navigation controller [#2011](https://github.com/GetStream/stream-chat-swift/pull/2011)
 - Show channel screen as right detail when channel list is embedded by split view controller [#2011](https://github.com/GetStream/stream-chat-swift/pull/2011)
+- Show typing users within a thread [#2079](https://github.com/GetStream/stream-chat-swift/issues/2079)
 ### 🐞 Fixed
 - Fix DM Channel with multiple members displaying only 1 user avatar [#2019](https://github.com/GetStream/stream-chat-swift/pull/2019)
 - Improve stability of Message List with Diffing disabled [#2006](https://github.com/GetStream/stream-chat-swift/pull/2006) [#2076](https://github.com/GetStream/stream-chat-swift/pull/2076)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 ## StreamChat
-### 🐞 Fixed
-- Fix Logger persisting config after usage, preventing changing parameters (such as LogLevel) [#2081](https://github.com/GetStream/stream-chat-swift/issues/2081)
-
-## StreamChat
+### ✅ Added
+- `parentMessageId` parameter for typing events [#2080](https://github.com/GetStream/stream-chat-swift/issues/2080)
 ### 🐞 Fixed
 - Fix hidden channels not appearing on relaunch [#2056](https://github.com/GetStream/stream-chat-swift/issues/2056)
 - Fix `channel.hidden` event failing to decode on launch/reconnection [#2056](https://github.com/GetStream/stream-chat-swift/issues/2056)
 - Fix messages in hidden channels with `clearHistory` re-appearing [#2056](https://github.com/GetStream/stream-chat-swift/issues/2056)
 - Fix last message of hidden channel with `clearHistory` visible in channel list [#2056](https://github.com/GetStream/stream-chat-swift/issues/2056)
 - Message action title now supports displaying 2 lines of text instead of 1 [#2082](https://github.com/GetStream/stream-chat-swift/pull/2082)
+- Fix Logger persisting config after usage, preventing changing parameters (such as LogLevel) [#2081](https://github.com/GetStream/stream-chat-swift/issues/2081)
+
+## StreamChatUI
+### ✅ Added
+- Show typing users within a thread [#2080](https://github.com/GetStream/stream-chat-swift/issues/2080)
 
 # [4.16.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.16.0)
 _June 10, 2022_
@@ -21,7 +24,6 @@ _June 10, 2022_
 - The `tokenProvider` property was removed from `ChatClient` [#2031](https://github.com/GetStream/stream-chat-swift/issues/2031)
 ### ✅ Added
 - Make it possible to call `ChatClient.connect` with a `tokenProvider` [#2031](https://github.com/GetStream/stream-chat-swift/issues/2031)
-- `parentMessageId` parameter for typing events [#2080](https://github.com/GetStream/stream-chat-swift/issues/2080)
 ### 🐞 Fixed
 - Saving payloads to local database is now 50% faster. Initial launch and displaying channel list should be noticeably faster [#1973](https://github.com/GetStream/stream-chat-swift/issues/1973)
 - Fix not waiting for last batch of events to be processed when connecting as another user [#2016](https://github.com/GetStream/stream-chat-swift/issues/2016)
@@ -38,7 +40,6 @@ _June 10, 2022_
 - Add Support for Slow Mode [#1953](https://github.com/GetStream/stream-chat-swift/pull/1953)
 - Present channel screen modally when channel list in not embedded by navigation controller [#2011](https://github.com/GetStream/stream-chat-swift/pull/2011)
 - Show channel screen as right detail when channel list is embedded by split view controller [#2011](https://github.com/GetStream/stream-chat-swift/pull/2011)
-- Show typing users within a thread [#2080](https://github.com/GetStream/stream-chat-swift/issues/2080)
 ### 🐞 Fixed
 - Fix DM Channel with multiple members displaying only 1 user avatar [#2019](https://github.com/GetStream/stream-chat-swift/pull/2019)
 - Improve stability of Message List with Diffing disabled [#2006](https://github.com/GetStream/stream-chat-swift/pull/2006) [#2076](https://github.com/GetStream/stream-chat-swift/pull/2076)

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
@@ -218,6 +218,40 @@ extension Endpoint {
         )
     }
     
+    static func startTypingEvent(cid: ChannelId, parentMessageId: MessageId?) -> Endpoint<EmptyResponse> {
+        let eventType = EventType.userStartTyping
+        let body: Encodable
+        if let parentMessageId = parentMessageId {
+            body = ["event": ["type": eventType.rawValue, "parent_id": parentMessageId]]
+        } else {
+            body = ["event": ["type": eventType]]
+        }
+        return .init(
+            path: .channelEvent(cid.apiPath),
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: body
+        )
+    }
+    
+    static func stopTypingEvent(cid: ChannelId, parentMessageId: MessageId?) -> Endpoint<EmptyResponse> {
+        let eventType = EventType.userStopTyping
+        let body: Encodable
+        if let parentMessageId = parentMessageId {
+            body = ["event": ["type": eventType.rawValue, "parent_id": parentMessageId]]
+        } else {
+            body = ["event": ["type": eventType]]
+        }
+        return .init(
+            path: .channelEvent(cid.apiPath),
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: body
+        )
+    }
+    
     static func enableSlowMode(cid: ChannelId, cooldownDuration: Int) -> Endpoint<EmptyResponse> {
         .init(
             path: .channelUpdate(cid.apiPath),

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -791,7 +791,7 @@ public extension ChatChannelController {
     ///
     /// - Parameter completion: a completion block with an error if the request was failed.
     ///
-    func sendKeystrokeEvent(completion: ((Error?) -> Void)? = nil) {
+    func sendKeystrokeEvent(parentMessageId: MessageId? = nil, completion: ((Error?) -> Void)? = nil) {
         /// Ignore if typing events are not enabled
         guard areTypingEventsEnabled else {
             callback {
@@ -806,7 +806,7 @@ public extension ChatChannelController {
             return
         }
         
-        eventSender.keystroke(in: cid) { error in
+        eventSender.keystroke(in: cid, parentMessageId: parentMessageId) { error in
             self.callback {
                 completion?(error)
             }
@@ -821,7 +821,7 @@ public extension ChatChannelController {
     ///
     /// - Parameter completion: a completion block with an error if the request was failed.
     ///
-    func sendStartTypingEvent(completion: ((Error?) -> Void)? = nil) {
+    func sendStartTypingEvent(parentMessageId: MessageId? = nil, completion: ((Error?) -> Void)? = nil) {
         /// Ignore if typing events are not enabled
         guard areTypingEventsEnabled else {
             channelFeatureDisabled(feature: "typing events", completion: completion)
@@ -834,7 +834,7 @@ public extension ChatChannelController {
             return
         }
         
-        eventSender.startTyping(in: cid) { error in
+        eventSender.startTyping(in: cid, parentMessageId: parentMessageId) { error in
             self.callback {
                 completion?(error)
             }
@@ -849,7 +849,7 @@ public extension ChatChannelController {
     ///
     /// - Parameter completion: a completion block with an error if the request was failed.
     ///
-    func sendStopTypingEvent(completion: ((Error?) -> Void)? = nil) {
+    func sendStopTypingEvent(parentMessageId: MessageId? = nil, completion: ((Error?) -> Void)? = nil) {
         /// Ignore if typing events are not enabled
         guard areTypingEventsEnabled else {
             channelFeatureDisabled(feature: "typing events", completion: completion)
@@ -862,7 +862,7 @@ public extension ChatChannelController {
             return
         }
         
-        eventSender.stopTyping(in: cid) { error in
+        eventSender.stopTyping(in: cid, parentMessageId: parentMessageId) { error in
             self.callback {
                 completion?(error)
             }
@@ -901,7 +901,7 @@ public extension ChatChannelController {
         }
         
         /// Send stop typing event.
-        eventSender.stopTyping(in: cid)
+        eventSender.stopTyping(in: cid, parentMessageId: nil)
         
         updater.createNewMessage(
             in: cid,

--- a/Sources/StreamChat/Workers/TypingEventsSender.swift
+++ b/Sources/StreamChat/Workers/TypingEventsSender.swift
@@ -6,7 +6,7 @@ import Foundation
 
 extension TimeInterval {
     /// The number of seconds from the last `typingStart` event until the `typingStop` event is automatically sent.
-    static let startTypingEventTimeout: TimeInterval = 5
+    static let startTypingEventTimeout: TimeInterval = 7
     
     /// If the user is typing too long, `EventSender` should resend the `.typingStart` event.
     /// It should be before `.startTypingEventTimeout` and after `.startTypingEventTimeout` will be sent the stop typing event.

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -288,22 +288,22 @@ open class ChatThreadVC: _ViewController,
     
     // MARK: - EventsControllerDelegate
     
-    private var currentlyTypingUsers: [ChatUser] = []
+    private var currentlyTypingUsers: Set<ChatUser> = []
     
     open func eventsController(_ controller: EventsController, didReceiveEvent event: Event) {
         switch event {
         case let event as TypingEvent:
             guard event.parentId == messageController.messageId && event.user.id != client.currentUserId else { return }
             if event.isTyping {
-                currentlyTypingUsers.append(event.user)
+                currentlyTypingUsers.insert(event.user)
             } else {
-                currentlyTypingUsers.removeAll(where: { $0.id == event.user.id })
+                currentlyTypingUsers.remove(event.user)
             }
             
             if currentlyTypingUsers.isEmpty {
                 messageListVC.hideTypingIndicator()
             } else {
-                messageListVC.showTypingIndicator(typingUsers: currentlyTypingUsers)
+                messageListVC.showTypingIndicator(typingUsers: Array(currentlyTypingUsers))
             }
         default:
             break

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -382,7 +382,7 @@ open class ComposerVC: _ViewController,
         }
 
         if !content.isEmpty && channelConfig?.typingEventsEnabled == true {
-            channelController?.sendKeystrokeEvent()
+            channelController?.sendKeystrokeEvent(parentMessageId: content.threadMessage?.id)
         }
 
         switch content.state {

--- a/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
@@ -562,4 +562,52 @@ extension MessageList_Tests {
                 .assertDeletedMessage()
         }
     }
+    
+    func test_threadTypingIndicatorShown_whenParticipantStartsTyping() {
+        linkToScenario(withId: 243)
+        
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user sends a message") {
+            userRobot.sendMessage("Hey")
+        }
+        AND("user opens the thread") {
+            userRobot.showThread()
+        }
+        WHEN("participant starts typing in thread") {
+            participantRobot.startTypingInThread()
+        }
+        THEN("user observes typing indicator is shown") {
+            let typingUserName = UserDetails.userName(for: participantRobot.currentUserId)
+            userRobot.assertTypingIndicatorShown(typingUserName: typingUserName)
+        }
+    }
+    
+    func test_threadTypingIndicatorHidden_whenParticipantStopsTyping() {
+        linkToScenario(withId: 244)
+        
+        GIVEN("user opens the channel") {
+            userRobot
+                .login()
+                .openChannel()
+        }
+        AND("user sends a message") {
+            userRobot.sendMessage("Hey")
+        }
+        AND("user opens the thread") {
+            userRobot.showThread()
+        }
+        WHEN("participant starts typing in thread") {
+            participantRobot.startTypingInThread()
+        }
+        AND("participant stops typing in thread") {
+            participantRobot.stopTypingInThread()
+        }
+        THEN("user observes typing indicator has disappeared") {
+            userRobot.assertTypingIndicatorHidden()
+        }
+    }
 }

--- a/TestTools/StreamChatTestMockServer/MockServer/WebsocketResponses.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/WebsocketResponses.swift
@@ -19,20 +19,27 @@ public extension StreamMockServer {
     func websocketEvent(
         _ eventType: EventType,
         user: [String: Any]?,
-        channelId: String
+        channelId: String,
+        parentMessageId: String? = nil
     ) -> Self {
-        let json = websocketEventJSON(eventType, user: user, channelId: channelId)
+        let json = websocketEventJSON(eventType, user: user, channelId: channelId, parentMessageId: parentMessageId)
         writeText(json.jsonToString())
         return self
     }
 
-    private func websocketEventJSON(_ eventType: EventType, user: [String: Any]?, channelId: String) -> [String: Any] {
+    private func websocketEventJSON(
+        _ eventType: EventType,
+        user: [String: Any]?,
+        channelId: String,
+        parentMessageId: String? = nil
+    ) -> [String: Any] {
         var json = TestData.getMockResponse(fromFile: .wsChatEvent).json
         json[EventPayload.CodingKeys.user.rawValue] = user
         json[EventPayload.CodingKeys.createdAt.rawValue] = TestData.currentDate
         json[EventPayload.CodingKeys.eventType.rawValue] = eventType.rawValue
         json[EventPayload.CodingKeys.channelId.rawValue] = channelId
         json[EventPayload.CodingKeys.channelType.rawValue] = ChannelType.messaging.rawValue
+        json[EventPayload.CodingKeys.parentId.rawValue] = parentMessageId
         json[EventPayload.CodingKeys.cid.rawValue] = "\(ChannelType.messaging.rawValue):\(channelId)"
         return json
     }

--- a/TestTools/StreamChatTestMockServer/Robots/ParticipantRobot.swift
+++ b/TestTools/StreamChatTestMockServer/Robots/ParticipantRobot.swift
@@ -31,11 +31,35 @@ public class ParticipantRobot {
     }
     
     @discardableResult
+    public func startTypingInThread() -> Self {
+        let parentId = threadParentId ?? (server.lastMessage?[MessagePayloadsCodingKeys.id.rawValue] as? String)
+        server.websocketEvent(
+            .userStartTyping,
+            user: participant(),
+            channelId: server.currentChannelId,
+            parentMessageId: parentId
+        )
+        return self
+    }
+    
+    @discardableResult
     public func stopTyping() -> Self {
         server.websocketEvent(
             .userStopTyping,
             user: participant(),
             channelId: server.currentChannelId
+        )
+        return self
+    }
+    
+    @discardableResult
+    public func stopTypingInThread() -> Self {
+        let parentId = threadParentId ?? (server.lastMessage?[MessagePayloadsCodingKeys.id.rawValue] as? String)
+        server.websocketEvent(
+            .userStopTyping,
+            user: participant(),
+            channelId: server.currentChannelId,
+            parentMessageId: parentId
         )
         return self
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/TypingEventsSender_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/TypingEventsSender_Mock.swift
@@ -8,37 +8,46 @@ import Foundation
 /// Mock implementation of ChannelUpdater
 final class TypingEventsSender_Mock: TypingEventsSender {
     @Atomic var keystroke_cid: ChannelId?
+    @Atomic var keystroke_parentMessageId: MessageId?
     @Atomic var keystroke_completion: ((Error?) -> Void)?
 
     @Atomic var startTyping_cid: ChannelId?
+    @Atomic var startTyping_parentMessageId: MessageId?
     @Atomic var startTyping_completion: ((Error?) -> Void)?
 
     @Atomic var stopTyping_cid: ChannelId?
+    @Atomic var stopTyping_parentMessageId: MessageId?
     @Atomic var stopTyping_completion: ((Error?) -> Void)?
 
-    override func keystroke(in cid: ChannelId, completion: ((Error?) -> Void)? = nil) {
+    override func keystroke(in cid: ChannelId, parentMessageId: MessageId?, completion: ((Error?) -> Void)? = nil) {
         keystroke_cid = cid
+        keystroke_parentMessageId = parentMessageId
         keystroke_completion = completion
     }
     
-    override func startTyping(in cid: ChannelId, completion: ((Error?) -> Void)? = nil) {
+    override func startTyping(in cid: ChannelId, parentMessageId: MessageId?, completion: ((Error?) -> Void)? = nil) {
         startTyping_cid = cid
+        startTyping_parentMessageId = parentMessageId
         startTyping_completion = completion
     }
     
-    override func stopTyping(in cid: ChannelId, completion: ((Error?) -> Void)? = nil) {
+    override func stopTyping(in cid: ChannelId, parentMessageId: MessageId?, completion: ((Error?) -> Void)? = nil) {
         stopTyping_cid = cid
+        stopTyping_parentMessageId = parentMessageId
         stopTyping_completion = completion
     }
     
     func cleanUp() {
         keystroke_cid = nil
+        keystroke_parentMessageId = nil
         keystroke_completion = nil
         
         startTyping_cid = nil
+        startTyping_parentMessageId = nil
         startTyping_completion = nil
         
         stopTyping_cid = nil
+        stopTyping_parentMessageId = nil
         stopTyping_completion = nil
     }
 }

--- a/Tests/StreamChatTests/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -388,6 +388,80 @@ final class ChannelEndpoints_Tests: XCTestCase {
         XCTAssertEqual("channels/\(cid.type.rawValue)/\(cid.id)/event", endpoint.path.value)
     }
     
+    func test_startTypingEvent_withParentMessageId_buildsCorrectly() {
+        let cid = ChannelId.unique
+        let messageId = MessageId.unique
+        let eventType = EventType.userStartTyping
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: .channelEvent(cid.apiPath),
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["event": ["type": eventType.rawValue, "parent_id": messageId]]
+        )
+        
+        let endpoint = Endpoint<EmptyResponse>.startTypingEvent(cid: cid, parentMessageId: messageId)
+        
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        XCTAssertEqual("channels/\(cid.type.rawValue)/\(cid.id)/event", endpoint.path.value)
+    }
+    
+    func test_startTypingEvent_withoutParentMessageId_buildsCorrectly() {
+        let cid = ChannelId.unique
+        let eventType = EventType.userStartTyping
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: .channelEvent(cid.apiPath),
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["event": ["type": eventType]]
+        )
+        
+        let endpoint = Endpoint<EmptyResponse>.startTypingEvent(cid: cid, parentMessageId: nil)
+        
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        XCTAssertEqual("channels/\(cid.type.rawValue)/\(cid.id)/event", endpoint.path.value)
+    }
+    
+    func test_stopTypingEvent_withParentMessageId_buildsCorrectly() {
+        let cid = ChannelId.unique
+        let messageId = MessageId.unique
+        let eventType = EventType.userStopTyping
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: .channelEvent(cid.apiPath),
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["event": ["type": eventType.rawValue, "parent_id": messageId]]
+        )
+        
+        let endpoint = Endpoint<EmptyResponse>.stopTypingEvent(cid: cid, parentMessageId: messageId)
+        
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        XCTAssertEqual("channels/\(cid.type.rawValue)/\(cid.id)/event", endpoint.path.value)
+    }
+    
+    func test_stopTypingEvent_withoutParentMessageId_buildsCorrectly() {
+        let cid = ChannelId.unique
+        let eventType = EventType.userStopTyping
+        
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: .channelEvent(cid.apiPath),
+            method: .post,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: ["event": ["type": eventType]]
+        )
+        
+        let endpoint = Endpoint<EmptyResponse>.stopTypingEvent(cid: cid, parentMessageId: nil)
+        
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        XCTAssertEqual("channels/\(cid.type.rawValue)/\(cid.id)/event", endpoint.path.value)
+    }
+    
     func test_enableSlowMode_buildsCorrectly() {
         let cid = ChannelId.unique
         let cooldownDuration = Int.random(in: 0...120)

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -2287,6 +2287,41 @@ final class ChannelController_Tests: XCTestCase {
         AssertAsync.canBeReleased(&weakController)
     }
     
+    func test_keystroke_withParentMessageId() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(typingEventsEnabled: true))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+        
+        let parentMessageId = MessageId.unique
+        
+        // Simulate `keystroke` call and catch the completion
+        var completionCalledError: Error?
+        controller.sendKeystrokeEvent(parentMessageId: parentMessageId) { completionCalledError = $0 }
+        
+        // Keep a weak ref so we can check if it's actually deallocated
+        weak var weakController = controller
+        
+        // (Try to) deallocate the controller
+        // by not keeping any references to it
+        controller = nil
+        
+        // Check keystroke cid and parentMessageId.
+        XCTAssertEqual(env.eventSender!.keystroke_cid, channelId)
+        XCTAssertEqual(env.eventSender!.keystroke_parentMessageId, parentMessageId)
+        
+        // Simulate failed update
+        let testError = TestError()
+        env.eventSender!.keystroke_completion!(testError)
+        // Release reference of completion so we can deallocate stuff
+        env.eventSender!.keystroke_completion = nil
+        
+        // Completion should be called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
+        // `weakController` should be deallocated too
+        AssertAsync.canBeReleased(&weakController)
+    }
+    
     func test_startTyping() throws {
         let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(typingEventsEnabled: true))
         try client.databaseContainer.writeSynchronously { session in
@@ -2323,6 +2358,41 @@ final class ChannelController_Tests: XCTestCase {
         AssertAsync.canBeReleased(&weakController)
     }
     
+    func test_startTyping_withParentMessageId() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(typingEventsEnabled: true))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+        
+        let parentMessageId = MessageId.unique
+        
+        // Simulate `startTyping` call and catch the completion
+        var completionCalledError: Error?
+        controller.sendStartTypingEvent(parentMessageId: parentMessageId) { completionCalledError = $0 }
+        
+        // Keep a weak ref so we can check if it's actually deallocated
+        weak var weakController = controller
+        
+        // (Try to) deallocate the controller
+        // by not keeping any references to it
+        controller = nil
+        
+        // Check `startTyping` cid and parentMessageId.
+        XCTAssertEqual(env.eventSender!.startTyping_cid, channelId)
+        XCTAssertEqual(env.eventSender!.startTyping_parentMessageId, parentMessageId)
+        
+        // Simulate failed update
+        let testError = TestError()
+        env.eventSender!.startTyping_completion!(testError)
+        // Release reference of completion so we can deallocate stuff
+        env.eventSender!.startTyping_completion = nil
+        
+        // Completion should be called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
+        // `weakController` should be deallocated too
+        AssertAsync.canBeReleased(&weakController)
+    }
+    
     func test_stopTyping() throws {
         let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(typingEventsEnabled: true))
         try client.databaseContainer.writeSynchronously { session in
@@ -2346,6 +2416,41 @@ final class ChannelController_Tests: XCTestCase {
         
         // Check `stopTyping` cid.
         XCTAssertEqual(env.eventSender!.stopTyping_cid, channelId)
+        
+        // Simulate failed update
+        let testError = TestError()
+        env.eventSender!.stopTyping_completion!(testError)
+        // Release reference of completion so we can deallocate stuff
+        env.eventSender!.stopTyping_completion = nil
+        
+        // Completion should be called with the error
+        AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
+        // `weakController` should be deallocated too
+        AssertAsync.canBeReleased(&weakController)
+    }
+    
+    func test_stopTyping_withParentMessageId() throws {
+        let payload = dummyPayload(with: channelId, channelConfig: ChannelConfig(typingEventsEnabled: true))
+        try client.databaseContainer.writeSynchronously { session in
+            try session.saveChannel(payload: payload)
+        }
+        
+        let parentMessageId = MessageId.unique
+        
+        // Simulate `stopTyping` call and catch the completion
+        var completionCalledError: Error?
+        controller.sendStopTypingEvent(parentMessageId: parentMessageId) { completionCalledError = $0 }
+        
+        // Keep a weak ref so we can check if it's actually deallocated
+        weak var weakController = controller
+        
+        // (Try to) deallocate the controller
+        // by not keeping any references to it
+        controller = nil
+        
+        // Check `stopTyping` cid and parentMessageId.
+        XCTAssertEqual(env.eventSender!.stopTyping_cid, channelId)
+        XCTAssertEqual(env.eventSender!.stopTyping_parentMessageId, parentMessageId)
         
         // Simulate failed update
         let testError = TestError()

--- a/Tests/StreamChatTests/Workers/TypingEventSender_Tests.swift
+++ b/Tests/StreamChatTests/Workers/TypingEventSender_Tests.swift
@@ -37,12 +37,13 @@ final class TypingEventsSender_Tests: XCTestCase {
         super.tearDown()
     }
     
-    func test_keystroke_sendsStartTypingAndStopTypingEvents() {
+    func test_keystroke_withoutParentMessageId_makesCorrectAPICalls() {
         // Send keystroke.
         let cid = ChannelId.unique
-        eventSender.keystroke(in: cid)
+        let parentMessageId: MessageId? = nil
+        eventSender.keystroke(in: cid, parentMessageId: parentMessageId)
         
-        let startTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStartTyping)
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .startTypingEvent(cid: cid, parentMessageId: parentMessageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(startTypingEndpoint))
         apiClient.request_endpoint = nil
         
@@ -50,21 +51,40 @@ final class TypingEventsSender_Tests: XCTestCase {
         time.run(numberOfSeconds: .startTypingEventTimeout)
         
         // Make sure the stop typing event has been sent.
-        let stopTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStopTyping)
+        let stopTypingEndpoint: Endpoint<EmptyResponse> = .stopTypingEvent(cid: cid, parentMessageId: parentMessageId)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(stopTypingEndpoint))
+    }
+    
+    func test_keystroke_sendsStartTypingAndStopTypingEvents() {
+        // Send keystroke.
+        let cid = ChannelId.unique
+        let parentMessageId = MessageId.unique
+        eventSender.keystroke(in: cid, parentMessageId: parentMessageId)
+        
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .startTypingEvent(cid: cid, parentMessageId: parentMessageId)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(startTypingEndpoint))
+        apiClient.request_endpoint = nil
+        
+        // Wait for the start typing event timeout.
+        time.run(numberOfSeconds: .startTypingEventTimeout)
+        
+        // Make sure the stop typing event has been sent.
+        let stopTypingEndpoint: Endpoint<EmptyResponse> = .stopTypingEvent(cid: cid, parentMessageId: parentMessageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(stopTypingEndpoint))
     }
     
     func test_keystroke_sendsStartTyping_andResetsTimer() {
         // Send keystroke.
         let cid = ChannelId.unique
-        eventSender.keystroke(in: cid)
+        let parentMessageId = MessageId.unique
+        eventSender.keystroke(in: cid, parentMessageId: parentMessageId)
         
-        let startTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStartTyping)
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .startTypingEvent(cid: cid, parentMessageId: parentMessageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(startTypingEndpoint))
         
         // Before typing timeout send keystroke after `.startTypingEventTimeout` - 1 to avoid sending the stop typing event.
         time.run(numberOfSeconds: .startTypingEventTimeout - 1)
-        eventSender.keystroke(in: cid)
+        eventSender.keystroke(in: cid, parentMessageId: parentMessageId)
         
         // Check the stop typing event wasn't sent after another `.startTypingEventTimeout` - 1.
         time.run(numberOfSeconds: .startTypingEventTimeout - 1)
@@ -74,36 +94,50 @@ final class TypingEventsSender_Tests: XCTestCase {
     func test_keystroke_sendsStartTypingEvent_afterResendInterval() {
         // Send keystroke.
         let cid = ChannelId.unique
-        eventSender.keystroke(in: cid)
+        let parentMessageId = MessageId.unique
+        eventSender.keystroke(in: cid, parentMessageId: parentMessageId)
         
         // Make a loop with a step less than `.startTypingEventTimeout` until `.startTypingResendInterval`.
         let stepTimeInterval = .startTypingEventTimeout - 1
         
         repeat {
             time.run(numberOfSeconds: stepTimeInterval)
-            eventSender.keystroke(in: cid)
+            eventSender.keystroke(in: cid, parentMessageId: parentMessageId)
         } while time.currentTime < .startTypingResendInterval
         
         // Only 1 other startTyping event should be sent, for a total of 2 events
-        let startTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStartTyping)
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .startTypingEvent(cid: cid, parentMessageId: parentMessageId)
         let calls: [AnyEndpoint] = apiClient.request_allRecordedCalls.map(\.endpoint)
         XCTAssertEqual(calls, [AnyEndpoint(startTypingEndpoint), AnyEndpoint(startTypingEndpoint)])
+    }
+    
+    func test_stopTyping_withoutParentMessageId_makesCorrectAPICall() {
+        let cid = ChannelId.unique
+        let parentMessageId: MessageId? = nil
+        
+        // Call stopTyping
+        eventSender.stopTyping(in: cid, parentMessageId: parentMessageId)
+        
+        // Check the start typing event has been sent.
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .stopTypingEvent(cid: cid, parentMessageId: parentMessageId)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(startTypingEndpoint))
     }
     
     func test_stopTyping_afterKeystroke() {
         // Send keystroke.
         let cid = ChannelId.unique
-        eventSender.keystroke(in: cid)
+        let parentMessageId = MessageId.unique
+        eventSender.keystroke(in: cid, parentMessageId: parentMessageId)
         
         // Check the start typing event has been sent.
-        let startTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStartTyping)
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .startTypingEvent(cid: cid, parentMessageId: parentMessageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(startTypingEndpoint))
         
         time.run(numberOfSeconds: .startTypingEventTimeout - 1)
         
         // Force to stop typing and it should reset scheduled stop typing timer.
-        eventSender.stopTyping(in: cid)
-        let stopTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStopTyping)
+        eventSender.stopTyping(in: cid, parentMessageId: parentMessageId)
+        let stopTypingEndpoint: Endpoint<EmptyResponse> = .stopTypingEvent(cid: cid, parentMessageId: parentMessageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(stopTypingEndpoint))
         XCTAssertEqual(apiClient.request_allRecordedCalls.count, 2)
         
@@ -114,84 +148,101 @@ final class TypingEventsSender_Tests: XCTestCase {
     
     func test_stopTypingIsSent_afterKeystroke_whenDeallocated() {
         let cid = ChannelId.unique
+        let parentMessageId = MessageId.unique
         
         // First send keystroke to store `cid` internally inside `typingEventsSender` to have CID for stopTyping.
-        eventSender.keystroke(in: cid)
+        eventSender.keystroke(in: cid, parentMessageId: parentMessageId)
         
         // Check the start typing event has been sent.
-        let startTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStartTyping)
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .startTypingEvent(cid: cid, parentMessageId: parentMessageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(startTypingEndpoint))
         
         // Deinit the eventSender
         eventSender = nil
         
         // Make sure the stop typing event has been sent.
-        let stopTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStopTyping)
+        let stopTypingEndpoint: Endpoint<EmptyResponse> = .stopTypingEvent(cid: cid, parentMessageId: parentMessageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(stopTypingEndpoint))
+    }
+    
+    func test_startTyping_withoutParentMessageId_makesCorrectAPICall() {
+        let cid = ChannelId.unique
+        let parentMessageId: MessageId? = nil
+        
+        // Call startTyping
+        eventSender.startTyping(in: cid, parentMessageId: parentMessageId)
+        
+        // Check the start typing event has been sent.
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .startTypingEvent(cid: cid, parentMessageId: parentMessageId)
+        XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(startTypingEndpoint))
     }
     
     func test_startTyping_sendsStartTypingEvent() {
         let cid = ChannelId.unique
+        let parentMessageId = MessageId.unique
         
         // Call startTyping
-        eventSender.startTyping(in: cid)
+        eventSender.startTyping(in: cid, parentMessageId: parentMessageId)
         
         // Check the start typing event has been sent.
-        let startTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStartTyping)
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .startTypingEvent(cid: cid, parentMessageId: parentMessageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(startTypingEndpoint))
     }
     
     func test_stopTyping_afterStartTyping() {
         let cid = ChannelId.unique
+        let parentMessageId = MessageId.unique
         
         // Call startTyping
-        eventSender.startTyping(in: cid)
+        eventSender.startTyping(in: cid, parentMessageId: parentMessageId)
         
         // Check the start typing event has been sent.
-        let startTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStartTyping)
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .startTypingEvent(cid: cid, parentMessageId: parentMessageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(startTypingEndpoint))
         
         // Call stopTyping
-        eventSender.stopTyping(in: cid)
+        eventSender.stopTyping(in: cid, parentMessageId: parentMessageId)
         
         // Make sure the stop typing event has been sent.
-        let stopTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStopTyping)
+        let stopTypingEndpoint: Endpoint<EmptyResponse> = .stopTypingEvent(cid: cid, parentMessageId: parentMessageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(stopTypingEndpoint))
     }
     
     func test_stopTypingIsSent_afterStartTyping_whenDeallocated() {
         let cid = ChannelId.unique
+        let parentMessageId = MessageId.unique
         
         // First send startTyping to store `cid` internally inside `typingEventsSender` to have CID for stopTyping.
-        eventSender.startTyping(in: cid)
+        eventSender.startTyping(in: cid, parentMessageId: parentMessageId)
         
         // Check the start typing event has been sent.
-        let startTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStartTyping)
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .startTypingEvent(cid: cid, parentMessageId: parentMessageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(startTypingEndpoint))
         
         // Deinit the eventSender
         eventSender = nil
         
         // Make sure the stop typing event has been sent.
-        let stopTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStopTyping)
+        let stopTypingEndpoint: Endpoint<EmptyResponse> = .stopTypingEvent(cid: cid, parentMessageId: parentMessageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(stopTypingEndpoint))
     }
     
     func test_stopTypingIsNotSentTwice_afterKeystroke_whenDeallocated() {
         let cid = ChannelId.unique
+        let parentMessageId = MessageId.unique
         
         // First send startTyping to store `cid` internally inside `typingEventsSender` to have CID for stopTyping.
-        eventSender.keystroke(in: cid)
+        eventSender.keystroke(in: cid, parentMessageId: parentMessageId)
         
         // Check the start typing event has been sent.
-        let startTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStartTyping)
+        let startTypingEndpoint: Endpoint<EmptyResponse> = .startTypingEvent(cid: cid, parentMessageId: parentMessageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(startTypingEndpoint))
         
         // Run the time until stopTyping is sent by the timer
         time.run(numberOfSeconds: .startTypingEventTimeout)
         
         // Make sure the stop typing event has been sent.
-        let stopTypingEndpoint: Endpoint<EmptyResponse> = .sendEvent(cid: cid, eventType: .userStopTyping)
+        let stopTypingEndpoint: Endpoint<EmptyResponse> = .stopTypingEvent(cid: cid, parentMessageId: parentMessageId)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(stopTypingEndpoint))
         XCTAssertEqual(apiClient.request_allRecordedCalls.count, 2)
         


### PR DESCRIPTION
### 🔗 Issue Links

#1828 
CIS-425

### 🎯 Goal

Thread typing indicators were introduced to backend long time ago, and iOS client should support them

### 📝 Summary

* Typing-related functions now accept `parentMessageId: MessageId?`
* `ChatThreadVC` now shows typing users within a thread

### 🛠 Implementation

Feature is implemented with API-parity in mind. Now, typing related functions in `ChannelController` accept `parentMessageId: MessageId?` and this param is passed to backend in typing events. Receiving part was already implemented so this PR does not touch there.

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  ![Simulator Screen Recording - iPhone 13 Pro - 2022-06-09 at 17 08 36](https://user-images.githubusercontent.com/770464/172880852-74afc419-123b-4a8a-b6d4-aaba91573bbf.gif)   |  ![Simulator Screen Recording - iPhone 13 Pro - 2022-06-09 at 17 09 51](https://user-images.githubusercontent.com/770464/172881119-9d92249a-d683-4587-9f31-0d0de4c7a906.gif)  |

### 🧪 Manual Testing Notes

Launch 2 clients, enter a thread, start typing!

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)
