### PR TITLE
[CIS-1811] Add Extra Data Usage Improvements

### DIFF
--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MessageAttachmentPayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MessageAttachmentPayload.swift
@@ -21,10 +21,8 @@ struct MessageAttachmentPayload {
 
 extension MessageAttachmentPayload: Encodable {
     func encode(to encoder: Encoder) throws {
-        let payload = self.payload.dictionary(
-            with: .string(type.rawValue),
-            forKey: AttachmentCodingKeys.type.rawValue
-        )
+        var payload = self.payload
+        payload[AttachmentCodingKeys.type.rawValue] = .string(type.rawValue)
         try payload.encode(to: encoder)
     }
 }
@@ -48,14 +46,13 @@ extension MessageAttachmentPayload: Decodable {
             }
         }()
 
-        guard
-            let payload = try decoder
-            .singleValueContainer()
-            .decode(RawJSON.self)
-            .dictionary(with: nil, forKey: AttachmentCodingKeys.type.rawValue)
-        else {
+        var payload = try decoder.singleValueContainer().decode(RawJSON.self)
+
+        guard payload.dictionaryValue != nil else {
             throw ClientError.AttachmentDecoding("Payload must be keyed container")
         }
+
+        payload[AttachmentCodingKeys.type.rawValue] = nil
 
         self.init(
             type: attachmentType,

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// A `RawJSON` type.
+/// A `RawJSON` type. The type use for handling extra data.
 /// Used to store and operate objects of unknown structure that's not possible to decode.
 /// https://forums.swift.org/t/new-unevaluated-type-for-decoder-to-allow-later-re-encoding-of-data-with-unknown-structure/11117
 public indirect enum RawJSON: Codable, Hashable {
@@ -38,11 +38,10 @@ public indirect enum RawJSON: Codable, Hashable {
             self = .nil
             return
         }
-        throw DecodingError
-            .dataCorrupted(
-                DecodingError
-                    .Context(codingPath: decoder.codingPath, debugDescription: "Could not find reasonable type to map to JSONValue")
-            )
+        throw DecodingError.dataCorrupted(DecodingError.Context(
+            codingPath: decoder.codingPath,
+            debugDescription: "Could not find reasonable type to map to JSONValue"
+        ))
     }
     
     public func encode(to encoder: Encoder) throws {

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON.swift
@@ -188,6 +188,99 @@ public extension RawJSON {
     }
 }
 
+// MARK: ExpressibleByLiteral
+
+extension RawJSON: ExpressibleByDictionaryLiteral {
+    public typealias Key = String
+    public typealias Value = RawJSON
+
+    /// RawJSON can be created by using a Dictionary Literal.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData: [String: RawJSON] = [
+    ///     "flight": [
+    ///         "price": .number(1000),
+    ///         "destination": .string("Lisbon")
+    ///     ]
+    /// ]
+    /// ```
+    public init(dictionaryLiteral elements: (String, RawJSON)...) {
+        let dict: [String: RawJSON] = elements.reduce(into: [:]) { partialResult, element in
+            partialResult[element.0] = element.1
+        }
+        self = .dictionary(dict)
+    }
+}
+
+extension RawJSON: ExpressibleByArrayLiteral {
+    /// RawJSON can be created by using an Array Literal.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData: [String: RawJSON] = [
+    ///     "names": [.string("John"), string("Doe")]
+    /// ]
+    /// ```
+    public init(arrayLiteral elements: RawJSON...) {
+        self = .array(elements)
+    }
+}
+
+extension RawJSON: ExpressibleByStringLiteral {
+    /// RawJSON can be created by using a String Literal.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData: [String: RawJSON] = [
+    ///     "names": ["John", "Doe"] // instead of [.string("John"), .string("Doe")]
+    /// ]
+    /// ```
+    public init(stringLiteral value: StringLiteralType) {
+        self = .string(value)
+    }
+}
+
+extension RawJSON: ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral {
+    /// RawJSON can be created by using a Float Literal.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData: [String: RawJSON] = [
+    ///     "distances": [3.5, 4.5] // instead of [.number(3.5), .number(3.5)]
+    /// ]
+    /// ```
+    public init(floatLiteral value: FloatLiteralType) {
+        self = .number(value)
+    }
+
+    /// RawJSON can be created by using an Integer Literal.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData: [String: RawJSON] = [
+    ///     "ages": [23, 32] // instead of [.number(23.0), .number(32.0)]
+    /// ]
+    /// ```
+    public init(integerLiteral value: IntegerLiteralType) {
+        self = .number(Double(value))
+    }
+}
+
+extension RawJSON: ExpressibleByBooleanLiteral {
+    /// RawJSON can be created by using a Bool Literal.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData: [String: RawJSON] = [
+    ///     "isManager": true // instead of .bool(true)
+    /// ]
+    /// ```
+    public init(booleanLiteral value: BooleanLiteralType) {
+        self = .bool(value)
+    }
+}
+
 // MARK: Deprecations
 
 public extension RawJSON {

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON.swift
@@ -59,9 +59,14 @@ public indirect enum RawJSON: Codable, Hashable {
 }
 
 public extension RawJSON {
+// MARK: Deprecations
+
+public extension RawJSON {
+    @available(*, deprecated, message: "dictionaryValue property should be used instead.")
     func dictionary(with value: RawJSON?, forKey key: String) -> RawJSON? {
         guard case var .dictionary(content) = self else { return nil }
         content[key] = value
         return .dictionary(content)
     }
 }
+

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON.swift
@@ -57,7 +57,137 @@ public indirect enum RawJSON: Codable, Hashable {
     }
 }
 
+// MARK: Value extract helpers
+
 public extension RawJSON {
+    /// Extracts a number value of RawJSON.
+    /// Returns nil if the value is not a number.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData = message.extraData
+    /// let price = extraData["price"]?.numberValue ?? 0
+    /// ```
+    var numberValue: Double? {
+        guard case let .number(value) = self else {
+            return nil
+        }
+        return value
+    }
+
+    /// Extracts a string value of RawJSON.
+    /// Returns nil if the value is not a string.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData = message.extraData
+    /// let email = extraData["email"]?.stringValue ?? ""
+    /// ```
+    var stringValue: String? {
+        guard case let .string(value) = self else {
+            return nil
+        }
+        return value
+    }
+
+    /// Extracts a bool value of RawJSON.
+    /// Returns nil if the value is not a bool.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData = message.extraData
+    /// let isManager = extraData["isManager"]?.boolValue ?? false
+    /// ```
+    var boolValue: Bool? {
+        guard case let .bool(value) = self else {
+            return nil
+        }
+        return value
+    }
+
+    /// Extracts a dictionary value of RawJSON.
+    /// Returns nil if the value is not a dictionary.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData = message.extraData
+    /// let flightPrice = extraData["flight"]?.dictionaryValue?["price"]?.numberValue ?? 0
+    /// ```
+    var dictionaryValue: [String: RawJSON]? {
+        guard case let .dictionary(value) = self else {
+            return nil
+        }
+        return value
+    }
+
+    /// Extracts an array value of RawJSON.
+    /// Returns nil if the value is not an array.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData = message.extraData
+    /// let flights: [RawJSON]? = extraData["flights"]?.arrayValue
+    /// ```
+    var arrayValue: [RawJSON]? {
+        guard case let .array(value) = self else {
+            return nil
+        }
+        return value
+    }
+
+    /// Extracts a number array of RawJSON.
+    /// Returns nil if the value is not an array of numbers.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData = message.extraData
+    /// let ages = extraData["ages"]?.numberArrayValue ?? []
+    /// ```
+    var numberArrayValue: [Double]? {
+        guard let rawArrayValue = arrayValue else {
+            return nil
+        }
+
+        return rawArrayValue.compactMap(\.numberValue)
+    }
+
+    /// Extracts a string array of RawJSON.
+    /// Returns nil if the value is not an array of strings.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData = message.extraData
+    /// let names = extraData["names"]?.stringArrayValue ?? []
+    /// ```
+    var stringArrayValue: [String]? {
+        guard let rawArrayValue = arrayValue else {
+            return nil
+        }
+
+        return rawArrayValue.compactMap(\.stringValue)
+    }
+
+    /// Extracts a bool array of RawJSON.
+    /// Returns nil if the value is not an array of bools.
+    var boolArrayValue: [Bool]? {
+        guard let rawArrayValue = arrayValue else {
+            return nil
+        }
+
+        return rawArrayValue.compactMap(\.boolValue)
+    }
+
+    /// Checks if the RawJSON value is null.
+    var isNil: Bool {
+        switch self {
+        case .nil:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 // MARK: Deprecations
 
 public extension RawJSON {
@@ -68,4 +198,3 @@ public extension RawJSON {
         return .dictionary(content)
     }
 }
-

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/RawJSON.swift
@@ -281,6 +281,63 @@ extension RawJSON: ExpressibleByBooleanLiteral {
     }
 }
 
+// MARK: Subscripts
+
+extension RawJSON {
+    /// Accesses the RawJSON as a dictionary with the given key for reading and writing.
+    /// This is specially useful for accessing nested types inside the extra data dictionary.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData = message.extraData
+    /// let price = extraData["flight"]?["price"].numberValue
+    /// let destination = extraData["flight"]?["destination"].stringValue
+    /// ```
+    subscript(key: String) -> RawJSON? {
+        get {
+            guard case let .dictionary(dict) = self else {
+                return nil
+            }
+
+            return dict[key]
+        }
+        set {
+            guard case var .dictionary(dict) = self else {
+                return
+            }
+
+            dict[key] = newValue
+            self = .dictionary(dict)
+        }
+    }
+
+    /// Accesses RawJSON as an array and accesses the element at the specified position.
+    /// This is specially useful for accessing arrays of nested types inside the extra data dictionary.
+    ///
+    /// Example:
+    /// ```
+    /// let extraData = message.extraData
+    /// let secondFlightPrice = extraData["flights"]?[1]?["price"] ?? 0
+    /// ```
+    subscript(index: Int) -> RawJSON? {
+        get {
+            guard case let .array(array) = self else {
+                return nil
+            }
+
+            return array[index]
+        }
+        set {
+            guard case var .array(array) = self, let newValue = newValue else {
+                return
+            }
+
+            array[index] = newValue
+            self = .array(array)
+        }
+    }
+}
+
 // MARK: Deprecations
 
 public extension RawJSON {

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/RawJSON_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/RawJSON_Tests.swift
@@ -52,7 +52,7 @@ final class RawJSON_Tests: XCTestCase {
         }
     }
 
-    func test_rawJSON_encodedAndDecoded() throws {
+    func test_encodedAndDecoded() throws {
         let attachmentType: String = "route"
         let routeId: Int = 123
         let routeType: String = "hike"
@@ -90,5 +90,159 @@ final class RawJSON_Tests: XCTestCase {
         XCTAssertEqual(decoded.routeMapURL, routeMapURL)
         XCTAssertEqual(decoded.route.type, routeType)
         XCTAssertEqual(decoded.route.id, routeId)
+    }
+
+    func test_numberValue() {
+        let validNumber = RawJSON.number(30)
+        XCTAssertEqual(validNumber.numberValue, 30)
+
+        let invalidNumber = RawJSON.bool(true)
+        XCTAssertEqual(invalidNumber.numberValue, nil)
+    }
+
+    func test_stringValue() {
+        let validString = RawJSON.string("hello")
+        XCTAssertEqual(validString.stringValue, "hello")
+
+        let invalidString = RawJSON.number(30)
+        XCTAssertEqual(invalidString.stringValue, nil)
+    }
+
+    func test_boolValue() {
+        let validBool = RawJSON.bool(true)
+        XCTAssertEqual(validBool.boolValue, true)
+
+        let invalidBool = RawJSON.string("true")
+        XCTAssertEqual(invalidBool.boolValue, nil)
+    }
+
+    func test_dictionaryValue() {
+        let validDictionary = RawJSON.dictionary([
+            "price": .number(23)
+        ])
+        XCTAssertEqual(validDictionary.dictionaryValue, ["price": .number(23)])
+
+        let invalidDictionary = RawJSON.array([.number(23)])
+        XCTAssertEqual(invalidDictionary.dictionaryValue, nil)
+    }
+
+    func test_arrayValue() {
+        let validArray = RawJSON.array([.string("Hello"), .string("World")])
+        XCTAssertEqual(validArray.arrayValue, [.string("Hello"), .string("World")])
+
+        let invalidArray = RawJSON.string("Not an array")
+        XCTAssertEqual(invalidArray.arrayValue, nil)
+    }
+
+    func test_numberArrayValue() {
+        let validNumberArray = RawJSON.array([.number(10), .number(20)])
+        XCTAssertEqual(validNumberArray.numberArrayValue, [10, 20])
+
+        let partiallyValidNumberArray = RawJSON.array([.number(10), .string("wrong")])
+        XCTAssertEqual(partiallyValidNumberArray.numberArrayValue, [10])
+
+        let invalidNumberArray = RawJSON.string("Not an array")
+        XCTAssertEqual(invalidNumberArray.numberArrayValue, nil)
+    }
+
+    func test_stringArrayValue() {
+        let validStringArray = RawJSON.array([.string("Hello"), .string("World")])
+        XCTAssertEqual(validStringArray.stringArrayValue, ["Hello", "World"])
+
+        let partiallyValidStringArray = RawJSON.array([.number(10), .string("wrong")])
+        XCTAssertEqual(partiallyValidStringArray.stringArrayValue, ["wrong"])
+
+        let invalidStringArray = RawJSON.string("Not an array")
+        XCTAssertEqual(invalidStringArray.stringArrayValue, nil)
+    }
+
+    func test_boolArrayValue() {
+        let validBoolArray = RawJSON.array([.bool(false), .bool(false)])
+        XCTAssertEqual(validBoolArray.boolArrayValue, [false, false])
+
+        let partiallyValidBoolArray = RawJSON.array([.number(10), .bool(false)])
+        XCTAssertEqual(partiallyValidBoolArray.boolArrayValue, [false])
+
+        let invalidBoolArray = RawJSON.string("Not an array")
+        XCTAssertEqual(invalidBoolArray.boolArrayValue, nil)
+    }
+
+    func test_isNil() {
+        let validNil = RawJSON.nil
+        XCTAssertTrue(validNil.isNil)
+
+        let notNil = RawJSON.string("Hey")
+        XCTAssertFalse(notNil.isNil)
+    }
+
+    func test_init_dictionaryLiteral() {
+        let rawJSONDictionary: RawJSON = [
+            "price": .number(23)
+        ]
+
+        XCTAssertEqual(rawJSONDictionary, RawJSON.dictionary(["price": .number(23)]))
+    }
+
+    func test_init_arrayLiteral() {
+        let rawJSONArray: RawJSON = [.number(20), .number(30)]
+        XCTAssertEqual(rawJSONArray, RawJSON.array([.number(20), .number(30)]))
+    }
+
+    func test_init_stringLiteral() {
+        let rawJSONString: RawJSON = "Hello"
+        XCTAssertEqual(rawJSONString, .string("Hello"))
+    }
+
+    func test_init_floatLiteral() {
+        let rawJSONDouble: RawJSON = 23.50
+        XCTAssertEqual(rawJSONDouble, .number(23.50))
+    }
+
+    func test_init_integerLiteral() {
+        let rawJSONInteger: RawJSON = 23
+        XCTAssertEqual(rawJSONInteger, .number(23))
+    }
+
+    func test_init_booleanLiteral() {
+        let rawJSONBoolean: RawJSON = true
+        XCTAssertEqual(rawJSONBoolean, .bool(true))
+    }
+
+    func test_subscriptKey_get() {
+        let rawJSONDictionary: RawJSON = .dictionary([
+            "price": .number(23),
+            "destination": .string("Lisbon")
+        ])
+        XCTAssertEqual(rawJSONDictionary["price"]?.numberValue, 23)
+    }
+
+    func test_subscriptKey_set() {
+        var rawJSONDictionary: RawJSON = .dictionary([
+            "price": .number(23),
+            "destination": .string("Lisbon")
+        ])
+        rawJSONDictionary["destination"] = .string("Madrid")
+        
+        XCTAssertEqual(rawJSONDictionary, .dictionary([
+            "price": .number(23),
+            "destination": .string("Madrid")
+        ]))
+    }
+
+    func test_subscriptIndex_get() {
+        let rawJSONArray: RawJSON = .array([
+            .string("Hello"), .string("World")
+        ])
+
+        XCTAssertEqual(rawJSONArray[1], .string("World"))
+    }
+
+    func test_subscriptIndex_set() {
+        var rawJSONArray: RawJSON = .array([
+            .string("Hello"), .string("World")
+        ])
+        rawJSONArray[1] = .string("Stream")
+
+        XCTAssertEqual(rawJSONArray, .array([.string("Hello"), .string("Stream")]))
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links
CIS-1811

### 🎯 Goal
Improve the way Extra Data is used by simplifying the API. With this, pretty much all the boilerplate code is not required anymore. 

- [ ] Extra Data documentation has also been added for custom self-serve improvements. (TODO)

### 🛠 Implementation
- Provides properties in RawJSON to automatically extract the raw values from the RawJSON enum types.
- Implements ExpressByLiteral and subscript APIs so that ExtraData can feel more like a real dictionary or array when using `RawJSON.dictionary` and `RawJSON.array`

### 🎨 Showcase

The Docs will have more and better examples, but here is a quick sneak peek:

**Before:**
```swift
var email: String {
    guard case .string(let value) = extraData["email"] else { return "" }
    return value
}
```
**After:**
```swift
let email = extraData["email"]?.stringValue ?? ""
```

### 🧪 Manual Testing Notes
N/A. Unit Tests were added to cover all the new APIs introduced.

### ☑️ Contributor Checklist
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)