### PR TITLE
[CIS-1407] Improve JSON decoding robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### ✅ Added
 - Added missing `ChannelListFilterScope` and `MemberListFilterScope` filter keys [#2119](https://github.com/GetStream/stream-chat-swift/issues/2119)
-
 ### 🔄 Changed
 - Improved performance when saving big payloads (by 50% in some edge cases)[#2113](https://github.com/GetStream/stream-chat-swift/pull/2113)
 - Chat SDK now leverages `chat.stream-io-api.com` endpoint by default [#2125](https://github.com/GetStream/stream-chat-swift/pull/2125)
 - JSON decoding performance is futher increased, parsing time reduced by another %50 [#2128](https://github.com/GetStream/stream-chat-swift/issues/2128)
+- Better errors in case JSON decoding fails [#2126](https://github.com/GetStream/stream-chat-swift/issues/2126)
 
 ### 🐞 Fixed
 - Allow sending giphy messages programmatically [#2124](https://github.com/GetStream/stream-chat-swift/pull/2124)
-
+- JSON decoding is now more robust, single incomplete/broken object won't disable whole channel list [#2126](https://github.com/GetStream/stream-chat-swift/issues/2126)
 
 # [4.17.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.17.0)
 _June 22, 2022_

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/ChannelListPayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/ChannelListPayload.swift
@@ -58,10 +58,10 @@ extension ChannelPayload: Decodable {
             channel: try container.decode(ChannelDetailPayload.self, forKey: .channel),
             watcherCount: try container.decodeIfPresent(Int.self, forKey: .watcherCount),
             watchers: try container.decodeIfPresent([UserPayload].self, forKey: .watchers),
-            members: try container.decode([MemberPayload].self, forKey: .members),
+            members: try container.decodeArrayIgnoringFailures([MemberPayload].self, forKey: .members),
             membership: try container.decodeIfPresent(MemberPayload.self, forKey: .membership),
-            messages: try container.decode([MessagePayload].self, forKey: .messages),
-            pinnedMessages: try container.decode([MessagePayload].self, forKey: .pinnedMessages),
+            messages: try container.decodeArrayIgnoringFailures([MessagePayload].self, forKey: .messages),
+            pinnedMessages: try container.decodeArrayIgnoringFailures([MessagePayload].self, forKey: .pinnedMessages),
             channelReads: try container.decodeIfPresent([ChannelReadPayload].self, forKey: .channelReads) ?? [],
             isHidden: try container.decodeIfPresent(Bool.self, forKey: .hidden)
         )

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessagePayloads.swift
@@ -110,12 +110,12 @@ class MessagePayload: Decodable {
         parentId = try container.decodeIfPresent(String.self, forKey: .parentId)
         showReplyInChannel = try container.decodeIfPresent(Bool.self, forKey: .showReplyInChannel) ?? false
         quotedMessage = try container.decodeIfPresent(MessagePayload.self, forKey: .quotedMessage)
-        mentionedUsers = try container.decode([UserPayload].self, forKey: .mentionedUsers)
+        mentionedUsers = try container.decodeArrayIgnoringFailures([UserPayload].self, forKey: .mentionedUsers)
         // backend returns `thread_participants` only if message is a thread, we are fine with to have it on all messages
         threadParticipants = try container.decodeIfPresent([UserPayload].self, forKey: .threadParticipants) ?? []
         replyCount = try container.decode(Int.self, forKey: .replyCount)
-        latestReactions = try container.decode([MessageReactionPayload].self, forKey: .latestReactions)
-        ownReactions = try container.decode([MessageReactionPayload].self, forKey: .ownReactions)
+        latestReactions = try container.decodeArrayIgnoringFailures([MessageReactionPayload].self, forKey: .latestReactions)
+        ownReactions = try container.decodeArrayIgnoringFailures([MessageReactionPayload].self, forKey: .ownReactions)
 
         reactionScores = try container
             .decodeIfPresent([String: Int].self, forKey: .reactionScores)?

--- a/Sources/StreamChat/Utils/KeyedDecodingContainer+Array.swift
+++ b/Sources/StreamChat/Utils/KeyedDecodingContainer+Array.swift
@@ -6,6 +6,7 @@ import Foundation
 
 private struct ElementWrapper<T: Decodable>: Decodable {
     let value: T?
+    var rawJSON: [String: RawJSON]?
     var error: Error?
     init(from decoder: Decoder) throws {
         do {
@@ -13,18 +14,75 @@ private struct ElementWrapper<T: Decodable>: Decodable {
         } catch {
             value = nil
             self.error = error
+            // We decode the payload as RawJSON to be able to display the payload in case of error
+            rawJSON = try? [String: RawJSON](from: decoder)
         }
     }
 }
 
 extension KeyedDecodingContainer {
     func decodeArrayIgnoringFailures<T: Decodable>(_ type: [T].Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> [T] {
-        let wrapper = try decode([ElementWrapper<T>].self, forKey: key)
-        let errors = wrapper.compactMap(\.error)
-        if !errors.isEmpty {
-            let errorsDescription = errors.map(String.init(describing:))
-            log.error("Failed decoding elements from array: \(errorsDescription)", subsystems: .httpRequests)
+        let wrappers = try decode([ElementWrapper<T>].self, forKey: key)
+        for wrapper in wrappers where wrapper.error != nil {
+            let rawJSONPrettyPrinted = (try? JSONEncoder.default.encode(wrapper.rawJSON))?.debugPrettyPrintedJSON
+                ?? String(describing: wrapper.rawJSON)
+            var errorDescription = String(describing: wrapper.error)
+            if let error = wrapper.error as? DecodingError {
+                errorDescription = error.prettyPrintedDescription
+            }
+            log.error("Failed to decode \(T.self) in array: \(rawJSONPrettyPrinted), error: \(errorDescription)")
         }
-        return wrapper.compactMap(\.value)
+        return wrappers.compactMap(\.value)
+    }
+}
+
+private extension DecodingError {
+    var prettyPrintedDescription: String {
+        var errorDescription = String(describing: self)
+        switch self {
+        case let .typeMismatch(any, context):
+            errorDescription = "typeMismatch for value \(any), path: \(context.prettyPrintedCodingPath), debugDescription: \(context.debugDescription)"
+            if let underlyingError = context.underlyingError {
+                errorDescription.append(", underlyingError: \(underlyingError)")
+            }
+        case let .valueNotFound(any, context):
+            errorDescription = "valueNotFound for value \(any), path: \(context.prettyPrintedCodingPath), debugDescription: \(context.debugDescription)"
+            if let underlyingError = context.underlyingError {
+                errorDescription.append(", underlyingError: \(underlyingError)")
+            }
+        case let .keyNotFound(codingKey, context):
+            errorDescription = "valueNotFound for key \(codingKey), path: \(context.prettyPrintedCodingPath), debugDescription: \(context.debugDescription)"
+            if let underlyingError = context.underlyingError {
+                errorDescription.append(", underlyingError: \(underlyingError)")
+            }
+        case let .dataCorrupted(context):
+            errorDescription = "dataCorrupted, path: \(context.prettyPrintedCodingPath), debugDescription: \(context.debugDescription)"
+            if let underlyingError = context.underlyingError {
+                errorDescription.append(", underlyingError: \(underlyingError)")
+            }
+        @unknown default:
+            break
+        }
+        return errorDescription
+    }
+}
+
+private extension DecodingError.Context {
+    var prettyPrintedCodingPath: String {
+        var lastCodingKey: CodingKey?
+        var description = "<"
+        for key in codingPath {
+            if let intValue = key.intValue, lastCodingKey?.intValue == nil {
+                description.append("[\(intValue)]")
+            } else {
+                if lastCodingKey != nil {
+                    description.append(".")
+                }
+                description.append("\(key.stringValue)")
+            }
+            lastCodingKey = key
+        }
+        description.append(">")
+        return description
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

CIS-1407
https://getstream.zendesk.com/agent/tickets/24700

### 🎯 Goal

* JSON decoding should be much more robust
* JSON decoding errors must be more understandable

### 📝 Summary

This PR makes it so a single deformed entity in JSON arrays won't disable decoding for the whole entity itself, but will print a fat, very verbose error instead.

### 🛠 Implementation

We already have `decodeArrayIgnoringFailures` which decodes the array elements where decodable and prints the error where they are deformed. This was used for Event decoding. We can safely use this for any array decoding.

The error function didn't print understandable information. The errors look like:
> 2022-06-27 11:41:05.837 [ERROR] [com.apple.NSURLSession-delegate] [RequestDecoder.swift:79] [decodeRequestResponse(data:response:error:)] > valueNotFound(Swift.KeyedDecodingContainer<StreamChat.UserPayloadsCodingKeys>, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "channels", intValue: nil), _JSONKey(stringValue: "Index 1", intValue: 1), CodingKeys(stringValue: "messages", intValue: nil), _JSONKey(stringValue: "Index 22", intValue: 22), MessagePayloadsCodingKeys(stringValue: "own_reactions", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "user", intValue: nil)], debugDescription: "Cannot get keyed decoding container -- found null value instead.", underlyingError: nil))

With the PR, errors look like:
> 2022-06-27 11:41:05.837 [ERROR] [com.apple.NSURLSession-delegate] [RequestDecoder.swift:79] [decodeRequestResponse(data:response:error:)] > Failed to decode MessageReactionPayload in array: {
  "score" : 1,
  "message_id" : "8268DBDE-6B10-4326-8F1E-2564CA3F20B9",
  "created_at" : "2022-05-15T19:31:25.96832Z",
  "user_id" : "8bee5134-5d06-43a2-b2f7-76e4f12aeb8b",
  "updated_at" : "2022-05-15T19:31:25.96832Z",
  "type" : "like",
  "enforce_unique" : false,
  "user" : null
}, error: valueNotFound for value KeyedDecodingContainer<UserPayloadsCodingKeys>, path: <channels[8].messages[15].own_reactions[0].user>, debugDescription: Cannot get keyed decoding container -- found null value instead.

The error has all the information - the failed payload, legible coding path, and the description - and it's much more legible.

More importantly, 1 single deformed object won't cause whole channel list to go blank.

### 🧪 Manual Testing Notes

You can use any channel list payload, just deform an object and run this test with the payload:
```swift
    func test_decode_deformedChannelListPayload() {
        let url = XCTestCase.mockData(fromJSONFile: "<#Deformed Channel List Payload#>")

        do {
                _ = try JSONDecoder.default.decode(ChannelListPayload.self, from: url)
            } catch {
                XCTFail("Failed to parse JSON: \(error)")
            }
    }
```
This will print the `log.error` to the console.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)
