### PR TITLE
[Internal] Move Old SDK tests to 13 - Currently disabled

### DIFF
--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -164,29 +164,29 @@ jobs:
       run: echo "::set-output name=launch_id::${{env.LAUNCH_ID}}"
       if: env.LAUNCH_ID != ''
 
-  build-xcode13:
-    name: Build LLC + UI (Xcode 13)
-    runs-on: macos-12
-    if: ${{ github.event_name != 'push' }}
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./.github/actions/bootstrap
-    - name: List Xcode versions xcversion sees
-      run: mdfind "kMDItemCFBundleIdentifier = 'com.apple.dt.Xcode'"
-    - name: Build LLC (Xcode 13)
-      run: bundle exec fastlane test device:"iPhone 13" build_for_testing:true
-      timeout-minutes: 25
-      env:
-        XCODE_VERSION: "13"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_EVENT: ${{ toJson(github.event) }}
-    - name: Build UI (Xcode 13)
-      run: bundle exec fastlane test_ui device:"iPhone 13" build_for_testing:true
-      timeout-minutes: 25
-      env:
-        XCODE_VERSION: "13"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_EVENT: ${{ toJson(github.event) }}
+  # build-xcode13:
+  #   name: Build LLC + UI (Xcode 13)
+  #   runs-on: macos-12
+  #   if: ${{ github.event_name != 'push' }}
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./.github/actions/bootstrap
+  #   - name: List Xcode versions xcversion sees
+  #     run: mdfind "kMDItemCFBundleIdentifier = 'com.apple.dt.Xcode'"
+  #   - name: Build LLC (Xcode 13)
+  #     run: bundle exec fastlane test device:"iPhone 13" build_for_testing:true
+  #     timeout-minutes: 25
+  #     env:
+  #       XCODE_VERSION: "13"
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       GITHUB_EVENT: ${{ toJson(github.event) }}
+  #   - name: Build UI (Xcode 13)
+  #     run: bundle exec fastlane test_ui device:"iPhone 13" build_for_testing:true
+  #     timeout-minutes: 25
+  #     env:
+  #       XCODE_VERSION: "13"
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       GITHUB_EVENT: ${{ toJson(github.event) }}
 
   build-apps:
     name: Build Sample + Demo Apps

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -164,25 +164,27 @@ jobs:
       run: echo "::set-output name=launch_id::${{env.LAUNCH_ID}}"
       if: env.LAUNCH_ID != ''
 
-  build-xcode12:
-    name: Build LLC + UI (Xcode 12)
-    runs-on: macos-11
+  build-xcode13:
+    name: Build LLC + UI (Xcode 13)
+    runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/bootstrap
-    - name: Build LLC (Xcode 12)
-      run: bundle exec fastlane test device:"iPhone 12" build_for_testing:true
+    - name: List Xcode versions xcversion sees
+      run: mdfind "kMDItemCFBundleIdentifier = 'com.apple.dt.Xcode'"
+    - name: Build LLC (Xcode 13)
+      run: bundle exec fastlane test device:"iPhone 13" build_for_testing:true
       timeout-minutes: 25
       env:
-        XCODE_VERSION: "12.5.1"
+        XCODE_VERSION: "13"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_EVENT: ${{ toJson(github.event) }}
-    - name: Build UI (Xcode 12)
-      run: bundle exec fastlane test_ui device:"iPhone 12" build_for_testing:true
+    - name: Build UI (Xcode 13)
+      run: bundle exec fastlane test_ui device:"iPhone 13" build_for_testing:true
       timeout-minutes: 25
       env:
-        XCODE_VERSION: "12.5.1"
+        XCODE_VERSION: "13"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_EVENT: ${{ toJson(github.event) }}
 

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -2170,8 +2170,8 @@ final class ChannelController_Tests: XCTestCase {
 
         waitForExpectations(timeout: 0.1)
 
-        let paginatonParameter = env.channelUpdater?.update_channelQuery?.pagination?.parameter
-        guard case let .lessThan(paginationMessageId) = paginatonParameter else {
+        let paginationParameter = env.channelUpdater?.update_channelQuery?.pagination?.parameter
+        guard case let .lessThan(paginationMessageId) = paginationParameter else {
             XCTFail("Missing pagination parameter")
             return
         }
@@ -2212,8 +2212,8 @@ final class ChannelController_Tests: XCTestCase {
 
         waitForExpectations(timeout: 0.1)
 
-        let paginatonParameter = env.channelUpdater?.update_channelQuery?.pagination?.parameter
-        guard case let .lessThan(paginationMessageId) = paginatonParameter else {
+        let paginationParameter = env.channelUpdater?.update_channelQuery?.pagination?.parameter
+        guard case let .lessThan(paginationMessageId) = paginationParameter else {
             XCTFail("Missing pagination parameter")
             return
         }


### PR DESCRIPTION
### 📝 Summary

Smoke tests running on Xcode 12 are failing because xcversion fails to find the application.
Reason described here: https://github.com/xcpretty/xcode-install/issues/465
We are preparing old SDK smoke tests to run on Xcode 13 instead of 12, but disabling them for now until Xcode 14 is used.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/lXiRoyqj7vnHfBeBG/giphy.gif)