### PR TITLE
[CIS-2183] Handle Global Ban Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Do not mark channels as read when the controller is not on screen [#2288](https://github.com/GetStream/stream-chat-swift/pull/2288)
 - Do not show old messages not belonging to the history when paginating [#2298](https://github.com/GetStream/stream-chat-swift/pull/2298)). Caveat: [Explained here](https://github.com/GetStream/stream-chat-swift/pull/2298)
 - Fix logic to determine errors related to connectivity [#2311](https://github.com/GetStream/stream-chat-swift/pull/2311)
+- Properly handle Global Ban events [#2312](https://github.com/GetStream/stream-chat-swift/pull/2312)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/WebSocketClient/Events/EventType.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/EventType.swift
@@ -117,9 +117,11 @@ extension EventType {
         case .userUpdated: return try UserUpdatedEventDTO(from: response)
         case .userStartWatching, .userStopWatching: return try UserWatchingEventDTO(from: response)
         case .userStartTyping, .userStopTyping: return try TypingEventDTO(from: response)
-        case .userBanned: return try UserBannedEventDTO(from: response)
-        case .userUnbanned: return try UserUnbannedEventDTO(from: response)
-        
+        case .userBanned:
+            return try (try? UserBannedEventDTO(from: response)) ?? UserGloballyBannedEventDTO(from: response)
+        case .userUnbanned:
+            return try (try? UserUnbannedEventDTO(from: response)) ?? UserGloballyUnbannedEventDTO(from: response)
+
         case .channelUpdated: return try ChannelUpdatedEventDTO(from: response)
         case .channelDeleted: return try ChannelDeletedEventDTO(from: response)
         case .channelHidden: return try ChannelHiddenEventDTO(from: response)

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1634,6 +1634,8 @@
 		C152F5FE27C65C18003B4805 /* MessageRepository_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C152F5FD27C65C18003B4805 /* MessageRepository_Tests.swift */; };
 		C15C8838286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15C8837286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift */; };
 		C15C8839286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15C8837286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift */; };
+		C1616DB128DC4D7F00FF993B /* UserGloballyUnbanned.json in Resources */ = {isa = PBXBuildFile; fileRef = C1616DAF28DC4D7F00FF993B /* UserGloballyUnbanned.json */; };
+		C1616DB228DC4D7F00FF993B /* UserGloballyBanned.json in Resources */ = {isa = PBXBuildFile; fileRef = C1616DB028DC4D7F00FF993B /* UserGloballyBanned.json */; };
 		C171041E2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */; };
 		C171041F2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */; };
 		C173538E27D9F804008AC412 /* KeyedDecodingContainer+Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = C173538D27D9F804008AC412 /* KeyedDecodingContainer+Array.swift */; };
@@ -3348,6 +3350,8 @@
 		C152F5FB27C3DC53003B4805 /* MessageRepository_Spy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRepository_Spy.swift; sourceTree = "<group>"; };
 		C152F5FD27C65C18003B4805 /* MessageRepository_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRepository_Tests.swift; sourceTree = "<group>"; };
 		C15C8837286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundListDatabaseObserver.swift; sourceTree = "<group>"; };
+		C1616DAF28DC4D7F00FF993B /* UserGloballyUnbanned.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UserGloballyUnbanned.json; sourceTree = "<group>"; };
+		C1616DB028DC4D7F00FF993B /* UserGloballyBanned.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UserGloballyBanned.json; sourceTree = "<group>"; };
 		C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeSubscript.swift"; sourceTree = "<group>"; };
 		C173538D27D9F804008AC412 /* KeyedDecodingContainer+Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+Array.swift"; sourceTree = "<group>"; };
 		C174E0F5284DFA5A0040B936 /* IdentifiablePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiablePayload.swift; sourceTree = "<group>"; };
@@ -4897,6 +4901,8 @@
 			isa = PBXGroup;
 			children = (
 				8A0C3BC224C0AD8300CAFD19 /* UserBanned.json */,
+				C1616DB028DC4D7F00FF993B /* UserGloballyBanned.json */,
+				C1616DAF28DC4D7F00FF993B /* UserGloballyUnbanned.json */,
 				8A0C3BBD24C0AC6400CAFD19 /* UserPresence.json */,
 				8A62706024BE31C30040BFD6 /* UserStartTyping.json */,
 				43BAAD482664F59600323D8E /* UserStartTypingThread.json */,
@@ -8198,6 +8204,7 @@
 				A311B3F427E8B99800CFCF6D /* ChannelUpdated.json in Resources */,
 				A311B42627E8B9CE00CFCF6D /* MessageReactionPayload+DefaultExtraData.json in Resources */,
 				A311B3FC27E8B9A800CFCF6D /* MessageUpdated.json in Resources */,
+				C1616DB228DC4D7F00FF993B /* UserGloballyBanned.json in Resources */,
 				A311B3DC27E8B98C00CFCF6D /* MessagePayload.json in Resources */,
 				A311B3D427E8B98C00CFCF6D /* Channel.json in Resources */,
 				A311B3F627E8B9A200CFCF6D /* MemberAdded.json in Resources */,
@@ -8224,6 +8231,7 @@
 				A368E71627F33E16009063C1 /* MissingEventsPayload-IncompleteChannel.json in Resources */,
 				A311B40B27E8B9AD00CFCF6D /* NotificationMessageNew.json in Resources */,
 				A311B41027E8B9B300CFCF6D /* ReactionNew.json in Resources */,
