### PR TITLE
Fix auto-filtering when filter and DB value types don't match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
+## StreamChat
+### 🐞 Fixed
+- Fix channel auto-filtering when the filter contains the `type` key [#2497](https://github.com/GetStream/stream-chat-swift/pull/2497)
 
 ## StreamChat
 ### ✅ Added

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -74,7 +74,7 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
 
     /// A filter key for matching the `type` value.
     /// Supported operators: `in`, `equal`
-    static var type: FilterKey<Scope, ChannelType> { .init(rawValue: "type", keyPathString: #keyPath(ChannelDTO.typeRawValue), inputValueMapper: { $0.rawValue }) }
+    static var type: FilterKey<Scope, ChannelType> { .init(rawValue: "type", keyPathString: #keyPath(ChannelDTO.typeRawValue), valueMapper: { $0.rawValue }) }
 
     /// A filter key for matching the `lastMessageAt` value.
     /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -74,7 +74,7 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
 
     /// A filter key for matching the `type` value.
     /// Supported operators: `in`, `equal`
-    static var type: FilterKey<Scope, ChannelType> { .init(rawValue: "type", keyPathString: #keyPath(ChannelDTO.typeRawValue)) }
+    static var type: FilterKey<Scope, ChannelType> { .init(rawValue: "type", keyPathString: #keyPath(ChannelDTO.typeRawValue), inputValueMapper: { $0.rawValue }) }
 
     /// A filter key for matching the `lastMessageAt` value.
     /// Supported operators: `equal`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`, `notEqual`

--- a/Sources/StreamChat/Query/Filter.swift
+++ b/Sources/StreamChat/Query/Filter.swift
@@ -215,34 +215,34 @@ public struct FilterKey<Scope: FilterScope, Value: FilterValue>: ExpressibleBySt
 
     /// The mapper that will transform the input value to a value that
     /// can be compared with the DB value
-    typealias InputValueMapper = (Any) -> FilterValue?
-    typealias TypeInputValueMapper = (Value) -> FilterValue?
-    let inputValueMapper: InputValueMapper?
+    typealias ValueMapper = (Any) -> FilterValue?
+    typealias TypedValueMapper = (Value) -> FilterValue?
+    let valueMapper: ValueMapper?
 
     public init(stringLiteral value: String) {
         rawValue = value
-        inputValueMapper = nil
+        valueMapper = nil
         keyPathString = nil
     }
 
     public init(rawValue value: String) {
         rawValue = value
         keyPathString = nil
-        inputValueMapper = nil
+        valueMapper = nil
     }
 
     init(
         rawValue value: String,
         keyPathString: String,
-        inputValueMapper: TypeInputValueMapper? = nil
+        valueMapper: TypedValueMapper? = nil
     ) {
         rawValue = value
         self.keyPathString = keyPathString
-        self.inputValueMapper = {
-            guard let inputValueMapper = inputValueMapper, let castInputValue = ($0 as? Value) else {
+        self.valueMapper = {
+            guard let valueMapper = valueMapper, let castInputValue = ($0 as? Value) else {
                 return nil
             }
-            return inputValueMapper(castInputValue)
+            return valueMapper(castInputValue)
         }
     }
 }
@@ -254,7 +254,7 @@ public extension Filter {
             operator: .equal,
             key: key,
             value: value,
-            valueMapper: key.inputValueMapper,
+            valueMapper: key.valueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -265,7 +265,7 @@ public extension Filter {
             operator: .notEqual,
             key: key,
             value: value,
-            valueMapper: key.inputValueMapper,
+            valueMapper: key.valueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -276,7 +276,7 @@ public extension Filter {
             operator: .greater,
             key: key,
             value: value,
-            valueMapper: key.inputValueMapper,
+            valueMapper: key.valueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -287,7 +287,7 @@ public extension Filter {
             operator: .greaterOrEqual,
             key: key,
             value: value,
-            valueMapper: key.inputValueMapper,
+            valueMapper: key.valueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -298,7 +298,7 @@ public extension Filter {
             operator: .less,
             key: key,
             value: value,
-            valueMapper: key.inputValueMapper,
+            valueMapper: key.valueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -309,7 +309,7 @@ public extension Filter {
             operator: .lessOrEqual,
             key: key,
             value: value,
-            valueMapper: key.inputValueMapper,
+            valueMapper: key.valueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -320,7 +320,7 @@ public extension Filter {
             operator: .in,
             key: key,
             value: values,
-            valueMapper: key.inputValueMapper,
+            valueMapper: key.valueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -331,7 +331,7 @@ public extension Filter {
             operator: .notIn,
             key: key,
             value: values,
-            valueMapper: key.inputValueMapper,
+            valueMapper: key.valueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -342,7 +342,7 @@ public extension Filter {
             operator: .query,
             key: key,
             value: text,
-            valueMapper: key.inputValueMapper,
+            valueMapper: key.valueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -353,7 +353,7 @@ public extension Filter {
             operator: .autocomplete,
             key: key,
             value: text,
-            valueMapper: key.inputValueMapper,
+            valueMapper: key.valueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -368,7 +368,7 @@ public extension Filter {
             operator: .exists,
             key: key,
             value: exists,
-            valueMapper: key.inputValueMapper,
+            valueMapper: key.valueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -379,7 +379,7 @@ public extension Filter {
             operator: .contains,
             key: key,
             value: value,
-            valueMapper: key.inputValueMapper,
+            valueMapper: key.valueMapper,
             keyPathString: key.keyPathString
         )
     }

--- a/Sources/StreamChat/Query/Filter.swift
+++ b/Sources/StreamChat/Query/Filter.swift
@@ -99,18 +99,27 @@ public struct Filter<Scope: FilterScope> {
     /// The "right-hand" side of the filter. Specifies the value the filter should match.
     public let value: FilterValue
 
+    /// The mapper that will transform the input value to a value that
+    /// can be compared with the DB value
+    typealias ValueMapper = (Any) -> FilterValue?
+    let valueMapper: ValueMapper?
+
+    /// The keypath of the DB object that will be compared with the input value during
+    /// a local filtering.
     let keyPathString: String?
 
     init(
         operator: String,
         key: String?,
         value: FilterValue,
+        valueMapper: ValueMapper?,
         keyPathString: String?
     ) {
         log.assert(`operator`.hasPrefix("$"), "A filter operator must have `$` prefix.")
         self.operator = `operator`
         self.key = key
         self.value = value
+        self.valueMapper = valueMapper
         self.keyPathString = keyPathString
     }
 
@@ -136,6 +145,7 @@ public struct Filter<Scope: FilterScope> {
             operator: `operator`,
             key: key,
             value: value,
+            valueMapper: nil,
             keyPathString: nil
         )
     }
@@ -148,12 +158,14 @@ extension Filter {
         operator: FilterOperator,
         key: FilterKey<Scope, Value>,
         value: FilterValue,
+        valueMapper: ValueMapper?,
         keyPathString: String?
     ) {
         self.init(
             operator: `operator`.rawValue,
             key: key.rawValue,
             value: value,
+            valueMapper: valueMapper,
             keyPathString: keyPathString
         )
     }
@@ -196,24 +208,42 @@ public extension Filter {
 public struct FilterKey<Scope: FilterScope, Value: FilterValue>: ExpressibleByStringLiteral, RawRepresentable {
     /// The raw value of the key. This value should match the "encodable" key for the given object.
     public let rawValue: String
+
+    /// The keypath of the DB object that will be compared with the input value during
+    /// a local filtering.
     let keyPathString: String?
+
+    /// The mapper that will transform the input value to a value that
+    /// can be compared with the DB value
+    typealias InputValueMapper = (Any) -> FilterValue?
+    typealias TypeInputValueMapper = (Value) -> FilterValue?
+    let inputValueMapper: InputValueMapper?
 
     public init(stringLiteral value: String) {
         rawValue = value
+        inputValueMapper = nil
         keyPathString = nil
     }
 
     public init(rawValue value: String) {
         rawValue = value
         keyPathString = nil
+        inputValueMapper = nil
     }
 
     init(
         rawValue value: String,
-        keyPathString: String
+        keyPathString: String,
+        inputValueMapper: TypeInputValueMapper? = nil
     ) {
         rawValue = value
         self.keyPathString = keyPathString
+        self.inputValueMapper = {
+            guard let inputValueMapper = inputValueMapper, let castInputValue = ($0 as? Value) else {
+                return nil
+            }
+            return inputValueMapper(castInputValue)
+        }
     }
 }
 
@@ -224,6 +254,7 @@ public extension Filter {
             operator: .equal,
             key: key,
             value: value,
+            valueMapper: key.inputValueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -234,6 +265,7 @@ public extension Filter {
             operator: .notEqual,
             key: key,
             value: value,
+            valueMapper: key.inputValueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -244,6 +276,7 @@ public extension Filter {
             operator: .greater,
             key: key,
             value: value,
+            valueMapper: key.inputValueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -254,6 +287,7 @@ public extension Filter {
             operator: .greaterOrEqual,
             key: key,
             value: value,
+            valueMapper: key.inputValueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -264,6 +298,7 @@ public extension Filter {
             operator: .less,
             key: key,
             value: value,
+            valueMapper: key.inputValueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -274,6 +309,7 @@ public extension Filter {
             operator: .lessOrEqual,
             key: key,
             value: value,
+            valueMapper: key.inputValueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -284,6 +320,7 @@ public extension Filter {
             operator: .in,
             key: key,
             value: values,
+            valueMapper: key.inputValueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -294,6 +331,7 @@ public extension Filter {
             operator: .notIn,
             key: key,
             value: values,
+            valueMapper: key.inputValueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -304,6 +342,7 @@ public extension Filter {
             operator: .query,
             key: key,
             value: text,
+            valueMapper: key.inputValueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -314,6 +353,7 @@ public extension Filter {
             operator: .autocomplete,
             key: key,
             value: text,
+            valueMapper: key.inputValueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -328,6 +368,7 @@ public extension Filter {
             operator: .exists,
             key: key,
             value: exists,
+            valueMapper: key.inputValueMapper,
             keyPathString: key.keyPathString
         )
     }
@@ -338,6 +379,7 @@ public extension Filter {
             operator: .contains,
             key: key,
             value: value,
+            valueMapper: key.inputValueMapper,
             keyPathString: key.keyPathString
         )
     }

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -1380,6 +1380,24 @@ final class ChannelListController_Tests: XCTestCase {
             expectedResult: [cid]
         )
     }
+
+    func test_filterPredicate_filterKeyContainsAValueMapper_containsExpectedItems() throws {
+        let cid = ChannelId(type: .custom("test"), id: .unique)
+        let memberId = UserId.unique
+
+        try assertFilterPredicate(
+            .and([
+                .equal(.type, to: .custom("test")),
+                .containMembers(userIds: [memberId])
+            ]),
+            channelsInDB: [
+                .dummy(channel: .dummy(cid: cid), members: [.dummy(user: .dummy(userId: memberId))]),
+                .dummy(members: [.dummy(user: .dummy(userId: memberId))]),
+                .dummy(members: [.dummy(), .dummy()])
+            ],
+            expectedResult: [cid]
+        )
+    }
 }
 
 private class TestEnvironment {

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -1387,6 +1387,8 @@ final class ChannelListController_Tests: XCTestCase {
 
         try assertFilterPredicate(
             .and([
+                /// Type's filter-key has value type of ChannelType. The stored value in DB though, is a String.
+                /// The filter-key provides a value mapper that transforms the ChannelType into the DB Type (String)
                 .equal(.type, to: .custom("test")),
                 .containMembers(userIds: [memberId])
             ]),


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [Link](https://github.com/GetStream/ios-issues-tracking/issues/326)

### 📝 Summary

The following filter doesn't work correctly with auto filtering.

```swift
let controller = streamChatClient.channelListController(
      query: ChannelListQuery(filter: .and([
            .equal(.type, to: .custom("test")),
            .containMembers(userIds: ["12632287"]),
      ]))
)
```

### 🛠 Implementation

The issue appears to be that the filter's and DB's value type don't match and when they are being compared it fails.

To maintain our type-safe API while supporting auto-filtering, we will provide a valueMapper on the filter that will allow in cases where the filter's and DB's value type don't match, to disambiguate the problem by mapping the filter's value to the a value that matches the DB's value type.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![meme](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExODgxNjlmMDM3NjA2M2E1YmJjMWU1ZTYxMjZjOWEwYjM2ZDA4MmNlOCZjdD1n/Z9zo37ooUzwNwzmw4w/giphy.gif)
