### PR TITLE
Do not store messages from extension if app is receiving events

### DIFF
--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -224,6 +224,9 @@ public class ChatClient {
         )
     }()
 
+    /// Used as a bridge to communicate between the host app and the notification extension. Holds the state for the app lifecycle.
+    private(set) lazy var extensionLifecycle = NotificationExtensionLifecycle(appGroupIdentifier: config.applicationGroupIdentifier)
+
     /// The environment object containing all dependencies of this `Client` instance.
     private let environment: Environment
 
@@ -290,6 +293,7 @@ public class ChatClient {
             webSocketClient,
             eventNotificationCenter,
             syncRepository,
+            extensionLifecycle,
             environment.backgroundTaskSchedulerBuilder(),
             environment.internetConnection(eventNotificationCenter, environment.internetMonitor),
             config.staysConnectedInBackground
@@ -613,6 +617,7 @@ extension ChatClient {
             _ webSocketClient: WebSocketClient,
             _ eventNotificationCenter: EventNotificationCenter,
             _ syncRepository: SyncRepository,
+            _ extensionLifecycle: NotificationExtensionLifecycle,
             _ backgroundTaskScheduler: BackgroundTaskScheduler?,
             _ internetConnection: InternetConnection,
             _ keepConnectionAliveInBackground: Bool
@@ -621,11 +626,12 @@ extension ChatClient {
                 webSocketClient: $0,
                 eventNotificationCenter: $1,
                 syncRepository: $2,
-                backgroundTaskScheduler: $3,
-                internetConnection: $4,
+                extensionLifecycle: $3,
+                backgroundTaskScheduler: $4,
+                internetConnection: $5,
                 reconnectionStrategy: DefaultRetryStrategy(),
                 reconnectionTimerType: DefaultTimer.self,
-                keepConnectionAliveInBackground: $5
+                keepConnectionAliveInBackground: $6
             )
         }
 

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -225,7 +225,7 @@ public class ChatClient {
     }()
 
     /// Used as a bridge to communicate between the host app and the notification extension. Holds the state for the app lifecycle.
-    private(set) lazy var extensionLifecycle = NotificationExtensionLifecycle(appGroupIdentifier: config.applicationGroupIdentifier)
+    private(set) lazy var extensionLifecycle = environment.extensionLifecycleBuilder(config.applicationGroupIdentifier)
 
     /// The environment object containing all dependencies of this `Client` instance.
     private let environment: Environment
@@ -569,6 +569,8 @@ extension ChatClient {
                 shouldShowShadowedMessages: $5
             )
         }
+
+        var extensionLifecycleBuilder = NotificationExtensionLifecycle.init
 
         var requestEncoderBuilder: (_ baseURL: URL, _ apiKey: APIKey) -> RequestEncoder = DefaultRequestEncoder.init
         var requestDecoderBuilder: () -> RequestDecoder = DefaultRequestDecoder.init

--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -374,9 +374,7 @@ extension NSManagedObjectContext {
     func discardChanges(for object: NSManagedObject) {
         refresh(object, mergeChanges: false)
     }
-}
 
-extension NSManagedObjectContext {
     func discardCurrentChanges() {
         insertedObjects.forEach { discardChanges(for: $0) }
         updatedObjects.forEach { discardChanges(for: $0) }

--- a/Sources/StreamChat/Database/DatabaseContainer.swift
+++ b/Sources/StreamChat/Database/DatabaseContainer.swift
@@ -212,7 +212,7 @@ class DatabaseContainer: NSPersistentContainer {
                 // By reseting such objects we remove updates that are not updates.
                 for object in self.writableContext.updatedObjects {
                     if object.changedValues().isEmpty {
-                        self.writableContext.refresh(object, mergeChanges: false)
+                        self.writableContext.discardChanges(for: object)
                     }
                 }
 
@@ -366,5 +366,20 @@ class DatabaseContainer: NSPersistentContainer {
                 log.error("Error resetting ephemeral values: \(error)", subsystems: .database)
             }
         }
+    }
+}
+
+extension NSManagedObjectContext {
+    /// Discards any changes on the passed object that are pending to be saved.
+    func discardChanges(for object: NSManagedObject) {
+        refresh(object, mergeChanges: false)
+    }
+}
+
+extension NSManagedObjectContext {
+    func discardCurrentChanges() {
+        insertedObjects.forEach { discardChanges(for: $0) }
+        updatedObjects.forEach { discardChanges(for: $0) }
+        deletedObjects.forEach { discardChanges(for: $0) }
     }
 }

