### PR TITLE
[CIS-2215] Implement UI tests attachments

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -6,14 +6,14 @@ runs:
     - run: echo "IMAGE=${ImageOS}-${ImageVersion}" >> $GITHUB_ENV
       shell: bash
     - name: Cache RubyGems
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: rubygem-cache
       with:
         path: vendor/bundle
         key: ${{ env.IMAGE }}-gem-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: ${{ env.IMAGE }}-gem-
     - name: Cache Mint
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: mint-cache
       with:
         path: ~/.mint

--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -27,7 +27,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ALLURE_TOKEN: ${{ secrets.ALLURE_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.5.0
     - uses: ./.github/actions/bootstrap
       env:
         INSTALL_ALLURE: true
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.5.0
     - uses: ./.github/actions/bootstrap
     - name: Run LLC Tests (Debug)
       run: bundle exec fastlane test device:"iPhone 8"

--- a/.github/workflows/docusaurus-prod.yml
+++ b/.github/workflows/docusaurus-prod.yml
@@ -9,7 +9,7 @@ jobs:
     name: Publish docusaurus docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5.0
       - name: push
         uses: GetStream/push-stream-chat-docusaurus-action@main
         with:

--- a/.github/workflows/docusaurus-staging.yml
+++ b/.github/workflows/docusaurus-staging.yml
@@ -11,7 +11,7 @@ jobs:
     name: Publish docusaurus docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5.0
       - name: push
         uses: GetStream/push-stream-chat-docusaurus-action@main
         with:

--- a/.github/workflows/emerge.yml
+++ b/.github/workflows/emerge.yml
@@ -28,7 +28,7 @@ jobs:
         uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.BOT_SSH_PRIVATE_KEY }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5.0
       - uses: ./.github/actions/bootstrap
       - name: Run match_me
         env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.BOT_SSH_PRIVATE_KEY }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5.0
       - name: Extract version from branch name (for release branches)
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         run: |

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5.0
       - uses: ./.github/actions/bootstrap
       - name: Run Danger
         run: bundle exec danger
