### PR TITLE
[CIS-2014] Support message hard/soft deletion in Mock Server

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "StreamChatTestHelpers", url: "https://github.com/GetStream/stream-chat-swift-test-helpers.git", .exact("0.2.2")),
+        .package(name: "StreamChatTestHelpers", url: "https://github.com/GetStream/stream-chat-swift-test-helpers.git", .exact("0.2.3")),
         .package(name: "Swifter", url: "https://github.com/httpswift/swifter", .exact("1.5.0"))
     ],
     targets: [

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -335,6 +335,7 @@
 		826B1C3528895AFD005DDF13 /* http_youtube_link.json in Resources */ = {isa = PBXBuildFile; fileRef = 826B1C3428895AFD005DDF13 /* http_youtube_link.json */; };
 		826B1C3728895BB5005DDF13 /* http_unsplash_link.json in Resources */ = {isa = PBXBuildFile; fileRef = 826B1C3628895BB5005DDF13 /* http_unsplash_link.json */; };
 		826B1C39288FD756005DDF13 /* http_truncate.json in Resources */ = {isa = PBXBuildFile; fileRef = 826B1C38288FD756005DDF13 /* http_truncate.json */; };
+		827DD1A0289D5B3300910AC5 /* MessageActionsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827DD19F289D5B3300910AC5 /* MessageActionsVC.swift */; };
 		829CD5C52848C2EA003C3877 /* ParticipantRobot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829CD5C32848C25F003C3877 /* ParticipantRobot.swift */; };
 		829CD5C72848C71B003C3877 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829CD5C62848C71B003C3877 /* Settings.swift */; };
 		829CD5CC2848C8D6003C3877 /* BackendRobot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829CD5CB2848C8D6003C3877 /* BackendRobot.swift */; };
@@ -2581,6 +2582,7 @@
 		826B1C3428895AFD005DDF13 /* http_youtube_link.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = http_youtube_link.json; sourceTree = "<group>"; };
 		826B1C3628895BB5005DDF13 /* http_unsplash_link.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = http_unsplash_link.json; sourceTree = "<group>"; };
 		826B1C38288FD756005DDF13 /* http_truncate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = http_truncate.json; sourceTree = "<group>"; };
+		827DD19F289D5B3300910AC5 /* MessageActionsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageActionsVC.swift; sourceTree = "<group>"; };
 		8298C8E827D22C3E004082D3 /* UserRobot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRobot.swift; sourceTree = "<group>"; };
 		829CD5C32848C25F003C3877 /* ParticipantRobot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantRobot.swift; sourceTree = "<group>"; };
 		829CD5C62848C71B003C3877 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
@@ -5205,6 +5207,7 @@
 				A34407FB27D8C9040044F150 /* StreamChatWrapper.swift */,
 				A34407F527D8C8A70044F150 /* User.swift */,
 				A3813B4D2825C8A30076E838 /* ThreadVC.swift */,
+				827DD19F289D5B3300910AC5 /* MessageActionsVC.swift */,
 			);
 			path = StreamChat;
 			sourceTree = "<group>";
@@ -9460,6 +9463,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A3BD4818281A984C0090D511 /* DispatchQueue+AsyncAfter.swift in Sources */,
+				827DD1A0289D5B3300910AC5 /* MessageActionsVC.swift in Sources */,
 				A3BD484E281ABB620090D511 /* CustomChannelListRouter.swift in Sources */,
 				A3698DD828215E2F00814143 /* Settings.swift in Sources */,
 				A3813B4C2825C8030076E838 /* CustomChatMessageListRouter.swift in Sources */,
@@ -12335,7 +12339,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift-test-helpers.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.2.2;
+				version = 0.2.3;
 			};
 		};
 		AD472EF625C425FB00A96E70 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/StreamChatUITestsApp/Settings.swift
