### PR TITLE
[Fix]Crash on Demo when user creates channel

### DIFF
--- a/DemoApp/Screens/Create Chat/CreateChatViewController.swift
+++ b/DemoApp/Screens/Create Chat/CreateChatViewController.swift
@@ -72,9 +72,7 @@ class CreateChatViewController: UIViewController {
 
     var searchController: ChatUserSearchController!
 
-    var users: [ChatUser] {
-        searchController.userArray
-    }
+    var users: [ChatUser] = []
 
     var selectedUserIds: Set<String> {
         Set(searchField.tokens.compactMap { ($0.representedObject as? ChatUser)?.id })
@@ -285,6 +283,7 @@ extension CreateChatViewController: ChatUserSearchControllerDelegate {
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
         if case .remoteDataFetched = state {
             print("\(users.count) users found")
+            users = searchController.userArray
             update(for: users.isEmpty ? .noUsers : .searching)
         }
     }


### PR DESCRIPTION
### 🎯 Goal

The app is crashing due to a race condition that is happening while the tableView updates its contents and the SearchController updates its users state.

We want to fix the race condition and effectively update the UI without crashing.

### 📝 Summary

When the user is trying to create a new channel and type back and forth queries on the search box the Demo app is crashing.

### 🛠 Implementation

The issue is being caused because the SearchController state (that asynchronously fetches users) is the same as the UI state in the CreateChatViewController. The solution to the problem is to decouple the 2 states and only rely on the delegate calls from the SearchController to update the users state in the CreateChatViewController and thus update the UI.

### 🧪 Manual Testing Notes

1. Open the Create Channel
2. Wait until the user list is populated
3. Type something in the search box
4. While the activityIndicator is visible, delete the text in the search box
5. Repeat

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_

![meme](https://media.giphy.com/media/5xrkJe3IJKSze/giphy.gif)