@@ -46,7 +46,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_EVENT: ${{ toJson(github.event) }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.5.0
       with:
         fetch-depth: 100
     - uses: actions/setup-python@v3.0.0
@@ -63,7 +63,7 @@ jobs:
       timeout-minutes: 30
     - name: Get branch name
       id: get_branch_name
-      run: echo "##[set-output name=branch;]${GITHUB_REF#refs/heads/}"
+      run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
     - name: Run Sonar analysis
       run: bundle exec fastlane sonar_upload
       env:
@@ -87,7 +87,7 @@ jobs:
     runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.5.0
     - uses: ./.github/actions/bootstrap
     - name: Run UI Tests (Debug)
       run: bundle exec fastlane test_ui device:"${{ env.IOS_SIMULATOR_DEVICE }}"
@@ -110,12 +110,13 @@ jobs:
         batch: [0, 1, 2]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.5.0
       if: env.LAUNCH_ID != ''
     - uses: ./.github/actions/bootstrap
       if: env.LAUNCH_ID != ''
       env:
         INSTALL_ALLURE: true
+        INSTALL_XCPARSE: true
     - name: Run UI Tests (Debug)
       if: env.LAUNCH_ID != ''
       run: bundle exec fastlane test_e2e_mock device:"${{ env.IOS_SIMULATOR_DEVICE }}" batch:'${{ matrix.batch }}'
@@ -135,6 +136,17 @@ jobs:
       run: bundle exec fastlane allure_launch_removal launch_id:$LAUNCH_ID
       env:
         ALLURE_TOKEN: ${{ secrets.ALLURE_TOKEN }}
+    - name: Parse xcresult
+      if: failure()
+      run: xcparse logs fastlane/test_output/StreamChatUITestsApp.xcresult fastlane/test_output/logs/
+    - uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: Test Data
+        path: |
+          fastlane/recordings
+          fastlane/sinatra_log.txt
+          fastlane/test_output/logs/*/Diagnostics/StreamChatUITestsAppUITests-*/*/*.txt
 
   allure_testops_launch:
     name: Launch Allure TestOps
@@ -143,7 +155,7 @@ jobs:
     outputs:
       launch_id: ${{ steps.get_launch_id.outputs.launch_id }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.5.0
     - uses: ./.github/actions/bootstrap
       env:
         XCODE_ACTIONS: false
@@ -154,7 +166,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_EVENT: ${{ toJson(github.event) }}
     - id: get_launch_id
-      run: echo "::set-output name=launch_id::${{env.LAUNCH_ID}}"
+      run: echo "launch_id=${{env.LAUNCH_ID}}" >> $GITHUB_OUTPUT
       if: env.LAUNCH_ID != ''
 
   build-xcode13:
@@ -166,7 +178,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_EVENT: ${{ toJson(github.event) }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.5.0
     - uses: ./.github/actions/bootstrap
     - name: List Xcode versions xcversion sees
       run: mdfind "kMDItemCFBundleIdentifier = 'com.apple.dt.Xcode'"
@@ -185,7 +197,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_EVENT: ${{ toJson(github.event) }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.5.0
     - uses: ./.github/actions/bootstrap
     - name: Build Sample App
       run: bundle exec fastlane build_sample
@@ -211,7 +223,7 @@ jobs:
     runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.5.0
     - uses: ./.github/actions/bootstrap
     - name: Build Test Project
       run: bundle exec fastlane spm_integration
@@ -225,7 +237,7 @@ jobs:
     runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.5.0
     - uses: ./.github/actions/bootstrap
     - name: Build Test Project
       run: bundle exec fastlane cocoapods_integration

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -20,7 +20,7 @@ jobs:
       uses: webfactory/ssh-agent@v0.4.1
       with:
         ssh-private-key: ${{ secrets.BOT_SSH_PRIVATE_KEY }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.5.0
     - uses: ./.github/actions/bootstrap
     - name: Deploy Demo app
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ fastlane/screenshots
 fastlane/test_output
 fastlane/allurectl
 fastlane/xcresults
+fastlane/recordings
 StreamChatCore.framework.coverage.txt
 StreamChatCoreTests.xctest.coverage.txt
 vendor/bundle/

--- a/Scripts/bootstrap.sh
+++ b/Scripts/bootstrap.sh
@@ -67,3 +67,7 @@ if [[ ${INSTALL_ALLURE-default} == true ]]; then
   curl -sL "${DOWNLOAD_URL}" -o ./fastlane/xcresults
   chmod +x ./fastlane/xcresults
 fi
+
+if [[ ${INSTALL_XCPARSE-default} == true ]]; then
+  brew install chargepoint/xcparse/xcparse
+fi

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		825A32CB27DBB463000402A9 /* MessageListPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825A32CA27DBB463000402A9 /* MessageListPage.swift */; };
 		825A32CD27DBB46F000402A9 /* ChannelListPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825A32CC27DBB46F000402A9 /* ChannelListPage.swift */; };
 		825A32CF27DBB48D000402A9 /* StartPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825A32CE27DBB48D000402A9 /* StartPage.swift */; };
+		826992C82900628500D2D470 /* DeviceRemoteControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826992C72900628500D2D470 /* DeviceRemoteControl.swift */; };
 		826B1C3528895AFD005DDF13 /* http_youtube_link.json in Resources */ = {isa = PBXBuildFile; fileRef = 826B1C3428895AFD005DDF13 /* http_youtube_link.json */; };
 		826B1C3728895BB5005DDF13 /* http_unsplash_link.json in Resources */ = {isa = PBXBuildFile; fileRef = 826B1C3628895BB5005DDF13 /* http_unsplash_link.json */; };
 		826B1C39288FD756005DDF13 /* http_truncate.json in Resources */ = {isa = PBXBuildFile; fileRef = 826B1C38288FD756005DDF13 /* http_truncate.json */; };
@@ -2671,6 +2672,7 @@
 		825A32CC27DBB46F000402A9 /* ChannelListPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListPage.swift; sourceTree = "<group>"; };
 		825A32CE27DBB48D000402A9 /* StartPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartPage.swift; sourceTree = "<group>"; };
 		8261340927F20B7A0034AC37 /* StreamChatUITestsApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = StreamChatUITestsApp.xctestplan; sourceTree = "<group>"; };
+		826992C72900628500D2D470 /* DeviceRemoteControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceRemoteControl.swift; sourceTree = "<group>"; };
 		826B1C3428895AFD005DDF13 /* http_youtube_link.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = http_youtube_link.json; sourceTree = "<group>"; };
 		826B1C3628895BB5005DDF13 /* http_unsplash_link.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = http_unsplash_link.json; sourceTree = "<group>"; };
 		826B1C38288FD756005DDF13 /* http_truncate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = http_truncate.json; sourceTree = "<group>"; };
@@ -4622,6 +4624,7 @@
 				82D2E81E27D10F4300169ADA /* StreamMockServer.swift */,
 				82E4CBDF27F322EA0013B02D /* User.swift */,
 				82E4CBDB27F240C60013B02D /* WebsocketResponses.swift */,