--- a/Sources/StreamChat/Repositories/MessageRepository.swift
+++ b/Sources/StreamChat/Repositories/MessageRepository.swift
@@ -172,7 +172,7 @@ class MessageRepository {
     ///   - messageId: The message identifier.
     ///   - store: A boolean indicating if the message should be stored to database or should only be retrieved
     ///   - completion: The completion. Will be called with an error if something goes wrong, otherwise - will be called with `nil`.
-    func getMessage(cid: ChannelId, messageId: MessageId, store: Bool = false, completion: ((Result<ChatMessage, Error>) -> Void)? = nil) {
+    func getMessage(cid: ChannelId, messageId: MessageId, store: Bool, completion: ((Result<ChatMessage, Error>) -> Void)? = nil) {
         let endpoint: Endpoint<MessagePayload.Boxed> = .getMessage(messageId: messageId)
         apiClient.request(endpoint: endpoint) {
             switch $0 {

--- a/Sources/StreamChat/Repositories/MessageRepository.swift
+++ b/Sources/StreamChat/Repositories/MessageRepository.swift
@@ -172,7 +172,7 @@ class MessageRepository {
     ///   - messageId: The message identifier.
     ///   - store: A boolean indicating if the message should be stored to database or should only be retrieved
     ///   - completion: The completion. Will be called with an error if something goes wrong, otherwise - will be called with `nil`.
-    func getMessage(cid: ChannelId, messageId: MessageId, store: Bool = true, completion: ((Result<ChatMessage, Error>) -> Void)? = nil) {
+    func getMessage(cid: ChannelId, messageId: MessageId, store: Bool = false, completion: ((Result<ChatMessage, Error>) -> Void)? = nil) {
         let endpoint: Endpoint<MessagePayload.Boxed> = .getMessage(messageId: messageId)
         apiClient.request(endpoint: endpoint) {
             switch $0 {

--- a/Sources/StreamChat/Repositories/MessageRepository.swift
+++ b/Sources/StreamChat/Repositories/MessageRepository.swift
@@ -170,8 +170,9 @@ class MessageRepository {
     /// - Parameters:
     ///   - cid: The channel identifier the message relates to.
     ///   - messageId: The message identifier.
+    ///   - store: A boolean indicating if the message should be stored to database or should only be retrieved
     ///   - completion: The completion. Will be called with an error if something goes wrong, otherwise - will be called with `nil`.
-    func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Result<ChatMessage, Error>) -> Void)? = nil) {
+    func getMessage(cid: ChannelId, messageId: MessageId, store: Bool = true, completion: ((Result<ChatMessage, Error>) -> Void)? = nil) {
         let endpoint: Endpoint<MessagePayload.Boxed> = .getMessage(messageId: messageId)
         apiClient.request(endpoint: endpoint) {
             switch $0 {
@@ -179,6 +180,9 @@ class MessageRepository {
                 var message: ChatMessage?
                 self.database.write({ session in
                     message = try session.saveMessage(payload: boxed.message, for: cid, syncOwnReactions: true, cache: nil).asModel()
+                    if !store {
+                        self.database.writableContext.discardCurrentChanges()
+                    }
                 }, completion: { error in
                     if let error = error {
                         completion?(.failure(error))

--- a/Sources/StreamChat/Utils/NotificationExtension+Lifecycle.swift
+++ b/Sources/StreamChat/Utils/NotificationExtension+Lifecycle.swift
@@ -1,0 +1,33 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+class NotificationExtensionLifecycle {
+    private lazy var userDefaults = appGroupIdentifier.flatMap(UserDefaults.init(suiteName:))
+    private let isReceivingEventsKey = "stream.extension.is-receiving-events"
+    private let appGroupIdentifier: String?
+
+    init(appGroupIdentifier: String?) {
+        self.appGroupIdentifier = appGroupIdentifier
+    }
+
+    var isAppReceivingWebSocketEvents: Bool {
+        guard let userDefaults = userDefaults else {
+            logMissingAppGroupIfNeeded()
+            return false
+        }
+        return userDefaults.bool(forKey: isReceivingEventsKey)
+    }
+
+    func setAppState(isReceivingEvents: Bool) {
+        userDefaults?.set(isReceivingEvents, forKey: isReceivingEventsKey)
+    }
+
+    private func logMissingAppGroupIfNeeded() {
+        let isExtension = Bundle.main.bundleURL.pathExtension == "appex"
+        guard isExtension else { return }
+        log.debug("Unable to share data between the host app and the extension. App Groups is not set up, or has incorrect values")
+    }
+}

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -22,7 +22,7 @@ class MessageUpdater: Worker {
     ///   - messageId: The message identifier.
     ///   - completion: The completion. Will be called with an error if something goes wrong, otherwise - will be called with `nil`.
     func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Result<ChatMessage, Error>) -> Void)? = nil) {
-        repository.getMessage(cid: cid, messageId: messageId, completion: completion)
+        repository.getMessage(cid: cid, messageId: messageId, store: true, completion: completion)
     }
 
     /// Deletes the message.

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1708,6 +1708,8 @@
 		C1616DB428DC9F0B00FF993B /* ChannelCreated.json in Resources */ = {isa = PBXBuildFile; fileRef = C1616DB328DC9F0B00FF993B /* ChannelCreated.json */; };
 		C163ECFB299155D0006D6124 /* NotificationExtension+Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C163ECFA299155D0006D6124 /* NotificationExtension+Lifecycle.swift */; };
 		C163ECFC299155D0006D6124 /* NotificationExtension+Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C163ECFA299155D0006D6124 /* NotificationExtension+Lifecycle.swift */; };
+		C163ECFE2992B06C006D6124 /* NotificationExtensionLifecycle_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C163ECFD2992B06C006D6124 /* NotificationExtensionLifecycle_Tests.swift */; };
+		C163ED012992B378006D6124 /* NotificationExtensionLifecycle_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C163ECFF2992B24E006D6124 /* NotificationExtensionLifecycle_Mock.swift */; };
 		C171041E2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */; };
 		C171041F2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */; };
 		C173538E27D9F804008AC412 /* KeyedDecodingContainer+Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = C173538D27D9F804008AC412 /* KeyedDecodingContainer+Array.swift */; };
@@ -3463,6 +3465,8 @@
 		C1616DB028DC4D7F00FF993B /* UserGloballyBanned.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UserGloballyBanned.json; sourceTree = "<group>"; };
 		C1616DB328DC9F0B00FF993B /* ChannelCreated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ChannelCreated.json; sourceTree = "<group>"; };
 		C163ECFA299155D0006D6124 /* NotificationExtension+Lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationExtension+Lifecycle.swift"; sourceTree = "<group>"; };
+		C163ECFD2992B06C006D6124 /* NotificationExtensionLifecycle_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationExtensionLifecycle_Tests.swift; sourceTree = "<group>"; };
+		C163ECFF2992B24E006D6124 /* NotificationExtensionLifecycle_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationExtensionLifecycle_Mock.swift; sourceTree = "<group>"; };
 		C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeSubscript.swift"; sourceTree = "<group>"; };
 		C173538D27D9F804008AC412 /* KeyedDecodingContainer+Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+Array.swift"; sourceTree = "<group>"; };
 		C174E0F5284DFA5A0040B936 /* IdentifiablePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiablePayload.swift; sourceTree = "<group>"; };
@@ -5766,6 +5770,7 @@
 			isa = PBXGroup;
 			children = (
 				F6C56D1324F7B89D0012BB1F /* EventMiddleware_Mock.swift */,
+				C163ECFF2992B24E006D6124 /* NotificationExtensionLifecycle_Mock.swift */,
 			);
 			path = EventMiddlewares;
 			sourceTree = "<group>";
@@ -6047,6 +6052,7 @@
 				A364D0BE27D12C950029857A /* InternetConnection */,
 				88EA9AE125471999007EE76B /* Dictionary_Tests.swift */,
 				84ABF699274E570600EDDA68 /* EventBatcher_Tests.swift */,
+				C163ECFD2992B06C006D6124 /* NotificationExtensionLifecycle_Tests.swift */,
 				BCE48068C1C02C0689BEB64E /* JSONDecoder_Tests.swift */,
 				BCE489A4B136D48249DD6969 /* JSONEncoder_Tests.swift */,
 				DB842E4425C9F94C000AAC46 /* LazyCachedMapCollection_Tests.swift */,
@@ -9305,6 +9311,7 @@
 				A3C3BC2D27E87F2000224761 /* TestCustomEventPayload.swift in Sources */,
 				A3C3BC9527E8AC0A00224761 /* RequestDecoder_Spy.swift in Sources */,
 				A311B43027E8BC8400CFCF6D /* ChatUserController_Delegate.swift in Sources */,
+				C163ED012992B378006D6124 /* NotificationExtensionLifecycle_Mock.swift in Sources */,
 				A3C3BC6D27E8AA4300224761 /* TestManagedObject.swift in Sources */,
 				A3C3BC2427E87F1800224761 /* ChatChannelController_Spy.swift in Sources */,
 				A3C3BC1927E87EFE00224761 /* ConnectionRepository_Mock.swift in Sources */,
@@ -9668,6 +9675,7 @@
 				7964F3AA249A19EA002A09EC /* Filter_Tests.swift in Sources */,
 				AD45333225D153A500CD9D47 /* ConnectionController_Tests.swift in Sources */,
 				DA84072D2525EF8D005A0F62 /* UserEndpoints_Tests.swift in Sources */,
+				C163ECFE2992B06C006D6124 /* NotificationExtensionLifecycle_Tests.swift in Sources */,
 				889B00E9252CACCB007709A8 /* ChannelMemberListQueryDTO_Tests.swift in Sources */,
 				A34ECB4827F5C9FA00A804C1 /* UserEvents_IntegrationTests.swift in Sources */,
 				8A0175F425013B6400570345 /* TypingEventSender_Tests.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1706,6 +1706,8 @@
 		C1616DB128DC4D7F00FF993B /* UserGloballyUnbanned.json in Resources */ = {isa = PBXBuildFile; fileRef = C1616DAF28DC4D7F00FF993B /* UserGloballyUnbanned.json */; };
 		C1616DB228DC4D7F00FF993B /* UserGloballyBanned.json in Resources */ = {isa = PBXBuildFile; fileRef = C1616DB028DC4D7F00FF993B /* UserGloballyBanned.json */; };
 		C1616DB428DC9F0B00FF993B /* ChannelCreated.json in Resources */ = {isa = PBXBuildFile; fileRef = C1616DB328DC9F0B00FF993B /* ChannelCreated.json */; };
+		C163ECFB299155D0006D6124 /* NotificationExtension+Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C163ECFA299155D0006D6124 /* NotificationExtension+Lifecycle.swift */; };
+		C163ECFC299155D0006D6124 /* NotificationExtension+Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C163ECFA299155D0006D6124 /* NotificationExtension+Lifecycle.swift */; };
 		C171041E2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */; };
 		C171041F2768C34E008FB3F2 /* Array+SafeSubscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */; };
 		C173538E27D9F804008AC412 /* KeyedDecodingContainer+Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = C173538D27D9F804008AC412 /* KeyedDecodingContainer+Array.swift */; };
@@ -3460,6 +3462,7 @@
 		C1616DAF28DC4D7F00FF993B /* UserGloballyUnbanned.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UserGloballyUnbanned.json; sourceTree = "<group>"; };
 		C1616DB028DC4D7F00FF993B /* UserGloballyBanned.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UserGloballyBanned.json; sourceTree = "<group>"; };
 		C1616DB328DC9F0B00FF993B /* ChannelCreated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ChannelCreated.json; sourceTree = "<group>"; };
+		C163ECFA299155D0006D6124 /* NotificationExtension+Lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationExtension+Lifecycle.swift"; sourceTree = "<group>"; };
 		C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeSubscript.swift"; sourceTree = "<group>"; };
 		C173538D27D9F804008AC412 /* KeyedDecodingContainer+Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+Array.swift"; sourceTree = "<group>"; };
 		C174E0F5284DFA5A0040B936 /* IdentifiablePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiablePayload.swift; sourceTree = "<group>"; };
@@ -4252,6 +4255,7 @@
 				C173538D27D9F804008AC412 /* KeyedDecodingContainer+Array.swift */,
 				79D5CDD027EA1BA100BE7D8B /* TranslationLanguage.swift */,
 				C14D27B52869EEE40063F6F2 /* Array+CompactMapLoggingError.swift */,
+				C163ECFA299155D0006D6124 /* NotificationExtension+Lifecycle.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -9345,6 +9349,7 @@
 				DAE566E724FFD22300E39431 /* ChannelController+SwiftUI.swift in Sources */,
 				88DA57202631AC3100FA8C53 /* ChannelMuteDTO.swift in Sources */,
 				C1FC2F9E2742579D0062530F /* FoundationTransport.swift in Sources */,
+				C163ECFB299155D0006D6124 /* NotificationExtension+Lifecycle.swift in Sources */,
 				CFA41B6727DA952100427602 /* SystemEnvironment+XStreamClient.swift in Sources */,
 				792CA62624CEE93700D70A5E /* ChannelListUpdater.swift in Sources */,
 				882C5756252C791400E60C44 /* ChannelMemberListUpdater.swift in Sources */,
@@ -10160,6 +10165,7 @@
 				C121E88F274544AF00023E4C /* CurrentUser.swift in Sources */,
 				C121E890274544AF00023E4C /* Device.swift in Sources */,
 				C121E891274544AF00023E4C /* Member.swift in Sources */,
+				C163ECFC299155D0006D6124 /* NotificationExtension+Lifecycle.swift in Sources */,
 				C121E892274544B000023E4C /* User.swift in Sources */,
 				C121E893274544B000023E4C /* UserInfo.swift in Sources */,
 				C121E894274544B000023E4C /* ChatMessage.swift in Sources */,

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/ChatClient_Mock.swift
@@ -154,6 +154,10 @@ extension ChatClient {
         databaseContainer as! DatabaseContainer_Spy
     }
 
+    var mockExtensionLifecycle: NotificationExtensionLifecycle_Mock {
+        extensionLifecycle as! NotificationExtensionLifecycle_Mock
+    }
+
     var mockSyncRepository: SyncRepository_Mock {
         syncRepository as! SyncRepository_Mock
     }
@@ -200,6 +204,7 @@ extension ChatClient.Environment {
                     shouldShowShadowedMessages: $5
                 )
             },
