### PR TITLE
[CIS-2081] Update tests to work on iOS 16

### DIFF
--- a/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
+++ b/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
@@ -82,6 +82,7 @@ class MessageListPage {
         static var cooldown: XCUIElement { app.staticTexts["cooldownLabel"] }
         static var placeholder: XCUIElement { textView.staticTexts.firstMatch }
         static var selectAllButton: XCUIElement { app.menuItems.matching(NSPredicate(format: "label LIKE 'Select All'")).firstMatch }
+        static var pasteButton: XCUIElement { app.menuItems.matching(NSPredicate(format: "label LIKE 'Paste'")).firstMatch }
     }
     
     enum Reactions {

--- a/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
@@ -120,7 +120,9 @@ extension UserRobot {
                        file: file,
                        line: line)
         
-        let endTime = Date().timeIntervalSince1970 * 1000 + XCUIElement.waitTimeout * 1000
+        let iosVersion = ProcessInfo().operatingSystemVersion.majorVersion
+        let duration = iosVersion >= 16 ? 20 : XCUIElement.waitTimeout
+        let endTime = Date().timeIntervalSince1970 * 1000 + duration * 1000
         while !expectedChannelExist && endTime > Date().timeIntervalSince1970 * 1000 {
             ChannelListPage.list.swipeUp()
             expectedChannelExist = expectedChannel.exists

--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -65,7 +65,9 @@ extension UserRobot {
 
     @discardableResult
     func openContextMenu(messageCellIndex: Int = 0) -> Self {
-        messageCell(withIndex: messageCellIndex).safePress(forDuration: 1)
+        let iosMajorVersion = ProcessInfo().operatingSystemVersion.majorVersion
+        let duration: TimeInterval = iosMajorVersion == 16 ? 2 : 1
+        messageCell(withIndex: messageCellIndex).safePress(forDuration: duration)
         return self
     }
     
@@ -120,6 +122,9 @@ extension UserRobot {
     @discardableResult
     func editMessage(_ newText: String, messageCellIndex: Int = 0) -> Self {
         composer.inputField.obtainKeyboardFocus()
+        if ProcessInfo().operatingSystemVersion.majorVersion == 16 && composer.pasteButton.exists {
+            composer.inputField.tap()
+        }
         openContextMenu(messageCellIndex: messageCellIndex)
         contextMenu.edit.element.wait().safeTap()
         clearComposer()
@@ -300,7 +305,7 @@ extension UserRobot {
     }
     
     @discardableResult
-    func sendGiphy(useComposerCommand: Bool = false, shuffle: Bool = false, send: Bool = true) -> Self {
+    func sendGiphy(useComposerCommand: Bool = false, send: Bool = true) -> Self {
         let giphyText = "Test"
         if useComposerCommand {
             openComposerCommands()
@@ -309,26 +314,20 @@ extension UserRobot {
         } else {
             sendMessage("/giphy\(giphyText)", waitForAppearance: false)
         }
-        if shuffle { tapOnShuffleGiphyButton() }
         if send { tapOnSendGiphyButton() }
         return self
     }
     
     @discardableResult
-    func replyWithGiphy(
-        useComposerCommand: Bool = false,
-        shuffle: Bool = false,
-        messageCellIndex: Int = 0
-    ) -> Self {
+    func replyWithGiphy(useComposerCommand: Bool = false, messageCellIndex: Int = 0) -> Self {
         return self
             .selectOptionFromContextMenu(option: .reply, forMessageAtIndex: messageCellIndex)
-            .sendGiphy(useComposerCommand: useComposerCommand, shuffle: shuffle)
+            .sendGiphy(useComposerCommand: useComposerCommand)
     }
     
     @discardableResult
     func replyWithGiphyInThread(
         useComposerCommand: Bool = false,
-        shuffle: Bool = false,
         alsoSendInChannel: Bool = false,
         messageCellIndex: Int = 0
     ) -> Self {
@@ -339,27 +338,13 @@ extension UserRobot {
         if alsoSendInChannel {
             threadCheckbox.wait().safeTap()
         }
-        return sendGiphy(useComposerCommand: useComposerCommand, shuffle: shuffle)
+        return sendGiphy(useComposerCommand: useComposerCommand)
     }
     
     @discardableResult
     func tapOnSendGiphyButton(messageCellIndex: Int = 0) -> Self {
         let messageCell = messageCell(withIndex: messageCellIndex)
         MessageListPage.Attributes.giphySendButton(in: messageCell).wait().safeTap()
-        return self
-    }
-    
-    @discardableResult
-    func tapOnShuffleGiphyButton(messageCellIndex: Int = 0) -> Self {
-        let messageCell = messageCell(withIndex: messageCellIndex)
-        MessageListPage.Attributes.giphyShuffleButton(in: messageCell).wait().safeTap()
-        return self
-    }
-    
-    @discardableResult
-    func tapOnCancelGiphyButton(messageCellIndex: Int = 0) -> Self {
-        let messageCell = messageCell(withIndex: messageCellIndex)
-        MessageListPage.Attributes.giphyCancelButton(in: messageCell).wait().safeTap()
         return self
     }
     

--- a/StreamChatUITestsAppUITests/Tests/Ephemeral_Messages_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Ephemeral_Messages_Tests.swift
@@ -114,35 +114,18 @@ final class Ephemeral_Messages_Tests: StreamTestCase {
         linkToScenario(withId: 183)
 
         GIVEN("user opens a channel") {
-            backendRobot.generateChannels(count: 1, messagesCount: 1)
             userRobot.login().openChannel()
         }
         WHEN("user runs a giphy command in thread") {
-            userRobot.openThread().sendGiphy(send: false)
+            userRobot
+                .sendMessage("test")
+                .openThread()
+                .sendGiphy(send: false)
         }
         THEN("delivery status is hidden for ephemeral messages") {
             userRobot
                 .assertMessageDeliveryStatus(nil)
                 .assertMessageReadCount(readBy: 0)
-        }
-    }
-    
-    func test_userObservesAnimatedGiphy_afterShufflingAndSendingGiphyMessage() throws {
-        linkToScenario(withId: 277)
-        
-        try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12,
-                      "[CIS-2054] Giphy is not loaded")
-
-        GIVEN("user opens a channel") {
-            userRobot
-                .login()
-                .openChannel()
-        }
-        WHEN("user sends a giphy using giphy command") {
-            userRobot.sendGiphy(shuffle: true)
-        }
-        THEN("user observes the animated gif") {
-            userRobot.assertGiphyImage()
         }
     }
     


### PR DESCRIPTION
### 🔗 Issue Links

- https://stream-io.atlassian.net/browse/CIS-2081

### 🎯 Goal

- Update E2E and Unit tests so that they work stably on iOS 16
- Perform a manual smoke test on iOS 16

### 📝 Summary

**Smoke test:**
- it went well, no unforeseen problems were found

**Unit tests:**
- there is only one failing test, an assumption is that it's failing because of the bug in Xcode 14 beta 4: `test_defaultDecoder_isStreamDecoder`. We will keep an eye on it in the following betas

**E2E tests:**
- Test case [#277](https://streamio.testops.cloud/project/1/test-cases/277) becomes manual => [#286](https://streamio.testops.cloud/project/1/test-cases/286)
- Long-press time increased for iOS 16 from 1 to 2 sec
- Provided a workaround for the new "Paste" menu item
- Pagination on channel list timeout was bumped due to scroll time was significantly increased on iOS 16 (hope it will be fixed in the following betas)
- There are still 11 unfixed tests that are failing because of the XCTest issue, long-press works incorrectly in some cases

```bash
Failing tests:
	MessageDeliveryStatus_Tests.test_errorIndicatorShown_whenThreadReplyFailedToBeSent()
	MessageList_Tests.test_quotedReplyInList_whenUserAddsQuotedReply()
	MessageList_Tests.test_quotedReplyIsDeletedByUser_deletedMessageIsShown()
	MessageList_Tests.test_threadReplyAppearsInChannelAndThread_whenUserAddsThreadReplySentAlsoToChannel()
	MessageList_Tests.test_threadReplyAppearsInThread_whenParticipantAddsThreadReply()
	MessageList_Tests.test_threadReplyIsRemovedEverywhere_whenUserRemovesItFromChannel()
	MessageList_Tests.test_threadReplyIsRemovedEverywhere_whenUserRemovesItFromThread()
	MessageList_Tests.test_threadTypingIndicatorHidden_whenParticipantStopsTyping()
	MessageList_Tests.test_userRemovesThreadReply()
	Reactions_Tests.test_reactionIsAdded_whenReactingToParticipantsMessage()
	SlowMode_Tests.test_slowModeIsNotActiveAndCooldownIsNotShown_whenAMessageIsEdited()
```

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/1HZ1wggAdwVIA/giphy.gif)
