### PR TITLE
Fix channel stays selected when coming back to list

### DIFF
--- a/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
@@ -57,6 +57,7 @@ final class DemoChatChannelListVC: ChatChannelListVC, EventsControllerDelegate {
     var selectedChannel: ChatChannel?
 
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        collectionView.deselectItem(at: indexPath, animated: true)
         let channel = controller.channels[indexPath.row]
         selectedChannel = controller.channels[indexPath.row]
         router.showChannel(for: channel.cid)


### PR DESCRIPTION
### 🔗 Issue Links

[JIRA](https://stream-io.atlassian.net/browse/CIS-2042)

### 🎯 Goal

Fix in the demo app, when going back to the channel list, sometimes the channels remained selected.

### 🛠 Implementation

Call deselect item on when the collection view selection method is invoked.

### 🧪 Manual Testing Notes

Run the app, open few channels, and come back. The channel shouldn't be selected anymore.

### ☑️ Contributor Checklist
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
