### PR TITLE
[CIS-2084, CIS-2085] Refactor Message List with DifferenceKit

### DIFF
--- a/DemoApp/DemoAppConfiguration.swift
+++ b/DemoApp/DemoAppConfiguration.swift
@@ -32,7 +32,6 @@ enum DemoAppConfiguration {
 
         configureAtlantisIfNeeded()
         trackPerformanceIfNeeded()
-        enableMessageDiffingIfNeeded()
     }
 
     // HTTP and WebSocket Proxy with Proxyman.app
@@ -50,10 +49,5 @@ enum DemoAppConfiguration {
             PerformanceMonitor.shared().performanceViewConfigurator.options = [.performance]
             PerformanceMonitor.shared().start()
         }
-    }
-
-    // Enable message diffing in Message List
-    private static func enableMessageDiffingIfNeeded() {
-        StreamChatWrapper.shared.setMessageDiffingEnabled(isStreamInternalConfiguration)
     }
 }

--- a/DemoApp/StreamChat/StreamChatWrapper.swift
+++ b/DemoApp/StreamChat/StreamChatWrapper.swift
@@ -163,11 +163,3 @@ extension StreamChatWrapper {
         try? ChatPushNotificationInfo(content: response.notification.request.content)
     }
 }
-
-// MARK: Develop configuration
-
-extension StreamChatWrapper {
-    func setMessageDiffingEnabled(_ isEnabled: Bool) {
-        Components.default._messageListDiffingEnabled = isEnabled
-    }
-}

--- a/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
@@ -64,6 +64,60 @@ extension ListChange {
             return item
         }
     }
