### PR TITLE
[CIS-2264] Make sure to reload rows after moving them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Properly recover from a missing/expired token on the first execution of `TokenProvider` [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
 - Fix data races created by `AsyncOperation` looped execution when refreshing tokens [#2361](https://github.com/GetStream/stream-chat-swift/pull/2361)
 
+## StreamChatUI
+### 🐞 Fixed
+- Fix issue where cell content would not be updated when order changes in Channel List [#2371](https://github.com/GetStream/stream-chat-swift/pull/2371)
+
 # [4.23.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.23.0)
 _October 27, 2022_
 

--- a/Sources/StreamChatUI/Utils/ListChangeUpdater/CollectionViewListChangeUpdater.swift
+++ b/Sources/StreamChatUI/Utils/ListChangeUpdater/CollectionViewListChangeUpdater.swift
@@ -2,7 +2,6 @@
 // Copyright © 2022 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
 import StreamChat
 import UIKit
 
@@ -22,23 +21,6 @@ final class CollectionViewListChangeUpdater: ListChangeUpdater {
     ///   - changes: The provided changes reported by a list controller.
     ///   - completion: A callback when the changes are fully executed.
     func performUpdate<Item>(with changes: [ListChange<Item>], completion: ((_ finished: Bool) -> Void)? = nil) {
-        guard let indices = listChangeIndexPathResolver.resolve(
-            changes: changes
-        ) else {
-            collectionView?.reloadData()
-            completion?(true)
-            return
-        }
-
-        collectionView?.performBatchUpdates({
-            collectionView?.deleteItems(at: Array(indices.remove))
-            collectionView?.insertItems(at: Array(indices.insert))
-            collectionView?.reloadItems(at: Array(indices.update))
-            indices.move.forEach {
-                collectionView?.moveItem(at: $0.fromIndex, to: $0.toIndex)
-            }
-        }, completion: { finished in
-            completion?(finished)
-        })
+        performUpdate(on: collectionView, with: changes, pathResolver: listChangeIndexPathResolver, completion: completion)
     }
 }

--- a/Sources/StreamChatUI/Utils/ListChangeUpdater/ListChangeUpdater.swift
+++ b/Sources/StreamChatUI/Utils/ListChangeUpdater/ListChangeUpdater.swift
@@ -2,8 +2,8 @@
 // Copyright © 2022 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
 import StreamChat
+import UIKit
 
 /// Component responsible to process an array of `[ListChange<Item>]`'s and apply those changes to a view.
 protocol ListChangeUpdater {
@@ -22,5 +22,69 @@ extension ListChangeUpdater {
     ///   - completion: A callback when the changes are fully executed.
     func performUpdate<Item>(with changes: [ListChange<Item>], completion: ((_ finished: Bool) -> Void)? = nil) {
         performUpdate(with: changes, completion: completion)
+    }
+
+    /// Perform the data changes in the collection view.
+    /// - Parameters:
+    ///   - changes: The provided changes reported by a list controller.
+    ///   - completion: A callback when the changes are fully executed.
+    func performUpdate<Item>(
+        on view: ListReloadableView?,
+        with changes: [ListChange<Item>],
+        pathResolver: ListChangeIndexPathResolver,
+        completion: ((_ finished: Bool) -> Void)?
+    ) {
+        guard let indices = pathResolver.resolve(
+            changes: changes
+        ) else {
+            view?.reloadData()
+            completion?(true)
+            return
+        }
+
+        view?.performBatchUpdates({
+            view?.deleteItems(at: Array(indices.remove))
+            view?.insertItems(at: Array(indices.insert))
+            view?.reloadItems(at: Array(indices.update))
+            indices.move.forEach {
+                view?.moveItem(at: $0.fromIndex, to: $0.toIndex)
+            }
+        }, completion: { [weak view] finished in
+            // Move changes from NSFetchController also can mean an update of the content.
+            // Since a `moveItem` in collections do not update the content of the cell, we need to reload those cells.
+            let moveIndexes = Array(indices.move.map(\.toIndex))
+            if !moveIndexes.isEmpty {
+                view?.reloadItems(at: moveIndexes)
+            }
+            completion?(finished)
+        })
+    }
+}
+
+protocol ListReloadableView: AnyObject {
+    func reloadData()
+    func insertItems(at indexPaths: [IndexPath])
+    func reloadItems(at indexPaths: [IndexPath])
+    func deleteItems(at indexPaths: [IndexPath])
+    func moveItem(at indexPath: IndexPath, to newIndexPath: IndexPath)
+    func performBatchUpdates(_ updates: (() -> Void)?, completion: ((Bool) -> Void)?)
+}
+
+extension UICollectionView: ListReloadableView {}
+extension UITableView: ListReloadableView {
+    func insertItems(at indexPaths: [IndexPath]) {
+        insertRows(at: indexPaths, with: .none)
+    }
+
+    func reloadItems(at indexPaths: [IndexPath]) {
+        reloadRows(at: indexPaths, with: .none)
+    }
+
+    func deleteItems(at indexPaths: [IndexPath]) {
+        deleteRows(at: indexPaths, with: .none)
+    }
+
+    func moveItem(at indexPath: IndexPath, to newIndexPath: IndexPath) {
+        moveRow(at: indexPath, to: newIndexPath)
     }
 }

--- a/Sources/StreamChatUI/Utils/ListChangeUpdater/TableViewListChangeUpdater.swift
+++ b/Sources/StreamChatUI/Utils/ListChangeUpdater/TableViewListChangeUpdater.swift
@@ -2,7 +2,6 @@
 // Copyright © 2022 Stream.io Inc. All rights reserved.
 //
 
-import Foundation
 import StreamChat
 import UIKit
 
@@ -22,23 +21,6 @@ final class TableViewListChangeUpdater: ListChangeUpdater {
     ///   - changes: The provided changes reported by a list controller.
     ///   - completion: A callback when the changes are fully executed.
     func performUpdate<Item>(with changes: [ListChange<Item>], completion: ((_ finished: Bool) -> Void)? = nil) {
-        guard let indices = listChangeIndexPathResolver.resolve(
-            changes: changes
-        ) else {
-            tableView?.reloadData()
-            completion?(true)
-            return
-        }
-
-        tableView?.performBatchUpdates({
-            tableView?.deleteRows(at: Array(indices.remove), with: .none)
-            tableView?.insertRows(at: Array(indices.insert), with: .none)
-            tableView?.reloadRows(at: Array(indices.update), with: .none)
-            indices.move.forEach {
-                tableView?.moveRow(at: $0.fromIndex, to: $0.toIndex)
-            }
-        }, completion: { finished in
-            completion?(finished)
-        })
+        performUpdate(on: tableView, with: changes, pathResolver: listChangeIndexPathResolver, completion: completion)
     }
 }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -12750,7 +12750,7 @@
 			repositoryURL = "https://github.com/ProxymanApp/atlantis";
 			requirement = {
 				kind = exactVersion;
-				version = 1.17.0;
+				version = 1.18.0;
 			};
 		};
 		C1B49B39282283C100F4E89E /* XCRemoteSwiftPackageReference "GDPerformanceView-Swift" */ = {


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-2264

### 📝 Summary

UIKit does not reload rows when they are moved. This is really bad for us because when we receive a .move update, it comes with changes to the cell itself. In most of the cases, because of other events, this is not an issue. But in edge cases, the cell stays with the old state until a new event comes in.

This PR ensures that whenever those .move events come, we always update the cell just in case.

### 🛠 Implementation

- Unified logic for CollectionViewListChangeUpdater and TableViewListChangeUpdater so that we don't need to repeat the code around
- Ensured cells are reloaded after a move

### 🧪 Manual Testing Notes

1. Open the channel list
2. Send A SINGLE message to a channel that is on screen, but it is not in the first position.

Expected result:
- The channel should move to the first position
- The cell should display an updated read indicator, and the typing indicator should be gone

Previous result:
- The channel would move to the first position
- BUT the cell was displaying old information, and the typing indicator was still there

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/AuQvTyPtkZu8w/giphy.gif)
