### PR TITLE
[CIS-1634] Fix Channel missing messages from NSE push updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add hide history option when adding a new member [#2155](https://github.com/GetStream/stream-chat-swift/issues/2155)
 ### 🐞 Fixed
 - Avoid triggering CoreData updates in willSave() [#2156](https://github.com/GetStream/stream-chat-swift/pull/2156)
+- Fix Channel missing messages from NSE push updates [#2166](https://github.com/GetStream/stream-chat-swift/pull/2166)
 
 # [4.18.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.18.0)
 _July 05, 2022_

--- a/DemoAppPush/NotificationService.swift
+++ b/DemoAppPush/NotificationService.swift
@@ -82,7 +82,6 @@ class NotificationService: UNNotificationServiceExtension {
         }
 
         var config = ChatClientConfig(apiKey: .init(apiKeyString))
-//        config.isLocalStorageEnabled = false
         config.applicationGroupIdentifier = applicationGroupIdentifier
 
         let client = ChatClient(config: config)

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -68,6 +68,14 @@ open class ChatChannelVC: _ViewController,
     override open func setUp() {
         super.setUp()
 
+        let notificationCenter = NotificationCenter.default
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(appMovedToForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+
         messageListVC.delegate = self
         messageListVC.dataSource = self
         messageListVC.client = client
@@ -274,5 +282,12 @@ open class ChatChannelVC: _ViewController,
         } else {
             messageListVC.showTypingIndicator(typingUsers: typingUsersWithoutCurrentUser)
         }
+    }
+
+    // When app becomes active, and channel is open, recreate the database observers and reload
+    // the data source so that any missed database updates from the NotificationService are refreshed.
+    @objc func appMovedToForeground() {
+        channelController.delegate = self
+        messageListVC.dataSource = self
     }
 }

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -58,6 +58,14 @@ open class ChatThreadVC: _ViewController,
     override open func setUp() {
         super.setUp()
 
+        let notificationCenter = NotificationCenter.default
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(appMovedToForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+
         messageListVC.delegate = self
         messageListVC.dataSource = self
         messageListVC.client = client
@@ -308,5 +316,12 @@ open class ChatThreadVC: _ViewController,
         default:
             break
         }
+    }
+
+    // When app becomes active, and channel is open, recreate the database observers and reload
+    // the data source so that any missed database updates from the NotificationService are refreshed.
+    @objc func appMovedToForeground() {
+        messageController.delegate = self
+        messageListVC.dataSource = self
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links
CIS-1634
https://github.com/GetStream/stream-chat-swift/issues/1827

### 🎯 Goal
Details of the issue are here: https://github.com/GetStream/stream-chat-swift/issues/1827

### 🛠 Implementation
The way this is currently solved is that we monitor in the Channel if the app has become active again from the background, when this happens, we recreate the database observers and reload the data of the message list. 

### 🧪 Manual Testing Notes
- In the initial screen, change the configuration of the app to stay connected in the background to false
- Open a channel
- Go to background
- Open the same channel in another device with a different user
- Send a message
- In the initial device, open the app again (Don't click on the Push Notification)
- Observe the new message is there

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
