### PR TITLE
Change upload file size limit to 100MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Chat SDK now leverages `chat.stream-io-api.com` endpoint by default [#2125](https://github.com/GetStream/stream-chat-swift/pull/2125)
 - JSON decoding performance is futher increased, parsing time reduced by another %50 [#2128](https://github.com/GetStream/stream-chat-swift/issues/2128)
 - Better errors in case JSON decoding fails [#2126](https://github.com/GetStream/stream-chat-swift/issues/2126)
-- File size limit is increased to 100MB [#2136](https://github.com/GetStream/stream-chat-swift/pull/2136)
+- File upload size limit is increased to 100MB [#2136](https://github.com/GetStream/stream-chat-swift/pull/2136)
 
 ### 🐞 Fixed
 - Allow sending giphy messages programmatically [#2124](https://github.com/GetStream/stream-chat-swift/pull/2124)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Chat SDK now leverages `chat.stream-io-api.com` endpoint by default [#2125](https://github.com/GetStream/stream-chat-swift/pull/2125)
 - JSON decoding performance is futher increased, parsing time reduced by another %50 [#2128](https://github.com/GetStream/stream-chat-swift/issues/2128)
 - Better errors in case JSON decoding fails [#2126](https://github.com/GetStream/stream-chat-swift/issues/2126)
+- File size limit is increased to 100MB [#2136](https://github.com/GetStream/stream-chat-swift/pull/2136)
 
 ### 🐞 Fixed
 - Allow sending giphy messages programmatically [#2124](https://github.com/GetStream/stream-chat-swift/pull/2124)

--- a/Sources/StreamChat/APIClient/CDNClient.swift
+++ b/Sources/StreamChat/APIClient/CDNClient.swift
@@ -22,7 +22,7 @@ public protocol CDNClient {
 
 /// Default implementation of CDNClient that uses Stream CDN
 class StreamCDNClient: CDNClient {
-    static var maxAttachmentSize: Int64 { 20 * 1024 * 1024 }
+    static var maxAttachmentSize: Int64 { 100 * 1024 * 1024 }
 
     private let decoder: RequestDecoder
     private let encoder: RequestEncoder

--- a/Tests/StreamChatTests/APIClient/StreamCDNClient_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/StreamCDNClient_Tests.swift
@@ -202,8 +202,4 @@ final class StreamCDNClient_Tests: XCTestCase {
             body: multipartFormData.getMultipartFormData()
         )
     }
-    
-    func test_maxAttachmentSize() {
-        XCTAssertEqual(StreamCDNClient.maxAttachmentSize, 20 * 1024 * 1024)
-    }
 }


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
The backend now supports a 100MB file size. This changes that config.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
