### PR TITLE
Move all messager sender tests to flaky test plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix jumps in Message List [#2226](https://github.com/GetStream/stream-chat-swift/pull/2226)
 - Fix image flickers when adding image attachment to a message [#2226](https://github.com/GetStream/stream-chat-swift/pull/2226)
 - Fix message list scrolling when popping from navigation stack [#2239](https://github.com/GetStream/stream-chat-swift/pull/2239)
-- Fix message timestamp not appering after hard deleting last message in group [#2226](https://github.com/GetStream/stream-chat-swift/pull/2226)
+- Fix message timestamp not appearing after hard deleting the last message in the group [#2226](https://github.com/GetStream/stream-chat-swift/pull/2226)
 
 # [4.20.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.20.0)
 _August 02, 2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix jumps in Message List [#2226](https://github.com/GetStream/stream-chat-swift/pull/2226)
 - Fix image flickers when adding image attachment to a message [#2226](https://github.com/GetStream/stream-chat-swift/pull/2226)
 - Fix message list scrolling when popping from navigation stack [#2239](https://github.com/GetStream/stream-chat-swift/pull/2239)
+- Fix message timestamp not appering after hard deleting last message in group [#2226](https://github.com/GetStream/stream-chat-swift/pull/2226)
 
 # [4.20.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.20.0)
 _August 02, 2022_

--- a/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
+++ b/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
@@ -14,16 +14,17 @@
   "testTargets" : [
     {
       "selectedTests" : [
-        "MessageSender_Tests\/test_senderSendsMessages_forMultipleChannelsInParalel_butStillInTheCorrectOrder()",
-        "MessageSender_Tests\/test_sender_doesNotRetainItself()",
+        "APIClient_Tests\/test_startingMultipleRequestsAtTheSameTimeShouldResultInParallelRequests()",
+        "ChannelUpdater_Tests\/test_hideChannel_successfulResponse_isPropagatedToCompletion()",
         "MessageSender_Tests\/test_senderSendsMessage_inTheOrderTheyWereCreatedLocally()",
         "MessageSender_Tests\/test_senderSendsMessage_withPendingSendLocalState_and_uploadedOrEmptyAttachments()",
+        "MessageSender_Tests\/test_senderSendsMessages_forMultipleChannelsInParalel_butStillInTheCorrectOrder()",
+        "MessageSender_Tests\/test_sender_doesNotRetainItself()",
         "MessageSender_Tests\/test_sender_sendsMessage_withBothNotUploadableAttachmentAndUploadedAttachments()",
+        "MessageSender_Tests\/test_sender_sendsMessage_withUploadedAttachments()",
+        "MessageUpdater_Tests\/test_flagMessage_happyPath()",
         "SyncRepository_Tests\/test_cancelRecoveryFlow_cancelsAllOperations()",
-        "APIClient_Tests\/test_startingMultipleRequestsAtTheSameTimeShouldResultInParallelRequests()",
-        "WebSocketClient_Tests\/test_whenHealthCheckEventComes_itGetProcessedSilentlyWithoutBatching()",
-        "ChannelUpdater_Tests\/test_hideChannel_successfulResponse_isPropagatedToCompletion()",
-        "MessageUpdater_Tests\/test_flagMessage_happyPath()"
+        "WebSocketClient_Tests\/test_whenHealthCheckEventComes_itGetProcessedSilentlyWithoutBatching()"
       ],
       "target" : {
         "containerPath" : "container:StreamChat.xcodeproj",

--- a/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
@@ -27,19 +27,20 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "APIClient_Tests\/test_startingMultipleRequestsAtTheSameTimeShouldResultInParallelRequests()",
         "ChannelListPayload_Tests\/test_decode_bigChannelListPayload()",
         "ChannelListPayload_Tests\/test_hugeChannelListQuery_save()",
         "ChannelListPayload_Tests\/test_hugeChannelListQuery_save_DB_empty()",
         "ChannelListPayload_Tests\/test_hugeChannelListQuery_save_DB_filled()",
         "ChannelUpdater_Tests\/test_hideChannel_successfulResponse_isPropagatedToCompletion()",
-        "MessageUpdater_Tests\/test_flagMessage_happyPath()",
-        "MessageSender_Tests\/test_senderSendsMessages_forMultipleChannelsInParalel_butStillInTheCorrectOrder()",
-        "MessageSender_Tests\/test_sender_doesNotRetainItself()",
         "MessageSender_Tests\/test_senderSendsMessage_inTheOrderTheyWereCreatedLocally()",
         "MessageSender_Tests\/test_senderSendsMessage_withPendingSendLocalState_and_uploadedOrEmptyAttachments()",
+        "MessageSender_Tests\/test_senderSendsMessages_forMultipleChannelsInParalel_butStillInTheCorrectOrder()",
+        "MessageSender_Tests\/test_sender_doesNotRetainItself()",
         "MessageSender_Tests\/test_sender_sendsMessage_withBothNotUploadableAttachmentAndUploadedAttachments()",
+        "MessageSender_Tests\/test_sender_sendsMessage_withUploadedAttachments()",
+        "MessageUpdater_Tests\/test_flagMessage_happyPath()",
         "SyncRepository_Tests\/test_cancelRecoveryFlow_cancelsAllOperations()",
-        "APIClient_Tests\/test_startingMultipleRequestsAtTheSameTimeShouldResultInParallelRequests()",
         "WebSocketClient_Tests\/test_whenHealthCheckEventComes_itGetProcessedSilentlyWithoutBatching()"
       ],
       "target" : {


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal

There are some tests from Message Sender that keeps failing. So, moved all Message Sender tests to the flaky test plan.

Bonus: Also updates Changelog with a forgotten item. 