### PR TITLE
[DemoApp] Properly navigate to chat when opening a notification

### DIFF
--- a/DemoApp/DemoAppCoordinator.swift
+++ b/DemoApp/DemoAppCoordinator.swift
@@ -34,7 +34,7 @@ final class DemoAppCoordinator: NSObject {
     }
 
     func handlePushNotificationResponse() {
-        pushNotifications.onNotificationResponse = { [weak self] response in
+        pushNotifications.listenToNotificationsResponse { [weak self] response in
             guard case UNNotificationDefaultActionIdentifier = response.actionIdentifier else {
                 return
             }
@@ -127,10 +127,10 @@ private extension DemoAppCoordinator {
             splitVC.preferredDisplayMode = .oneBesideSecondary
             splitVC.viewControllers = [channelListNVC, tuple.channelNVC].compactMap { $0 }
             return splitVC
-        } else {
-            tuple.channelVC.map { channelListNVC.pushViewController($0, animated: false) }
-            return channelListNVC
+        } else if let channelVC = tuple.channelVC {
+            channelListNVC.pushViewController(channelVC, animated: false)
         }
+        return channelListNVC
     }
     
     func makeChannelListVC(

--- a/DemoApp/PushNotifications.swift
+++ b/DemoApp/PushNotifications.swift
@@ -15,13 +15,17 @@ final class PushNotifications: NSObject {
         [.alert, .sound, .badge]
     }
 
-    var onNotificationResponse: ((UNNotificationResponse) -> Void)?
+    private var onNotificationResponse: ((UNNotificationResponse) -> Void)?
+
+    func listenToNotificationsResponse(with onNotificationResponse: @escaping (UNNotificationResponse) -> Void) {
+        center.delegate = self
+        self.onNotificationResponse = onNotificationResponse
+    }
 
     func registerForPushNotifications() {
         center.requestAuthorization(options: authorizationOptions) { [weak self] granted, _ in
             print("Permission granted: \(granted)")
             self?.getNotificationSettings()
-            self?.center.delegate = self
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal

When opening a chat push notification, if the app was closed, it was not navigating to the chat as the Push Notification delegate was not set.

### 🧪 Manual Testing Notes

With the app closed, send a push notification.
It should land on the chat, with the content preloaded

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/h7zqTXl02vFPI9BzFo/giphy-downsized-large.gif)