### PR TITLE
Add skip push support when sending a message 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Add `UploadedAttachmentPostProcessor` in `ChatClientConfig` to allow changing custom attachment payloads after an attachment has been uploaded [#2457](https://github.com/GetStream/stream-chat-swift/pull/2457)
 - Add `AnyAttachmentPayload(localFileURL:customPayload:)` initializer to allow creating custom attachments without a remote URL [#2457](https://github.com/GetStream/stream-chat-swift/pull/2457)
+- Add skip push support when sending a message [#2486](https://github.com/GetStream/stream-chat-swift/pull/2486)
 
 ## StreamChatUI
 ### 🔄 Changed

--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -356,6 +356,15 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
                         )
                     }
                 }
+            }),
+            .init(title: "Send message with skip push", style: .default, handler: { [unowned self] _ in
+                self.rootViewController.presentAlert(title: "Enter the message text", textFieldPlaceholder: "Send message") { message in
+                    guard let message = message, !message.isEmpty else {
+                        self.rootViewController.presentAlert(title: "Message is not valid")
+                        return
+                    }
+                    channelController.createNewMessage(text: message, skipPush: true)
+                }
             })
         ])
     }

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
@@ -103,14 +103,18 @@ extension Endpoint {
         )
     }
 
-    static func sendMessage(cid: ChannelId, messagePayload: MessageRequestBody)
+    static func sendMessage(cid: ChannelId, messagePayload: MessageRequestBody, skipPush: Bool)
         -> Endpoint<MessagePayload.Boxed> {
-        .init(
+        let body: [String: AnyEncodable] = [
+            "message": AnyEncodable(messagePayload),
+            "skip_push": AnyEncodable(skipPush)
+        ]
+        return .init(
             path: .sendMessage(cid),
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
-            body: ["message": messagePayload]
+            body: body
         )
     }
 

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -899,6 +899,7 @@ public extension ChatChannelController {
     ///     `Note`: can be built-in types, custom attachment types conforming to `AttachmentEnvelope` protocol
     ///     and `ChatMessageAttachmentSeed`s.
     ///   - quotedMessageId: An id of the message new message quotes. (inline reply)
+    ///   - skipPush: If true, skips sending push notification to channel members.
     ///   - extraData: Additional extra data of the message object.
     ///   - completion: Called when saving the message to the local DB finishes.
     ///
@@ -909,6 +910,7 @@ public extension ChatChannelController {
         attachments: [AnyAttachmentPayload] = [],
         mentionedUserIds: [UserId] = [],
         quotedMessageId: MessageId? = nil,
+        skipPush: Bool = false,
         extraData: [String: RawJSON] = [:],
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -933,6 +935,7 @@ public extension ChatChannelController {
             attachments: attachments,
             mentionedUserIds: mentionedUserIds,
             quotedMessageId: quotedMessageId,
+            skipPush: skipPush,
             extraData: extraData
         ) { result in
             self.callback {

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -247,6 +247,7 @@ public extension ChatMessageController {
     ///   - showReplyInChannel: Set this flag to `true` if you want the message to be also visible in the channel, not only
     ///   in the response thread.
     ///   - quotedMessageId: An id of the message new message quotes. (inline reply)
+    ///   - skipPush: If true, skips sending push notification to channel members.
     ///   - extraData: Additional extra data of the message object.
     ///   - completion: Called when saving the message to the local DB finishes.
     ///
@@ -258,6 +259,7 @@ public extension ChatMessageController {
         showReplyInChannel: Bool = false,
         isSilent: Bool = false,
         quotedMessageId: MessageId? = nil,
+        skipPush: Bool = false,
         extraData: [String: RawJSON] = [:],
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -273,6 +275,7 @@ public extension ChatMessageController {
             showReplyInChannel: showReplyInChannel,
             isSilent: isSilent,
             quotedMessageId: quotedMessageId,
+            skipPush: skipPush,
             extraData: extraData
         ) { result in
             self.callback {

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -36,6 +36,7 @@ class MessageDTO: NSManagedObject {
     @NSManaged var extraData: Data?
     @NSManaged var isBounced: Bool
     @NSManaged var isSilent: Bool
+    @NSManaged var skipPush: Bool
     @NSManaged var isShadowed: Bool
     @NSManaged var reactionScores: [String: Int]
     @NSManaged var reactionCounts: [String: Int]
@@ -482,6 +483,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         isSilent: Bool,
         quotedMessageId: MessageId?,
         createdAt: Date?,
+        skipPush: Bool,
         extraData: [String: RawJSON]
     ) throws -> MessageDTO {
         guard let currentUserDTO = currentUser else {
@@ -516,6 +518,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         message.parentMessageId = parentMessageId
         message.extraData = try JSONEncoder.default.encode(extraData)
         message.isSilent = isSilent
+        message.skipPush = skipPush
         message.reactionScores = [:]
         message.reactionCounts = [:]
 

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -80,6 +80,7 @@ protocol MessageDatabaseSession {
         isSilent: Bool,
         quotedMessageId: MessageId?,
         createdAt: Date?,
+        skipPush: Bool,
         extraData: [String: RawJSON]
     ) throws -> MessageDTO
 
@@ -189,6 +190,7 @@ extension MessageDatabaseSession {
         pinning: MessagePinning?,
         quotedMessageId: MessageId?,
         isSilent: Bool = false,
+        skipPush: Bool,
         attachments: [AnyAttachmentPayload] = [],
         mentionedUserIds: [UserId] = [],
         extraData: [String: RawJSON] = [:]
@@ -206,6 +208,7 @@ extension MessageDatabaseSession {
             isSilent: isSilent,
             quotedMessageId: quotedMessageId,
             createdAt: nil,
+            skipPush: skipPush,
             extraData: extraData
         )
     }

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -206,6 +206,7 @@
         <attribute name="reactionScores" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
         <attribute name="replyCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="showReplyInChannel" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="skipPush" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="text" attributeType="String"/>
         <attribute name="translations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
         <attribute name="type" attributeType="String"/>

--- a/Sources/StreamChat/Models/Attachments/ChatMessageImageAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageImageAttachment.swift
@@ -65,7 +65,7 @@ public struct ImageAttachmentPayload: AttachmentPayload {
     /// Creates `ImageAttachmentPayload` instance.
     ///
     /// Use this initializer if the attachment is already uploaded and you have the remote URLs.
-    @available(*, deprecated, renamed: "init(title:imageRemoteURL:imagePreviewRemoteURL:originalWidth:originalHeight:extraData:)")
+    @available(*, deprecated, renamed: "init(title:imageRemoteURL:originalWidth:originalHeight:extraData:)")
     public init(
         title: String?,
         imageRemoteURL: URL,

--- a/Sources/StreamChat/Repositories/MessageRepository.swift
+++ b/Sources/StreamChat/Repositories/MessageRepository.swift
@@ -46,6 +46,7 @@ class MessageRepository {
             }
 
             let requestBody = dto.asRequestBody() as MessageRequestBody
+            let skipPush: Bool = dto.skipPush
 
             // Change the message state to `.sending` and the proceed with the actual sending
             self?.database.write({
@@ -60,7 +61,11 @@ class MessageRepository {
                     return
                 }
 
-                let endpoint: Endpoint<MessagePayload.Boxed> = .sendMessage(cid: cid, messagePayload: requestBody)
+                let endpoint: Endpoint<MessagePayload.Boxed> = .sendMessage(
+                    cid: cid,
+                    messagePayload: requestBody,
+                    skipPush: skipPush
+                )
                 self?.apiClient.request(endpoint: endpoint) {
                     switch $0 {
                     case let .success(payload):

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -226,6 +226,7 @@ class ChannelUpdater: Worker {
     ///   - isSilent: A flag indicating whether the message is a silent message. Silent messages are special messages that don't increase the unread messages count nor mark a channel as unread.
     ///   - attachments: An array of the attachments for the message.
     ///   - quotedMessageId: An id of the message new message quotes. (inline reply)
+    ///   - skipPush: If true, skips sending push notification to channel members.
     ///   - extraData: Additional extra data of the message object.
     ///   - completion: Called when saving the message to the local DB finishes.
     ///
@@ -239,6 +240,7 @@ class ChannelUpdater: Worker {
         attachments: [AnyAttachmentPayload] = [],
         mentionedUserIds: [UserId],
         quotedMessageId: MessageId?,
+        skipPush: Bool,
         extraData: [String: RawJSON],
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -257,6 +259,7 @@ class ChannelUpdater: Worker {
                 isSilent: isSilent,
                 quotedMessageId: quotedMessageId,
                 createdAt: nil,
+                skipPush: skipPush,
                 extraData: extraData
             )
 

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -150,6 +150,7 @@ class MessageUpdater: Worker {
     ///   - showReplyInChannel: Set this flag to `true` if you want the message to be also visible in the channel, not only
     ///   in the response thread.
     ///   - quotedMessageId: An id of the message new message quotes. (inline reply)
+    ///   - skipPush: If true, skips sending push notification to channel members.
     ///   - extraData: Additional extra data of the message object.
     ///   - completion: Called when saving the message to the local DB finishes.
     ///
@@ -165,6 +166,7 @@ class MessageUpdater: Worker {
         showReplyInChannel: Bool,
         isSilent: Bool,
         quotedMessageId: MessageId?,
+        skipPush: Bool,
         extraData: [String: RawJSON],
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -183,6 +185,7 @@ class MessageUpdater: Worker {
                 isSilent: isSilent,
                 quotedMessageId: quotedMessageId,
                 createdAt: nil,
+                skipPush: skipPush,
                 extraData: extraData
             )
 

--- a/TestTools/StreamChatTestTools/Mocks/Models + Extensions/Attachments/ChatMessageImageAttachment_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/Models + Extensions/Attachments/ChatMessageImageAttachment_Mock.swift
@@ -20,7 +20,6 @@ extension ChatMessageImageAttachment {
             payload: .init(
                 title: title,
                 imageRemoteURL: imageURL,
-                imagePreviewRemoteURL: imageURL,
                 extraData: extraData
             ),
             uploadingState: localState.map {

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -134,6 +134,7 @@ extension DatabaseSession_Mock {
         isSilent: Bool,
         quotedMessageId: MessageId?,
         createdAt: Date?,
+        skipPush: Bool,
         extraData: [String: RawJSON]
     ) throws -> MessageDTO {
         try throwErrorIfNeeded()
@@ -151,6 +152,7 @@ extension DatabaseSession_Mock {
             isSilent: isSilent,
             quotedMessageId: quotedMessageId,
             createdAt: createdAt,
+            skipPush: skipPush,
             extraData: extraData
         )
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ChannelUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ChannelUpdater_Mock.swift
@@ -58,6 +58,7 @@ final class ChannelUpdater_Mock: ChannelUpdater {
     @Atomic var createNewMessage_cid: ChannelId?
     @Atomic var createNewMessage_text: String?
     @Atomic var createNewMessage_isSilent: Bool?
+    @Atomic var createNewMessage_skipPush: Bool?
     @Atomic var createNewMessage_command: String?
     @Atomic var createNewMessage_arguments: String?
     @Atomic var createNewMessage_attachments: [AnyAttachmentPayload]?
@@ -149,6 +150,7 @@ final class ChannelUpdater_Mock: ChannelUpdater {
         createNewMessage_cid = nil
         createNewMessage_text = nil
         createNewMessage_isSilent = nil
+        createNewMessage_skipPush = nil
         createNewMessage_command = nil
         createNewMessage_arguments = nil
         createNewMessage_attachments = nil
@@ -253,12 +255,14 @@ final class ChannelUpdater_Mock: ChannelUpdater {
         attachments: [AnyAttachmentPayload],
         mentionedUserIds: [UserId],
         quotedMessageId: MessageId?,
+        skipPush: Bool,
         extraData: [String: RawJSON] = [:],
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
         createNewMessage_cid = cid
         createNewMessage_text = text
         createNewMessage_isSilent = isSilent
+        createNewMessage_skipPush = skipPush
         createNewMessage_command = command
         createNewMessage_arguments = arguments
         createNewMessage_attachments = attachments

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -29,6 +29,7 @@ final class MessageUpdater_Mock: MessageUpdater {
     @Atomic var createNewReply_mentionedUserIds: [UserId]?
     @Atomic var createNewReply_showReplyInChannel: Bool?
     @Atomic var createNewReply_isSilent: Bool?
+    @Atomic var createNewReply_skipPush: Bool?
     @Atomic var createNewReply_quotedMessageId: MessageId?
     @Atomic var createNewReply_pinning: MessagePinning?
     @Atomic var createNewReply_extraData: [String: RawJSON]?
@@ -112,6 +113,7 @@ final class MessageUpdater_Mock: MessageUpdater {
         createNewReply_mentionedUserIds = nil
         createNewReply_showReplyInChannel = nil
         createNewReply_isSilent = nil
+        createNewReply_skipPush = nil
         createNewReply_extraData = nil
         createNewReply_completion = nil
 
@@ -212,6 +214,7 @@ final class MessageUpdater_Mock: MessageUpdater {
         showReplyInChannel: Bool,
         isSilent: Bool,
         quotedMessageId: MessageId?,
+        skipPush: Bool,
         extraData: [String: RawJSON],
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -224,6 +227,7 @@ final class MessageUpdater_Mock: MessageUpdater {
         createNewReply_mentionedUserIds = mentionedUserIds
         createNewReply_showReplyInChannel = showReplyInChannel
         createNewReply_isSilent = isSilent
+        createNewReply_skipPush = skipPush
         createNewReply_quotedMessageId = quotedMessageId
         createNewReply_pinning = pinning
         createNewReply_extraData = extraData

--- a/TestTools/StreamChatTestTools/TestData/AnyEndpoint.swift
+++ b/TestTools/StreamChatTestTools/TestData/AnyEndpoint.swift
@@ -31,6 +31,14 @@ public struct AnyEndpoint: Equatable {
             && lhs.body == rhs.body
             && lhs.payloadType == rhs.payloadType
     }
+
+    func bodyAsDictionary() throws -> [String: Any] {
+        let data = try JSONEncoder().encode(body)
+        guard let requestBody = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw NSError(domain: "com.getstream.io.any-endpoint", code: 1)
+        }
+        return requestBody
+    }
 }
 
 func AssertEqualEndpoint<A, B>(

--- a/Tests/StreamChatTests/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -229,11 +229,14 @@ final class ChannelEndpoints_Tests: XCTestCase {
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
-            body: ["message": messageBody]
+            body: [
+                "message": AnyEncodable(messageBody),
+                "skip_push": AnyEncodable(true)
+            ]
         )
 
         // Build endpoint
-        let endpoint: Endpoint<MessagePayload.Boxed> = .sendMessage(cid: cid, messagePayload: messageBody)
+        let endpoint: Endpoint<MessagePayload.Boxed> = .sendMessage(cid: cid, messagePayload: messageBody, skipPush: true)
 
         // Assert endpoint is built correctly
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -417,6 +417,7 @@ final class ChannelController_Tests: XCTestCase {
                 isSilent: false,
                 quotedMessageId: nil,
                 createdAt: oldMessageCreatedAt,
+                skipPush: false,
                 extraData: [:]
             )
             // Simulate sending failed for this message
@@ -2722,6 +2723,7 @@ final class ChannelController_Tests: XCTestCase {
         ]
         let quotedMessageId: MessageId = .unique
         let pin = MessagePinning(expirationDate: .unique)
+        let skipPush = true
 
         // Simulate `createNewMessage` calls and catch the completion
         var completionCalled = false
@@ -2730,6 +2732,7 @@ final class ChannelController_Tests: XCTestCase {
             pinning: pin,
             attachments: attachments,
             quotedMessageId: quotedMessageId,
+            skipPush: skipPush,
             extraData: extraData
         ) { [callbackQueueID] result in
             AssertTestQueue(withId: callbackQueueID)
@@ -2753,6 +2756,7 @@ final class ChannelController_Tests: XCTestCase {
         XCTAssertEqual(env.channelUpdater?.createNewMessage_extraData, extraData)
         XCTAssertEqual(env.channelUpdater?.createNewMessage_attachments, attachments)
         XCTAssertEqual(env.channelUpdater?.createNewMessage_quotedMessageId, quotedMessageId)
+        XCTAssertEqual(env.channelUpdater?.createNewMessage_skipPush, skipPush)
         XCTAssertEqual(env.channelUpdater?.createNewMessage_pinning?.expirationDate, pin.expirationDate!)
 
         // Simulate successful update
@@ -4370,6 +4374,7 @@ extension ChannelController_Tests {
             pinning: nil,
             quotedMessageId: nil,
             isSilent: false,
+            skipPush: false,
             attachments: [
                 .mockImage,
                 .mockFile,

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -979,6 +979,7 @@ final class MessageController_Tests: XCTestCase {
         let extraData: [String: RawJSON] = [:]
         let attachments: [AnyAttachmentPayload] = [.mockFile, .mockImage, .init(payload: TestAttachmentPayload.unique)]
         let pin = MessagePinning(expirationDate: .unique)
+        let skipPush = true
 
         // Simulate `createNewReply` calls and catch the completion
         var completionCalled = false
@@ -988,6 +989,7 @@ final class MessageController_Tests: XCTestCase {
             attachments: attachments,
             showReplyInChannel: showReplyInChannel,
             quotedMessageId: quotedMessageId,
+            skipPush: skipPush,
             extraData: extraData
         ) { [callbackQueueID] result in
             AssertTestQueue(withId: callbackQueueID)
@@ -1012,6 +1014,7 @@ final class MessageController_Tests: XCTestCase {
         XCTAssertEqual(env.messageUpdater.createNewReply_showReplyInChannel, showReplyInChannel)
         XCTAssertEqual(env.messageUpdater.createNewReply_extraData, extraData)
         XCTAssertEqual(env.messageUpdater.createNewReply_attachments, attachments)
+        XCTAssertEqual(env.messageUpdater.createNewReply_skipPush, skipPush)
         XCTAssertEqual(env.messageUpdater.createNewReply_quotedMessageId, quotedMessageId)
 
         // Simulate successful update

--- a/Tests/StreamChatTests/Database/DTOs/AttachmentDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/AttachmentDTO_Tests.swift
@@ -270,6 +270,7 @@ final class AttachmentDTO_Tests: XCTestCase {
                 pinning: nil,
                 quotedMessageId: nil,
                 isSilent: false,
+                skipPush: false,
                 attachments: [.init(payload: TestAttachmentPayload.unique)],
                 extraData: [:]
             )

--- a/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
@@ -772,6 +772,7 @@ final class MessageDTO_Tests: XCTestCase {
                 isSilent: messageIsSilent,
                 quotedMessageId: nil,
                 createdAt: nil,
+                skipPush: false,
                 extraData: messageExtraData
             ).id
         }
@@ -880,6 +881,7 @@ final class MessageDTO_Tests: XCTestCase {
                     isSilent: false,
                     quotedMessageId: nil,
                     createdAt: nil,
+                    skipPush: false,
                     extraData: [:]
                 )
                 message1Id = message1DTO.id
@@ -899,6 +901,7 @@ final class MessageDTO_Tests: XCTestCase {
                     isSilent: false,
                     quotedMessageId: nil,
                     createdAt: nil,
+                    skipPush: false,
                     extraData: [:]
                 )
                 // Reset the `locallyCreateAt` value of the second message to simulate the message was sent
@@ -992,14 +995,18 @@ final class MessageDTO_Tests: XCTestCase {
                 isSilent: false,
                 quotedMessageId: nil,
                 createdAt: nil,
+                skipPush: true,
                 extraData: [:]
             )
             newMessageId = messageDTO.id
         }
 
         let loadedChannel: ChatChannel = try XCTUnwrap(database.viewContext.channel(cid: cid)).asModel()
-        let loadedMessage: ChatMessage = try XCTUnwrap(database.viewContext.message(id: newMessageId)).asModel()
 
+        let messageDTO: MessageDTO = try XCTUnwrap(database.viewContext.message(id: newMessageId))
+        XCTAssertEqual(messageDTO.skipPush, true)
+
+        let loadedMessage: ChatMessage = try messageDTO.asModel()
         XCTAssertEqual(loadedMessage.text, newMessageText)
         XCTAssertEqual(loadedMessage.command, newMessageCommand)
         XCTAssertEqual(loadedMessage.arguments, newMessageArguments)
@@ -1051,6 +1058,7 @@ final class MessageDTO_Tests: XCTestCase {
                 isSilent: false,
                 quotedMessageId: nil,
                 createdAt: nil,
+                skipPush: false,
                 extraData: [:]
             )
             messageId = messageDTO.id
@@ -1093,6 +1101,7 @@ final class MessageDTO_Tests: XCTestCase {
                 isSilent: false,
                 quotedMessageId: nil,
                 createdAt: nil,
+                skipPush: false,
                 extraData: [:]
             )
             threadReplyId = replyShownInChannelDTO.id
@@ -1148,6 +1157,7 @@ final class MessageDTO_Tests: XCTestCase {
                 isSilent: false,
                 quotedMessageId: nil,
                 createdAt: nil,
+                skipPush: false,
                 extraData: [:]
             )
         }
@@ -1172,6 +1182,7 @@ final class MessageDTO_Tests: XCTestCase {
                     isSilent: false,
                     quotedMessageId: nil,
                     createdAt: nil,
+                    skipPush: false,
                     extraData: [:]
                 )
             }, completion: completion)
@@ -1210,6 +1221,7 @@ final class MessageDTO_Tests: XCTestCase {
                     isSilent: false,
                     quotedMessageId: nil,
                     createdAt: nil,
+                    skipPush: false,
                     extraData: [:]
                 )
             }, completion: completion)
@@ -1246,6 +1258,7 @@ final class MessageDTO_Tests: XCTestCase {
                 pinning: MessagePinning(expirationDate: .unique),
                 quotedMessageId: nil,
                 isSilent: false,
+                skipPush: false,
                 extraData: [:]
             )
             newMessageId = messageDTO.id
@@ -1290,6 +1303,7 @@ final class MessageDTO_Tests: XCTestCase {
                 isSilent: false,
                 quotedMessageId: nil,
                 createdAt: nil,
+                skipPush: false,
                 extraData: [:]
             )
             // Get reply messageId
@@ -1973,7 +1987,6 @@ final class MessageDTO_Tests: XCTestCase {
         let type: MessageReactionType = "fake"
         prepareEnvironment(createdUserId: userId, createdMessageId: messageId)
 
-        let reactionId = makeReactionId(userId: userId, messageId: messageId, type: type)
         let result = runAddReaction(messageId: messageId, type: type, localState: .sending)
 
         XCTAssertEqual(result.value?.reactionType, "fake")

--- a/Tests/StreamChatTests/Database/DTOs/NSManagedObject+Validation_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/NSManagedObject+Validation_Tests.swift
@@ -74,7 +74,13 @@ private extension NSManagedObject_Validation_Tests {
         try database.createCurrentUser()
         try database.createChannel(cid: channelId)
         try database.writeSynchronously { session in
-            message = try session.createNewMessage(in: channelId, text: "Hello", pinning: nil, quotedMessageId: nil)
+            message = try session.createNewMessage(
+                in: channelId,
+                text: "Hello",
+                pinning: nil,
+                quotedMessageId: nil,
+                skipPush: false
+            )
         }
         return message
     }

--- a/Tests/StreamChatTests/Workers/Background/MessageSender_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/MessageSender_Tests.swift
@@ -70,6 +70,7 @@ final class MessageSender_Tests: XCTestCase {
                 pinning: nil,
                 quotedMessageId: nil,
                 isSilent: false,
+                skipPush: false,
                 extraData: [:]
             )
             message1.localMessageState = .pendingSend
@@ -81,6 +82,7 @@ final class MessageSender_Tests: XCTestCase {
                 pinning: nil,
                 quotedMessageId: nil,
                 isSilent: false,
+                skipPush: false,
                 attachments: [
                     .mockFile,
                     .mockImage,
@@ -98,6 +100,7 @@ final class MessageSender_Tests: XCTestCase {
                 pinning: nil,
                 quotedMessageId: nil,
                 isSilent: false,
+                skipPush: false,
                 attachments: [],
                 extraData: [:]
             )
@@ -138,6 +141,7 @@ final class MessageSender_Tests: XCTestCase {
                 pinning: nil,
                 quotedMessageId: nil,
                 isSilent: false,
+                skipPush: false,
                 attachments: [
                     .init(payload: TestAttachmentPayload.unique),
                     .init(payload: TestAttachmentPayload.unique)
@@ -162,6 +166,7 @@ final class MessageSender_Tests: XCTestCase {
                 pinning: nil,
                 quotedMessageId: nil,
                 isSilent: false,
+                skipPush: false,
                 attachments: [
                     .mockImage,
                     .init(payload: TestAttachmentPayload.unique)
@@ -199,6 +204,7 @@ final class MessageSender_Tests: XCTestCase {
                 pinning: nil,
                 quotedMessageId: nil,
                 isSilent: false,
+                skipPush: false,
                 extraData: [:]
             )
             message1.localMessageState = .pendingSend
@@ -210,6 +216,7 @@ final class MessageSender_Tests: XCTestCase {
                 pinning: nil,
                 quotedMessageId: nil,
                 isSilent: false,
+                skipPush: false,
                 extraData: [:]
             )
             message2.localMessageState = .pendingSend
@@ -221,6 +228,7 @@ final class MessageSender_Tests: XCTestCase {
                 pinning: nil,
                 quotedMessageId: nil,
                 isSilent: false,
+                skipPush: false,
                 extraData: [:]
             )
             message3.localMessageState = .pendingSend
@@ -267,6 +275,7 @@ final class MessageSender_Tests: XCTestCase {
                 pinning: nil,
                 quotedMessageId: nil,
                 isSilent: false,
+                skipPush: false,
                 extraData: [:]
             )
             messageA1.localMessageState = .pendingSend
@@ -278,6 +287,7 @@ final class MessageSender_Tests: XCTestCase {
                 pinning: nil,
                 quotedMessageId: nil,
                 isSilent: false,
+                skipPush: false,
                 extraData: [:]
             )
             messageA2.localMessageState = .pendingSend
@@ -289,6 +299,7 @@ final class MessageSender_Tests: XCTestCase {
                 pinning: nil,
                 quotedMessageId: nil,
                 isSilent: false,
+                skipPush: false,
                 extraData: [:]
             )
             messageB1.localMessageState = .pendingSend
@@ -300,6 +311,7 @@ final class MessageSender_Tests: XCTestCase {
                 pinning: nil,
                 quotedMessageId: nil,
                 isSilent: false,
+                skipPush: false,
                 extraData: [:]
             )
             messageB2.localMessageState = .pendingSend

--- a/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
@@ -479,6 +479,7 @@ final class ChannelUpdater_Tests: XCTestCase {
                 attachments: attachmentEnvelopes,
                 mentionedUserIds: [currentUserId],
                 quotedMessageId: nil,
+                skipPush: true,
                 extraData: extraData
             ) { result in
                 do {
@@ -494,10 +495,12 @@ final class ChannelUpdater_Tests: XCTestCase {
             .init(cid: cid, messageId: newMessageId, index: attachmentEnvelopes.firstIndex(of: envelope)!)
         }
 
-        let message: ChatMessage = try XCTUnwrap(
-            database.viewContext.message(id: newMessageId)?.asModel()
+        let messageDTO: MessageDTO = try XCTUnwrap(
+            database.viewContext.message(id: newMessageId)
         )
+        XCTAssertEqual(messageDTO.skipPush, true)
 
+        let message = try messageDTO.asModel()
         XCTAssertEqual(message.text, text)
         XCTAssertEqual(message.command, command)
         XCTAssertEqual(message.arguments, arguments)
@@ -549,6 +552,7 @@ final class ChannelUpdater_Tests: XCTestCase {
                 arguments: .unique,
                 mentionedUserIds: [.unique],
                 quotedMessageId: nil,
+                skipPush: false,
                 extraData: [:]
             ) { completion($0) }
         }

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -837,6 +837,7 @@ final class MessageUpdater_Tests: XCTestCase {
                 showReplyInChannel: showReplyInChannel,
                 isSilent: isSilent,
                 quotedMessageId: nil,
+                skipPush: true,
                 extraData: extraData
             ) { result in
                 if let newMessageId = try? result.get() {
@@ -851,8 +852,10 @@ final class MessageUpdater_Tests: XCTestCase {
             .init(cid: cid, messageId: newMessageId, index: attachmentEnvelopes.firstIndex(of: envelope)!)
         }
 
-        let message: ChatMessage = try XCTUnwrap(database.viewContext.message(id: newMessageId)?.asModel())
+        let messageDTO: MessageDTO = try XCTUnwrap(database.viewContext.message(id: newMessageId))
+        XCTAssertEqual(messageDTO.skipPush, true)
 
+        let message: ChatMessage = try messageDTO.asModel()
         XCTAssertEqual(message.text, text)
         XCTAssertEqual(message.command, command)
         XCTAssertEqual(message.arguments, arguments)
@@ -897,6 +900,7 @@ final class MessageUpdater_Tests: XCTestCase {
                 showReplyInChannel: false,
                 isSilent: false,
                 quotedMessageId: nil,
+                skipPush: false,
                 extraData: [:]
             ) { completion($0) }
         }


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/313

### 🎯 Goal
Add skip push support when sending a message 

### 📝 Summary
Adds a new `skipPush: Bool` argument to
- `channelController.createNewMessage()` 
- `messageController.createNewReply()`.

### 🧪 Manual Testing Notes
- Open a Channel
- Tap the Debug Button
- Tap "Send message with skip push" action
- Write a message
- Click "OK"
- Should send a message without triggering a push notification to the members of the channel

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)