### PR TITLE
Implement Pinned Message UI in DemoApp

### DIFF
--- a/DemoApp/StreamChat/Components/DemoChatMessageActionsVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatMessageActionsVC.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import StreamChat
 import StreamChatUI
 import UIKit
 
@@ -10,11 +11,39 @@ final class DemoChatMessageActionsVC: ChatMessageActionsVC {
     // For the propose of the demo app, we add an extra hard delete message to test it.
     override var messageActions: [ChatMessageActionItem] {
         var actions = super.messageActions
-        if message?.isSentByCurrentUser == true && AppConfig.shared.demoAppConfig.isHardDeleteEnabled {
-            actions.append(hardDeleteActionItem())
+        if message?.isSentByCurrentUser == true {
+            actions.append(pinMessageActionItem())
+            if AppConfig.shared.demoAppConfig.isHardDeleteEnabled {
+                actions.append(hardDeleteActionItem())
+            }
         }
         actions.append(translateActionItem())
         return actions
+    }
+    
+    func pinMessageActionItem() -> PinMessageActionItem {
+        PinMessageActionItem(
+            title: message?.isPinned == false ? "Pin to Conversation" : "Unpin from Conservation",
+            action: { [weak self] _ in
+                guard let self = self else { return }
+                if self.messageController.message?.isPinned == false {
+                    self.messageController.pin(.noExpiration) { error in
+                        if let error = error {
+                            log.error("Error when pinning message: \(error)")
+                        }
+                        self.delegate?.chatMessageActionsVCDidFinish(self)
+                    }
+                } else {
+                    self.messageController.unpin { error in
+                        if let error = error {
+                            log.error("Error when unpinning message: \(error)")
+                        }
+                        self.delegate?.chatMessageActionsVCDidFinish(self)
+                    }
+                }
+            },
+            appearance: appearance
+        )
     }
 
     func hardDeleteActionItem() -> ChatMessageActionItem {
@@ -45,6 +74,23 @@ final class DemoChatMessageActionsVC: ChatMessageActionsVC {
             appearance: appearance
         )
     }
+    
+    struct PinMessageActionItem: ChatMessageActionItem {
+        var title: String
+        var isDestructive: Bool { false }
+        let icon: UIImage
+        let action: (ChatMessageActionItem) -> Void
+        
+        init(
+            title: String,
+            action: @escaping (ChatMessageActionItem) -> Void,
+            appearance: Appearance = .default
+        ) {
+            self.title = title
+            self.action = action
+            icon = UIImage(systemName: "pin")!
+        }
+    }
 
     struct HardDeleteActionItem: ChatMessageActionItem {
         var title: String { "Hard Delete Message" }
@@ -72,7 +118,7 @@ final class DemoChatMessageActionsVC: ChatMessageActionsVC {
             appearance: Appearance = .default
         ) {
             self.action = action
-            icon = UIImage(systemName: "flag.fill")!
+            icon = UIImage(systemName: "flag")!
         }
     }
 }

--- a/DemoApp/StreamChat/Components/DemoChatMessageContentView.swift
+++ b/DemoApp/StreamChat/Components/DemoChatMessageContentView.swift
@@ -3,9 +3,25 @@
 //
 
 import Foundation
+import StreamChat
 import StreamChatUI
+import UIKit
 
 final class DemoChatMessageContentView: ChatMessageContentView {
+    var pinInfoLabel: UILabel?
+    
+    override func layout(options: ChatMessageLayoutOptions) {
+        super.layout(options: options)
+        
+        if options.contains(.pinInfo) {
+            backgroundColor = UIColor(red: 0.984, green: 0.957, blue: 0.867, alpha: 1)
+            pinInfoLabel = UILabel()
+            pinInfoLabel?.font = appearance.fonts.footnote
+            pinInfoLabel?.textColor = appearance.colorPalette.textLowEmphasis
+            bubbleThreadFootnoteContainer.insertArrangedSubview(pinInfoLabel!, at: 0)
+        }
+    }
+    
     override func updateContent() {
         super.updateContent()
 
@@ -16,8 +32,16 @@ final class DemoChatMessageContentView: ChatMessageContentView {
 
         if let translations = content?.translations, let turkishTranslation = translations[.turkish] {
             textView?.text = turkishTranslation
-            if let timestampLabelText = timestampLabel?.text {
-                timestampLabel?.text = "\(timestampLabelText) - Translated to Turkish"
+            timestampLabel?.text?.append(" - Translated to Turkish")
+        }
+        
+        if content?.isPinned == true, let pinInfoLabel = pinInfoLabel {
+            pinInfoLabel.text = "📌 Pinned"
+            if let pinDetails = content?.pinDetails {
+                let pinnedByName = content?.isSentByCurrentUser == true
+                    ? (content?.author.id == pinDetails.pinnedBy.id ? "You" : pinDetails.pinnedBy.name ?? pinDetails.pinnedBy.id)
+                    : pinDetails.pinnedBy.name ?? pinDetails.pinnedBy.id
+                pinInfoLabel.text?.append(" by \(pinnedByName)")
             }
         }
 

--- a/DemoApp/StreamChat/Components/DemoChatMessageLayoutOptionsResolver.swift
+++ b/DemoApp/StreamChat/Components/DemoChatMessageLayoutOptionsResolver.swift
@@ -1,0 +1,27 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamChat
+import StreamChatUI
+
+extension ChatMessageLayoutOption {
+    static let pinInfo: Self = "pinInfo"
+}
+
+final class DemoChatMessageLayoutOptionsResolver: ChatMessageLayoutOptionsResolver {
+    override func optionsForMessage(at indexPath: IndexPath, in channel: ChatChannel, with messages: AnyRandomAccessCollection<ChatMessage>, appearance: Appearance) -> ChatMessageLayoutOptions {
+        var options = super.optionsForMessage(at: indexPath, in: channel, with: messages, appearance: appearance)
+        guard indexPath.item < messages.count else {
+            return options
+        }
+        
+        let messageIndex = messages.index(messages.startIndex, offsetBy: indexPath.item)
+        let message = messages[messageIndex]
+        if message.isPinned {
+            options.insert(.pinInfo)
+        }
+        return options
+    }
+}

--- a/DemoApp/StreamChat/StreamChatWrapper.swift
+++ b/DemoApp/StreamChat/StreamChatWrapper.swift
@@ -67,6 +67,7 @@ final class StreamChatWrapper {
         Components.default.messageContentView = DemoChatMessageContentView.self
         Components.default.messageActionsVC = DemoChatMessageActionsVC.self
         Components.default.reactionsSorting = { $0.type.position < $1.type.position }
+        Components.default.messageLayoutOptionsResolver = DemoChatMessageLayoutOptionsResolver()
     }
 }
 

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 		79B5517824E5969700CE9FEC /* UserPayloads_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B5517024E593C200CE9FEC /* UserPayloads_Tests.swift */; };
 		79B5517C24E6A1CA00CE9FEC /* MessagePayloads_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B5517B24E6A1CA00CE9FEC /* MessagePayloads_Tests.swift */; };
 		79B8B649285B5ADD0059FB2D /* ChannelListSortingKey_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B8B648285B5ADD0059FB2D /* ChannelListSortingKey_Tests.swift */; };
+		79B8B64B285CBDC00059FB2D /* DemoChatMessageLayoutOptionsResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B8B64A285CBDC00059FB2D /* DemoChatMessageLayoutOptionsResolver.swift */; };
 		79BA19F324B3386B00E11FC2 /* CurrentUserDTO_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BA19F224B3386B00E11FC2 /* CurrentUserDTO_Tests.swift */; };
 		79BF83F2248F8F60007611A1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BF83F1248F8F60007611A1 /* Logger.swift */; };
 		79C5CBE825F66DBD00D98001 /* ChatChannelWatcherListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C5CBE725F66DBD00D98001 /* ChatChannelWatcherListController.swift */; };