+
+    /// Returns true if the change is a move.
+    public var isMove: Bool {
+        switch self {
+        case .move:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Returns true if the change is an insertions.
+    public var isInsertion: Bool {
+        switch self {
+        case .insert:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Returns true if the change is a remove.
+    public var isRemove: Bool {
+        switch self {
+        case .remove:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Returns true if the change is an update.
+    public var isUpdate: Bool {
+        switch self {
+        case .update:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// The IndexPath of the change.
+    public var indexPath: IndexPath {
+        switch self {
+        case let .insert(_, index):
+            return index
+        case let .move(_, _, toIndex):
+            return toIndex
+        case let .update(_, index):
+            return index
+        case let .remove(_, index):
+            return index
+        }
+    }
     
     /// Returns `ListChange` of the same type but for the specific `Item` field.
     func fieldChange<Value>(_ path: KeyPath<Item, Value>) -> ListChange<Value> {

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -625,6 +625,12 @@ private extension ChatMessageController {
                 { try $0.asModel() as ChatMessage },
                 NSFetchedResultsController<MessageDTO>.self
             )
+            observer.onWillChange = { [weak self] in
+                self?.delegateCallback {
+                    guard let self = self else { return }
+                    $0.messageControllerWillChangeReplies(self)
+                }
+            }
             observer.onChange = { [weak self] changes in
                 self?.delegateCallback { [weak self] in
                     guard let self = self else {
@@ -647,7 +653,10 @@ private extension ChatMessageController {
 public protocol ChatMessageControllerDelegate: DataControllerStateDelegate {
     /// The controller observed a change in the `ChatMessage` its observes.
     func messageController(_ controller: ChatMessageController, didChangeMessage change: EntityChange<ChatMessage>)
-    
+
+    /// The controller is notifying that the replies will be updated after this call.
+    func messageControllerWillChangeReplies(_ controller: ChatMessageController)
+
     /// The controller observed changes in the replies of the observed `ChatMessage`.
     func messageController(_ controller: ChatMessageController, didChangeReplies changes: [ListChange<ChatMessage>])
 
@@ -657,6 +666,8 @@ public protocol ChatMessageControllerDelegate: DataControllerStateDelegate {
 
 public extension ChatMessageControllerDelegate {
     func messageController(_ controller: ChatMessageController, didChangeMessage change: EntityChange<ChatMessage>) {}
+
+    func messageControllerWillChangeReplies(_ controller: ChatMessageController) {}
     
     func messageController(_ controller: ChatMessageController, didChangeReplies changes: [ListChange<ChatMessage>]) {}
 

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -195,7 +195,7 @@ open class ChatChannelVC: _ViewController,
             return
         }
 
-        if indexPath.row < channelController.messages.count - 10 {
+        if indexPath.row < messages.count - 10 {
             return
         }
 

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -2,7 +2,6 @@
 // Copyright © 2022 Stream.io Inc. All rights reserved.
 //
 
-import DifferenceKit
 import StreamChat
 import UIKit
 
@@ -99,6 +98,9 @@ open class ChatChannelVC: _ViewController,
             setChannelControllerToComposerIfNeeded(cid: self?.channelController.cid)
             self?.messageComposerVC.updateContent()
         }
+
+        // Initial messages data
+        messages = Array(channelController.messages)
     }
 
     override open func setUpLayout() {
@@ -151,15 +153,7 @@ open class ChatChannelVC: _ViewController,
 
     // MARK: - ChatMessageListVCDataSource
 
-    private var _messages: [DiffChatMessage] = []
-
-    public var messages: [ChatMessage] {
-        if _messages.isEmpty {
-            return Array(channelController.messages)
-        }
-
-        return _messages.map(\.message)
-    }
+    public var messages: [ChatMessage] = []
     
     open func channel(for vc: ChatMessageListVC) -> ChatChannel? {
         channelController.channel
@@ -256,75 +250,20 @@ open class ChatChannelVC: _ViewController,
 
     // MARK: - ChatChannelControllerDelegate
 
-    var previousMessagesSnapshot: [DiffChatMessage] = []
-
     open func channelControllerWillUpdateMessages(_ channelController: ChatChannelController) {
-        previousMessagesSnapshot = channelController.messages.map(DiffChatMessage.init)
+        messageListVC.listView.previousMessagesSnapshot = Array(channelController.messages)
     }
 
     open func channelController(
         _ channelController: ChatChannelController,
         didUpdateMessages changes: [ListChange<ChatMessage>]
     ) {
-        let target = Array(channelController.messages).map(DiffChatMessage.init)
-        let changeset = StagedChangeset(
-            source: previousMessagesSnapshot,
-            target: target
-        )
-
         if isLastMessageFullyVisible {
             channelController.markRead()
         }
-//        messageListVC.updateMessages(with: changes)
 
-//        messageListVC.listView.reload(
-//            using: changeset,
-//            with: .fade,
-//            setData: { [weak self] newData in
-//                self?._messages = newData
-//            },
-//            completion: {
-//                if changeset.first?.elementInserted.contains(.init(element: 0, section: 0)) == true {
-//                    self.messageListVC.listView.scrollToRow(at: IndexPath(item: 0, section: 0), at: .bottom, animated: true)
-//                }
-//            }
-//        )
-
-        let newMessageInserted = changeset.first?.elementInserted.contains(.init(element: 0, section: 0)) == true
-
-        let reload = {
-            self.messageListVC.listView.reload(
-                using: changeset,
-                with: .fade,
-                setData: { [weak self] newData in
-                    self?._messages = newData
-                }
-            )
-        }
-
-        if messageListVC.listView.isLastCellFullyVisible {
-            UIView.performWithoutAnimation {
-                reload()
-            }
-        } else {
-            reload()
-        }
-
-        if newMessageInserted && messageListVC.listView.isLastCellFullyVisible {
-            UIView.performWithoutAnimation {
-                self.messageListVC.listView.reloadRows(at: [IndexPath(item: 1, section: 0)], with: .none)
-            }
-        }
-
-        if newMessageInserted && target.first?.message.isSentByCurrentUser == true {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                self.messageListVC.listView.scrollToRow(at: IndexPath(item: 0, section: 0), at: .bottom, animated: true)
-            }
-        }
-
-//        if changeset.first?.elementInserted.contains(.init(element: 0, section: 0)) == true {
-//            messageListVC.listView.scrollToRow(at: IndexPath(item: 0, section: 0), at: .bottom, animated: true)
-//        }
+        messageListVC.listView.newMessagesSnapshot = Array(channelController.messages)
+        messageListVC.updateMessages(with: changes)
     }
 
     open func channelController(
@@ -357,53 +296,5 @@ open class ChatChannelVC: _ViewController,
     @objc func appMovedToForeground() {
         channelController.delegate = self
         messageListVC.dataSource = self
-    }
-}
-
-struct DiffChatMessage: Hashable, Differentiable {
-    let message: ChatMessage
-
-    func isContentEqual(to source: DiffChatMessage) -> Bool {
-        message.text == source.message.text
-            && message.type == source.message.type
-            && message.command == source.message.command
-            && message.arguments == source.message.arguments
-            && message.parentMessageId == source.message.parentMessageId
-            && message.showReplyInChannel == source.message.showReplyInChannel
-            && message.replyCount == source.message.replyCount
-            && message.extraData == source.message.extraData
-            && message.quotedMessage == source.message.quotedMessage
-            && message.isShadowed == source.message.isShadowed
-            && message.reactionCounts.count == source.message.reactionCounts.count
-            && message.reactionScores.count == source.message.reactionScores.count
-            && message.threadParticipants.count == source.message.threadParticipants.count
-            && message.attachmentCounts.count == source.message.attachmentCounts.count
-            && message.giphyAttachments == source.message.giphyAttachments
-            && message.localState == source.message.localState
-            && message.isFlaggedByCurrentUser == source.message.isFlaggedByCurrentUser
-            && message.readBy == source.message.readBy
-    }
-
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.message.id == rhs.message.id
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(message.id)
-    }
-}
-
-extension UITableView {
-    func reload<C>(
-        using stagedChangeset: StagedChangeset<C>,
-        with animation: @autoclosure () -> RowAnimation,
-        interrupt: ((Changeset<C>) -> Bool)? = nil,
-        setData: (C) -> Void,
-        completion: (() -> Void)? = nil
-    ) {
-        CATransaction.begin()
-        CATransaction.setCompletionBlock(completion)
-        reload(using: stagedChangeset, with: animation(), setData: setData)
-        CATransaction.commit()
     }
 }

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -237,11 +237,6 @@ open class ChatChannelVC: _ViewController,
             channelController.markRead()
 
             messageListVC.scrollToLatestMessageButton.content = .noUnread
-
-            skippedMessages = []
-            if messages.count != channelController.messages.count {
-                channelController(channelController, didUpdateMessages: [])
-            }
         }
     }
 
@@ -255,10 +250,8 @@ open class ChatChannelVC: _ViewController,
 
     // MARK: - ChatChannelControllerDelegate
 
-    var skippedMessages: Set<MessageId> = []
-
     open func channelControllerWillUpdateMessages(_ channelController: ChatChannelController) {
-        messageListVC.listView.previousMessagesSnapshot = channelController.messages.filter { !skippedMessages.contains($0.id) }
+        messageListVC.listView.previousMessagesSnapshot = Array(channelController.messages)
     }
 
     open func channelController(
@@ -269,17 +262,7 @@ open class ChatChannelVC: _ViewController,
             channelController.markRead()
         }
 
-        debugPrint("Insertions:", changes.filter(\.isInsertion).map(\.indexPath))
-        if !isLastMessageFullyVisible && changes.first(where: { $0.indexPath.item == 0 }) != nil {
-            changes.filter(\.isInsertion).forEach {
-                skippedMessages.insert($0.item.id)
-            }
-            // Don't update messages if we are skipping
-            return
-        }
-
-        let newMessages = channelController.messages.filter { !skippedMessages.contains($0.id) }
-        messageListVC.listView.newMessagesSnapshot = newMessages
+        messageListVC.listView.newMessagesSnapshot = Array(channelController.messages)
         messageListVC.updateMessages(with: changes)
     }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -215,7 +215,7 @@ open class ChatMessageListVC: _ViewController,
         listView.scrollToMostRecentMessage(animated: animated)
     }
 
-    /// Updates the collection view data with given `changes`.
+    /// Updates the table view data with given `changes`.
     open func updateMessages(with changes: [ListChange<ChatMessage>], completion: (() -> Void)? = nil) {
         // Because we use an inverted table view, we need to avoid animations since they look odd.
         UIView.performWithoutAnimation {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -448,8 +448,22 @@ open class ChatMessageListVC: _ViewController,
         return cell
     }
 
+    private var cellHeightsCache: [MessageId: CGFloat] = [:]
+
     open func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if let message = dataSource?.chatMessageListVC(self, messageAt: indexPath) {
+            cellHeightsCache[message.id] = cell.bounds.size.height
+        }
+
         delegate?.chatMessageListVC(self, willDisplayMessageAt: indexPath)
+    }
+
+    open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        if let message = dataSource?.chatMessageListVC(self, messageAt: indexPath) {
+            return cellHeightsCache[message.id] ?? UITableView.automaticDimension
+        }
+
+        return UITableView.automaticDimension
     }
 
     open func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -217,17 +217,11 @@ open class ChatMessageListVC: _ViewController,
 
     /// Updates the table view data with given `changes`.
     open func updateMessages(with changes: [ListChange<ChatMessage>], completion: (() -> Void)? = nil) {
-        // Because we use an inverted table view, we need to avoid animations since they look odd.
-        UIView.performWithoutAnimation {
-            listView.updateMessages(with: changes) { [weak self] in
-                if let newMessageInserted = changes.first(where: { ($0.isInsertion || $0.isMoved) && $0.indexPath.row == 0 })?.item {
-                    if newMessageInserted.isSentByCurrentUser {
-                        self?.listView.scrollToMostRecentMessage()
-                    }
-                }
-                completion?()
-            }
+        listView.onNewDataSource = { [weak self] messages in
+            self?.dataSource?.messages = messages
         }
+
+        listView.updateMessages(with: changes, completion: completion)
     }
 
     /// Handles tap action on the table view.
@@ -626,38 +620,5 @@ open class ChatMessageListVC: _ViewController,
     ) -> Bool {
         // To prevent the gesture recognizer consuming up the events from UIControls, we receive touch only when the view isn't a UIControl.
         !(touch.view is UIControl)
-    }
-}
-
-private extension ListChange {
-    var isMoved: Bool {
-        switch self {
-        case .move:
-            return true
-        default:
-            return false
-        }
-    }
-    
-    var isInsertion: Bool {
-        switch self {
-        case .insert:
-            return true
-        default:
-            return false
-        }
-    }
-
-    var indexPath: IndexPath {
-        switch self {
-        case let .insert(_, index):
-            return index
-        case let .move(_, _, toIndex):
-            return toIndex
-        case let .update(_, index):
-            return index
-        case let .remove(_, index):
-            return index
-        }
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -435,6 +435,12 @@ open class ChatMessageListVC: _ViewController,
         delegate?.chatMessageListVC(self, scrollViewDidScroll: scrollView)
 
         setScrollToLatestMessageButton(visible: isScrollToBottomButtonVisible)
+
+        // If the user scrolled to the bottom, update the UI for the skipped messages
+        if listView.isLastCellFullyVisible && !listView.skippedMessages.isEmpty {
+            listView.skippedMessages = []
+            listView.updateMessages(with: [])
+        }
     }
 
     // MARK: - ChatMessageListScrollOverlayDataSource

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -36,26 +36,6 @@ open class ChatMessageListVC: _ViewController,
     open lazy var router: ChatMessageListRouter = components
         .messageListRouter
         .init(rootViewController: self)
-
-    /// The diffing data sources are only used if iOS 13 is available and if the feature is enabled.
-    internal var isDiffingEnabled: Bool {
-        if #available(iOS 13.0, *) {
-            return self.components._messageListDiffingEnabled
-        }
-        return false
-    }
-
-    /// Strong reference of the `UITableViewDiffableDataSource`.
-    internal var _diffableDataSource: UITableViewDataSource?
-
-    /// Only stored properties support being marked with @available, so we need to maintain
-    /// a private _diffableDataSource property to keep the strong reference. This stored
-    /// property will cast the regular table view data source to the diffing one.
-    @available(iOS 13.0, *)
-    internal var diffableDataSource: UITableViewDiffableDataSource<Int, ChatMessage>? {
-        get { _diffableDataSource as? UITableViewDiffableDataSource }
-        set { _diffableDataSource = newValue }
-    }
     
     /// Strong reference of message actions view controller to allow performing async operations.
     private var messageActionsVC: ChatMessageActionsVC?
@@ -179,13 +159,8 @@ open class ChatMessageListVC: _ViewController,
         super.updateContent()
 
         listView.delegate = self
-
-        if #available(iOS 13.0, *), isDiffingEnabled {
-            setupDiffableDataSource(for: listView)
-        } else {
-            listView.dataSource = self
-            listView.reloadData()
-        }
+        listView.dataSource = self
+        listView.reloadData()
     }
 
     override open func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -242,19 +217,15 @@ open class ChatMessageListVC: _ViewController,
 
     /// Updates the collection view data with given `changes`.
     open func updateMessages(with changes: [ListChange<ChatMessage>], completion: (() -> Void)? = nil) {
-        if #available(iOS 13.0, *), isDiffingEnabled {
-            updateMessagesSnapshot(with: changes, completion: completion)
-        } else {
-            // Because we use an inverted table view, we need to avoid animations since they look odd.
-            UIView.performWithoutAnimation {
-                listView.updateMessages(with: changes) { [weak self] in
-                    if let newMessageInserted = changes.first(where: { ($0.isInsertion || $0.isMoved) && $0.indexPath.row == 0 })?.item {
-                        if newMessageInserted.isSentByCurrentUser {
-                            self?.listView.scrollToMostRecentMessage()
-                        }
+        // Because we use an inverted table view, we need to avoid animations since they look odd.
+        UIView.performWithoutAnimation {
+            listView.updateMessages(with: changes) { [weak self] in
+                if let newMessageInserted = changes.first(where: { ($0.isInsertion || $0.isMoved) && $0.indexPath.row == 0 })?.item {
+                    if newMessageInserted.isSentByCurrentUser {
+                        self?.listView.scrollToMostRecentMessage()
                     }
-                    completion?()
                 }
+                completion?()
             }
         }
     }
@@ -655,133 +626,6 @@ open class ChatMessageListVC: _ViewController,
     ) -> Bool {
         // To prevent the gesture recognizer consuming up the events from UIControls, we receive touch only when the view isn't a UIControl.
         !(touch.view is UIControl)
-    }
-}
-
-// MARK: - Backwards Compatibility DataSource Diffing
-
-@available(iOS 13.0, *)
-internal extension ChatMessageListVC {
-    /// Setup the `UITableViewDiffableDataSource`.
-    func setupDiffableDataSource(for listView: ChatMessageListView) {
-        let diffableDataSource = UITableViewDiffableDataSource<Int, ChatMessage>(
-            tableView: listView
-        ) { [weak self] _, indexPath, _ -> UITableViewCell? in
-            /// Re-use old `cellForRowAt` to maintain customer's customisations.
-            let cell = self?.tableView(listView, cellForRowAt: indexPath)
-            return cell
-        }
-
-        self.diffableDataSource = diffableDataSource
-        listView.dataSource = diffableDataSource
-
-        /// Populate the Initial messages data.
-        var snapshot = NSDiffableDataSourceSnapshot<Int, ChatMessage>()
-        snapshot.appendSections([0])
-        snapshot.appendItems(dataSource?.messages ?? [], toSection: 0)
-        diffableDataSource.apply(snapshot, animatingDifferences: false)
-    }
-
-    /// Transforms an array of changes to a diffable data source snapshot.
-    func updateMessagesSnapshot(with changes: [ListChange<ChatMessage>], completion: (() -> Void)?) {
-        var snapshot = diffableDataSource?.snapshot() ?? NSDiffableDataSourceSnapshot<Int, ChatMessage>()
-
-        let currentMessages: Set<ChatMessage> = Set(snapshot.itemIdentifiers)
-        var updatedMessages: [ChatMessage] = []
-        var insertedMessages: [(ChatMessage, row: Int)] = []
-        var removedMessages: [(ChatMessage, row: Int)] = []
-        var movedMessages: [(from: ChatMessage, to: ChatMessage)] = []
-
-        var hasNewInsertions = false
-        var hasInsertions = false
-
-        changes.forEach { change in
-            switch change {
-            case let .insert(message, indexPath):
-                hasInsertions = true
-                if !hasNewInsertions {
-                    hasNewInsertions = indexPath.row == 0
-                }
-                insertedMessages.append((message, row: indexPath.row))
-            case let .update(message, _):
-                // Check if it is a valid update. In rare occasions we get an update for a message which
-                // is not in the scope of the current pagination, although it is in the database.
-                guard currentMessages.contains(message) else { break }
-                updatedMessages.append(message)
-            case let .remove(message, indexPath):
-                removedMessages.append((message, row: indexPath.row))
-            case let .move(_, fromIndex, toIndex):
-                guard let fromMessage = snapshot.itemIdentifiers[safe: fromIndex.row] else { break }
-                guard let toMessage = snapshot.itemIdentifiers[safe: toIndex.row] else { break }
-                movedMessages.append((from: fromMessage, to: toMessage))
-            }
-        }
-
-        let sortedInsertedMessages = insertedMessages
-            .sorted(by: { $0.row < $1.row })
-            .map(\.0)
-
-        if hasNewInsertions, let currentFirstMessage = snapshot.itemIdentifiers.first {
-            // Insert new messages at the bottom.
-            snapshot.insertItems(sortedInsertedMessages, beforeItem: currentFirstMessage)
-        } else if hasInsertions, let currentLastMessage = snapshot.itemIdentifiers.last {
-            // Load new messages at the top.
-            snapshot.insertItems(sortedInsertedMessages, afterItem: currentLastMessage)
-        } else if hasInsertions {
-            snapshot.appendItems(sortedInsertedMessages)
-        }
-
-        snapshot.deleteItems(removedMessages.map(\.0))
-        snapshot.reloadItems(updatedMessages)
-
-        movedMessages.forEach {
-            snapshot.moveItem($0.from, afterItem: $0.to)
-            snapshot.reloadItems([$0.from, $0.to])
-        }
-
-        // The reason we call `performWithoutAnimation` and `animatingDifferences: true` at the same time
-        // is because we don't want animations, but on iOS 14 calling `animatingDifferences: false`
-        // is the same as calling `reloadData()`. Info: https://developer.apple.com/videos/play/wwdc2021/10252/?time=158
-        UIView.performWithoutAnimation {
-            diffableDataSource?.apply(snapshot, animatingDifferences: true) { [weak self] in
-
-                let newestMessage = snapshot.itemIdentifiers.first
-                if hasNewInsertions && newestMessage?.isSentByCurrentUser == true {
-                    self?.listView.scrollToMostRecentMessage()
-                }
-
-                // When new message is inserted, update the previous message to hide the timestamp if needed.
-                if hasNewInsertions, let previousMessage = snapshot.itemIdentifiers[safe: 1] {
-                    let indexPath = IndexPath(row: 1, section: 0)
-                    // The completion block from `apply()` should always be called on main thread,
-                    // but on iOS 14 this doesn't seem to be the case, and it crashes.
-                    DispatchQueue.main.async {
-                        self?.updateMessagesSnapshot(
-                            with: [.update(previousMessage, index: indexPath)],
-                            completion: nil
-                        )
-                    }
-                }
-
-                // When there are deletions, we should update the previous message, so that we add the avatar image back.
-                // Because we have an inverted list, the previous message has the same index of the deleted message after
-                // the deletion has been executed.
-                let previousRemovedMessages = removedMessages.compactMap { _, row -> (ChatMessage, IndexPath)? in
-                    guard let message = snapshot.itemIdentifiers[safe: row] else { return nil }
-                    return (message, IndexPath(row: row, section: 0))
-                }
-                if !previousRemovedMessages.isEmpty {
-                    DispatchQueue.main.async {
-                        self?.updateMessagesSnapshot(
-                            with: previousRemovedMessages.map { ListChange.update($0, index: $1) },
-                            completion: nil
-                        )
-                    }
-                }
-
-                completion?()
-            }
-        }
     }
 }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVCDataSource.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVCDataSource.swift
@@ -8,7 +8,7 @@ import StreamChat
 /// The object that acts as the data source of the message list.
 public protocol ChatMessageListVCDataSource: AnyObject {
     /// Asks the data source to return all the available messages.
-    var messages: [ChatMessage] { get }
+    var messages: [ChatMessage] { get set }
 
     /// Asks the data source to return the channel for the given message list.
     /// - Parameter vc: The message list requesting the channel.

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
@@ -46,11 +46,10 @@ extension ChatMessage: Differentiable {
             && reactionCounts.count == source.reactionCounts.count
             && reactionScores.count == source.reactionScores.count
             && threadParticipants.count == source.threadParticipants.count
-            && attachmentCounts.count == source.attachmentCounts.count
             && giphyAttachments == source.giphyAttachments
             && localState == source.localState
             && isFlaggedByCurrentUser == source.isFlaggedByCurrentUser
-            && readBy == source.readBy
+            && readBy.count == source.readBy.count
             && imageAttachments.map(\.uploadingState) == source.imageAttachments.map(\.uploadingState)
             && videoAttachments.map(\.uploadingState) == source.videoAttachments.map(\.uploadingState)
             && fileAttachments.map(\.uploadingState) == source.fileAttachments.map(\.uploadingState)

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
@@ -46,10 +46,10 @@ extension ChatMessage: Differentiable {
             && reactionCounts.count == source.reactionCounts.count
             && reactionScores.count == source.reactionScores.count
             && threadParticipants.count == source.threadParticipants.count
-            && giphyAttachments == source.giphyAttachments
             && localState == source.localState
             && isFlaggedByCurrentUser == source.isFlaggedByCurrentUser
             && readBy.count == source.readBy.count
+            && giphyAttachments.map(\.previewURL) == source.giphyAttachments.map(\.previewURL)
             && imageAttachments.map(\.uploadingState) == source.imageAttachments.map(\.uploadingState)
             && videoAttachments.map(\.uploadingState) == source.videoAttachments.map(\.uploadingState)
             && fileAttachments.map(\.uploadingState) == source.fileAttachments.map(\.uploadingState)

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
@@ -13,8 +13,8 @@ extension ChatMessageListView {
         with animation: @autoclosure () -> RowAnimation,
         completion: (() -> Void)? = nil
     ) {
-        let source = previousSnapshot.map(DiffChatMessage.init)
-        let target = newSnapshot.map(DiffChatMessage.init)
+        let source = previousSnapshot
+        let target = newSnapshot
         let changeset = StagedChangeset(
             source: source,
             target: target
@@ -24,47 +24,37 @@ extension ChatMessageListView {
         reload(
             using: changeset,
             with: animation()
-        ) { [weak self] diffMessages in
-            self?.onNewDataSource?(diffMessages.map(\.message))
+        ) { [weak self] newMessages in
+            self?.onNewDataSource?(newMessages)
         }
         CATransaction.commit()
     }
 }
 
-private struct DiffChatMessage: Hashable, Differentiable {
-    let message: ChatMessage
-
-    func isContentEqual(to source: DiffChatMessage) -> Bool {
-        message.text == source.message.text
-            && message.type == source.message.type
-            && message.command == source.message.command
-            && message.arguments == source.message.arguments
-            && message.parentMessageId == source.message.parentMessageId
-            && message.showReplyInChannel == source.message.showReplyInChannel
-            && message.replyCount == source.message.replyCount
-            && message.extraData == source.message.extraData
-            && message.quotedMessage == source.message.quotedMessage
-            && message.isShadowed == source.message.isShadowed
-            && message.reactionCounts.count == source.message.reactionCounts.count
-            && message.reactionScores.count == source.message.reactionScores.count
-            && message.threadParticipants.count == source.message.threadParticipants.count
-            && message.attachmentCounts.count == source.message.attachmentCounts.count
-            && message.giphyAttachments == source.message.giphyAttachments
-            && message.localState == source.message.localState
-            && message.isFlaggedByCurrentUser == source.message.isFlaggedByCurrentUser
-            && message.readBy == source.message.readBy
-            && message.imageAttachments.map(\.uploadingState) == source.message.imageAttachments.map(\.uploadingState)
-            && message.videoAttachments.map(\.uploadingState) == source.message.videoAttachments.map(\.uploadingState)
-            && message.fileAttachments.map(\.uploadingState) == source.message.fileAttachments.map(\.uploadingState)
-            && message.audioAttachments.map(\.uploadingState) == source.message.audioAttachments.map(\.uploadingState)
-            && message.linkAttachments.map(\.uploadingState) == source.message.linkAttachments.map(\.uploadingState)
-    }
-
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.message.id == rhs.message.id
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(message.id)
+extension ChatMessage: Differentiable {
+    public func isContentEqual(to source: ChatMessage) -> Bool {
+        text == source.text
+            && type == source.type
+            && command == source.command
+            && arguments == source.arguments
+            && parentMessageId == source.parentMessageId
+            && showReplyInChannel == source.showReplyInChannel
+            && replyCount == source.replyCount
+            && extraData == source.extraData
+            && quotedMessage == source.quotedMessage
+            && isShadowed == source.isShadowed
+            && reactionCounts.count == source.reactionCounts.count
+            && reactionScores.count == source.reactionScores.count
+            && threadParticipants.count == source.threadParticipants.count
+            && attachmentCounts.count == source.attachmentCounts.count
+            && giphyAttachments == source.giphyAttachments
+            && localState == source.localState
+            && isFlaggedByCurrentUser == source.isFlaggedByCurrentUser
+            && readBy == source.readBy
+            && imageAttachments.map(\.uploadingState) == source.imageAttachments.map(\.uploadingState)
+            && videoAttachments.map(\.uploadingState) == source.videoAttachments.map(\.uploadingState)
+            && fileAttachments.map(\.uploadingState) == source.fileAttachments.map(\.uploadingState)
+            && audioAttachments.map(\.uploadingState) == source.audioAttachments.map(\.uploadingState)
+            && linkAttachments.map(\.uploadingState) == source.linkAttachments.map(\.uploadingState)
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
@@ -1,0 +1,70 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import DifferenceKit
+import StreamChat
+import UIKit
+
+extension ChatMessageListView {
+    internal func reloadMessages(
+        previousSnapshot: [ChatMessage],
+        newSnapshot: [ChatMessage],
+        with animation: @autoclosure () -> RowAnimation,
+        completion: (() -> Void)? = nil
+    ) {
+        let source = previousSnapshot.map(DiffChatMessage.init)
+        let target = newSnapshot.map(DiffChatMessage.init)
+        let changeset = StagedChangeset(
+            source: source,
+            target: target
+        )
+        CATransaction.begin()
+        CATransaction.setCompletionBlock(completion)
+        reload(
+            using: changeset,
+            with: animation()
+        ) { [weak self] diffMessages in
+            self?.onNewDataSource?(diffMessages.map(\.message))
+        }
+        CATransaction.commit()
+    }
+}
+
+private struct DiffChatMessage: Hashable, Differentiable {
+    let message: ChatMessage
+
+    func isContentEqual(to source: DiffChatMessage) -> Bool {
+        message.text == source.message.text
+            && message.type == source.message.type
+            && message.command == source.message.command
+            && message.arguments == source.message.arguments
+            && message.parentMessageId == source.message.parentMessageId
+            && message.showReplyInChannel == source.message.showReplyInChannel
+            && message.replyCount == source.message.replyCount
+            && message.extraData == source.message.extraData
+            && message.quotedMessage == source.message.quotedMessage
+            && message.isShadowed == source.message.isShadowed
+            && message.reactionCounts.count == source.message.reactionCounts.count
+            && message.reactionScores.count == source.message.reactionScores.count
+            && message.threadParticipants.count == source.message.threadParticipants.count
+            && message.attachmentCounts.count == source.message.attachmentCounts.count
+            && message.giphyAttachments == source.message.giphyAttachments
+            && message.localState == source.message.localState
+            && message.isFlaggedByCurrentUser == source.message.isFlaggedByCurrentUser
+            && message.readBy == source.message.readBy
+            && message.imageAttachments.map(\.uploadingState) == source.message.imageAttachments.map(\.uploadingState)
+            && message.videoAttachments.map(\.uploadingState) == source.message.videoAttachments.map(\.uploadingState)
+            && message.fileAttachments.map(\.uploadingState) == source.message.fileAttachments.map(\.uploadingState)
+            && message.audioAttachments.map(\.uploadingState) == source.message.audioAttachments.map(\.uploadingState)
+            && message.linkAttachments.map(\.uploadingState) == source.message.linkAttachments.map(\.uploadingState)
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.message.id == rhs.message.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(message.id)
+    }
+}

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -190,16 +190,11 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
             )
         }
 
-        // When inserting new messages, we want to avoid weird animation
-        // but when these messages are not visible we actually want the animation
-        // because they avoid the message list jumps.
-        if isLastCellFullyVisible {
-            UIView.performWithoutAnimation {
-                reload()
+        UIView.performWithoutAnimation {
+            reload()
+            if self.isLastCellFullyVisible {
                 reloadPreviousMessage()
             }
-        } else {
-            reload()
         }
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -29,11 +29,6 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
     open func setUp() {
         keyboardDismissMode = .onDrag
         rowHeight = UITableView.automaticDimension
-        if #available(iOS 13, *), components._messageListDiffingEnabled {
-            estimatedRowHeight = UITableView.automaticDimension
-        } else {
-            estimatedRowHeight = 150
-        }
         separatorStyle = .none
         transform = .mirrorY
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -201,39 +201,6 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
 
 // MARK: Helpers
 
-private extension ListChange {
-    var isMove: Bool {
-        switch self {
-        case .move:
-            return true
-        default:
-            return false
-        }
-    }
-
-    var isInsertion: Bool {
-        switch self {
-        case .insert:
-            return true
-        default:
-            return false
-        }
-    }
-
-    var indexPath: IndexPath {
-        switch self {
-        case let .insert(_, index):
-            return index
-        case let .move(_, _, toIndex):
-            return toIndex
-        case let .update(_, index):
-            return index
-        case let .remove(_, index):
-            return index
-        }
-    }
-}
-
 private extension CGAffineTransform {
     static let mirrorY = Self(scaleX: 1, y: -1)
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -217,6 +217,13 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
                         if newMessage.isSentByCurrentUser {
                             self?.scrollToMostRecentMessage()
                         }
+
+                        // When a Giphy moves to the bottom, we need to also trigger a reload
+                        // Since a move doesn't trigger a reload of the cell.
+                        if bottomChange?.isMove == true {
+                            let movedIndexPath = IndexPath(item: 0, section: 0)
+                            self?.reloadRows(at: [movedIndexPath], with: .none)
+                        }
                     }
                     completion?()
                 }

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -293,6 +293,10 @@ open class ChatThreadVC: _ViewController,
         messageListVC.updateMessages(with: [listChange])
     }
 
+    public func messageControllerWillChangeReplies(
+        _ controller: ChatMessageController
+    ) {}
+
     open func messageController(
         _ controller: ChatMessageController,
         didChangeReplies changes: [ListChange<ChatMessage>]

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -119,11 +119,6 @@ public struct Components {
     /// A boolean value that determines wether date separators should be shown between each message.
     public var messageListDateSeparatorEnabled = false
 
-    /// A boolean value that determines whether the message list should use a diffable data source.
-    /// Note: This is currently an experimental feature that we are actively
-    /// working on and testing to make sure it is stable.
-    public var _messageListDiffingEnabled = false
-
     /// The view controller used to perform message actions.
     public var messageActionsVC: ChatMessageActionsVC.Type = ChatMessageActionsVC.self
 

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1058,6 +1058,8 @@
 		ADCDDD0025AE2784004E15FB /* UserUpdateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCDDCEC25AE2214004E15FB /* UserUpdateViewController.swift */; };
 		ADCDDD0825AE2F4A004E15FB /* InputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCDDD0725AE2F4A004E15FB /* InputViewController.swift */; };
 		ADDFDE2B2779EC8A003B3B07 /* Atlantis in Frameworks */ = {isa = PBXBuildFile; productRef = ADDFDE2A2779EC8A003B3B07 /* Atlantis */; };
+		ADEE888D289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEE888C289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift */; };
+		ADEE888E289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEE888C289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift */; };
 		ADEED08127F202C100A42B52 /* yoda_with_long_file_name.txt in Resources */ = {isa = PBXBuildFile; fileRef = ADEED08027F202C100A42B52 /* yoda_with_long_file_name.txt */; };
 		ADF34F8A25CDC58900AD637C /* ConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF34F6A25CD6A1D00AD637C /* ConnectionController.swift */; };
 		ADF34F9E25CDD8E600AD637C /* ConnectionController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF34F9D25CDD8E600AD637C /* ConnectionController+SwiftUI.swift */; };
@@ -3194,6 +3196,7 @@
 		ADD5A9E725DE8AF6006DC88A /* ChatSuggestionsVC_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSuggestionsVC_Tests.swift; sourceTree = "<group>"; };
 		ADEA7F21261D2F8C00CA2289 /* chewbacca.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = chewbacca.jpg; sourceTree = "<group>"; };
 		ADEA7F22261D2F8C00CA2289 /* r2.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = r2.jpg; sourceTree = "<group>"; };
+		ADEE888C289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatMessageListView+DiffKit.swift"; sourceTree = "<group>"; };
 		ADEED08027F202C100A42B52 /* yoda_with_long_file_name.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = yoda_with_long_file_name.txt; sourceTree = "<group>"; };
 		ADF34F6A25CD6A1D00AD637C /* ConnectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionController.swift; sourceTree = "<group>"; };
 		ADF34F9D25CDD8E600AD637C /* ConnectionController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionController+SwiftUI.swift"; sourceTree = "<group>"; };
@@ -3895,6 +3898,7 @@
 				AD470C9B26C6D8C60090759A /* ChatMessageListVCDataSource.swift */,
 				AD470C9D26C6D9030090759A /* ChatMessageListVCDelegate.swift */,
 				79088331254876C100896F03 /* ChatMessageListView.swift */,
+				ADEE888C289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift */,
 				BD69F5D42669392E00E9E3FA /* ScrollToLatestMessageButton.swift */,
 				E768AAFA2627691600328E6E /* TypingAnimationView.swift */,
 				E768AA882625C18D00328E6E /* TypingIndicatorView.swift */,
@@ -8480,6 +8484,7 @@
 				790882F725486B8000896F03 /* ChatChannelListCollectionViewDelegate.swift in Sources */,
 				43F4750C26F4E4FF0009487D /* ChatMessageReactionItemView.swift in Sources */,
 				DBF12128258BAFC1001919C6 /* OnlyLinkTappableTextView.swift in Sources */,
+				ADEE888D289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift in Sources */,
 				ADFB7E97283E73C600ABB6CF /* ListChangeUpdater.swift in Sources */,
 				E79AC10B25831A1500C3CE5D /* ChatCommandSuggestionView.swift in Sources */,
 				AD4473B3263ABFA20030E583 /* ChatSuggestionsCollectionReusableView.swift in Sources */,
@@ -9942,6 +9947,7 @@
 				C121EBB62746A1E900023E4C /* BaseViews.swift in Sources */,
 				C121EBB72746A1E900023E4C /* SwiftUIViewRepresentable.swift in Sources */,
 				C121EBB82746A1E900023E4C /* ChatLoadingIndicator.swift in Sources */,
+				ADEE888E289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift in Sources */,
 				CFE5F85C2874A9330099A6A1 /* ChatChannelListEmptyView.swift in Sources */,
 				C121EBB92746A1E900023E4C /* PlayerView.swift in Sources */,
 				C121EBBA2746A1E900023E4C /* GalleryCollectionViewCell.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1036,6 +1036,7 @@
 		ADA5A0F9276790C100E1C465 /* ChatMessageListDateSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA5A0F7276790C100E1C465 /* ChatMessageListDateSeparatorView.swift */; };
 		ADAA377125E43C3700C31528 /* ChatSuggestionsVC_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADD5A9E725DE8AF6006DC88A /* ChatSuggestionsVC_Tests.swift */; };
 		ADAC47AA275A7C960027B672 /* ChatMessageContentView_Documentation_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADAC47A9275A7C960027B672 /* ChatMessageContentView_Documentation_Tests.swift */; };
+		ADB1ED4F289A8EEB009188B2 /* DifferenceKit in Frameworks */ = {isa = PBXBuildFile; productRef = ADB1ED4E289A8EEB009188B2 /* DifferenceKit */; };
 		ADB22F7C25F1626200853C92 /* OnlineIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB22F7A25F1626200853C92 /* OnlineIndicatorView.swift */; };
 		ADB22F7D25F1626200853C92 /* ChatPresenceAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB22F7B25F1626200853C92 /* ChatPresenceAvatarView.swift */; };
 		ADB4166C26208F1C00E623E3 /* AttachmentPreviewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB4165026208C7900E623E3 /* AttachmentPreviewProvider.swift */; };
@@ -3633,6 +3634,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ADB1ED4F289A8EEB009188B2 /* DifferenceKit in Frameworks */,
 				E334B386282468F2002E9640 /* Sentry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -7634,6 +7636,7 @@
 			name = StreamChat;
 			packageProductDependencies = (
 				E334B385282468F2002E9640 /* Sentry */,
+				ADB1ED4E289A8EEB009188B2 /* DifferenceKit */,
 			);
 			productName = Sources;
 			productReference = 799C941B247D2F80001F1104 /* StreamChat.framework */;
@@ -7952,6 +7955,7 @@
 				A3BD4869281FD4500090D511 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */,
 				C1B49B39282283C100F4E89E /* XCRemoteSwiftPackageReference "GDPerformanceView-Swift" */,
 				E334B384282468F2002E9640 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+				ADB1ED4D289A8EEB009188B2 /* XCRemoteSwiftPackageReference "DifferenceKit" */,
 			);
 			productRefGroup = 8AD5EC9022E9A3E8005CFAC9 /* Products */;
 			projectDirPath = "";
