### PR TITLE
[CIS-2232] Fix message actions popup in cached thread replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix connecting user with non-expiring tokens (ex: development token) [#2393](https://github.com/GetStream/stream-chat-swift/pull/2393)
 - Fix crash when calling `addDevice()` from background thread [#2398](https://github.com/GetStream/stream-chat-swift/pull/2398)
 
+## StreamChatUI
+### 🐞 Fixed
+- Fix message actions popup in cached thread replies [#2415](https://github.com/GetStream/stream-chat-swift/pull/2415)
+
 # [4.24.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.24.1)
 _November 23, 2022_
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCell.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageCell.swift
@@ -8,7 +8,7 @@ import UIKit
 /// The cell that displays the message content of a dynamic type and layout.
 /// Once the cell is set up it is expected to be dequeued for messages with
 /// the same content and layout the cell has already been configured with.
-public final class ChatMessageCell: _TableViewCell, ComponentsProvider {
+public class ChatMessageCell: _TableViewCell, ComponentsProvider {
     public static var reuseId: String { "\(self)" }
 
     /// The container that holds the date separator and the message content view.

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -274,7 +274,7 @@ open class ChatMessageListVC: _ViewController,
             let messageContentView = cell.messageContentView,
             let message = messageContentView.content,
             message.isInteractionEnabled == true,
-            let cid = message.cid
+            let cid = dataSource?.channel(for: self)?.cid
         else { return }
 
         let messageController = client.messageController(

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1160,6 +1160,7 @@
 		ADDFDE2B2779EC8A003B3B07 /* Atlantis in Frameworks */ = {isa = PBXBuildFile; productRef = ADDFDE2A2779EC8A003B3B07 /* Atlantis */; };
 		ADE40043291B1A510000C98B /* AttachmentUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE40042291B1A510000C98B /* AttachmentUploader.swift */; };
 		ADE40044291B1A510000C98B /* AttachmentUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE40042291B1A510000C98B /* AttachmentUploader.swift */; };
+		ADE88A142949453200C0F084 /* ChatMessageListRouter_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE88A132949453200C0F084 /* ChatMessageListRouter_Mock.swift */; };
 		ADEE888D289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEE888C289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift */; };
 		ADEE888E289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEE888C289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift */; };
 		ADEED08127F202C100A42B52 /* yoda_with_long_file_name.txt in Resources */ = {isa = PBXBuildFile; fileRef = ADEED08027F202C100A42B52 /* yoda_with_long_file_name.txt */; };
@@ -3368,6 +3369,7 @@
 		ADD2A99928FF4F4B00A83305 /* StreamCDN.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCDN.swift; sourceTree = "<group>"; };
 		ADD5A9E725DE8AF6006DC88A /* ChatSuggestionsVC_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSuggestionsVC_Tests.swift; sourceTree = "<group>"; };
 		ADE40042291B1A510000C98B /* AttachmentUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentUploader.swift; sourceTree = "<group>"; };
+		ADE88A132949453200C0F084 /* ChatMessageListRouter_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListRouter_Mock.swift; sourceTree = "<group>"; };
 		ADEA7F21261D2F8C00CA2289 /* chewbacca.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = chewbacca.jpg; sourceTree = "<group>"; };
 		ADEA7F22261D2F8C00CA2289 /* r2.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = r2.jpg; sourceTree = "<group>"; };
 		ADEE888C289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatMessageListView+DiffKit.swift"; sourceTree = "<group>"; };
@@ -6378,6 +6380,7 @@
 			isa = PBXGroup;
 			children = (
 				2208246925DFD0060033544B /* ChatChannelListRouter_Mock.swift */,
+				ADE88A132949453200C0F084 /* ChatMessageListRouter_Mock.swift */,
 			);
 			path = Navigation;
 			sourceTree = "<group>";
@@ -9006,6 +9009,7 @@
 				AC1E16FF269C70530040548B /* String+Extensions_Tests.swift in Sources */,
 				845CEE5A270F2A06002C7EBD /* ChatReactionsBubbleView_Tests.swift in Sources */,
 				79567F35266F6F12007EADD3 /* CommandLabelView_Tests.swift in Sources */,
+				ADE88A142949453200C0F084 /* ChatMessageListRouter_Mock.swift in Sources */,
 				849AE666270CB55F00423A20 /* VideoAttachmentGalleryCell_Tests.swift in Sources */,
 				CF38F5B4287DB64B00E24D10 /* ChatChannelListErrorView_Tests.swift in Sources */,
 				AD71131225F138D500932AEE /* ChatUserAvatarView_Tests.swift in Sources */,

--- a/TestTools/StreamChatTestTools/TestData/DummyData/XCTestCase+Dummy.swift
+++ b/TestTools/StreamChatTestTools/TestData/DummyData/XCTestCase+Dummy.swift
@@ -50,10 +50,12 @@ extension XCTestCase {
     
     func dummyMessagePayload(
         id: MessageId = .unique,
+        cid: ChannelId? = nil,
         createdAt: Date = XCTestCase.channelCreatedDate.addingTimeInterval(.random(in: 60...900_000))
     ) -> MessagePayload {
         MessagePayload(
             id: id,
+            cid: cid,
             type: .regular,
             user: dummyUser,
             createdAt: createdAt,

--- a/Tests/StreamChatUITests/Mocks/Navigation/ChatMessageListRouter_Mock.swift
+++ b/Tests/StreamChatUITests/Mocks/Navigation/ChatMessageListRouter_Mock.swift
@@ -1,0 +1,19 @@
+//
+// Copyright © 2022 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+@testable import StreamChatUI
+import XCTest
+
+class ChatMessageListRouter_Mock: ChatMessageListRouter {
+    var showMessageActionsPopUpCallCount = 0
+
+    override func showMessageActionsPopUp(
+        messageContentView: ChatMessageContentView,
+        messageActionsController: ChatMessageActionsVC,
+        messageReactionsController: ChatMessageReactionsPickerVC?
+    ) {
+        showMessageActionsPopUpCallCount += 1
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links
CIS-2232
https://github.com/GetStream/stream-chat-swift/issues/2343

### 🎯 Goal
Fixes message actions popup not opening in thread replies, after restarting the app (loading replies from the local cache).

### 📝 Summary
When calling `didSelectMessageCell()` the router would not be called because `message.cid` would be `nil`. This should not happen, and replies from the local cache should have the `cid` property. For now, as a workaround, we will use the cid from the data source, so that it is more reliable. I spent quite a lot of time trying to understand why the channel is not attached to the thread reply in the local database, so for now, we will go with the workaround approach.

### 🧪 Manual Testing Notes
- Open a Channel
- Send a message
- Send a thread reply
- Open the thread
- Restart the app (To make sure the threads are loaded from local db)
- Go to the thread above
- Long press a thread reply
- It should open the message actions

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)