### PR TITLE
Fix outdated docs for custom attachments

### DIFF
--- a/docusaurus/docs/iOS/swiftui/chat-channel-components/message-composer.md
+++ b/docusaurus/docs/iOS/swiftui/chat-channel-components/message-composer.md
@@ -405,9 +405,10 @@ The final step that we need to do is to provide a new view that the message list
 
 ```swift
 func makeCustomAttachmentViewType(
-        for message: ChatMessage,
-        isFirst: Bool,
-        availableWidth: CGFloat
+    for message: ChatMessage,
+    isFirst: Bool,
+    availableWidth: CGFloat,
+    scrolledId: Binding<String?>
 ) -> some View {
     let contactAttachments = message.attachments(payloadType: ContactAttachmentPayload.self)
     return VStack {


### PR DESCRIPTION
### 🎯 Goal

There was an old method signature for the custom attachments in SwiftUI.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)