### PR TITLE
[CIS-2017] Make it possible to send giphy messages programmatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+### 🐞 Fixed
+- Allow sending giphy messages programmatically [#2124](https://github.com/GetStream/stream-chat-swift/pull/2124)
+
 # [4.17.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.17.0)
 _June 22, 2022_
 ## StreamChat

--- a/Sources/StreamChat/Models/Attachments/ChatMessageGiphyAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageGiphyAttachment.swift
@@ -21,6 +21,16 @@ public struct GiphyAttachmentPayload: AttachmentPayload {
     public var previewURL: URL
     /// Actions when gif is not sent yet. (e.g. `Shuffle`)
     public var actions: [AttachmentAction]
+
+    /// - Parameters:
+    ///   - title: Title of the giphy
+    ///   - previewURL: thumb url of the giphy
+    ///   - actions: Leave empty
+    public init(title: String, previewURL: URL, actions: [AttachmentAction] = []) {
+        self.title = title
+        self.previewURL = previewURL
+        self.actions = actions
+    }
 }
 
 extension GiphyAttachmentPayload: Hashable {}

--- a/Sources/StreamChat/Models/Attachments/ChatMessageLinkAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageLinkAttachment.swift
@@ -36,6 +36,24 @@ public struct LinkAttachmentPayload: AttachmentPayload {
     public var assetURL: URL?
     /// A preview image URL.
     public var previewURL: URL?
+
+    public init(
+        originalURL: URL,
+        title: String? = nil,
+        text: String? = nil,
+        author: String? = nil,
+        titleLink: URL? = nil,
+        assetURL: URL? = nil,
+        previewURL: URL? = nil
+    ) {
+        self.originalURL = originalURL
+        self.title = title
+        self.text = text
+        self.author = author
+        self.titleLink = titleLink
+        self.assetURL = assetURL
+        self.previewURL = previewURL
+    }
 }
 
 extension LinkAttachmentPayload: Hashable {}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -801,6 +801,7 @@
 		A3227E7A284A4CE000EBE6CC /* DemoChatChannelListVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3227E79284A4CE000EBE6CC /* DemoChatChannelListVC.swift */; };
 		A3227E7E284A511200EBE6CC /* DemoAppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3227E7D284A511200EBE6CC /* DemoAppConfiguration.swift */; };
 		A3227EC9284A52EE00EBE6CC /* PushNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3227EC8284A52EE00EBE6CC /* PushNotifications.swift */; };
+		A32B6D9E2869DABD002B1312 /* GiphyAttachmentPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32B6D9D2869DABD002B1312 /* GiphyAttachmentPayload_Tests.swift */; };
 		A32D55142860B40B00E66AF9 /* ChatMessageLinkAttachment_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32D55132860B40B00E66AF9 /* ChatMessageLinkAttachment_Tests.swift */; };
 		A32D55162860B54700E66AF9 /* AttachmentPayloadLink_without_title_link.json in Resources */ = {isa = PBXBuildFile; fileRef = A32D55152860B54700E66AF9 /* AttachmentPayloadLink_without_title_link.json */; };
 		A32D55182860B70200E66AF9 /* AttachmentPayloadLink_with_title_link.json in Resources */ = {isa = PBXBuildFile; fileRef = A32D55172860B70200E66AF9 /* AttachmentPayloadLink_with_title_link.json */; };
