### PR TITLE
[BW] Split up truncation test

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     # Runs "At 03:00 every night"
     - cron: '0 3 * * *'
-  push:
-    branches:
-      - "feature/BW-split-up-truncation-test"
 
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
@@ -63,38 +60,38 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       if: failure()
 
-  # build-and-test-debug:
-  #   name: Test LLC (Debug)
-  #   strategy:
-  #     matrix:
-  #       xcode: [13.4.1, 13.1]
-  #       os: [macos-12]
-  #       include:
-  #         - xcode: 12.5.1
-  #           os: macos-11
-  #     fail-fast: false
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: ./.github/actions/bootstrap
-  #   - name: Run LLC Tests (Debug)
-  #     run: bundle exec fastlane test cron:true device:"iPhone 8"
-  #     timeout-minutes: 30
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       GITHUB_EVENT: ${{ toJson(github.event) }}
-  #       XCODE_VERSION: ${{ matrix.xcode }}
-  #   - uses: test-summary/action@v1
-  #     with:
-  #       paths: fastlane/test_output/report.junit
-  #     if: failure()
-  #   - uses: 8398a7/action-slack@v3
-  #     with:
-  #       status: ${{ job.status }}
-  #       text: "You shall not pass!"
-  #       job_name: "${{ github.workflow }}: ${{ github.job }}"
-  #       fields: message,commit,author,action,workflow,job,took
-  #     env:
-  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #       MATRIX_CONTEXT: ${{ toJson(matrix) }}
-  #     if: failure()
+  build-and-test-debug:
+    name: Test LLC (Debug)
+    strategy:
+      matrix:
+        xcode: [13.4.1, 13.1]
+        os: [macos-12]
+        include:
+          - xcode: 12.5.1
+            os: macos-11
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/bootstrap
+    - name: Run LLC Tests (Debug)
+      run: bundle exec fastlane test cron:true device:"iPhone 8"
+      timeout-minutes: 30
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_EVENT: ${{ toJson(github.event) }}
+        XCODE_VERSION: ${{ matrix.xcode }}
+    - uses: test-summary/action@v1
+      with:
+        paths: fastlane/test_output/report.junit
+      if: failure()
+    - uses: 8398a7/action-slack@v3
+      with:
+        status: ${{ job.status }}
+        text: "You shall not pass!"
+        job_name: "${{ github.workflow }}: ${{ github.job }}"
+        fields: message,commit,author,action,workflow,job,took
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        MATRIX_CONTEXT: ${{ toJson(matrix) }}
+      if: failure()

--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     # Runs "At 03:00 every night"
     - cron: '0 3 * * *'
+  push:
+    branches:
+      - "feature/BW-split-up-truncation-test"
 
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
@@ -60,38 +63,38 @@ jobs:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       if: failure()
 
-  build-and-test-debug:
-    name: Test LLC (Debug)
-    strategy:
-      matrix:
-        xcode: [13.4.1, 13.1]
-        os: [macos-12]
-        include:
-          - xcode: 12.5.1
-            os: macos-11
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./.github/actions/bootstrap
-    - name: Run LLC Tests (Debug)
-      run: bundle exec fastlane test cron:true device:"iPhone 8"
-      timeout-minutes: 30
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_EVENT: ${{ toJson(github.event) }}
-        XCODE_VERSION: ${{ matrix.xcode }}
-    - uses: test-summary/action@v1
-      with:
-        paths: fastlane/test_output/report.junit
-      if: failure()
-    - uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        text: "You shall not pass!"
-        job_name: "${{ github.workflow }}: ${{ github.job }}"
-        fields: message,commit,author,action,workflow,job,took
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        MATRIX_CONTEXT: ${{ toJson(matrix) }}
-      if: failure()
+  # build-and-test-debug:
+  #   name: Test LLC (Debug)
+  #   strategy:
+  #     matrix:
+  #       xcode: [13.4.1, 13.1]
+  #       os: [macos-12]
+  #       include:
+  #         - xcode: 12.5.1
+  #           os: macos-11
+  #     fail-fast: false
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./.github/actions/bootstrap
+  #   - name: Run LLC Tests (Debug)
+  #     run: bundle exec fastlane test cron:true device:"iPhone 8"
+  #     timeout-minutes: 30
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       GITHUB_EVENT: ${{ toJson(github.event) }}
+  #       XCODE_VERSION: ${{ matrix.xcode }}
+  #   - uses: test-summary/action@v1
+  #     with:
+  #       paths: fastlane/test_output/report.junit
+  #     if: failure()
+  #   - uses: 8398a7/action-slack@v3
+  #     with:
+  #       status: ${{ job.status }}
+  #       text: "You shall not pass!"
+  #       job_name: "${{ github.workflow }}: ${{ github.job }}"
+  #       fields: message,commit,author,action,workflow,job,took
+  #     env:
+  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #       MATRIX_CONTEXT: ${{ toJson(matrix) }}
+  #     if: failure()

--- a/StreamChatUITestsAppUITests/Tests/ChannelList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/ChannelList_Tests.swift
@@ -258,7 +258,7 @@ extension ChannelList_Tests {
 // MARK: - Truncate channel
 
 extension ChannelList_Tests {
-    func test_messageList_and_channelPreview_AreUpdatedWhenChannelTruncatedWithoutMessage() {
+    func test_messageListIsUpdatedWhenChannelTruncatedWithoutMessage() {
         linkToScenario(withId: 200)
 
         GIVEN("user opens the channel") {
@@ -271,7 +271,21 @@ extension ChannelList_Tests {
         THEN("previous messages are no longer visible") {
             userRobot.assertMessageCount(0)
         }
-        WHEN("user goes to channel list") {
+    }
+    
+    func test_channelPreviewIsUpdatedWhenChannelTruncatedWithoutMessage() {
+        linkToScenario(withId: 206)
+
+        GIVEN("user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        AND("user sends a message") {
+            userRobot.sendMessage(message)
+        }
+        WHEN("user truncates the channel without system message") {
+            userRobot.truncateChannel(withMessage: false)
+        }
+        AND("user goes to channel list") {
             userRobot.tapOnBackButton()
         }
         THEN("the channel preview shows No messages") {


### PR DESCRIPTION
### 🔗 Issue Links

- N/A

### 🎯 Goal

- `Truncation without message` test is failing on multiple iOS versions. We need to fix it
- Split up the test into two separate ones, it might help

### 📝 Summary

- Then:
    - `test_messageList_and_channelPreview_AreUpdatedWhenChannelTruncatedWithoutMessage`
- Now: 
    - `test_messageListIsUpdatedWhenChannelTruncatedWithoutMessage`
    - `test_channelPreviewIsUpdatedWhenChannelTruncatedWithoutMessage`
- Cron checks [result](https://github.com/GetStream/stream-chat-swift/actions/runs/2759347255) ✅

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
