### PR TITLE
[CIS-2150, CIS-2115 ] Fix broken pagination when quoting or pinning old messages

### DIFF
--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -232,6 +232,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
     )
     
     private var markingRead: Bool = false
+    private var lastFetchedMessageId: MessageId?
 
     /// A type-erased delegate.
     var multicastDelegate: MulticastDelegate<ChatChannelControllerDelegate> = .init() {
@@ -408,8 +409,9 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
             channelCreatedCallback: channelCreatedCallback
         ) { result in
             switch result {
-            case .success:
+            case let .success(value):
                 self.state = .remoteDataFetched
+                self.updateLastFetchedId(with: value)
                 self.callback { completion?(nil) }
             case let .failure(error):
                 self.state = .remoteDataFetchFailed(ClientError(with: error))
@@ -734,8 +736,8 @@ public extension ChatChannelController {
             channelModificationFailed(completion)
             return
         }
-        
-        guard let messageId = messageId ?? messages.last?.id else {
+
+        guard let messageId = lastFetchedMessageId ?? messageId ?? messages.last?.id else {
             log.error(ClientError.ChannelEmptyMessages().localizedDescription)
             callback { completion?(ClientError.ChannelEmptyMessages()) }
             return
@@ -749,12 +751,18 @@ public extension ChatChannelController {
         updater.update(channelQuery: channelQuery, isInRecoveryMode: false, completion: { result in
             switch result {
             case let .success(payload):
+                self.updateLastFetchedId(with: payload)
                 self.hasLoadedAllPreviousMessages = payload.messages.count < limit
                 self.callback { completion?(nil) }
             case let .failure(error):
                 self.callback { completion?(error) }
             }
         })
+    }
+
+    private func updateLastFetchedId(with payload: ChannelPayload) {
+        // Payload messages are ordered from oldest to newest
+        lastFetchedMessageId = payload.messages.first?.id
     }
     
     /// Loads next messages from backend.

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -737,7 +737,7 @@ public extension ChatChannelController {
             return
         }
 
-        guard let messageId = lastFetchedMessageId ?? messageId ?? messages.last?.id else {
+        guard let messageId = messageId ?? lastFetchedMessageId else {
             log.error(ClientError.ChannelEmptyMessages().localizedDescription)
             callback { completion?(ClientError.ChannelEmptyMessages()) }
             return

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -204,7 +204,8 @@ open class ChatChannelVC: _ViewController,
         }
         isLoadingPreviousMessages = true
 
-        channelController.loadPreviousMessages { [weak self] _ in
+        let lastMessageId = messages.last?.id
+        channelController.loadPreviousMessages(before: lastMessageId) { [weak self] _ in
             self?.isLoadingPreviousMessages = false
         }
     }

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -204,8 +204,7 @@ open class ChatChannelVC: _ViewController,
         }
         isLoadingPreviousMessages = true
 
-        let lastMessageId = messages.last?.id
-        channelController.loadPreviousMessages(before: lastMessageId) { [weak self] _ in
+        channelController.loadPreviousMessages { [weak self] _ in
             self?.isLoadingPreviousMessages = false
         }
     }


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-2150
https://stream-io.atlassian.net/browse/CIS-2115

### 🎯 Goal

This PR fixes a case where quoting or pinning old messages can lead to broken pagination

### 📝 Summary

When we fetch a page, it can contain pinned and/or quoted messages. Those are also saved in the database.
Because those messages meet the current criteria of our DB listener, they appear in the channel.

If there is a case where the quoted/pinned message is old, we were using it as the last id to fetch the following page.
That meant that we were leaving a gap in some cases.

### 🛠 Implementation

This PR addresses the above-mentioned issue by keeping track of the last *fetched* message id. This id will be the one used, instead of the last visible one.

### ⚠️ Caveat:
When scrolling really fast, you might see the old messages at the top while waiting for the page to be loaded

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/TeC6PUufsNFza/giphy.gif)