### PR TITLE
Fix message cell not updated when custom attachment data is different

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChatUI
+### 🐞 Fixed
+- Fix message cell not updated when custom attachment data is different [#2454](https://github.com/GetStream/stream-chat-swift/pull/2454)
 
 # [4.26.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.26.0)
 _January 11, 2023_

--- a/Sources/StreamChat/Models/ChatMessage.swift
+++ b/Sources/StreamChat/Models/ChatMessage.swift
@@ -259,6 +259,11 @@ public extension ChatMessage {
         reactionCounts.values.reduce(0, +)
     }
 
+    /// Returns all the attachments with the payload type-erased.
+    var allAttachments: [AnyChatMessageAttachment] {
+        _attachments
+    }
+
     /// Returns all the attachments with the payload of the provided type.
     ///
     /// - Important: Attachments are loaded lazily and cached to maintain high performance.

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
@@ -50,11 +50,6 @@ extension ChatMessage: Differentiable {
             && localState == source.localState
             && isFlaggedByCurrentUser == source.isFlaggedByCurrentUser
             && readBy.count == source.readBy.count
-            && giphyAttachments.map(\.previewURL) == source.giphyAttachments.map(\.previewURL)
-            && imageAttachments.map(\.uploadingState) == source.imageAttachments.map(\.uploadingState)
-            && videoAttachments.map(\.uploadingState) == source.videoAttachments.map(\.uploadingState)
-            && fileAttachments.map(\.uploadingState) == source.fileAttachments.map(\.uploadingState)
-            && audioAttachments.map(\.uploadingState) == source.audioAttachments.map(\.uploadingState)
-            && linkAttachments.map(\.uploadingState) == source.linkAttachments.map(\.uploadingState)
+            && allAttachments == source.allAttachments
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links
https://github.com/GetStream/stream-chat-swift/issues/2451

### 🎯 Goal
Fix the message cell not being updated when custom data in attachments are different.

### 🛠 Implementation
We now use all the available data in the attachments for the diffing, instead of trying to be smart and only choosing some properties. The reality is that each customer will have different logic here, so there can't be any assumptions.

### 🧪 Manual Testing Notes
N/A, it is hard to manually test this one right now. (Soon we will add custom attachments to the DemoApp)
But unit tests have been added to prove it works. 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
