### PR TITLE
[CIS-2287] Fix connecting user with non-expiring tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Add support for hiding connection status with `isInvisible` [#2373](https://github.com/GetStream/stream-chat-swift/pull/2373)
 
+### 🐞 Fixed
+- Fix connecting user with non-expiring tokens [#2393](https://github.com/GetStream/stream-chat-swift/pull/2393)
+
 # [4.24.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.24.1)
 _November 23, 2022_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add support for hiding connection status with `isInvisible` [#2373](https://github.com/GetStream/stream-chat-swift/pull/2373)
 
 ### 🐞 Fixed
-- Fix connecting user with non-expiring tokens [#2393](https://github.com/GetStream/stream-chat-swift/pull/2393)
+- Fix connecting user with non-expiring tokens (ex: development token) [#2393](https://github.com/GetStream/stream-chat-swift/pull/2393)
 
 # [4.24.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.24.1)
 _November 23, 2022_

--- a/Sources/StreamChat/Config/Token.swift
+++ b/Sources/StreamChat/Config/Token.swift
@@ -57,7 +57,7 @@ public extension Token {
     ///
     /// Is used by `anonymous` token provider.
     static var anonymous: Self {
-        .init(rawValue: "", userId: .anonymous, expiration: .distantFuture)
+        .init(rawValue: "", userId: .anonymous, expiration: nil)
     }
 
     /// The token which can be used during the development.
@@ -72,7 +72,7 @@ public extension Token {
 
         let jwt = [header, payload, devSignature].joined(separator: ".")
             
-        return .init(rawValue: jwt, userId: userId, expiration: .distantFuture)
+        return .init(rawValue: jwt, userId: userId, expiration: nil)
     }
 }
 

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1053,6 +1053,7 @@
 		AD7909922811CBDF0013C434 /* ChatMessageReactionsView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7909902811CBCB0013C434 /* ChatMessageReactionsView_Tests.swift */; };
 		AD793F49270B767500B05456 /* ChatMessageReactionAuthorsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD793F48270B767500B05456 /* ChatMessageReactionAuthorsVC.swift */; };
 		AD793F4B270B769E00B05456 /* ChatMessageReactionAuthorViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD793F4A270B769E00B05456 /* ChatMessageReactionAuthorViewCell.swift */; };
+		AD7977BA2936D9450008B5FB /* Token_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7977B92936D9450008B5FB /* Token_Tests.swift */; };
 		AD7AC99B260A9572004AADA5 /* MessagePinning.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7AC98B260A94C6004AADA5 /* MessagePinning.swift */; };
 		AD7B51D327EDECA80068CBD1 /* MixedAttachmentViewInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7B51D227EDECA80068CBD1 /* MixedAttachmentViewInjector.swift */; };
 		AD7B51D427EDECA80068CBD1 /* MixedAttachmentViewInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7B51D227EDECA80068CBD1 /* MixedAttachmentViewInjector.swift */; };
