### PR TITLE
[#2435] Fix UserInfo not being updated on connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix truncated channels being moved to the bottom of the channel list [#2420](https://github.com/GetStream/stream-chat-swift/pull/2420)
 - Fix reactions not insantly updating when enforce unique is true [#2421](https://github.com/GetStream/stream-chat-swift/pull/2421)
 - Fix not being able to delete messages in `pendingSend` state [#2432](https://github.com/GetStream/stream-chat-swift/pull/2432)
+- Fix UserInfo not being updated on connect [#2438](https://github.com/GetStream/stream-chat-swift/pull/2438)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2023 Stream.io Inc. All rights reserved.
+// Copyright © 2022 Stream.io Inc. All rights reserved.
 //
 
 import Foundation

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -257,7 +257,7 @@ class AuthenticationRepository {
             queue: .main
         ) { [weak self] in
             log.debug("Firing timer for a new token request", subsystems: .authentication)
-            self?.getToken(isRetry: isRetry, userInfo: nil, tokenProvider: tokenProvider, completion: completion)
+            self?.getToken(isRetry: isRetry, userInfo: userInfo, tokenProvider: tokenProvider, completion: completion)
         }
     }
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/ConnectionRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/ConnectionRepository_Mock.swift
@@ -25,6 +25,7 @@ final class ConnectionRepository_Mock: ConnectionRepository, Spy {
     var disconnectResult: Result<Void, Error>?
 
     var updateWebSocketEndpointToken: Token?
+    var updateWebSocketEndpointUserInfo: UserInfo?
     var completeWaitersConnectionId: ConnectionId?
     var connectionUpdateState: WebSocketConnectionState?
     var simulateInvalidTokenOnConnectionUpdate = false
@@ -85,6 +86,7 @@ final class ConnectionRepository_Mock: ConnectionRepository, Spy {
 
     override func updateWebSocketEndpoint(with token: Token, userInfo: UserInfo?) {
         updateWebSocketEndpointToken = token
+        updateWebSocketEndpointUserInfo = userInfo
         record()
     }
 

--- a/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2023 Stream.io Inc. All rights reserved.
+// Copyright © 2022 Stream.io Inc. All rights reserved.
 //
 
 @testable import StreamChat

--- a/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
@@ -225,6 +225,8 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertEqual(repository.currentToken, providedToken)
         XCTAssertNil(receivedError)
         XCTAssertEqual(tokenCalls, 9)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointUserInfo, userInfo)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointToken, providedToken)
         XCTAssertCall(ConnectionRepository_Mock.Signature.connect, on: connectionRepository)
         XCTAssertCall(ConnectionRepository_Mock.Signature.forceConnectionInactiveMode, on: connectionRepository)
     }
@@ -279,6 +281,8 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertNotNil(repository.tokenProvider)
         waitForExpectations(timeout: 0.1)
         XCTAssertEqual(repository.currentToken, providedToken)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointUserInfo, userInfo)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointToken, providedToken)
         XCTAssertCall(ConnectionRepository_Mock.Signature.connect, on: connectionRepository)
         XCTAssertCall(ConnectionRepository_Mock.Signature.forceConnectionInactiveMode, on: connectionRepository)
         XCTAssertNil(receivedError)
@@ -314,6 +318,8 @@ final class AuthenticationRepository_Tests: XCTestCase {
         waitForExpectations(timeout: 0.2)
 
         XCTAssertEqual(repository.currentToken, providedToken)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointUserInfo, userInfo)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointToken, providedToken)
         XCTAssertCall(ConnectionRepository_Mock.Signature.connect, on: connectionRepository, times: 1)
         XCTAssertCall(ConnectionRepository_Mock.Signature.forceConnectionInactiveMode, on: connectionRepository, times: 1)
     }
@@ -419,6 +425,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertEqual(repository.currentUserId, userId)
         XCTAssertEqual(repository.currentToken, newToken)
         XCTAssertEqual(connectionRepository.updateWebSocketEndpointToken, newToken)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointUserInfo, newUserInfo)
         XCTAssertCall(ConnectionRepository_Mock.Signature.updateWebSocketEndpointTokenInfo, on: connectionRepository)
         XCTAssertEqual(delegate.newStateCalls, 1)
         XCTAssertEqual(delegate.clearDataCalls, 0)
@@ -445,6 +452,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertEqual(repository.currentUserId, existingUserId)
         XCTAssertEqual(repository.currentToken, newToken)
         XCTAssertEqual(connectionRepository.updateWebSocketEndpointToken, newToken)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointUserInfo, existingUserInfo)
         XCTAssertCall(ConnectionRepository_Mock.Signature.updateWebSocketEndpointTokenInfo, on: connectionRepository)
         XCTAssertEqual(delegate.newStateCalls, 1)
         XCTAssertEqual(delegate.clearDataCalls, 0)
@@ -471,6 +479,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertEqual(existingToken, newToken)
         XCTAssertEqual(repository.currentUserId, existingUserId)
         XCTAssertEqual(repository.currentToken, newToken)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointUserInfo, existingUserInfo)
         XCTAssertEqual(connectionRepository.updateWebSocketEndpointToken, newToken)
         XCTAssertCall(ConnectionRepository_Mock.Signature.updateWebSocketEndpointTokenInfo, on: connectionRepository)
         XCTAssertEqual(delegate.newStateCalls, 1)
@@ -509,6 +518,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertNil(error)
         XCTAssertEqual(repository.currentUserId, newUserId)
         XCTAssertEqual(repository.currentToken, newToken)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointUserInfo, newUserInfo)
         XCTAssertEqual(connectionRepository.updateWebSocketEndpointToken, newToken)
         XCTAssertCall(ConnectionRepository_Mock.Signature.updateWebSocketEndpointTokenInfo, on: connectionRepository)
         XCTAssertEqual(delegate.newStateCalls, 1)
