### PR TITLE
[Docs] Add links to the Channel List blog post in the docs

### DIFF
--- a/docusaurus/docs/iOS/swiftui/channel-list-components/channel-list-header.md
+++ b/docusaurus/docs/iOS/swiftui/channel-list-components/channel-list-header.md
@@ -39,6 +39,10 @@ func navigationBarDisplayMode() -> NavigationBarItem.TitleDisplayMode {
 
 In most cases, you will need to customize the navigation bar even further - either by adding branding information, like logo and text, or even additional buttons that will either push a new view, display a modal sheet or an alert.
 
+:::info
+In case you want to see a more detailed tutorial on how to customize the channel list header, you can see [this article on our blog](https://getstream.io/blog/customize-chat-channel-list-with-swiftui/#add-a-custom-made-channel-list-header).
+:::
+
 In order to do this, you will need to perform a few steps. First, you need to create your own header, conforming to SwiftUI's `ToolbarContent` protocol. Let's create a header that will show title and two buttons, one opening a sheet and the other pushing a new view.
 
 ```swift

--- a/docusaurus/docs/iOS/swiftui/channel-list-components/helper-views.md
+++ b/docusaurus/docs/iOS/swiftui/channel-list-components/helper-views.md
@@ -8,23 +8,23 @@ While the channels are loaded, a loading view is displayed, with a simple animat
 
 ```swift
 class CustomFactory: ViewFactory {
-    
+
     @Injected(\.chatClient) public var chatClient
-    
+
     private init() {}
-    
+
     public static let shared = CustomFactory()
-    
+
     func makeLoadingView() -> some View {
         VStack {
             Text("This is custom loading view")
             ProgressView()
         }
     }
-}    
+}
 ```
- 
- Afterwards, you will need to inject the newly created `CustomFactory` into our view hierarchy.
+
+Afterwards, you will need to inject the newly created `CustomFactory` into our view hierarchy.
 
 ```swift
 var body: some Scene {
@@ -48,6 +48,10 @@ func makeNoChannelsView() -> some View {
 }
 ```
 
+:::info
+We also have a more in-detail [article on customization of the channel list](https://getstream.io/blog/customize-chat-channel-list-with-swiftui/) and you can find an example of how to provide a no channels available view [here](https://getstream.io/blog/customize-chat-channel-list-with-swiftui/#how-to-customize-the-no-channels-view).
+:::
+
 ## Changing the Background of the Channel List
 
 You can change the background of the channel list to be any SwiftUI `View` (`Color`, `LinearGradient`, `Image` etc.). In order to do this, you will need to implement the `makeChannelListBackground` in the `ViewFactory`.
@@ -59,7 +63,7 @@ func makeChannelListBackground(colors: ColorPalette) -> some View {
 }
 ```
 
-In this method, you receive the `colors` used in the SDK, but you can ignore them if you want to use custom colors that are not setup via the SDK. 
+In this method, you receive the `colors` used in the SDK, but you can ignore them if you want to use custom colors that are not setup via the SDK.
 
 ## Changing the Chat Channel List Item
 
@@ -189,12 +193,12 @@ func makeChannelListModifier() -> some ViewModifier {
 }
 
 struct VerticalPaddingViewModifier: ViewModifier {
-    
+
     public func body(content: Content) -> some View {
         content
             .padding(.vertical, 8)
     }
-    
+
 }
 ```
 


### PR DESCRIPTION
### 🎯 Goal

Add links to [the Channel List blog post](https://getstream.io/blog/customize-chat-channel-list-with-swiftui/#customize-the-list-divider) from Amos in the documentation where it fits.

### 📝 Summary

Added the links.

### 🧪 Manual Testing Notes

Run the docs locally (`npx stream-chat-docusaurus -s`).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)
