### PR TITLE
[CIS-2147] Do not parse ErrorPayload's details

### DIFF
--- a/Sources/StreamChat/Errors/ErrorPayload.swift
+++ b/Sources/StreamChat/Errors/ErrorPayload.swift
@@ -10,7 +10,6 @@ public struct ErrorPayload: LocalizedError, Codable, CustomDebugStringConvertibl
         case code
         case message
         case statusCode = "StatusCode"
-        case details
     }
     
     /// An error code.
@@ -19,9 +18,7 @@ public struct ErrorPayload: LocalizedError, Codable, CustomDebugStringConvertibl
     public let message: String
     /// An HTTP status code.
     public let statusCode: Int
-    /// An array of specific details that compose the error.
-    public let details: [ErrorPayloadDetail]
-    
+
     public var errorDescription: String? {
         "Error #\(code): \(message)"
     }

--- a/Tests/StreamChatTests/APIClient/RequestDecoder_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/RequestDecoder_Tests.swift
@@ -54,7 +54,7 @@ final class RequestDecoder_Tests: XCTestCase {
     
     func test_decodingResponseWithServerError() throws {
         // Prepare test data to simulate error payload from the server
-        let errorPayload = ErrorPayload(code: 0, message: "Test", statusCode: 400, details: [])
+        let errorPayload = ErrorPayload(code: 0, message: "Test", statusCode: 400)
         let data = try JSONEncoder.stream.encode(errorPayload)
         let response = HTTPURLResponse(url: .unique(), statusCode: 400, httpVersion: nil, headerFields: nil)
         
@@ -68,7 +68,7 @@ final class RequestDecoder_Tests: XCTestCase {
     
     func test_decodingResponseWithServerError_containingExpiredToken() throws {
         // Prepare test data to simulate the "token expired" server error
-        let errorPayload = ErrorPayload(code: 40, message: "Test", statusCode: 400, details: [])
+        let errorPayload = ErrorPayload(code: 40, message: "Test", statusCode: 400)
         let data = try JSONEncoder.stream.encode(errorPayload)
         let response = HTTPURLResponse(url: .unique(), statusCode: 400, httpVersion: nil, headerFields: nil)
         

--- a/Tests/StreamChatTests/Errors/ClientError_Tests.swift
+++ b/Tests/StreamChatTests/Errors/ClientError_Tests.swift
@@ -12,8 +12,7 @@ final class ClientError_Tests: XCTestCase {
         let error = ErrorPayload(
             code: .random(in: ClosedRange.tokenInvalidErrorCodes),
             message: .unique,
-            statusCode: .unique,
-            details: []
+            statusCode: .unique
         )
         
         // Assert `isInvalidTokenError` returns true
@@ -31,8 +30,7 @@ final class ClientError_Tests: XCTestCase {
         let error = ErrorPayload(
             code: ClosedRange.tokenInvalidErrorCodes.lowerBound - 1,
             message: .unique,
-            statusCode: .unique,
-            details: []
+            statusCode: .unique
         )
         
         // Assert `isInvalidTokenError` returns false
@@ -49,8 +47,7 @@ final class ClientError_Tests: XCTestCase {
         let error = ErrorPayload(
             code: 73,
             message: .unique,
-            statusCode: .unique,
-            details: []
+            statusCode: .unique
         )
         
         // Assert `isBouncedMessageError` returns true
@@ -61,8 +58,7 @@ final class ClientError_Tests: XCTestCase {
         let error = ErrorPayload(
             code: 72,
             message: .unique,
-            statusCode: .unique,
-            details: []
+            statusCode: .unique
         )
         
         // Assert `isBouncedMessageError` returns false

--- a/Tests/StreamChatTests/Errors/ErrorPayload_Tests.swift
+++ b/Tests/StreamChatTests/Errors/ErrorPayload_Tests.swift
@@ -15,8 +15,7 @@ final class ErrorPayload_Tests: XCTestCase {
             let error = ErrorPayload(
                 code: code,
                 message: .unique,
-                statusCode: .unique,
-                details: []
+                statusCode: .unique
             )
             
             // Assert `isInvalidTokenError` returns true
@@ -37,8 +36,7 @@ final class ErrorPayload_Tests: XCTestCase {
             let error = ErrorPayload(
                 code: code,
                 message: .unique,
-                statusCode: .unique,
-                details: []
+                statusCode: .unique
             )
             
             // Assert `isInvalidTokenError` returns false
@@ -55,8 +53,7 @@ final class ErrorPayload_Tests: XCTestCase {
             let error = ErrorPayload(
                 code: .unique,
                 message: .unique,
-                statusCode: code,
-                details: []
+                statusCode: code
             )
             
             // Assert `isClientError` returns true
@@ -77,8 +74,7 @@ final class ErrorPayload_Tests: XCTestCase {
             let error = ErrorPayload(
                 code: .unique,
                 message: .unique,
-                statusCode: code,
-                details: []
+                statusCode: code
             )
             
             // Assert `isClientError` returns false

--- a/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/SyncRepository_Tests.swift
@@ -400,7 +400,7 @@ final class SyncRepository_Tests: XCTestCase {
             try session.saveChannel(payload: .dummy(cid: .unique), query: query, cache: nil)
         }
 
-        let expectedError = ErrorPayload(code: 1, message: "Too many events", statusCode: 400, details: [])
+        let expectedError = ErrorPayload(code: 1, message: "Too many events", statusCode: 400)
         let result = getSyncExistingChannelEventsResult(requestResult: .failure(ClientError(with: expectedError)))
 
         guard let value = result.value else {

--- a/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
@@ -411,7 +411,7 @@ final class ChatClient_Tests: XCTestCase {
         XCTAssertEqual(testEnv.clientUpdater!.reloadUserIfNeeded_callsCount, 1)
 
         // Simulate WebSocketConnection change to "disconnected"
-        let error = ClientError(with: ErrorPayload(code: 40, message: "", statusCode: 200, details: []))
+        let error = ClientError(with: ErrorPayload(code: 40, message: "", statusCode: 200))
         testEnv.webSocketClient?
             .connectionStateDelegate?
             .webSocketClient(

--- a/Tests/StreamChatTests/Utils/InternetConnection/Error+InternetNotAvailable_Tests.swift
+++ b/Tests/StreamChatTests/Utils/InternetConnection/Error+InternetNotAvailable_Tests.swift
@@ -102,12 +102,12 @@ final class Error_Tests: XCTestCase {
     func test_isBackendErrorWith400StatusCode_errorIsClientErrorWithErrorPayload() {
         // When error is a ClientError, it's unerdlying error is a backend error,
         // but it's status code is not 400
-        let error = ClientError(with: ErrorPayload(code: 0, message: "", statusCode: 503, details: []))
+        let error = ClientError(with: ErrorPayload(code: 0, message: "", statusCode: 503))
         XCTAssertFalse(error.isBackendErrorWith400StatusCode)
     }
     
     func test_isBackendErrorWith400StatusCode() {
-        let error = ClientError(with: ErrorPayload(code: 0, message: "", statusCode: 400, details: []))
+        let error = ClientError(with: ErrorPayload(code: 0, message: "", statusCode: 400))
         XCTAssertTrue(error.isBackendErrorWith400StatusCode)
     }
 }

--- a/Tests/StreamChatTests/WebSocketClient/ConnectionStatus_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/ConnectionStatus_Tests.swift
@@ -14,8 +14,7 @@ final class ChatClientConnectionStatus_Tests: XCTestCase {
             with: ErrorPayload(
                 code: ClosedRange.tokenInvalidErrorCodes.lowerBound,
                 message: .unique,
-                statusCode: .unique,
-                details: []
+                statusCode: .unique
             )
         )
 
@@ -132,8 +131,7 @@ final class WebSocketConnectionState_Tests: XCTestCase {
         let invalidTokenError = ErrorPayload(
             code: ClosedRange.tokenInvalidErrorCodes.lowerBound,
             message: .unique,
-            statusCode: .unique,
-            details: []
+            statusCode: .unique
         )
         
         // Create disconnected state intiated by the server with invalid token error
@@ -150,8 +148,7 @@ final class WebSocketConnectionState_Tests: XCTestCase {
         let clientError = ErrorPayload(
             code: .unique,
             message: .unique,
-            statusCode: ClosedRange.clientErrorCodes.lowerBound,
-            details: []
+            statusCode: ClosedRange.clientErrorCodes.lowerBound
         )
         
         // Create disconnected state intiated by the server with client error

--- a/Tests/StreamChatTests/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/WebSocketClient_Tests.swift
@@ -196,8 +196,7 @@ final class WebSocketClient_Tests: XCTestCase {
         let errorPayload = ErrorPayload(
             code: .unique,
             message: .unique,
-            statusCode: .unique,
-            details: []
+            statusCode: .unique
         )
         let engineError = WebSocketEngineError(
             reason: UUID().uuidString,

--- a/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
@@ -399,8 +399,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
             with: ErrorPayload(
                 code: .unique,
                 message: .unique,
-                statusCode: ClosedRange.clientErrorCodes.lowerBound,
-                details: []
+                statusCode: ClosedRange.clientErrorCodes.lowerBound
             )
         )
         disconnectWebSocket(source: .serverInitiated(error: clientError))
@@ -423,8 +422,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
             with: ErrorPayload(
                 code: ClosedRange.tokenInvalidErrorCodes.lowerBound,
                 message: .unique,
-                statusCode: .unique,
-                details: []
+                statusCode: .unique
             )
         )
         disconnectWebSocket(source: .serverInitiated(error: tokenError))


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-2147

### 🎯 Goal

We are failing to decode ErrorPayload's `details` field as it is optional and only returned in certain situations. This is blocking token refreshes as parsing the payload is failing.

### 🧪 Manual Testing Notes

Use an expiring token, and make sure everything works after it has expired

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/9mEPFPEwBA0JlDvYlQ/giphy.gif)