### PR TITLE
Make EventPayload decoding errors more verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `ChannelListSortingKey.unreadCount` causing database crash [#2094](https://github.com/GetStream/stream-chat-swift/issues/2094)
 ### 🔄 Changed
 - JSON decoding performance is increased 3 times, parsing time reduced by %70 [#2081](https://github.com/GetStream/stream-chat-swift/issues/2081)
+- EventPayload decoding errors are now more verbose [#2099](https://github.com/GetStream/stream-chat-swift/issues/2099)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/WebSocketClient/Events/EventDecoder.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/EventDecoder.swift
@@ -32,6 +32,10 @@ extension ClientError {
         init<T>(missingValue: String, for type: T.Type, _ file: StaticString = #file, _ line: UInt = #line) {
             super.init("`\(missingValue)` field can't be `nil` for the `\(type)` event.", file, line)
         }
+        
+        init(missingValue: String, for type: EventType, _ file: StaticString = #file, _ line: UInt = #line) {
+            super.init("`\(missingValue)` field can't be `nil` for the `\(type.rawValue)` event.", file, line)
+        }
     }
 }
 

--- a/Sources/StreamChat/WebSocketClient/Events/EventPayload.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/EventPayload.swift
@@ -118,11 +118,46 @@ class EventPayload: Decodable {
     }
 }
 
+/// Extension to make decoding error messages better.
+/// The error message:
+/// ```
+/// `Swift.KeyPath<StreamChat.EventPayload, Swift.Optional<StreamChat.MemberPayload>>` field can't be `nil` for the `EventPayload` event.
+/// ```
+/// becomes:
+/// ```
+/// `memberContainer` field can't be `nil` for the `notification.added_to_channel` event.
+/// ```
+private extension PartialKeyPath where Root == EventPayload {
+    var stringValue: String {
+        switch self {
+        case \EventPayload.eventType: return "eventType"
+        case \EventPayload.connectionId: return "connectionId"
+        case \EventPayload.cid: return "cid"
+        case \EventPayload.currentUser: return "currentUser"
+        case \EventPayload.user: return "user"
+        case \EventPayload.createdBy: return "createdBy"
+        case \EventPayload.memberContainer: return "memberContainer"
+        case \EventPayload.channel: return "channel"
+        case \EventPayload.message: return "message"
+        case \EventPayload.reaction: return "reaction"
+        case \EventPayload.watcherCount: return "watcherCount"
+        case \EventPayload.unreadCount: return "unreadCount"
+        case \EventPayload.createdAt: return "createdAt"
+        case \EventPayload.isChannelHistoryCleared: return "isChannelHistoryCleared"
+        case \EventPayload.banReason: return "banReason"
+        case \EventPayload.banExpiredAt: return "banExpiredAt"
+        case \EventPayload.parentId: return "parentId"
+        case \EventPayload.hardDelete: return "hardDelete"
+        default: return String(describing: self)
+        }
+    }
+}
+
 extension EventPayload {
     /// Get an unwrapped value from the payload or throw an error.
     func value<Value>(at keyPath: KeyPath<EventPayload, Value?>) throws -> Value {
         guard let value = self[keyPath: keyPath] else {
-            throw ClientError.EventDecoding(missingValue: String(describing: keyPath), for: Self.self)
+            throw ClientError.EventDecoding(missingValue: keyPath.stringValue, for: eventType)
         }
         
         return value


### PR DESCRIPTION
### 📝 Summary

`EventPayload` decoding errors, which happen when an expected field in an event payload is missing, are too generic.
They look like:
> `Swift.KeyPath<StreamChat.EventPayload, Swift.Optional<StreamChat.MemberPayload>>` field can't be `nil` for the `EventPayload` event.

This doesn't have the context, which key is missing from which payload type.

### 🛠 Implementation

There's no elegant way to get a "field" string from KeyPath.
The commonly suggested
```swift
NSExpression(forKeyPath: keyPath).keyPath
```
does not work since our KeyPaths are not marked `@objc`.
Per https://stackoverflow.com/a/46555654, a private extension to manually expose path make the errors much nicer.
Now they look like:
> `memberContainer` field can't be `nil` for the `notification.added_to_channel` event.

### 🧪 Manual Testing Notes

Paste this in `EventPayload_Tests`:
```swift
func test_errorMessage() throws {
        let payload = EventPayload(eventType: .notificationAddedToChannel)
        
        try payload.value(at: \.memberContainer)
    }
```
run it and observe the error.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)
