### PR TITLE
Fixed a broken link in the synchronize docs

### DIFF
--- a/docusaurus/docs/iOS/guides/importance-of-synchronize.md
+++ b/docusaurus/docs/iOS/guides/importance-of-synchronize.md
@@ -35,4 +35,4 @@ Additionally, as with all StreamChat Controllers, `ChannelController` has `state
 func controller(_ controller: DataController, didChangeState state: DataController.State)
 ```
 
-You can use this delegate function to show any error states you might see. For more information, see [DataController Overview](404).
+You can use this delegate function to show any error states you might see. For more information, see [DataControllerStateDelegate Overview](../common-content/reference-docs/stream-chat/controllers/data-controller-state-delegate.md).


### PR DESCRIPTION
### 🎯 Goal

We have a broken link here: https://getstream.io/chat/docs/sdk/ios/guides/importance-of-synchronize/. 

The referenced page doesn't seem to exist anymore. I've provided an alternative, open to suggestions for a better fit.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