@@ -3099,6 +3100,7 @@
 		A3227E79284A4CE000EBE6CC /* DemoChatChannelListVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoChatChannelListVC.swift; sourceTree = "<group>"; };
 		A3227E7D284A511200EBE6CC /* DemoAppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppConfiguration.swift; sourceTree = "<group>"; };
 		A3227EC8284A52EE00EBE6CC /* PushNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotifications.swift; sourceTree = "<group>"; };
+		A32B6D9D2869DABD002B1312 /* GiphyAttachmentPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiphyAttachmentPayload_Tests.swift; sourceTree = "<group>"; };
 		A32D55132860B40B00E66AF9 /* ChatMessageLinkAttachment_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageLinkAttachment_Tests.swift; sourceTree = "<group>"; };
 		A32D55152860B54700E66AF9 /* AttachmentPayloadLink_without_title_link.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = AttachmentPayloadLink_without_title_link.json; sourceTree = "<group>"; };
 		A32D55172860B70200E66AF9 /* AttachmentPayloadLink_with_title_link.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = AttachmentPayloadLink_with_title_link.json; sourceTree = "<group>"; };
@@ -6168,6 +6170,7 @@
 				843C53AA269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift */,
 				843C53AC269373EA00C7D8EA /* VideoAttachmentPayload_Tests.swift */,
 				A32D55132860B40B00E66AF9 /* ChatMessageLinkAttachment_Tests.swift */,
+				A32B6D9D2869DABD002B1312 /* GiphyAttachmentPayload_Tests.swift */,
 			);
 			path = Attachments;
 			sourceTree = "<group>";
@@ -10055,6 +10058,7 @@
 				79A9EB572625798000F2A72D /* CoreDataLazy_StressTests.swift in Sources */,
 				DAF1BED92506612F003CEDC0 /* MessageController+SwiftUI_Tests.swift in Sources */,
 				A3A52B6627EB61FC00311DFC /* EventPayload_Tests.swift in Sources */,
+				A32B6D9E2869DABD002B1312 /* GiphyAttachmentPayload_Tests.swift in Sources */,
 				A3C7BAD327E4E05300BBF4FA /* MemberListFilterScope_Tests.swift in Sources */,
 				8A0D649D24E579F70017A3C0 /* GuestUserTokenPayload_Tests.swift in Sources */,
 				8A0C3BE224C1F74200CAFD19 /* MessageEvents_Tests.swift in Sources */,

--- a/Tests/StreamChatTests/Models/Attachments/GiphyAttachmentPayload_Tests.swift
+++ b/Tests/StreamChatTests/Models/Attachments/GiphyAttachmentPayload_Tests.swift
@@ -1,0 +1,32 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class GiphyAttachmentPayload_Tests: XCTestCase {
+    let giphyURL: URL = URL(string: "https://media2.giphy.com/media/SY9klAvBdbcPiQGfdN/giphy.gif?cid=c4b03675cvbts7fssybzy83bdtpfr21jpcekvcto96i1vjk5&rid=giphy.gif&ct=g")!
+    let title = "title"
+
+    var sut: GiphyAttachmentPayload?
+
+    override func tearDownWithError() throws {
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    func test_ItInitializesPayloadWithGivenData() {
+        // WHEN
+        sut = GiphyAttachmentPayload(
+            title: title,
+            previewURL: giphyURL,
+            actions: []
+        )
+
+        // THEN
+        XCTAssertEqual(sut?.title, title)
+        XCTAssertEqual(sut?.previewURL, giphyURL)
+        XCTAssertEqual(sut?.actions, [])
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

CIS-2017
#2120

### 🎯 Goal

Make it possible to send giphy messages programmatically

### 📝 Summary

This change exposes initializer of `GiphyAttachmentPayload` & `LinkAttachmentPayload`. This change allows the integrator to create new giphy messages in chat.

Example:
```swift
...
let gifURL = media.url(rendition: .fixedWidth, fileType: .gif)

// StreamChat part
let attachment = GiphyAttachmentPayload(title: "Title of the giphy", previewURL: gifURL)
let attachments = [AnyAttachmentPayload(payload: attachment)]
channelController?.createNewMessage(
    text: "",
    attachments: attachments)
)
```

### 🎨 Showcase

![Simulator Screen Shot - iPhone 12 Pro - 2022-06-27 at 14 36 08](https://user-images.githubusercontent.com/4924709/175943191-5e5f1124-a6a4-43ab-847b-cabfb03dc972.png)

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
