### PR TITLE
[CIS-2083] Fix hidden channels showing past history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _August 02, 2022_
 - Fix build issues in Xcode 14 beta [#2202](https://github.com/GetStream/stream-chat-swift/pull/2202)
 - Improve consistency when retrieving Message after Push Notification [#2200](https://github.com/GetStream/stream-chat-swift/pull/2200)
 - Make sure ChannelDTO is still valid when accessing Lazy blocks [#2204](https://github.com/GetStream/stream-chat-swift/pull/2204)
+- Fix hidden channels showing past history [#2216](https://github.com/GetStream/stream-chat-swift/pull/2216)
 
 ## StreamChatUI
 ### ✅ Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix hidden channels showing past history [#2216](https://github.com/GetStream/stream-chat-swift/pull/2216)
 
 # [4.20.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.20.0)
 _August 02, 2022_
@@ -17,7 +19,6 @@ _August 02, 2022_
 - Fix build issues in Xcode 14 beta [#2202](https://github.com/GetStream/stream-chat-swift/pull/2202)
 - Improve consistency when retrieving Message after Push Notification [#2200](https://github.com/GetStream/stream-chat-swift/pull/2200)
 - Make sure ChannelDTO is still valid when accessing Lazy blocks [#2204](https://github.com/GetStream/stream-chat-swift/pull/2204)
-- Fix hidden channels showing past history [#2216](https://github.com/GetStream/stream-chat-swift/pull/2216)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -189,14 +189,21 @@ extension NSManagedObjectContext {
         dto.defaultSortingAt = (payload.lastMessageAt ?? payload.createdAt).bridgeDate
         dto.lastMessageAt = payload.lastMessageAt?.bridgeDate
         dto.memberCount = Int64(clamping: payload.memberCount)
-        dto.truncatedAt = payload.truncatedAt?.bridgeDate
-        // We don't always set `truncatedAt` directly since we also use this property as `hiddenAt`
-        // when a channel is hidden with `clearHistory`
-        // Backend doesn't send `truncatedAt` for this case and we reset it, causing the hidden messages to re-appear
-        // It's not possible to set `truncatedAt` to `nil` once it's set on backend side
-        // so it's safe to keep client-side changes when backend sends `nil`
-        if payload.truncatedAt != nil {
-            dto.truncatedAt = payload.truncatedAt?.bridgeDate
+
+        // Because `truncatedAt` is used, client side, for both truncation and channel hiding cases, we need to avoid using the
+        // value returned by the Backend in some cases.
+        //
+        // Whenever our Backend is not returning a value for `truncatedAt`, we simply do nothing. It is possible that our
+        // DTO already has a value for it if it has been hidden in the past, but we are not touching it.
+        //
+        // Whenever we do receive a value from our Backend, we have 2 options:
+        //  1. If we don't have a value for `truncatedAt` in the DTO -> We set the date from the payload
+        //  2. If we have a value for `truncatedAt` in the DTO -> We pick the latest date.
+        if let newTruncatedAt = payload.truncatedAt {
+            let canUpdateTruncatedAt = dto.truncatedAt.map { $0.bridgeDate < newTruncatedAt } ?? true
+            if canUpdateTruncatedAt {
+                dto.truncatedAt = newTruncatedAt.bridgeDate
+            }
         }
 
         dto.isFrozen = payload.isFrozen

--- a/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
@@ -278,7 +278,7 @@ final class ChannelDTO_Tests: XCTestCase {
         try database.writeSynchronously { session in
             try session.saveChannel(payload: newPayload, query: nil, cache: nil)
         }
-        g
+
         XCTAssertEqual(database.viewContext.channel(cid: channelId)?.truncatedAt, newTruncatedAt.bridgeDate)
     }
 


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-2083

### 🎯 Goal

Fix an issue where hidden history would be visible for some time after hiding a channel

### 📝 Summary

There was an error in the logic to handle incoming truncatedAt values from the Backend, setting an old value for it. This is because we currently use `truncatedAt` for both hiding and truncating channels.

### 🛠 Implementation

The value for `truncatedAt` is now only updated if the backend returns a date for `truncatedAt` AND if that date is older than the currently set in the DTO

### 🧪 Manual Testing Notes

1. Create a 1-1 channel
2. Send few messages
3. User A hides the channel, clearing history
4. User B sends more messages

Expected result:
- Only the new messages are shown

Previous result:
- Some old messages were shown

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/LmgKC5pk5TRYSGdRvG/giphy.gif)