### PR TITLE
[CIS-2168] Do not mark channels as read when the controller is not on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fixed pagination in message list not working when synchronize does not succeed [#2241](https://github.com/GetStream/stream-chat-swift/pull/2241)
+- Do not mark channels as read when the controller is not on screen [#2288](https://github.com/GetStream/stream-chat-swift/pull/2288)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -81,12 +81,6 @@ open class ChatChannelVC: _ViewController,
         messageListVC.client = client
         
         messageComposerVC.userSearchController = userSuggestionSearchController
-        
-        func setChannelControllerToComposerIfNeeded(cid: ChannelId?) {
-            guard messageComposerVC.channelController == nil else { return }
-            let composerChannelController = channelController.cid.map { client.channelController(for: $0) }
-            messageComposerVC.channelController = composerChannelController
-        }
 
         setChannelControllerToComposerIfNeeded(cid: channelController.cid)
 
@@ -95,12 +89,17 @@ open class ChatChannelVC: _ViewController,
             if let error = error {
                 log.error("Error when synchronizing ChannelController: \(error)")
             }
-            setChannelControllerToComposerIfNeeded(cid: self?.channelController.cid)
+            self?.setChannelControllerToComposerIfNeeded(cid: self?.channelController.cid)
             self?.messageComposerVC.updateContent()
         }
 
         // Initial messages data
         messages = Array(channelController.messages)
+    }
+
+    private func setChannelControllerToComposerIfNeeded(cid: ChannelId?) {
+        guard messageComposerVC.channelController == nil, let cid = cid else { return }
+        messageComposerVC.channelController = client.channelController(for: cid)
     }
 
     override open func setUpLayout() {

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -1705,7 +1705,7 @@ final class MessageUpdater_Tests: XCTestCase {
                 }
                 exp.fulfill()
             }
-            wait(for: [exp], timeout: 1)
+            wait(for: [exp], timeout: 2)
 
             // Create current user is the database
             try database.createCurrentUser(id: currentUserId)


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-2168
https://github.com/GetStream/stream-chat-swift/issues/2284

### 🎯 Goal

Do not mark channels as read when the controller is not in the stack

### 🛠 Implementation

There was a temporary leak during the execution of ChatChannelVC.synchronize that was keeping the ChatController alive. That was translated into the controller marking the channel as read even if the chat was not visible on screen.

### 🧪 Manual Testing Notes

1. Open a channel
2. Go back to the channel list
3. From another device, send a message
4. Wait until the unread count show as 1 in the list

Previous result:
The unread count was showing 1 for a second, and then going back to 0

Expected result:
The unread count should stay as 1

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/8dYmJ6Buo3lYY/giphy.gif)