@@ -3284,6 +3285,7 @@
 		AD7909902811CBCB0013C434 /* ChatMessageReactionsView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageReactionsView_Tests.swift; sourceTree = "<group>"; };
 		AD793F48270B767500B05456 /* ChatMessageReactionAuthorsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageReactionAuthorsVC.swift; sourceTree = "<group>"; };
 		AD793F4A270B769E00B05456 /* ChatMessageReactionAuthorViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageReactionAuthorViewCell.swift; sourceTree = "<group>"; };
+		AD7977B92936D9450008B5FB /* Token_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token_Tests.swift; sourceTree = "<group>"; };
 		AD7AC98B260A94C6004AADA5 /* MessagePinning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagePinning.swift; sourceTree = "<group>"; };
 		AD7B51D227EDECA80068CBD1 /* MixedAttachmentViewInjector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAttachmentViewInjector.swift; sourceTree = "<group>"; };
 		AD7BBFCA2901AF3F004E8B76 /* ImageResultsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageResultsMapper.swift; sourceTree = "<group>"; };
@@ -5457,6 +5459,7 @@
 		A364D08B27D0BD650029857A /* Config */ = {
 			isa = PBXGroup;
 			children = (
+				AD7977B92936D9450008B5FB /* Token_Tests.swift */,
 				84F6126F268B415C00DDF6EE /* ChatClientConfig_Tests.swift */,
 			);
 			path = Config;
@@ -9745,6 +9748,7 @@
 				DA7229E424E140600074503A /* ChannelEditDetailPayload_Tests.swift in Sources */,
 				88DA57EA2631E82B00FA8C53 /* MutedChannelPayload_Tests.swift in Sources */,
 				8A0D64A924E57A560017A3C0 /* GuestUserTokenRequestPayload_Tests.swift in Sources */,
+				AD7977BA2936D9450008B5FB /* Token_Tests.swift in Sources */,
 				79280F732487CD3100CDEB89 /* Atomic_StressTests.swift in Sources */,
 				7964F3BE249A5E6E002A09EC /* RequestEncoder_Tests.swift in Sources */,
 				79DDF810249CB92E002F4412 /* RequestDecoder_Tests.swift in Sources */,

--- a/Tests/StreamChatTests/Config/Token_Tests.swift
+++ b/Tests/StreamChatTests/Config/Token_Tests.swift
@@ -1,0 +1,58 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class Token_Tests: XCTestCase {
+    func test_init() throws {
+        let jwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIifQ.kFSLHRB5X62t0Zlc7nwczWUfsQMwfkpylC6jCUZ6Mc0"
+        let token = try Token(rawValue: jwtToken)
+        XCTAssertEqual(token.userId, "luke_skywalker")
+        XCTAssertEqual(token.rawValue, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIifQ.kFSLHRB5X62t0Zlc7nwczWUfsQMwfkpylC6jCUZ6Mc0")
+    }
+
+    func test_init_whenNoUserId() {
+        let jwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjoibHVrZV9za3l3YWxrZXIifQ.4d5JxYi_bcpvQJZix-goe534b_CsSM1dV-lEuq1L-1g"
+        XCTAssertThrowsError(try Token(rawValue: jwtToken))
+    }
+
+    func test_expiration_whenNoExpProvided() throws {
+        let jwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIifQ.kFSLHRB5X62t0Zlc7nwczWUfsQMwfkpylC6jCUZ6Mc0"
+        let token = try Token(rawValue: jwtToken)
+        XCTAssertEqual(token.expiration, nil)
+        XCTAssertEqual(token.isExpired, false)
+    }
+
+    func test_expiration_whenExpired() throws {
+        let jwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIiLCJleHAiOjI1NTMzODE1Mjl9.i1vpWu_9uV6DO7eIYuUokQxfMaTgh-Xq089wKLGw_sY"
+        let token = try Token(rawValue: jwtToken)
+        XCTAssertEqual(token.expiration?.timeIntervalSince1970, 2_553_381_529)
+        XCTAssertEqual(token.isExpired, false)
+    }
+
+    func test_expiration_whenNotExpired() throws {
+        let jwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIiLCJleHAiOjE2MDY2OTY3Mjl9.AkmNHUTKEFR8UP0W2HLFsS006Bi2IT7-fzMtJuI_J9Q"
+        let token = try Token(rawValue: jwtToken)
+        XCTAssertEqual(token.expiration?.timeIntervalSince1970, 1_606_696_729)
+        XCTAssertEqual(token.isExpired, true)
+    }
+
+    func test_anonymousToken() {
+        let token = Token.anonymous
+        XCTAssertEqual(token.expiration, nil)
+        XCTAssertEqual(token.isExpired, false)
+        XCTAssertEqual(token.rawValue, "")
+        XCTAssertTrue(!token.userId.isEmpty)
+    }
+
+    func test_developmentToken() {
+        let expectedUserId = "luke_skywalker"
+        let token = Token.development(userId: expectedUserId)
+        XCTAssertEqual(token.expiration, nil)
+        XCTAssertEqual(token.isExpired, false)
+        XCTAssertEqual(token.rawValue, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIifQ==.devtoken")
+        XCTAssertEqual(token.userId, expectedUserId)
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links
https://github.com/GetStream/stream-chat-swift/issues/2382
CIS-2287

### 🎯 Goal
Fix development tokens not working, it errors with Missing Token Provider.

### 🛠 Implementation
When creating a development token, we were incorrectly setting the expiration to "distantFuture". We actually need to set it to `nil`. Since there is no expiration at all. With this, the `connectUser` now works correctly.

### 🧪 Manual Testing Notes
N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