@@ -2594,6 +2595,7 @@
 		79B5517624E595DA00CE9FEC /* CurrentUserPayloads_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserPayloads_Tests.swift; sourceTree = "<group>"; };
 		79B5517B24E6A1CA00CE9FEC /* MessagePayloads_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagePayloads_Tests.swift; sourceTree = "<group>"; };
 		79B8B648285B5ADD0059FB2D /* ChannelListSortingKey_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListSortingKey_Tests.swift; sourceTree = "<group>"; };
+		79B8B64A285CBDC00059FB2D /* DemoChatMessageLayoutOptionsResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoChatMessageLayoutOptionsResolver.swift; sourceTree = "<group>"; };
 		79BA19F224B3386B00E11FC2 /* CurrentUserDTO_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserDTO_Tests.swift; sourceTree = "<group>"; };
 		79BF83F1248F8F60007611A1 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		79C5CBE725F66DBD00D98001 /* ChatChannelWatcherListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelWatcherListController.swift; sourceTree = "<group>"; };
@@ -5651,6 +5653,7 @@
 				A3227E6F284A4BC700EBE6CC /* DemoChatChannelVC.swift */,
 				A3227E73284A4C3300EBE6CC /* DemoChatMessageActionsVC.swift */,
 				A3227E77284A4CAD00EBE6CC /* DemoChatMessageContentView.swift */,
+				79B8B64A285CBDC00059FB2D /* DemoChatMessageLayoutOptionsResolver.swift */,
 				A3227E71284A4BF700EBE6CC /* HiddenChannelListVC.swift */,
 				A3227E67284A4AA400EBE6CC /* Banner */,
 			);
@@ -9353,6 +9356,7 @@
 				A3227E5B284A489000EBE6CC /* UIViewController+Alert.swift in Sources */,
 				A3227E6D284A4B6A00EBE6CC /* UserCredentialsCell.swift in Sources */,
 				A3227E59284A484300EBE6CC /* UIImage+Resized.swift in Sources */,
+				79B8B64B285CBDC00059FB2D /* DemoChatMessageLayoutOptionsResolver.swift in Sources */,
 				79330604256FEBE600FBB586 /* AdvancedOptionsViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
### 🎯 Goal

Pinned messages are hard to debug since we don't have the message action and/or a UI to indicate the message is pinned

### 📝 Summary

DemoApp has custom pinned message logic to pin/unpin the messages and indicate if a message is pinned

### 🛠 Implementation

All UI is DemoApp only and is implemented with what's possible with the SDK.

The design is not 1-1 to actual design that will get implemented in the SDK in the future, and it doesn't cover all cases, but it'll make debugging easier for now.

Actual design can be found [here](https://www.figma.com/file/ekifwChR9tR7zRJg1QEzSM/Chat-Design-Kit---Current-version?node-id=12713%3A142209)

### 🎨 Showcase

The same chat:

| Before | After |
| ------ | ----- |
|  ![SCR-20220617-n4h](https://user-images.githubusercontent.com/770464/174320174-8260535c-786b-48e6-9621-359f9e6fa0ce.jpeg)   | ![SCR-20220617-n2v](https://user-images.githubusercontent.com/770464/174320135-57256d9d-9048-43cf-95f7-60969a0fecdc.jpeg)  |

### 🧪 Manual Testing Notes

Open DemoApp and long press a message sent by current user

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)
