### PR TITLE
[CIS-2086] Make BaseOperation thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix crash in ListDatabaseObserver.startObserving() [#2177](https://github.com/GetStream/stream-chat-swift/pull/2177)
+- Make BaseOperation thread safe [#2198](https://github.com/GetStream/stream-chat-swift/pull/2198)
 
 # [4.19.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.19.0)
 _July 21, 2022_

--- a/Sources/StreamChat/Utils/Operations/AsyncOperation.swift
+++ b/Sources/StreamChat/Utils/Operations/AsyncOperation.swift
@@ -51,25 +51,34 @@ class AsyncOperation: BaseOperation {
 class BaseOperation: Operation {
     private var _finished = false
     private var _executing = false
+    private let stateQueue = DispatchQueue(label: "io.getstream.base-operation")
 
     override var isExecuting: Bool {
         get {
-            _executing
+            stateQueue.sync {
+                _executing
+            }
         }
         set {
             willChangeValue(for: \.isExecuting)
-            _executing = newValue
+            stateQueue.async(flags: .barrier) {
+                self._executing = newValue
+            }
             didChangeValue(for: \.isExecuting)
         }
     }
 
     override var isFinished: Bool {
         get {
-            _finished
+            stateQueue.sync {
+                _finished
+            }
         }
         set {
             willChangeValue(for: \.isFinished)
-            _finished = newValue
+            stateQueue.async(flags: .barrier) {
+                self._finished = newValue
+            }
             didChangeValue(for: \.isFinished)
         }
     }

--- a/Tests/StreamChatTests/Utils/Operations/AsyncOperation_Tests.swift
+++ b/Tests/StreamChatTests/Utils/Operations/AsyncOperation_Tests.swift
@@ -115,6 +115,60 @@ final class AsyncOperation_Tests: XCTestCase {
         waitForOperationToFinish(operation)
         XCTAssertEqual(operationBlockCalls, 0)
     }
+
+    func test_baseOperation_isThreadSafe() {
+        let operation = BaseOperation()
+
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            operation.isFinished = true
+        }
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            _ = operation.isFinished
+        }
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            operation.isFinished = false
+        }
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            operation.isExecuting = true
+        }
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            _ = operation.isExecuting
+        }
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            operation.isExecuting = false
+        }
+    }
+
+    func test_operation_isThreadSafe() {
+        for _ in (1...100) {
+            let operation = AsyncOperation { _, done in
+                DispatchQueue.global().async {
+                    done(.continue)
+                }
+            }
+
+            operation.start()
+
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                operation.isFinished = true
+            }
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                _ = operation.isFinished
+            }
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                operation.isFinished = false
+            }
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                operation.isExecuting = true
+            }
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                _ = operation.isExecuting
+            }
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                operation.isExecuting = false
+            }
+        }
+    }
 }
 
 // MARK: Test Helpers


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-2086

### 📝 Summary

A user reported that there was a race condition in BaseOperation. This was not an issue at the moment, but we were indeed allowing different threads to mutate the values that formed the state of the Operation.

### 🛠 Implementation

This PR adds thread safety guards to ensure no more data races happen

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/6Z3D5t31ZdoNW/giphy.gif)
