### PR TITLE
[CIS-2234, CIS-2239, CIS-1727, CIS-2172] Improve Authentication Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ _October 27, 2022_
 - Fix CurrentChatUserController+Combine initialValue hard coded to `.noUnread` instead of using the initial value from the current user data model [#2334](https://github.com/GetStream/stream-chat-swift/pull/2334)
 - Allow Message Search pagination when using sort parameters [#2347](https://github.com/GetStream/stream-chat-swift/pull/2347)
 - Fix TokenProvider sometimes being invoked two times when token is expired [#2337](https://github.com/GetStream/stream-chat-swift/pull/2347)
+- Add timeout for token/connectionId providers so that `ChatClient.connect()` completes even in edge cases where we cannot get the needed data [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
+- Stop spamming the console with "Socket is not connected" error when token is being refreshed [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
+- Update documentation around `CurrentUserController.currentUser` to state that a non-nil value does not mean there is a valid authentication [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
+- Allow flow where `ChatClient.setToken()` is called before `ChatClient.connect()` [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
+- Properly recover from a missing/expired token on the first execution of `TokenProvider` [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
+- Fix data races created by `AsyncOperation` looped execution when refreshing tokens [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
 
 ## StreamChatUI
 ### ✅ Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Add timeout for token/connectionId providers so that `ChatClient.connect()` completes even in edge cases where we cannot get the needed data [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
+- Stop spamming the console with "Socket is not connected" error when token is being refreshed [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
+- Update documentation around `CurrentUserController.currentUser` to state that a non-nil value does not mean there is a valid authentication [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
+- Allow flow where `ChatClient.setToken()` is called before `ChatClient.connect()` [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
+- Properly recover from a missing/expired token on the first execution of `TokenProvider` [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
+- Fix data races created by `AsyncOperation` looped execution when refreshing tokens [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
 
 # [4.23.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.23.0)
 _October 27, 2022_
@@ -17,12 +24,6 @@ _October 27, 2022_
 - Fix CurrentChatUserController+Combine initialValue hard coded to `.noUnread` instead of using the initial value from the current user data model [#2334](https://github.com/GetStream/stream-chat-swift/pull/2334)
 - Allow Message Search pagination when using sort parameters [#2347](https://github.com/GetStream/stream-chat-swift/pull/2347)
 - Fix TokenProvider sometimes being invoked two times when token is expired [#2337](https://github.com/GetStream/stream-chat-swift/pull/2347)
-- Add timeout for token/connectionId providers so that `ChatClient.connect()` completes even in edge cases where we cannot get the needed data [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
-- Stop spamming the console with "Socket is not connected" error when token is being refreshed [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
-- Update documentation around `CurrentUserController.currentUser` to state that a non-nil value does not mean there is a valid authentication [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
-- Allow flow where `ChatClient.setToken()` is called before `ChatClient.connect()` [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
-- Properly recover from a missing/expired token on the first execution of `TokenProvider` [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
-- Fix data races created by `AsyncOperation` looped execution when refreshing tokens [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
 
 ## StreamChatUI
 ### ✅ Added

--- a/DemoApp/DemoAppConfiguration.swift
+++ b/DemoApp/DemoAppConfiguration.swift
@@ -29,6 +29,7 @@ enum DemoAppConfiguration {
     static func setInternalConfiguration() {
         StreamRuntimeCheck.assertionsEnabled = isStreamInternalConfiguration
         StreamRuntimeCheck._isBackgroundMappingEnabled = isStreamInternalConfiguration
+        AppConfig.shared.demoAppConfig.isTokenRefreshEnabled = isStreamInternalConfiguration
 
         configureAtlantisIfNeeded()
     }

--- a/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
+++ b/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
@@ -11,6 +11,8 @@ struct DemoAppConfig {
     var isHardDeleteEnabled: Bool
     /// A Boolean value to define if Atlantis will be started to proxy HTTP and WebSocket calls.
     var isAtlantisEnabled: Bool
+    /// A Boolean value to define if we should mimic token refresh scenarios
+    var isTokenRefreshEnabled: Bool
 }
 
 class AppConfig {
@@ -23,7 +25,8 @@ class AppConfig {
         // Default DemoAppConfig
         demoAppConfig = DemoAppConfig(
             isHardDeleteEnabled: false,
-            isAtlantisEnabled: false
+            isAtlantisEnabled: false,
+            isTokenRefreshEnabled: false
         )
     }
 }

--- a/DemoApp/Shared/StreamChatWrapper.swift
+++ b/DemoApp/Shared/StreamChatWrapper.swift
@@ -43,9 +43,17 @@ extension StreamChatWrapper {
     func connect(user: DemoUserType, completion: @escaping (Error?) -> Void) {
         switch user {
         case let .credentials(userCredentials):
+            guard AppConfig.shared.demoAppConfig.isTokenRefreshEnabled else {
+                client?.connectUser(
+                    userInfo: userCredentials.userInfo,
+                    token: userCredentials.token,
+                    completion: completion
+                )
+                return
+            }
             client?.connectUser(
                 userInfo: userCredentials.userInfo,
-                token: userCredentials.token,
+                tokenProvider: refreshingTokenProvider(initialToken: userCredentials.token, tokenDurationInMinutes: 60),
                 completion: completion
             )
         case let .guest(userId):

--- a/DemoApp/Shared/Token+Development.swift
+++ b/DemoApp/Shared/Token+Development.swift
@@ -1,0 +1,5 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import Foundation

--- a/DemoApp/Shared/Token+Development.swift
+++ b/DemoApp/Shared/Token+Development.swift
@@ -2,6 +2,9 @@
 // Copyright © 2022 Stream.io Inc. All rights reserved.
 //
 
+import Foundation
+import StreamChat
+
 extension StreamChatWrapper {
     func refreshingTokenProvider(initialToken: Token, tokenDurationInMinutes: Double) -> TokenProvider {
         { completion in
@@ -16,7 +19,7 @@ extension StreamChatWrapper {
                     expirationDate: Date().addingTimeInterval(timeInterval)
                 )
                 if generatedToken == nil {
-                    print("Unable to generate token. Falling back to initialToken")
+                    log.warning("Unable to generate token. Falling back to initialToken")
                 }
                 token = generatedToken ?? initialToken
                 #else

--- a/DemoApp/Shared/Token+Development.swift
+++ b/DemoApp/Shared/Token+Development.swift
@@ -2,4 +2,78 @@
 // Copyright © 2022 Stream.io Inc. All rights reserved.
 //
 
+extension StreamChatWrapper {
+    func refreshingTokenProvider(initialToken: Token, tokenDurationInMinutes: Double) -> TokenProvider {
+        { completion in
+            // Simulate API call delay
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                let token: Token
+                #if GENERATE_JWT
+                let timeInterval = TimeInterval(tokenDurationInMinutes * 60)
+                let generatedToken = _generateUserToken(
+                    secret: appSecret,
+                    userID: initialToken.userId,
+                    expirationDate: Date().addingTimeInterval(timeInterval)
+                )
+                if generatedToken == nil {
+                    print("Unable to generate token. Falling back to initialToken")
+                }
+                token = generatedToken ?? initialToken
+                #else
+                token = initialToken
+                #endif
+                completion(.success(token))
+            }
+        }
+    }
+}
+
+#if GENERATE_JWT
+
+import CryptoKit
 import Foundation
+import StreamChat
+
+let appSecret = ""
+
+extension Data {
+    func urlSafeBase64EncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+struct Header: Encodable {
+    let alg = "HS256"
+    let typ = "JWT"
+}
+
+struct JWTPayload: Encodable {
+    let user_id: String
+    let exp: Int
+}
+
+// DO NOT USE THIS FOR REAL APPS! This function is only here to make it easier to
+// have expired token renewal while using the standalone demo application
+func _generateUserToken(secret: String, userID: String, expirationDate: Date) -> Token? {
+    guard !secret.isEmpty else { return nil }
+    let privateKey = SymmetricKey(data: secret.data(using: .utf8)!)
+
+    guard let headerJSONData = try? JSONEncoder().encode(Header()) else { return nil }
+    let headerBase64String = headerJSONData.urlSafeBase64EncodedString()
+
+    let expiration = Int(expirationDate.timeIntervalSince1970)
+    guard let payloadJSONData = try? JSONEncoder().encode(JWTPayload(user_id: userID, exp: expiration)) else { return nil }
+    let payloadBase64String = payloadJSONData.urlSafeBase64EncodedString()
+
+    let toSign = (headerBase64String + "." + payloadBase64String).data(using: .utf8)!
+    let signature = HMAC<SHA256>.authenticationCode(for: toSign, using: privateKey)
+    let signatureBase64String = Data(signature).urlSafeBase64EncodedString()
+
+    let token = [headerBase64String, payloadBase64String, signatureBase64String].joined(separator: ".")
+    return try? Token(rawValue: token)
+}
+
+#endif

--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -198,7 +198,7 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
                     UIAlertAction(title: member.id, style: .default) { _ in
                         channelController.client
                             .memberController(userId: member.id, in: channelController.cid!)
-                            .ban() { error in
+                            .ban { error in
                                 if let error = error {
                                     self.rootViewController.presentAlert(
                                         title: "Couldn't ban user \(member.id) from channel \(cid)",
@@ -215,7 +215,7 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
                     UIAlertAction(title: member.id, style: .default) { _ in
                         channelController.client
                             .memberController(userId: member.id, in: channelController.cid!)
-                            .unban() { error in
+                            .unban { error in
                                 if let error = error {
                                     self.rootViewController.presentAlert(
                                         title: "Couldn't unban user \(member.id) from channel \(cid)",

--- a/Sources/StreamChat/APIClient/APIClient.swift
+++ b/Sources/StreamChat/APIClient/APIClient.swift
@@ -172,7 +172,8 @@ class APIClient {
         completion: @escaping (Result<Response, Error>) -> Void
     ) {
         if tokenRefreshConsecutiveFailures > maximumTokenRefreshAttempts {
-            return completion(.failure(ClientError.TooManyTokenRefreshAttempts()))
+            completion(.failure(ClientError.TooManyTokenRefreshAttempts()))
+            return
         }
 
         guard !isRefreshingToken else {

--- a/Sources/StreamChat/APIClient/RequestEncoder.swift
+++ b/Sources/StreamChat/APIClient/RequestEncoder.swift
@@ -62,7 +62,6 @@ extension RequestEncoder {
 struct DefaultRequestEncoder: RequestEncoder {
     let baseURL: URL
     let apiKey: APIKey
-    let timerType: Timer.Type
 
     /// The most probable reason why a RequestEncoder can timeout when waiting for token or connectionId is because there's no connection.
     /// When returning an error, it will just fail without giving an opportunity to know if the timeout occurred because of a networking problem.
@@ -116,13 +115,8 @@ struct DefaultRequestEncoder: RequestEncoder {
     }
 
     init(baseURL: URL, apiKey: APIKey) {
-        self.init(baseURL: baseURL, apiKey: apiKey, timerType: DefaultTimer.self)
-    }
-
-    init(baseURL: URL, apiKey: APIKey, timerType: Timer.Type) {
         self.baseURL = baseURL
         self.apiKey = apiKey
-        self.timerType = timerType
     }
     
     // MARK: - Private

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -62,6 +62,7 @@ public class CurrentChatUserController: DataController, DelegateCallable, DataSt
     
     /// The currently logged-in user. `nil` if the connection hasn't been fully established yet, or the connection
     /// wasn't successful.
+    /// Having a non-nil currentUser does not mean the user is authenticated. Make sure to call `connect()` before performing any API call.
     public var currentUser: CurrentChatUser? {
         startObservingIfNeeded()
         return currentUserObserver.item

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -109,12 +109,17 @@ public class CurrentChatUserController: DataController, DelegateCallable, DataSt
         // Unlike the other DataControllers, this one does not make a remote call when synchronising.
         // But we can assume that if we wait for the connection of the WebSocket, it means the local data
         // is in sync with the remote server, so we can set the state to remoteDataFetched.
-        client.provideConnectionId { connectionId in
+        client.provideConnectionId { result in
             var error: ClientError?
-            if connectionId == nil {
+            if case .failure = result {
                 error = ClientError.ConnectionNotSuccessful()
             }
-            self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(error!)
+
+            // ConnectionId updates might come in a different thread than the main one. In order to ensure data consistency
+            // for `state`, we move this to the main thread
+            DispatchQueue.main.async {
+                self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(error!)
+            }
             self.callback { completion?(error) }
         }
     }

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -109,18 +109,14 @@ public class CurrentChatUserController: DataController, DelegateCallable, DataSt
         // Unlike the other DataControllers, this one does not make a remote call when synchronising.
         // But we can assume that if we wait for the connection of the WebSocket, it means the local data
         // is in sync with the remote server, so we can set the state to remoteDataFetched.
-        client.provideConnectionId { result in
+        client.provideConnectionId { [weak self] result in
             var error: ClientError?
             if case .failure = result {
                 error = ClientError.ConnectionNotSuccessful()
             }
 
-            // ConnectionId updates might come in a different thread than the main one. In order to ensure data consistency
-            // for `state`, we move this to the main thread
-            DispatchQueue.main.async {
-                self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(error!)
-            }
-            self.callback { completion?(error) }
+            self?.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(error!)
+            self?.callback { completion?(error) }
         }
     }
     

--- a/Sources/StreamChat/Errors/ClientError.swift
+++ b/Sources/StreamChat/Errors/ClientError.swift
@@ -68,6 +68,11 @@ extension ClientError: Equatable {
 }
 
 extension ClientError {
+    /// Returns `true` the stream code determines that the token is expired.
+    var isExpiredTokenError: Bool {
+        (underlyingError as? ErrorPayload)?.isExpiredTokenError == true
+    }
+
     /// Returns `true` if underlaying error is `ErrorPayload` with code is inside invalid token codes range.
     var isInvalidTokenError: Bool {
         (underlyingError as? ErrorPayload)?.isInvalidTokenError == true

--- a/Sources/StreamChat/Errors/ErrorPayload.swift
+++ b/Sources/StreamChat/Errors/ErrorPayload.swift
@@ -29,7 +29,7 @@ public struct ErrorPayload: LocalizedError, Codable, CustomDebugStringConvertibl
 }
 
 /// https://getstream.io/chat/docs/ios-swift/api_errors_response/
-private enum StreamCode {
+private enum StreamErrorCode {
     static let bouncedMessage = 73
     /// Usually returned when trying to perform an API call without a token.
     static let accessKeyInvalid = 2
@@ -42,12 +42,12 @@ private enum StreamCode {
 extension ErrorPayload {
     /// Returns `true` if the code determines that the token is expired.
     var isExpiredTokenError: Bool {
-        code == StreamCode.expiredToken
+        code == StreamErrorCode.expiredToken
     }
 
     /// Returns `true` if code is within invalid token codes range.
     var isInvalidTokenError: Bool {
-        ClosedRange.tokenInvalidErrorCodes ~= code || code == StreamCode.accessKeyInvalid
+        ClosedRange.tokenInvalidErrorCodes ~= code || code == StreamErrorCode.accessKeyInvalid
     }
     
     /// Returns `true` if status code is within client error codes range.
@@ -57,13 +57,13 @@ extension ErrorPayload {
     
     /// Returns `true` if internal status code is related to a moderation bouncing error.
     var isBouncedMessageError: Bool {
-        code == StreamCode.bouncedMessage
+        code == StreamErrorCode.bouncedMessage
     }
 }
 
 extension ClosedRange where Bound == Int {
     /// The error codes for token-related errors. Typically, a refreshed token is required to recover.
-    static let tokenInvalidErrorCodes: Self = StreamCode.expiredToken...StreamCode.invalidTokenSignature
+    static let tokenInvalidErrorCodes: Self = StreamErrorCode.expiredToken...StreamErrorCode.invalidTokenSignature
     
     /// The range of HTTP request status codes for client errors.
     static let clientErrorCodes: Self = 400...499

--- a/Sources/StreamChat/Errors/ErrorPayload.swift
+++ b/Sources/StreamChat/Errors/ErrorPayload.swift
@@ -31,6 +31,8 @@ public struct ErrorPayload: LocalizedError, Codable, CustomDebugStringConvertibl
 /// https://getstream.io/chat/docs/ios-swift/api_errors_response/
 private enum StreamCode {
     static let bouncedMessage = 73
+    /// Usually returned when trying to perform an API call without a token.
+    static let accessKeyInvalid = 2
     static let expiredToken = 40
     static let notYetValidToken = 41
     static let invalidTokenDate = 42
@@ -43,12 +45,12 @@ extension ErrorPayload {
         code == StreamCode.expiredToken
     }
 
-    /// Returns `true` if code is withing invalid token codes range.
+    /// Returns `true` if code is within invalid token codes range.
     var isInvalidTokenError: Bool {
-        ClosedRange.tokenInvalidErrorCodes ~= code
+        ClosedRange.tokenInvalidErrorCodes ~= code || code == StreamCode.accessKeyInvalid
     }
     
-    /// Returns `true` if status code is withing client error codes range.
+    /// Returns `true` if status code is within client error codes range.
     var isClientError: Bool {
         ClosedRange.clientErrorCodes ~= statusCode
     }

--- a/Sources/StreamChat/Errors/ErrorPayload.swift
+++ b/Sources/StreamChat/Errors/ErrorPayload.swift
@@ -28,11 +28,21 @@ public struct ErrorPayload: LocalizedError, Codable, CustomDebugStringConvertibl
     }
 }
 
+/// https://getstream.io/chat/docs/ios-swift/api_errors_response/
+private enum StreamCode {
+    static let bouncedMessage = 73
+    static let expiredToken = 40
+    static let notYetValidToken = 41
+    static let invalidTokenDate = 42
+    static let invalidTokenSignature = 43
+}
+
 extension ErrorPayload {
-    private enum ErrorCodes: Int {
-        case bouncedMessage = 73
+    /// Returns `true` if the code determines that the token is expired.
+    var isExpiredTokenError: Bool {
+        code == StreamCode.expiredToken
     }
-    
+
     /// Returns `true` if code is withing invalid token codes range.
     var isInvalidTokenError: Bool {
         ClosedRange.tokenInvalidErrorCodes ~= code
@@ -45,13 +55,13 @@ extension ErrorPayload {
     
     /// Returns `true` if internal status code is related to a moderation bouncing error.
     var isBouncedMessageError: Bool {
-        code == ErrorCodes.bouncedMessage.rawValue
+        code == StreamCode.bouncedMessage
     }
 }
 
 extension ClosedRange where Bound == Int {
     /// The error codes for token-related errors. Typically, a refreshed token is required to recover.
-    static let tokenInvalidErrorCodes: Self = 40...43
+    static let tokenInvalidErrorCodes: Self = StreamCode.expiredToken...StreamCode.invalidTokenSignature
     
     /// The range of HTTP request status codes for client errors.
     static let clientErrorCodes: Self = 400...499

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -137,16 +137,10 @@ class AuthenticationRepository {
             }
         }
 
-        tokenRetryTimer = timerType.schedule(
-            timeInterval: tokenExpirationRetryStrategy.getDelayAfterTheFailure(),
-            queue: .main
-        ) { [weak self] in
-            log.debug("Firing timer for a new token request", subsystems: .authentication)
-            self?.getToken(userInfo: nil, tokenProvider: tokenProviderCheckingSuccess, completion: completion)
-        }
+        scheduleTokenFetch(userInfo: nil, tokenProvider: tokenProviderCheckingSuccess, completion: completion)
     }
 
-    private func getToken(userInfo: UserInfo?, tokenProvider: @escaping TokenProvider, completion: @escaping (Error?) -> Void) {
+    private func scheduleTokenFetch(userInfo: UserInfo?, tokenProvider: @escaping TokenProvider, completion: @escaping (Error?) -> Void) {
         tokenRequestCompletions.append(completion)
         guard !isGettingToken else {
             log.debug("Trying to get a token while already getting one", subsystems: .authentication)
@@ -155,7 +149,20 @@ class AuthenticationRepository {
 
         isGettingToken = true
 
+        tokenRetryTimer = timerType.schedule(
+            timeInterval: tokenExpirationRetryStrategy.getDelayAfterTheFailure(),
+            queue: .main
+        ) { [weak self] in
+            log.debug("Firing timer for a new token request", subsystems: .authentication)
+            self?.getToken(userInfo: nil, tokenProvider: tokenProvider) { _ in
+                self?.isGettingToken = false
+            }
+        }
+    }
+
+    private func getToken(userInfo: UserInfo?, tokenProvider: @escaping TokenProvider, completion: @escaping (Error?) -> Void) {
         log.debug("Requesting a new token", subsystems: .authentication)
+        tokenRequestCompletions.append(completion)
         clientUpdater.reloadUserIfNeeded(userInfo: userInfo, tokenProvider: tokenProvider) { [weak self] error in
             if let error = error {
                 log.error("Error when getting token: \(error)", subsystems: .authentication)
@@ -164,7 +171,6 @@ class AuthenticationRepository {
             }
             let completionBlocks: [(Error?) -> Void]? = self?.tokenRequestCompletions
             completionBlocks?.forEach { $0(error) }
-            self?.isGettingToken = false
         }
     }
 

--- a/Sources/StreamChat/Utils/InternetConnection/Error+InternetNotAvailable.swift
+++ b/Sources/StreamChat/Utils/InternetConnection/Error+InternetNotAvailable.swift
@@ -40,4 +40,8 @@ extension Error {
         }
         return false
     }
+
+    var isSocketNotConnectedError: Bool {
+        has(parameters: (NSPOSIXErrorDomain, 57))
+    }
 }

--- a/Sources/StreamChat/WebSocketClient/Engine/URLSessionWebSocketEngine.swift
+++ b/Sources/StreamChat/WebSocketClient/Engine/URLSessionWebSocketEngine.swift
@@ -82,7 +82,11 @@ class URLSessionWebSocketEngine: NSObject, WebSocketEngine {
                 self.doRead()
                 
             case let .failure(error):
-                log.error("Failed receiving Web Socket Message with error: \(error)", subsystems: .webSocket)
+                if error.isSocketNotConnectedError {
+                    log.debug("Web Socket got disconnected with error: \(error)", subsystems: .webSocket)
+                } else {
+                    log.error("Failed receiving Web Socket Message with error: \(error)", subsystems: .webSocket)
+                }
             }
         }
     }

--- a/Sources/StreamChat/Workers/ChatClientUpdater.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater.swift
@@ -127,10 +127,11 @@ class ChatClientUpdater {
         }
 
         // Set up a waiter for the new connection id to know when the connection process is finished
-        client.provideConnectionId { [weak client] connectionId in
-            if connectionId != nil {
+        client.provideConnectionId { [weak client] result in
+            switch result {
+            case .success:
                 completion?(nil)
-            } else {
+            case .failure:
                 // Try to get a concrete error
                 if case let .disconnected(source) = client?.webSocketClient?.connectionState {
                     completion?(ClientError.ConnectionNotSuccessful(with: source.serverError))

--- a/Sources/StreamChat/Workers/ChatClientUpdater.swift
+++ b/Sources/StreamChat/Workers/ChatClientUpdater.swift
@@ -39,12 +39,6 @@ class ChatClientUpdater {
 
         case .newToken:
             client.updateWebSocketEndpoint(with: newToken, userInfo: userInfo)
-
-            guard newToken != client.currentToken else {
-                completion(nil)
-                return
-            }
-
             client.updateUser(with: newToken, completeTokenWaiters: true, isFirstConnection: false)
             completion(nil)
 

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1714,6 +1714,10 @@
 		C1E8AD58278C8A6F0041B775 /* SyncRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E8AD55278C8A440041B775 /* SyncRepository.swift */; };
 		C1E8AD5E278EF5F30041B775 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E8AD5B278DDEC70041B775 /* AsyncOperation.swift */; };
 		C1E8AD5F278EF5F40041B775 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E8AD5B278DDEC70041B775 /* AsyncOperation.swift */; };
+		C1ED2BFF291401D4005AFA82 /* AppConfigViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD6BEFF127862F9300E184B4 /* AppConfigViewController.swift */; };
+		C1ED2C00291401E7005AFA82 /* Token+Development.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B15A1329115E8D00C9CD80 /* Token+Development.swift */; };
+		C1ED2C01291401F7005AFA82 /* SwitchButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD6BEFEF2786070800E184B4 /* SwitchButton.swift */; };
+		C1ED2C0229140202005AFA82 /* OptionsSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD75CB6A27886746005F5FF7 /* OptionsSelectorViewController.swift */; };
 		C1EE53A727BA53F300B1A6CA /* Endpoint_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1EE53A627BA53F300B1A6CA /* Endpoint_Tests.swift */; };
 		C1EE53A927BA662B00B1A6CA /* QueuedRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1EE53A827BA662B00B1A6CA /* QueuedRequestDTO.swift */; };
 		C1EE53AA27BA662B00B1A6CA /* QueuedRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1EE53A827BA662B00B1A6CA /* QueuedRequestDTO.swift */; };
@@ -9803,11 +9807,15 @@
 				A36F997A2818459C0078260D /* InternetConnectionMonitor_Mock.swift in Sources */,
 				84AD17E028F8582C008C69BF /* DemoUsers.swift in Sources */,
 				A34407BD27D8C33F0044F150 /* AppDelegate.swift in Sources */,
+				C1ED2C0229140202005AFA82 /* OptionsSelectorViewController.swift in Sources */,
 				84A33ABC28F86BBB00CEC8FD /* StreamChatWrapper+TestApp.swift in Sources */,
+				C1ED2BFF291401D4005AFA82 /* AppConfigViewController.swift in Sources */,
+				C1ED2C01291401F7005AFA82 /* SwitchButton.swift in Sources */,
 				84AD17DD28F85701008C69BF /* PushNotifications.swift in Sources */,
 				84AD17E128F85870008C69BF /* ChatUser+CustomFields.swift in Sources */,
 				84AD17DE28F8572F008C69BF /* UserDefaults+Shared.swift in Sources */,
 				8440860F28FBFEE10027849C /* DemoAppCoordinator+TestApp.swift in Sources */,
+				C1ED2C00291401E7005AFA82 /* Token+Development.swift in Sources */,
 				84AD17DC28F853B0008C69BF /* DemoAppCoordinator.swift in Sources */,
 				A3813B4E2825C8A30076E838 /* ThreadVC.swift in Sources */,
 				84AD17DF28F857A5008C69BF /* StreamChatWrapper.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1703,6 +1703,7 @@
 		C1B0B38427BFC08900C8207D /* EndpointPath+OfflineRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B0B38227BFC08800C8207D /* EndpointPath+OfflineRequest.swift */; };
 		C1B0B38627BFE8AB00C8207D /* MessageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B0B38527BFE8AB00C8207D /* MessageRepository.swift */; };
 		C1B0B38727BFE8AB00C8207D /* MessageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B0B38527BFE8AB00C8207D /* MessageRepository.swift */; };
+		C1B15A1429115E8D00C9CD80 /* Token+Development.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B15A1329115E8D00C9CD80 /* Token+Development.swift */; };
 		C1B49B3B282283C100F4E89E /* GDPerformanceView-Swift in Frameworks */ = {isa = PBXBuildFile; productRef = C1B49B3A282283C100F4E89E /* GDPerformanceView-Swift */; };
 		C1B49B3D2822A7AD00F4E89E /* StreamRuntimeCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B49B3C2822A7AD00F4E89E /* StreamRuntimeCheck.swift */; };
 		C1B49B3E2822A7AD00F4E89E /* StreamRuntimeCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B49B3C2822A7AD00F4E89E /* StreamRuntimeCheck.swift */; };
@@ -3431,6 +3432,7 @@
 		C19B9C3127D0FB0800D308C0 /* EndpointPath_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndpointPath_Tests.swift; sourceTree = "<group>"; };
 		C1B0B38227BFC08800C8207D /* EndpointPath+OfflineRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EndpointPath+OfflineRequest.swift"; sourceTree = "<group>"; };
 		C1B0B38527BFE8AB00C8207D /* MessageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRepository.swift; sourceTree = "<group>"; };
+		C1B15A1329115E8D00C9CD80 /* Token+Development.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Token+Development.swift"; sourceTree = "<group>"; };
 		C1B49B3C2822A7AD00F4E89E /* StreamRuntimeCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamRuntimeCheck.swift; sourceTree = "<group>"; };
 		C1B49B3F2822C01C00F4E89E /* NSManagedObject+Validation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Validation.swift"; sourceTree = "<group>"; };
 		C1BE72762732CB7B006EB51E /* ImageViewExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageViewExtensions.swift; sourceTree = "<group>"; };
@@ -4724,6 +4726,7 @@
 				7933064825712C8B00FBB586 /* DemoUsers.swift */,
 				A3227EC8284A52EE00EBE6CC /* PushNotifications.swift */,
 				A3227E64284A4A5C00EBE6CC /* StreamChatWrapper.swift */,
+				C1B15A1329115E8D00C9CD80 /* Token+Development.swift */,
 				A31783DC285B79EB005009B9 /* Bundle+PushProvider.swift */,
 				43016E1526B734410054E805 /* ChatUser+CustomFields.swift */,
 			);
@@ -9061,6 +9064,7 @@
 				A3227E7A284A4CE000EBE6CC /* DemoChatChannelListVC.swift in Sources */,
 				792DDA5E256FB69E001DB91B /* LoginViewController.swift in Sources */,
 				792DDAA825753BEA001DB91B /* CreateGroupViewController.swift in Sources */,
+				C1B15A1429115E8D00C9CD80 /* Token+Development.swift in Sources */,
 				7933064925712C8B00FBB586 /* DemoUsers.swift in Sources */,
 				792DDA5A256FB69E001DB91B /* AppDelegate.swift in Sources */,
 				792DDAA125711AF2001DB91B /* CreateChatViewController.swift in Sources */,

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/ConnectionDetailsProviderDelegate_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/ConnectionDetailsProviderDelegate_Spy.swift
@@ -20,25 +20,31 @@ final class ConnectionDetailsProviderDelegate_Spy: ConnectionDetailsProviderDele
         tokenWaiters.removeAll()
     }
 
-    func provideConnectionId(timeout: TimeInterval, completion: @escaping (StreamChat.ConnectionId?) -> Void) {
+    func provideConnectionId(timeout: TimeInterval, completion: @escaping (Result<StreamChat.ConnectionId, Error>) -> Void) {
         let waiterToken = String.newUniqueId
+        let valueCompletion: (StreamChat.ConnectionId?) -> Void = { value in
+            completion(value.map { .success($0) } ?? .failure(ClientError.WaiterTimeout()))
+        }
         _connectionWaiters.mutate {
-            $0[waiterToken] = completion
+            $0[waiterToken] = valueCompletion
         }
 
         if let connectionId = connectionId {
-            completion(connectionId)
+            completion(.success(connectionId))
         }
     }
 
-    func provideToken(timeout: TimeInterval, completion: @escaping (StreamChat.Token?) -> Void) {
+    func provideToken(timeout: TimeInterval, completion: @escaping (Result<StreamChat.Token, Error>) -> Void) {
         let waiterToken = String.newUniqueId
+        let valueCompletion: (StreamChat.Token?) -> Void = { value in
+            completion(value.map { .success($0) } ?? .failure(ClientError.WaiterTimeout()))
+        }
         _tokenWaiters.mutate {
-            $0[waiterToken] = completion
+            $0[waiterToken] = valueCompletion
         }
 
         if let token = token {
-            completion(token)
+            completion(.success(token))
         }
     }
 

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/ConnectionDetailsProviderDelegate_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/ConnectionDetailsProviderDelegate_Spy.swift
@@ -23,7 +23,7 @@ final class ConnectionDetailsProviderDelegate_Spy: ConnectionDetailsProviderDele
     func provideConnectionId(timeout: TimeInterval, completion: @escaping (Result<StreamChat.ConnectionId, Error>) -> Void) {
         let waiterToken = String.newUniqueId
         let valueCompletion: (StreamChat.ConnectionId?) -> Void = { value in
-            completion(value.map { .success($0) } ?? .failure(ClientError.WaiterTimeout()))
+            completion(value.map { .success($0) } ?? .failure(ClientError.MissingConnectionId()))
         }
         _connectionWaiters.mutate {
             $0[waiterToken] = valueCompletion
@@ -37,7 +37,7 @@ final class ConnectionDetailsProviderDelegate_Spy: ConnectionDetailsProviderDele
     func provideToken(timeout: TimeInterval, completion: @escaping (Result<StreamChat.Token, Error>) -> Void) {
         let waiterToken = String.newUniqueId
         let valueCompletion: (StreamChat.Token?) -> Void = { value in
-            completion(value.map { .success($0) } ?? .failure(ClientError.WaiterTimeout()))
+            completion(value.map { .success($0) } ?? .failure(ClientError.MissingToken()))
         }
         _tokenWaiters.mutate {
             $0[waiterToken] = valueCompletion

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/ConnectionDetailsProviderDelegate_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/ConnectionDetailsProviderDelegate_Spy.swift
@@ -20,7 +20,7 @@ final class ConnectionDetailsProviderDelegate_Spy: ConnectionDetailsProviderDele
         tokenWaiters.removeAll()
     }
 
-    func provideConnectionId(completion: @escaping (ConnectionId?) -> Void) -> WaiterToken {
+    func provideConnectionId(timeout: TimeInterval, completion: @escaping (StreamChat.ConnectionId?) -> Void) {
         let waiterToken = String.newUniqueId
         _connectionWaiters.mutate {
             $0[waiterToken] = completion
@@ -29,10 +29,9 @@ final class ConnectionDetailsProviderDelegate_Spy: ConnectionDetailsProviderDele
         if let connectionId = connectionId {
             completion(connectionId)
         }
-        return waiterToken
     }
 
-    func provideToken(completion: @escaping (Token?) -> Void) -> WaiterToken {
+    func provideToken(timeout: TimeInterval, completion: @escaping (StreamChat.Token?) -> Void) {
         let waiterToken = String.newUniqueId
         _tokenWaiters.mutate {
             $0[waiterToken] = completion
@@ -41,7 +40,6 @@ final class ConnectionDetailsProviderDelegate_Spy: ConnectionDetailsProviderDele
         if let token = token {
             completion(token)
         }
-        return waiterToken
     }
 
     func invalidateTokenWaiter(_ waiter: WaiterToken) {}

--- a/Tests/StreamChatTests/APIClient/RequestEncoder_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/RequestEncoder_Tests.swift
@@ -117,45 +117,6 @@ final class RequestEncoder_Tests: XCTestCase {
         AssertAsync.willBeTrue(encodingResult?.error is ClientError.MissingToken)
     }
 
-    func test_endpointRequiringToken_ifTokenProviderTimeouts() throws {
-        // Prepare a new endpoint.
-        let endpoint = Endpoint<Data>(
-            path: .guest,
-            method: .get,
-            requiresConnectionId: false,
-            requiresToken: true
-        )
-
-        // Reset the token.
-        connectionDetailsProvider.token = nil
-
-        let connectionDetailsProviderDelegate = encoder.connectionDetailsProviderDelegate
-        encoder = DefaultRequestEncoder(baseURL: baseURL, apiKey: apiKey, timerType: VirtualTimeTimer.self)
-        encoder.connectionDetailsProviderDelegate = connectionDetailsProviderDelegate
-
-        // Encode the request and capture the result
-        var receivedRequest: URLRequest?
-        let expectation = self.expectation(description: "Encoding Request Completes")
-        encoder.encodeRequest(for: endpoint) {
-            receivedRequest = try? $0.get()
-            expectation.fulfill()
-        }
-
-        AssertAsync.willBeTrue(VirtualTimeTimer.time.scheduledTimers.count == 1)
-
-        // We execute the timeout timer
-        VirtualTimeTimer.time.scheduledTimers.first.map { $0.callback($0) }
-
-        waitForExpectations(timeout: 0.5, handler: nil)
-        guard let request = receivedRequest else {
-            XCTFail("We should have received a request here")
-            return
-        }
-
-        // When we timeout, we succeed but with a request that does not contain the token
-        XCTAssertNil(request.allHTTPHeaderFields?["Stream-Auth-Type"])
-    }
-    
     func test_endpointRequiringConnectionId_hasCorrectQueryItems_ifConnectionIdIsProvided() throws {
         // Prepare an endpoint that requires connection id
         let endpoint = Endpoint<Data>(
@@ -202,46 +163,6 @@ final class RequestEncoder_Tests: XCTestCase {
 
         // Assert request encoding has failed.
         AssertAsync.willBeTrue(encodingResult?.error is ClientError.MissingConnectionId)
-    }
-
-    func test_endpointRequiringConnectionId_ifTokenProviderTimeouts() throws {
-        // Prepare a new endpoint.
-        let endpoint = Endpoint<Data>(
-            path: .guest,
-            method: .get,
-            requiresConnectionId: true,
-            requiresToken: false
-        )
-
-        // Reset the token.
-        connectionDetailsProvider.connectionId = nil
-
-        let connectionDetailsProviderDelegate = encoder.connectionDetailsProviderDelegate
-        encoder = DefaultRequestEncoder(baseURL: baseURL, apiKey: apiKey, timerType: VirtualTimeTimer.self)
-        encoder.connectionDetailsProviderDelegate = connectionDetailsProviderDelegate
-
-        // Encode the request and capture the result
-        var receivedRequest: URLRequest?
-        let expectation = self.expectation(description: "Encoding Request Completes")
-        encoder.encodeRequest(for: endpoint) {
-            receivedRequest = try? $0.get()
-            expectation.fulfill()
-        }
-
-        AssertAsync.willBeTrue(VirtualTimeTimer.time.scheduledTimers.count == 1)
-
-        // We execute the timeout timer
-        VirtualTimeTimer.time.scheduledTimers.first.map { $0.callback($0) }
-
-        waitForExpectations(timeout: 0.5, handler: nil)
-        guard let request = receivedRequest else {
-            XCTFail("We should have received a request here")
-            return
-        }
-
-        // When we timeout, we succeed but with a request that does not contain the connection id
-        let urlComponents = try XCTUnwrap(URLComponents(url: request.url!, resolvingAgainstBaseURL: false))
-        XCTAssertNil(urlComponents.queryItems?["connection_id"])
     }
 
     func test_endpointRequiringConnectionIdAndToken_isEncodedCorrectly_ifBothAreProvided() throws {

--- a/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
@@ -319,7 +319,7 @@ final class ChatClient_Tests: XCTestCase {
         // Set a connection Id waiter and assert it's `nil`
         var providedConnectionId: ConnectionId?
         client.provideConnectionId {
-            providedConnectionId = $0
+            providedConnectionId = $0.value
         }
         XCTAssertNil(providedConnectionId)
         
@@ -337,7 +337,7 @@ final class ChatClient_Tests: XCTestCase {
             .webSocketClient(testEnv.webSocketClient!, didUpdateConnectionState: .connected(connectionId: connectionId))
         
         AssertAsync.willBeEqual(providedConnectionId, connectionId)
-        XCTAssertEqual(try waitFor { client.provideConnectionId(completion: $0) }, connectionId)
+        XCTAssertEqual(try waitFor { client.provideConnectionId(completion: $0) }.value, connectionId)
         
         // Simulate WebSocketConnection disconnecting and assert connectionId is reset
         testEnv.webSocketClient?.connectionStateDelegate?
@@ -345,7 +345,7 @@ final class ChatClient_Tests: XCTestCase {
         
         providedConnectionId = nil
         client.provideConnectionId {
-            providedConnectionId = $0
+            providedConnectionId = $0.value
         }
         AssertAsync.staysTrue(providedConnectionId == nil)
     }
@@ -365,7 +365,7 @@ final class ChatClient_Tests: XCTestCase {
         // Set a connection Id waiter and set `providedConnectionId` to a non-nil value
         var providedConnectionId: ConnectionId? = .unique
         client.provideConnectionId {
-            providedConnectionId = $0
+            providedConnectionId = $0.value
         }
         XCTAssertNotNil(providedConnectionId)
         
@@ -462,7 +462,7 @@ final class ChatClient_Tests: XCTestCase {
             // This is to simulate the case where 2 entities call this func
             // Like, calling `synchronize` in a delegate callback
             client.provideConnectionId {
-                providedConnectionId = $0
+                providedConnectionId = $0.value
             }
         }
         XCTAssertNil(providedConnectionId)
@@ -846,8 +846,8 @@ final class ChatClient_Tests: XCTestCase {
 
         let expectation = self.expectation(description: "Token waiter")
         var providedToken: Token?
-        client.provideToken { token in
-            providedToken = token
+        client.provideToken { result in
+            providedToken = result.value
             expectation.fulfill()
         }
 
@@ -875,8 +875,8 @@ final class ChatClient_Tests: XCTestCase {
 
         let expectation = self.expectation(description: "Token waiter")
         var providedToken: Token?
-        client.provideToken { token in
-            providedToken = token
+        client.provideToken { result in
+            providedToken = result.value
             expectation.fulfill()
         }
 
@@ -901,8 +901,8 @@ final class ChatClient_Tests: XCTestCase {
         XCTAssertNil(client.currentUserId)
         XCTAssertEqual(client.backgroundWorkers.count, 0)
 
-        client.provideToken { token in
-            if token != nil {
+        client.provideToken { result in
+            if result.value != nil {
                 XCTFail("Should not complete waiters")
             }
         }
@@ -997,8 +997,8 @@ final class ChatClient_Tests: XCTestCase {
 
         let expectation = self.expectation(description: "Complete existing waiter")
         var providedToken: Token?
-        client.provideToken { token in
-            providedToken = token
+        client.provideToken { result in
+            providedToken = result.value
             expectation.fulfill()
         }
 
@@ -1011,8 +1011,8 @@ final class ChatClient_Tests: XCTestCase {
 
         client.logout()
 
-        client.provideToken { token in
-            if token != nil {
+        client.provideToken { result in
+            if result.value != nil {
                 XCTFail("Should not complete waiters for new token")
             }
         }
@@ -1050,7 +1050,7 @@ final class ChatClient_Tests: XCTestCase {
         var providedConnectionId: ConnectionId? = .unique
         var connectionIdCallbackCalled = false
         client.provideConnectionId {
-            providedConnectionId = $0
+            providedConnectionId = $0.value
             connectionIdCallbackCalled = true
         }
         

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -1062,10 +1062,10 @@ final class MessageUpdater_Tests: XCTestCase {
         messageRepository.getMessageResult = .success(.mock(id: messageId, cid: cid, text: "", author: .mock(id: currentUserId)))
 
         // Simulate `flagMessage` call.
-        var flagCompletionCalled = false
+        let expectation = self.expectation(description: "Flag message completion")
         messageUpdater.flagMessage(true, with: messageId, in: cid) { error in
             XCTAssertNil(error)
-            flagCompletionCalled = true
+            expectation.fulfill()
         }
 
         // Assert flag endpoint is called.
@@ -1088,6 +1088,8 @@ final class MessageUpdater_Tests: XCTestCase {
             flaggedMessageId: messageId
         )
         apiClient.test_simulateResponse(.success(flagMessagePayload))
+
+        waitForExpectations(timeout: 0.1)
 
         // Load the message.
         var messageDTO: MessageDTO? {


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-2234
https://stream-io.atlassian.net/browse/CIS-2239
https://stream-io.atlassian.net/browse/CIS-1727
https://stream-io.atlassian.net/browse/CIS-2172

### 🎯 Goal

Improve overall logic around Authentication

### 📝 Summary

- Make sure waiters for token and connectionId timeout after certain time to avoid never completing calls to `connect()`
- Stop spamming errors to console while we refresh tokens upon expiration
- Update documentation around `currentUser` stating that a non-nil value does not mean that it is authenticated and the token is valid
- Add a development only way to test refresh token mechanisms
- Allow calling `connect()` after calling `setToken()`. This was an issue before as it was not creating background workers.

### 🛠 Implementation

- Token/ConnectionId requests are by default agnostic of whether they need a timeout or not. This is applied on the called function itself as a mechanism to streamline this logic.
- We are now not logging errors when "Socket is not connected" error is received. This is misleading, and is returned when the token expires.

### ⏭ Next steps

- Create internal Keychain to store token so that we
    - Add public APIs to know if token is expired
- Move token/connectionId waiters logic + protocols to a place where it makes sense
- Move token attempts logic away from the APIClient and into the Authentication Repository
- Properly handle expired tokens on open (either cached logic or initial token received being expired)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/81xwEHX23zhvy/giphy.gif)