### PR TITLE
Fixed wrong code sample in the SwiftUI docs

### DIFF
--- a/docusaurus/docs/iOS/swiftui/message-components/message-reactions.md
+++ b/docusaurus/docs/iOS/swiftui/message-components/message-reactions.md
@@ -13,10 +13,9 @@ When reactions are added to a message, a view displaying the added reactions is 
 The simplest way to customize the message reactions view is to replace its reaction icons. Those are available under the `availableReactions` property in the Images class, which is part of the Appearance class in the StreamChat object. The `availableReactions` property is a dictionary, which contains mappings between `MessageReactionType` and its corresponding `ChatMessageReactionAppearanceType`, which consists of small and large icon for a reaction. If you change these properties, make sure to inject the updated `Images` class in the StreamChat object.
 
 ```swift
-let customReactions = [.init(rawValue: "custom"): ChatMessageReactionAppearance(
-                        smallIcon: reactionCustomSmall,
-                        largeIcon: reactionCustomBig
-                      )]
+let customReactions: [MessageReactionType: ChatMessageReactionAppearance] = [
+    .init(rawValue: "custom"): .init(smallIcon: smallIcon, largeIcon: largeIcon)
+]
 var images = Images()
 images.availableReactions = customReactions
 let appearance = Appearance(images: images)


### PR DESCRIPTION
### 🔗 Issue Links

https://github.com/GetStream/stream-chat-swiftui/issues/270

### 🎯 Goal

Fix a wrong code sample in the SwiftUI Docs, as reported by a customer.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
