### PR TITLE
[BW] Fix emerge lane on push

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -635,8 +635,8 @@ lane :emerge_upload do
   emerge(
     build_type: 'release',
     repo_name: github_repo,
-    pr_number: ENV.fetch('GITHUB_PR_NUM', nil), # If `nil` then local run or merge to main
-    sha: ENV['GITHUB_COMMIT_SHA'] || ENV['GITHUB_SHA'] || last_git_commit[:commit_hash]
+    pr_number: ENV['GITHUB_PR_NUM'] || nil, # If `nil` then local run or merge to develop/main
+    sha: last_git_commit[:commit_hash]
   )
 end
 


### PR DESCRIPTION
## Description

`Then` fastlane was not able to pick up a commit sha on `push` event
`Now` it will be able to do so