### PR TITLE
Fix parsing `member` field in `notification.removed_from_channel` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix hidden channels showing past history [#2216](https://github.com/GetStream/stream-chat-swift/pull/2216)
 - Fix token not being refreshed because of parsing error [#2248](https://github.com/GetStream/stream-chat-swift/pull/2248)
 - Fix deadlock caused by ListDatabaseObserver.startObserving() changes [#2252](https://github.com/GetStream/stream-chat-swift/pull/2252)
+- Fix parsing `member` field in `notification.removed_from_channel` event [#2259](https://github.com/GetStream/stream-chat-swift/pull/2259)
 
 ## StreamChatUI
 ### 🔄 Changed

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/IdentifiablePayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/IdentifiablePayload.swift
@@ -200,7 +200,7 @@ extension MemberPayload: IdentifiablePayload {
 
     func fillIds(cache: inout [DatabaseType: Set<DatabaseId>]) {
         addId(cache: &cache)
-        user.fillIds(cache: &cache)
+        user?.fillIds(cache: &cache)
     }
 }
 

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/MemberPayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/MemberPayload.swift
@@ -29,6 +29,7 @@ struct MemberContainerPayload: Decodable {
 struct MemberPayload: Decodable {
     private enum CodingKeys: String, CodingKey {
         case user
+        case userId = "user_id"
         case role = "channel_role"
         case isBanned = "banned"
         case isShadowBanned = "shadow_banned"
@@ -39,8 +40,9 @@ struct MemberPayload: Decodable {
         case inviteAcceptedAt = "invite_accepted_at"
         case inviteRejectedAt = "invite_rejected_at"
     }
-    
-    let user: UserPayload
+
+    let userId: String
+    let user: UserPayload?
     let role: MemberRole?
     let createdAt: Date
     let updatedAt: Date
@@ -62,7 +64,8 @@ struct MemberPayload: Decodable {
     let inviteRejectedAt: Date?
     
     init(
-        user: UserPayload,
+        user: UserPayload?,
+        userId: String,
         role: MemberRole?,
         createdAt: Date,
         updatedAt: Date,
@@ -74,6 +77,7 @@ struct MemberPayload: Decodable {
         inviteRejectedAt: Date? = nil
     ) {
         self.user = user
+        self.userId = userId
         self.role = role
         self.createdAt = createdAt
         self.updatedAt = updatedAt
@@ -83,6 +87,26 @@ struct MemberPayload: Decodable {
         self.isInvited = isInvited
         self.inviteAcceptedAt = inviteAcceptedAt
         self.inviteRejectedAt = inviteRejectedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        user = try container.decodeIfPresent(UserPayload.self, forKey: .user)
+        role = try container.decodeIfPresent(MemberRole.self, forKey: .role)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        banExpiresAt = try container.decodeIfPresent(Date.self, forKey: .banExpiresAt)
+        isBanned = try container.decodeIfPresent(Bool.self, forKey: .isBanned)
+        isShadowBanned = try container.decodeIfPresent(Bool.self, forKey: .isShadowBanned)
+        isInvited = try container.decodeIfPresent(Bool.self, forKey: .isInvited)
+        inviteAcceptedAt = try container.decodeIfPresent(Date.self, forKey: .inviteAcceptedAt)
+        inviteRejectedAt = try container.decodeIfPresent(Date.self, forKey: .inviteRejectedAt)
+
+        if let user = user {
+            userId = user.id
+        } else {
+            userId = try container.decode(String.self, forKey: .userId)
+        }
     }
 }
 

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -110,10 +110,12 @@ extension NSManagedObjectContext {
         query: ChannelMemberListQuery?,
         cache: PreWarmedCache?
     ) throws -> MemberDTO {
-        let dto = MemberDTO.loadOrCreate(userId: payload.user.id, channelId: channelId, context: self, cache: cache)
+        let dto = MemberDTO.loadOrCreate(userId: payload.userId, channelId: channelId, context: self, cache: cache)
         
         // Save user-part of member first
-        dto.user = try saveUser(payload: payload.user)
+        if let userPayload = payload.user {
+            dto.user = try saveUser(payload: userPayload)
+        }
         
         // Save member specific data
         if let role = payload.role {

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware.swift
@@ -17,7 +17,7 @@ struct MemberEventMiddleware: EventMiddleware {
                     let member = try session.saveMember(payload: event.member, channelId: event.cid)
                     
                     // Mark all messages in channel as read
-                    session.markChannelAsRead(cid: event.cid, userId: event.member.user.id, at: event.createdAt)
+                    session.markChannelAsRead(cid: event.cid, userId: event.member.userId, at: event.createdAt)
                     
                     insertMemberToMemberListQueries(channel, member)
                 }
@@ -60,9 +60,9 @@ struct MemberEventMiddleware: EventMiddleware {
                     break
                 }
                 
-                guard let member = channel.members.first(where: { $0.user.id == event.member.user.id }) else {
+                guard let member = channel.members.first(where: { $0.user.id == event.member.userId }) else {
                     // No need to throw MemberNotFound error here
-                    log.debug("Member \(event.member.user.id) not found for NotificationRemovedFromChannelEventDTO")
+                    log.debug("Member \(event.member.userId) not found for NotificationRemovedFromChannelEventDTO")
                     break
                 }
                 

--- a/Sources/StreamChat/WebSocketClient/Events/MemberEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/MemberEvents.swift
@@ -37,7 +37,7 @@ class MemberAddedEventDTO: EventDTO {
     func toDomainEvent(session: DatabaseSession) -> Event? {
         guard
             let userDTO = session.user(id: user.id),
-            let memberDTO = session.member(userId: member.user.id, cid: cid)
+            let memberDTO = session.member(userId: member.userId, cid: cid)
         else { return nil }
         
         return try? MemberAddedEvent(
@@ -82,7 +82,7 @@ class MemberUpdatedEventDTO: EventDTO {
     func toDomainEvent(session: DatabaseSession) -> Event? {
         guard
             let userDTO = session.user(id: user.id),
-            let memberDTO = session.member(userId: member.user.id, cid: cid)
+            let memberDTO = session.member(userId: member.userId, cid: cid)
         else { return nil }
         
         return try? MemberUpdatedEvent(

--- a/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/NotificationEvents.swift
@@ -197,7 +197,7 @@ class NotificationAddedToChannelEventDTO: EventDTO {
     func toDomainEvent(session: DatabaseSession) -> Event? {
         guard
             let channelDTO = session.channel(cid: channel.cid),
-            let memberDTO = session.member(userId: member.user.id, cid: channel.cid)
+            let memberDTO = session.member(userId: member.userId, cid: channel.cid)
         else { return nil }
 
         return try? NotificationAddedToChannelEvent(
@@ -243,7 +243,7 @@ class NotificationRemovedFromChannelEventDTO: EventDTO {
     func toDomainEvent(session: DatabaseSession) -> Event? {
         guard
             let userDTO = session.user(id: user.id),
-            let memberDTO = session.member(userId: member.user.id, cid: cid)
+            let memberDTO = session.member(userId: member.userId, cid: cid)
         else { return nil }
         
         return try? NotificationRemovedFromChannelEvent(
@@ -319,7 +319,7 @@ class NotificationInvitedEventDTO: EventDTO {
     func toDomainEvent(session: DatabaseSession) -> Event? {
         guard
             let userDTO = session.user(id: user.id),
-            let memberDTO = session.member(userId: member.user.id, cid: cid)
+            let memberDTO = session.member(userId: member.userId, cid: cid)
         else { return nil }
         
         return try? NotificationInvitedEvent(
@@ -369,7 +369,7 @@ class NotificationInviteAcceptedEventDTO: EventDTO {
         guard
             let userDTO = session.user(id: user.id),
             let channelDTO = session.channel(cid: channel.cid),
-            let memberDTO = session.member(userId: member.user.id, cid: channel.cid)
+            let memberDTO = session.member(userId: member.userId, cid: channel.cid)
         else { return nil }
         
         return try? NotificationInviteAcceptedEvent(
@@ -419,7 +419,7 @@ class NotificationInviteRejectedEventDTO: EventDTO {
         guard
             let userDTO = session.user(id: user.id),
             let channelDTO = session.channel(cid: channel.cid),
-            let memberDTO = session.member(userId: member.user.id, cid: channel.cid)
+            let memberDTO = session.member(userId: member.userId, cid: channel.cid)
         else { return nil }
         
         return try? NotificationInviteRejectedEvent(

--- a/TestTools/StreamChatTestTools/Fixtures/JSONs/Events/Notification/NotificationRemovedFromChannel.json
+++ b/TestTools/StreamChatTestTools/Fixtures/JSONs/Events/Notification/NotificationRemovedFromChannel.json
@@ -1,161 +1,60 @@
 {
-  "member" : {
-    "banned" : false,
-    "shadow_banned" : false,
-    "user_id" : "anakin_skywalker",
-    "updated_at" : "2021-04-23T10:42:21.146483Z",
-    "role" : "member",
-    "created_at" : "2021-04-23T10:42:21.146483Z",
-    "user" : {
-      "banned" : false,
-      "online" : true,
-      "id" : "anakin_skywalker",
-      "role" : "user",
-      "created_at" : "2020-12-07T11:37:36.43453Z",
-      "image" : "https:\/\/vignette.wikia.nocookie.net\/starwars\/images\/6\/6f\/Anakin_Skywalker_RotS.png",
-      "updated_at" : "2021-04-15T12:25:51.702406Z",
-      "last_active" : "2021-04-23T10:54:07.572844789Z",
-      "name" : "Anakin Skywalker"
-    },
-  },
-  "channel" : {
-    "last_message_at" : "2021-04-23T10:42:32.048809Z",
-    "created_by" : {
-      "banned" : false,
-      "online" : true,
-      "id" : "leia_organa",
-      "role" : "user",
-      "created_at" : "2021-04-23T10:41:35.430918Z",
-      "image" : ".\/static\/media\/photo-1517202383675-eb0a6e27775f.1864b915.jpeg",
-      "updated_at" : "2021-04-23T10:41:38.5503Z",
-      "last_active" : "2021-04-23T10:54:09.447654705Z",
-      "name" : "leia_organa"
-    },
-    "frozen" : false,
-    "id" : "!members-jkE22mnWM5tjzHPBurvjoVz0spuz4FULak93veyK0lY",
-    "created_at" : "2021-04-23T10:42:21.144202Z",
-    "members" : [
+  "type": "notification.removed_from_channel",
+  "cid": "messaging:91DC91CC-0",
+  "channel_id": "91DC91CC-0",
+  "channel_type": "messaging",
+  "channel": {
+    "id": "91DC91CC-0",
+    "type": "messaging",
+    "cid": "messaging:91DC91CC-0",
+    "created_by": null,
+    "frozen": false,
+    "disabled": false,
+    "members": [
       {
-        "banned" : false,
-        "shadow_banned" : false,
-        "role" : "member",
-        "created_at" : "2021-04-23T10:42:21.146483Z",
-        "user_id" : "c-3po",
-        "updated_at" : "2021-04-23T10:42:21.146483Z",
-        "user" : {
-          "banned" : false,
-          "online" : false,
-          "id" : "c-3po",
-          "role" : "user",
-          "created_at" : "2020-12-07T11:37:35.550588Z",
-          "image" : "https:\/\/vignette.wikia.nocookie.net\/starwars\/images\/3\/3f\/C-3PO_TLJ_Card_Trader_Award_Card.png",
-          "updated_at" : "2021-04-15T12:16:26.99681Z",
-          "last_active" : "2021-04-22T04:50:56.973457Z",
-          "name" : "C-3PO"
-        }
-      },
-      {
-        "banned" : false,
-        "shadow_banned" : false,
-        "role" : "member",
-        "created_at" : "2021-04-23T10:42:21.146483Z",
-        "user_id" : "count_dooku",
-        "updated_at" : "2021-04-23T10:42:21.146483Z",
-        "user" : {
-          "banned" : false,
-          "online" : false,
-          "id" : "count_dooku",
-          "role" : "user",
-          "created_at" : "2020-12-07T11:37:39.487938Z",
-          "image" : "https:\/\/vignette.wikia.nocookie.net\/starwars\/images\/b\/b8\/Dooku_Headshot.jpg",
-          "updated_at" : "2021-04-15T12:41:22.065746Z",
-          "last_active" : "2021-04-15T11:02:42.641941Z",
-          "name" : "Count Dooku"
-        }
-      },
-      {
-        "banned" : false,
-        "shadow_banned" : false,
-        "role" : "owner",
-        "created_at" : "2021-04-23T10:42:21.146484Z",
-        "user_id" : "leia_organa",
-        "updated_at" : "2021-04-23T10:42:21.146484Z",
-        "user" : {
-          "banned" : false,
-          "online" : true,
-          "id" : "leia_organa",
-          "role" : "user",
-          "created_at" : "2021-04-23T10:41:35.430918Z",
-          "image" : ".\/static\/media\/photo-1517202383675-eb0a6e27775f.1864b915.jpeg",
-          "updated_at" : "2021-04-23T10:41:38.5503Z",
-          "last_active" : "2021-04-23T10:54:09.447654705Z",
-          "name" : "leia_organa"
-        }
+        "user_id": "leia_organa",
+        "user": {
+          "id": "leia_organa",
+          "role": "user",
+          "created_at": "2020-12-07T11:37:33.78879Z",
+          "updated_at": "2022-08-09T14:55:13.310023Z",
+          "last_active": "2022-08-30T15:16:00.095532653Z",
+          "banned": false,
+          "online": true,
+          "birthland": "Polis Massa",
+          "AdditionalProperties": {},
+          "name": "Leia Organa",
+          "image": "https://vignette.wikia.nocookie.net/starwars/images/f/fc/Leia_Organa_TLJ.png"
+        },
+        "created_at": "2022-08-30T15:16:00.650720097Z",
+        "updated_at": "2022-08-30T15:16:00.650720097Z",
+        "banned": false,
+        "shadow_banned": false,
+        "channel_role": ""
       }
     ],
-    "member_count" : 3,
-    "config" : {
-      "typing_events" : true,
-      "connect_events" : true,
-      "reactions" : true,
-      "replies" : true,
-      "quotes" : true,
-      "uploads" : true,
-      "push_notifications" : true,
-      "updated_at" : "2021-03-01T19:26:18.406502Z",
-      "automod_behavior" : "flag",
-      "commands" : [
-        {
-          "set" : "fun_set",
-          "args" : "[text]",
-          "name" : "giphy",
-          "description" : "Post a random gif to the channel"
-        }
-      ],
-      "url_enrichment" : true,
-      "mutes" : true,
-      "custom_events" : true,
-      "message_retention" : "infinite",
-      "name" : "messaging",
-      "automod" : "AI",
-      "automod_thresholds" : {
-        "spam" : {
-          "flag" : 0.84999999999999998,
-          "block" : 0.90000000000000002
-        },
-        "toxic" : {
-          "flag" : 0.84999999999999998,
-          "block" : 0.90000000000000002
-        },
-        "explicit" : {
-          "flag" : 0.84999999999999998,
-          "block" : 0.90000000000000002
-        }
-      },
-      "created_at" : "2021-03-01T19:26:18.406502Z",
-      "max_message_length" : 5000,
-      "blocklist_behavior" : "flag",
-      "read_events" : true,
-      "search" : true
-    },
-    "type" : "messaging",
-    "updated_at" : "2021-04-23T10:42:21.144202Z",
-    "cid" : "messaging:!members-jkE22mnWM5tjzHPBurvjoVz0spuz4FULak93veyK0lY"
+    "config": {}
   },
-  "channel_type" : "messaging",
-  "channel_id" : "!members-jkE22mnWM5tjzHPBurvjoVz0spuz4FULak93veyK0lY",
-  "user" : {
-    "banned" : false,
-    "online" : true,
-    "id" : "anakin_skywalker",
-    "role" : "user",
-    "created_at" : "2020-12-07T11:37:36.43453Z",
-    "image" : "https:\/\/vignette.wikia.nocookie.net\/starwars\/images\/6\/6f\/Anakin_Skywalker_RotS.png",
-    "updated_at" : "2021-04-15T12:25:51.702406Z",
-    "last_active" : "2021-04-23T10:54:07.572844789Z",
-    "name" : "Anakin Skywalker"
+  "member": {
+    "user_id": "leia_organa",
+    "created_at": "0001-01-01T00:00:00Z",
+    "updated_at": "0001-01-01T00:00:00Z",
+    "banned": false,
+    "shadow_banned": false,
+    "channel_role": ""
   },
-  "created_at" : "2021-04-23T10:54:10.183275486Z",
-  "type" : "notification.removed_from_channel",
-  "cid" : "messaging:!members-jkE22mnWM5tjzHPBurvjoVz0spuz4FULak93veyK0lY"
+  "user": {
+    "id": "leia_organa",
+    "role": "user",
+    "created_at": "2020-12-07T11:37:33.78879Z",
+    "updated_at": "2022-08-09T14:55:13.310023Z",
+    "last_active": "2022-08-30T15:16:00.095532653Z",
+    "banned": false,
+    "online": true,
+    "birthland": "Polis Massa",
+    "AdditionalProperties": {},
+    "name": "Leia Organa",
+    "image": "https://vignette.wikia.nocookie.net/starwars/images/f/fc/Leia_Organa_TLJ.png"
+  },
+  "created_at": "2022-08-30T15:15:56.430062017Z"
 }

--- a/TestTools/StreamChatTestTools/TestData/DummyData/MemberPayload.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/MemberPayload.swift
@@ -16,6 +16,7 @@ extension MemberPayload {
     ) -> MemberPayload {
         .init(
             user: user,
+            userId: user.id,
             role: role,
             createdAt: createdAt,
             updatedAt: updatedAt,

--- a/TestTools/StreamChatTestTools/TestData/DummyData/XCTestCase+Dummy.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/XCTestCase+Dummy.swift
@@ -237,6 +237,7 @@ extension XCTestCase {
                     teams: [],
                     extraData: [:]
                 ),
+                userId: .unique,
                 role: .member,
                 createdAt: .unique,
                 updatedAt: .unique
@@ -307,9 +308,10 @@ private extension MemberPayload {
     }
     
     static func withLastActivity(at date: Date) -> MemberPayload {
-        .init(
+        let userId = String.unique
+        return .init(
             user: .init(
-                id: .unique,
+                id: userId,
                 name: .unique,
                 imageURL: nil,
                 role: .admin,
@@ -322,6 +324,7 @@ private extension MemberPayload {
                 teams: [],
                 extraData: [:]
             ),
+            userId: userId,
             role: .moderator,
             createdAt: .unique,
             updatedAt: .unique

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/ChannelListPayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/ChannelListPayload_Tests.swift
@@ -292,7 +292,7 @@ final class ChannelPayload_Tests: XCTestCase {
         XCTAssertEqual(config.createdAt, "2019-03-21T15:49:15.40182Z".toDate())
         XCTAssertEqual(config.updatedAt, "2020-03-17T18:54:09.460881Z".toDate())
 
-        XCTAssertEqual(payload.membership?.user.id, "broken-waterfall-5")
+        XCTAssertEqual(payload.membership?.user?.id, "broken-waterfall-5")
     }
     
     func test_newestMessage_whenMessagesAreSortedDesc() throws {

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/MemberPayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/MemberPayload_Tests.swift
@@ -21,18 +21,18 @@ final class MemberPayload_Tests: XCTestCase {
         XCTAssertEqual(payload.isShadowBanned, true)
         
         XCTAssertNotNil(payload.user)
-        XCTAssertEqual(payload.user.id, "broken-waterfall-5")
-        XCTAssertEqual(payload.user.isBanned, false)
-        XCTAssertEqual(payload.user.createdAt, "2019-12-12T15:33:46.488935Z".toDate())
-        XCTAssertEqual(payload.user.lastActiveAt, "2020-06-10T13:24:00.501797Z".toDate())
-        XCTAssertEqual(payload.user.updatedAt, "2020-06-10T14:11:29.946106Z".toDate())
-        XCTAssertEqual(payload.user.name, "Broken Waterfall")
+        XCTAssertEqual(payload.user!.id, "broken-waterfall-5")
+        XCTAssertEqual(payload.user!.isBanned, false)
+        XCTAssertEqual(payload.user!.createdAt, "2019-12-12T15:33:46.488935Z".toDate())
+        XCTAssertEqual(payload.user!.lastActiveAt, "2020-06-10T13:24:00.501797Z".toDate())
+        XCTAssertEqual(payload.user!.updatedAt, "2020-06-10T14:11:29.946106Z".toDate())
+        XCTAssertEqual(payload.user!.name, "Broken Waterfall")
         XCTAssertEqual(
-            payload.user.imageURL,
+            payload.user!.imageURL,
             URL(string: "https://getstream.io/random_svg/?id=broken-waterfall-5&amp;name=Broken+waterfall")!
         )
-        XCTAssertEqual(payload.user.role, .user)
-        XCTAssertEqual(payload.user.isOnline, true)
+        XCTAssertEqual(payload.user!.role, .user)
+        XCTAssertEqual(payload.user!.isOnline, true)
     }
     
     func test_memberJSON_channelRole_isCustomRole() throws {

--- a/Tests/StreamChatTests/Controllers/MemberListController/MemberListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MemberListController/MemberListController_Tests.swift
@@ -360,7 +360,7 @@ final class MemberListController_Tests: XCTestCase {
         
         // Update second member to be created earlier than the first one.
         try client.databaseContainer.writeSynchronously { session in
-            session.member(userId: member2.user.id, cid: self.query.cid)?.memberCreatedAt = DBDate()
+            session.member(userId: member2.user!.id, cid: self.query.cid)?.memberCreatedAt = DBDate()
         }
         
         // Assert `move` change is received for the second member.

--- a/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
@@ -138,7 +138,7 @@ final class ChannelDTO_Tests: XCTestCase {
         
         let anotherMember: MemberPayload = .dummy(user: .dummy(userId: .unique))
         let anotherMemberRead: ChannelReadPayload = .init(
-            user: anotherMember.user,
+            user: anotherMember.user!,
             lastReadAt: .init(),
             unreadMessagesCount: 0
         )
@@ -154,7 +154,7 @@ final class ChannelDTO_Tests: XCTestCase {
             authorUserId: currentUser.id,
             createdAt: anotherMemberRead.lastReadAt.addingTimeInterval(-20),
             pinned: true,
-            pinnedByUserId: anotherMember.user.id
+            pinnedByUserId: anotherMember.user!.id
         )
         
         let channelPayload: ChannelPayload = .dummy(
@@ -185,8 +185,8 @@ final class ChannelDTO_Tests: XCTestCase {
         // THEN
         //
         // Messages have reads.
-        XCTAssertTrue(loadedOwnMessage.readBy.contains { $0.id == anotherMember.user.id })
-        XCTAssertTrue(loadedOwnPinnedMessage.readBy.contains { $0.id == anotherMember.user.id })
+        XCTAssertTrue(loadedOwnMessage.readBy.contains { $0.id == anotherMember.user!.id })
+        XCTAssertTrue(loadedOwnPinnedMessage.readBy.contains { $0.id == anotherMember.user!.id })
     }
     
     func test_saveChannel_removesReadsNotPresentInPayload() throws {
@@ -375,17 +375,17 @@ final class ChannelDTO_Tests: XCTestCase {
             Assert.willBeEqual(payload.members[0].createdAt, loadedChannel.lastActiveMembers.first?.memberCreatedAt)
             Assert.willBeEqual(payload.members[0].updatedAt, loadedChannel.lastActiveMembers.first?.memberUpdatedAt)
             
-            Assert.willBeEqual(payload.members[0].user.id, loadedChannel.lastActiveMembers.first?.id)
-            Assert.willBeEqual(payload.members[0].user.createdAt, loadedChannel.lastActiveMembers.first?.userCreatedAt)
-            Assert.willBeEqual(payload.members[0].user.updatedAt, loadedChannel.lastActiveMembers.first?.userUpdatedAt)
-            Assert.willBeEqual(payload.members[0].user.lastActiveAt, loadedChannel.lastActiveMembers.first?.lastActiveAt)
-            Assert.willBeEqual(payload.members[0].user.isOnline, loadedChannel.lastActiveMembers.first?.isOnline)
-            Assert.willBeEqual(payload.members[0].user.isBanned, loadedChannel.lastActiveMembers.first?.isBanned)
-            Assert.willBeEqual(payload.members[0].user.role, loadedChannel.lastActiveMembers.first?.userRole)
-            Assert.willBeEqual(payload.members[0].user.extraData, loadedChannel.lastActiveMembers.first?.extraData)
+            Assert.willBeEqual(payload.members[0].user!.id, loadedChannel.lastActiveMembers.first?.id)
+            Assert.willBeEqual(payload.members[0].user!.createdAt, loadedChannel.lastActiveMembers.first?.userCreatedAt)
+            Assert.willBeEqual(payload.members[0].user!.updatedAt, loadedChannel.lastActiveMembers.first?.userUpdatedAt)
+            Assert.willBeEqual(payload.members[0].user!.lastActiveAt, loadedChannel.lastActiveMembers.first?.lastActiveAt)
+            Assert.willBeEqual(payload.members[0].user!.isOnline, loadedChannel.lastActiveMembers.first?.isOnline)
+            Assert.willBeEqual(payload.members[0].user!.isBanned, loadedChannel.lastActiveMembers.first?.isBanned)
+            Assert.willBeEqual(payload.members[0].user!.role, loadedChannel.lastActiveMembers.first?.userRole)
+            Assert.willBeEqual(payload.members[0].user!.extraData, loadedChannel.lastActiveMembers.first?.extraData)
 
             // Membership
-            Assert.willBeEqual(payload.membership!.user.id, loadedChannel.membership?.id)
+            Assert.willBeEqual(payload.membership!.user!.id, loadedChannel.membership?.id)
 
             // Messages
             Assert.willBeEqual(payload.messages[0].id, loadedChannel.latestMessages.first?.id)
@@ -671,9 +671,9 @@ final class ChannelDTO_Tests: XCTestCase {
 
         XCTAssertEqual(
             channel.lastActiveMembers.map(\.id),
-            allMembers.sorted { $0.user.lastActiveAt! > $1.user.lastActiveAt! }
+            allMembers.sorted { $0.user!.lastActiveAt! > $1.user!.lastActiveAt! }
                 .prefix(memberLimit)
-                .map(\.user.id)
+                .map(\.user!.id)
         )
     }
     

--- a/Tests/StreamChatTests/Database/DTOs/ChannelReadDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/ChannelReadDTO_Tests.swift
@@ -73,13 +73,13 @@ final class ChannelReadDTO_Tests: XCTestCase {
         let readAt = Date()
         database.viewContext.markChannelAsRead(
             cid: channel.channel.cid,
-            userId: member.user.id,
+            userId: member.userId,
             at: readAt
         )
         
         // THEN
         let createdReadDTO = try XCTUnwrap(
-            ChannelReadDTO.load(cid: channel.channel.cid, userId: member.user.id, context: database.viewContext)
+            ChannelReadDTO.load(cid: channel.channel.cid, userId: member.userId, context: database.viewContext)
         )
         XCTAssertNearlySameDate(createdReadDTO.lastReadAt.bridgeDate, readAt)
         XCTAssertEqual(createdReadDTO.unreadMessageCount, 0)
@@ -106,7 +106,7 @@ final class ChannelReadDTO_Tests: XCTestCase {
         )
         
         // THEN
-        let readDTO = ChannelReadDTO.load(cid: channel.channel.cid, userId: member.user.id, context: database.viewContext)
+        let readDTO = ChannelReadDTO.load(cid: channel.channel.cid, userId: member.userId, context: database.viewContext)
         XCTAssertNil(readDTO)
     }
     
@@ -278,7 +278,7 @@ final class ChannelReadDTO_Tests: XCTestCase {
         // GIVEN
         let member: MemberPayload = .dummy()
         let read = ChannelReadPayload(
-            user: member.user,
+            user: member.user!,
             lastReadAt: .init(),
             unreadMessagesCount: 10
         )
@@ -299,7 +299,7 @@ final class ChannelReadDTO_Tests: XCTestCase {
             
         // WHEN
         try database.writeSynchronously { session in
-            session.markChannelAsUnread(cid: channel.channel.cid, by: member.user.id)
+            session.markChannelAsUnread(cid: channel.channel.cid, by: member.userId)
         }
         
         // THEN

--- a/Tests/StreamChatTests/Database/DTOs/MemberModelDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MemberModelDTO_Tests.swift
@@ -41,6 +41,7 @@ final class MemberModelDTO_Tests: XCTestCase {
         
         let payload: MemberPayload = .init(
             user: userPayload,
+            userId: userPayload.id,
             role: .moderator,
             createdAt: .unique,
             updatedAt: .unique,
@@ -67,15 +68,15 @@ final class MemberModelDTO_Tests: XCTestCase {
             Assert.willBeEqual(payload.banExpiresAt, loadedMember?.banExpiresAt)
             Assert.willBeEqual(payload.isShadowBanned, loadedMember?.isShadowBannedFromChannel)
 
-            Assert.willBeEqual(payload.user.id, loadedMember?.id)
-            Assert.willBeEqual(payload.user.isOnline, loadedMember?.isOnline)
-            Assert.willBeEqual(payload.user.isBanned, loadedMember?.isBanned)
-            Assert.willBeEqual(payload.user.role, loadedMember?.userRole)
-            Assert.willBeEqual(payload.user.createdAt, loadedMember?.userCreatedAt)
-            Assert.willBeEqual(payload.user.updatedAt, loadedMember?.userUpdatedAt)
-            Assert.willBeEqual(payload.user.lastActiveAt, loadedMember?.lastActiveAt)
-            Assert.willBeEqual(payload.user.extraData, loadedMember?.extraData)
-            Assert.willBeEqual(Set(payload.user.teams), loadedMember?.teams)
+            Assert.willBeEqual(payload.user!.id, loadedMember?.id)
+            Assert.willBeEqual(payload.user!.isOnline, loadedMember?.isOnline)
+            Assert.willBeEqual(payload.user!.isBanned, loadedMember?.isBanned)
+            Assert.willBeEqual(payload.user!.role, loadedMember?.userRole)
+            Assert.willBeEqual(payload.user!.createdAt, loadedMember?.userCreatedAt)
+            Assert.willBeEqual(payload.user!.updatedAt, loadedMember?.userUpdatedAt)
+            Assert.willBeEqual(payload.user!.lastActiveAt, loadedMember?.lastActiveAt)
+            Assert.willBeEqual(payload.user!.extraData, loadedMember?.extraData)
+            Assert.willBeEqual(Set(payload.user!.teams), loadedMember?.teams)
         }
     }
     
@@ -99,6 +100,7 @@ final class MemberModelDTO_Tests: XCTestCase {
         
         let payload: MemberPayload = .init(
             user: userPayload,
+            userId: userPayload.id,
             role: .moderator,
             createdAt: .unique,
             updatedAt: .unique

--- a/Tests/StreamChatTests/Database/DTOs/UserDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/UserDTO_Tests.swift
@@ -287,6 +287,7 @@ final class UserDTO_Tests: XCTestCase {
 
         let payload: MemberPayload = .init(
             user: userPayload,
+            userId: userPayload.id,
             role: .moderator,
             createdAt: .init(timeIntervalSince1970: 4000),
             updatedAt: .init(timeIntervalSince1970: 5000)

--- a/Tests/StreamChatTests/Database/DatabaseSession_Tests.swift
+++ b/Tests/StreamChatTests/Database/DatabaseSession_Tests.swift
@@ -56,10 +56,10 @@ final class DatabaseSession_Tests: XCTestCase {
         // Try to load the saved member from DB
         if let member = channelPayload.channel.members?.first {
             var loadedMember: ChatUser? {
-                try? database.viewContext.member(userId: member.user.id, cid: channelId)?.asModel()
+                try? database.viewContext.member(userId: member.userId, cid: channelId)?.asModel()
             }
             
-            AssertAsync.willBeEqual(loadedMember?.id, member.user.id)
+            AssertAsync.willBeEqual(loadedMember?.id, member.userId)
         }
     }
     

--- a/Tests/StreamChatTests/ListChange_Tests.swift
+++ b/Tests/StreamChatTests/ListChange_Tests.swift
@@ -35,23 +35,23 @@ final class ListChange_Tests: XCTestCase {
         let movedFrom = IndexPath(item: 5, section: 6)
         let movedTo = IndexPath(item: 7, section: 8)
 
-        let path = \MemberPayload.user.id
+        let path = \MemberPayload.user?.id
 
         XCTAssertEqual(
             ListChange.insert(insertedItem, index: insertedAt).fieldChange(path),
-            .insert(insertedItem.user.id, index: insertedAt)
+            .insert(insertedItem.user!.id, index: insertedAt)
         )
         XCTAssertEqual(
             ListChange.update(updatedItem, index: updatedAt).fieldChange(path),
-            .update(updatedItem.user.id, index: updatedAt)
+            .update(updatedItem.user!.id, index: updatedAt)
         )
         XCTAssertEqual(
             ListChange.remove(removedItem, index: removedAt).fieldChange(path),
-            .remove(removedItem.user.id, index: removedAt)
+            .remove(removedItem.user!.id, index: removedAt)
         )
         XCTAssertEqual(
             ListChange.move(movedItem, fromIndex: movedFrom, toIndex: movedTo).fieldChange(path),
-            .move(movedItem.user.id, fromIndex: movedFrom, toIndex: movedTo)
+            .move(movedItem.user!.id, fromIndex: movedFrom, toIndex: movedTo)
         )
     }
 

--- a/Tests/StreamChatTests/Query/ChannelMemberListQuery_Tests.swift
+++ b/Tests/StreamChatTests/Query/ChannelMemberListQuery_Tests.swift
@@ -145,7 +145,7 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
         
         // Assert members order is correct
         XCTAssertEqual(
-            [member1.user.id, member2.user.id],
+            [member1.user!.id, member2.user!.id],
             fetchedMembers.map(\.user.id)
         )
     }
@@ -194,7 +194,7 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
         
         // Assert members order is correct
         XCTAssertEqual(
-            [member2.user.id, member1.user.id],
+            [member2.user!.id, member1.user!.id],
             fetchedMembers.map(\.user.id)
         )
     }
@@ -243,7 +243,7 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
         
         // Assert members order is correct
         XCTAssertEqual(
-            [member1.user.id, member2.user.id],
+            [member1.user!.id, member2.user!.id],
             fetchedMembers.map(\.user.id)
         )
     }
@@ -302,7 +302,7 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
         
         // Assert members order is correct
         XCTAssertEqual(
-            [member1.user.id, member3.user.id, member2.user.id],
+            [member1.user!.id, member3.user!.id, member2.user!.id],
             fetchedMembers.map(\.user.id)
         )
     }
@@ -368,7 +368,7 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
         
         // Assert members order is correct
         XCTAssertEqual(
-            [member1.user.id, member3.user.id, member2.user.id],
+            [member1.user!.id, member3.user!.id, member2.user!.id],
             fetchedMemberIDs
         )
     }

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/ChannelReadUpdaterMiddleware_Tests.swift
@@ -1026,7 +1026,7 @@ final class ChannelReadUpdaterMiddleware_Tests: XCTestCase {
         XCTAssertEqual(loadedChannel?.reads.first?.lastReadAt, Date(timeIntervalSince1970: 1))
         
         // Create an event that won't be handled by this middleware
-        let startTypingEvent = TypingEventDTO.startTyping(cid: channelId, userId: payload.members.first!.user.id)
+        let startTypingEvent = TypingEventDTO.startTyping(cid: channelId, userId: payload.members.first!.user!.id)
         
         // Let the middleware handle the event
         let handledEvent = middleware.handle(event: startTypingEvent, session: database.viewContext)

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/MemberEventMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/MemberEventMiddleware_Tests.swift
@@ -136,14 +136,14 @@ final class MemberEventMiddleware_Tests: XCTestCase {
         }
         
         // Assert that there's only 1 member linked to the query
-        XCTAssertEqual(memberListQueryDTO?.members.map(\.user.id), [existingMember.user.id])
+        XCTAssertEqual(memberListQueryDTO?.members.map(\.user.id), [existingMember.user!.id])
         
         // Simulate `MemberAddedEventDTO` event.
         _ = middleware.handle(event: event, session: database.viewContext)
         
         // Assert the new member is linked to the query
         XCTAssertEqual(memberListQueryDTO?.members.count, 2)
-        XCTAssertEqual(memberListQueryDTO?.members.map(\.user.id).sorted(), [existingMember.user.id, newMemberId].sorted())
+        XCTAssertEqual(memberListQueryDTO?.members.map(\.user.id).sorted(), [existingMember.user!.id, newMemberId].sorted())
     }
     
     func test_memberAddedEvent_marksChannelAsRead() throws {
@@ -171,7 +171,7 @@ final class MemberEventMiddleware_Tests: XCTestCase {
         
         // THEN
         XCTAssertEqual(mockSession.markChannelAsReadParams?.cid, event.cid)
-        XCTAssertEqual(mockSession.markChannelAsReadParams?.userId, event.member.user.id)
+        XCTAssertEqual(mockSession.markChannelAsReadParams?.userId, event.member.userId)
         XCTAssertEqual(mockSession.markChannelAsReadParams?.at, event.createdAt)
     }
     
@@ -467,14 +467,14 @@ final class MemberEventMiddleware_Tests: XCTestCase {
         }
         
         // Assert that there's only 1 member linked to the query
-        XCTAssertEqual(memberListQueryDTO?.members.map(\.user.id), [existingMember.user.id])
+        XCTAssertEqual(memberListQueryDTO?.members.map(\.user.id), [existingMember.user!.id])
         
         // Simulate `NotificationAddedToChannelEvent` event.
         _ = middleware.handle(event: event, session: database.viewContext)
         
         // Assert the new member is linked to the query
         XCTAssertEqual(memberListQueryDTO?.members.count, 2)
-        XCTAssertEqual(memberListQueryDTO?.members.map(\.user.id).sorted(), [existingMember.user.id, newMemberId].sorted())
+        XCTAssertEqual(memberListQueryDTO?.members.map(\.user.id).sorted(), [existingMember.user!.id, newMemberId].sorted())
     }
     
     // MARK: - NotificationRemovedFromChannelEvent
@@ -603,14 +603,14 @@ final class MemberEventMiddleware_Tests: XCTestCase {
         }
         
         // Assert that there's only 1 member linked to the query
-        XCTAssertEqual(memberListQueryDTO?.members.map(\.user.id), [existingMember.user.id])
+        XCTAssertEqual(memberListQueryDTO?.members.map(\.user.id), [existingMember.user!.id])
         
         // Simulate `NotificationInvitedEventDTO` event.
         _ = middleware.handle(event: event, session: database.viewContext)
         
         // Assert the new member is linked to the query
         XCTAssertEqual(memberListQueryDTO?.members.count, 2)
-        XCTAssertEqual(memberListQueryDTO?.members.map(\.user.id).sorted(), [existingMember.user.id, newMemberId].sorted())
+        XCTAssertEqual(memberListQueryDTO?.members.map(\.user.id).sorted(), [existingMember.user!.id, newMemberId].sorted())
     }
     
     // MARK: - NotificationInviteAcceptedEvent

--- a/Tests/StreamChatTests/WebSocketClient/Events/MemberEvents_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/Events/MemberEvents_Tests.swift
@@ -22,14 +22,14 @@ final class MemberEvents_Tests: XCTestCase {
     func test_added() throws {
         let json = XCTestCase.mockData(fromJSONFile: "MemberAdded")
         let event = try eventDecoder.decode(from: json) as? MemberAddedEventDTO
-        XCTAssertEqual(event?.member.user.id, "steep-moon-9")
+        XCTAssertEqual(event?.member.userId, "steep-moon-9")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_9125"))
     }
     
     func test_updated() throws {
         let json = XCTestCase.mockData(fromJSONFile: "MemberUpdated")
         let event = try eventDecoder.decode(from: json) as? MemberUpdatedEventDTO
-        XCTAssertEqual(event?.member.user.id, "count_dooku")
+        XCTAssertEqual(event?.member.userId, "count_dooku")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "!members-jkE22mnWM5tjzHPBurvjoVz0spuz4FULak93veyK0lY"))
     }
     
@@ -73,7 +73,7 @@ final class MemberEvents_Tests: XCTestCase {
         let event = try XCTUnwrap(dto.toDomainEvent(session: session) as? MemberAddedEvent)
         XCTAssertEqual(event.cid, eventPayload.cid)
         XCTAssertEqual(event.user.id, eventPayload.user?.id)
-        XCTAssertEqual(event.member.id, eventPayload.memberContainer?.member?.user.id)
+        XCTAssertEqual(event.member.id, eventPayload.memberContainer?.member?.user!.id)
         XCTAssertEqual(event.member.memberRole, eventPayload.memberContainer?.member?.role)
         XCTAssertEqual(event.createdAt, eventPayload.createdAt)
     }
@@ -109,7 +109,7 @@ final class MemberEvents_Tests: XCTestCase {
         let event = try XCTUnwrap(dto.toDomainEvent(session: session) as? MemberUpdatedEvent)
         XCTAssertEqual(event.cid, eventPayload.cid)
         XCTAssertEqual(event.user.id, eventPayload.user?.id)
-        XCTAssertEqual(event.member.id, eventPayload.memberContainer?.member?.user.id)
+        XCTAssertEqual(event.member.id, eventPayload.memberContainer?.member?.user!.id)
         XCTAssertEqual(event.member.memberRole, eventPayload.memberContainer?.member?.role)
         XCTAssertEqual(event.createdAt, eventPayload.createdAt)
     }

--- a/Tests/StreamChatTests/WebSocketClient/Events/NotificationEvents_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/Events/NotificationEvents_Tests.swift
@@ -94,7 +94,7 @@ final class NotificationsEvents_Tests: XCTestCase {
     func test_removedFromChannel() throws {
         let json = XCTestCase.mockData(fromJSONFile: "NotificationRemovedFromChannel")
         let event = try eventDecoder.decode(from: json) as? NotificationRemovedFromChannelEventDTO
-        XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "!members-jkE22mnWM5tjzHPBurvjoVz0spuz4FULak93veyK0lY"))
+        XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "91DC91CC-0"))
     }
     
     func test_channelDeleted() throws {
@@ -292,7 +292,7 @@ final class NotificationsEvents_Tests: XCTestCase {
         let event = try XCTUnwrap(dto.toDomainEvent(session: session) as? NotificationRemovedFromChannelEvent)
         XCTAssertEqual(event.cid, eventPayload.cid)
         XCTAssertEqual(event.user.id, eventPayload.user?.id)
-        XCTAssertEqual(event.member.id, eventPayload.memberContainer?.member?.user.id)
+        XCTAssertEqual(event.member.id, eventPayload.memberContainer?.member?.user!.id)
         XCTAssertEqual(event.createdAt, eventPayload.createdAt)
     }
     
@@ -352,7 +352,7 @@ final class NotificationsEvents_Tests: XCTestCase {
         let event = try XCTUnwrap(dto.toDomainEvent(session: session) as? NotificationInvitedEvent)
         XCTAssertEqual(event.cid, eventPayload.cid)
         XCTAssertEqual(event.user.id, eventPayload.user?.id)
-        XCTAssertEqual(event.member.id, eventPayload.memberContainer?.member?.user.id)
+        XCTAssertEqual(event.member.id, eventPayload.memberContainer?.member?.user!.id)
         XCTAssertEqual(event.createdAt, eventPayload.createdAt)
     }
     
@@ -387,7 +387,7 @@ final class NotificationsEvents_Tests: XCTestCase {
         let event = try XCTUnwrap(dto.toDomainEvent(session: session) as? NotificationInviteAcceptedEvent)
         XCTAssertEqual(event.cid, eventPayload.channel?.cid)
         XCTAssertEqual(event.user.id, eventPayload.user?.id)
-        XCTAssertEqual(event.member.id, eventPayload.memberContainer?.member?.user.id)
+        XCTAssertEqual(event.member.id, eventPayload.memberContainer?.member?.user!.id)
         XCTAssertEqual(event.createdAt, eventPayload.createdAt)
     }
     
@@ -422,7 +422,7 @@ final class NotificationsEvents_Tests: XCTestCase {
         let event = try XCTUnwrap(dto.toDomainEvent(session: session) as? NotificationInviteRejectedEvent)
         XCTAssertEqual(event.cid, eventPayload.channel?.cid)
         XCTAssertEqual(event.user.id, eventPayload.user?.id)
-        XCTAssertEqual(event.member.id, eventPayload.memberContainer?.member?.user.id)
+        XCTAssertEqual(event.member.id, eventPayload.memberContainer?.member?.user!.id)
         XCTAssertEqual(event.createdAt, eventPayload.createdAt)
     }
     

--- a/Tests/StreamChatTests/Workers/ChannelMemberListUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelMemberListUpdater_Tests.swift
@@ -74,7 +74,7 @@ final class ChannelMemberListUpdater_Tests: XCTestCase {
             // Assert query is saved to the database.
             Assert.willBeTrue(queryDTO != nil)
             // Assert query members are saved to the database.
-            Assert.willBeEqual(Set(queryDTO?.members.map(\.user.id) ?? []), Set(payload.members.map(\.user.id)))
+            Assert.willBeEqual(Set(queryDTO?.members.map(\.user.id) ?? []), Set(payload.members.map(\.user!.id)))
         }
     }
     
@@ -129,7 +129,7 @@ final class ChannelMemberListUpdater_Tests: XCTestCase {
             // Assert query is saved to the database.
             Assert.willBeTrue(queryDTO != nil)
             // Assert query members are saved to the database.
-            Assert.willBeEqual(Set(queryDTO?.members.map(\.user.id) ?? []), Set(payload.members.map(\.user.id)))
+            Assert.willBeEqual(Set(queryDTO?.members.map(\.user.id) ?? []), Set(payload.members.map(\.user!.id)))
         }
     }
     

--- a/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
@@ -56,8 +56,9 @@ final class ChannelUpdater_Tests: XCTestCase {
         // Simulate `update(channelQuery:)` call
         let query = ChannelQuery(cid: .unique)
         let expectation = self.expectation(description: "Update completes")
+        var updateResult: Result<ChannelPayload, Error>!
         channelUpdater.update(channelQuery: query, isInRecoveryMode: false, completion: { result in
-            XCTAssertNil(result.error)
+            updateResult = result
             expectation.fulfill()
         })
         
@@ -70,6 +71,7 @@ final class ChannelUpdater_Tests: XCTestCase {
         
         let channel = database.viewContext.channel(cid: cid)
         XCTAssertNotNil(channel)
+        XCTAssertNil(updateResult.error)
         XCTAssertEqual(channel?.messages.count, 2)
     }
 


### PR DESCRIPTION
### 🔗 Issue Links
https://github.com/GetStream/stream-chat-swift/issues/2251

### 🎯 Goal
In the `notification.removed_from_channel` event, the `user` field is not present inside the `member` field, although the `user_id` is. This PR adds a fallback so that if the `user` is not present, we use the id from the `user_id` property. 

The backend will change this meanwhile, and make sure the `user` field is always present. But since we don't have an ETA for this, it makes sense to add this fallback.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
