### PR TITLE
[CIS-2048] Make sure ChannelDTO is still valid when accessing Lazy blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Make BaseOperation thread safe [#2198](https://github.com/GetStream/stream-chat-swift/pull/2198)
 - Fix build issues in Xcode 14 beta [#2202](https://github.com/GetStream/stream-chat-swift/pull/2202)
 - Improve consistency when retrieving Message after Push Notification [#2200](https://github.com/GetStream/stream-chat-swift/pull/2200)
+- Make sure ChannelDTO is still valid when accessing Lazy blocks [#2204](https://github.com/GetStream/stream-chat-swift/pull/2204)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -381,7 +381,7 @@ extension ChatChannel {
         let reads: [ChatChannelRead] = try dto.reads.map { try $0.asModel() }
         
         let unreadCount: () -> ChannelUnreadCount = {
-            guard let currentUser = context.currentUser else { return .noUnread }
+            guard dto.isValid, let currentUser = context.currentUser else { return .noUnread }
             
             let currentUserRead = reads.first(where: { $0.user.id == currentUser.user.id })
             
@@ -412,7 +412,8 @@ extension ChatChannel {
         }
         
         let fetchMessages: () -> [ChatMessage] = {
-            MessageDTO
+            guard dto.isValid else { return [] }
+            return MessageDTO
                 .load(
                     for: dto.cid,
                     limit: dto.managedObjectContext?.localCachingSettings?.chatChannel.latestMessagesLimit ?? 25,
@@ -424,7 +425,7 @@ extension ChatChannel {
         }
         
         let fetchLatestMessageFromUser: () -> ChatMessage? = {
-            guard let currentUser = context.currentUser else { return nil }
+            guard dto.isValid, let currentUser = context.currentUser else { return nil }
             
             return try? MessageDTO
                 .loadLastMessage(


### PR DESCRIPTION
### 🔗 Issue Links

Related to https://stream-io.atlassian.net/browse/CIS-2048

### 🎯 Goal

Mitigate crash when accessing unread count for a channel

### 📝 Summary

The crash suggests that there are values that are null when trying to evaluate the predicate. This smells like a predicate being evaluated on a deleted object. Because the unread count is accessed on demand, and not when creating ChatChannel, it can be that the DTO is deleted whenever the values is accessed.

Whenever a DTO is deleted, its values are reset to defaults. BUT, CoreData is not able to represent a `Date?` whenever this happens, leading to a crash.

All the above is just a theory, and there was no way to consistently reproduce the scenario where it crashed. In any case, it adds a safety net.

### 🛠 Implementation

We now check if the ChannelDTO is valid before performing any lazy fetch request using it.

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/Pj6w9VJQ9azYdVW9fd/giphy.gif)