### PR TITLE
[BW] Set up a previous version as a code definition on develop

### DIFF
--- a/fastlane/Sonarfile
+++ b/fastlane/Sonarfile
@@ -36,10 +36,8 @@ private_lane :sonar_options do |options|
     default_options.merge(pull_request_branch: ENV['GITHUB_HEAD_REF'],
                           pull_request_base: ENV['GITHUB_BASE_REF'],
                           pull_request_key: ENV['PR_NUMBER'])
-  elsif sonar_branch == 'main'
-    default_options.merge(branch_name: sonar_branch, project_version: options[:version_number])
   else
-    default_options.merge(branch_name: sonar_branch)
+    default_options.merge(branch_name: sonar_branch, project_version: options[:version_number])
   end
 end
 


### PR DESCRIPTION
### 🔗 Issue Links

- N/A

### 🎯 Goal

- As discussed in Tech Discussion, we are going to return a previous SDK version as a new code definition on SonarCloud on push to `develop`

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

