### PR TITLE
Ban/Unban Demo App Example + Expose `EntityChange.item`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### ✅ Added
 - Added support for Stream's Image CDN v2 [#2339](https://github.com/GetStream/stream-chat-swift/pull/2339)
+- Expose `EntityChange.item` [#2351](https://github.com/GetStream/stream-chat-swift/pull/2351)
 
 ### 🐞 Fixed
 - Fix CurrentChatUserController+Combine initialValue hard coded to `.noUnread` instead of using the initial value from the current user data model [#2334](https://github.com/GetStream/stream-chat-swift/pull/2334)

--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -193,6 +193,40 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
                 } ?? []
                 self.rootViewController.presentAlert(title: "Select a member", actions: actions)
             }),
+            .init(title: "Ban member", style: .default, handler: { [unowned self] _ in
+                let actions = channelController.channel?.lastActiveMembers.map { member in
+                    UIAlertAction(title: member.id, style: .default) { _ in
+                        channelController.client
+                            .memberController(userId: member.id, in: channelController.cid!)
+                            .ban() { error in
+                                if let error = error {
+                                    self.rootViewController.presentAlert(
+                                        title: "Couldn't ban user \(member.id) from channel \(cid)",
+                                        message: "\(error)"
+                                    )
+                                }
+                            }
+                    }
+                } ?? []
+                self.rootViewController.presentAlert(title: "Select a member", actions: actions)
+            }),
+            .init(title: "Unban member", style: .default, handler: { [unowned self] _ in
+                let actions = channelController.channel?.lastActiveMembers.map { member in
+                    UIAlertAction(title: member.id, style: .default) { _ in
+                        channelController.client
+                            .memberController(userId: member.id, in: channelController.cid!)
+                            .unban() { error in
+                                if let error = error {
+                                    self.rootViewController.presentAlert(
+                                        title: "Couldn't unban user \(member.id) from channel \(cid)",
+                                        message: "\(error)"
+                                    )
+                                }
+                            }
+                    }
+                } ?? []
+                self.rootViewController.presentAlert(title: "Select a member", actions: actions)
+            }),
             .init(title: "Freeze channel", style: .default, handler: { [unowned self] _ in
                 channelController.freezeChannel { error in
                     if let error = error {

--- a/Sources/StreamChat/Controllers/EntityDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/EntityDatabaseObserver.swift
@@ -33,7 +33,7 @@ extension EntityChange: CustomStringConvertible {
 
 extension EntityChange {
     /// Returns the underlaying item that was changed
-    var item: Item {
+    public var item: Item {
         switch self {
         case let .create(item):
             return item


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
While testing Ban and Unban issues, there was no way to test this in the Demo App, so this PR introduces that capability.
Also, it exposes the `EntityChange.item` property so that it is easier to access the model which the entity change represents.

### 🧪 Manual Testing Notes
- Open a channel
- Tap on Debug icon
- Ban a member
- Unban a member
- Should not have any alert error

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)