### PR TITLE
Fixed lost links after docs restructuring

### DIFF
--- a/docusaurus/sidebars-ios.json
+++ b/docusaurus/sidebars-ios.json
@@ -115,6 +115,10 @@
         "guides/working-with-attachments",
         "guides/customize-message-composer",
         "guides/message-composer-custom-attachments",
+        "guides/message-list-delivery-status",
+        "guides/customize-message-delivery-status",
+        "guides/video-100ms",
+        "guides/video-agora",
         "guides/migrating-from-3-to-4",
         "guides/migrating-from-1.x-and-2.x"
       ]


### PR DESCRIPTION
### 🎯 Goal

Some docs links were lost after the docs restructuring.

### 📝 Summary

Brought the links back. We need to have a single source of truth in the docs.

### 🧪 Manual Testing Notes

Run the docusaurus locally.

### ☑️ Contributor Checklist
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![Alt Text](https://media.giphy.com/media/Ih6f3JK5YkZCY9azoQ/giphy-downsized-large.gif)