### PR TITLE
[CIS-2027] Deal with flaky unit tests

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -75,7 +75,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/bootstrap
     - name: Run LLC Tests (Debug)
-      run: bundle exec fastlane test cron:true device:"iPhone 8"
+      run: bundle exec fastlane test device:"iPhone 8"
       timeout-minutes: 30
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -2588,6 +2588,7 @@
 		829CD5C62848C71B003C3877 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		829CD5CB2848C8D6003C3877 /* BackendRobot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendRobot.swift; sourceTree = "<group>"; };
 		82A6F5BF27E2031000F4A2F6 /* Reactions_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reactions_Tests.swift; sourceTree = "<group>"; };
+		82AA16CF28A400F8009816CD /* StreamChatFlakyTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = StreamChatFlakyTests.xctestplan; sourceTree = "<group>"; };
 		82AD02BA27D8E433000611B7 /* LaunchArgument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArgument.swift; sourceTree = "<group>"; };
 		82AD02BC27D8E44B000611B7 /* StreamTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamTestCase.swift; sourceTree = "<group>"; };
 		82B350F827EA294900FEB6A0 /* MockServerAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockServerAttributes.swift; sourceTree = "<group>"; };
@@ -3843,6 +3844,7 @@
 				A3D15D9527EA0723006B34D7 /* StreamChatTests.swift */,
 				A382131D2805C8AC0068D30E /* TestsEnvironmentSetup.swift */,
 				7908824725432CC600896F03 /* StreamChatStressTestPlan.xctestplan */,
+				82AA16CF28A400F8009816CD /* StreamChatFlakyTests.xctestplan */,
 				7908824825432CC600896F03 /* StreamChatTestPlan.xctestplan */,
 				A364D09127D0BECE0029857A /* APIClient */,
 				A364D08B27D0BD650029857A /* Config */,

--- a/StreamChat.xcodeproj/xcshareddata/xcschemes/StreamChat.xcscheme
+++ b/StreamChat.xcodeproj/xcshareddata/xcschemes/StreamChat.xcscheme
@@ -32,6 +32,9 @@
             reference = "container:Tests/StreamChatTests/StreamChatTestPlan.xctestplan"
             default = "YES">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Tests/StreamChatTests/StreamChatFlakyTests.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
