### PR TITLE
[CIS-1961] Run E2E & Unit tests by cron on multiple iOS & Xcode versions

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -11,6 +11,7 @@ env:
 jobs:
   build-and-test-e2e-debug:
     name: Test E2E UI (Debug)
+    timeout-minutes: 90
     strategy:
       matrix:
         ios: [12.4, 13.7, 14.5, latest]
@@ -62,6 +63,7 @@ jobs:
 
   build-and-test-debug:
     name: Test LLC (Debug)
+    timeout-minutes: 30
     strategy:
       matrix:
         xcode: [13.4.1, 13.1]

--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -1,0 +1,96 @@
+name: Cron Checks
+
+on:
+  schedule:
+    # Runs "At 03:00 every night"
+    - cron: '0 3 * * *'
+
+env:
+  HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
+
+jobs:
+  build-and-test-e2e-debug:
+    name: Test E2E UI (Debug)
+    strategy:
+      matrix:
+        ios: [12.4, 13.7, 14.5, latest]
+        device: ["iPhone 8"]
+        include:
+          - ios: latest
+            device: "iPhone SE (3rd generation)"
+          - ios: latest
+            device: "iPad Air (5th generation)"
+      fail-fast: false
+    runs-on: macos-12
+    env:
+      GITHUB_EVENT: ${{ toJson(github.event) }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ALLURE_TOKEN: ${{ secrets.ALLURE_TOKEN }}
+      IOS_VERSION: ${{ matrix.ios }}
+      DEVICE_NAME: ${{ matrix.device }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/bootstrap
+      env:
+        INSTALL_ALLURE: true
+    - name: Setup iOS ${{ matrix.ios }} Runtime
+      if: ${{ matrix.ios != 'latest' }}
+      run: xcversion simulators --install='iOS ${{ matrix.ios }}'
+    - name: Launch Allure TestOps
+      run: bundle exec fastlane allure_launch
+    - name: Run UI Tests (Debug)
+      run: bundle exec fastlane test_e2e_mock cron:true device:"${{ matrix.device }}" ios:"${{ matrix.ios }}"
+    - name: Allure TestOps Upload
+      if: success() || failure()
+      run: bundle exec fastlane allure_upload launch_id:$LAUNCH_ID
+    - name: Allure TestOps Launch Removal
+      if: cancelled()
+      run: bundle exec fastlane allure_launch_removal launch_id:$LAUNCH_ID
+      env:
+        ALLURE_TOKEN: ${{ secrets.ALLURE_TOKEN }}
+    - uses: 8398a7/action-slack@v3
+      with:
+        status: ${{ job.status }}
+        text: "You shall not pass!"
+        job_name: "${{ github.workflow }}: ${{ github.job }}"
+        fields: message,commit,author,action,workflow,job,took
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        MATRIX_CONTEXT: ${{ toJson(matrix) }}
+      if: failure()
+
+
+  build-and-test-debug:
+    name: Test LLC (Debug)
+    strategy:
+      matrix:
+        xcode: [13.4.1, 13.1]
+        os: [macos-12]
+        include:
+          - xcode: 12.5.1
+            os: macos-11
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/bootstrap
+    - name: Run LLC Tests (Debug)
+      run: bundle exec fastlane test cron:true device:"iPhone 8"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_EVENT: ${{ toJson(github.event) }}
+        XCODE_VERSION: ${{ matrix.xcode }}
+    - uses: test-summary/action@v1
+      with:
+        paths: fastlane/test_output/report.junit
+      if: failure()
+    - uses: 8398a7/action-slack@v3
+      with:
+        status: ${{ job.status }}
+        text: "You shall not pass!"
+        job_name: "${{ github.workflow }}: ${{ github.job }}"
+        fields: message,commit,author,action,workflow,job,took
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        MATRIX_CONTEXT: ${{ toJson(matrix) }}
+      if: failure()

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -9,9 +9,11 @@ on:
   pull_request:
     branches:
       - '**'
+
   release:
     types:
       - created
+
   workflow_dispatch:
 
 concurrency:
@@ -132,10 +134,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_EVENT: ${{ toJson(github.event) }}
         MATRIX_SIZE: ${{ strategy.job-total }}
-    - uses: test-summary/action@v1
-      with:
-        paths: fastlane/test_output/report.junit
-      if: failure()
     - name: Allure TestOps Upload
       if: env.LAUNCH_ID != '' && (success() || failure())
       run: bundle exec fastlane allure_upload launch_id:$LAUNCH_ID
@@ -159,7 +157,7 @@ jobs:
     - uses: ./.github/actions/bootstrap
       env:
         XCODE_ACTIONS: false
-    - name: Create a new launch on Allure TestOps
+    - name: Launch Allure TestOps
       run: bundle exec fastlane allure_launch
       env:
         ALLURE_TOKEN: ${{ secrets.ALLURE_TOKEN }}
@@ -193,6 +191,9 @@ jobs:
     name: Build Sample + Demo Apps
     runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_EVENT: ${{ toJson(github.event) }}
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/bootstrap
@@ -228,6 +229,9 @@ jobs:
     - uses: ./.github/actions/bootstrap
     - name: Build Test Project
       run: bundle exec fastlane spm_integration
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_EVENT: ${{ toJson(github.event) }}
 
   cocoapods-integration:
     name: Test Integration (CocoaPods)
@@ -238,3 +242,6 @@ jobs:
     - uses: ./.github/actions/bootstrap
     - name: Build Test Project
       run: bundle exec fastlane cocoapods_integration
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_EVENT: ${{ toJson(github.event) }}

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -30,6 +30,7 @@ env:
 jobs:
   automated-code-review:
     name: Automated Code Review
+    timeout-minutes: 25
     runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     steps:
@@ -44,6 +45,7 @@ jobs:
 
   build-and-test-debug:
     name: Test LLC (Debug)
+    timeout-minutes: 25
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
@@ -88,6 +90,7 @@ jobs:
 
   build-and-test-ui-debug:
     name: Test UI (Debug)
+    timeout-minutes: 25
     runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     steps:
@@ -111,6 +114,7 @@ jobs:
 
   build-and-test-e2e-debug:
     name: Test E2E UI (Debug)
+    timeout-minutes: 35
     runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     needs: allure_testops_launch
@@ -148,6 +152,7 @@ jobs:
 
   allure_testops_launch:
     name: Launch Allure TestOps
+    timeout-minutes: 25
     runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     outputs:
@@ -169,6 +174,7 @@ jobs:
 
   build-xcode12:
     name: Build LLC + UI (Xcode 12)
+    timeout-minutes: 25
     runs-on: macos-11
     if: ${{ github.event_name != 'push' }}
     steps:
@@ -189,6 +195,7 @@ jobs:
 
   build-apps:
     name: Build Sample + Demo Apps
+    timeout-minutes: 25
     runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     env:
@@ -222,6 +229,7 @@ jobs:
 
   spm-integration:
     name: Test Integration (SPM)
+    timeout-minutes: 25
     runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     steps:
@@ -235,6 +243,7 @@ jobs:
 
   cocoapods-integration:
     name: Test Integration (CocoaPods)
+    timeout-minutes: 25
     runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     steps:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">
   <a href="https://getstream.io/chat/docs/sdk/ios/"><img src="https://img.shields.io/badge/iOS-11%2B-lightblue" /></a>
   <a href="https://swift.org"><img src="https://img.shields.io/badge/Swift-5.2-orange.svg" /></a>
-  <a href="https://github.com/GetStream/stream-chat-swift/actions"><img src="https://github.com/GetStream/stream-chat-swift/actions/workflows/smoke-checks.yml/badge.svg" /></a>
+  <a href="https://github.com/GetStream/stream-chat-swift/actions"><img src="https://github.com/GetStream/stream-chat-swift/actions/workflows/cron-checks.yml/badge.svg" /></a>
   <a href="https://sonarcloud.io/summary/new_code?id=GetStream_stream-chat-swift"><img src="https://sonarcloud.io/api/project_badges/measure?project=GetStream_stream-chat-swift&metric=coverage" /></a>
 </p>
 <p align="center">

--- a/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
+++ b/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
@@ -72,7 +72,7 @@ class MessageListPage {
         static var inputField: XCUIElement { app.otherElements["inputTextContainer"] }
         static var textView: XCUIElement { inputField.textViews.firstMatch }
         static var cooldown: XCUIElement { app.staticTexts["cooldownLabel"] }
-        static var cutButton: XCUIElement { app.menuItems.matching(NSPredicate(format: "label LIKE 'Cut'")).firstMatch }
+        static var selectAllButton: XCUIElement { app.menuItems.matching(NSPredicate(format: "label LIKE 'Select All'")).firstMatch }
     }
     
     enum Reactions {
@@ -209,14 +209,6 @@ class MessageListPage {
             attachmentActionButton(in: messageCell, label: "Cancel")
         }
 
-        static func giphyImageView(in messageCell: XCUIElement) -> XCUIElement {
-            messageCell.images["imageView"]
-        }
-
-        static func giphyBadge(in messageCell: XCUIElement) -> XCUIElement {
-            messageCell.images["lightning"]
-        }
-
         static func giphyLabel(in messageCell: XCUIElement) -> XCUIElement {
             messageCell.staticTexts["GIPHY"]
         }
@@ -234,12 +226,12 @@ class MessageListPage {
             messageCell.images.matching(NSPredicate(format: "identifier LIKE 'imageView'"))
         }
         
-        static func fileNames(in messageCell: XCUIElement) -> XCUIElementQuery {
-            messageCell.staticTexts.matching(NSPredicate(format: "identifier LIKE 'fileNameLabel'"))
+        static func fullscreenImage() -> XCUIElement {
+            app.cells["ImageAttachmentGalleryCell"].images.firstMatch
         }
         
-        static func fileIcons(in messageCell: XCUIElement) -> XCUIElementQuery {
-            messageCell.images.matching(NSPredicate(format: "identifier LIKE 'fileIconImageView'"))
+        static func fileNames(in messageCell: XCUIElement) -> XCUIElementQuery {
+            messageCell.staticTexts.matching(NSPredicate(format: "identifier LIKE 'fileNameLabel'"))
         }
         
         static func videoPlayer() -> XCUIElement {
@@ -249,29 +241,33 @@ class MessageListPage {
     
     enum PopUpButtons {
         static var cancel: XCUIElement {
-            app.scrollViews.buttons.matching(NSPredicate(format: "label LIKE 'Cancel'")).firstMatch
+            app.buttons.matching(NSPredicate(format: "label LIKE 'Cancel'")).firstMatch
         }
         
         static var delete: XCUIElement {
-            app.scrollViews.buttons.matching(NSPredicate(format: "label LIKE 'Delete'")).firstMatch
+            app.buttons.matching(NSPredicate(format: "label LIKE 'Delete'")).firstMatch
         }
     }
     
     enum AttachmentMenu {
         static var fileButton: XCUIElement {
-            app.scrollViews.buttons.matching(NSPredicate(format: "label LIKE 'File'")).firstMatch
+            app.buttons.matching(NSPredicate(format: "label LIKE 'File'")).firstMatch
         }
         
         static var photoOrVideoButton: XCUIElement {
-            app.scrollViews.buttons.matching(NSPredicate(format: "label LIKE 'Photo or Video'")).firstMatch
+            app.buttons.matching(NSPredicate(format: "label LIKE 'Photo or Video'")).firstMatch
         }
         
         static var cancelButton: XCUIElement {
-            app.scrollViews.buttons.matching(NSPredicate(format: "label LIKE 'Cancel'")).firstMatch
+            app.buttons.matching(NSPredicate(format: "label LIKE 'Cancel'")).firstMatch
         }
         
         static var images: XCUIElementQuery {
-            app.scrollViews.images
+            if ProcessInfo().operatingSystemVersion.majorVersion > 13 {
+                return app.scrollViews.images
+            } else {
+                return app.collectionViews.cells
+            }
         }
     }
     

--- a/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
@@ -209,7 +209,8 @@ extension UserRobot {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> Self {
-        let typingIndicatorView = MessageListPage.typingIndicator
+        let typingIndicatorView = MessageListPage.typingIndicator.wait()
+        XCTAssertTrue(typingIndicatorView.exists, "Element hidden", file: file, line: line)
         let typingUserText = typingIndicatorView.waitForText(typingUserName).text
         XCTAssert(typingUserText.contains(typingUserName), file: file, line: line)
         return self
@@ -322,12 +323,15 @@ extension UserRobot {
                                               line: UInt = #line) {
         let messageCell = messageCell(withIndex: messageCellIndex, file: file, line: line)
         let cellHeight = messageCell.height
-        let textView = MessageListPage.Attributes.text(in: messageCell)
+        let textView = attributes.text(in: messageCell)
         let newLine = "new line"
-        let newText = linesCountShouldBeIncreased ? "\(textView.text)\n\(newLine)" : newLine
+        let newText = linesCountShouldBeIncreased ? "ok\n\(textView.text)\n\(newLine)" : newLine
         
         editMessage(newText, messageCellIndex: messageCellIndex)
-        assertMessage(newText, at: messageCellIndex, file: file, line: line)
+        if ProcessInfo().operatingSystemVersion.majorVersion > 12 {
+            // XCUITest does not get text from a cell after editing it on iOS 12
+            assertMessage(newText, at: messageCellIndex, file: file, line: line)
+        }
         
         if linesCountShouldBeIncreased {
             XCTAssertLessThan(cellHeight, messageCell.height, file: file, line: line)
@@ -470,9 +474,7 @@ extension UserRobot {
         line: UInt = #line
     ) -> Self {
         let cell = messageCell(withIndex: messageCellIndex, file: file, line: line).wait()
-        XCTAssertTrue(attributes.giphyImageView(in: cell).wait().exists)
         XCTAssertTrue(attributes.giphyLabel(in: cell).wait().exists)
-        XCTAssertTrue(attributes.giphyBadge(in: cell).wait().exists)
         XCTAssertFalse(attributes.giphySendButton(in: cell).exists)
         XCTAssertFalse(attributes.giphyShuffleButton(in: cell).exists)
         XCTAssertFalse(attributes.giphyCancelButton(in: cell).exists)
@@ -519,17 +521,15 @@ extension UserRobot {
     
     @discardableResult
     func assertImage(
-        count: Int = 1,
         isPresent: Bool,
         at messageCellIndex: Int? = nil,
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> Self {
-        let messageCell = messageCell(withIndex: messageCellIndex, file: file, line: line)
-        let images = attributes.images(in: messageCell)
-        let errMessage = isPresent ? "There are no images" : "Image are presented"
-        _ = isPresent ? images.firstMatch.wait() : images.firstMatch.waitForLoss()
-        XCTAssertEqual(images.count, count, errMessage, file: file, line: line)
+        tapOnMessage(at: messageCellIndex)
+        let fullscreenImage = attributes.fullscreenImage().wait()
+        let errMessage = isPresent ? "There is no image" : "Image is presented"
+        XCTAssertTrue(fullscreenImage.exists, errMessage, file: file, line: line)
         return self
     }
     
@@ -556,12 +556,10 @@ extension UserRobot {
         line: UInt = #line
     ) -> Self {
         let messageCell = messageCell(withIndex: messageCellIndex, file: file, line: line)
-        let fileIcons = attributes.fileIcons(in: messageCell)
         let fileNames = attributes.fileNames(in: messageCell)
         let errMessage = isPresent ? "There are no files" : "Files are presented"
         _ = isPresent ? fileNames.firstMatch.wait() : fileNames.firstMatch.waitForLoss()
         XCTAssertEqual(fileNames.count, count, errMessage, file: file, line: line)
-        XCTAssertEqual(fileIcons.count, count, errMessage, file: file, line: line)
         return self
     }
 }

--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -117,14 +117,11 @@ extension UserRobot {
     
     @discardableResult
     func clearComposer() -> Self {
-        let currentText = composer.textView.text
-        if currentText.isEmpty { return self }
-        
-        for _ in (0...currentText.split(separator: "\n").count - 1) {
-            composer.inputField.tap(withNumberOfTaps: 3, numberOfTouches: 1)
-            composer.cutButton.wait().safeTap()
+        if !composer.textView.text.isEmpty {
+            composer.inputField.tap()
+            composer.selectAllButton.wait().safeTap()
+            composer.inputField.typeText(XCUIKeyboardKey.delete.rawValue)
         }
-        
         return self
     }
     
@@ -210,7 +207,7 @@ extension UserRobot {
     @discardableResult
     func tapOnMessage(at messageCellIndex: Int? = 0) -> Self {
         let messageCell = messageCell(withIndex: messageCellIndex)
-        messageCell.safeTap()
+        messageCell.waitForHitPoint().tap()
         return self
     }
     
@@ -259,8 +256,7 @@ extension UserRobot {
 
     @discardableResult
     func scrollMessageListUp() -> Self {
-        let topMessage = MessageListPage.cells.element(boundBy: 0)
-        MessageListPage.list.press(forDuration: 0.1, thenDragTo: topMessage)
+        MessageListPage.list.swipeDown()
         return self
     }
     
@@ -343,7 +339,7 @@ extension UserRobot {
         for i in 1...count {
             MessageListPage.Composer.attachmentButton.wait().safeTap()
             MessageListPage.AttachmentMenu.photoOrVideoButton.wait().safeTap()
-            MessageListPage.AttachmentMenu.images.waitCount(1).allElementsBoundByIndex[i-1].safeTap()
+            MessageListPage.AttachmentMenu.images.waitCount(1).allElementsBoundByIndex[i].safeTap()
         }
         if send { sendMessage("", waitForAppearance: false) }
         return self

--- a/StreamChatUITestsAppUITests/Tests/Base TestCase/StreamTestCase.swift
+++ b/StreamChatUITestsAppUITests/Tests/Base TestCase/StreamTestCase.swift
@@ -30,6 +30,7 @@ class StreamTestCase: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        takeElementTree()
         app.terminate()
         server.stop()
         server = nil
@@ -52,5 +53,11 @@ extension StreamTestCase {
             .httpHost: "\(MockServerConfiguration.httpHost)",
             .port: "\(MockServerConfiguration.port)"
         ])
+    }
+    
+    private func takeElementTree() {
+        let attachment = XCTAttachment(string: app.debugDescription)
+        attachment.lifetime = .deleteOnSuccess
+        add(attachment)
     }
 }

--- a/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
@@ -243,6 +243,7 @@ final class MessageList_Tests: StreamTestCase {
             userRobot
                 .login()
                 .openChannel()
+                .sendMessage("Hey")
         }
         WHEN("participant starts typing") {
             participantRobot.startTyping()
@@ -260,6 +261,7 @@ final class MessageList_Tests: StreamTestCase {
             userRobot
                 .login()
                 .openChannel()
+                .sendMessage("Hey")
         }
         WHEN("participant starts typing") {
             participantRobot.startTyping()
@@ -272,9 +274,13 @@ final class MessageList_Tests: StreamTestCase {
         }
     }
 
-    func test_messageListScrollsDown_whenMessageListIsScrolledUp_andUserSendsNewMessage() {
+    func test_messageListScrollsDown_whenMessageListIsScrolledUp_andUserSendsNewMessage() throws {
         linkToScenario(withId: 193)
+        
+        try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12,
+                      "[CIS-2020] Scroll on message list does not work well enough")
 
+        let count = 30
         let newMessage = "New message"
 
         GIVEN("user opens the channel") {
@@ -283,7 +289,7 @@ final class MessageList_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("channel is scrollable") {
-            participantRobot.sendMultipleMessages(repeatingText: "message", count: 50)
+            participantRobot.sendMultipleMessages(repeatingText: "message", count: count)
         }
         WHEN("user scrolls up") {
             userRobot.scrollMessageListUp()
@@ -299,7 +305,7 @@ final class MessageList_Tests: StreamTestCase {
     func test_messageListScrollsDown_whenMessageListIsScrolledDown_andUserReceivesNewMessage() {
         linkToScenario(withId: 75)
 
-        let count = 50
+        let count = 30
         let message = "message"
         let newMessage = "New message"
 
@@ -322,6 +328,7 @@ final class MessageList_Tests: StreamTestCase {
     func test_messageListDoesNotScrollDown_whenMessageListIsScrolledUp_andUserReceivesNewMessage() {
         linkToScenario(withId: 194)
 
+        let count = 30
         let newMessage = "New message"
 
         GIVEN("user opens the channel") {
@@ -330,7 +337,7 @@ final class MessageList_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("channel is scrollable") {
-            participantRobot.sendMultipleMessages(repeatingText: "message", count: 50)
+            participantRobot.sendMultipleMessages(repeatingText: "message", count: count)
         }
         WHEN("user scrolls up") {
             userRobot.scrollMessageListUp()
@@ -633,7 +640,7 @@ extension MessageList_Tests {
             userRobot.showThread()
         }
         WHEN("participant starts typing in thread") {
-            participantRobot.startTypingInThread()
+            participantRobot.wait(1).startTypingInThread()
         }
         THEN("user observes typing indicator is shown") {
             let typingUserName = UserDetails.userName(for: participantRobot.currentUserId)
@@ -656,7 +663,7 @@ extension MessageList_Tests {
             userRobot.showThread()
         }
         WHEN("participant starts typing in thread") {
-            participantRobot.startTypingInThread()
+            participantRobot.wait(1).startTypingInThread()
         }
         AND("participant stops typing in thread") {
             participantRobot.stopTypingInThread()

--- a/StreamChatUITestsAppUITests/Tests/SlowMode_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/SlowMode_Tests.swift
@@ -27,7 +27,7 @@ final class SlowMode_Tests: StreamTestCase {
                 .openChannel()
         }
         WHEN("user sends a new text message") {
-            userRobot.sendMessage(message)
+            userRobot.sendMessage(message, waitForAppearance: false)
         }
         THEN("slow mode is active and cooldown is shown") {
             userRobot.assertCooldownIsShown()
@@ -50,13 +50,13 @@ final class SlowMode_Tests: StreamTestCase {
             userRobot.selectOptionFromContextMenu(option: .reply)
         }
         WHEN("user types a new text message") {
-            userRobot.sendMessage(replyMessage)
+            userRobot.sendMessage(replyMessage, waitForAppearance: false)
         }
-        THEN("message is sent") {
-            userRobot.assertQuotedMessage(replyText: replyMessage, quotedText: message)
-        }
-        AND("slow mode is active and cooldown is shown") {
+        THEN("slow mode is active and cooldown is shown") {
             userRobot.assertCooldownIsShown()
+        }
+        AND("message is sent") {
+            userRobot.assertQuotedMessage(replyText: replyMessage, quotedText: message)
         }
     }
     
@@ -70,7 +70,7 @@ final class SlowMode_Tests: StreamTestCase {
                 .openChannel()
         }
         AND("user sends a new text message") {
-            userRobot.sendMessage(message)
+            userRobot.sendMessage(message, waitForAppearance: false)
         }
         AND("slow mode is active and cooldown is shown") {
             userRobot.assertCooldownIsShown()

--- a/TestTools/StreamChatTestMockServer/Robots/ParticipantRobot.swift
+++ b/TestTools/StreamChatTestMockServer/Robots/ParticipantRobot.swift
@@ -67,7 +67,7 @@ public class ParticipantRobot {
     // Sleep in seconds
     @discardableResult
     public func wait(_ duration: TimeInterval) -> Self {
-        let sleepTime = UInt32(duration * 1000)
+        let sleepTime = UInt32(duration * 1000000)
         usleep(sleepTime)
         return self
     }
@@ -126,7 +126,7 @@ public class ParticipantRobot {
 
         texts.forEach {
             sendMessage($0, waitForAppearance: false)
-            wait(0.5)
+            wait(0.3)
         }
         return self
     }

--- a/fastlane/Allurefile
+++ b/fastlane/Allurefile
@@ -16,7 +16,7 @@ end
 
 desc 'Create launch on Allure TestOps'
 lane :allure_launch do
-  next unless testing_required?(:e2e)
+  next unless check_required?(:e2e)
 
   tags = []
   github_run = github_run_details

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -471,9 +471,11 @@ end
 
 desc "Runs tests in Debug config"
 lane :test do |options|
-  next unless testing_required?(:unit)
+  next unless check_required?(:unit)
 
   add_ci_env_var_to("../Tests/StreamChatTests/StreamChatTestPlan.xctestplan")
+
+  number_of_retries = options[:cron] ? 1 : 0
 
   scan(
     project: "StreamChat.xcodeproj",
@@ -482,27 +484,33 @@ lane :test do |options|
     configuration: "Debug",
     clean: true,
     devices: options[:device],
-    build_for_testing: options[:build_for_testing]
+    build_for_testing: options[:build_for_testing],
+    number_of_retries: number_of_retries
   )
 end
 
 desc "Runs e2e ui tests using mock server in Debug config"
 lane :test_e2e_mock do |options|
-  next unless testing_required?(:e2e)
+  next unless check_required?(:e2e)
 
   add_ci_env_var_to('../StreamChatUITestsAppUITests/StreamChatUITestsApp.xctestplan')
+
+  ios = options[:ios]
+  device = ios && ios != 'latest' ? "#{options[:device]} (#{ios})" : options[:device]
+  build_for_testing = is_ci && options[:cron].nil?
+  number_of_retries = options[:cron] ? 2 : 1
 
   scan_options = {
     project: 'StreamChat.xcodeproj',
     scheme: 'StreamChatUITestsApp',
     testplan: 'StreamChatUITestsApp',
     configuration: 'Debug',
-    devices: options[:device],
-    number_of_retries: 1
+    devices: device,
+    number_of_retries: number_of_retries
   }
-  scan(scan_options.merge(clean: true, build_for_testing: is_ci))
+  scan(scan_options.merge(clean: true, build_for_testing: build_for_testing))
 
-  if is_ci
+  if build_for_testing
     parallelize_tests_on_ci(
       scan: scan_options,
       derived_data: lane_context[SharedValues::SCAN_DERIVED_DATA_PATH],
@@ -531,7 +539,7 @@ end
 
 desc "Runs ui tests in Debug config"
 lane :test_ui do |options|
-  next unless testing_required?(:ui)
+  next unless check_required?(:ui)
 
   add_ci_env_var_to('../Tests/StreamChatUITests/StreamChatUITestPlan.xctestplan')
 
@@ -699,6 +707,8 @@ lane :build_youtube_clone do |options|
 end
 
 def build_example_app(scheme, options)
+  return unless check_required?(:sample_apps)
+
   scan(
     project: "StreamChat.xcodeproj",
     scheme: scheme,
@@ -720,7 +730,9 @@ lane :build_docs_snippets do |options|
 end
 
 desc "Test SPM Integration"
-lane :spm_integration do |options|
+lane :spm_integration do
+  next unless check_required?(:integration)
+
   build_app(
     project: "Integration/SPM/SwiftPackageManager.xcodeproj",
     scheme: "SwiftPackageManager",
@@ -732,6 +744,7 @@ end
 
 desc "Test CocoaPods Integration"
 lane :cocoapods_integration do
+  next unless check_required?(:integration)
 
   cocoapods(
     clean_install: true,
@@ -786,13 +799,15 @@ lane :emerge_upload do
   )
 end
 
-def testing_required?(type)
+def check_required?(type)
   return true if ENV['GITHUB_EVENT_NAME'] != 'pull_request'
 
   sources = {
-    e2e: %w[Sources StreamChatUITestsAppUITests StreamChatUITestsApp],
+    e2e: %w[Sources StreamChatUITestsAppUITests StreamChatUITestsApp StreamChat.xcodeproj],
     unit: %w[Sources Tests StreamChat.xcodeproj],
-    ui: %w[Sources Tests/StreamChatUITests Tests/UISDKdocumentationTests]
+    ui: %w[Sources Tests/StreamChatUITests Tests/UISDKdocumentationTests StreamChat.xcodeproj],
+    sample_apps: %w[Sources Examples DemoApp StreamChatSample StreamChat.xcodeproj],
+    integration: %w[Sources Integration StreamChat.xcodeproj]
   }
 
   pr_number = JSON.parse(ENV['GITHUB_EVENT'])['pull_request']['number']


### PR DESCRIPTION
### 🔗 Issue Links

- https://stream-io.atlassian.net/browse/CIS-1961

### 🎯 Goal

- Run E2E tests by cron on multiple iOS versions
- Run Unit tests by cron on multiple Xcode versions

### 📝 Summary

- `cron-checks` will be executed `"At 03:00 every night"`
- Readme now points to `cron-checks` instead of `smoke-checks`
- Unit tests executed using `xcode: [12.5.1, 13.1, 13.4.1]`
- E2E tests executed using `ios: [12.4, 13.7, 14.5, latest]`
- E2E tests are adopted to older iOS versions
- Building sample фззы and SPM/Cocoapods integration checks will be skipped if the changes do not affect the source code

### 🧪 Manual Testing Notes

- N/A

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/61XRgiopTwXYda9sTX/giphy.gif)