@@ -12346,6 +12350,14 @@
 				version = 1.8.2;
 			};
 		};
+		ADB1ED4D289A8EEB009188B2 /* XCRemoteSwiftPackageReference "DifferenceKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ra1028/DifferenceKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 		ADDFDE272779EC67003B3B07 /* XCRemoteSwiftPackageReference "atlantis" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ProxymanApp/atlantis";
@@ -12448,6 +12460,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AD472EF625C425FB00A96E70 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
 			productName = SnapshotTesting;
+		};
+		ADB1ED4E289A8EEB009188B2 /* DifferenceKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = ADB1ED4D289A8EEB009188B2 /* XCRemoteSwiftPackageReference "DifferenceKit" */;
+			productName = DifferenceKit;
 		};
 		ADDFDE2A2779EC8A003B3B07 /* Atlantis */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
### 🔗 Issue Links
CIS-2084
CIS-2085
https://github.com/GetStream/stream-chat-swift/issues/2094

Bonus:
https://github.com/GetStream/stream-chat-swift/issues/2184

### 🎯 Goal
The goal of this PR is to fix the crashes in the message list related to data inconsistencies in `performBatchUpdates` and also to fix the message list jumps when receiving multiple messages and the user is scrolled up.

### 📝 Summary
- Adds [DifferenceKit](https://github.com/ra1028/DifferenceKit) dependency to `StreamChatUI`.
- Removes the`_messageListDiffingEnabled` flag, since now we only have 1 implementation of the message list and it is not experimental anymore
- Instead of relying on `ListChange` updates from `StreamChat`, now the `StreamChatUI` applies changes from the diffing calculation of the old messages snapshot, and the newest message snapshot
- Skips bottom insertions at the bottom when the user is scrolled up.  With the diffing logic in place, now it is easier to skip bottom insertion updates when the user is scrolled up. This avoids the message list jumps because the insertions at the bottom don't actually happen until the user scrolls to the bottom again. This not only avoids the message list jumps but also makes the message list more performant and efficient.
- Improves the performance of the message list when multiple messages are being inserted at the same time and there are already quite some messages loaded. (Most of this improvement was by skipping channel list updates while the channel list is not visible. After profiling the application, the main thread was mostly blocked by the channel list updates, and the root cause is being fixed here: https://github.com/GetStream/stream-chat-swift/pull/2168. Either way, it doesn't make sense for the channel list to impact the message list while the user is on the message list. The https://github.com/GetStream/stream-chat-swift/pull/2168 PR will also improve even further the message list performance especially when it is being overloaded. Right now the DTO mappings on the main thread are the only optimisation left in the Message List. Even though we have right now a good 56/60FPS average when the message list is being overloaded.

Missing Tasks:
- [ ] Skipping logic test coverage
- [ ] Properly add the DifferenceKit dependency using the bash script

### 🎨 Showcase
TODO

### 🧪 Manual Testing Notes
- [ ] Mob Regression Testing

### ☑️ Contributor Checklist
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

<img src="https://media.giphy.com/media/Ry1MOAeAYXvRVQLPw3/giphy.gif"/>
