### PR TITLE
[CIS-2169] Do not show old messages not belonging to the history when paginating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fixed pagination in message list not working when synchronize does not succeed [#2241](https://github.com/GetStream/stream-chat-swift/pull/2241)
 - Do not mark channels as read when the controller is not on screen [#2288](https://github.com/GetStream/stream-chat-swift/pull/2288)
+- Do not show old messages not belonging to the history when paginating [#2298](https://github.com/GetStream/stream-chat-swift/pull/2298)). Caveat: [Explained here](https://github.com/GetStream/stream-chat-swift/pull/2298)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -220,7 +220,7 @@ class MessageDTO: NSManagedObject {
 
         let messageTypePredicate = NSCompoundPredicate(format: "type IN %@", validTypes)
 
-        // Some pinned messages might be in the local database, but should not be fetched
+        // Some quoted/pinned messages might be in the local database, but should not be fetched
         // if they do not belong to the regular channel query.
         let ignoreOlderMessagesPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [
             .init(format: "channel.oldestMessageAt == nil"),

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -226,6 +226,7 @@ protocol ChannelDatabaseSession {
     func saveChannel(
         payload: ChannelPayload,
         query: ChannelListQuery?,
+        isPaginatedPayload: Bool,
         cache: PreWarmedCache?
     ) throws -> ChannelDTO
     
@@ -363,8 +364,8 @@ protocol DatabaseSession: UserDatabaseSession,
 
 extension DatabaseSession {
     @discardableResult
-    func saveChannel(payload: ChannelPayload) throws -> ChannelDTO {
-        try saveChannel(payload: payload, query: nil, cache: nil)
+    func saveChannel(payload: ChannelPayload, isPaginatedPayload: Bool) throws -> ChannelDTO {
+        try saveChannel(payload: payload, query: nil, isPaginatedPayload: isPaginatedPayload, cache: nil)
     }
     
     @discardableResult

--- a/Sources/StreamChat/Workers/ChannelMemberListUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelMemberListUpdater.swift
@@ -52,7 +52,7 @@ private extension ChannelMemberListUpdater {
             switch $0 {
             case let .success(payload):
                 self?.database.write({ session in
-                    try session.saveChannel(payload: payload)
+                    try session.saveChannel(payload: payload, isPaginatedPayload: false)
                 }, completion: { error in
                     if let error = error {
                         log.error("Failed to save channel to the database. Error: \(error)")

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -31,7 +31,7 @@ class ChannelUpdater: Worker {
         channelCreatedCallback: ((ChannelId) -> Void)? = nil,
         completion: ((Result<ChannelPayload, Error>) -> Void)? = nil
     ) {
-        let clearMessageHistory = channelQuery.pagination?.parameter == nil
+        let isFirstPage = channelQuery.pagination?.parameter == nil
         let isChannelCreate = channelCreatedCallback != nil
 
         let completion: (Result<ChannelPayload, Error>) -> Void = { [weak database] result in
@@ -43,11 +43,11 @@ class ChannelUpdater: Worker {
                         channelDTO.cleanMessagesThatFailedToBeEditedDueToModeration()
                     }
                     
-                    if clearMessageHistory, let channelDTO = session.channel(cid: payload.channel.cid) {
+                    if isFirstPage, let channelDTO = session.channel(cid: payload.channel.cid) {
                         channelDTO.messages = channelDTO.messages.filter { $0.localMessageState?.isLocalOnly == true }
                     }
 
-                    try session.saveChannel(payload: payload)
+                    try session.saveChannel(payload: payload, isPaginatedPayload: !isFirstPage)
                 } completion: { error in
                     if let error = error {
                         completion?(.failure(error))
@@ -425,7 +425,7 @@ class ChannelUpdater: Worker {
                     }
                     // In any case (backend reported another page of watchers or no watchers)
                     // we should save the payload as it's the latest state of the channel
-                    try session.saveChannel(payload: payload)
+                    try session.saveChannel(payload: payload, isPaginatedPayload: false)
                 } completion: { error in
                     completion?(error)
                 }

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -39,11 +39,10 @@ class ChannelUpdater: Worker {
                 let payload = try result.get()
                 channelCreatedCallback?(payload.channel.cid)
                 database?.write { session in
-                    if let channelDTO = session.channel(cid: payload.channel.cid) {
-                        channelDTO.cleanMessagesThatFailedToBeEditedDueToModeration()
-                    }
-                    
-                    if isFirstPage, let channelDTO = session.channel(cid: payload.channel.cid) {
+                    let channelDTO = session.channel(cid: payload.channel.cid)
+                    channelDTO?.cleanMessagesThatFailedToBeEditedDueToModeration()
+
+                    if isFirstPage, let channelDTO = channelDTO {
                         channelDTO.messages = channelDTO.messages.filter { $0.localMessageState?.isLocalOnly == true }
                     }
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -23,6 +23,18 @@ final class DatabaseSession_Mock: DatabaseSession {
 
 // Here start the boilerplate that forwards and intercepts the session calls if needed
 
+extension DatabaseSession {
+    @discardableResult
+    func saveChannel(
+        payload: ChannelPayload,
+        isPaginatedPayload: Bool = false,
+        query: ChannelListQuery? = nil,
+        cache: PreWarmedCache? = nil
+    ) throws -> ChannelDTO {
+        return try saveChannel(payload: payload, query: query, isPaginatedPayload: isPaginatedPayload, cache: cache)
+    }
+}
+
 extension DatabaseSession_Mock {
     func addReaction(
         to messageId: MessageId,
@@ -59,7 +71,7 @@ extension DatabaseSession_Mock {
     func saveChannelList(payload: ChannelListPayload, query: ChannelListQuery?) -> [ChannelDTO] {
         return underlyingSession.saveChannelList(payload: payload, query: query)
     }
-    
+
     func saveChannel(
         payload: ChannelDetailPayload,
         query: ChannelListQuery?,
@@ -248,16 +260,17 @@ extension DatabaseSession_Mock {
     func loadAllChannelListQueries() -> [ChannelListQueryDTO] {
         underlyingSession.loadAllChannelListQueries()
     }
-    
+
     func saveChannel(
         payload: ChannelPayload,
         query: ChannelListQuery?,
+        isPaginatedPayload: Bool,
         cache: PreWarmedCache?
     ) throws -> ChannelDTO {
         try throwErrorIfNeeded()
-        return try underlyingSession.saveChannel(payload: payload, query: query, cache: cache)
+        return try underlyingSession.saveChannel(payload: payload, query: query, isPaginatedPayload: isPaginatedPayload, cache: cache)
     }
-    
+
     func channel(cid: ChannelId) -> ChannelDTO? {
         underlyingSession.channel(cid: cid)
     }


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-2169

### 🎯 Goal

This PR aims to stop showing, in most situations, old messages not belonging to the chronological order when scrolling to older messages.

### 📝 Summary

Whenever we query a channel page, the payload returns the channel, its messages, and its pinned messages. It can also be that the returned messages contain quoted messages.

Those quoted/pinned messages can or cannot be part of the current page, but in order for those to be displayed when requested, they have to be stored in the database . They can be way older than the page we are requesting (Imagine there is a message that is quoting a message from 10 months ago, we need it in the DB, but we should not be showing the original message alone, just show it as part of a quote)

Because Stream relies on the database to show the elements on the channel view, those are effectively "part of the channel", and thus, those were shown under one circumstance.

We keep track of what's the latest message that belongs to the chronological order given pagination. That way, we can exclude situations like the ones mentioned above. But, there was a case that was not covered:

If you were to scroll to the origin of the channel, this logic keeping track of the latest message that belongs to the chronological order now has the oldest date in the whole channel stored.

### 🛠 Implementation

We are now resetting `oldestMessageAt` when we are fetching the initial page of any channel

### ⚠️ Caveats:

Because we are resetting `oldestMessageAt` for each channel when we receive the initial Channel List API response, this fix should solve this issue for most of the users. There is an edge case, though:
If you open the channel and scroll to the top, `oldestMessageAt` for the channel will be set to the oldest message in the history. If yo go back to the channel list, and then reenter the chat, the initial DB load will be done with that `oldestMessageAt`, which is the oldest in the history, and therefore showing messages that do not belong to the chronological order for the initial page.

### 🧪 Manual Testing Notes

1. Create a channel with a lot of messages. Ideally more than 100
2. Pin the oldest message
3. In the last message quote the 2nd message
4. Scroll to the top, and go back to the channel list
5. Open the channel again
6. Start scrolling up

Previous behavior:
- You would see the 2 oldest channels on top while requesting the 2n page

Current behavior:
- Pagination works as expected, and you only see the 2 oldest messages when the history reaches there.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://giphy.com/clips/buzzfeed-buzzfeed-celeb-locke-key-the-cast-finds-out-which-characters-they-zA3ds0sMSiJBc5AqH5)
