### PR TITLE
[CIS-2087] Improve consistency when retrieving Message after Push Notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix crash in ListDatabaseObserver.startObserving() [#2177](https://github.com/GetStream/stream-chat-swift/pull/2177)
 - Make BaseOperation thread safe [#2198](https://github.com/GetStream/stream-chat-swift/pull/2198)
 - Fix build issues in Xcode 14 beta [#2202](https://github.com/GetStream/stream-chat-swift/pull/2202)
+- Improve consistency when retrieving Message after Push Notification [#2200](https://github.com/GetStream/stream-chat-swift/pull/2200)
 
 ## StreamChatUI
 ### ✅ Added

--- a/DemoApp/StreamChat/Components/DemoChatMessageActionsVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatMessageActionsVC.swift
@@ -12,7 +12,6 @@ final class DemoChatMessageActionsVC: ChatMessageActionsVC {
     override var messageActions: [ChatMessageActionItem] {
         var actions = super.messageActions
         if message?.isSentByCurrentUser == true {
-            
             if message?.isBounced == false {
                 actions.append(pinMessageActionItem())
             }

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -169,7 +169,8 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
     override public func synchronize(_ completion: ((Error?) -> Void)? = nil) {
         startObserversIfNeeded()
         
-        messageUpdater.getMessage(cid: cid, messageId: messageId) { error in
+        messageUpdater.getMessage(cid: cid, messageId: messageId) { result in
+            let error = result.error
             self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
             self.callback { completion?(error) }
         }

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -690,7 +690,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         for cid: ChannelId?,
         syncOwnReactions: Bool = true,
         cache: PreWarmedCache?
-    ) throws -> MessageDTO? {
+    ) throws -> MessageDTO {
         guard payload.channel != nil || cid != nil else {
             throw ClientError.MessagePayloadSavingFailure("""
             Either `payload.channel` or `cid` must be provided to sucessfuly save the message payload.
@@ -710,23 +710,22 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         } else if let cid = cid {
             channelDTO = ChannelDTO.load(cid: cid, context: self)
         } else {
-            log.assertionFailure("Should never happen because either `cid` or `payload.channel` should be present.")
-            return nil
+            let description = "Should never happen because either `cid` or `payload.channel` should be present."
+            log.assertionFailure(description)
+            throw ClientError.MessagePayloadSavingFailure(description)
         }
 
         guard let channel = channelDTO else {
-            log.assertionFailure("Should never happen, a channel should have been fetched.")
-            return nil
+            let description = "Should never happen, a channel should have been fetched."
+            log.assertionFailure(description)
+            throw ClientError.MessagePayloadSavingFailure(description)
         }
         
         return try saveMessage(payload: payload, channelDTO: channel, syncOwnReactions: syncOwnReactions, cache: cache)
     }
     
-    func saveMessage(payload: MessagePayload, for query: MessageSearchQuery, cache: PreWarmedCache?) throws -> MessageDTO? {
-        guard let messageDTO = try saveMessage(payload: payload, for: nil, cache: cache) else {
-            return nil
-        }
-
+    func saveMessage(payload: MessagePayload, for query: MessageSearchQuery, cache: PreWarmedCache?) throws -> MessageDTO {
+        let messageDTO = try saveMessage(payload: payload, for: nil, cache: cache)
         messageDTO.searches.insert(saveQuery(query: query))
         return messageDTO
     }

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -104,7 +104,7 @@ protocol MessageDatabaseSession {
         for cid: ChannelId?,
         syncOwnReactions: Bool,
         cache: PreWarmedCache?
-    ) throws -> MessageDTO?
+    ) throws -> MessageDTO
     
     /// Saves the provided message payload to the DB. Return's the matching `MessageDTO` if the save was successful.
     /// Throws an error if the save fails.
@@ -120,7 +120,7 @@ protocol MessageDatabaseSession {
     ) throws -> MessageDTO
 
     @discardableResult
-    func saveMessage(payload: MessagePayload, for query: MessageSearchQuery, cache: PreWarmedCache?) throws -> MessageDTO?
+    func saveMessage(payload: MessagePayload, for query: MessageSearchQuery, cache: PreWarmedCache?) throws -> MessageDTO
 
     func addReaction(
         to messageId: MessageId,

--- a/Sources/StreamChat/Repositories/MessageRepository.swift
+++ b/Sources/StreamChat/Repositories/MessageRepository.swift
@@ -175,10 +175,12 @@ class MessageRepository {
                 self.database.write({ session in
                     message = try session.saveMessage(payload: boxed.message, for: cid, syncOwnReactions: true, cache: nil).asModel()
                 }, completion: { error in
-                    if let message = message {
+                    if let error = error {
+                        completion?(.failure(error))
+                    } else if let message = message {
                         completion?(.success(message))
                     } else {
-                        let error = error ?? ClientError.MessagePayloadSavingFailure("Missing message or error")
+                        let error = ClientError.MessagePayloadSavingFailure("Missing message or error")
                         completion?(.failure(error))
                     }
                 })

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -158,9 +158,9 @@ extension DatabaseSession_Mock {
         for cid: ChannelId?,
         syncOwnReactions: Bool,
         cache: PreWarmedCache?
-    ) throws -> MessageDTO? {
+    ) throws -> MessageDTO {
         try throwErrorIfNeeded()
-        return try? underlyingSession.saveMessage(payload: payload, for: cid, syncOwnReactions: syncOwnReactions, cache: cache)
+        return try underlyingSession.saveMessage(payload: payload, for: cid, syncOwnReactions: syncOwnReactions, cache: cache)
     }
     
     func saveMessage(payload: MessagePayload, channelDTO: ChannelDTO, syncOwnReactions: Bool, cache: PreWarmedCache?) throws -> MessageDTO {
@@ -314,7 +314,7 @@ extension DatabaseSession_Mock {
         underlyingSession.delete(query: query)
     }
 
-    func saveMessage(payload: MessagePayload, for query: MessageSearchQuery, cache: PreWarmedCache?) throws -> MessageDTO? {
+    func saveMessage(payload: MessagePayload, for query: MessageSearchQuery, cache: PreWarmedCache?) throws -> MessageDTO {
         try throwErrorIfNeeded()
         return try underlyingSession.saveMessage(payload: payload, for: query, cache: cache)
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -9,7 +9,7 @@ import XCTest
 final class MessageUpdater_Mock: MessageUpdater {
     @Atomic var getMessage_cid: ChannelId?
     @Atomic var getMessage_messageId: MessageId?
-    @Atomic var getMessage_completion: ((Error?) -> Void)?
+    @Atomic var getMessage_completion: ((Result<ChatMessage, Error>) -> Void)?
 
     @Atomic var deleteMessage_messageId: MessageId?
     @Atomic var deleteMessage_completion: ((Error?) -> Void)?
@@ -171,7 +171,7 @@ final class MessageUpdater_Mock: MessageUpdater {
         translate_completion = nil
     }
     
-    override func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Error?) -> Void)? = nil) {
+    override func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Result<ChatMessage, Error>) -> Void)? = nil) {
         getMessage_cid = cid
         getMessage_messageId = messageId
         getMessage_completion = completion

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/DatabaseContainer_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/DatabaseContainer_Spy.swift
@@ -284,7 +284,7 @@ extension DatabaseContainer {
                     extraData: extraData
                 )
                 
-                let replyDTO = try session.saveMessage(payload: reply, for: cid, syncOwnReactions: true, cache: nil)!
+                let replyDTO = try session.saveMessage(payload: reply, for: cid, syncOwnReactions: true, cache: nil)
                 messageDTO.replies.insert(replyDTO)
             }
         }

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/MessageRepository_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/MessageRepository_Spy.swift
@@ -13,6 +13,7 @@ final class MessageRepository_Spy: MessageRepository, Spy {
 
     var sendMessageResult: Result<ChatMessage, MessageRepositoryError>?
     var sendMessageCalls: [MessageId: (Result<ChatMessage, MessageRepositoryError>) -> Void] = [:]
+    var getMessageResult: Result<ChatMessage, Error>?
     var saveSuccessfullyDeletedMessageError: Error?
     let lock = NSLock()
     var updatedMessageLocalState: LocalMessageState?
@@ -45,6 +46,11 @@ final class MessageRepository_Spy: MessageRepository, Spy {
     override func saveSuccessfullyEditedMessage(for id: MessageId, completion: @escaping () -> Void) {
         record()
         completion()
+    }
+
+    override func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Result<ChatMessage, Error>) -> Void)? = nil) {
+        record()
+        getMessageResult.map { completion?($0) }
     }
 
     override func saveSuccessfullyDeletedMessage(message: MessagePayload, completion: ((Error?) -> Void)? = nil) {

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -87,7 +87,7 @@ final class MessageController_Tests: XCTestCase {
         
         // Simulate network response with the error
         let networkError = TestError()
-        env.messageUpdater.getMessage_completion?(networkError)
+        env.messageUpdater.getMessage_completion?(.failure(networkError))
         
         AssertAsync {
             // Assert network error is propagated
@@ -117,7 +117,7 @@ final class MessageController_Tests: XCTestCase {
         controller = nil
         
         // Simulate network response with the error
-        env.messageUpdater.getMessage_completion?(nil)
+        env.messageUpdater.getMessage_completion?(.success(ChatMessage.unique))
         // Release reference of completion so we can deallocate stuff
         env.messageUpdater.getMessage_completion = nil
         
@@ -182,7 +182,7 @@ final class MessageController_Tests: XCTestCase {
         )
         
         // Simulate updater completion call
-        env.messageUpdater.getMessage_completion?(nil)
+        env.messageUpdater.getMessage_completion?(.success(ChatMessage.unique))
         
         XCTAssertEqual(controller.message?.id, messageId)
         XCTAssertEqual(controller.replies.count, 10)
@@ -582,7 +582,7 @@ final class MessageController_Tests: XCTestCase {
         controller.synchronize()
             
         // Simulate network call response
-        env.messageUpdater.getMessage_completion?(nil)
+        env.messageUpdater.getMessage_completion?(.success(ChatMessage.unique))
         
         // Assert delegate is notified about state changes
         AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)
@@ -610,7 +610,7 @@ final class MessageController_Tests: XCTestCase {
         try client.databaseContainer.writeSynchronously { session in
             try session.saveMessage(payload: messagePayload, for: self.cid, syncOwnReactions: true, cache: nil)
         }
-        env.messageUpdater.getMessage_completion?(nil)
+        env.messageUpdater.getMessage_completion?(.success(ChatMessage.unique))
         
         // Assert `create` entity change is received by the delegate
         AssertAsync {
@@ -647,7 +647,7 @@ final class MessageController_Tests: XCTestCase {
         try client.databaseContainer.writeSynchronously { session in
             try session.saveMessage(payload: messagePayload, for: self.cid, syncOwnReactions: true, cache: nil)
         }
-        env.messageUpdater.getMessage_completion?(nil)
+        env.messageUpdater.getMessage_completion?(.success(ChatMessage.unique))
         
         // Assert `update` entity change is received by the delegate
         AssertAsync {
@@ -683,7 +683,7 @@ final class MessageController_Tests: XCTestCase {
         
         var replyModel: ChatMessage?
         try client.databaseContainer.writeSynchronously { session in
-            replyModel = try session.saveMessage(payload: reply, for: self.cid, syncOwnReactions: true, cache: nil)!.asModel()
+            replyModel = try session.saveMessage(payload: reply, for: self.cid, syncOwnReactions: true, cache: nil).asModel()
         }
     
         // Assert `insert` entity change is received by the delegate

--- a/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
@@ -2680,7 +2680,7 @@ final class MessageDTO_Tests: XCTestCase {
         try database.writeSynchronously { session in
             let savedMessage = try session.saveMessage(payload: message, for: channelId, syncOwnReactions: true, cache: nil)
             if isHardDeleted {
-                savedMessage?.isHardDeleted = isHardDeleted
+                savedMessage.isHardDeleted = isHardDeleted
             }
         }
 

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -670,7 +670,7 @@ final class MessageUpdater_Tests: XCTestCase {
             }
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 1)
+        waitForExpectations(timeout: 0.1)
         
         let firstPreviewMessage: MessagePayload = .dummy(
             type: .regular,

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -706,8 +706,12 @@ final class MessageUpdater_Tests: XCTestCase {
         XCTAssertTrue(message.failedToBeSentDueToModeration)
         
         // Delete second message
-        messageUpdater.deleteMessage(messageId: secondMessageId, hard: false)
-        
+        let expectation = expectation(description: "deleteMessage completes")
+        messageUpdater.deleteMessage(messageId: secondMessageId, hard: false) { _ in
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 0.1)
         let channelDTO = try XCTUnwrap(database.viewContext.channel(cid: cid))
         
         // Assert channel preview is updated with the previous message


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-2087

### 🎯 Goal

It's been a while that we randomly get reports of inconsistencies when retrieving a message from a Push Notification

### 📝 Summary

ChatRemoteNotificationHandler was using MessageController to retrieve the message that was coming from a Push Notification. This was both unreliable and overcomplex. This PR move the responsibility of doing so to the MessageRepository, to ensure we don't rely on the DB to return it.

### 🛠 Implementation

MessageRepository now has a new method, getMessage, that returns a ChatMessage object. ChatRemoteNotificationHandler directly requests the message to MessageRepository, reducing inconsistencies


### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/huyZxIJvtqVeRp7QcS/giphy.gif)
