### PR TITLE
[Release Bug] Bring back check for truncation in ChannelDTO.willSave

### DIFF
--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -68,7 +68,19 @@ class ChannelDTO: NSManagedObject {
         guard !isDeleted else {
             return
         }
-        
+
+        // Change to the `truncatedAt` value have effect on messages, we need to mark them dirty manually
+        // to triggers related FRC updates
+        if changedValues().keys.contains("truncatedAt") {
+            messages
+                .filter { !$0.hasChanges }
+                .forEach {
+                    // Simulate an update
+                    $0.willChangeValue(for: \.id)
+                    $0.didChangeValue(for: \.id)
+                }
+        }
+
         // Update the date for sorting every time new message in this channel arrive.
         // This will ensure that the channel list is updated/sorted when new message arrives.
         let lastDate = lastMessageAt ?? createdAt


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-2079

### 🎯 Goal

Brings back check for truncation in ChannelDTO.willSave for the information to be broadcasted

### 📝 Summary

There was an issue during Release QA where truncation was not broadcasting information to the FRC, and thus leaving the content of the channel there until reentering it.

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🧪 Manual Testing Notes

- User A creates a channel
- Users A and B fill it with messages
- Both users A and B stay in the chat
- User A truncates the channel
- Both users A and B should not see the history

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/yrP4rcak7ZjxK/giphy.gif)
