### PR TITLE
Fix deadlock caused by ListDatabaseObserver.startObserving() changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - From now on, if you want to logout the user from the app, especially when switching users, you should call the `client.logout()` method instead of `client.disconnect()`. Read more [here](https://getstream.io/chat/docs/sdk/ios/uikit/getting-started/#disconnect--logout) [#2241](https://github.com/GetStream/stream-chat-swift/pull/2241)
 ### 🐞 Fixed
 - Fix hidden channels showing past history [#2216](https://github.com/GetStream/stream-chat-swift/pull/2216)
+- Fix deadlock caused by ListDatabaseObserver.startObserving() changes [#2252](https://github.com/GetStream/stream-chat-swift/pull/2252)
 
 ## StreamChatUI
 ### 🔄 Changed

--- a/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/ListDatabaseObserver.swift
@@ -236,19 +236,20 @@ class ListDatabaseObserver<Item, DTO: NSManagedObject> {
             guard let frc = self?.frc,
                   let itemCreator = self?.itemCreator,
                   let context = self?.context else { return [] }
-            var result = LazyCachedMapCollection<Item?>()
+            var result = LazyCachedMapCollection<Item>()
             result = (frc.fetchedObjects ?? []).lazyCachedMap { dto in
-                var result: Item?
+                // `itemCreator` returns non-optional value, so we can use implicitly unwrapped optional
+                var result: Item!
                 context.performAndWait {
                     do {
                         result = try itemCreator(dto)
                     } catch {
-                        log.error("Unable to convert a DB entity to model: \(error.localizedDescription)")
+                        log.assertionFailure("Unable to convert a DB entity to model: \(error.localizedDescription)")
                     }
                 }
                 return result
             }
-            return .init(source: result.compactMap { $0 }, map: { $0 })
+            return result
         }
         
         try frc.performFetch()


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal

This PR reverts this change: https://github.com/GetStream/stream-chat-swift/pull/2177 which caused a deadlock in `@CoreDataLazy `because of the usage of `@Atomic`. Besides this, that change also makes the Channel List Loading less performant because the LazyCachedCollection is not really being used, and it is not lazy with that change.

With the newly introduced `logout()` the fix above is not needed anymore, since we can guarantee there won't be nullable items.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
