### PR TITLE
[BW] Retry mock server start on CI

### DIFF
--- a/StreamChatUITestsAppUITests/Tests/Base TestCase/StreamTestCase.swift
+++ b/StreamChatUITestsAppUITests/Tests/Base TestCase/StreamTestCase.swift
@@ -82,10 +82,16 @@ extension StreamTestCase {
     private func startMockServer() {
         server = StreamMockServer()
         server.configure()
-        let result = server.start(port: in_port_t(MockServerConfiguration.port))
-        if !result {
-            XCTFail("Mock server failed on start")
+        
+        for _ in 0...3 {
+            let serverHasStarted = server.start(port: in_port_t(MockServerConfiguration.port))
+            if serverHasStarted {
+                return
+            }
+            server.stop()
         }
+        
+        XCTFail("Mock server failed on start")
     }
 
     private func startVideo() {


### PR DESCRIPTION
### 📝 Summary

I've noticed that sometimes the mock server fails on start on CI ([example](https://streamio.testops.cloud/launch/3341/tree/321654)). Hope this change will help.
