### PR TITLE
[CIS-1583] Fix Thread not loading more replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - User mentions suggestions would not show when typing in a new line [#2253](https://github.com/GetStream/stream-chat-swift/pull/2253)
 - User mentions suggestions would stop showing when typing a space [#2253](https://github.com/GetStream/stream-chat-swift/pull/2253)
+- Fix Thread not loading more replies [#2297](https://github.com/GetStream/stream-chat-swift/pull/2297)
+- Fix Channel and Thread pagination not working when initialized offline [#2297](https://github.com/GetStream/stream-chat-swift/pull/2297)
 
 # [4.21.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.21.1)
 _September 06, 2022_

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -187,10 +187,6 @@ open class ChatChannelVC: _ViewController,
         _ vc: ChatMessageListVC,
         willDisplayMessageAt indexPath: IndexPath
     ) {
-        if channelController.state != .remoteDataFetched {
-            return
-        }
-
         guard messageListVC.listView.isTrackingOrDecelerating else {
             return
         }

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -216,10 +216,6 @@ open class ChatThreadVC: _ViewController,
         _ vc: ChatMessageListVC,
         willDisplayMessageAt indexPath: IndexPath
     ) {
-        if messageController.state != .remoteDataFetched {
-            return
-        }
-
         if indexPath.row < messages.count - 10 {
             return
         }


### PR DESCRIPTION
### 🔗 Issue Links
CIS-1583

### 🎯 Goal
Fix not loading more replies in Threads

### 📝 Summary
- Fixes threads not loading more replies because of the controller state not being remote fetched (which is not needed)
- Fixes threads and channels not loading more messages when initialized offline

### 🎨 Showcase
None

### 🧪 Manual Testing Notes
- Open a Channel Thread with multiple replies
- Scroll to the top
- Should load more messages

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)