### PR TITLE
Fix links to UIKit and SwiftUI tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,19 @@
 This is the official iOS SDK for [Stream Chat](https://getstream.io/chat/sdk/ios/), a service for building chat and messaging applications. This library includes both a low-level SDK and a set of reusable UI components.
 
 ## Low Level Client (LLC)
+
 The **StreamChat SDK** is a low level client for Stream chat service that doesn't contain any UI components. It is meant to be used when you want to build a fully custom UI. For the majority of use cases though, we recommend using our highly customizable UI SDK's.
 
 ## UIKit SDK
+
 The **StreamChatUI SDK** is our UI SDK for UIKit components. If your application needs to support iOS 13 and below, this is the right UI SDK for you.
 
 ## SwiftUI SDK
+
 The **StreamChatSwiftUI SDK** is our UI SDK for SwiftUI components. If your application only needs to support iOS 14 and above, this is the right UI SDK for you. This SDK is available in another repository **[stream-chat-swiftui](https://github.com/GetStream/stream-chat-swiftui)**.
 
 ## Using Xcode 14 beta?
+
 Since our 4.20.0 release, the SDK can be built using Xcode 14 beta versions. We are regularly testing the SDK when new betas are released, to ensure smooth transition to iOS 16. If you spot an issue, please create a ticket.
 
 ---
@@ -47,14 +51,14 @@ Since our 4.20.0 release, the SDK can be built using Xcode 14 beta versions. We 
 
 ## **Quick Links**
 
-* [iOS/Swift Chat Tutorial](https://getstream.io/tutorials/ios-chat/): Learn how to use the SDK by following our simple tutorial.
-* [Register](https://getstream.io/chat/trial/): Register to get an API key for Stream Chat.
-* [Installation](https://getstream.io/chat/docs/sdk/ios/basics/integration): Learn more about how to install the SDK using CocoaPods, SPM or Carthage.
-  * Do you want to use Module Stable XCFrameworks? [Check this out](https://getstream.io/chat/docs/sdk/ios/basics/integration#xcframeworks)
-* [Documentation](https://getstream.io/chat/docs/sdk/ios/): An extensive documentation is available to help with you integration.
-* [SwiftUI](https://github.com/GetStream/stream-chat-swiftui): Check our SwiftUI SDK if you are developing with SwiftUI.
-* [Demo app](https://github.com/GetStream/stream-chat-swift/tree/main/DemoApp): This repo includes a fully functional demo app with example usage of the SDK.
-* [Example apps](https://github.com/GetStream/stream-chat-swift/tree/main/Examples): This section of the repo includes fully functional sample apps that you can use as reference.
+- [iOS/Swift Chat Tutorial](https://getstream.io/tutorials/ios-chat/): Learn how to use the SDK by following our simple tutorial with UIKit (or [SwiftUI](https://getstream.io/tutorials/swiftui-chat/)).
+- [Register](https://getstream.io/chat/trial/): Register to get an API key for Stream Chat.
+- [Installation](https://getstream.io/chat/docs/sdk/ios/basics/integration): Learn more about how to install the SDK using CocoaPods, SPM or Carthage.
+  - Do you want to use Module Stable XCFrameworks? [Check this out](https://getstream.io/chat/docs/sdk/ios/basics/integration#xcframeworks)
+- [Documentation](https://getstream.io/chat/docs/sdk/ios/): An extensive documentation is available to help with you integration.
+- [SwiftUI](https://github.com/GetStream/stream-chat-swiftui): Check our SwiftUI SDK if you are developing with SwiftUI.
+- [Demo app](https://github.com/GetStream/stream-chat-swift/tree/main/DemoApp): This repo includes a fully functional demo app with example usage of the SDK.
+- [Example apps](https://github.com/GetStream/stream-chat-swift/tree/main/Examples): This section of the repo includes fully functional sample apps that you can use as reference.
 
 ## Free for Makers
 
@@ -62,13 +66,13 @@ Stream is free for most side and hobby projects. You can use Stream Chat for fre
 
 ## Main Principles
 
-* **Progressive disclosure:** The SDK can be used easily with very minimal knowledge of it. As you become more familiar with it, you can dig deeper and start customizing it on all levels.
+- **Progressive disclosure:** The SDK can be used easily with very minimal knowledge of it. As you become more familiar with it, you can dig deeper and start customizing it on all levels.
 
-* **Highly customizable:** Every element is designed to be easily customizable. You can modify the brand color by setting `tintColor`, apply appearance changes using custom UI rules, or subclass existing elements and inject them everywhere in the system, no matter how deep is the logic hierarchy.
+- **Highly customizable:** Every element is designed to be easily customizable. You can modify the brand color by setting `tintColor`, apply appearance changes using custom UI rules, or subclass existing elements and inject them everywhere in the system, no matter how deep is the logic hierarchy.
 
-* **`open` by default:** Everything is `open` unless there's a strong reason for it to not be. This means you can easily modify almost every behavior of the SDK such that it fits your needs.
+- **`open` by default:** Everything is `open` unless there's a strong reason for it to not be. This means you can easily modify almost every behavior of the SDK such that it fits your needs.
 
-* **Good platform citizen:** The UI elements behave like good platform citizens. They use existing iOS patterns; their behavior is predictable and matches system UI components; they respect `tintColor`, `layourMargins`, dynamic font sizes, and other system-defined UI constants.
+- **Good platform citizen:** The UI elements behave like good platform citizens. They use existing iOS patterns; their behavior is predictable and matches system UI components; they respect `tintColor`, `layourMargins`, dynamic font sizes, and other system-defined UI constants.
 
 ## Dependencies
 
@@ -81,6 +85,7 @@ Learn more about our dependencies [here](https://getstream.io/chat/docs/sdk/ios/
 ---
 
 ## We are hiring
+
 We've recently closed a [\$38 million Series B funding round](https://techcrunch.com/2021/03/04/stream-raises-38m-as-its-chat-and-activity-feed-apis-power-communications-for-1b-users/) and we keep actively growing.
 Our APIs are used by more than a billion end-users, and you'll have a chance to make a huge impact on the product within a team of the strongest engineers all over the world.
 Check out our current openings and apply via [Stream's website](https://getstream.io/team/#jobs).

--- a/docusaurus/docs/iOS/swiftui/getting-started.md
+++ b/docusaurus/docs/iOS/swiftui/getting-started.md
@@ -2,7 +2,7 @@
 title: Getting Started
 ---
 
-This section provides a high-level overview of the SwiftUI components library. It is a great starting point for discovering how to use Stream's SwiftUI components in your app. For a complete, step-by-step guide check out [iOS Chat tutorial](/tutorials/ios-chat/).
+This section provides a high-level overview of the SwiftUI components library. It is a great starting point for discovering how to use Stream's SwiftUI components in your app. For a complete, step-by-step guide check out [iOS Chat tutorial](https://getstream.io/tutorials/swiftui-chat/).
 
 ## Your First App with Stream Chat
 

--- a/docusaurus/docs/iOS/uikit/getting-started.md
+++ b/docusaurus/docs/iOS/uikit/getting-started.md
@@ -2,7 +2,7 @@
 title: Getting Started
 ---
 
-This section provides a high-level overview of the library, core components, and how they fit together. It's a great starting point that you can follow along in your code editor. For a complete, step-by-step guide check our [iOS Chat tutorial](/tutorials/ios-chat/).
+This section provides a high-level overview of the library, core components, and how they fit together. It's a great starting point that you can follow along in your code editor. For a complete, step-by-step guide check our [iOS Chat tutorial](https://getstream.io/tutorials/ios-chat/).
 
 ## Your First App with Stream Chat
 
@@ -11,15 +11,16 @@ Before starting, make sure you have installed `StreamChatUI` as explained in the
 ### Chat Setup
 
 The first step to use the library is to create an instance of `ChatClient`. It's recommended to instantiate the `ChatClient` as early as possible and ensure that only one `ChatClient` instance is used across your application. For the sake of simplicity, we are going to show this using a singleton pattern:
+
 ```swift
 extension ChatClient {
     static let shared: ChatClient = {
         // You can grab your API Key from https://getstream.io/dashboard/
         let config = ChatClientConfig(apiKeyString: "<# Your API Key Here #>")
-        
+
         // Create an instance of the `ChatClient` with the given config
         let client = ChatClient(config: config)
-        
+
         return client
     }()
 }
@@ -30,6 +31,7 @@ extension ChatClient {
 The next step is to connect the `ChatClient` with a user. In order to connect, the chat client needs an authorization token.
 
 In case the **token does not expire**, the connection step can look as follows:
+
 ```swift
 // You can generate the token for this user from https://getstream.io/chat/docs/ios-swift/token_generator/?language=swift
 // make sure to use the `leia_organa` as user id and the correct API Key Secret.
@@ -53,6 +55,7 @@ This example has the user and its token hard-coded. But the best practice is to 
 :::
 
 In case of a **token with an expiration date**, the chat client should be connected by giving the token provider that is invoked for initial connection and also to obtain the new token when the current token expires:
+
 ```swift
 // Create the user info to connect with
 let userInfo = UserInfo(
@@ -75,6 +78,7 @@ ChatClient.shared.connectUser(userInfo: userInfo, tokenProvider: tokenProvider) 
 ### Disconnect & Logout
 
 Whenever your users leave the chat component, you should use disconnect to stop receiving chat updates and events while using other features of your app. You disconnect by calling:
+
 ```swift
 chatClient.disconnect()
 ```
@@ -87,9 +91,10 @@ chatClient.logout()
 
 ### Show Channel List
 
-Once the `ChatClient` is connected, we can show the list of channels. 
+Once the `ChatClient` is connected, we can show the list of channels.
 
 To modally show the channel list screen, add the following code-snippet to your app (read more about presentation styles [here](./components/channel-list.md)):
+
 ```swift
 let query = ChannelListQuery(filter: .containMembers(userIds: [userId]))
 let controller = ChatClient.shared.channelListController(query: query)
@@ -100,16 +105,17 @@ rootViewController.present(channelListNVC)
 ```
 
 We also support loading the channel list screen from the storyboard by passing in the reference of the `UIStoryboard` and the identifier:
+
 ```swift
 let storyboard = UIStoryboard(name: "Main", bundle: /*bundle containing the storyboard*/)
 let channelListVC = ChatChannelList.make(
-    with: controller, 
-    storyboard: storyboard, 
+    with: controller,
+    storyboard: storyboard,
     storyboardId: "<# Storyboard ID Here #>"
 )
 ```
 
-The code snippets above will also create the `ChatChannelListController` with the specified query. `ChannelListQuery` allows us to define the channels to fetch and their order. Here we are listing channels where the current user is a member. In this case, the query will load all the channels the user is a member of. 
+The code snippets above will also create the `ChatChannelListController` with the specified query. `ChannelListQuery` allows us to define the channels to fetch and their order. Here we are listing channels where the current user is a member. In this case, the query will load all the channels the user is a member of.
 
 Read more about channel list query and low-level channel list controller [here](./controllers/channels.md).
 


### PR DESCRIPTION
### 🔗 Issue Links

No ticket available.

### 🎯 Goal

The links to the UIKit and SwiftUI tutorials from both our `README.md` and the docusaurus docs (found in the `getting-started` sections) are linking to the wrong paths.

### 📝 Summary

Apparently, the tutorials have been moved:

* We currently point towards: https://getstream.io/chat/docs/sdk/tutorials/ios-chat/
* The correct path is: https://getstream.io/tutorials/ios-chat/

I searched through the project and these were the only links pointing towards there.

### 🛠 Implementation

Due to the fact that the new path to the tutorials is not part of our docusaurus docs anymore, I needed to switch from relative links to absolute ones.

To my knowledge there is no downside in doing this, if there is, please let me know.

### 🧪 Manual Testing Notes

Run docusaurus locally (with `npx stream-chat-docusaurus -i -s`) and check the links from the `Getting started` pages.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [x] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![Cats do not like 404s](https://seranking.com/blog/wp-content/uploads/2021/01/404_01-min.jpg)
