### PR TITLE
[CIS-2044] Add hide history option when adding a new member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### ✅ Added
+- Add hide history option when adding a new member [#2155](https://github.com/GetStream/stream-chat-swift/issues/2155)
 
 # [4.18.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.18.0)
 _July 05, 2022_

--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -160,6 +160,22 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
                     }
                 }
             }),
+            .init(title: "Add member w/o history", style: .default, handler: { [unowned self] _ in
+                self.rootViewController.presentAlert(title: "Enter user id", textFieldPlaceholder: "User ID") { id in
+                    guard let id = id, !id.isEmpty else {
+                        self.rootViewController.presentAlert(title: "User ID is not valid")
+                        return
+                    }
+                    channelController.addMembers(userIds: [id], hideHistory: true) { error in
+                        if let error = error {
+                            self.rootViewController.presentAlert(
+                                title: "Couldn't add user \(id) to channel \(cid)",
+                                message: "\(error)"
+                            )
+                        }
+                    }
+                }
+            }),
             .init(title: "Remove a member", style: .default, handler: { [unowned self] _ in
                 let actions = channelController.channel?.lastActiveMembers.map { member in
                     UIAlertAction(title: member.id, style: .default) { _ in

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
@@ -114,13 +114,17 @@ extension Endpoint {
         )
     }
     
-    static func addMembers(cid: ChannelId, userIds: Set<UserId>) -> Endpoint<EmptyResponse> {
-        .init(
+    static func addMembers(cid: ChannelId, userIds: Set<UserId>, hideHistory: Bool) -> Endpoint<EmptyResponse> {
+        let body: [String: AnyEncodable] = [
+            "add_members": AnyEncodable(userIds),
+            "hide_history": AnyEncodable(hideHistory)
+        ]
+        return .init(
             path: .channelUpdate(cid.apiPath),
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
-            body: ["add_members": userIds]
+            body: body
         )
     }
     

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -945,17 +945,18 @@ public extension ChatChannelController {
     ///
     /// - Parameters:
     ///   - users: Users Id to add to a channel.
+    ///   - hideHistory: Hide the history of the channel to the added member. By default, it is false.
     ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
     ///                 If request fails, the completion will be called with an error.
     ///
-    func addMembers(userIds: Set<UserId>, completion: ((Error?) -> Void)? = nil) {
+    func addMembers(userIds: Set<UserId>, hideHistory: Bool = false, completion: ((Error?) -> Void)? = nil) {
         /// Perform action only if channel is already created on backend side and have a valid `cid`.
         guard let cid = cid, isChannelAlreadyCreated else {
             channelModificationFailed(completion)
             return
         }
         
-        updater.addMembers(cid: cid, userIds: userIds) { error in
+        updater.addMembers(cid: cid, userIds: userIds, hideHistory: hideHistory) { error in
             self.callback {
                 completion?(error)
             }

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -266,9 +266,10 @@ class ChannelUpdater: Worker {
     /// - Parameters:
     ///   - cid: The Id of the channel where you want to add the users.
     ///   - users: User Ids to add to the channel.
+    ///   - hideHistory: Hide the history of the channel to the added member.
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
-    func addMembers(cid: ChannelId, userIds: Set<UserId>, completion: ((Error?) -> Void)? = nil) {
-        apiClient.request(endpoint: .addMembers(cid: cid, userIds: userIds)) {
+    func addMembers(cid: ChannelId, userIds: Set<UserId>, hideHistory: Bool, completion: ((Error?) -> Void)? = nil) {
+        apiClient.request(endpoint: .addMembers(cid: cid, userIds: userIds, hideHistory: hideHistory)) {
             completion?($0.error)
         }
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ChannelUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ChannelUpdater_Mock.swift
@@ -37,6 +37,7 @@ final class ChannelUpdater_Mock: ChannelUpdater {
     
     @Atomic var addMembers_cid: ChannelId?
     @Atomic var addMembers_userIds: Set<UserId>?
+    @Atomic var addMembers_hideHistory: Bool?
     @Atomic var addMembers_completion: ((Error?) -> Void)?
     
     @Atomic var inviteMembers_cid: ChannelId?
@@ -262,9 +263,10 @@ final class ChannelUpdater_Mock: ChannelUpdater {
         createNewMessage_completion = completion
     }
     
-    override func addMembers(cid: ChannelId, userIds: Set<UserId>, completion: ((Error?) -> Void)? = nil) {
+    override func addMembers(cid: ChannelId, userIds: Set<UserId>, hideHistory: Bool, completion: ((Error?) -> Void)? = nil) {
         addMembers_cid = cid
         addMembers_userIds = userIds
+        addMembers_hideHistory = hideHistory
         addMembers_completion = completion
     }
     

--- a/Tests/StreamChatTests/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -249,11 +249,11 @@ final class ChannelEndpoints_Tests: XCTestCase {
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
-            body: ["add_members": userIds]
+            body: ["add_members": AnyEncodable(userIds), "hide_history": AnyEncodable(true)]
         )
 
         // Build endpoint
-        let endpoint: Endpoint<EmptyResponse> = .addMembers(cid: cid, userIds: userIds)
+        let endpoint: Endpoint<EmptyResponse> = .addMembers(cid: cid, userIds: userIds, hideHistory: true)
 
         // Assert endpoint is built correctly
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))

--- a/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
@@ -947,10 +947,10 @@ final class ChannelUpdater_Tests: XCTestCase {
         let userIds: Set<UserId> = Set([UserId.unique])
 
         // Simulate `addMembers(cid:, mute:, userIds:)` call
-        channelUpdater.addMembers(cid: channelID, userIds: userIds)
+        channelUpdater.addMembers(cid: channelID, userIds: userIds, hideHistory: false)
 
         // Assert correct endpoint is called
-        let referenceEndpoint: Endpoint<EmptyResponse> = .addMembers(cid: channelID, userIds: userIds)
+        let referenceEndpoint: Endpoint<EmptyResponse> = .addMembers(cid: channelID, userIds: userIds, hideHistory: false)
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
     }
 
@@ -960,7 +960,7 @@ final class ChannelUpdater_Tests: XCTestCase {
         
         // Simulate `addMembers(cid:, mute:, userIds:)` call
         var completionCalled = false
-        channelUpdater.addMembers(cid: channelID, userIds: userIds) { error in
+        channelUpdater.addMembers(cid: channelID, userIds: userIds, hideHistory: false) { error in
             XCTAssertNil(error)
             completionCalled = true
         }
@@ -981,7 +981,7 @@ final class ChannelUpdater_Tests: XCTestCase {
         
         // Simulate `muteChannel(cid:, mute:, completion:)` call
         var completionCalledError: Error?
-        channelUpdater.addMembers(cid: channelID, userIds: userIds) { completionCalledError = $0 }
+        channelUpdater.addMembers(cid: channelID, userIds: userIds, hideHistory: false) { completionCalledError = $0 }
 
         // Simulate API response with failure
         let error = TestError()


### PR DESCRIPTION
### 🔗 Issue Links
CIS-2044
https://github.com/GetStream/stream-chat-swift/discussions/1612

### 🎯 Goal
Add an option to hide the history of the channel when adding a new member.

### 📝 Summary
- `ChannelController.addMembers()` has now a new `hideHistory: Bool` argument to hide the history of the channel for that member. By default it is false.

### 🧪 Manual Testing Notes
1. Open a Channel
2. Tap on the 🐞 button
3. Tap on "Add Member w/o history"
4. Select a user id to add, ex: lando_calrissian
5. Login with lando_calrissian
6. Verify that the channel doesn't have any messages

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)