### PR TITLE
Package: update macOS to "11.0"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     name: "StreamChat",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v11), .macOS(.v10_15)
+        .iOS(.v11), .macOS("11.0")
     ],
     products: [
         .library(


### PR DESCRIPTION
this appears to still not be working: i initially offered over at https://github.com/GetStream/stream-chat-swift/pull/2357. i'm still getting this error on `develop`:

```
error: the library 'StreamChatTestMockServer' requires macos 10.15, but depends on the product 'StreamChatTestHelpers' which requires macos 11.0; consider changing the library 'StreamChatTestMockServer' to require macos 11.0 or later, or the product 'StreamChatTestHelpers' to require macos 10.15 or earlier.
```