### PR TITLE
Disable CoreData performance tests

### DIFF
--- a/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
@@ -28,7 +28,9 @@
     {
       "skippedTests" : [
         "ChannelListPayload_Tests\/test_decode_bigChannelListPayload()",
-        "ChannelListPayload_Tests\/test_hugeChannelListQuery_save()"
+        "ChannelListPayload_Tests\/test_hugeChannelListQuery_save()",
+        "ChannelListPayload_Tests\/test_hugeChannelListQuery_save_DB_empty()",
+        "ChannelListPayload_Tests\/test_hugeChannelListQuery_save_DB_filled()"
       ],
       "target" : {
         "containerPath" : "container:StreamChat.xcodeproj",


### PR DESCRIPTION
Each test takes around 15 secs (1.5 sec times 10 iterations), we can keep them disabled and use them locally when needed

#skip_changelog