### PR TITLE
[CIS-2212] Add message search filter to query messages with/without attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - Add support for hiding connection status with `isInvisible` [#2373](https://github.com/GetStream/stream-chat-swift/pull/2373)
+- Add `.withAttachments` in `MessageSearchFilterScope` to filter messages with attachments only [#2417](https://github.com/GetStream/stream-chat-swift/pull/2417)
+- Add `.withoutAttachments` in `MessageSearchFilterScope` to filter messages without any attachments [#2417](https://github.com/GetStream/stream-chat-swift/pull/2417)
 
 ### 🐞 Fixed
 - Fix connecting user with non-expiring tokens (ex: development token) [#2393](https://github.com/GetStream/stream-chat-swift/pull/2393)

--- a/Sources/StreamChat/Query/MessageSearchQuery.swift
+++ b/Sources/StreamChat/Query/MessageSearchQuery.swift
@@ -66,9 +66,20 @@ public extension Filter where Scope: AnyMessageSearchFilterScope {
     static func queryText(_ text: String) -> Filter<Scope> {
         .query(.text, text: text)
     }
-    
+
+    // Filter messages with the given attachment types.
     static func withAttachments(_ types: Set<AttachmentType>) -> Filter<Scope> {
         .in(.hasAttachmentsOfType, values: .init(types))
+    }
+
+    // Filter messages which contain attachments.
+    static var withAttachments: Filter<Scope> {
+        .exists(FilterKey<Scope, String>(stringLiteral: "attachments"))
+    }
+
+    // Filter messages that don't contain attachments.
+    static var withoutAttachments: Filter<Scope> {
+        .exists(FilterKey<Scope, String>(stringLiteral: "attachments"), exists: false)
     }
 }
 

--- a/Tests/StreamChatTests/Query/MessageSearchQuery_Tests.swift
+++ b/Tests/StreamChatTests/Query/MessageSearchQuery_Tests.swift
@@ -6,16 +6,29 @@
 import XCTest
 
 final class MessageSearchFilterScope_Tests: StressTestCase {
-    func test_withAttachments() {
-        // Declare attachment types
+    func test_withAttachments_givenAttachmentTypes() {
         let attachmentTypes: Set<AttachmentType> = [.image, .video]
-        
-        // Build a filter
+
         let filter: Filter<MessageSearchFilterScope> = .withAttachments(attachmentTypes)
-        
-        // Assert correct filter is built
-        XCTAssertEqual(filter.key, FilterKey<MessageSearchFilterScope, AttachmentType>.hasAttachmentsOfType.rawValue)
-        XCTAssertEqual(filter.operator, FilterOperator.in.rawValue)
+
+        XCTAssertEqual(filter.key, "attachments.type")
+        XCTAssertEqual(filter.operator, "$in")
         XCTAssertEqual(Set(filter.value as! [AttachmentType]), attachmentTypes)
+    }
+
+    func test_withAttachments() {
+        let filter: Filter<MessageSearchFilterScope> = .withAttachments
+
+        XCTAssertEqual(filter.key, "attachments")
+        XCTAssertEqual(filter.operator, "$exists")
+        XCTAssertEqual(filter.value as! Bool, true)
+    }
+
+    func test_withoutAttachments() {
+        let filter: Filter<MessageSearchFilterScope> = .withoutAttachments
+
+        XCTAssertEqual(filter.key, "attachments")
+        XCTAssertEqual(filter.operator, "$exists")
+        XCTAssertEqual(filter.value as! Bool, false)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links
CIS-2212
https://github.com/GetStream/stream-chat-swift/issues/2363

### 🎯 Goal
Provide an easy way to filter messages with any attachment type or without any attachments at all.

### 🧪 Manual Testing Notes
N/A. Unit tests were provided to make sure the query is built correctly.

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
