### PR TITLE
Fix Logger persisting config after usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
+## StreamChat
+### 🐞 Fixed
+- Fix Logger persisting config after usage, preventing changing parameters (such as LogLevel) [#2081](https://github.com/GetStream/stream-chat-swift/issues/2081)
 
 ## StreamChat
 ### 🐞 Fixed

--- a/Sources/StreamChat/Utils/Logger/Logger.swift
+++ b/Sources/StreamChat/Utils/Logger/Logger.swift
@@ -133,30 +133,39 @@ public enum LogConfig {
         }
     }
     
+    private static var _destinations: [LogDestination]?
+    
     /// Destinations for the default logger. Please see `LogDestination`.
     /// Defaults to only `ConsoleLogDestination`, which only prints the messages.
     ///
     /// - Important: Other options in `ChatClientConfig.Logging` will not take affect if this is changed.
-    public static var destinations: [LogDestination] = {
-        destinationTypes.map {
-            $0.init(
-                identifier: identifier,
-                level: level,
-                subsystems: subsystems,
-                showDate: showDate,
-                dateFormatter: dateFormatter,
-                formatters: formatters,
-                showLevel: showLevel,
-                showIdentifier: showIdentifier,
-                showThreadName: showThreadName,
-                showFileName: showFileName,
-                showLineNumber: showLineNumber,
-                showFunctionName: showFunctionName
-            )
+    public static var destinations: [LogDestination] {
+        get {
+            if let destinations = _destinations {
+                return destinations
+            } else {
+                _destinations = destinationTypes.map {
+                    $0.init(
+                        identifier: identifier,
+                        level: level,
+                        subsystems: subsystems,
+                        showDate: showDate,
+                        dateFormatter: dateFormatter,
+                        formatters: formatters,
+                        showLevel: showLevel,
+                        showIdentifier: showIdentifier,
+                        showThreadName: showThreadName,
+                        showFileName: showFileName,
+                        showLineNumber: showLineNumber,
+                        showFunctionName: showFunctionName
+                    )
+                }
+                return _destinations!
+            }
         }
-    }() {
-        didSet {
+        set {
             invalidateLogger()
+            _destinations = newValue
         }
     }
     
@@ -183,6 +192,7 @@ public enum LogConfig {
     /// Invalidates the current logger instance so it can be recreated.
     private static func invalidateLogger() {
         _logger = nil
+        _destinations = nil
     }
 }
 


### PR DESCRIPTION
### 📝 Summary

`LogConfig` persisted `destinations` so any change made after it was created did not take affect

### 🛠 Implementation

After the DemoApp restructure, `Logger` initialized before we set `level` on it, and it persisted the default level (`error`)

Investigation showed that `Logger` initializes when we create an `APIKey`, and `destinations` persist so changing `level` do not create new `destinations`

### 🧪 Manual Testing Notes

Try to change `LogLevel.level = .debug` and observe it doesn't work

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)
