### PR TITLE
[CIS-2288] Fix Reaction Picker not updating when enforce unique

### DIFF
--- a/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
+++ b/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
@@ -3,6 +3,7 @@
 //
 
 import StreamChat
+import StreamChatUI
 import UIKit
 
 /// The Demo App Configuration.
@@ -68,6 +69,7 @@ class AppConfigViewController: UITableViewController {
     enum ConfigOption {
         case info([DemoAppInfoOption])
         case demoApp([DemoAppConfigOption])
+        case components([ComponentsConfigOption])
         case chatClient([ChatClientConfigOption])
         case user([UserConfigOption])
 
@@ -76,6 +78,8 @@ class AppConfigViewController: UITableViewController {
             case let .info(options):
                 return options.count
             case let .demoApp(options):
+                return options.count
+            case let .components(options):
                 return options.count
             case let .chatClient(options):
                 return options.count
@@ -88,6 +92,8 @@ class AppConfigViewController: UITableViewController {
             switch self {
             case .demoApp:
                 return "Demo App Configuration"
+            case .components:
+                return "Components Configuration"
             case .chatClient:
                 return "Chat Client Configuration"
             case .info:
@@ -115,6 +121,10 @@ class AppConfigViewController: UITableViewController {
         case isAtlantisEnabled
     }
 
+    enum ComponentsConfigOption: String, CaseIterable {
+        case isUniqueReactionsEnabled
+    }
+
     enum ChatClientConfigOption: String, CaseIterable {
         case isLocalStorageEnabled
         case staysConnectedInBackground
@@ -129,6 +139,7 @@ class AppConfigViewController: UITableViewController {
     let options: [ConfigOption] = [
         .info(DemoAppInfoOption.allCases),
         .demoApp(DemoAppConfigOption.allCases),
+        .components(ComponentsConfigOption.allCases),
         .chatClient(ChatClientConfigOption.allCases),
         .user(UserConfigOption.allCases)
     ]
@@ -163,6 +174,9 @@ class AppConfigViewController: UITableViewController {
         case let .demoApp(options):
             configureDemoAppOptionsCell(cell, at: indexPath, options: options)
 
+        case let .components(options):
+            configureComponentsOptionsCell(cell, at: indexPath, options: options)
+
         case let .chatClient(options):
             configureChatClientOptionsCell(cell, at: indexPath, options: options)
 
@@ -177,7 +191,7 @@ class AppConfigViewController: UITableViewController {
         guard let cell = tableView.cellForRow(at: indexPath) else { return }
 
         switch options[indexPath.section] {
-        case .info, .user:
+        case .info, .user, .components:
             break
 
         case let .demoApp(options):
@@ -296,6 +310,24 @@ class AppConfigViewController: UITableViewController {
         case .isInvisible:
             cell.accessoryView = makeSwitchButton(UserConfig.shared.isInvisible) { newValue in
                 UserConfig.shared.isInvisible = newValue
+            }
+        }
+    }
+
+    // MARK: Components Options
+
+    private func configureComponentsOptionsCell(
+        _ cell: UITableViewCell,
+        at indexPath: IndexPath,
+        options: [ComponentsConfigOption]
+    ) {
+        let option = options[indexPath.row]
+        cell.textLabel?.text = option.rawValue
+
+        switch option {
+        case .isUniqueReactionsEnabled:
+            cell.accessoryView = makeSwitchButton(Components.default.isUniqueReactionsEnabled) { newValue in
+                Components.default.isUniqueReactionsEnabled = newValue
             }
         }
     }

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -126,6 +126,7 @@ protocol MessageDatabaseSession {
         to messageId: MessageId,
         type: MessageReactionType,
         score: Int,
+        enforceUnique: Bool,
         extraData: [String: RawJSON],
         localState: LocalReactionState?
     ) throws -> MessageReactionDTO

--- a/Sources/StreamChat/Repositories/MessageRepository.swift
+++ b/Sources/StreamChat/Repositories/MessageRepository.swift
@@ -233,7 +233,7 @@ class MessageRepository {
         completion: (() -> Void)? = nil
     ) {
         database.write {
-            _ = try $0.addReaction(to: messageId, type: type, score: score, extraData: [:], localState: .deletingFailed)
+            _ = try $0.addReaction(to: messageId, type: type, score: score, enforceUnique: false, extraData: [:], localState: .deletingFailed)
         } completion: { error in
             if let error = error {
                 log.error("Error adding reaction for message with id \(messageId): \(error)")

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -334,6 +334,7 @@ class MessageUpdater: Worker {
                     to: messageId,
                     type: type,
                     score: score,
+                    enforceUnique: enforceUnique,
                     extraData: extraData,
                     localState: .sending
                 )

--- a/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsPickerVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/Reactions/ChatMessageReactionsPickerVC.swift
@@ -66,7 +66,7 @@ open class ChatMessageReactionsPickerVC: _ViewController, ThemeProvider, ChatMes
         let shouldRemove = message.currentUserReactions.contains { $0.type == reaction }
         shouldRemove
             ? messageController.deleteReaction(reaction, completion: completion)
-            : messageController.addReaction(reaction, completion: completion)
+            : messageController.addReaction(reaction, enforceUnique: components.isUniqueReactionsEnabled, completion: completion)
     }
     
     // MARK: - MessageControllerDelegate

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -269,6 +269,10 @@ public struct Components {
         $0.type.rawValue < $1.type.rawValue
     }
 
+    /// A boolean value that determines whether if the reaction types are unique per user.
+    /// By default it is false, so each user can have multiple reaction types.
+    public var isUniqueReactionsEnabled: Bool = false
+
     // MARK: - Thread components
 
     /// The view controller used to display the detail of a message thread.

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -40,6 +40,7 @@ extension DatabaseSession_Mock {
         to messageId: MessageId,
         type: MessageReactionType,
         score: Int,
+        enforceUnique: Bool,
         extraData: [String: RawJSON],
         localState: LocalReactionState?
     ) throws -> MessageReactionDTO {
@@ -48,6 +49,7 @@ extension DatabaseSession_Mock {
             to: messageId,
             type: type,
             score: score,
+            enforceUnique: enforceUnique,
             extraData: extraData,
             localState: localState
         )

--- a/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
@@ -447,7 +447,7 @@ final class MessageRepositoryTests: XCTestCase {
                 syncOwnReactions: false,
                 cache: nil
             )
-            _ = try session.addReaction(to: messageId, type: reactionType, score: 1, extraData: [:], localState: nil)
+            _ = try session.addReaction(to: messageId, type: reactionType, score: 1, enforceUnique: false, extraData: [:], localState: nil)
         }
 
         // We undo reaction


### PR DESCRIPTION
### 🔗 Issue Links
CIS-2288
https://github.com/GetStream/stream-chat-swift/issues/2383

### 🎯 Goal
- Fix reaction picker not updating when reaction added with enforce unique
- Add a flag in `Components` to enable unique reactions

### 🎨 Showcase

https://user-images.githubusercontent.com/12814114/208181967-31cc884e-d35f-44b9-802c-35e9e04a2526.mov

### 🧪 Manual Testing Notes
Shown in the video above.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
