### PR TITLE
[CIS-2179] Add support for bypassing the messages and replies data source

### DIFF
--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -63,15 +63,15 @@ open class ChatChannelVC: _ViewController,
         messageListVC.listView.isLastCellFullyVisible
     }
 
-    /// A closure to filter messages and override the message list data source.
-    public var messagesFilter: ((ChatMessage) -> Bool)?
+    /// A closure to bypass the message list channel data source.
+    public var messagesBypass: (([ChatMessage]) -> [ChatMessage])?
 
     private var isLoadingPreviousMessages: Bool = false
 
     override open func setUp() {
         super.setUp()
 
-        messagesFilter = components.messagesFilter
+        messagesBypass = components.messagesBypass
 
         let notificationCenter = NotificationCenter.default
         notificationCenter.addObserver(
@@ -162,15 +162,15 @@ open class ChatChannelVC: _ViewController,
 
     /// The messages data source.
     public var messages: [ChatMessage] {
+        get {
+            _messages
+        }
         set {
-            if let messagesFilter = messagesFilter {
-                _messages = newValue.filter(messagesFilter)
+            if let messagesBypass = messagesBypass {
+                _messages = messagesBypass(newValue)
                 return
             }
             _messages = newValue
-        }
-        get {
-            _messages
         }
     }
     
@@ -274,8 +274,8 @@ open class ChatChannelVC: _ViewController,
         }
 
         let newMessages: [ChatMessage]
-        if let messagesFilter = messagesFilter {
-            newMessages = channelController.messages.filter(messagesFilter)
+        if let messagesBypass = messagesBypass {
+            newMessages = messagesBypass(Array(channelController.messages))
         } else {
             newMessages = Array(channelController.messages)
         }

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -274,15 +274,19 @@ open class ChatChannelVC: _ViewController,
         }
 
         let newMessages: [ChatMessage]
-        if let messagesBypass = messagesBypass {
+        let newChanges: [ListChange<ChatMessage>]
+        if let messagesBypass = self.messagesBypass {
             newMessages = messagesBypass(Array(channelController.messages))
+            let messageIds = Set(newMessages.map(\.id))
+            newChanges = changes.filter { messageIds.contains($0.item.id) }
         } else {
             newMessages = Array(channelController.messages)
+            newChanges = changes
         }
 
         messageListVC.setPreviousMessagesSnapshot(messages)
         messageListVC.setNewMessagesSnapshot(newMessages)
-        messageListVC.updateMessages(with: changes)
+        messageListVC.updateMessages(with: newChanges)
     }
 
     open func channelController(

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -53,8 +53,8 @@ open class ChatThreadVC: _ViewController,
 
     public var messageComposerBottomConstraint: NSLayoutConstraint?
 
-    /// A closure to filter replies and override the message list data source.
-    public var repliesFilter: ((ChatMessage) -> Bool)?
+    /// A closure to bypass the message list thread data source.
+    public var repliesBypass: (([ChatMessage]) -> [ChatMessage])?
 
     private var isLoadingPreviousMessages: Bool = false
 
@@ -63,7 +63,7 @@ open class ChatThreadVC: _ViewController,
     override open func setUp() {
         super.setUp()
 
-        repliesFilter = components.repliesFilter
+        repliesBypass = components.repliesBypass
 
         let notificationCenter = NotificationCenter.default
         notificationCenter.addObserver(
@@ -157,15 +157,15 @@ open class ChatThreadVC: _ViewController,
 
     // The replies data source.
     public var messages: [ChatMessage] {
+        get {
+            replies
+        }
         set {
-            if let repliesFilter = repliesFilter {
-                replies = newValue.filter(repliesFilter)
+            if let repliesBypass = repliesBypass {
+                replies = repliesBypass(newValue)
                 return
             }
             replies = newValue
-        }
-        get {
-            replies
         }
     }
 
@@ -334,8 +334,8 @@ open class ChatThreadVC: _ViewController,
 
         let messages = getRepliesWithThreadRootMessage(from: messageController)
         let newMessages: [ChatMessage]
-        if let repliesFilter = repliesFilter {
-            newMessages = messages.filter(repliesFilter)
+        if let repliesBypass = repliesBypass {
+            newMessages = repliesBypass(messages)
         } else {
             newMessages = messages
         }

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -330,18 +330,22 @@ open class ChatThreadVC: _ViewController,
     }
 
     private func updateMessages(with changes: [ListChange<ChatMessage>]) {
-        messageListVC.setPreviousMessagesSnapshot(self.messages)
-
         let messages = getRepliesWithThreadRootMessage(from: messageController)
+
         let newMessages: [ChatMessage]
+        let newChanges: [ListChange<ChatMessage>]
         if let repliesBypass = repliesBypass {
             newMessages = repliesBypass(messages)
+            let messageIds = Set(newMessages.map(\.id))
+            newChanges = changes.filter { messageIds.contains($0.item.id) }
         } else {
             newMessages = messages
+            newChanges = changes
         }
 
+        messageListVC.setPreviousMessagesSnapshot(self.messages)
         messageListVC.setNewMessagesSnapshot(newMessages)
-        messageListVC.updateMessages(with: changes)
+        messageListVC.updateMessages(with: newChanges)
     }
 
     private func getRepliesWithThreadRootMessage(from messageController: ChatMessageController) -> [ChatMessage] {

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -103,6 +103,9 @@ public struct Components {
 
     /// A closure to filter messages and override the message list channel data source.
     public var messagesFilter: ((ChatMessage) -> Bool)?
+
+    /// A closure to filter replies and override the message list thread data source.
+    public var repliesFilter: ((ChatMessage) -> Bool)?
     
     /// The controller that handles `ChatMessageListVC <-> ChatMessagePopUp` transition.
     public var messageActionsTransitionController: ChatMessageActionsTransitionController.Type =

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -100,6 +100,9 @@ public struct Components {
     /// Used in both the Channel and Thread view controllers.
     @available(iOSApplicationExtension, unavailable)
     public var messageListVC: ChatMessageListVC.Type = ChatMessageListVC.self
+
+    /// A closure to filter messages and override the message list channel data source.
+    public var messagesFilter: ((ChatMessage) -> Bool)?
     
     /// The controller that handles `ChatMessageListVC <-> ChatMessagePopUp` transition.
     public var messageActionsTransitionController: ChatMessageActionsTransitionController.Type =

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -101,11 +101,11 @@ public struct Components {
     @available(iOSApplicationExtension, unavailable)
     public var messageListVC: ChatMessageListVC.Type = ChatMessageListVC.self
 
-    /// A closure to filter messages and override the message list channel data source.
-    public var messagesFilter: ((ChatMessage) -> Bool)?
+    /// A closure to bypass the message list channel data source.
+    public var messagesBypass: (([ChatMessage]) -> [ChatMessage])?
 
-    /// A closure to filter replies and override the message list thread data source.
-    public var repliesFilter: ((ChatMessage) -> Bool)?
+    /// A closure to bypass the message list thread data source.
+    public var repliesBypass: (([ChatMessage]) -> [ChatMessage])?
     
     /// The controller that handles `ChatMessageListVC <-> ChatMessagePopUp` transition.
     public var messageActionsTransitionController: ChatMessageActionsTransitionController.Type =

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
@@ -549,6 +549,24 @@ final class ChatChannelVC_Tests: XCTestCase {
 
         AssertSnapshot(vc, variants: [.defaultLight])
     }
+
+    // MARK: - Messages Bypass
+
+    func test_messagesBypass_shouldOverrideChannelDataSource() {
+        /// Empty case
+        vc.messagesBypass = { _ in [] }
+        vc.messages = [.mock(), .mock(), .mock()]
+        XCTAssertEqual(vc.messages.count, 0)
+
+        /// Regular case
+        vc.messagesBypass = { messages in messages.filter(\.isBounced) }
+        vc.messages = [.mock(isBounced: false), .mock(isBounced: true), .mock(isBounced: true)]
+        XCTAssertEqual(vc.messages.count, 2)
+    }
+
+    func test_messagesBypass_whenDidChangeMessages_shouldOverrideNewSnapshot_shouldOverrideChanges() {
+        XCTFail()
+    }
 }
 
 private extension ChatChannelVC_Tests {

--- a/Tests/StreamChatUITests/SnapshotTests/ChatThread/ChatThreadVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatThread/ChatThreadVC_Tests.swift
@@ -99,4 +99,23 @@ final class ChatThreadVC_Tests: XCTestCase {
         XCTAssertTrue(vc.messageListVC.listView is TestMessageListView)
         XCTAssertTrue(vc.messageComposerVC.composerView is TestComposerView)
     }
+
+    // MARK: - Replies Bypass
+
+    func test_repliesBypass_shouldOverrideThreadDataSource() {
+        /// Empty case
+        vc.repliesBypass = { _ in [] }
+        vc.messages = [.mock(), .mock(), .mock()]
+        XCTAssertEqual(vc.messages.count, 0)
+
+        /// Regular case
+        vc.repliesBypass = { messages in messages.filter(\.isBounced) }
+        vc.messages = [.mock(isBounced: false), .mock(isBounced: true), .mock(isBounced: true)]
+        XCTAssertEqual(vc.messages.count, 2)
+    }
+
+    func test_repliesBypass_whenDidChangeReplies_shouldOverrideNewSnapshot_shouldOverrideChanges() {
+        // vc.messageController(ChatMessageController_Mock.mock(), didChangeReplies: [])
+        XCTFail()
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links
CIS-2179
https://github.com/GetStream/stream-chat-swift/issues/2305

### 🎯 Goal
Add support for bypassing the messages and replies data source.

### 🛠 Implementation
Provide a `Components.messagesBypass` and `Components.repliesBypass` to be able to override the message list data source. It is also possible to change directly inside the `ChatThreadVC` and `ChatChannelVC`.

TODO:
- [ ] Add DemoApp example to test this
- [ ] Finish test coverage
- [ ] Refactor and reuse some logic between Thread and Channel

Limitations:
- The pagination number won't be respected. If the pagination is 25 by 25, for example, since the filter happens after fetching from the DB. If the bypass removes 2 messages, it will be loading 23, and not 25. Either way, the same thing happens already when hiding deleted messages on the client side.

### 🧪 Manual Testing Notes
TODO: Add an example in the DemoApp

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)