+            extensionLifecycleBuilder: NotificationExtensionLifecycle_Mock.init,
             requestEncoderBuilder: DefaultRequestEncoder.init,
             requestDecoderBuilder: DefaultRequestDecoder.init,
             eventDecoderBuilder: EventDecoder.init,

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/MessageRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/MessageRepository_Mock.swift
@@ -48,7 +48,7 @@ final class MessageRepository_Mock: MessageRepository, Spy {
         completion()
     }
 
-    override func getMessage(cid: ChannelId, messageId: MessageId, completion: ((Result<ChatMessage, Error>) -> Void)? = nil) {
+    override func getMessage(cid: ChannelId, messageId: MessageId, store: Bool = true, completion: ((Result<ChatMessage, Error>) -> Void)? = nil) {
         record()
         getMessageResult.map { completion?($0) }
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/MessageRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/MessageRepository_Mock.swift
@@ -14,6 +14,7 @@ final class MessageRepository_Mock: MessageRepository, Spy {
     var sendMessageResult: Result<ChatMessage, MessageRepositoryError>?
     var sendMessageCalls: [MessageId: (Result<ChatMessage, MessageRepositoryError>) -> Void] = [:]
     var getMessageResult: Result<ChatMessage, Error>?
+    var receivedGetMessageStore: Bool?
     var saveSuccessfullyDeletedMessageError: Error?
     let lock = NSLock()
     var updatedMessageLocalState: LocalMessageState?
@@ -50,6 +51,7 @@ final class MessageRepository_Mock: MessageRepository, Spy {
 
     override func getMessage(cid: ChannelId, messageId: MessageId, store: Bool = true, completion: ((Result<ChatMessage, Error>) -> Void)? = nil) {
         record()
+        receivedGetMessageStore = store
         getMessageResult.map { completion?($0) }
     }
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/WebSocketClient/EventMiddlewares/NotificationExtensionLifecycle_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/WebSocketClient/EventMiddlewares/NotificationExtensionLifecycle_Mock.swift
@@ -1,0 +1,24 @@
+//
+//  NotificationExtensionLifecycle_Mock.swift
+//  StreamChatTests
+//
+//  Created by Pol Quintana on 7/2/23.
+//  Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+
+final class NotificationExtensionLifecycle_Mock: NotificationExtensionLifecycle {
+
+    var mockIsAppReceivingWebSocketEvents: Bool?
+    var receivedIsReceivingEvents: Bool?
+
+    override var isAppReceivingWebSocketEvents: Bool {
+        mockIsAppReceivingWebSocketEvents ?? super.isAppReceivingWebSocketEvents
+    }
+
+    override func setAppState(isReceivingEvents: Bool) {
+        receivedIsReceivingEvents = isReceivingEvents
+    }
+}

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/WebSocketClient/EventMiddlewares/NotificationExtensionLifecycle_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/WebSocketClient/EventMiddlewares/NotificationExtensionLifecycle_Mock.swift
@@ -15,7 +15,7 @@ final class NotificationExtensionLifecycle_Mock: NotificationExtensionLifecycle 
     var receivedIsReceivingEvents: Bool?
 
     override var isAppReceivingWebSocketEvents: Bool {
-        mockIsAppReceivingWebSocketEvents ?? super.isAppReceivingWebSocketEvents
+        mockIsAppReceivingWebSocketEvents ?? false
     }
 
     override func setAppState(isReceivingEvents: Bool) {

--- a/Tests/StreamChatTests/APIClient/ChatPushNotificationContent_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/ChatPushNotificationContent_Tests.swift
@@ -120,7 +120,7 @@ final class ChatPushNotificationContent_Tests: XCTestCase {
         let handler = ChatRemoteNotificationHandler(client: clientWithOffline, content: content)
         XCTAssertTrue(handler.handleNotification(completion: { _ in }))
         // Should only store the fetched message if the host app is not listening to events
-        XCTAssertTrue(messageRepository.receivedGetMessageStore == false)
+        XCTAssert(messageRepository.receivedGetMessageStore == false)
     }
 
     func test_contentHandled_newMessage_appIsNotReceivingWebSocketEvents() {
@@ -137,7 +137,7 @@ final class ChatPushNotificationContent_Tests: XCTestCase {
         let handler = ChatRemoteNotificationHandler(client: clientWithOffline, content: content)
         XCTAssertTrue(handler.handleNotification(completion: { _ in }))
         // Should only store the fetched message if the host app is not listening to events
-        XCTAssertTrue(messageRepository.receivedGetMessageStore == true)
+        XCTAssert(messageRepository.receivedGetMessageStore == true)
     }
 
     func test_callsCompletion_whenHandled() throws {

--- a/Tests/StreamChatTests/APIClient/ChatPushNotificationContent_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/ChatPushNotificationContent_Tests.swift
@@ -11,6 +11,8 @@ final class ChatPushNotificationContent_Tests: XCTestCase {
     var webSocketClient: WebSocketClient_Mock!
     var apiClient: APIClient_Spy!
     var database: DatabaseContainer_Spy!
+    var messageRepository: MessageRepository_Mock!
+    var extensionLifecycle: NotificationExtensionLifecycle_Mock!
     var currentUserUpdater: CurrentUserUpdater!
     var clientWithOffline: ChatClient!
     let apiKey: APIKey = .init("123")
@@ -29,10 +31,14 @@ final class ChatPushNotificationContent_Tests: XCTestCase {
         webSocketClient = WebSocketClient_Mock()
         apiClient = APIClient_Spy()
         database = DatabaseContainer_Spy()
+        messageRepository = MessageRepository_Mock(database: database, apiClient: apiClient)
+        extensionLifecycle = NotificationExtensionLifecycle_Mock(appGroupIdentifier: "test")
 
         var env = ChatClient.Environment()
         env.databaseContainerBuilder = { _, _, _, _, _, _ in self.database }
         env.apiClientBuilder = { _, _, _, _, _, _ in self.apiClient }
+        env.extensionLifecycleBuilder = { _ in self.extensionLifecycle }
+        env.messageRepositoryBuilder = { _, _ in self.messageRepository }
 
         clientWithOffline = ChatClient_Mock(
             config: configOffline,
@@ -100,10 +106,45 @@ final class ChatPushNotificationContent_Tests: XCTestCase {
         XCTAssertTrue(handler.handleNotification(completion: { _ in }))
     }
 
+    func test_contentHandled_newMessage_appIsReceivingWebSocketEvents() {
+        extensionLifecycle.mockIsAppReceivingWebSocketEvents = true
+
+        let content = UNMutableNotificationContent()
+        let payload = [
+            "type": "message.new",
+            "cid": "a:b",
+            "id": "42"
+        ]
+        content.userInfo["stream"] = payload
+        content.categoryIdentifier = "stream.chat"
+        let handler = ChatRemoteNotificationHandler(client: clientWithOffline, content: content)
+        XCTAssertTrue(handler.handleNotification(completion: { _ in }))
+        // Should only store the fetched message if the host app is not listening to events
+        XCTAssertTrue(messageRepository.receivedGetMessageStore == false)
+    }
+
+    func test_contentHandled_newMessage_appIsNotReceivingWebSocketEvents() {
+        extensionLifecycle.mockIsAppReceivingWebSocketEvents = false
+
+        let content = UNMutableNotificationContent()
+        let payload = [
+            "type": "message.new",
+            "cid": "a:b",
+            "id": "42"
+        ]
+        content.userInfo["stream"] = payload
+        content.categoryIdentifier = "stream.chat"
+        let handler = ChatRemoteNotificationHandler(client: clientWithOffline, content: content)
+        XCTAssertTrue(handler.handleNotification(completion: { _ in }))
+        // Should only store the fetched message if the host app is not listening to events
+        XCTAssertTrue(messageRepository.receivedGetMessageStore == true)
+    }
+
     func test_callsCompletion_whenHandled() throws {
         let handler = ChatRemoteNotificationHandler(client: clientWithOffline, content: exampleMessageNotificationContent)
         let expectation = XCTestExpectation(description: "Receive a message content")
 
+        messageRepository.getMessageResult = .success(ChatMessage.mock())
         XCTAssertTrue(handler.handleNotification(completion: { notification in
             expectation.fulfill()
 

--- a/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
@@ -358,7 +358,7 @@ final class MessageRepositoryTests: XCTestCase {
         // Assert completion is called
         AssertAsync.willBeTrue(completionCalled)
 
-        // Assert fetched message is saved to the database
+        // Assert fetched message is NOT saved to the database
         XCTAssertNil(database.viewContext.message(id: messageId))
     }
 

--- a/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
@@ -254,7 +254,7 @@ final class MessageRepositoryTests: XCTestCase {
         let messageId: MessageId = .unique
 
         // Simulate `getMessage(cid:, messageId:)` call
-        repository.getMessage(cid: cid, messageId: messageId)
+        repository.getMessage(cid: cid, messageId: messageId, store: true)
 
         // Assert correct endpoint is called
         let expectedEndpoint: Endpoint<MessagePayload.Boxed> = .getMessage(messageId: messageId)
@@ -264,7 +264,7 @@ final class MessageRepositoryTests: XCTestCase {
     func test_getMessage_propogatesRequestError() {
         // Simulate `getMessage(cid:, messageId:)` call
         var completionCalledError: Error?
-        repository.getMessage(cid: .unique, messageId: .unique) {
+        repository.getMessage(cid: .unique, messageId: .unique, store: true) {
             completionCalledError = $0.error
         }
 
@@ -291,7 +291,7 @@ final class MessageRepositoryTests: XCTestCase {
 
         // Simulate `getMessage(cid:, messageId:)` call
         var completionCalledError: Error?
-        repository.getMessage(cid: channelId, messageId: messagePayload.message.id) {
+        repository.getMessage(cid: channelId, messageId: messagePayload.message.id, store: true) {
             completionCalledError = $0.error
         }
 

--- a/Tests/StreamChatTests/Utils/Database/NSManagedObject_Tests.swift
+++ b/Tests/StreamChatTests/Utils/Database/NSManagedObject_Tests.swift
@@ -4,6 +4,7 @@
 
 import CoreData
 @testable import StreamChat
+@testable import StreamChatTestTools
 import XCTest
 
 final class NSManagedObject_Tests: XCTestCase {
@@ -13,6 +14,52 @@ final class NSManagedObject_Tests: XCTestCase {
 
     func test_entityName_custom() {
         XCTAssertEqual(EntityWithCustomName.entityName, "CustomName")
+    }
+
+    func test_discardChanges_shouldClearChangesForTheObject() throws {
+        let database = DatabaseContainer_Spy()
+        try database.writeSynchronously { session in
+            let dto1 = try session.saveUser(payload: .dummy(userId: "1"))
+            try session.saveUser(payload: .dummy(userId: "2"))
+            database.writableContext.discardChanges(for: dto1)
+        }
+
+        XCTAssertNil(database.viewContext.user(id: "1"))
+        XCTAssertNotNil(database.viewContext.user(id: "2"))
+    }
+
+    func test_discardCurrentChanges_shouldClearChangesForTheTransaction() throws {
+        let database = DatabaseContainer_Spy()
+
+        // We create 2 objects at first
+        var dto1: UserDTO!
+        try database.writeSynchronously { session in
+            dto1 = try session.saveUser(payload: .dummy(userId: "1", name: "1"))
+            try session.saveUser(payload: .dummy(userId: "2", name: "2"))
+        }
+        XCTAssertNotNil(database.viewContext.user(id: "1"))
+        XCTAssertNotNil(database.viewContext.user(id: "2"))
+
+        // We are now going to add an insertion, an update and a deletion, to then discard it.
+
+        let context = database.writableContext
+        try database.writeSynchronously { session in
+            context.delete(dto1)
+            try session.saveUser(payload: .dummy(userId: "2", name: "new2"))
+            try session.saveUser(payload: .dummy(userId: "3", name: "3"))
+
+            XCTAssertEqual(context.insertedObjects.count, 1)
+            XCTAssertEqual(context.updatedObjects.count, 1)
+            XCTAssertEqual(context.deletedObjects.count, 1)
+            database.writableContext.discardCurrentChanges()
+        }
+
+        // The state is the same as the one after the initial transaction that was not discarded.
+
+        XCTAssertNotNil(database.viewContext.user(id: "1"))
+        XCTAssertNotNil(database.viewContext.user(id: "2"))
+        XCTAssertEqual(database.viewContext.user(id: "2")?.name, "2")
+        XCTAssertNil(database.viewContext.user(id: "3"))
     }
 }
 

--- a/Tests/StreamChatTests/Utils/NotificationExtensionLifecycle_Tests.swift
+++ b/Tests/StreamChatTests/Utils/NotificationExtensionLifecycle_Tests.swift
@@ -1,0 +1,36 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class NotificationExtensionLifecycleTests: XCTestCase {
+    func test_initializingWithNilIdentifier_shouldAlwaysReturnFalse() {
+        let extensionLifecycle = NotificationExtensionLifecycle(appGroupIdentifier: nil)
+        XCTAssertFalse(extensionLifecycle.isAppReceivingWebSocketEvents)
+        extensionLifecycle.setAppState(isReceivingEvents: true)
+        XCTAssertFalse(extensionLifecycle.isAppReceivingWebSocketEvents)
+    }
+
+    func test_initializingWithValidIdentifier_isAppReceivingWebSocketEvents_shouldReturnFalseAsDefaultValue() {
+        let extensionLifecycle = NotificationExtensionLifecycle(appGroupIdentifier: UUID().uuidString)
+        XCTAssertFalse(extensionLifecycle.isAppReceivingWebSocketEvents)
+    }
+
+    func test_initializingWithValidIdentifier_isAppReceivingWebSocketEvents_settingStateToReceivingEvents_shouldProperlyReflectItsValue() {
+        let extensionLifecycle = NotificationExtensionLifecycle(appGroupIdentifier: UUID().uuidString)
+        extensionLifecycle.setAppState(isReceivingEvents: true)
+        XCTAssertTrue(extensionLifecycle.isAppReceivingWebSocketEvents)
+    }
+
+    func test_initializingWithValidIdentifier_isAppReceivingWebSocketEvents_settingStateToNotReceivingEvents_shouldProperlyReflectItsValue() {
+        let extensionLifecycle = NotificationExtensionLifecycle(appGroupIdentifier: UUID().uuidString)
+        extensionLifecycle.setAppState(isReceivingEvents: true)
+        XCTAssertTrue(extensionLifecycle.isAppReceivingWebSocketEvents)
+        extensionLifecycle.setAppState(isReceivingEvents: false)
+        XCTAssertFalse(extensionLifecycle.isAppReceivingWebSocketEvents)
+    }
+}

--- a/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
@@ -494,6 +494,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         handler.webSocketClient(mockChatClient.mockWebSocketClient, didUpdateConnectionState: .connecting)
 
         XCTAssertNotCall("syncLocalState(completion:)", on: mockChatClient.mockSyncRepository)
+        XCTAssertNil(mockChatClient.mockExtensionLifecycle.receivedIsReceivingEvents)
     }
 
     func test_webSocketStateUpdate_connected() {
@@ -504,6 +505,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
 
         XCTAssertCall(RetryStrategy_Spy.Signature.resetConsecutiveFailures, on: mockRetryStrategy, times: 1)
         XCTAssertCall("syncLocalState(completion:)", on: mockChatClient.mockSyncRepository, times: 1)
+        XCTAssertTrue(mockChatClient.mockExtensionLifecycle.receivedIsReceivingEvents == true)
     }
 
     func test_webSocketStateUpdate_disconnected_userInitiated() {
@@ -519,6 +521,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         XCTAssertNotCall(RetryStrategy_Spy.Signature.nextRetryDelay, on: mockRetryStrategy)
         XCTAssertNotCall("incrementConsecutiveFailures()", on: mockRetryStrategy)
         XCTAssertNotCall("syncLocalState(completion:)", on: mockChatClient.mockSyncRepository)
+        XCTAssertTrue(mockChatClient.mockExtensionLifecycle.receivedIsReceivingEvents == false)
     }
 
     func test_webSocketStateUpdate_disconnected_systemInitiated() {
@@ -538,6 +541,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         XCTAssertCall(RetryStrategy_Spy.Signature.nextRetryDelay, on: mockRetryStrategy, times: 1)
         XCTAssertCall("incrementConsecutiveFailures()", on: mockRetryStrategy, times: 1)
         XCTAssertNotCall("syncLocalState(completion:)", on: mockChatClient.mockSyncRepository)
+        XCTAssertTrue(mockChatClient.mockExtensionLifecycle.receivedIsReceivingEvents == false)
     }
 
     func test_webSocketStateUpdate_initialized() {
@@ -547,6 +551,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         handler.webSocketClient(mockChatClient.mockWebSocketClient, didUpdateConnectionState: .initialized)
 
         XCTAssertNotCall("syncLocalState(completion:)", on: mockChatClient.mockSyncRepository)
+        XCTAssertNil(mockChatClient.mockExtensionLifecycle.receivedIsReceivingEvents)
     }
 
     func test_webSocketStateUpdate_waitingForConnectionId() {
@@ -556,6 +561,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         handler.webSocketClient(mockChatClient.mockWebSocketClient, didUpdateConnectionState: .waitingForConnectionId)
 
         XCTAssertNotCall("syncLocalState(completion:)", on: mockChatClient.mockSyncRepository)
+        XCTAssertNil(mockChatClient.mockExtensionLifecycle.receivedIsReceivingEvents)
     }
 
     func test_webSocketStateUpdate_disconnecting() {
@@ -568,6 +574,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         )
 
         XCTAssertNotCall("syncLocalState(completion:)", on: mockChatClient.mockSyncRepository)
+        XCTAssertNil(mockChatClient.mockExtensionLifecycle.receivedIsReceivingEvents)
     }
 }
 
@@ -581,6 +588,7 @@ private extension ConnectionRecoveryHandler_Tests {
             webSocketClient: mockChatClient.mockWebSocketClient,
             eventNotificationCenter: mockChatClient.eventNotificationCenter,
             syncRepository: mockChatClient.mockSyncRepository,
+            extensionLifecycle: mockChatClient.extensionLifecycle,
             backgroundTaskScheduler: mockBackgroundTaskScheduler,
             internetConnection: mockInternetConnection,
             reconnectionStrategy: mockRetryStrategy,

--- a/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/ConnectionRecoveryHandler_Tests.swift
@@ -505,7 +505,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
 
         XCTAssertCall(RetryStrategy_Spy.Signature.resetConsecutiveFailures, on: mockRetryStrategy, times: 1)
         XCTAssertCall("syncLocalState(completion:)", on: mockChatClient.mockSyncRepository, times: 1)
-        XCTAssertTrue(mockChatClient.mockExtensionLifecycle.receivedIsReceivingEvents == true)
+        XCTAssert(mockChatClient.mockExtensionLifecycle.receivedIsReceivingEvents == true)
     }
 
     func test_webSocketStateUpdate_disconnected_userInitiated() {
@@ -521,7 +521,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         XCTAssertNotCall(RetryStrategy_Spy.Signature.nextRetryDelay, on: mockRetryStrategy)
         XCTAssertNotCall("incrementConsecutiveFailures()", on: mockRetryStrategy)
         XCTAssertNotCall("syncLocalState(completion:)", on: mockChatClient.mockSyncRepository)
-        XCTAssertTrue(mockChatClient.mockExtensionLifecycle.receivedIsReceivingEvents == false)
+        XCTAssert(mockChatClient.mockExtensionLifecycle.receivedIsReceivingEvents == false)
     }
 
     func test_webSocketStateUpdate_disconnected_systemInitiated() {
@@ -541,7 +541,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase {
         XCTAssertCall(RetryStrategy_Spy.Signature.nextRetryDelay, on: mockRetryStrategy, times: 1)
         XCTAssertCall("incrementConsecutiveFailures()", on: mockRetryStrategy, times: 1)
         XCTAssertNotCall("syncLocalState(completion:)", on: mockChatClient.mockSyncRepository)
-        XCTAssertTrue(mockChatClient.mockExtensionLifecycle.receivedIsReceivingEvents == false)
+        XCTAssert(mockChatClient.mockExtensionLifecycle.receivedIsReceivingEvents == false)
     }
 
     func test_webSocketStateUpdate_initialized() {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/stream-chat-swift/issues/2309
Resolves https://github.com/GetStream/ios-issues-tracking/issues/264

### 🎯 Goal

Make channel unread counts accurate

### 📝 Summary

Unread counts were not accurate when the app was in the foreground handling the updates both using WS events and Push Notifications

### 🛠 Implementation

This PR stops the notification extension from saving data to the DB if the host app is connected through WS, and processing those events.
This communication is done using a shared UserDefaults based on App Groups.

### 🧪 Manual Testing Notes

1. Open the app and leave it on the channel list
2. Using another device/simulator, send messages to the previous device
3. The unread count should have the correct amount

The issue was frequently visible when sending replies to a thread (sending those messages to the channel, as well)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/xUPGcqaVH1cDeKZTBS/giphy.gif)