### PR TITLE
[CIS-651] Extract failing snapshots from CI

### DIFF
--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -89,6 +89,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2.5.0
     - uses: ./.github/actions/bootstrap
+      env:
+        INSTALL_XCPARSE: true
     - name: Run UI Tests (Debug)
       run: bundle exec fastlane test_ui device:"${{ env.IOS_SIMULATOR_DEVICE }}"
       timeout-minutes: 25
@@ -97,6 +99,15 @@ jobs:
         GITHUB_EVENT: ${{ toJson(github.event) }}
         IOS_SIMULATOR_DEVICE: "iPhone 12 Pro (15.5)"
         XCODE_VERSION: "13.4.1"
+    - name: Parse xcresult
+      if: failure()
+      run: xcparse screenshots fastlane/test_output/StreamChatUI.xcresult fastlane/test_output/snapshots --test
+    - uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: Test Data
+        path: |
+          fastlane/test_output/snapshots
 
   build-and-test-e2e-debug:
     name: Test E2E UI (Debug)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -534,6 +534,7 @@ lane :test_ui do |options|
     scheme: 'StreamChatUI',
     testplan: 'StreamChatUITestPlan',
     clean: true,
+    result_bundle: true,
     devices: options[:device],
     build_for_testing: options[:build_for_testing]
   )


### PR DESCRIPTION
### 🔗 Issue Links

- https://stream-io.atlassian.net/browse/CIS-651

### 🎯 Goal

- Extract failing snapshots from CI 

### 🛠 Implementation

- Parse `xcresult` via `xcparse` and grab the snapshots
- [Example](https://github.com/GetStream/stream-chat-swift/actions/runs/3319910374)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/pslmyy93fH2JboH8qB/giphy.gif)