+				C1616DB128DC4D7F00FF993B /* UserGloballyUnbanned.json in Resources */,
 				A311B40327E8B9AD00CFCF6D /* NotificationInviteAccepted.json in Resources */,
 				A311B3D327E8B98C00CFCF6D /* Message.json in Resources */,
 				A311B3E427E8B98C00CFCF6D /* MessagePayloadWithCustom.json in Resources */,

--- a/TestTools/StreamChatTestTools/Fixtures/JSONs/Events/User/UserGloballyBanned.json
+++ b/TestTools/StreamChatTestTools/Fixtures/JSONs/Events/User/UserGloballyBanned.json
@@ -1,0 +1,33 @@
+{
+  "type": "user.banned",
+  "user": {
+    "id": "c-3po",
+    "role": "user",
+    "created_at": "2020-12-07T11:37:35.550588Z",
+    "updated_at": "2022-06-29T13:32:45.340252Z",
+    "banned": false,
+    "online": true,
+    "birthland": "Affa",
+    "extraData": {},
+    "image_url": "https://vignette.wikia.nocookie.net/starwars/images/3/3f/C-3PO_TLJ_Card_Trader_Award_Card.png",
+    "dashboard_ban_channel_cid": "messaging:55DE2AA9-4",
+    "name": "C-3PO",
+    "image": "https://vignette.wikia.nocookie.net/starwars/images/3/3f/C-3PO_TLJ_Card_Trader_Award_Card.png"
+  },
+  "created_by": {
+    "id": "stream-pol",
+    "role": "admin",
+    "created_at": "2022-02-11T14:43:41.668064Z",
+    "updated_at": "2022-02-11T14:43:41.668064Z",
+    "banned": false,
+    "online": true,
+    "language": "en",
+    "last_name": "",
+    "first_name": "",
+    "staff_user": true,
+    "dashboard_user": true,
+    "email": "pol.quintana@getstream.io"
+  },
+  "created_at": "2022-09-22T07:59:24.236543236Z",
+  "expiration": "2022-09-23T07:59:24.229744Z"
+}

--- a/TestTools/StreamChatTestTools/Fixtures/JSONs/Events/User/UserGloballyUnbanned.json
+++ b/TestTools/StreamChatTestTools/Fixtures/JSONs/Events/User/UserGloballyUnbanned.json
@@ -1,0 +1,19 @@
+{
+  "type": "user.unbanned",
+  "user": {
+    "id": "c-3po",
+    "role": "user",
+    "created_at": "2020-12-07T11:37:35.550588Z",
+    "updated_at": "2022-06-29T13:32:45.340252Z",
+    "last_active": "2022-09-22T07:59:25.021211Z",
+    "banned": false,
+    "online": true,
+    "image_url": "https://vignette.wikia.nocookie.net/starwars/images/3/3f/C-3PO_TLJ_Card_Trader_Award_Card.png",
+    "dashboard_ban_channel_cid": "messaging:55DE2AA9-4",
+    "name": "C-3PO",
+    "image": "https://vignette.wikia.nocookie.net/starwars/images/3/3f/C-3PO_TLJ_Card_Trader_Award_Card.png",
+    "birthland": "Affa",
+    "extraData": {}
+  },
+  "created_at": "2022-09-22T08:00:15.980131897Z"
+}

--- a/Tests/StreamChatTests/WebSocketClient/Events/UserEvents_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/Events/UserEvents_Tests.swift
@@ -58,7 +58,21 @@ final class UserEvents_Tests: XCTestCase {
         XCTAssertEqual(event?.user.id, "broken-waterfall-5")
         XCTAssertEqual(event?.cid, ChannelId(type: .messaging, id: "new_channel_7070"))
     }
-    
+
+    func test_userGloballyBannedEvent() throws {
+        let json = XCTestCase.mockData(fromJSONFile: "UserGloballyBanned")
+        let event = try eventDecoder.decode(from: json) as? UserGloballyBannedEventDTO
+        XCTAssertEqual(event?.user.id, "c-3po")
+        XCTAssertEqual(event?.createdAt.description, "2022-09-22 07:59:24 +0000")
+    }
+
+    func test_userGloballyUnbannedEvent() throws {
+        let json = XCTestCase.mockData(fromJSONFile: "UserGloballyUnbanned")
+        let event = try eventDecoder.decode(from: json) as? UserGloballyUnbannedEventDTO
+        XCTAssertEqual(event?.user.id, "c-3po")
+        XCTAssertEqual(event?.createdAt.description, "2022-09-22 08:00:15 +0000")
+    }
+
     // MARK: DTO -> Event
     
     func test_userPresenceChangedEventDTO_toDomainEvent() throws {


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-2183

### 🎯 Goal

Properly handle Global Ban events

### 📝 Summary

Seems like at some point we did a mistake and removed the handling to handle Global Ban events. The models were there, but were not used 🙃 

### 🛠 Implementation

When receiving `user.banned` / `user.unbanned` events, we try to parse it using the channel ban model, otherwise, we try with the global ban.

### 🧪 Manual Testing Notes

1. Create an EventsController and listen to events
2. From the dashboard, globally ban a user

Expected result:

You should receive a UserGloballyBannedEvent in the EventsController handler.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/qPD4yGsrc0pdm/giphy.gif)