+++ b/StreamChatUITestsApp/Settings.swift
@@ -9,6 +9,7 @@ enum Setting: String, CaseIterable {
     case setConnectivity
     case isConnected
     case isLocalStorageEnabled
+    case staysConnectedInBackground
 }
 
 struct SettingValue {
@@ -25,10 +26,12 @@ struct Settings {
 
     // Config
     var isLocalStorageEnabled = SettingValue(setting: .isLocalStorageEnabled, isOn: false)
+    var staysConnectedInBackground = SettingValue(setting: .staysConnectedInBackground, isOn: false)
 
     var all: [SettingValue] {
         [
             isLocalStorageEnabled,
+            staysConnectedInBackground,
             showsConnectivity,
             setConnectivity,
             isConnected
@@ -51,6 +54,8 @@ struct Settings {
             showsConnectivity = setting
         case .isLocalStorageEnabled:
             isLocalStorageEnabled = setting
+        case .staysConnectedInBackground:
+            staysConnectedInBackground = setting
         }
     }
 }

--- a/StreamChatUITestsApp/StreamChat/MessageActionsVC.swift
+++ b/StreamChatUITestsApp/StreamChat/MessageActionsVC.swift
@@ -1,0 +1,50 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamChat
+import StreamChatUI
+import UIKit
+
+final class MessageActionsVC: ChatMessageActionsVC {
+    override var messageActions: [ChatMessageActionItem] {
+        var actions = super.messageActions
+        if message?.isSentByCurrentUser == true {
+            actions.append(hardDeleteActionItem())
+        }
+        
+        return actions
+    }
+
+    func hardDeleteActionItem() -> ChatMessageActionItem {
+        HardDeleteActionItem(
+            action: { [weak self] _ in
+                guard let self = self else { return }
+                self.alertsRouter.showMessageDeletionConfirmationAlert { confirmed in
+                    guard confirmed else { return }
+
+                    self.messageController.deleteMessage(hard: true) { _ in
+                        self.delegate?.chatMessageActionsVCDidFinish(self)
+                    }
+                }
+            },
+            appearance: appearance
+        )
+    }
+
+    struct HardDeleteActionItem: ChatMessageActionItem {
+        var title: String { "Hard Delete Message" }
+        var isDestructive: Bool { true }
+        let icon: UIImage
+        let action: (ChatMessageActionItem) -> Void
+
+        init(
+            action: @escaping (ChatMessageActionItem) -> Void,
+            appearance: Appearance = .default
+        ) {
+            self.action = action
+            icon = appearance.images.messageActionDelete
+        }
+    }
+}

--- a/StreamChatUITestsApp/StreamChat/StreamChatWrapper.swift
+++ b/StreamChatUITestsApp/StreamChat/StreamChatWrapper.swift
@@ -22,7 +22,8 @@ final class StreamChatWrapper {
         self.userCredentials = userCredentials
 
         var config = ChatClientConfig(apiKey: .init(apiKey))
-        config.isLocalStorageEnabled = false
+        config.isLocalStorageEnabled = settings.isLocalStorageEnabled.isOn
+        config.staysConnectedInBackground = settings.staysConnectedInBackground.isOn
 
         // Customization
         var components = Components.default
@@ -31,6 +32,7 @@ final class StreamChatWrapper {
         components.channelVC = ChannelVC.self
         components.threadVC = ThreadVC.self
         Components.default = components
+        Components.default.messageActionsVC = MessageActionsVC.self
 
         // create an instance of ChatClient and share it using the singleton
         let environment = ChatClient.Environment()

--- a/StreamChatUITestsApp/ViewController.swift
+++ b/StreamChatUITestsApp/ViewController.swift
@@ -6,10 +6,11 @@ import UIKit
 import StreamChat
 import StreamChatUI
 
+var settings = Settings()
+
 final class ViewController: UIViewController {
 
     var streamChat = StreamChatWrapper()
-    var settings = Settings()
 
     var channelController: ChatChannelController?
     var router: CustomChannelListRouter?
@@ -113,10 +114,10 @@ final class ViewController: UIViewController {
 extension ViewController {
 
     func createIsConnectedSwitchIfNeeded() -> UISwitch? {
-        guard self.settings.showsConnectivity.isOn else { return nil }
+        guard settings.showsConnectivity.isOn else { return nil }
         let sw = UISwitch()
-        sw.isOn = self.settings.isConnected.isOn
-        sw.accessibilityIdentifier = self.settings.isConnected.setting.rawValue
+        sw.isOn = settings.isConnected.isOn
+        sw.accessibilityIdentifier = settings.isConnected.setting.rawValue
         sw.addTarget(self, action: #selector(self.valueChanged(_:)), for: .valueChanged)
 
         return sw

--- a/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
+++ b/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
@@ -82,7 +82,6 @@ class MessageListPage {
         static var cooldown: XCUIElement { app.staticTexts["cooldownLabel"] }
         static var placeholder: XCUIElement { textView.staticTexts.firstMatch }
         static var selectAllButton: XCUIElement { app.menuItems.matching(NSPredicate(format: "label LIKE 'Select All'")).firstMatch }
-        static var pasteButton: XCUIElement { app.menuItems.matching(NSPredicate(format: "label LIKE 'Paste'")).firstMatch }
     }
     
     enum Reactions {
@@ -111,6 +110,7 @@ class MessageListPage {
         case mute
         case edit
         case delete
+        case hardDelete
         case resend
         case block
         case unblock
@@ -133,6 +133,8 @@ class MessageListPage {
                 return Element.edit
             case .delete:
                 return Element.delete
+            case .hardDelete:
+                return Element.hardDelete
             case .resend:
                 return Element.resend
             case .block:
@@ -152,6 +154,7 @@ class MessageListPage {
             static var unmute: XCUIElement { app.otherElements["UnmuteUserActionItem"] }
             static var edit: XCUIElement { app.otherElements["EditActionItem"] }
             static var delete: XCUIElement { app.otherElements["DeleteActionItem"] }
+            static var hardDelete: XCUIElement { app.otherElements["HardDeleteActionItem"] }
             static var resend: XCUIElement { app.otherElements["ResendActionItem"] }
             static var block: XCUIElement { app.otherElements["BlockUserActionItem"] }
             static var unblock: XCUIElement { app.otherElements["UnblockUserActionItem"] }

--- a/StreamChatUITestsAppUITests/Pages/Settings.swift
+++ b/StreamChatUITestsAppUITests/Pages/Settings.swift
@@ -10,6 +10,7 @@ enum Settings: String {
     case setConnectivity
     case isConnected
     case isLocalStorageEnabled
+    case staysConnectedInBackground
 
     var element: XCUIElement { app.switches[rawValue] }
 }

--- a/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
@@ -120,9 +120,7 @@ extension UserRobot {
                        file: file,
                        line: line)
         
-        let iosVersion = ProcessInfo().operatingSystemVersion.majorVersion
-        let duration = iosVersion >= 16 ? 20 : XCUIElement.waitTimeout
-        let endTime = Date().timeIntervalSince1970 * 1000 + duration * 1000
+        let endTime = Date().timeIntervalSince1970 * 1000 + XCUIElement.waitTimeout * 1000
         while !expectedChannelExist && endTime > Date().timeIntervalSince1970 * 1000 {
             ChannelListPage.list.swipeUp()
             expectedChannelExist = expectedChannel.exists
@@ -255,15 +253,17 @@ extension UserRobot {
 
     @discardableResult
     func assertHardDeletedMessage(
+        withText deletedText: String,
         at messageCellIndex: Int = 0,
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> Self {
-        let messageCell = messageCell(withIndex: messageCellIndex, file: file, line: line)
-        let message = attributes.text(in: messageCell).wait()
-        let expectedMessage = attributes.deletedMessagePlaceholder
-        let actualMessage = message.waitForText(expectedMessage).text
-        XCTAssertEqual(expectedMessage, actualMessage, "Text is wrong", file: file, line: line)
+        if MessageListPage.cells.count > 0 {
+            let messageCell = messageCell(withIndex: messageCellIndex, file: file, line: line)
+            let actualText = attributes.text(in: messageCell).waitForTextDisappearance(deletedText).text
+            XCTAssertNotEqual(attributes.deletedMessagePlaceholder, actualText, file: file, line: line)
+            XCTAssertNotEqual(deletedText, actualText, file: file, line: line)
+        }
         return self
     }
 

--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -65,9 +65,7 @@ extension UserRobot {
 
     @discardableResult
     func openContextMenu(messageCellIndex: Int = 0) -> Self {
-        let iosMajorVersion = ProcessInfo().operatingSystemVersion.majorVersion
-        let duration: TimeInterval = iosMajorVersion == 16 ? 2 : 1
-        messageCell(withIndex: messageCellIndex).safePress(forDuration: duration)
+        messageCell(withIndex: messageCellIndex).safePress(forDuration: 1)
         return self
     }
     
@@ -112,9 +110,10 @@ extension UserRobot {
     }
     
     @discardableResult
-    func deleteMessage(messageCellIndex: Int = 0) -> Self {
+    func deleteMessage(messageCellIndex: Int = 0, hard: Bool = false) -> Self {
         openContextMenu(messageCellIndex: messageCellIndex)
-        contextMenu.delete.element.wait().safeTap()
+        let deleteButton = hard ? contextMenu.hardDelete : contextMenu.delete
+        deleteButton.element.wait().safeTap()
         MessageListPage.PopUpButtons.delete.wait().safeTap()
         return self
     }
@@ -122,9 +121,6 @@ extension UserRobot {
     @discardableResult
     func editMessage(_ newText: String, messageCellIndex: Int = 0) -> Self {
         composer.inputField.obtainKeyboardFocus()
-        if ProcessInfo().operatingSystemVersion.majorVersion == 16 && composer.pasteButton.exists {
-            composer.inputField.tap()
-        }
         openContextMenu(messageCellIndex: messageCellIndex)
         contextMenu.edit.element.wait().safeTap()
         clearComposer()
@@ -439,6 +435,11 @@ extension UserRobot {
     @discardableResult
     func setIsLocalStorageEnabled(to state: SwitchState) -> Self {
         setSwitchState(Settings.isLocalStorageEnabled.element, state: state)
+    }
+    
+    @discardableResult
+    func setStaysConnectedInBackground(to state: SwitchState) -> Self {
+        setSwitchState(Settings.staysConnectedInBackground.element, state: state)
     }
     
 }

--- a/StreamChatUITestsAppUITests/Tests/Ephemeral_Messages_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Ephemeral_Messages_Tests.swift
@@ -114,11 +114,11 @@ final class Ephemeral_Messages_Tests: StreamTestCase {
         linkToScenario(withId: 183)
 
         GIVEN("user opens a channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: 1)
             userRobot.login().openChannel()
         }
         WHEN("user runs a giphy command in thread") {
             userRobot
-                .sendMessage("test")
                 .openThread()
                 .sendGiphy(send: false)
         }

--- a/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus_Tests.swift
@@ -555,8 +555,8 @@ extension MessageDeliveryStatus_Tests {
         }
         AND("delivery status is hidden") {
             userRobot
-            .assertMessageDeliveryStatus(nil)
-            .assertMessageReadCount(readBy: 0)
+                .assertMessageDeliveryStatus(nil)
+                .assertMessageReadCount(readBy: 0)
         }
     }
 

--- a/StreamChatUITestsAppUITests/Tests/Reactions_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Reactions_Tests.swift
@@ -187,4 +187,32 @@ final class Reactions_Tests: StreamTestCase {
         }
     }
     
+    func test_addReactionWhileOffline() {
+        linkToScenario(withId: 94)
+        
+        let message = "test message"
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .setIsLocalStorageEnabled(to: .on)
+                .setConnectivitySwitchVisibility(to: .on)
+                .login()
+                .openChannel()
+        }
+        AND("user sends a message") {
+            userRobot.sendMessage(message)
+        }
+        AND("user becomes offline") {
+            userRobot.setConnectivity(to: .off)
+        }
+        WHEN("participant adds a reaction") {
+            participantRobot.addReaction(type: .like)
+        }
+        AND("user becomes online") {
+            userRobot.setConnectivity(to: .on)
+        }
+        THEN("user observes a new reaction") {
+            userRobot.assertReaction(isPresent: true)
+        }
+    }
 }

--- a/TestTools/StreamChatTestMockServer/MockServer/MessageResponses.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/MessageResponses.swift
@@ -123,9 +123,12 @@ public extension StreamMockServer {
         let channelId = cid?.split(separator: ":").last.map { String($0) }
         switch request.method {
         case EndpointMethod.delete.rawValue:
+            let hardParam = request.queryParams.filter { $0.0 == JSONKey.hard }.first?.1
+            let hardDelete = (hardParam == "1")
             return messageDeletion(
                 messageId: messageId,
-                channelId: channelId
+                channelId: channelId,
+                hardDelete: hardDelete
             )
         case EndpointMethod.get.rawValue:
             return messageInfo(messageId: messageId)
@@ -475,7 +478,7 @@ public extension StreamMockServer {
         }
     }
     
-    private func messageDeletion(messageId: String, channelId: String?) -> HttpResponse {
+    private func messageDeletion(messageId: String, channelId: String?, hardDelete: Bool) -> HttpResponse {
         var json = TestData.toJson(.message)
         let message = findMessageById(messageId)
         let timestamp: String = TestData.currentDate
@@ -487,7 +490,8 @@ public extension StreamMockServer {
             messageId: messageId,
             timestamp: timestamp,
             eventType: .messageDeleted,
-            user: user
+            user: user,
+            hardDelete: hardDelete
         )
         
         json[JSONKey.message] = mockedMessage

--- a/TestTools/StreamChatTestMockServer/MockServer/MockServerAttributes.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/MockServerAttributes.swift
@@ -87,6 +87,7 @@ public enum JSONKey {
     public static let attachmentAction = "image_action"
     public static let file = "file"
     public static let payload = "payload"
+    public static let hard = "hard"
 
     public enum Channel {
         public static let addMembers = "add_members"

--- a/TestTools/StreamChatTestMockServer/Robots/ParticipantRobot.swift
+++ b/TestTools/StreamChatTestMockServer/Robots/ParticipantRobot.swift
@@ -145,7 +145,7 @@ public class ParticipantRobot {
     }
     
     @discardableResult
-    public func deleteMessage() -> Self {
+    public func deleteMessage(hard: Bool = false) -> Self {
         let user = participant()
         guard let userId = user?[userKey.id.rawValue] as? String else { return self }
         let message = server.findMessageByUserId(userId)
@@ -154,7 +154,8 @@ public class ParticipantRobot {
             channelId: server.currentChannelId,
             messageId: messageId,
             eventType: .messageDeleted,
-            user: user
+            user: user,
+            hardDelete: hard
         )
         return self
     }


### PR DESCRIPTION
### 🔗 Issue Links

- https://stream-io.atlassian.net/browse/CIS-2014

### 🎯 Goal

- Support message hard/soft deletion in Mock Server
- Automate related scenarios

### 📝 Summary

- The mock server fully supports message hard/soft deletion
- Related scenarios are automated
- A couple of additional unrelated scenarios have also been automated
- Test app was updated accordingly
- iOS 16 workarounds have been removed as issues with XCTest have been fixed on `Xcode 14 beta 5`

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/9xlzhm7XZFaja1E6QX/giphy.gif)
