### PR TITLE
[Internal] Add retries to Authentication Repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add support for hiding connection status with `isInvisible` [#2373](https://github.com/GetStream/stream-chat-swift/pull/2373)
 - Add `.withAttachments` in `MessageSearchFilterScope` to filter messages with attachments only [#2417](https://github.com/GetStream/stream-chat-swift/pull/2417)
 - Add `.withoutAttachments` in `MessageSearchFilterScope` to filter messages without any attachments [#2417](https://github.com/GetStream/stream-chat-swift/pull/2417)
+- Add retries mechanism to AuthenticationRepository [#2414](https://github.com/GetStream/stream-chat-swift/pull/2414)
 
 ### 🐞 Fixed
 - Fix connecting user with non-expiring tokens (ex: development token) [#2393](https://github.com/GetStream/stream-chat-swift/pull/2393)

--- a/Sources/StreamChat/APIClient/RequestDecoder.swift
+++ b/Sources/StreamChat/APIClient/RequestDecoder.swift
@@ -90,12 +90,6 @@ extension ClientError {
     class RefreshingToken: ClientError {}
     class TokenRefreshed: ClientError {}
     class ConnectionError: ClientError {}
-    class TooManyTokenRefreshAttempts: ClientError {
-        override var localizedDescription: String {
-            "Authentication failed on expired tokens after too many refresh attempts, please check that your user tokens are created correctly."
-        }
-    }
-
     class ResponseBodyEmpty: ClientError {
         override var localizedDescription: String { "Response body is empty." }
     }

--- a/Sources/StreamChat/Repositories/ConnectionRepository.swift
+++ b/Sources/StreamChat/Repositories/ConnectionRepository.swift
@@ -153,11 +153,7 @@ class ConnectionRepository {
         case let .disconnecting(source) where source.serverError?.isInvalidTokenError == true,
              let .disconnected(source) where source.serverError?.isInvalidTokenError == true:
             onInvalidToken()
-            if case .disconnected = state {
-                shouldNotifyConnectionIdWaiters = true
-            } else {
-                shouldNotifyConnectionIdWaiters = false
-            }
+            shouldNotifyConnectionIdWaiters = false
             connectionId = nil
         case .disconnected:
             shouldNotifyConnectionIdWaiters = true

--- a/Sources/StreamChat/Repositories/ConnectionRepository.swift
+++ b/Sources/StreamChat/Repositories/ConnectionRepository.swift
@@ -149,14 +149,18 @@ class ConnectionRepository {
         case let .connected(connectionId: id):
             shouldNotifyConnectionIdWaiters = true
             connectionId = id
-        case let .disconnected(source):
-            if let error = source.serverError,
-               error.isInvalidTokenError {
-                onInvalidToken()
-                shouldNotifyConnectionIdWaiters = false
-            } else {
+
+        case let .disconnecting(source) where source.serverError?.isInvalidTokenError == true,
+             let .disconnected(source) where source.serverError?.isInvalidTokenError == true:
+            onInvalidToken()
+            if case .disconnected = state {
                 shouldNotifyConnectionIdWaiters = true
+            } else {
+                shouldNotifyConnectionIdWaiters = false
             }
+            connectionId = nil
+        case .disconnected:
+            shouldNotifyConnectionIdWaiters = true
             connectionId = nil
         case .initialized,
              .connecting,

--- a/StreamChatUITestsApp/StreamChat/ChannelList.swift
+++ b/StreamChatUITestsApp/StreamChat/ChannelList.swift
@@ -48,5 +48,6 @@ final class ChannelList: ChatChannelListVC, ChatConnectionControllerDelegate {
         case .disconnected:
             title = "disconnected"
         }
+        navigationItem.titleView?.accessibilityIdentifier = title
     }
 }

--- a/StreamChatUITestsApp/ViewController.swift
+++ b/StreamChatUITestsApp/ViewController.swift
@@ -36,11 +36,8 @@ final class ViewController: UIViewController {
     @objc func didTap() {
         // Setup chat client
         streamChat.setUpChat()
-        streamChat.connectUser(completion: { [weak self] _ in
-            DispatchQueue.main.async {
-                self?.showChannelList()
-            }
-        })
+        streamChat.connectUser(completion: { _ in })
+        showChannelList()
     }
 
     private func showChannelList() {

--- a/StreamChatUITestsApp/ViewController.swift
+++ b/StreamChatUITestsApp/ViewController.swift
@@ -36,12 +36,18 @@ final class ViewController: UIViewController {
     @objc func didTap() {
         // Setup chat client
         streamChat.setUpChat()
-        streamChat.connectUser(completion: { _ in})
+        streamChat.connectUser(completion: { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.showChannelList()
+            }
+        })
+    }
 
+    private func showChannelList() {
         // create UI
         let channelList = streamChat.makeChannelListViewController()
         router = channelList.router as? CustomChannelListRouter
-        
+
         // create connection switch if needed
         let switchControl = self.createIsConnectedSwitchIfNeeded()
 

--- a/StreamChatUITestsAppUITests/Pages/ChannelListPage.swift
+++ b/StreamChatUITestsAppUITests/Pages/ChannelListPage.swift
@@ -23,12 +23,8 @@ enum ChannelListPage {
             format: "identifier LIKE 'titleLabel' AND label LIKE '\(withName)'")).firstMatch
     }
     
-    static var connectionStatus: XCUIElement {
-        if ProcessInfo().operatingSystemVersion.majorVersion == 12 {
-            return app.navigationBars.otherElements.firstMatch
-        } else {
-            return app.navigationBars.staticTexts.firstMatch
-        }
+    static func connectionLabel(withStatus: ChannelListPage.ConnectionStatus) -> XCUIElement {
+        app.navigationBars.matching(NSPredicate(format: "identifier LIKE '\(withStatus.rawValue)'")).firstMatch
     }
     
     enum ConnectionStatus: String {

--- a/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
@@ -153,7 +153,7 @@ extension UserRobot {
     ) -> Self {
         let expectedStatus = status.rawValue
         let actualStatus = ChannelListPage.connectionStatus.waitForText(expectedStatus, timeout: timeout).text
-        XCTAssertEqual(actualStatus, expectedStatus, file: file, line: line)
+        XCTAssertEqual(expectedStatus, actualStatus, file: file, line: line)
         return self
     }
 }

--- a/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
@@ -151,9 +151,8 @@ extension UserRobot {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> Self {
-        let expectedStatus = status.rawValue
-        let actualStatus = ChannelListPage.connectionStatus.waitForText(expectedStatus, timeout: timeout).text
-        XCTAssertEqual(expectedStatus, actualStatus, file: file, line: line)
+        let correctStatus = ChannelListPage.connectionLabel(withStatus: status).wait(timeout: timeout).exists
+        XCTAssertTrue(correctStatus, file: file, line: line)
         return self
     }
 }

--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -21,6 +21,8 @@ final class UserRobot: Robot {
     @discardableResult
     func login() -> Self {
         StartPage.startButton.safeTap()
+        sleep(2)
+        print(app.debugDescription)
         return self
     }
     

--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -21,8 +21,6 @@ final class UserRobot: Robot {
     @discardableResult
     func login() -> Self {
         StartPage.startButton.safeTap()
-        sleep(2)
-        print(app.debugDescription)
         return self
     }
     

--- a/StreamChatUITestsAppUITests/Tests/Authentication_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Authentication_Tests.swift
@@ -11,7 +11,6 @@ final class Authentication_Tests: StreamTestCase {
         mockServerEnabled = false
         app.setLaunchArguments(.jwt)
         try super.setUpWithError()
-        throw XCTSkip("[CIS-2309] JWT authentication issues")
     }
     
     func test_tokenExpiriesBeforeUserLogsIn() {

--- a/StreamChatUITestsAppUITests/Tests/Authentication_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Authentication_Tests.swift
@@ -101,7 +101,7 @@ final class Authentication_Tests: StreamTestCase {
         AND("server returns an error") {}
         AND("JWT generation recovers on server side") {}
         THEN("app requests a token refresh a second time") {
-            userRobot.assertConnectionStatus(.connected, timeout: 30)
+            userRobot.assertConnectionStatus(.connected)
         }
     }
 }

--- a/Tests/StreamChatTests/APIClient/APIClient_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/APIClient_Tests.swift
@@ -416,38 +416,6 @@ final class APIClient_Tests: XCTestCase {
         XCTEnsureRequestsWereExecuted(times: 2)
     }
     
-    func test_requestFailedWithExpiredToken_retriesRequestUntilReachingMaximumAttempts() throws {
-        var tokenRefresherWasCalled = false
-        createClient(tokenRefresher: { completion in
-            tokenRefresherWasCalled = true
-            completion()
-        })
-        
-        let encoderError = ClientError.ExpiredToken()
-        decoder.decodeRequestResponse = .failure(encoderError)
-
-        var result: Result<TestUser, Error>?
-        waitUntil(timeout: 0.5) { done in
-            apiClient.request(
-                endpoint: Endpoint<TestUser>.mock(),
-                completion: {
-                    result = $0; done()
-                }
-            )
-        }
-
-        XCTAssertTrue(tokenRefresherWasCalled)
-
-        guard let result = result, case let .failure(error) = result else {
-            XCTFail()
-            return
-        }
-
-        XCTAssertTrue(error is ClientError.TooManyTokenRefreshAttempts)
-        // 1 request + 10 refresh attempts
-        XCTEnsureRequestsWereExecuted(times: 11)
-    }
-
     // MARK: - Flush
 
     func test_flushRequestsQueue_whenThereAreOperationsOngoing_shouldStopQueuedOnes() {

--- a/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
@@ -571,7 +571,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         })
 
         XCTAssertNotNil(repository.tokenProvider)
-        waitForExpectations(timeout: 10000)
+        waitForExpectations(timeout: defaultTimeout)
         XCTAssertNil(repository.currentToken)
         XCTAssertEqual(receivedError, apiError)
         let request = try XCTUnwrap(apiClient.request_endpoint)
@@ -591,7 +591,13 @@ final class AuthenticationRepository_Tests: XCTestCase {
         connectionRepository.connectResult = .failure(testError)
 
         // API Result
-        apiClient.test_mockResponseResult(Result<GuestUserTokenPayload, Error>.success(GuestUserTokenPayload(user: CurrentUserPayload.dummy(userId: "", role: .user), token: apiToken)))
+        apiClient.test_mockResponseResult(
+            Result<GuestUserTokenPayload, Error>.success(GuestUserTokenPayload(
+                user: CurrentUserPayload.dummy(userId: "", role: .user),
+                token: apiToken
+            )
+            )
+        )
 
         let completionExpectation = expectation(description: "Connect completion")
         var receivedError: Error?
@@ -622,7 +628,13 @@ final class AuthenticationRepository_Tests: XCTestCase {
         connectionRepository.connectResult = .success(())
 
         // API Result
-        apiClient.test_mockResponseResult(Result<GuestUserTokenPayload, Error>.success(GuestUserTokenPayload(user: CurrentUserPayload.dummy(userId: "", role: .user), token: apiToken)))
+        apiClient.test_mockResponseResult(
+            Result<GuestUserTokenPayload, Error>.success(GuestUserTokenPayload(
+                user: CurrentUserPayload.dummy(userId: "", role: .user),
+                token: apiToken
+            )
+            )
+        )
 
         let completionExpectation = expectation(description: "Connect completion")
         var receivedError: Error?

--- a/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
@@ -310,9 +310,13 @@ final class ChatClient_Tests: XCTestCase {
 
         // Create a new chat client
         var client: ChatClient! = ChatClient(config: config)
-        
-        client.connectAnonymousUser()
-        
+
+        let expectation = self.expectation(description: "Connect completes")
+        client.connectAnonymousUser { _ in
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: defaultTimeout)
+
         // Check all the mandatory background workers are initialized
         XCTAssert(client.backgroundWorkers.contains { $0 is MessageSender })
         XCTAssert(client.backgroundWorkers.contains { $0 is NewUserQueryUpdater })

--- a/fastlane/sinatra.rb
+++ b/fastlane/sinatra.rb
@@ -54,12 +54,14 @@ end
 
 post '/jwt/revoke/:udid' do
   jwt[:expiration_timeout] = install_jwt_timeout(udid: params['udid'], duration: params['duration'])
+  status 200
 end
 
 post '/jwt/break/:udid' do
   jwt[:generation_error_timeout] = install_jwt_timeout(udid: params['udid'], duration: params['duration'])
+  status 200
 end
 
 def install_jwt_timeout(udid:, duration:)
-  { params['udid'] => Time.now.to_i + params['duration'].to_i }
+  { udid => Time.now.to_i + duration.to_i }
 end

--- a/fastlane/sinatra.rb
+++ b/fastlane/sinatra.rb
@@ -54,12 +54,12 @@ end
 
 post '/jwt/revoke/:udid' do
   jwt[:expiration_timeout] = install_jwt_timeout(udid: params['udid'], duration: params['duration'])
-  status 200
+  halt(200)
 end
 
 post '/jwt/break/:udid' do
   jwt[:generation_error_timeout] = install_jwt_timeout(udid: params['udid'], duration: params['duration'])
-  status 200
+  halt(200)
 end
 
 def install_jwt_timeout(udid:, duration:)


### PR DESCRIPTION
### 🔗 Issue Links


### 🎯 Goal

Fix E2E tests which were failing due to missing retries after a token fetch failure

### 🛠 Implementation

This PR adds retries when a token fetch process fails. It does it under the following circumstances:
- If the fetched token is expired
- If there is an error returned
- All the above is done a up to a maximum of 10 times

In order to do that, it also removes state tracking of token attempts refresh from the APIClient.
Now, whenever the Authentication Repository is fetching a token, it notifies the APIClient so it can temporarily suspend the queue. In the case where requests are already in the queue and are being executed, those will be requeued as soon as an expired token is received, to then be relaunched when the queue is resumed.

To be quicker detecting expired tokens, we also try to refresh tokens when the connection changes to `.disconnecting`, as well as when it does to `.disconnected`, and the server error reflects an expired token. Before we were only doing so when the state was `.disconnected`.

### 🎨 Showcase
![LLC excalidraw copy](https://user-images.githubusercontent.com/7887319/207960116-c0efcc9b-0843-43a0-a0fd-0f13c4d22df7.png)

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/xT5LMFJPKupWHjznJ6/giphy.gif)
