### PR TITLE
[CIS-2162] Fix message list crash when inserting message in empty list [iOS <15]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,28 +3,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-## StreamChat
-### ✅ Added
-- From now on, if you want to logout the user from the app, especially when switching users, you should call the `client.logout()` method instead of `client.disconnect()`. Read more [here](https://getstream.io/chat/docs/sdk/ios/uikit/getting-started/#disconnect--logout) [#2241](https://github.com/GetStream/stream-chat-swift/pull/2241)
-### 🐞 Fixed
-- Fix hidden channels showing past history [#2216](https://github.com/GetStream/stream-chat-swift/pull/2216)
-- Fix token not being refreshed because of parsing error [#2248](https://github.com/GetStream/stream-chat-swift/pull/2248)
-- Fix deadlock caused by ListDatabaseObserver.startObserving() changes [#2252](https://github.com/GetStream/stream-chat-swift/pull/2252)
-- Fix parsing `member` field in `notification.removed_from_channel` event [#2259](https://github.com/GetStream/stream-chat-swift/pull/2259)
-- Fix broken pagination when quoting or pinning old messages [#2258](https://github.com/GetStream/stream-chat-swift/pull/2258)
-
 ## StreamChatUI
-### 🔄 Changed
-- New Message List Diffing Implementation [#2226](https://github.com/GetStream/stream-chat-swift/pull/2226)
-- `_messageListDiffingEnabled` flag has been removed [#2226](https://github.com/GetStream/stream-chat-swift/pull/2226)
 ### 🐞 Fixed
-- Fix jumps in Message List [#2226](https://github.com/GetStream/stream-chat-swift/pull/2226)
-- Fix image flickers when adding image attachment to a message [#2226](https://github.com/GetStream/stream-chat-swift/pull/2226)
-- Fix message list scrolling when popping from navigation stack [#2239](https://github.com/GetStream/stream-chat-swift/pull/2239)
-- Fix message timestamp not appearing after hard deleting the last message in the group [#2226](https://github.com/GetStream/stream-chat-swift/pull/2226)
+- Fix message list crash when inserting message in empty list on iOS <15 [#2269](https://github.com/GetStream/stream-chat-swift/pull/2269)
 
 # [4.21.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.21.0)
 _September 01, 2022_
+
+🚨 **Known Issue: There is a crash on iOS <15 when inserting messages in an empty list, please update to [4.21.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.21.1)**
 
 ## StreamChat
 ### 🔄 Changed

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -239,7 +239,7 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
 
             // If we are inserting messages at the bottom, update the previous cell
             // to hide the timestamp of the previous message if needed.
-            if self.isLastCellFullyVisible {
+            if self.isLastCellFullyVisible, self.previousMessagesSnapshot.count > 1 {
                 let previousMessageIndexPath = IndexPath(item: 1, section: 0)
                 self.reloadRows(at: [previousMessageIndexPath], with: .none)
             }

--- a/TestTools/StreamChatTestTools/Extensions/Unique/ChannelId+Unique.swift
+++ b/TestTools/StreamChatTestTools/Extensions/Unique/ChannelId+Unique.swift
@@ -5,7 +5,7 @@
 @testable import StreamChat
 
 extension ChannelId {
-    static var unique: ChannelId {
+    static public var unique: ChannelId {
         ChannelId(
             type: .custom(String.unique.lowercased().replacingOccurrences(of: "-", with: "_")),
             id: .unique

--- a/TestTools/StreamChatTestTools/Extensions/Unique/ChatUser+Unique.swift
+++ b/TestTools/StreamChatTestTools/Extensions/Unique/ChatUser+Unique.swift
@@ -6,7 +6,7 @@ import Foundation
 @testable import StreamChat
 
 extension ChatUser {
-    static var unique: ChatUser {
+    static public var unique: ChatUser {
         .mock(
             id: .unique,
             isOnline: true,

--- a/TestTools/StreamChatTestTools/Mocks/Models + Extensions/ChatMessage_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/Models + Extensions/ChatMessage_Mock.swift
@@ -8,11 +8,11 @@ import Foundation
 public extension ChatMessage {
     /// Creates a new `ChatMessage` object from the provided data.
     static func mock(
-        id: MessageId,
-        cid: ChannelId,
-        text: String,
+        id: MessageId = .unique,
+        cid: ChannelId = .unique,
+        text: String = .unique,
         type: MessageType = .reply,
-        author: ChatUser,
+        author: ChatUser = .unique,
         command: String? = nil,
         createdAt: Date = Date(timeIntervalSince1970: 113),
         locallyCreatedAt: Date? = nil,

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
@@ -2,8 +2,8 @@
 // Copyright © 2022 Stream.io Inc. All rights reserved.
 //
 
-import StreamChat
-@testable import StreamChatTestTools
+@testable import StreamChat
+import StreamChatTestTools
 @testable import StreamChatUI
 import XCTest
 
@@ -71,6 +71,35 @@ final class ChatMessageListVC_Tests: XCTestCase {
         XCTAssertEqual(mockedListView.reloadSkippedMessagesCallCount, 0)
     }
 
+    func test_updateMessages_whenLastCellIsFullyVisible_shouldReloadPreviousCell() {
+        let sut = ChatMessageListVC()
+        sut.components = .mock
+        sut.components.messageListView = ChatMessageListView_Mock.self
+
+        let mockedListView = sut.listView as! ChatMessageListView_Mock
+        mockedListView.mockIsLastCellFullyVisible = true
+        mockedListView.previousMessagesSnapshot = [ChatMessage.mock(), ChatMessage.mock()]
+
+        sut.updateMessages(with: [])
+
+        XCTAssertEqual(mockedListView.reloadRowsCallCount, 1)
+        XCTAssertEqual(mockedListView.reloadRowsCalledWith, [IndexPath(item: 1, section: 0)])
+    }
+
+    func test_updateMessages_whenLastCellIsFullyVisible_whenMessagesCountBelowTwo_shouldNotReloadPreviousCell() {
+        let sut = ChatMessageListVC()
+        sut.components = .mock
+        sut.components.messageListView = ChatMessageListView_Mock.self
+
+        let mockedListView = sut.listView as! ChatMessageListView_Mock
+        mockedListView.mockIsLastCellFullyVisible = true
+        mockedListView.previousMessagesSnapshot = [ChatMessage.mock()]
+
+        sut.updateMessages(with: [])
+
+        XCTAssertEqual(mockedListView.reloadRowsCallCount, 0)
+    }
+
     class ChatMessageListView_Mock: ChatMessageListView {
         var mockIsLastCellFullyVisible = false
         override var isLastCellFullyVisible: Bool {
@@ -80,6 +109,13 @@ final class ChatMessageListVC_Tests: XCTestCase {
         var reloadSkippedMessagesCallCount = 0
         override func reloadSkippedMessages() {
             reloadSkippedMessagesCallCount += 1
+        }
+
+        var reloadRowsCallCount = 0
+        var reloadRowsCalledWith: [IndexPath] = []
+        override func reloadRows(at indexPaths: [IndexPath], with animation: UITableView.RowAnimation) {
+            reloadRowsCallCount += 1
+            reloadRowsCalledWith = indexPaths
         }
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links
CIS-2162

### 🎯 Goal
Fix a crash when inserting a message in an empty message list on iOS Below 15.

It would try to attempt reloading a cell that does not exist, when the message list was empty or with 1 message.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
