### PR TITLE
WIP Custom attachments v2

### DIFF
--- a/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
+++ b/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
@@ -6,6 +6,21 @@ import Foundation
 import StreamChat
 import StreamChatUI
 
+extension AttachmentType {
+    static var workout: Self = "workout"
+}
+
+struct WorkoutAttachmentPayload: AttachmentPayload {
+    static var type: AttachmentType = .workout
+
+    var imageURL: URL?
+    var caloriesBurned: Int
+
+    mutating func updateRemoteUrl(_ url: URL) {
+        imageURL = url
+    }
+}
+
 extension StreamChatWrapper {
     // Instantiates chat client
     func setUpChat() {
@@ -22,6 +37,7 @@ extension StreamChatWrapper {
 
         // Create Client
         client = ChatClient(config: config)
+        client?.registerCustomAttachment(with: WorkoutAttachmentPayload.self)
 
         // Customize UI
         configureUI()

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -273,6 +273,17 @@ public class ChatClient {
         self.environment = environment
 
         setupConnectionRecoveryHandler(with: environment)
+
+        AttachmentDTO.register(FileAttachmentPayload.self)
+        AttachmentDTO.register(ImageAttachmentPayload.self)
+        AttachmentDTO.register(AudioAttachmentPayload.self)
+        AttachmentDTO.register(VideoAttachmentPayload.self)
+        AttachmentDTO.register(GiphyAttachmentPayload.self)
+        AttachmentDTO.register(LinkAttachmentPayload.self)
+    }
+
+    public func registerCustomAttachment<Payload: AttachmentPayload>(with payloadType: Payload.Type) {
+        AttachmentDTO.register(payloadType)
     }
 
     deinit {

--- a/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload.swift
+++ b/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload.swift
@@ -6,9 +6,22 @@ import Foundation
 
 /// A protocol an attachment payload type has to conform in order it can be
 /// attached to/exposed on the message.
-public protocol AttachmentPayload: Codable {
+public protocol AttachmentPayload: Codable, Equatable {
     /// A type of resulting attachment.
     static var type: AttachmentType { get }
+
+    /// Update the url of the attachment with the remote one.
+    /// This function will be called once an attachment has successfully uploaded.
+    /// - Parameter url: The remote url of the attachment.
+    mutating func updateRemoteUrl(_ url: URL)
+}
+
+public extension AttachmentPayload {
+    mutating func updateRemoteUrl(_ url: URL) {
+        // Implement this function to update the remote URL of the attachment.
+        // This function will be called when the attachment was successfully uploaded,
+        // in case the attachment was added to a message lazily.
+    }
 }
 
 /// A type-erased type that wraps either a local file URL that has to be uploaded
@@ -105,7 +118,7 @@ public extension AnyAttachmentPayload {
             .flatMap { try JSONEncoder.stream.encode($0.asAnyEncodable) }
             .flatMap { try JSONDecoder.stream.decode([String: RawJSON].self, from: $0) }
 
-        let payload: AttachmentPayload
+        let payload: any AttachmentPayload
         switch attachmentType {
         case .image:
             payload = ImageAttachmentPayload(

--- a/Sources/StreamChat/Models/Attachments/ChatMessageAudioAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageAudioAttachment.swift
@@ -43,6 +43,10 @@ public struct AudioAttachmentPayload: AttachmentPayload {
         self.file = file
         self.extraData = extraData
     }
+
+    public mutating func updateRemoteUrl(_ url: URL) {
+        audioURL = url
+    }
 }
 
 extension AudioAttachmentPayload: Hashable {}

--- a/Sources/StreamChat/Models/Attachments/ChatMessageFileAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageFileAttachment.swift
@@ -43,6 +43,10 @@ public struct FileAttachmentPayload: AttachmentPayload {
         self.file = file
         self.extraData = extraData
     }
+
+    public mutating func updateRemoteUrl(_ url: URL) {
+        assetURL = url
+    }
 }
 
 extension FileAttachmentPayload: Hashable {}

--- a/Sources/StreamChat/Models/Attachments/ChatMessageImageAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageImageAttachment.swift
@@ -27,6 +27,10 @@ public struct ImageAttachmentPayload: AttachmentPayload {
     /// An extra data.
     public var extraData: [String: RawJSON]?
 
+    public mutating func updateRemoteUrl(_ url: URL) {
+        imageURL = url
+    }
+
     /// Decodes extra data as an instance of the given type.
     /// - Parameter ofType: The type an extra data should be decoded as.
     /// - Returns: Extra data of the given type or `nil` if decoding fails.

--- a/Sources/StreamChat/Models/Attachments/ChatMessageVideoAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageVideoAttachment.swift
@@ -43,6 +43,10 @@ public struct VideoAttachmentPayload: AttachmentPayload {
         self.file = file
         self.extraData = extraData
     }
+
+    public mutating func updateRemoteUrl(_ url: URL) {
+        videoURL = url
+    }
 }
 
 extension VideoAttachmentPayload: Hashable {}

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -461,7 +461,7 @@ class ChannelUpdater: Worker {
             let attachment = AnyChatMessageAttachment(
                 id: .init(cid: cid, messageId: "", index: 0), // messageId and index won't be used for uploading
                 type: type,
-                payload: .init(), // payload won't be used for uploading
+                payload: Data(), // payload won't be used for uploading
                 uploadingState: .init(
                     localFileURL: localFileURL,
                     state: .pendingUpload, // will not be used

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
@@ -50,6 +50,35 @@ extension ChatMessage: Differentiable {
             && localState == source.localState
             && isFlaggedByCurrentUser == source.isFlaggedByCurrentUser
             && readBy.count == source.readBy.count
-            && allAttachments == source.allAttachments
+            && allAttachments.map(\.uploadingState) == source.allAttachments.map(\.uploadingState)
+            && areEqual(allAttachments.map(\.payload), source.allAttachments.map(\.payload))
+    }
+
+    private func areEqual(_ first: Any, _ second: Any) -> Bool {
+        if let equatableOne = first as? any Equatable, let equatableTwo = second as? any Equatable {
+            return equatableOne.isEqual(equatableTwo)
+        }
+        
+        if let arrayFirst = first as? [any Equatable], let secondArray = second as? [any Equatable] {
+            return zip(arrayFirst, secondArray).allSatisfy { areEqual($0, $1) }
+        }
+
+        return false
+    }
+}
+
+private extension Equatable {
+    func isEqual(_ other: any Equatable) -> Bool {
+        guard let other = other as? Self else {
+            return other.isExactlyEqual(self)
+        }
+        return self == other
+    }
+
+    private func isExactlyEqual(_ other: any Equatable) -> Bool {
+        guard let other = other as? Self else {
+            return false
+        }
+        return self == other
     }
 }

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
@@ -180,13 +180,10 @@ final class ChatMessageListVC_Tests: XCTestCase {
             let attachmentWithCommentsPayload = AnyAttachmentPayload(
                 payload: CustomAttachment(comments: comments)
             )
-            let attachmentWithCommentsData = try JSONEncoder.stream.encode(
-                attachmentWithCommentsPayload.payload.asAnyEncodable
-            )
             return AnyChatMessageAttachment(
                 id: attachmentId,
                 type: .unknown,
-                payload: attachmentWithCommentsData,
+                payload: attachmentWithCommentsPayload,
                 uploadingState: nil
             )
         }


### PR DESCRIPTION
This is a proof of concept to make it easier to handle custom attachments on the customer side. 

#### How to use
This is what a customer would need to do to add support for async attachment uploads:
1. Create the custom attachment payload and make sure to implement `func updateRemoteUrl(url:)`
```swift
extension AttachmentType {
    static var workout: Self = "workout"
}

struct WorkoutAttachmentPayload: AttachmentPayload {
    static var type: AttachmentType = .workout

    var imageURL: URL?
    var caloriesBurned: Int

    mutating func updateRemoteUrl(_ url: URL) {
        imageURL = url
    }
}
```
2. Register the custom attachment payload in `ChatClient`
```swift
ChatClient.shared.registerCustomAttachment(with: WorkoutAttachmentPayload.self)
```

#### Implementation

The basic idea is to change the `typealias AnyChatMessageAttachment` from `ChatMessageAttachment<Data>` to `ChatMessageAttachment<Any>`. Where instead of storing the Payload as `Data`, the idea is to store it as a type of `Payload: AttachmentPayload`. With this change, we can add common properties/functions to the `AttachmentPayload` protocol and update the payload data as needed.

This requires quite a few changes internally, and it adds a little bit of complexity, but with the advantage of making it really easy to add support for new custom attachments for the customer, but also for our own new attachments in the future.

**The new flow of `ChatMessageAttachment.payload` -> `AttachmentDTO.payload`:**
```mermaid
flowchart LR
    Any:AttachmentPayload-- asDTO -->Data
```
**The new flow of  `AttachmentDTO.payload` -> `ChatMessageAttachment.payload`:**
```mermaid
flowchart LR
    Data --> |asModel| Resgistered{Payload Registered?}
    Resgistered -->|Yes| A[Decoded to AttachmentPayload]
    Resgistered -->|Fallback| D[Remains Data]
    A -->|whenFetched| B[Casted to AttachmentPayload]
    D -->|whenFetched| C[Decoded to AttachmentPayload]
```

The 2nd flow diagram is important since it describes the fallback in case the customer does not register their custom attachment payload. If this is the case, the Attachment Model continues having the payload as `Data` and whenever it is accessed it is decoded to the custom payload type.

This new approach even has performance improvements, at least when fetching the attachments from the models, since at this stage, we only do a casting, instead of decoding it every time.

#### Caveats
- In theory, it is a breaking change since we are updating the typealias `AnyChatMessageAttachment` from `ChatMessageAttachment<Data>` to  `ChatMessageAttachment<Any>`, but in practice, this should not have any impact on the customer code base, so for that reason, I think this minor "breaking change" is worth it.
- The implementation relies a lot on existential types, so it means we would bump the min swift version to 5.6, which we are already only supporting officially since we only compile the project with Xcode 13.4+. We could also hide this feature behind a swift 5.6 compiler flag, but I think it would add a lot of complexity.
- Using existential types, and relying on typecasting, indeed adds a bit of complexity and unsafeness, but as long as we make sure we only have 1 place for each transformation (Model <-> DTO), it should be fine. 