### PR TITLE
[BW] Fix code example in Combine Events docs

### DIFF
--- a/docusaurus/docs/iOS/combine/events.md
+++ b/docusaurus/docs/iOS/combine/events.md
@@ -52,6 +52,7 @@ class YourCustomChannelListVC: ChatChannelListVC {
                 // do what you need with the event
                 print(messageNewEvent.messageId)
             }
+            .store(in: &cancellables)
     }
 }
 ```


### PR DESCRIPTION
Add `.store(in: &cancellables)` Missing in the `eventPublisher` code sample.