### PR TITLE
[CIS-2084] Fix message list jumps by removing the inverted table view

### DIFF
--- a/DemoApp/DemoAppConfiguration.swift
+++ b/DemoApp/DemoAppConfiguration.swift
@@ -32,7 +32,6 @@ enum DemoAppConfiguration {
 
         configureAtlantisIfNeeded()
         trackPerformanceIfNeeded()
-        enableMessageDiffingIfNeeded()
     }
 
     // HTTP and WebSocket Proxy with Proxyman.app
@@ -50,10 +49,5 @@ enum DemoAppConfiguration {
             PerformanceMonitor.shared().performanceViewConfigurator.options = [.performance]
             PerformanceMonitor.shared().start()
         }
-    }
-
-    // Enable message diffing in Message List
-    private static func enableMessageDiffingIfNeeded() {
-        StreamChatWrapper.shared.setMessageDiffingEnabled(isStreamInternalConfiguration)
     }
 }

--- a/DemoApp/StreamChat/StreamChatWrapper.swift
+++ b/DemoApp/StreamChat/StreamChatWrapper.swift
@@ -163,11 +163,3 @@ extension StreamChatWrapper {
         try? ChatPushNotificationInfo(content: response.notification.request.content)
     }
 }
-
-// MARK: Develop configuration
-
-extension StreamChatWrapper {
-    func setMessageDiffingEnabled(_ isEnabled: Bool) {
-        Components.default._messageListDiffingEnabled = isEnabled
-    }
-}

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -350,7 +350,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
                 return nil
             }
             guard let cid = self.cid else { return nil }