+				826992C72900628500D2D470 /* DeviceRemoteControl.swift */,
 			);
 			path = MockServer;
 			sourceTree = "<group>";
@@ -9769,6 +9772,7 @@
 				A3A0C9B3283E955200B18DA4 /* EventResponses.swift in Sources */,
 				A3A0C9A1283E955200B18DA4 /* ChannelResponses.swift in Sources */,
 				A3A0C9A9283E955200B18DA4 /* MessageResponses.swift in Sources */,
+				826992C82900628500D2D470 /* DeviceRemoteControl.swift in Sources */,
 				A3A0C9AD283E955200B18DA4 /* MessageList.swift in Sources */,
 				A3A0C9B1283E955200B18DA4 /* LaunchArgument.swift in Sources */,
 				A3A0C9B0283E955200B18DA4 /* StreamMockServer.swift in Sources */,

--- a/StreamChatUITestsApp/StreamChat/StreamChatWrapper+TestApp.swift
+++ b/StreamChatUITestsApp/StreamChat/StreamChatWrapper+TestApp.swift
@@ -13,6 +13,12 @@ import StreamChatUI
 extension StreamChatWrapper {
     
     func setUpChat() {
+        // Set the log level
+        LogConfig.level = .debug
+        LogConfig.formatters = [
+            PrefixLogFormatter(prefixes: [.info: "ℹ️", .debug: "🛠", .warning: "⚠️", .error: "🚨"])
+        ]
+        
         var config = ChatClientConfig(apiKey: .init(apiKeyString))
         config.isLocalStorageEnabled = settings.isLocalStorageEnabled.isOn
         config.staysConnectedInBackground = settings.staysConnectedInBackground.isOn

--- a/StreamChatUITestsAppUITests/Pages/SpringBoard.swift
+++ b/StreamChatUITestsAppUITests/Pages/SpringBoard.swift
@@ -8,15 +8,18 @@ import XCTest
 enum SpringBoard {
     static var bundleId = "com.apple.springboard"
     
-    static var notificationBanner: XCUIElement {
+    static var app: XCUIApplication {
         XCUIApplication(bundleIdentifier: bundleId)
-            .otherElements["Notification"]
-            .descendants(matching: .any)
-            .matching(NSPredicate(format: "label CONTAINS[c] ', now,'"))
-            .firstMatch
     }
     
-    static var appIcon: XCUIElement {
-        return XCUIApplication(bundleIdentifier: bundleId).icons["Chat UI Tests"]
+    static var notificationBanner: XCUIElement {
+        app.otherElements["Notification"]
+           .descendants(matching: .any)
+           .matching(NSPredicate(format: "label CONTAINS[c] ', now,'"))
+           .firstMatch
+    }
+    
+    static var testAppIcon: XCUIElement {
+        app.icons["Chat UI Tests"]
     }
 }

--- a/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
@@ -177,7 +177,7 @@ extension UserRobot {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> Self {
-        let messageCell = messageCell(withIndex: messageCellIndex, file: file, line: line)
+        let messageCell = messageCell(withIndex: messageCellIndex, file: file, line: line).wait()
         let message = attributes.text(in: messageCell).wait()
         let actualText = message.waitForText(text).text
         XCTAssertEqual(text, actualText, file: file, line: line)
@@ -225,7 +225,7 @@ extension UserRobot {
         line: UInt = #line
     ) -> Self {
         SpringBoard.notificationBanner.wait()
-        let appIconValue = SpringBoard.appIcon.value as? String
+        let appIconValue = SpringBoard.testAppIcon.value as? String
         XCTAssertEqual(appIconValue?.contains("1"),
                        shouldBeVisible,
                        "Badge should be visible: \(shouldBeVisible)",
@@ -321,7 +321,7 @@ extension UserRobot {
         let messageCell = messageCell(withIndex: messageCellIndex, file: file, line: line)
         let message = attributes.text(in: messageCell).wait()
         let expectedMessage = attributes.deletedMessagePlaceholder
-        let actualMessage = message.waitForText(expectedMessage).text
+        let actualMessage = message.wait().waitForText(expectedMessage).text
         XCTAssertEqual(expectedMessage, actualMessage, "Text is wrong", file: file, line: line)
         return self
     }

--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -37,10 +37,10 @@ final class UserRobot: Robot {
         
         // TODO: CIS-1737
         if !cells.firstMatch.exists {
-            for _ in 0...5 {
+            for _ in 0...10 {
                 server.stop()
                 app.terminate()
-                server.start(port: in_port_t(MockServerConfiguration.port))
+                _ = server.start(port: in_port_t(MockServerConfiguration.port))
                 sleep(1)
                 app.launch()
                 login()

--- a/StreamChatUITestsAppUITests/Tests/Base TestCase/StreamTestCase.swift
+++ b/StreamChatUITestsAppUITests/Tests/Base TestCase/StreamTestCase.swift
@@ -14,7 +14,7 @@ class StreamTestCase: XCTestCase {
     var backendRobot: BackendRobot!
     var participantRobot: ParticipantRobot!
     var server: StreamMockServer!
-    let recordVideo = false
+    var recordVideo = false
 
     override func setUpWithError() throws {
         continueAfterFailure = false

--- a/StreamChatUITestsAppUITests/Tests/Base TestCase/StreamTestCase.swift
+++ b/StreamChatUITestsAppUITests/Tests/Base TestCase/StreamTestCase.swift
@@ -14,12 +14,11 @@ class StreamTestCase: XCTestCase {
     var backendRobot: BackendRobot!
     var participantRobot: ParticipantRobot!
     var server: StreamMockServer!
+    let recordVideo = false
 
     override func setUpWithError() throws {
         continueAfterFailure = false
-        server = StreamMockServer()
-        server.configure()
-        server.start(port: in_port_t(MockServerConfiguration.port))
+        startMockServer()
         participantRobot = ParticipantRobot(server)
         backendRobot = BackendRobot(server)
         userRobot = UserRobot(server)
@@ -27,11 +26,13 @@ class StreamTestCase: XCTestCase {
         try super.setUpWithError()
         alertHandler()
         useMockServer()
+        startVideo()
         app.launch()
     }
 
     override func tearDownWithError() throws {
-        takeElementTree()
+        attachElementTree()
+        stopVideo()
         app.terminate()
         server.stop()
         server = nil
@@ -57,7 +58,7 @@ extension StreamTestCase {
         ])
     }
     
-    private func takeElementTree() {
+    private func attachElementTree() {
         let attachment = XCTAttachment(string: app.debugDescription)
         attachment.lifetime = .deleteOnSuccess
         add(attachment)
@@ -73,5 +74,38 @@ extension StreamTestCase {
             }
             return false
         }
+    }
+    
+    private func startMockServer() {
+        server = StreamMockServer()
+        server.configure()
+        let result = server.start(port: in_port_t(MockServerConfiguration.port))
+        if !result {
+            XCTFail("Mock server failed on start")
+        }
+    }
+    
+    private func startVideo() {
+        if recordVideo {
+            server.recordVideo(name: testName)
+        }
+    }
+    
+    private func stopVideo() {
+        if recordVideo {
+            server.recordVideo(name: testName, delete: !isTestFailed(), stop: true)
+        }
+    }
+    
+    private func isTestFailed() -> Bool {
+        if let testRun = testRun {
+            let failureCount = testRun.failureCount + testRun.unexpectedExceptionCount
+            return failureCount > 0
+        }
+        return false
+    }
+    
+    private var testName: String {
+        String(name.split(separator: " ")[1].dropLast())
     }
 }

--- a/StreamChatUITestsAppUITests/Tests/PushNotification_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/PushNotification_Tests.swift
@@ -22,10 +22,8 @@ final class PushNotification_Tests: StreamTestCase {
         }
     }
     
-    func test_goToBackgroundFromMessageList_and_tapOnPushNotification() throws {
+    func test_pushNotificationFromMessageList() throws {
         linkToScenario(withId: 95)
-        
-        throw XCTSkip("This test is flaky at the moment")
         
         GIVEN("user goes to message list") {
             userRobot.login().openChannel()
@@ -33,10 +31,8 @@ final class PushNotification_Tests: StreamTestCase {
         checkHappyPath(message: message, sender: sender)
     }
     
-    func test_goToBackgroundFromChannelList_and_tapOnPushNotification() throws {
+    func test_pushNotificationFromChannelList() throws {
         linkToScenario(withId: 291)
-        
-        throw XCTSkip("This test is flaky at the moment")
 
         GIVEN("user goes to channel list") {
             userRobot
@@ -261,7 +257,7 @@ final class PushNotification_Tests: StreamTestCase {
             userRobot.assertPushNotification(withText: message, from: sender)
         }
         WHEN("user taps on the push notification") {
-            userRobot.tapOnPushNotification().assertMessage(message)
+            userRobot.tapOnPushNotification()
         }
         THEN("message list updates") {
             userRobot.assertMessage(message)

--- a/TestTools/StreamChatTestMockServer/MockServer/ChannelResponses.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/ChannelResponses.swift
@@ -67,9 +67,8 @@ public extension StreamMockServer {
         server.register(MockEndpoint.truncate) { [weak self] request in
             self?.channelTruncation(request)
         }
-        server.register(MockEndpoint.sync) { request in
-            // TODO:
-            .ok(.json([JSONKey.events: []]))
+        server.register(MockEndpoint.sync) { [weak self] _ in
+            self?.handleSyncRequest()
         }
     }
 
@@ -205,6 +204,11 @@ public extension StreamMockServer {
         }
 
         return updateChannelMembers(request, ids: type.ids, eventType: type.eventType)
+    }
+    
+    // TODO: CIS-2230
+    private func handleSyncRequest() -> HttpResponse? {
+        .ok(.json([JSONKey.events: []]))
     }
 
     private func updateChannelMembers(_ request: HttpRequest,

--- a/TestTools/StreamChatTestMockServer/MockServer/ChannelResponses.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/ChannelResponses.swift
@@ -67,6 +67,10 @@ public extension StreamMockServer {
         server.register(MockEndpoint.truncate) { [weak self] request in
             self?.channelTruncation(request)
         }
+        server.register(MockEndpoint.sync) { request in
+            // TODO:
+            .ok(.json([JSONKey.events: []]))
+        }
     }
 
     func channelIndex(withId id: String) -> Int? {

--- a/TestTools/StreamChatTestMockServer/MockServer/DeviceRemoteControl.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/DeviceRemoteControl.swift
@@ -1,0 +1,55 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+public extension StreamMockServer {
+    
+    func pushNotification(
+        senderName: String,
+        text: String,
+        messageId: String,
+        cid: String,
+        targetBundleId: String
+    ) {
+        var json: [String: Any]
+        if pushNotificationPayload.isEmpty {
+            json = TestData.toJson(.pushNotification)
+            var aps = json[APNSKey.aps] as? [String: Any]
+            var alert = aps?[APNSKey.alert] as? [String: Any]
+            alert?[APNSKey.title] = "New message from \(senderName)"
+            alert?[APNSKey.body] = text
+            aps?[APNSKey.alert] = alert
+            json[APNSKey.aps] = aps
+            
+            var stream = json[APNSKey.stream] as? [String: Any]
+            stream?[APNSKey.messageId] = messageId
+            stream?[APNSKey.cid] = cid
+            json[APNSKey.stream] = stream
+        } else {
+            json = pushNotificationPayload
+        }
+        
+        let udid = ProcessInfo.processInfo.environment["SIMULATOR_UDID"] ?? ""
+        let urlString = "\(MockServerConfiguration.httpHost):4567/push/\(udid)/\(targetBundleId)"
+        guard let url = URL(string: urlString) else { return }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = json.jsonToString().data(using: .utf8)
+        URLSession.shared.dataTask(with: request).resume()
+    }
+    
+    func recordVideo(name: String, delete: Bool = false, stop: Bool = false) {
+        let json: [String: Any] = ["delete": delete, "stop": stop]
+        let udid = ProcessInfo.processInfo.environment["SIMULATOR_UDID"] ?? ""
+        let urlString = "\(MockServerConfiguration.httpHost):4567/record_video/\(udid)/\(name)"
+        guard let url = URL(string: urlString) else { return }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = json.jsonToString().data(using: .utf8)
+        URLSession.shared.dataTask(with: request).resume()
+    }
+}

--- a/TestTools/StreamChatTestMockServer/MockServer/MessageResponses.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/MessageResponses.swift
@@ -120,41 +120,6 @@ public extension StreamMockServer {
         return mockedMessage
     }
     
-    func pushNotification(
-        senderName: String,
-        text: String,
-        messageId: String,
-        cid: String,
-        targetBundleId: String
-    ) {
-        var json: [String: Any]
-        if pushNotificationPayload.isEmpty {
-            json = TestData.toJson(.pushNotification)
-            var aps = json[APNSKey.aps] as? [String: Any]
-            var alert = aps?[APNSKey.alert] as? [String: Any]
-            alert?[APNSKey.title] = "New message from \(senderName)"
-            alert?[APNSKey.body] = text
-            aps?[APNSKey.alert] = alert
-            json[APNSKey.aps] = aps
-            
-            var stream = json[APNSKey.stream] as? [String: Any]
-            stream?[APNSKey.messageId] = messageId
-            stream?[APNSKey.cid] = cid
-            json[APNSKey.stream] = stream
-        } else {
-            json = pushNotificationPayload
-        }
-        
-        let udid = ProcessInfo.processInfo.environment["SIMULATOR_UDID"] ?? ""
-        let urlString = "\(MockServerConfiguration.httpHost):4567/push/\(udid)/\(targetBundleId)"
-        guard let url = URL(string: urlString) else { return }
-        
-        var request = URLRequest(url: url)
-        request.httpMethod = EndpointMethod.post.rawValue
-        request.httpBody = json.jsonToString().data(using: .utf8)
-        URLSession.shared.dataTask(with: request).resume()
-    }
-    
     private func messageUpdate(_ request: HttpRequest) throws -> HttpResponse {
         let messageId = try XCTUnwrap(request.params[EndpointQuery.messageId])
         let message = findMessageById(messageId)
@@ -192,6 +157,10 @@ public extension StreamMockServer {
         
         switch attachmentAction {
         case JSONKey.AttachmentAction.send:
+            var attachments = message?[messageKey.attachments.rawValue] as? [[String: Any]]
+            attachments?[0][GiphyAttachmentSpecificCodingKeys.actions.rawValue] = nil
+            message?[messageKey.attachments.rawValue] = attachments
+            
             sendWebsocketMessages(
                 httpMessage: message,
                 messageText: "",

--- a/TestTools/StreamChatTestMockServer/MockServer/MockServerAttributes.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/MockServerAttributes.swift
@@ -59,6 +59,7 @@ public enum MockEndpoint {
     public static let image = "/channels/messaging/\(EndpointQuery.channelId)/image"
     public static let file = "/channels/messaging/\(EndpointQuery.channelId)/file"
     public static let truncate = "/channels/messaging/\(EndpointQuery.channelId)/truncate"
+    public static let sync = "/sync"
 }
 
 public enum EndpointQuery {
@@ -72,6 +73,7 @@ public enum JSONKey {
     public static let message = "message"
     public static let reaction = "reaction"
     public static let event = "event"
+    public static let events = "events"
     public static let channels = "channels"
     public static let user = "user"
     public static let userId = "user_id"

--- a/TestTools/StreamChatTestMockServer/MockServer/StreamMockServer.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/StreamMockServer.swift
@@ -30,12 +30,14 @@ public final class StreamMockServer {
 
     public init() {}
 
-    public func start(port: UInt16) {
+    public func start(port: UInt16) -> Bool {
         do {
             try server.start(port)
             print("Server status: \(server.state). Port: \(port)")
+            return true
         } catch {
             print("Server start error: \(error)")
+            return false
         }
     }
     

--- a/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
+++ b/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
@@ -15,6 +15,7 @@
     {
       "selectedTests" : [
         "APIClient_Tests\/test_startingMultipleRequestsAtTheSameTimeShouldResultInParallelRequests()",
+        "APIClient_Tests\/test_runningARequestAndSwitchingToRecoveryMode()",
         "ChannelController_Tests\/test_createCall_propagatesResultFromUpdater()",
         "ChannelUpdater_Tests\/test_hideChannel_successfulResponse_isPropagatedToCompletion()",
         "MessageSender_Tests\/test_senderSendsMessage_inTheOrderTheyWereCreatedLocally()",

--- a/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
@@ -28,6 +28,7 @@
     {
       "skippedTests" : [
         "APIClient_Tests\/test_startingMultipleRequestsAtTheSameTimeShouldResultInParallelRequests()",
+        "APIClient_Tests\/test_runningARequestAndSwitchingToRecoveryMode()",
         "ChannelController_Tests\/test_createCall_propagatesResultFromUpdater()",
         "ChannelListPayload_Tests\/test_decode_bigChannelListPayload()",
         "ChannelListPayload_Tests\/test_hugeChannelListQuery_save()",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -483,14 +483,14 @@ lane :test_e2e_mock do |options|
   ios = options[:ios]
   device = ios && ios != 'latest' ? "#{options[:device]} (#{ios})" : options[:device]
   build_for_testing = is_ci && options[:cron].nil?
-  number_of_retries = options[:cron] ? 2 : 1
 
   scan_options = {
     project: 'StreamChat.xcodeproj',
     scheme: 'StreamChatUITestsApp',
     testplan: 'StreamChatUITestsApp',
+    result_bundle: true,
     devices: device,
-    number_of_retries: number_of_retries
+    number_of_retries: 3 # TODO: CIS-1737
   }
   scan(scan_options.merge(clean: true, build_for_testing: build_for_testing))
 

--- a/fastlane/sinatra.rb
+++ b/fastlane/sinatra.rb
@@ -1,7 +1,37 @@
 require 'sinatra'
+require 'fileutils'
 
 post '/push/:udid/:bundle_id' do
   push_data_file = 'push_payload.json'
   File.open(push_data_file, 'w') { |f| f.write(request.body.read) }
   puts `xcrun simctl push #{params['udid']} #{params['bundle_id']} #{push_data_file}`
+end
+
+post '/record_video/:udid/:test_name' do
+  recordings_dir = 'recordings'
+  video_base_name = "#{recordings_dir}/#{params['test_name']}"
+  recordings = (0..Dir["#{recordings_dir}/*"].length + 1).to_a
+  body = JSON.parse(request.body.read)
+  FileUtils.mkdir_p(recordings_dir)
+
+  video_file = ''
+  if body['delete']
+    recordings.reverse_each do |i|
+      video_file = "#{video_base_name}_#{i}.mp4"
+      break if File.exist?(video_file)
+    end
+  else
+    recordings.each do |i|
+      video_file = "#{video_base_name}_#{i}.mp4"
+      break unless File.exist?(video_file)
+    end
+  end
+
+  if body['stop']
+    simctl_processes = `pgrep simctl`.strip.split("\n")
+    simctl_processes.each { |pid| `kill -s SIGINT #{pid}` }
+    File.delete(video_file) if body['delete'] && File.exist?(video_file)
+  else
+    puts `xcrun simctl io #{params['udid']} recordVideo --codec h264 --force #{video_file} &`
+  end
 end


### PR DESCRIPTION
### 🔗 Issue Links

- https://stream-io.atlassian.net/browse/CIS-2215

### 🎯 Goal

- Create a way to attach logs and video recordings of the failed tests to have a better idea of the failures

### 📝 Summary

- Video attachments are collected via custom implementation using `sinatra`, the same way as we automated push notification testing
- Log attachments are collected via `xcparse` tool
- Both logs and videos can be found in the `Summary` section of the failed Github Actions run
- Small refactoring was done of the testing framework and the mock server (required for SwiftUI repo)
- Bump retry count due to `CIS-1737`, unfortunately, it's getting flakier
- Github Actions warnings were resolved:
    - `cache` and `checkout` actions versions were bumped
    - `set-output` method was transformed to `$GITHUB_OUTPUT` variable

### 🎨 Showcase

<img width="294" alt="Screen Shot 2022-10-21 at 11 43 38 AM" src="https://user-images.githubusercontent.com/20794991/197179611-fd63d430-0062-4edd-9652-a655836b0c4c.png">
<img width="736" alt="Screen Shot 2022-10-21 at 11 52 07 AM" src="https://user-images.githubusercontent.com/20794991/197179618-4833ac8b-6d2b-4bf5-9c56-39359da643e1.png">


- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/reMzJR9xsmGvC/giphy.gif)
