### PR TITLE
Fix crash on iOS <15 when hard deleting message

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -239,7 +239,7 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
 
             // If we are inserting messages at the bottom, update the previous cell
             // to hide the timestamp of the previous message if needed.
-            if self.isLastCellFullyVisible, self.previousMessagesSnapshot.count > 1 {
+            if self.isLastCellFullyVisible, self.newMessagesSnapshot.count > 1 {
                 let previousMessageIndexPath = IndexPath(item: 1, section: 0)
                 self.reloadRows(at: [previousMessageIndexPath], with: .none)
             }

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
@@ -78,7 +78,7 @@ final class ChatMessageListVC_Tests: XCTestCase {
 
         let mockedListView = sut.listView as! ChatMessageListView_Mock
         mockedListView.mockIsLastCellFullyVisible = true
-        mockedListView.previousMessagesSnapshot = [ChatMessage.mock(), ChatMessage.mock()]
+        mockedListView.newMessagesSnapshot = [ChatMessage.mock(), ChatMessage.mock()]
 
         sut.updateMessages(with: [])
 
@@ -93,7 +93,7 @@ final class ChatMessageListVC_Tests: XCTestCase {
 
         let mockedListView = sut.listView as! ChatMessageListView_Mock
         mockedListView.mockIsLastCellFullyVisible = true
-        mockedListView.previousMessagesSnapshot = [ChatMessage.mock()]
+        mockedListView.newMessagesSnapshot = [ChatMessage.mock()]
 
         sut.updateMessages(with: [])
 


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
This fix [here](https://github.com/GetStream/stream-chat-swift/pull/2269) was incorrectly using the previous snapshot, and it should use the new snapshot instead. For hard deleting messages this was causing a crash.

### ☑️ Contributor Checklist
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] This change follows zero ⚠️ policy (required)
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
