### PR TITLE
[Internal] Use concurrent queues for internal queues using async(flags: .barrier)

### DIFF
--- a/Sources/StreamChat/Controllers/BackgroundListDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/BackgroundListDatabaseObserver.swift
@@ -102,7 +102,7 @@ class BackgroundListDatabaseObserver<Item, DTO: NSManagedObject> {
     /// When called, release the notification observers
     private(set) var releaseNotificationObservers: (() -> Void)?
 
-    private let queue = DispatchQueue(label: "io.getstream.list-database-observer", qos: .userInitiated)
+    private let queue = DispatchQueue(label: "io.getstream.list-database-observer", qos: .userInitiated, attributes: .concurrent)
 
     private var _items: [Item] = []
     var items: LazyCachedMapCollection<Item> {

--- a/Sources/StreamChat/Utils/Operations/AsyncOperation.swift
+++ b/Sources/StreamChat/Utils/Operations/AsyncOperation.swift
@@ -51,7 +51,7 @@ class AsyncOperation: BaseOperation {
 class BaseOperation: Operation {
     private var _finished = false
     private var _executing = false
-    private let stateQueue = DispatchQueue(label: "io.getstream.base-operation")
+    private let stateQueue = DispatchQueue(label: "io.getstream.base-operation", attributes: .concurrent)
 
     override var isExecuting: Bool {
         get {

--- a/Sources/StreamChat/Utils/ThreadSafeWeakCollection.swift
+++ b/Sources/StreamChat/Utils/ThreadSafeWeakCollection.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 final class ThreadSafeWeakCollection<T: AnyObject> {
-    private let queue = DispatchQueue(label: "io.stream.com.weak-collection")
+    private let queue = DispatchQueue(label: "io.stream.com.weak-collection", attributes: .concurrent)
     private let storage = NSHashTable<T>.weakObjects()
 
     var allObjects: [T] {


### PR DESCRIPTION
### 🔗 Issue Links

Closes https://github.com/GetStream/stream-chat-swift/issues/2299

### 🎯 Goal

Use concurrent queues for internal queues.

### 📝 Summary

As reported in https://github.com/GetStream/stream-chat-swift/issues/2299, we were wrongly creating serial queues for internal queues when the purpose was to allow concurrent reads, but block the queue while there is a write.

### 🛠 Implementation

Just add the `.concurrent` attribute in the creation of the queue.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/xT5LMuVtaVYI03uXsc/giphy.gif)