-            let sortAscending = self.messageOrdering == .topToBottom ? false : true
+            let sortAscending = self.messageOrdering == .topToBottom ? true : false
             var deletedMessageVisibility: ChatClientConfig.DeletedMessageVisibility?
             var shouldShowShadowedMessages: Bool?
             self.client.databaseContainer.viewContext.performAndWait { [weak self] in
@@ -731,7 +731,7 @@ public extension ChatChannelController {
             return
         }
         
-        guard let messageId = messageId ?? messages.last?.id else {
+        guard let messageId = messageId ?? messages.first?.id else {
             log.error(ClientError.ChannelEmptyMessages().localizedDescription)
             callback { completion?(ClientError.ChannelEmptyMessages()) }
             return

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -601,7 +601,7 @@ private extension ChatMessageController {
                 return nil
             }
 
-            let sortAscending = self.listOrdering == .topToBottom ? false : true
+            let sortAscending = self.listOrdering == .topToBottom ? true : false
             let deletedMessageVisibility = self.client.databaseContainer.viewContext
                 .deletedMessagesVisibility ?? .visibleForCurrentUser
             let shouldShowShadowedMessages = self.client.databaseContainer.viewContext.shouldShowShadowedMessages ?? false

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -148,6 +148,23 @@ open class ChatChannelVC: _ViewController,
         keyboardHandler.stop()
     }
 
+    /// Handles loading the previous messages.
+    open func loadPreviousMessages() {
+        guard channelController.state == .remoteDataFetched else {
+            return
+        }
+        guard !isLoadingPreviousMessages else {
+            return
+        }
+        isLoadingPreviousMessages = true
+
+        messageListVC.showLoadingPreviousMessagesView()
+        channelController.loadPreviousMessages { [weak self] _ in
+            self?.isLoadingPreviousMessages = false
+            self?.messageListVC.hideLoadingPreviousMessagesView()
+        }
+    }
+
     // MARK: - ChatMessageListVCDataSource
     
     public var messages: [ChatMessage] {
@@ -186,26 +203,7 @@ open class ChatChannelVC: _ViewController,
         _ vc: ChatMessageListVC,
         willDisplayMessageAt indexPath: IndexPath
     ) {
-        if channelController.state != .remoteDataFetched {
-            return
-        }
-
-        guard messageListVC.listView.isTrackingOrDecelerating else {
-            return
-        }
-
-        if indexPath.row < channelController.messages.count - 10 {
-            return
-        }
-
-        guard !isLoadingPreviousMessages else {
-            return
-        }
-        isLoadingPreviousMessages = true
-
-        channelController.loadPreviousMessages { [weak self] _ in
-            self?.isLoadingPreviousMessages = false
-        }
+        // No-op
     }
 
     open func chatMessageListVC(
@@ -245,6 +243,10 @@ open class ChatChannelVC: _ViewController,
         with gestureRecognizer: UITapGestureRecognizer
     ) {
         messageComposerVC.dismissSuggestions()
+    }
+
+    open func chatMessageListVCShouldLoadPreviousMessages(_ vc: ChatMessageListVC) {
+        loadPreviousMessages()
     }
 
     // MARK: - ChatChannelControllerDelegate

--- a/Sources/StreamChatUI/ChatChannel/StreamModalTransitioningDelegate.swift
+++ b/Sources/StreamChatUI/ChatChannel/StreamModalTransitioningDelegate.swift
@@ -5,10 +5,6 @@
 import UIKit
 
 /// Stream's custom transitioning delegate to handle a modal presentation.
-///
-/// This should be used if you are presenting the ``ChatChannelVC`` in a modal.
-/// The reason this custom transition should be used instead of the native one is because we use an inverted
-/// `UITableView` for the message list component which it doesn't play well with the native modal transition.
 open class StreamModalTransitioningDelegate: NSObject, UIViewControllerTransitioningDelegate {
     public func presentationController(
         forPresented presented: UIViewController,

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
@@ -159,9 +159,9 @@ open class ChatMessageLayoutOptionsResolver {
         }
 
         // The current message is the last message so it's either a standalone or last in sequence.
-        guard messageIndexPath.item > 0 else { return true }
+        guard messageIndexPath.item < messages.count - 1 else { return true }
 
-        let nextMessageIndex = messages.index(before: messageIndex)
+        let nextMessageIndex = messages.index(after: messageIndex)
         guard let nextMessage = messages[safe: nextMessageIndex] else {
             indexNotFoundAssertion()
             return true

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListScrollOverlayView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListScrollOverlayView.swift
@@ -48,9 +48,6 @@ open class ChatMessageListScrollOverlayView: _View, ThemeProvider {
                 else { return }
                 
                 let overlayText = self.dataSource?.scrollOverlay(self, textForItemAt: indexPath)
-                
-                // If we have no date we have no reason to display `dateView`
-                self.isHidden = (overlayText ?? "").isEmpty
                 self.content = overlayText
                 
                 // Apple's naming is quite weird as actually this property should rather be named `isScrolling`
@@ -62,6 +59,15 @@ open class ChatMessageListScrollOverlayView: _View, ThemeProvider {
                 // so this handler is not called, this is handled by `scrollStateChanged`
                 // that reacts on `panGestureRecognizer` states and can handle this case properly
                 if !tb.isDragging {
+                    self.setAlpha(0)
+                } else {
+                    self.setAlpha(1)
+                }
+
+                /// If the date separators are enabled per cell, don't show the overlay
+                /// for the the top cell since the top cell has always a list date separator.
+                let isDateSeparatorEnabled = self.components.messageListDateSeparatorEnabled
+                if isDateSeparatorEnabled, refPointInListView.y < tb.rectForRow(at: indexPath).height {
                     self.setAlpha(0)
                 }
             }
@@ -105,6 +111,7 @@ open class ChatMessageListScrollOverlayView: _View, ThemeProvider {
     open func setAlpha(_ alpha: CGFloat) {
         Animate(isAnimated: true) {
             self.alpha = alpha
+            self.isHidden = alpha == 0
         }
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -382,8 +382,27 @@ open class ChatMessageListVC: _ViewController,
         return cell
     }
 
+    private var cellHeightsCache: [MessageId: CGFloat] = [:]
+
     open func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if isFirstLoad {
+            scrollToMostRecentMessage(animated: false)
+            isFirstLoad = false
+        }
+
+        if let message = dataSource?.chatMessageListVC(self, messageAt: indexPath) {
+            cellHeightsCache[message.id] = cell.bounds.size.height
+        }
+
         delegate?.chatMessageListVC(self, willDisplayMessageAt: indexPath)
+    }
+
+    open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        if let message = dataSource?.chatMessageListVC(self, messageAt: indexPath) {
+            return cellHeightsCache[message.id] ?? UITableView.automaticDimension
+        }
+
+        return UITableView.automaticDimension
     }
 
     open func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -117,9 +117,7 @@ open class ChatMessageListVC: _ViewController,
 
         view.addSubview(listView)
         listView.pin(anchors: [.top, .leading, .trailing, .bottom], to: view)
-        // Add a top padding to the table view so that the top message is not in the edge of the nav bar
-        // Note: we use "bottom" because the table view is inverted.
-        listView.contentInset = .init(top: 0, left: 0, bottom: 8, right: 0)
+        listView.contentInset = .init(top: 8, left: 0, bottom: 0, right: 0)
 
         view.addSubview(typingIndicatorView)
         typingIndicatorView.isHidden = true
@@ -334,7 +332,7 @@ open class ChatMessageListVC: _ViewController,
             return false
         }
         
-        let previousIndexPath = IndexPath(row: indexPath.row + 1, section: indexPath.section)
+        let previousIndexPath = IndexPath(row: indexPath.row - 1, section: indexPath.section)
         guard let previousMessage = dataSource?.chatMessageListVC(self, messageAt: previousIndexPath) else {
             // If previous message doesn't exist show the separator as well.
             return true

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVCDelegate.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVCDelegate.swift
@@ -46,4 +46,11 @@ public protocol ChatMessageListVCDelegate: AnyObject {
         didTapOnMessageListView messageListView: ChatMessageListView,
         with gestureRecognizer: UITapGestureRecognizer
     )
+
+    /// Tells the delegate to load more messages.
+    /// - Parameters:
+    ///   - vc: The message list  informing the delegate of this event.
+    func chatMessageListVCShouldLoadPreviousMessages(
+        _ vc: ChatMessageListVC
+    )
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -28,12 +28,6 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
     
     open func setUp() {
         keyboardDismissMode = .onDrag
-        rowHeight = UITableView.automaticDimension
-        if #available(iOS 13, *), components._messageListDiffingEnabled {
-            estimatedRowHeight = UITableView.automaticDimension
-        } else {
-            estimatedRowHeight = 150
-        }
         separatorStyle = .none
         transform = .mirrorY
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -29,7 +29,7 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
     open func setUp() {
         keyboardDismissMode = .onDrag
         separatorStyle = .none
-        transform = .mirrorY
+        contentInsetAdjustmentBehavior = .never
     }
     
     open func setUpAppearance() { /* default empty implementation */ }
@@ -113,36 +113,26 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
             guard let cell = cell else { return nil }
             return self?.indexPath(for: cell)
         }
-        
-        cell.contentView.transform = .mirrorY
 
         return cell
     }
     
     /// Scrolls to most recent message
     open func scrollToMostRecentMessage(animated: Bool = true) {
-        let rowsRange = 0..<numberOfRows(inSection: 0)
-        let lastMessageIndexPath = IndexPath(row: 0, section: 0)
-        let prevMessageIndexPath = IndexPath(row: 1, section: 0)
-
-        if rectForRow(at: prevMessageIndexPath).minY < contentOffset.y,
-           rowsRange.contains(prevMessageIndexPath.row) {
-            scrollToRow(at: prevMessageIndexPath, at: .top, animated: animated)
-        }
-        
-        if rowsRange.contains(lastMessageIndexPath.row) {
-            scrollToRow(at: lastMessageIndexPath, at: .top, animated: animated)
-        }
+        let numberOfRows = numberOfRows(inSection: 0)
+        guard numberOfRows > 1 else { return }
+        let lastMessageIndexPath = IndexPath(row: numberOfRows - 1, section: 0)
+        scrollToRow(at: lastMessageIndexPath, at: .bottom, animated: animated)
     }
     
     /// A Boolean that returns true if the bottom cell is fully visible.
     /// Which is also means that the collection view is fully scrolled to the boom.
     open var isLastCellFullyVisible: Bool {
-        guard numberOfRows(inSection: 0) > 0 else { return false }
-        
-        let cellRect = rectForRow(at: .init(row: 0, section: 0))
-        
-        return cellRect.minY >= contentOffset.y
+        let numberOfRows = numberOfRows(inSection: 0)
+        guard numberOfRows > 0 else { return false }
+
+        let lastIndexPath = IndexPath(item: numberOfRows - 1, section: 0)
+        return indexPathsForVisibleRows?.contains(lastIndexPath) == true
     }
     
     /// Updates the table view data with given `changes`.
@@ -154,8 +144,4 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
             completion?()
         }
     }
-}
-
-private extension CGAffineTransform {
-    static let mirrorY = Self(scaleX: 1, y: -1)
 }

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -119,11 +119,6 @@ public struct Components {
     /// A boolean value that determines wether date separators should be shown between each message.
     public var messageListDateSeparatorEnabled = false
 
-    /// A boolean value that determines whether the message list should use a diffable data source.
-    /// Note: This is currently an experimental feature that we are actively
-    /// working on and testing to make sure it is stable.
-    public var _messageListDiffingEnabled = false
-
     /// The view controller used to perform message actions.
     public var messageActionsVC: ChatMessageActionsVC.Type = ChatMessageActionsVC.self
 


### PR DESCRIPTION
### 🔗 Issue Links
CIS-2084
https://github.com/GetStream/stream-chat-swift/issues/2094

### 🎯 Goal
Fx the jumping issues we currently have with the inverted table view solution.

### 📝 Summary
The inverted table view is the root cause of the jumps. Since our message list cells have unpredictable heights, especially because they can be totally customizable, the table view can't properly calculate the new content size of the table when new messages are being inserted. The jumps are basically caused by this, and when the message is not inverted, this is not a problem, because the table view grows to the bottom of the screen.

**This solution tries to remove the need for inverting the table view by:**
- If we were previously at the bottom of the message list, and a new message is inserted, keep the message list at the bottom by scrolling to the newest message always
- When loading the initial messages, we also make sure it starts at the bottom, by scrolling to the bottom.
- When loading previous messages, prepend the messages at the top and adjust the scroll content offset.

**This implementation requires some UX changes:**
- The loading of the previous messages is not prefetched anymore, and we show a loading spinner at the top. This is how iMessage, Instagram and FB Messenger are doing it as well. The reason is that without this, the scrolling would stop weirdly because we need to adjust the content offset of the table view when prepending new items.
- When opening a message list with few messages, they stick to the top instead of the bottom like it was before. This is also how the other major apps are doing it as well, so it doesn't seem like a problem.

**Known Issues:**
- When opening the message list, the start at the bottom is not yet very stable.
- Keyboard is not adjusting properly when it is open (Working on it at the moment)

**Why it is draft:**
- We are currently exploring another solution which is actually the one used by the SwiftUI SDK, and that is to keep everything like it is right now, and skip insertions at the bottom when the user is scrolled to the top. But this requires using a proper diffing algorithm, so until we check which is the best solution, we will keep this one in Draft.

### 🎨 Showcase

| Loading Previous Messages | Few messages UX | Stick to the bottom |
| ------ | ----- | ----- |
|  <video src="https://user-images.githubusercontent.com/12814114/182442291-6d7473c8-6519-4d4f-87d1-5a726181d421.mp4"/>   |  <video src="https://user-images.githubusercontent.com/12814114/182442421-76b080a3-6c15-49ff-ae02-570d02041309.mp4"/>  |  <video src="https://user-images.githubusercontent.com/12814114/182442467-6eaffcc0-4f1a-4cb3-a51a-a88bb9fcd639.mp4"/>  |


### 🧪 Manual Testing Notes

Full regression is required

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
