### PR TITLE
Package.swift: Update macOS deployment target to v11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     name: "StreamChat",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v11), .macOS(.v10_15)
+        .iOS(.v11), .macOS(.v11)
     ],
     products: [
         .library(


### PR DESCRIPTION
when running for macOS, as depended on through stream-chat-swiftui, the following error comes up

```
error: the library 'StreamChatTestMockServer' requires macos 10.15, but depends on the product 'StreamChatTestHelpers' which requires macos 11.0; consider changing the library 'StreamChatTestMockServer' to require macos 11.0 or later, or the product 'StreamChatTestHelpers' to require macos 10.15 or earlier.
error: the library 'StreamChatTestTools' requires macos 10.15, but depends on the product 'StreamChatTestHelpers' which requires macos 11.0; consider changing the library 'StreamChatTestTools' to require macos 11.0 or later, or the product 'StreamChatTestHelpers' to require macos 10.15 or earlier.
```

this should make it possible for the dependencies to resolve on macOS

### 🔗 Issue Links

_Provide all Jira tickets and/or Github issues related to this PR, if applicable._

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
