### PR TITLE
[BW] Update UI test related to commands pop-up

### DIFF
--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -228,6 +228,12 @@ extension UserRobot {
     }
     
     @discardableResult
+    func tapOnMessageList() -> Self {
+        MessageListPage.list.safeTap()
+        return self
+    }
+    
+    @discardableResult
     func replyToMessageInThread(
         _ text: String,
         alsoSendInChannel: Bool = false,

--- a/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
@@ -348,7 +348,7 @@ final class MessageList_Tests: StreamTestCase {
             userRobot.openComposerCommands()
         }
         WHEN("user taps on message list") {
-            userRobot.tapOnMessage()
+            userRobot.tapOnMessageList()
         }
         THEN("command suggestions disappear") {
             userRobot.assertComposerCommands(shouldBeVisible: false)


### PR DESCRIPTION
### 🔗 Issue Links

- N/A

### 🎯 Goal

- `test_commandsPopupDisappear_whenUserTapsOnMessageList` has failed already two times since last weeks during the `cron checks` (e.g.: [allure](https://streamio.testops.cloud/launch/833/?treeId=0)). The goal is to fix it.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