+++ b/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
@@ -1,0 +1,35 @@
+{
+  "configurations" : [
+    {
+      "id" : "998282BC-8EFC-48F6-999A-0BF82B19C122",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "MessageSender_Tests\/test_senderSendsMessages_forMultipleChannelsInParalel_butStillInTheCorrectOrder()",
+        "MessageSender_Tests\/test_sender_doesNotRetainItself()",
+        "MessageSender_Tests\/test_senderSendsMessage_inTheOrderTheyWereCreatedLocally()",
+        "MessageSender_Tests\/test_senderSendsMessage_withPendingSendLocalState_and_uploadedOrEmptyAttachments()",
+        "SyncRepository_Tests\/test_cancelRecoveryFlow_cancelsAllOperations()",
+        "APIClient_Tests\/test_startingMultipleRequestsAtTheSameTimeShouldResultInParallelRequests()",
+        "WebSocketClient_Tests\/test_whenHealthCheckEventComes_itGetProcessedSilentlyWithoutBatching()",
+        "ChannelUpdater_Tests\/test_hideChannel_successfulResponse_isPropagatedToCompletion()",
+        "MessageUpdater_Tests\/test_flagMessage_happyPath()"
+      ],
+      "target" : {
+        "containerPath" : "container:StreamChat.xcodeproj",
+        "identifier" : "799C9450247D59B1001F1104",
+        "name" : "StreamChatTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
@@ -30,7 +30,16 @@
         "ChannelListPayload_Tests\/test_decode_bigChannelListPayload()",
         "ChannelListPayload_Tests\/test_hugeChannelListQuery_save()",
         "ChannelListPayload_Tests\/test_hugeChannelListQuery_save_DB_empty()",
-        "ChannelListPayload_Tests\/test_hugeChannelListQuery_save_DB_filled()"
+        "ChannelListPayload_Tests\/test_hugeChannelListQuery_save_DB_filled()",
+        "ChannelUpdater_Tests\/test_hideChannel_successfulResponse_isPropagatedToCompletion()",
+        "MessageUpdater_Tests\/test_flagMessage_happyPath()",
+        "MessageSender_Tests\/test_senderSendsMessages_forMultipleChannelsInParalel_butStillInTheCorrectOrder()",
+        "MessageSender_Tests\/test_sender_doesNotRetainItself()",
+        "MessageSender_Tests\/test_senderSendsMessage_inTheOrderTheyWereCreatedLocally()",
+        "MessageSender_Tests\/test_senderSendsMessage_withPendingSendLocalState_and_uploadedOrEmptyAttachments()",
+        "SyncRepository_Tests\/test_cancelRecoveryFlow_cancelsAllOperations()",
+        "APIClient_Tests\/test_startingMultipleRequestsAtTheSameTimeShouldResultInParallelRequests()",
+        "WebSocketClient_Tests\/test_whenHealthCheckEventComes_itGetProcessedSilentlyWithoutBatching()"
       ],
       "target" : {
         "containerPath" : "container:StreamChat.xcodeproj",

--- a/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
@@ -830,8 +830,7 @@ final class ChannelUpdater_Tests: XCTestCase {
         XCTAssertEqual(apiClient.request_endpoint, AnyEndpoint(referenceEndpoint))
     }
 
-    // TODO: Disabling flaky test temporarily
-    func _test_hideChannel_successfulResponse_isPropagatedToCompletion() throws {
+    func test_hideChannel_successfulResponse_isPropagatedToCompletion() throws {
         // This part is for the case where the channel is already hidden on backend
         // But SDK is not aware of this (so channel.hiddenAt is not set)
         // Consecutive `hideChannel` calls won't generate `channel.hidden` events

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -440,7 +440,7 @@ lane :test do |options|
     clean: true,
     devices: options[:device],
     build_for_testing: options[:build_for_testing],
-    number_of_retries: 2
+    number_of_retries: 5
   )
 
   next if options[:build_for_testing]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -431,19 +431,28 @@ desc 'Runs tests in Debug config'
 lane :test do |options|
   next unless check_required?(:unit)
 
-  add_ci_env_var_to('../Tests/StreamChatTests/StreamChatTestPlan.xctestplan')
+  add_ci_env_var_to('../Tests/StreamChatTests/StreamChatFlakyTests.xctestplan')
 
-  number_of_retries = options[:cron] ? 1 : 0
+  scan(
+    project: 'StreamChat.xcodeproj',
+    scheme: 'StreamChat',
+    testplan: 'StreamChatFlakyTests',
+    clean: true,
+    devices: options[:device],
+    build_for_testing: options[:build_for_testing],
+    number_of_retries: 2
+  )
+
+  next if options[:build_for_testing]
+
+  add_ci_env_var_to('../Tests/StreamChatTests/StreamChatTestPlan.xctestplan')
 
   scan(
     project: 'StreamChat.xcodeproj',
     scheme: 'StreamChat',
     testplan: 'StreamChatTestPlan',
-    configuration: 'Debug',
-    clean: true,
     devices: options[:device],
-    build_for_testing: options[:build_for_testing],
-    number_of_retries: number_of_retries
+    skip_build: true
   )
 end
 
@@ -462,7 +471,6 @@ lane :test_e2e_mock do |options|
     project: 'StreamChat.xcodeproj',
     scheme: 'StreamChatUITestsApp',
     testplan: 'StreamChatUITestsApp',
-    configuration: 'Debug',
     devices: device,
     number_of_retries: number_of_retries
   }
@@ -505,7 +513,6 @@ lane :test_ui do |options|
     project: 'StreamChat.xcodeproj',
     scheme: 'StreamChatUI',
     testplan: 'StreamChatUITestPlan',
-    configuration: 'Debug',
     clean: true,
     devices: options[:device],
     build_for_testing: options[:build_for_testing]
@@ -567,7 +574,6 @@ lane :test_debug_macos do
     project: 'StreamChat.xcodeproj',
     scheme: 'StreamChat',
     testplan: 'StreamChatTestPlan',
-    configuration: 'Debug',
     clean: true,
     disable_xcpretty: true,
     destination: 'platform=macOS,arch=x86_64' # will select first from macOS and macOS Catalyst. Let's hope it always will be macOS


### PR DESCRIPTION
### 🔗 Issue Links

- https://stream-io.atlassian.net/browse/CIS-2027

### 📝 Summary

- Create a new test plan exclusively for flaky tests
- Set up a retry strategy for flaky tests
- `Debug` configuration is removed from `Fastfile` as it's set up in `Scanfile`

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/7MZ0v9KynmiSA/giphy.gif)
