### PR TITLE
Fixed wrong docs for the ChatClient init method

### DIFF
--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -237,9 +237,7 @@ public class ChatClient {
     }
 
     /// Creates a new instance of `ChatClient`.
-    /// - Parameters:
-    ///   - config: The config object for the `Client`. See `ChatClientConfig` for all configuration options.
-    ///   - tokenProvider: In case of token expiration this closure is used to obtain a new token
+    /// - Parameter config: The config object for the `Client`. See `ChatClientConfig` for all configuration options.
     public convenience init(
         config: ChatClientConfig
     ) {


### PR DESCRIPTION
### 🎯 Goal

Updating the docs for the ChatClient init method, which were outdated.

### ☑️ Contributor Checklist
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)