### PR TITLE
Fix ChannelListSortingKey.unreadCount crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix last message of hidden channel with `clearHistory` visible in channel list [#2056](https://github.com/GetStream/stream-chat-swift/issues/2056)
 - Message action title now supports displaying 2 lines of text instead of 1 [#2082](https://github.com/GetStream/stream-chat-swift/pull/2082)
 - Fix Logger persisting config after usage, preventing changing parameters (such as LogLevel) [#2081](https://github.com/GetStream/stream-chat-swift/issues/2081)
+- Fix `ChannelListSortingKey.unreadCount` causing database crash [#2094](https://github.com/GetStream/stream-chat-swift/issues/2094)
 ### 🔄 Changed
 - JSON decoding performance is increased 3 times, parsing time reduced by %70 [#2081](https://github.com/GetStream/stream-chat-swift/issues/2081)
 

--- a/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
+++ b/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
@@ -33,7 +33,7 @@ public enum ChannelListSortingKey: String, SortingKey {
         case .memberCount: return true
         case .cid: return true
         case .hasUnread: return false
-        case .unreadCount: return true
+        case .unreadCount: return false
         case .default: return true
         }
     }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 		79B5517724E595DA00CE9FEC /* CurrentUserPayloads_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B5517624E595DA00CE9FEC /* CurrentUserPayloads_Tests.swift */; };
 		79B5517824E5969700CE9FEC /* UserPayloads_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B5517024E593C200CE9FEC /* UserPayloads_Tests.swift */; };
 		79B5517C24E6A1CA00CE9FEC /* MessagePayloads_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B5517B24E6A1CA00CE9FEC /* MessagePayloads_Tests.swift */; };
+		79B8B649285B5ADD0059FB2D /* ChannelListSortingKey_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B8B648285B5ADD0059FB2D /* ChannelListSortingKey_Tests.swift */; };
 		79BA19F324B3386B00E11FC2 /* CurrentUserDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BA19F224B3386B00E11FC2 /* CurrentUserDTO_Tests.swift */; };
 		79BF83F2248F8F60007611A1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BF83F1248F8F60007611A1 /* Logger.swift */; };
 		79C5CBE825F66DBD00D98001 /* ChatChannelWatcherListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C5CBE725F66DBD00D98001 /* ChatChannelWatcherListController.swift */; };
@@ -2579,6 +2580,7 @@
 		79B5517424E595CC00CE9FEC /* CurrentUserPayloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserPayloads.swift; sourceTree = "<group>"; };
 		79B5517624E595DA00CE9FEC /* CurrentUserPayloads_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserPayloads_Tests.swift; sourceTree = "<group>"; };
 		79B5517B24E6A1CA00CE9FEC /* MessagePayloads_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagePayloads_Tests.swift; sourceTree = "<group>"; };
+		79B8B648285B5ADD0059FB2D /* ChannelListSortingKey_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListSortingKey_Tests.swift; sourceTree = "<group>"; };
 		79BA19F224B3386B00E11FC2 /* CurrentUserDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserDTO_Tests.swift; sourceTree = "<group>"; };
 		79BF83F1248F8F60007611A1 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		79C5CBE725F66DBD00D98001 /* ChatChannelWatcherListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelWatcherListController.swift; sourceTree = "<group>"; };
@@ -6347,6 +6349,7 @@
 			isa = PBXGroup;
 			children = (
 				791D3D8F26776BE400E3A0F9 /* ChannelMemberListSortingKey_Tests.swift */,
+				79B8B648285B5ADD0059FB2D /* ChannelListSortingKey_Tests.swift */,
 				DA958D5325309917005D23FA /* Sorting_Tests.swift */,
 			);
 			path = Sorting;
@@ -9888,6 +9891,7 @@
 				A3960E0D27DA5973003AB2B0 /* ConnectionRecoveryHandler_Tests.swift in Sources */,
 				7931818E24FD4275002F8C84 /* ChannelListController+Combine_Tests.swift in Sources */,
 				88EA9B0625472430007EE76B /* MessageReactionPayload_Tests.swift in Sources */,
+				79B8B649285B5ADD0059FB2D /* ChannelListSortingKey_Tests.swift in Sources */,
 				84F61270268B415C00DDF6EE /* ChatClientConfig_Tests.swift in Sources */,
 				79877A292498E51500015F8B /* ChannelDTO_Tests.swift in Sources */,
 				79D6CE1725F7C02400BE2EEC /* ChannelWatcherListQuery_Tests.swift in Sources */,

--- a/Tests/StreamChatTests/Query/Sorting/ChannelListSortingKey_Tests.swift
+++ b/Tests/StreamChatTests/Query/Sorting/ChannelListSortingKey_Tests.swift
@@ -1,0 +1,71 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class ChannelListSortingKey_Tests: XCTestCase {
+    func test_sortDescriptor_keyPaths_areValid() throws {
+        // Put all `ChannelListSortingKey`s in an array
+        // We don't use `CaseIterable` since we only need this for tests
+        let sortingKeys: [ChannelListSortingKey] = [
+            .default,
+            .createdAt,
+            .updatedAt,
+            .lastMessageAt,
+            .memberCount,
+            .cid,
+            .hasUnread,
+            .unreadCount
+        ]
+        
+        // Iterate over keys...
+        for key in sortingKeys {
+            switch key {
+            case .default:
+                XCTAssertNotNil(key.sortDescriptor(isAscending: true))
+                XCTAssertEqual(
+                    key.rawValue,
+                    NSExpression(forKeyPath: \ChannelDTO.defaultSortingAt).keyPath
+                )
+            case .createdAt:
+                XCTAssertNotNil(key.sortDescriptor(isAscending: true))
+                XCTAssertEqual(
+                    key.rawValue,
+                    NSExpression(forKeyPath: \ChannelDTO.createdAt).keyPath
+                )
+            case .updatedAt:
+                XCTAssertNotNil(key.sortDescriptor(isAscending: true))
+                XCTAssertEqual(
+                    key.rawValue,
+                    NSExpression(forKeyPath: \ChannelDTO.updatedAt).keyPath
+                )
+            case .lastMessageAt:
+                XCTAssertNotNil(key.sortDescriptor(isAscending: true))
+                XCTAssertEqual(
+                    key.rawValue,
+                    NSExpression(forKeyPath: \ChannelDTO.lastMessageAt).keyPath
+                )
+            case .memberCount:
+                XCTAssertNotNil(key.sortDescriptor(isAscending: true))
+                XCTAssertEqual(
+                    key.rawValue,
+                    NSExpression(forKeyPath: \ChannelDTO.memberCount).keyPath
+                )
+            case .cid:
+                XCTAssertNotNil(key.sortDescriptor(isAscending: true))
+                XCTAssertEqual(
+                    key.rawValue,
+                    NSExpression(forKeyPath: \ChannelDTO.cid).keyPath
+                )
+            case .hasUnread:
+                XCTAssertNil(key.sortDescriptor(isAscending: true))
+            case .unreadCount:
+                XCTAssertNil(key.sortDescriptor(isAscending: true))
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

https://getstream.zendesk.com/agent/tickets/24329

### 📝 Summary

`ChannelListSortingKey.unreadCount` cannot be used as sorting predicate in CoreData, since `unreadCount` does not exist in `ChannelDTO`

### 🛠 Implementation

`unreadCount` is a calculated property. We'd need to persist it to be able to use `unreadCount` as a sorting param, this is for another time.

### 🧪 Manual Testing Notes

Create a ChannelListQuery with unreadCount sorting and run the app. It'll crash.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)
