### PR TITLE
Allow for move operations to scroll to the bottom of the message list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Allow sending giphy messages programmatically [#2124](https://github.com/GetStream/stream-chat-swift/pull/2124)
-
+- Allow scroll automatically to the bottom when sending a giphy from the middle of the message list [#2129](https://github.com/GetStream/stream-chat-swift/pull/2129)
 
 # [4.17.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.17.0)
 _June 22, 2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Allow sending giphy messages programmatically [#2124](https://github.com/GetStream/stream-chat-swift/pull/2124)
-- Allow scroll automatically to the bottom when sending a giphy from the middle of the message list [#2129](https://github.com/GetStream/stream-chat-swift/pull/2129)
+- Allow scroll automatically to the bottom when sending a giphy from the middle of the message list [#2130](https://github.com/GetStream/stream-chat-swift/pull/2130)
 
 # [4.17.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.17.0)
 _June 22, 2022_

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -245,7 +245,7 @@ open class ChatMessageListVC: _ViewController,
             // Because we use an inverted table view, we need to avoid animations since they look odd.
             UIView.performWithoutAnimation {
                 listView.updateMessages(with: changes) { [weak self] in
-                    if let newMessageInserted = changes.first(where: { $0.isInsertion && $0.indexPath.row == 0 })?.item {
+                    if let newMessageInserted = changes.first(where: { ($0.isInsertion || $0.isMoved) && $0.indexPath.row == 0 })?.item {
                         if newMessageInserted.isSentByCurrentUser {
                             self?.listView.scrollToMostRecentMessage()
                         }
@@ -721,6 +721,15 @@ internal extension ChatMessageListVC {
 }
 
 private extension ListChange {
+    var isMoved: Bool {
+        switch self {
+        case .move:
+            return true
+        default:
+            return false
+        }
+    }
+    
     var isInsertion: Bool {
         switch self {
         case .insert:


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-1600
https://stream-io.atlassian.net/browse/CIS-1781

### 🎯 Goal

_Allow for move operations to scroll to the bottom of the message list_

### ☑️ Contributor Checklist
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