@@ -546,6 +556,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertTrue(error is ClientError.ClientIsNotInActiveMode)
         XCTAssertEqual(repository.currentUserId, newUserId)
         XCTAssertEqual(repository.currentToken, newToken)
+        XCTAssertNil(connectionRepository.updateWebSocketEndpointUserInfo)
         XCTAssertNotCall(ConnectionRepository_Mock.Signature.updateWebSocketEndpointTokenInfo, on: connectionRepository)
         XCTAssertEqual(delegate.newStateCalls, 1)
         XCTAssertEqual(delegate.clearDataCalls, 0)
@@ -613,6 +624,8 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertEqual(repository.currentToken, apiToken)
         let request = try XCTUnwrap(apiClient.request_endpoint)
         XCTAssertEqual(request.path, .guest)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointToken, apiToken)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointUserInfo, userInfo)
         XCTAssertCall(ConnectionRepository_Mock.Signature.connect, on: connectionRepository)
         XCTAssertCall(ConnectionRepository_Mock.Signature.forceConnectionInactiveMode, on: connectionRepository)
         XCTAssertEqual(receivedError, testError)
@@ -650,6 +663,8 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertEqual(repository.currentToken, apiToken)
         let request = try XCTUnwrap(apiClient.request_endpoint)
         XCTAssertEqual(request.path, .guest)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointToken, apiToken)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointUserInfo, userInfo)
         XCTAssertCall(ConnectionRepository_Mock.Signature.connect, on: connectionRepository)
         XCTAssertCall(ConnectionRepository_Mock.Signature.forceConnectionInactiveMode, on: connectionRepository)
         XCTAssertNil(receivedError)
@@ -701,13 +716,16 @@ final class AuthenticationRepository_Tests: XCTestCase {
     }
 
     func test_refreshToken_success() throws {
-        try setTokenProvider(mockedResult: .success(.unique()))
+        let token = Token.unique()
+        try setTokenProvider(mockedResult: .success(token))
 
         let receivedError = try refreshTokenAndWaitForResponse(mockedError: nil)
 
         XCTAssertCall(RetryStrategy_Spy.Signature.nextRetryDelay, on: retryStrategy)
         XCTAssertCall(RetryStrategy_Spy.Signature.resetConsecutiveFailures, on: retryStrategy)
         XCTAssertNil(receivedError)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointToken, token)
+        XCTAssertNil(connectionRepository.updateWebSocketEndpointUserInfo)
     }
 
     func test_refreshToken_failure() throws {
@@ -723,8 +741,9 @@ final class AuthenticationRepository_Tests: XCTestCase {
 
     // Theoretic approach: Calling refresh token 3 times on the same thread, without any delay
     func test_refreshToken_multipleCalls_theoreticApproach() throws {
+        let token = Token.unique()
         // Adding delay otherwise all the execution is 100% sync and we cannot simulate the scenario
-        try setTokenProvider(mockedResult: .success(.unique()), delay: .milliseconds(10))
+        try setTokenProvider(mockedResult: .success(token), delay: .milliseconds(10))
         retryStrategy.mock_nextRetryDelay.returns(0.01)
 
         connectionRepository.connectResult = .success(())
@@ -740,12 +759,15 @@ final class AuthenticationRepository_Tests: XCTestCase {
 
         XCTAssertCall(RetryStrategy_Spy.Signature.nextRetryDelay, on: retryStrategy, times: 3)
         XCTAssertCall(RetryStrategy_Spy.Signature.resetConsecutiveFailures, on: retryStrategy, times: 1)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointToken, token)
+        XCTAssertNil(connectionRepository.updateWebSocketEndpointUserInfo)
     }
 
     // Realistic approach: Calling refresh token 3 times. The 2nd and 3rd times are called in the following runloop
     func test_refreshToken_multipleCalls_forcingRealisticDispatch() throws {
+        let token = Token.unique()
         // Adding delay otherwise all the execution is 100% sync and we cannot simulate the scenario
-        try setTokenProvider(mockedResult: .success(.unique()), delay: .milliseconds(10))
+        try setTokenProvider(mockedResult: .success(token), delay: .milliseconds(10))
         retryStrategy.mock_nextRetryDelay.returns(0)
 
         connectionRepository.connectResult = .success(())
@@ -772,6 +794,8 @@ final class AuthenticationRepository_Tests: XCTestCase {
 
         XCTAssertCall(RetryStrategy_Spy.Signature.nextRetryDelay, on: retryStrategy, times: 1)
         XCTAssertCall(RetryStrategy_Spy.Signature.resetConsecutiveFailures, on: retryStrategy, times: 1)
+        XCTAssertEqual(connectionRepository.updateWebSocketEndpointToken, token)
+        XCTAssertNil(connectionRepository.updateWebSocketEndpointUserInfo)
     }
 
     // MARK: Provide Token
@@ -934,4 +958,11 @@ private class AuthenticationRepositoryDelegateMock: AuthenticationRepositoryDele
         clearDataCalls += 1
         completion(nil)
     }
+}
+
+extension UserInfo: Equatable {}
+
+public func == (lhs: UserInfo, rhs: UserInfo) -> Bool {
+    lhs.id == rhs.id && lhs.name == rhs.name
+        && lhs.isInvisible == rhs.isInvisible && lhs.imageURL == rhs.imageURL
 }


### PR DESCRIPTION
### 🔗 Issue Links

Reported through Github: #2435 

### 🎯 Goal

Allow clients to update user information when connecting a user.

### 📝 Summary

Due to a bug introduced in 4.25.0, we are no longer updating the user information when connecting a user.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/3oEdv5okG3TzMJ9pQY/giphy.gif)