### PR TITLE
Implement date-level caching for JSON decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Improved performance when saving big payloads (by 50% in some edge cases)[#2113](https://github.com/GetStream/stream-chat-swift/pull/2113)
 - Chat SDK now leverages `chat.stream-io-api.com` endpoint by default [#2125](https://github.com/GetStream/stream-chat-swift/pull/2125)
+- JSON decoding performance is futher increased, parsing time reduced by another %50 [#2128](https://github.com/GetStream/stream-chat-swift/issues/2128)
 
 ### 🐞 Fixed
 - Allow sending giphy messages programmatically [#2124](https://github.com/GetStream/stream-chat-swift/pull/2124)


### PR DESCRIPTION
### 🔗 Issue Links

This is an alternative take to PR #2115

### 📝 Summary

JSON decoding bottleneck appears to be parsing Date objects from string. There are many repeated User payloads, each UserPayload has 3 Dates to be decoded, which is the most expensive primitive to decode.

That being said, User-level caching during decoding has many problems:
1. When do we invalidate the cache?
1. What happens if there are 2 decoding happening in multiple threads?
1. User payload is not always sent it full. For example, `role` field is scope-dependent, `teams` field is not always sent. Which fields can be cached and which fields will always exists is not clear enough.

These problems make User-level caching too complex and dangerous, it can lead to incorrect-parsing in unexpected places. Instead, date-level caching is much simpler, only a couple of lines of code, and gives good-enough performance

### 🛠 Implementation

`NSCache` makes sure the cache is thread-safe, we don't need to invalidate the cache since after 5000 dates cached `NSCache` makes sure to dispose of unused objects. Also, cache is always valid since `String <-> Date` pairs never change.

### 🎨 Showcase

| Before | User-level caching | Date-level caching (This PR) | Both User and Date caching 
| ------ | ----- | ------ | ------ |
|  970ms   |  514ms  |  462ms | 185ms

### 🧪 Manual Testing Notes

You can use the disabled `ChannelListPayload_Tests.test_decode_bigChannelListPayload` test to measure.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)
