### PR TITLE
Add missing channel / member list filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### ✅ Added
+- Added missing `ChannelListFilterScope` and `MemberListFilterScope` filter keys [#2119](https://github.com/GetStream/stream-chat-swift/issues/2119)
 
 # [4.17.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.17.0)
 _June 22, 2022_

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -47,10 +47,24 @@ extension FilterKey where Scope: AnyChannelListFilterScope {
     static var members: FilterKey<Scope, UserId> { "members" }
 }
 
-/// Non extra-data-specific filer keys for channel list.
+/// Filter values to be used with `.invite` FilterKey.
+public enum InviteFilterValue: String, FilterValue {
+    case pending
+    case accepted
+    case rejected
+}
+
+/// Filter keys for channel list.
 public extension FilterKey where Scope: AnyChannelListFilterScope {
     /// A filter key for matching the `cid` value.
+    /// Supported operators: `in`, `equal`
     static var cid: FilterKey<Scope, ChannelId> { "cid" }
+    
+    /// A filter key for matching the `id` value.
+    /// Supported operators: `in`, `equal`
+    /// - Warning: Querying by the channel Identifier should be done using the `cid` field as much as possible to optimize API performance.
+    /// As the full channel ID, `cid`s are indexed everywhere in Stream database where `id` is not.
+    static var id: FilterKey<Scope, String> { "id" }
     
     /// A filter key for matching the `name` value.
     static var name: FilterKey<Scope, String> { "name" }
@@ -59,34 +73,65 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
     static var imageURL: FilterKey<Scope, URL> { "image" }
     
     /// A filter key for matching the `type` value.
+    /// Supported operators: `in`, `equal`
     static var type: FilterKey<Scope, ChannelType> { "type" }
     
     /// A filter key for matching the `lastMessageAt` value.
+    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`
     static var lastMessageAt: FilterKey<Scope, Date> { "last_message_at" }
     
     /// A filter key for matching the `createdBy` value.
+    /// Supported operators: `equal`
     static var createdBy: FilterKey<Scope, UserId> { "created_by_id" }
     
     /// A filter key for matching the `createdAt` value.
+    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`
     static var createdAt: FilterKey<Scope, Date> { "created_at" }
     
     /// A filter key for matching the `updatedAt` value.
+    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`
     static var updatedAt: FilterKey<Scope, Date> { "updated_at" }
     
     /// A filter key for matching the `deletedAt` value.
+    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`
     static var deletedAt: FilterKey<Scope, Date> { "deleted_at" }
     
     /// A filter key for querying hidden channels.
+    /// Supported operators: `equal`
     static var hidden: FilterKey<Scope, Bool> { "hidden" }
     
     /// A filter key for matching the `frozen` value.
+    /// Supported operators: `equal`
     static var frozen: FilterKey<Scope, Bool> { "frozen" }
 
     /// A filter key for matching the `memberCount` value.
+    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`
     static var memberCount: FilterKey<Scope, Int> { "member_count" }
     
     /// A filter key for matching the `team` value.
+    /// Supported operators: `equal`
     static var team: FilterKey<Scope, TeamId?> { "team" }
+    
+    /// Filter for checking whether current user is joined the channel or not (through invite or directly)
+    /// Supported operators: `equal`
+    static var joined: FilterKey<Scope, Bool> { "joined" }
+    
+    /// Filter for checking whether current user has muted the channel
+    /// Supported operators: `equal`
+    static var muted: FilterKey<Scope, Bool> { "muted " }
+    
+    /// Filter for checking the status of the invite
+    /// Supported operators: `equal`
+    static var invite: FilterKey<Scope, InviteFilterValue> { "invite" }
+    
+    /// Filter for checking the `name` property of a user who is a member of the channel
+    /// Supported operators: `equal`, `notEqual`, `autocomplete`
+    /// - Warning: This filter is considerably expensive for the backend so avoid using this when possible.
+    static var memberName: FilterKey<Scope, String> { "member.user.name" }
+    
+    /// Filter for the time of the last message in the channel. If the channel has no messages, then the time the channel was created.
+    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`
+    static var lastUpdatedAt: FilterKey<Scope, Date> { "last_updated" }
 }
 
 /// A query is used for querying specific channels from backend.

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -118,7 +118,7 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
     
     /// Filter for checking whether current user has muted the channel
     /// Supported operators: `equal`
-    static var muted: FilterKey<Scope, Bool> { "muted " }
+    static var muted: FilterKey<Scope, Bool> { "muted" }
     
     /// Filter for checking the status of the invite
     /// Supported operators: `equal`

--- a/Sources/StreamChat/Query/ChannelMemberListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelMemberListQuery.swift
@@ -14,7 +14,40 @@ public class MemberListFilterScope: UserListFilterScope, AnyMemberListFilterScop
 /// Non extra-data-specific filer keys for member list.
 public extension FilterKey where Scope: AnyMemberListFilterScope {
     /// A filter key for matching moderators of a channel.
+    /// Supported operators: `equal`, `notEqual`
     static var isModerator: FilterKey<Scope, Bool> { "is_moderator" }
+    
+    /// Filter key matching the id of the user
+    /// Supported operators: `equal`, `notEqual`, `in`, `notIn`
+    static var id: FilterKey<Scope, String> { "id" }
+    
+    /// Filter key matching the name of the user
+    /// Supported operators: `equal`, `notEqual`, `in`, `notIn`, `autocomplete`, `query`
+    static var name: FilterKey<Scope, String> { "name" }
+    
+    /// Filter key matching the banned status
+    /// Supported operators: `equal`
+    static var banned: FilterKey<Scope, Bool> { "banned" }
+    
+    /// Filter key matching the invite status
+    /// Supported operators: `equal`
+    static var invite: FilterKey<Scope, InviteFilterValue> { "invite" }
+    
+    /// Filter key matching the joined status
+    /// Supported operators: `equal`
+    static var joined: FilterKey<Scope, Bool> { "joined" }
+    
+    /// Filter key matching the time that the member was created
+    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`
+    static var createdAt: FilterKey<Scope, Date> { "created_at" }
+    
+    /// Filter key matching the time the member was last updated
+    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`
+    static var updatedAt: FilterKey<Scope, Date> { "updated_at" }
+    
+    /// Filter key matching the time the user was last active
+    /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`
+    static var lastActiveAt: FilterKey<Scope, Date> { "last_active" }
 }
 
 /// A query type used for fetching channel members from the backend.

--- a/Tests/StreamChatTests/Query/ChannelListFilterScope_Tests.swift
+++ b/Tests/StreamChatTests/Query/ChannelListFilterScope_Tests.swift
@@ -10,18 +10,27 @@ final class ChannelListFilterScope_Tests: XCTestCase {
     typealias Key<T: FilterValue> = FilterKey<ChannelListFilterScope, T>
 
     func test_filterKeys_matchChannelCodingKeys() {
+        // FilterKeys that exists in ChannelCodingKeys
         XCTAssertEqual(Key<ChannelId>.cid.rawValue, ChannelCodingKeys.cid.rawValue)
+        XCTAssertEqual(Key<String>.id.rawValue, ChannelCodingKeys.id.rawValue)
         XCTAssertEqual(Key<String>.name.rawValue, ChannelCodingKeys.name.rawValue)
         XCTAssertEqual(Key<URL>.imageURL.rawValue, ChannelCodingKeys.imageURL.rawValue)
         XCTAssertEqual(Key<ChannelType>.type.rawValue, ChannelCodingKeys.typeRawValue.rawValue)
         XCTAssertEqual(Key<Date>.lastMessageAt.rawValue, ChannelCodingKeys.lastMessageAt.rawValue)
-        XCTAssertEqual(Key<UserId>.createdBy.rawValue, "created_by_id")
         XCTAssertEqual(Key<Date>.createdAt.rawValue, ChannelCodingKeys.createdAt.rawValue)
         XCTAssertEqual(Key<Date>.updatedAt.rawValue, ChannelCodingKeys.updatedAt.rawValue)
         XCTAssertEqual(Key<Date>.deletedAt.rawValue, ChannelCodingKeys.deletedAt.rawValue)
         XCTAssertEqual(Key<Bool>.frozen.rawValue, ChannelCodingKeys.frozen.rawValue)
         XCTAssertEqual(Key<Int>.memberCount.rawValue, ChannelCodingKeys.memberCount.rawValue)
         XCTAssertEqual(Key<TeamId>.team.rawValue, ChannelCodingKeys.team.rawValue)
+        
+        // FilterKeys without corresponding ChannelCodingKeys
+        XCTAssertEqual(Key<UserId>.createdBy.rawValue, "created_by_id")
+        XCTAssertEqual(Key<Bool>.joined.rawValue, "joined")
+        XCTAssertEqual(Key<Bool>.muted.rawValue, "muted")
+        XCTAssertEqual(Key<InviteFilterValue>.invite.rawValue, "invite")
+        XCTAssertEqual(Key<String>.memberName.rawValue, "member.user.name")
+        XCTAssertEqual(Key<Date>.lastUpdatedAt.rawValue, "last_updated")
     }
 
     func test_containMembersHelper() {


### PR DESCRIPTION
### 🎯 Goal

Add missing Channel List and Member List filter keys so they can be used in a type-safe manner (and autocompletion rocks)

### 📝 Summary

We were missing a couple of Channel List filter keys:
https://getstream.io/chat/docs/ios-swift/query_channels/?language=javascript#channel-queryable-built-in-fields
and Member list filter keys:
https://getstream.io/chat/docs/ios-swift/query_members/?language=javascript#member-queryable-built-in-fields

Those are added to the already-existing filter infra, and comments are updated to reflect which operators are possible (this info already exists in our docs)

### 🛠 Implementation

Hypothetically, we can implement `var supportedOperators: [FilterOperator]` to `FilterKey` so we can know exactly which filter is usable with which operator. This is a bit more complicated, specifically because `FilterKey` is a struct and not an enum, so I'm leaving that out for now.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)
