### PR TITLE
[CIS-1882] Support pagination in mock server

### DIFF
--- a/Sources/StreamChat/Query/Pagination.swift
+++ b/Sources/StreamChat/Query/Pagination.swift
@@ -25,7 +25,7 @@ public struct Pagination: Encodable, Equatable {
     /// An offset.
     public let offset: Int
     
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case pageSize = "limit"
         case offset
     }
@@ -63,7 +63,7 @@ public struct MessagesPagination: Encodable, Equatable {
         self.parameter = parameter
     }
     
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case pageSize = "limit"
     }
     
@@ -76,7 +76,7 @@ public struct MessagesPagination: Encodable, Equatable {
 
 /// Pagination parameters
 public enum PaginationParameter: Encodable, Hashable {
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case greaterThan = "id_gt"
         case greaterThanOrEqual = "id_gte"
         case lessThan = "id_lt"

--- a/Sources/StreamChat/Query/Pagination.swift
+++ b/Sources/StreamChat/Query/Pagination.swift
@@ -25,7 +25,7 @@ public struct Pagination: Encodable, Equatable {
     /// An offset.
     public let offset: Int
     
-    private enum CodingKeys: String, CodingKey {
+    public enum CodingKeys: String, CodingKey {
         case pageSize = "limit"
         case offset
     }
@@ -63,7 +63,7 @@ public struct MessagesPagination: Encodable, Equatable {
         self.parameter = parameter
     }
     
-    private enum CodingKeys: String, CodingKey {
+    public enum CodingKeys: String, CodingKey {
         case pageSize = "limit"
     }
     
@@ -76,7 +76,7 @@ public struct MessagesPagination: Encodable, Equatable {
 
 /// Pagination parameters
 public enum PaginationParameter: Encodable, Hashable {
-    private enum CodingKeys: String, CodingKey {
+    public enum CodingKeys: String, CodingKey {
         case greaterThan = "id_gt"
         case greaterThanOrEqual = "id_gte"
         case lessThan = "id_lt"

--- a/StreamChatUITestsAppUITests/Pages/ChannelListPage.swift
+++ b/StreamChatUITestsAppUITests/Pages/ChannelListPage.swift
@@ -14,6 +14,15 @@ enum ChannelListPage {
         app.cells.matching(NSPredicate(format: "identifier LIKE 'ChatChannelListCollectionViewCell'"))
     }
     
+    static var list: XCUIElement {
+        app.collectionViews["collectionView"]
+    }
+    
+    static func channel(withName: String) -> XCUIElement {
+        app.staticTexts.matching(NSPredicate(
+            format: "identifier LIKE 'titleLabel' AND label LIKE '\(withName)'")).firstMatch
+    }
+    
     enum Attributes {
         static func name(in cell: XCUIElement) -> XCUIElement {
             cell.staticTexts["titleLabel"]

--- a/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
+++ b/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
@@ -290,4 +290,10 @@ class MessageListPage {
         }
     }
     
+    enum ComposerMentions {
+        static var cells: XCUIElementQuery {
+            app.cells.matching(NSPredicate(format: "identifier LIKE 'ChatMentionSuggestionCollectionViewCell'"))
+        }
+    }
+    
 }

--- a/StreamChatUITestsAppUITests/Tests/ChannelList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/ChannelList_Tests.swift
@@ -57,6 +57,20 @@ final class ChannelList_Tests: StreamTestCase {
             userRobot.assertLastMessageInChannelPreview(message)
         }
     }
+    
+    func test_paginationOnChannelList() {
+        linkToScenario(withId: 276)
+        
+        let channelsCount = 30
+        
+        WHEN("user opens the channel list") {
+            backendRobot.generateChannels(count: channelsCount)
+            userRobot.login()
+        }
+        THEN("user makes sure that all channels are loaded") {
+            userRobot.assertChannelListPagination(channelsCount: channelsCount)
+        }
+    }
 }
 
 // MARK: - Preview

--- a/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
@@ -15,7 +15,7 @@ final class MessageList_Tests: StreamTestCase {
         linkToScenario(withId: 25)
 
         let message = "message"
-        
+
         GIVEN("user opens the channel") {
             userRobot
                 .login()

--- a/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
@@ -15,7 +15,7 @@ final class MessageList_Tests: StreamTestCase {
         linkToScenario(withId: 25)
 
         let message = "message"
-
+        
         GIVEN("user opens the channel") {
             userRobot
                 .login()
@@ -431,6 +431,60 @@ extension MessageList_Tests {
         }
         THEN("deleted message is shown") {
             userRobot.assertDeletedMessage()
+        }
+    }
+    
+    func test_paginationOnMessageList() {
+        linkToScenario(withId: 56)
+        
+        let messagesCount = 60
+        
+        WHEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: messagesCount)
+            userRobot.login().openChannel()
+        }
+        THEN("user makes sure that chat history is loaded") {
+            userRobot.assertMessageListPagination(messagesCount: messagesCount)
+        }
+    }
+    
+    func test_addingCommandHidesLeftButtons() {
+        linkToScenario(withId: 104)
+        
+        GIVEN("user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        WHEN("user types '/'") {
+            userRobot.typeText("/")
+        }
+        THEN("composer left buttons disappear") {
+            userRobot.assertComposerLeftButtons(shouldBeVisible: false)
+        }
+        WHEN("user removes '/'") {
+            userRobot.typeText(XCUIKeyboardKey.delete.rawValue)
+        }
+        THEN("composer left buttons appear") {
+            userRobot.assertComposerLeftButtons(shouldBeVisible: true)
+        }
+    }
+    
+    func test_mentionsView() {
+        linkToScenario(withId: 61)
+        
+        GIVEN("user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        WHEN("user types '@'") {
+            userRobot.typeText("@")
+        }
+        THEN("composer mention view appears") {
+            userRobot.assertComposerMentions(shouldBeVisible: true)
+        }
+        WHEN("user removes '@'") {
+            userRobot.typeText(XCUIKeyboardKey.delete.rawValue)
+        }
+        THEN("composer mention view disappears") {
+            userRobot.assertComposerMentions(shouldBeVisible: false)
         }
     }
 }

--- a/TestTools/StreamChatTestMockServer/MockServer/ChannelResponses.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/ChannelResponses.swift
@@ -49,11 +49,12 @@ public extension StreamMockServer {
     func configureChannelEndpoints() {
         server.register(MockEndpoint.query) { [weak self] request in
             self?.channelQueryEndpointWasCalled = true
-            return self?.updateChannelList(request)
+            self?.updateChannelList(request)
+            return self?.limitQuery(request)
         }
         server.register(MockEndpoint.channels) { [weak self] request in
             self?.channelsEndpointWasCalled = true
-            return self?.updateChannelList(request)
+            return self?.limitChannels(request)
         }
         server.register(MockEndpoint.channel) { [weak self] request in
             self?.handleChannelRequest(request)
@@ -97,9 +98,9 @@ public extension StreamMockServer {
                 && endTime > Date().timeIntervalSince1970 * 1000 {}
     }
     
-    private func updateChannelList(_ request: HttpRequest) -> HttpResponse {
+    private func updateChannelList(_ request: HttpRequest) {
         var json = channelList
-        guard let id = request.params[EndpointQuery.channelId] else { return .ok(.json(json)) }
+        guard let id = request.params[EndpointQuery.channelId] else { return }
 
         var channels = json[JSONKey.channels] as? [[String: Any]]
         if let index = channels?.firstIndex(where: {
@@ -121,8 +122,88 @@ public extension StreamMockServer {
             currentChannelId = id
             channelList = json
         }
-
-        return .ok(.json(json))
+    }
+    
+    private func limitChannels(_ request: HttpRequest) -> HttpResponse {
+        guard
+            let payloadQuery = request.queryParams.first(where: { $0.0 == JSONKey.payload }),
+            let payload = payloadQuery.1.removingPercentEncoding?.json,
+            let limit = payload[Pagination.CodingKeys.pageSize.rawValue] as? Int
+        else {
+            return .ok(.json(channelList))
+        }
+        
+        let offset = payload[Pagination.CodingKeys.offset.rawValue] as? Int ?? 0
+        
+        var limitedChannelList = channelList
+        let channels = limitedChannelList[JSONKey.channels] as? [[String: Any]] ?? []
+        let channelCount = channels.count - 1
+        
+        if channelCount > limit {
+            let startWith = offset > channelCount ? channelCount : offset
+            let endWith = offset + limit < channelCount ? offset + limit - 1 : channelCount
+            limitedChannelList[JSONKey.channels] = Array(channels[startWith...endWith])
+        }
+        
+        return .ok(.json(limitedChannelList))
+    }
+    
+    private func limitQuery(_ request: HttpRequest) -> HttpResponse {
+        let json = TestData.toJson(request.body)
+        let messages = json[JSONKey.messages] as? [String: Any]
+        
+        guard let id = request.params[EndpointQuery.channelId] else { return .badRequest(nil) }
+        guard var channel = findChannelById(id) else { return .badRequest(nil) }
+        guard let limit = messages?[MessagesPagination.CodingKeys.pageSize.rawValue] as? Int else {
+            return .ok(.json(channel))
+        }
+        var messageList = findMessagesByChannelId(id)
+        let idKey = MessagePayloadsCodingKeys.id.rawValue
+        
+        if let idLt = messages?[PaginationParameter.CodingKeys.lessThan.rawValue] {
+            let messageIndex = messageList.firstIndex {
+                idLt as? String == $0[idKey] as? String
+            }
+            if let messageIndex = messageIndex {
+                let startWith = messageIndex - limit > 0 ? messageIndex - limit : 0
+                let endWith = messageIndex - 1 > 0 ? messageIndex - 1 : 0
+                messageList = Array(messageList[startWith...endWith])
+            }
+        } else if let idGt = messages?[PaginationParameter.CodingKeys.greaterThan.rawValue] {
+            let messageIndex = messageList.firstIndex {
+                idGt as? String == $0[idKey] as? String
+            }
+            if let messageIndex = messageIndex {
+                let messageCount = messageList.count - 1
+                let plusLimit = messageIndex + limit
+                let endWith = plusLimit < messageCount ? plusLimit : messageCount
+                messageList = Array(messageList[messageIndex + 1...endWith])
+            }
+        } else if let idLte = messages?[PaginationParameter.CodingKeys.lessThanOrEqual.rawValue] {
+            let messageIndex = messageList.firstIndex {
+                idLte as? String == $0[idKey] as? String
+            }
+            if let messageIndex = messageIndex {
+                let minusLimit = messageIndex - limit
+                let startWith = minusLimit > 0 ? minusLimit : 0
+                messageList = Array(messageList[startWith + 1...messageIndex])
+            }
+        } else if let idGte = messages?[PaginationParameter.CodingKeys.greaterThanOrEqual.rawValue] {
+            let messageIndex = messageList.firstIndex {
+                idGte as? String == $0[idKey] as? String
+            }
+            if let messageIndex = messageIndex {
+                let messageCount = messageList.count - 1
+                let plusLimit = messageIndex + limit
+                let endWith = plusLimit < messageCount ? plusLimit - 1 : messageCount
+                messageList = Array(messageList[messageIndex...endWith])
+            }
+        } else {
+            messageList = Array(messageList.suffix(limit))
+        }
+        
+        channel[ChannelPayload.CodingKeys.messages.rawValue] = messageList
+        return .ok(.json(channel))
     }
 
     // MARK: Channel Members
@@ -220,7 +301,7 @@ public extension StreamMockServer {
         var membership = sampleChannel[ChannelPayload.CodingKeys.membership.rawValue] as? [String: Any]
         membership?[JSONKey.user] = author
         
-        for _ in 1...count {
+        for channelIndex in 1...count {
             var newChannel = sampleChannel
             var messages: [[String: Any]?] = []
             newChannel[ChannelPayload.CodingKeys.members.rawValue] = members
@@ -228,18 +309,19 @@ public extension StreamMockServer {
             let channelDetails = mockChannelDetails(
                 channel: newChannel,
                 author: author,
-                memberCount: members.count
+                memberCount: members.count,
+                channelIndex: channelIndex
             )
             
             if messagesCount > 0 {
-                for i in 1...messagesCount {
-                    let oldDate = Date(timeIntervalSinceReferenceDate: TimeInterval(i * 1000 - 123_456))
-                    let timestamp = TestData.stringTimestamp(oldDate)
+                for messageIndex in 1...messagesCount {
+                    let timeInterval = TimeInterval(messageIndex * 1000 - 123_456_789)
+                    let timestamp = TestData.stringTimestamp(Date(timeIntervalSinceNow: timeInterval))
                     let message = mockMessage(
                         TestData.toJson(.message)[JSONKey.message] as? [String : Any],
                         channelId: channelDetails?[ChannelCodingKeys.id.rawValue] as? String,
                         messageId: TestData.uniqueId,
-                        text: String(i),
+                        text: String(messageIndex),
                         user: author,
                         createdAt: timestamp,
                         updatedAt: timestamp
@@ -260,16 +342,38 @@ public extension StreamMockServer {
     private func mockChannelDetails(
         channel: [String: Any],
         author: [String: Any]?,
-        memberCount: Int
+        memberCount: Int,
+        channelIndex: Int
     ) -> [String: Any]? {
         var channelDetails = channel[ChannelPayload.CodingKeys.channel.rawValue] as? [String: Any]
         let uniqueId = TestData.uniqueId
-        channelDetails?[ChannelCodingKeys.name.rawValue] = uniqueId
+        let timeInterval = TimeInterval(123_456_789 - channelIndex * 1000)
+        let timestamp = TestData.stringTimestamp(Date(timeIntervalSinceNow: timeInterval))
+        channelDetails?[ChannelCodingKeys.name.rawValue] = "\(channelIndex)"
         channelDetails?[ChannelCodingKeys.id.rawValue] = uniqueId
         channelDetails?[ChannelCodingKeys.cid.rawValue] = "\(ChannelType.messaging.rawValue):\(uniqueId)"
         channelDetails?[ChannelCodingKeys.createdBy.rawValue] = author
         channelDetails?[ChannelCodingKeys.memberCount.rawValue] = memberCount
+        channelDetails?[ChannelCodingKeys.createdAt.rawValue] = timestamp
+        channelDetails?[ChannelCodingKeys.updatedAt.rawValue] = timestamp
         return channelDetails
+    }
+    
+    private func findChannelById(_ id: String) -> [String: Any]? {
+        try? XCTUnwrap(waitForChannelWithId(id))
+    }
+    
+    private func waitForChannelWithId(_ id: String) -> [String: Any]? {
+        let endTime = TestData.waitingEndTime
+        var newChannelList: [[String: Any]] = []
+        while newChannelList.isEmpty && endTime > TestData.currentTimeInterval {
+            guard let channels = channelList[JSONKey.channels] as? [[String: Any]] else { return nil }
+            newChannelList = channels.filter {
+                let channel = $0[JSONKey.channel] as? [String: Any]
+                return id == channel?[ChannelCodingKeys.id.rawValue] as? String
+            }
+        }
+        return newChannelList.first
     }
     
 }

--- a/TestTools/StreamChatTestMockServer/MockServer/MockServerAttributes.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/MockServerAttributes.swift
@@ -81,6 +81,7 @@ public enum JSONKey {
     public static let cooldown = "cooldown"
     public static let attachmentAction = "image_action"
     public static let file = "file"
+    public static let payload = "payload"
 
     public enum Channel {
         public static let addMembers = "add_members"


### PR DESCRIPTION
### 🔗 Issue Links

- https://stream-io.atlassian.net/browse/CIS-1882

### 🎯 Goal

- Add support for pagination in Channel List, Message List and Thread List
- Automate related test-cases

### 📝 Summary

- From now on the mock server supports pagination in Channel List and Message List ([here is a blocker](https://stream-io.atlassian.net/browse/CIS-1583) for Thread List pagination)

### 🧪 Manual Testing Notes

1. Generate channels and/or messages using the mock server, e.g.:
```swift
backendRobot.generateChannels(count: 1, messagesCount: 60)
```
2. Freeze the test app:
```swift
sleep(10000)
```
3. Manually Open a Channel List / Message List and load the history
4. Observe pagination requests

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/dgrx6wVmdRbSo/giphy.gif)
