### PR TITLE
[CIS-2243, CIS-2244] Increase Safety by making Log Out and Disconnect async operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ## StreamChat
+### 🔄 Changed
+- `logOut` and `disconnect` methods are now asynchronous. Its sync versions are deprecated [#2386](https://github.com/GetStream/stream-chat-swift/pull/2386)
+
 ### ✅ Added
 - Add support for hiding connection status with `isInvisible` [#2373](https://github.com/GetStream/stream-chat-swift/pull/2373)
 

--- a/DemoApp/SceneDelegate.swift
+++ b/DemoApp/SceneDelegate.swift
@@ -2,6 +2,7 @@
 // Copyright © 2022 Stream.io Inc. All rights reserved.
 //
 
+import StreamChat
 import UIKit
 
 extension UIColor {
@@ -68,6 +69,12 @@ extension SceneDelegate {
             chat: chat,
             pushNotifications: pushNotifications
         )
-        coordinator.start()
+        coordinator.start { error in
+            if let error = error {
+                log.error("Error starting app \(error)")
+            } else {
+                log.debug("Successfully started app")
+            }
+        }
     }
 }

--- a/DemoApp/Shared/DemoAppCoordinator.swift
+++ b/DemoApp/Shared/DemoAppCoordinator.swift
@@ -36,7 +36,13 @@ final class DemoAppCoordinator: NSObject {
                 return
             }
 
-            self?.start(cid: cid)
+            self?.start(cid: cid) { error in
+                if let error = error {
+                    log.error("Error showing channel from notification \(error)")
+                } else {
+                    log.debug("Successfully showing channel from notification")
+                }
+            }
         }
     }
     

--- a/DemoApp/Shared/StreamChatWrapper.swift
+++ b/DemoApp/Shared/StreamChatWrapper.swift
@@ -70,7 +70,7 @@ extension StreamChatWrapper {
         }
     }
 
-    func logIn(as user: DemoUserType) {
+    func logIn(as user: DemoUserType, completion: @escaping (Error?) -> Void) {
         // Setup Stream Chat
         setUpChat()
 
@@ -81,10 +81,11 @@ extension StreamChatWrapper {
             } else {
                 self?.onRemotePushRegistration?()
             }
+            completion($0)
         }
     }
 
-    func logOut() {
+    func logOut(completion: @escaping () -> Void) {
         guard let client = self.client else {
             logClientNotInstantiated()
             return
@@ -98,7 +99,7 @@ extension StreamChatWrapper {
             }
         }
 
-        client.logout()
+        client.logout(completion: completion)
         
         self.client = nil
     }

--- a/StreamChatUITestsApp/AppDelegate.swift
+++ b/StreamChatUITestsApp/AppDelegate.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 import UserNotifications
+import StreamChat
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -47,7 +48,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             chat: chat,
             pushNotifications: pushNotifications
         )
-        coordinator.start()
+        coordinator.start { error in
+            if let error = error {
+                log.error("Error starting app \(error)")
+            } else {
+                log.debug("Successfully started app")
+            }
+        }
     }
     
     func disableAnimations() {

--- a/StreamChatUITestsApp/StreamChat/DemoAppCoordinator+TestApp.swift
+++ b/StreamChatUITestsApp/StreamChat/DemoAppCoordinator+TestApp.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension DemoAppCoordinator {
     
-    func start(cid: ChannelId? = nil) {
+    func start(cid: ChannelId? = nil, completion: @escaping (Error?) -> Void) {
         if let cid = cid {
             navigateToChannel(with: cid)
         } else {
@@ -18,6 +18,7 @@ extension DemoAppCoordinator {
             let navigationController = UINavigationController(rootViewController: viewController)
             set(rootViewController: navigationController, animated: false)
         }
+        completion(nil)
     }
     
     private func navigateToChannel(with cid: ChannelId) {


### PR DESCRIPTION
### 🔗 Issue Links

https://stream-io.atlassian.net/browse/CIS-2243
https://stream-io.atlassian.net/browse/CIS-2244
https://github.com/GetStream/stream-chat-swift/issues/2381

### 🎯 Goal

Avoid race conditions or crashes originated after calling log out

### 📝 Summary

`logOut` does not finish all the "clean up" synchronously, which can potentially create issues when interacting with the SDK just after calling it.

### 🛠 Implementation

Synchronous `logOut` and `disconnect` calls are deprecated in favour of its asynchronous version

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/pkfWxD1OWjwhnpF2Rb/giphy.gif)
