### PR TITLE
Fix missing messages in thread pagination

### DIFF
--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -300,18 +300,22 @@ public extension ChatMessageController {
             return
         }
 
-        let lastLocalMessageId: () -> MessageId? = {
-            self.replies.last { !$0.isLocalOnly }?.id
-        }
-
-        let lastMessageId = messageId ?? lastFetchedMessageId ?? lastLocalMessageId()
-
         let pageSize = limit ?? repliesPageSize
+        let pagination: MessagesPagination
+
+        if let lastMessageId = messageId ?? lastFetchedMessageId {
+            pagination = MessagesPagination(
+                pageSize: pageSize,
+                parameter: .lessThan(lastMessageId)
+            )
+        } else {
+            pagination = MessagesPagination(pageSize: pageSize)
+        }
 
         messageUpdater.loadReplies(
             cid: cid,
             messageId: self.messageId,
-            pagination: MessagesPagination(pageSize: pageSize, parameter: lastMessageId.map { PaginationParameter.lessThan($0) })
+            pagination: pagination
         ) { result in
             switch result {
             case let .success(payload):

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -293,8 +293,9 @@ class MessageDTO: NSManagedObject {
             deletedMessagesVisibility: deletedMessagesVisibility,
             shouldShowShadowedMessages: shouldShowShadowedMessages
         )
-        request.fetchLimit = pageSize
-        request.fetchBatchSize = pageSize
+        // TODO: Commented out until we enable mergeChanges: true when updating RefreshedObjects
+//        request.fetchLimit = pageSize
+//        request.fetchBatchSize = pageSize
         return request
     }
 

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -1082,7 +1082,7 @@ final class MessageController_Tests: XCTestCase {
         XCTAssertEqual(env.messageUpdater.loadReplies_pagination, .init(pageSize: 25))
     }
 
-    func test_loadPreviousReplies_noMessageIdPassed_noLastMessageFetched_usesLastMessageFromDB() {
+    func test_loadPreviousReplies_noMessageIdPassed_noLastMessageFetched_fetchWithoutParemeter() {
         // Create observers
         controller.synchronize()
 
@@ -1115,10 +1115,8 @@ final class MessageController_Tests: XCTestCase {
             completion: nil
         )
 
-        XCTAssertEqual(
-            env.messageUpdater.loadReplies_pagination?.parameter,
-            .lessThan("last message")
-        )
+        XCTAssertEqual(env.messageUpdater.loadReplies_pagination, .init(pageSize: 21))
+        XCTAssertEqual(env.messageUpdater.loadReplies_pagination?.parameter, nil)
     }
 
     func test_loadPreviousReplies_noMessageIdPassed_usesLastFetchedId() {

--- a/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
@@ -2762,8 +2762,11 @@ final class MessageDTO_Tests: XCTestCase {
             shouldShowShadowedMessages: false
         )
 
-        XCTAssertEqual(fetchRequest.fetchBatchSize, 20)
-        XCTAssertEqual(fetchRequest.fetchLimit, 20)
+        // TODO: Should be 20 after enable mergeChanges: true when updating RefreshedObjects
+        XCTAssertEqual(fetchRequest.fetchBatchSize, 0)
+        XCTAssertEqual(fetchRequest.fetchLimit, 0)
+//        XCTAssertEqual(fetchRequest.fetchBatchSize, 20)
+//        XCTAssertEqual(fetchRequest.fetchLimit, 20)
     }
 
     func test_repliesFetchRequest_shouldHaveFetchLimitAndBatchSize() {


### PR DESCRIPTION
### 🔗 Issue Links
N/A

### 🎯 Goal
Fix the issue spotted in 4.26.0 QA, where some paginations would be missing from Threads.

### 🛠 Implementation
For now, we are disabling the batchSize implementation until we update how we refresh the objects which don't contain changes to minimize the risk of the release

### 🧪 Manual Testing Notes
1. Open Release 4.26.0 Channel
2. Open the first thread
3. Leave the thread
4. Comeback to the thread
5. All pages should be loaded

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
