### PR TITLE
[CIS-2184] Ignore channel.created events

### DIFF
--- a/Sources/StreamChat/WebSocketClient/Events/EventDecoder.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/EventDecoder.swift
@@ -15,6 +15,8 @@ struct EventDecoder {
             return try decoder.decode(UnknownChannelEvent.self, from: data)
         } catch is ClientError.UnknownUserEvent {
             return try decoder.decode(UnknownUserEvent.self, from: data)
+        } catch let error as ClientError.UnsupportedEventType {
+            throw error
         }
     }
 }

--- a/Sources/StreamChat/WebSocketClient/Events/EventPayload.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/EventPayload.swift
@@ -173,7 +173,11 @@ extension Array where Element == EventPayload {
             do {
                 return try $0.event()
             } catch {
-                log.error("Failed to decode event from event payload: \($0), error: \(error)")
+                if error is ClientError.UnsupportedEventType {
+                    log.info("Skipping unsupported event type: \($0.eventType)")
+                } else {
+                    log.error("Failed to decode event from event payload: \($0), error: \(error)")
+                }
                 return nil
             }
         }

--- a/Sources/StreamChat/WebSocketClient/Events/EventType.swift
+++ b/Sources/StreamChat/WebSocketClient/Events/EventType.swift
@@ -42,6 +42,8 @@ public extension EventType {
     // MARK: Channel Events
     
     /// When a channel was updated.
+    static let channelCreated: Self = "channel.created"
+    /// When a channel was updated.
     static let channelUpdated: Self = "channel.updated"
     /// When a channel was deleted.
     static let channelDeleted: Self = "channel.deleted"
@@ -120,6 +122,7 @@ extension EventType {
         case .userBanned: return try UserBannedEventDTO(from: response)
         case .userUnbanned: return try UserUnbannedEventDTO(from: response)
         
+        case .channelCreated: throw ClientError.UnsupportedEventType()
         case .channelUpdated: return try ChannelUpdatedEventDTO(from: response)
         case .channelDeleted: return try ChannelDeletedEventDTO(from: response)
         case .channelHidden: return try ChannelHiddenEventDTO(from: response)

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -199,7 +199,6 @@ extension WebSocketClient: WebSocketEngineDelegate {
             }
         } catch is ClientError.UnsupportedEventType {
             log.info("Skipping unsupported event type with payload: \(message)", subsystems: .webSocket)
-            
         } catch {
             // Check if the message contains an error object from the server
             let webSocketError = message

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1634,6 +1634,7 @@
 		C152F5FE27C65C18003B4805 /* MessageRepository_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C152F5FD27C65C18003B4805 /* MessageRepository_Tests.swift */; };
 		C15C8838286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15C8837286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift */; };
 		C15C8839286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15C8837286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift */; };
+		C1616DB428DC9F0B00FF993B /* ChannelCreated.json in Resources */ = {isa = PBXBuildFile; fileRef = C1616DB328DC9F0B00FF993B /* ChannelCreated.json */; };
 		C171041E2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */; };
 		C171041F2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */; };
 		C173538E27D9F804008AC412 /* KeyedDecodingContainer+Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = C173538D27D9F804008AC412 /* KeyedDecodingContainer+Array.swift */; };
@@ -3348,6 +3349,7 @@
 		C152F5FB27C3DC53003B4805 /* MessageRepository_Spy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRepository_Spy.swift; sourceTree = "<group>"; };
 		C152F5FD27C65C18003B4805 /* MessageRepository_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRepository_Tests.swift; sourceTree = "<group>"; };
 		C15C8837286C7BF300E6A72C /* BackgroundListDatabaseObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundListDatabaseObserver.swift; sourceTree = "<group>"; };
+		C1616DB328DC9F0B00FF993B /* ChannelCreated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ChannelCreated.json; sourceTree = "<group>"; };
 		C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeSubscript.swift"; sourceTree = "<group>"; };
 		C173538D27D9F804008AC412 /* KeyedDecodingContainer+Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+Array.swift"; sourceTree = "<group>"; };
 		C174E0F5284DFA5A0040B936 /* IdentifiablePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiablePayload.swift; sourceTree = "<group>"; };
@@ -4919,6 +4921,7 @@
 				A3B0CFA327BCF66A00F352F9 /* ChannelTruncated_with_message.json */,
 				79158CE125F0E9DF00186102 /* ChannelTruncated.json */,
 				79433799260E04AF0094471F /* ChannelUpdated_ServerSide.json */,
+				C1616DB328DC9F0B00FF993B /* ChannelCreated.json */,
 				8A0C3BCB24C1C6AB00CAFD19 /* ChannelUpdated.json */,
 				E7DB9F372632B6500090D9C7 /* ChannelVisible.json */,
 			);
@@ -8246,6 +8249,7 @@
 				A311B42427E8B9CE00CFCF6D /* MessageReactionPayload+NoExtraData.json in Resources */,
 				A311B41E27E8B9C400CFCF6D /* FlagUserPayload+DefaultExtraData.json in Resources */,
 				A311B41927E8B9B900CFCF6D /* UserUpdated.json in Resources */,
+				C1616DB428DC9F0B00FF993B /* ChannelCreated.json in Resources */,
 				A311B3F927E8B9A800CFCF6D /* MessageRead+MissingUnreadCount.json in Resources */,
 				A311B40927E8B9AD00CFCF6D /* NotificationChannelMutesUpdatedWithNoMutedChannels.json in Resources */,
 				A311B3CF27E8B98C00CFCF6D /* MutedChannelPayload.json in Resources */,

--- a/TestTools/StreamChatTestTools/Fixtures/JSONs/Events/Channel/ChannelCreated.json
+++ b/TestTools/StreamChatTestTools/Fixtures/JSONs/Events/Channel/ChannelCreated.json
@@ -1,0 +1,3 @@
+{
+    "type" : "channel.created",
+}

--- a/Tests/StreamChatTests/WebSocketClient/Events/ChannelEvents_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/Events/ChannelEvents_Tests.swift
@@ -18,6 +18,16 @@ final class ChannelEvents_Tests: XCTestCase {
         super.tearDown()
         eventDecoder = nil
     }
+
+    func test_created() throws {
+        let json = XCTestCase.mockData(fromJSONFile: "ChannelCreated")
+        do {
+            _ = try eventDecoder.decode(from: json)
+            XCTFail("Should not be able to decode it")
+        } catch {
+            XCTAssertTrue(error is ClientError.UnsupportedEventType)
+        }
+    }
     
     func test_updated() throws {
         let json = XCTestCase.mockData(fromJSONFile: "ChannelUpdated")


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-2184

### 🎯 Goal

Stop logging error when 'channel.created' events are received

### 📝 Summary

We are already handling new channels when ‘notification.added_to_channel' are received.
’channel.created' events are only received through the sync endpoint, but we were logging an error as it was unhandled, but it seemed like there was a bug.

### 🛠 Implementation

When receiving 'channel.created', we are throwing `ClientError.UnsupportedEventType`, which is then only logged as info

### 🧪 Manual Testing Notes

1. Logged with user A, and the app closed
2. With user B, create a group including user A
3. Open the app with user A

Expected result:
No error logs regarding 'channel.created' should appear

Previous result:
An error log would be logged for 'channel.created'

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://giphy.com/clips/southpark-south-park-episode-9-season-13-uXngdu5Qxfq2Zs9xPs)
