### PR TITLE
One endpoint to rule them all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 - Improved performance when saving big payloads (by 50% in some edge cases)[#2113](https://github.com/GetStream/stream-chat-swift/pull/2113)
-- Chat SDK now leverages ```chat.stream-io-api.com/``` endpoint by default [#2125](https://github.com/GetStream/stream-chat-swift/pull/2125)
+- Chat SDK now leverages `chat.stream-io-api.com` endpoint by default [#2125](https://github.com/GetStream/stream-chat-swift/pull/2125)
 
 ### 🐞 Fixed
 - Allow sending giphy messages programmatically [#2124](https://github.com/GetStream/stream-chat-swift/pull/2124)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 - Improved performance when saving big payloads (by 50% in some edge cases)[#2113](https://github.com/GetStream/stream-chat-swift/pull/2113)
+- Chat SDK now leverages ```chat.stream-io-api.com/``` endpoint by default [#2125](https://github.com/GetStream/stream-chat-swift/pull/2125)
 
 ### 🐞 Fixed
 - Allow sending giphy messages programmatically [#2124](https://github.com/GetStream/stream-chat-swift/pull/2124)

--- a/Sources/StreamChat/Config/BaseURL.swift
+++ b/Sources/StreamChat/Config/BaseURL.swift
@@ -6,15 +6,18 @@ import Foundation
 
 /// A struct representing base URL for `ChatClient`.
 public struct BaseURL: CustomStringConvertible {
+    /// The default base URL  for StreamChat service.
+    public static let `default` = BaseURL(urlString: "https://chat.stream-io-api.com/")!
+
     /// The base url for StreamChat data center located in the US East Cost.
     public static let usEast = BaseURL(urlString: "https://chat-proxy-us-east.stream-io-api.com/")!
-    
+
     /// The base url for StreamChat data center located in Dublin.
     public static let dublin = BaseURL(urlString: "https://chat-proxy-dublin.stream-io-api.com/")!
-    
+
     /// The base url for StreamChat data center located in Singapore.
     public static let singapore = BaseURL(urlString: "https://chat-proxy-singapore.stream-io-api.com/")!
-    
+
     /// The base url for StreamChat data center located in Sydney.
     public static let sydney = BaseURL(urlString: "https://chat-proxy-sydney.stream-io-api.com/")!
     

--- a/Sources/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources/StreamChat/Config/ChatClientConfig.swift
@@ -53,7 +53,7 @@ public struct ChatClientConfig {
     }
 
     /// The datacenter `ChatClient` uses for connecting.
-    public var baseURL: BaseURL = .usEast
+    public var baseURL: BaseURL = .default
     
     /// Determines whether `ChatClient` caches the data locally. This makes it possible to browse the existing chat data also
     /// when the internet connection is not available.


### PR DESCRIPTION
### 🎯 Goal

Leverage single `https://chat.stream-io-api.com/` mediator.

### 📝 Summary

Previously the integrator could select the endpoint to connect to based on the preferred location. 
By providing a single endpoint the client no longer needs to think about the closest proxy server. 
New endpoint acts as a mediator that connects the end-user to the closest server with the best latency.

### 🧪 Manual Testing Notes

Run the app and verify all works fine.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
