### PR TITLE
[CIS-1591] Fix message list scrolling when popping from navigation stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fix hidden channels showing past history [#2216](https://github.com/GetStream/stream-chat-swift/pull/2216)
+
+## StreamChatUI
+### 🐞 Fixed
 - Fix message list scrolling when popping from navigation stack [#2239](https://github.com/GetStream/stream-chat-swift/pull/2239)
 
 # [4.20.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.20.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fix hidden channels showing past history [#2216](https://github.com/GetStream/stream-chat-swift/pull/2216)
+- Fix message list scrolling when popping from navigation stack [#2239](https://github.com/GetStream/stream-chat-swift/pull/2239)
 
 # [4.20.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.20.0)
 _August 02, 2022_

--- a/Sources/StreamChatUI/Composer/ComposerKeyboardHandler.swift
+++ b/Sources/StreamChatUI/Composer/ComposerKeyboardHandler.swift
@@ -63,8 +63,18 @@ open class ComposerKeyboardHandler: KeyboardHandler {
               let frame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
               let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
               let curve = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt,
-              let composerParentView = composerParentVC?.view else {
+              let composerParentView = composerParentVC?.view,
+              let composerParentVC = composerParentVC else {
             return
+        }
+
+        // This fixes a UI Glitch when popping the channel from the navigation stack,
+        // which makes the table view size to change because the hide notification is triggered.
+        if let viewControllersInNavigationStack = composerParentVC.navigationController?.viewControllers {
+            let isBeingPopped = !viewControllersInNavigationStack.contains(composerParentVC)
+            if isBeingPopped {
+                return
+            }
         }
 
         // When hiding, we reset the bottom constraint to the original value


### PR DESCRIPTION
### 🔗 Issue Links
CIS-1591
https://github.com/GetStream/stream-chat-swift/issues/1793

### 🎯 Goal
Fix the message list scrolling when popping the message list from the navigation stack.

### 🛠 Implementation
The reason this happened was that the Keyboard hide notification is still triggered when popping from the navigation stack, and the keyboard is dismissed but there's no animation, only the message list animates. To fix this, on the keyboard handler we check if the view controller is still present in the navigation stack. If not, we don't hide the keyboard.

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  <video src="https://user-images.githubusercontent.com/12814114/185121501-01f8bb92-d1a7-4474-947f-f5e445635c52.mov"/>  |  <video src="https://user-images.githubusercontent.com/12814114/185127580-486a01ac-bf06-4499-801a-aef747f63f31.mp4"/>  |

### 🧪 Manual Testing Notes
- Open a Channel
- Dismiss a Channel
- The message list should not move

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
