### PR TITLE
Add support for skip_enrich_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### ✅ Added
+- Add support for `skip_enrich_url` when sending a message [#2498](https://github.com/GetStream/stream-chat-swift/pull/2498)
 
 # [4.27.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.27.0)
 _February 16, 2023_

--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -365,6 +365,15 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
                     }
                     channelController.createNewMessage(text: message, skipPush: true)
                 }
+            }),
+            .init(title: "Send message without url enriching", style: .default, handler: { [unowned self] _ in
+                self.rootViewController.presentAlert(title: "Enter the message text", textFieldPlaceholder: "Send message") { message in
+                    guard let message = message, !message.isEmpty else {
+                        self.rootViewController.presentAlert(title: "Message is not valid")
+                        return
+                    }
+                    channelController.createNewMessage(text: message, skipEnrichUrl: true)
+                }
             })
         ])
     }

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
@@ -103,11 +103,12 @@ extension Endpoint {
         )
     }
 
-    static func sendMessage(cid: ChannelId, messagePayload: MessageRequestBody, skipPush: Bool)
+    static func sendMessage(cid: ChannelId, messagePayload: MessageRequestBody, skipPush: Bool, skipEnrichUrl: Bool)
         -> Endpoint<MessagePayload.Boxed> {
         let body: [String: AnyEncodable] = [
             "message": AnyEncodable(messagePayload),
-            "skip_push": AnyEncodable(skipPush)
+            "skip_push": AnyEncodable(skipPush),
+            "skip_enrich_url": AnyEncodable(skipEnrichUrl)
         ]
         return .init(
             path: .sendMessage(cid),

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -900,6 +900,7 @@ public extension ChatChannelController {
     ///     and `ChatMessageAttachmentSeed`s.
     ///   - quotedMessageId: An id of the message new message quotes. (inline reply)
     ///   - skipPush: If true, skips sending push notification to channel members.
+    ///   - skipEnrichUrl: If true, skips url enriching.
     ///   - extraData: Additional extra data of the message object.
     ///   - completion: Called when saving the message to the local DB finishes.
     ///
@@ -911,6 +912,7 @@ public extension ChatChannelController {
         mentionedUserIds: [UserId] = [],
         quotedMessageId: MessageId? = nil,
         skipPush: Bool = false,
+        skipEnrichUrl: Bool = false,
         extraData: [String: RawJSON] = [:],
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -936,6 +938,7 @@ public extension ChatChannelController {
             mentionedUserIds: mentionedUserIds,
             quotedMessageId: quotedMessageId,
             skipPush: skipPush,
+            skipEnrichUrl: skipEnrichUrl,
             extraData: extraData
         ) { result in
             self.callback {

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -248,6 +248,7 @@ public extension ChatMessageController {
     ///   in the response thread.
     ///   - quotedMessageId: An id of the message new message quotes. (inline reply)
     ///   - skipPush: If true, skips sending push notification to channel members.
+    ///   - skipEnrichUrl: If true, skips url enriching.
     ///   - extraData: Additional extra data of the message object.
     ///   - completion: Called when saving the message to the local DB finishes.
     ///
@@ -260,6 +261,7 @@ public extension ChatMessageController {
         isSilent: Bool = false,
         quotedMessageId: MessageId? = nil,
         skipPush: Bool = false,
+        skipEnrichUrl: Bool = false,
         extraData: [String: RawJSON] = [:],
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -276,6 +278,7 @@ public extension ChatMessageController {
             isSilent: isSilent,
             quotedMessageId: quotedMessageId,
             skipPush: skipPush,
+            skipEnrichUrl: skipEnrichUrl,
             extraData: extraData
         ) { result in
             self.callback {

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -37,6 +37,7 @@ class MessageDTO: NSManagedObject {
     @NSManaged var isBounced: Bool
     @NSManaged var isSilent: Bool
     @NSManaged var skipPush: Bool
+    @NSManaged var skipEnrichUrl: Bool
     @NSManaged var isShadowed: Bool
     @NSManaged var reactionScores: [String: Int]
     @NSManaged var reactionCounts: [String: Int]
@@ -484,6 +485,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         quotedMessageId: MessageId?,
         createdAt: Date?,
         skipPush: Bool,
+        skipEnrichUrl: Bool,
         extraData: [String: RawJSON]
     ) throws -> MessageDTO {
         guard let currentUserDTO = currentUser else {
@@ -519,6 +521,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
         message.extraData = try JSONEncoder.default.encode(extraData)
         message.isSilent = isSilent
         message.skipPush = skipPush
+        message.skipEnrichUrl = skipEnrichUrl
         message.reactionScores = [:]
         message.reactionCounts = [:]
 

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -81,6 +81,7 @@ protocol MessageDatabaseSession {
         quotedMessageId: MessageId?,
         createdAt: Date?,
         skipPush: Bool,
+        skipEnrichUrl: Bool,
         extraData: [String: RawJSON]
     ) throws -> MessageDTO
 
@@ -191,6 +192,7 @@ extension MessageDatabaseSession {
         quotedMessageId: MessageId?,
         isSilent: Bool = false,
         skipPush: Bool,
+        skipEnrichUrl: Bool,
         attachments: [AnyAttachmentPayload] = [],
         mentionedUserIds: [UserId] = [],
         extraData: [String: RawJSON] = [:]
@@ -209,6 +211,7 @@ extension MessageDatabaseSession {
             quotedMessageId: quotedMessageId,
             createdAt: nil,
             skipPush: skipPush,
+            skipEnrichUrl: skipEnrichUrl,
             extraData: extraData
         )
     }

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -206,6 +206,7 @@
         <attribute name="reactionScores" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
         <attribute name="replyCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="showReplyInChannel" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="skipEnrichUrl" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="skipPush" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="text" attributeType="String"/>
         <attribute name="translations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>

--- a/Sources/StreamChat/Repositories/MessageRepository.swift
+++ b/Sources/StreamChat/Repositories/MessageRepository.swift
@@ -47,6 +47,7 @@ class MessageRepository {
 
             let requestBody = dto.asRequestBody() as MessageRequestBody
             let skipPush: Bool = dto.skipPush
+            let skipEnrichUrl: Bool = dto.skipEnrichUrl
 
             // Change the message state to `.sending` and the proceed with the actual sending
             self?.database.write({
@@ -64,7 +65,8 @@ class MessageRepository {
                 let endpoint: Endpoint<MessagePayload.Boxed> = .sendMessage(
                     cid: cid,
                     messagePayload: requestBody,
-                    skipPush: skipPush
+                    skipPush: skipPush,
+                    skipEnrichUrl: skipEnrichUrl
                 )
                 self?.apiClient.request(endpoint: endpoint) {
                     switch $0 {

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -227,6 +227,7 @@ class ChannelUpdater: Worker {
     ///   - attachments: An array of the attachments for the message.
     ///   - quotedMessageId: An id of the message new message quotes. (inline reply)
     ///   - skipPush: If true, skips sending push notification to channel members.
+    ///   - skipEnrichUrl: If true, skips url enriching.
     ///   - extraData: Additional extra data of the message object.
     ///   - completion: Called when saving the message to the local DB finishes.
     ///
@@ -241,6 +242,7 @@ class ChannelUpdater: Worker {
         mentionedUserIds: [UserId],
         quotedMessageId: MessageId?,
         skipPush: Bool,
+        skipEnrichUrl: Bool,
         extraData: [String: RawJSON],
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -260,6 +262,7 @@ class ChannelUpdater: Worker {
                 quotedMessageId: quotedMessageId,
                 createdAt: nil,
                 skipPush: skipPush,
+                skipEnrichUrl: skipEnrichUrl,
                 extraData: extraData
             )
 

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -151,6 +151,7 @@ class MessageUpdater: Worker {
     ///   in the response thread.
     ///   - quotedMessageId: An id of the message new message quotes. (inline reply)
     ///   - skipPush: If true, skips sending push notification to channel members.
+    ///   - skipEnrichUrl: If true, skips url enriching.
     ///   - extraData: Additional extra data of the message object.
     ///   - completion: Called when saving the message to the local DB finishes.
     ///
@@ -167,6 +168,7 @@ class MessageUpdater: Worker {
         isSilent: Bool,
         quotedMessageId: MessageId?,
         skipPush: Bool,
+        skipEnrichUrl: Bool,
         extraData: [String: RawJSON],
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -186,6 +188,7 @@ class MessageUpdater: Worker {
                 quotedMessageId: quotedMessageId,
                 createdAt: nil,
                 skipPush: skipPush,
+                skipEnrichUrl: skipEnrichUrl,
                 extraData: extraData
             )
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -135,6 +135,7 @@ extension DatabaseSession_Mock {
         quotedMessageId: MessageId?,
         createdAt: Date?,
         skipPush: Bool,
+        skipEnrichUrl: Bool,
         extraData: [String: RawJSON]
     ) throws -> MessageDTO {
         try throwErrorIfNeeded()
@@ -153,6 +154,7 @@ extension DatabaseSession_Mock {
             quotedMessageId: quotedMessageId,
             createdAt: createdAt,
             skipPush: skipPush,
+            skipEnrichUrl: skipEnrichUrl,
             extraData: extraData
         )
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ChannelUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ChannelUpdater_Mock.swift
@@ -59,6 +59,7 @@ final class ChannelUpdater_Mock: ChannelUpdater {
     @Atomic var createNewMessage_text: String?
     @Atomic var createNewMessage_isSilent: Bool?
     @Atomic var createNewMessage_skipPush: Bool?
+    @Atomic var createNewMessage_skipEnrichUrl: Bool?
     @Atomic var createNewMessage_command: String?
     @Atomic var createNewMessage_arguments: String?
     @Atomic var createNewMessage_attachments: [AnyAttachmentPayload]?
@@ -151,6 +152,7 @@ final class ChannelUpdater_Mock: ChannelUpdater {
         createNewMessage_text = nil
         createNewMessage_isSilent = nil
         createNewMessage_skipPush = nil
+        createNewMessage_skipEnrichUrl = nil
         createNewMessage_command = nil
         createNewMessage_arguments = nil
         createNewMessage_attachments = nil
@@ -256,6 +258,7 @@ final class ChannelUpdater_Mock: ChannelUpdater {
         mentionedUserIds: [UserId],
         quotedMessageId: MessageId?,
         skipPush: Bool,
+        skipEnrichUrl: Bool,
         extraData: [String: RawJSON] = [:],
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -263,6 +266,7 @@ final class ChannelUpdater_Mock: ChannelUpdater {
         createNewMessage_text = text
         createNewMessage_isSilent = isSilent
         createNewMessage_skipPush = skipPush
+        createNewMessage_skipEnrichUrl = skipEnrichUrl
         createNewMessage_command = command
         createNewMessage_arguments = arguments
         createNewMessage_attachments = attachments

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -30,6 +30,7 @@ final class MessageUpdater_Mock: MessageUpdater {
     @Atomic var createNewReply_showReplyInChannel: Bool?
     @Atomic var createNewReply_isSilent: Bool?
     @Atomic var createNewReply_skipPush: Bool?
+    @Atomic var createNewReply_skipEnrichUrl: Bool?
     @Atomic var createNewReply_quotedMessageId: MessageId?
     @Atomic var createNewReply_pinning: MessagePinning?
     @Atomic var createNewReply_extraData: [String: RawJSON]?
@@ -114,6 +115,7 @@ final class MessageUpdater_Mock: MessageUpdater {
         createNewReply_showReplyInChannel = nil
         createNewReply_isSilent = nil
         createNewReply_skipPush = nil
+        createNewReply_skipEnrichUrl = nil
         createNewReply_extraData = nil
         createNewReply_completion = nil
 
@@ -215,6 +217,7 @@ final class MessageUpdater_Mock: MessageUpdater {
         isSilent: Bool,
         quotedMessageId: MessageId?,
         skipPush: Bool,
+        skipEnrichUrl: Bool,
         extraData: [String: RawJSON],
         completion: ((Result<MessageId, Error>) -> Void)? = nil
     ) {
@@ -228,6 +231,7 @@ final class MessageUpdater_Mock: MessageUpdater {
         createNewReply_showReplyInChannel = showReplyInChannel
         createNewReply_isSilent = isSilent
         createNewReply_skipPush = skipPush
+        createNewReply_skipEnrichUrl = skipEnrichUrl
         createNewReply_quotedMessageId = quotedMessageId
         createNewReply_pinning = pinning
         createNewReply_extraData = extraData

--- a/Tests/StreamChatTests/APIClient/Endpoints/ChannelEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/ChannelEndpoints_Tests.swift
@@ -231,12 +231,13 @@ final class ChannelEndpoints_Tests: XCTestCase {
             requiresConnectionId: false,
             body: [
                 "message": AnyEncodable(messageBody),
-                "skip_push": AnyEncodable(true)
+                "skip_push": AnyEncodable(true),
+                "skip_enrich_url": AnyEncodable(false)
             ]
         )
 
         // Build endpoint
-        let endpoint: Endpoint<MessagePayload.Boxed> = .sendMessage(cid: cid, messagePayload: messageBody, skipPush: true)
+        let endpoint: Endpoint<MessagePayload.Boxed> = .sendMessage(cid: cid, messagePayload: messageBody, skipPush: true, skipEnrichUrl: false)
 
         // Assert endpoint is built correctly
         XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -418,6 +418,7 @@ final class ChannelController_Tests: XCTestCase {
                 quotedMessageId: nil,
                 createdAt: oldMessageCreatedAt,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             )
             // Simulate sending failed for this message
@@ -2724,6 +2725,7 @@ final class ChannelController_Tests: XCTestCase {
         let quotedMessageId: MessageId = .unique
         let pin = MessagePinning(expirationDate: .unique)
         let skipPush = true
+        let skipEnrichUrl = false
 
         // Simulate `createNewMessage` calls and catch the completion
         var completionCalled = false
@@ -2733,6 +2735,7 @@ final class ChannelController_Tests: XCTestCase {
             attachments: attachments,
             quotedMessageId: quotedMessageId,
             skipPush: skipPush,
+            skipEnrichUrl: skipEnrichUrl,
             extraData: extraData
         ) { [callbackQueueID] result in
             AssertTestQueue(withId: callbackQueueID)
@@ -2757,6 +2760,7 @@ final class ChannelController_Tests: XCTestCase {
         XCTAssertEqual(env.channelUpdater?.createNewMessage_attachments, attachments)
         XCTAssertEqual(env.channelUpdater?.createNewMessage_quotedMessageId, quotedMessageId)
         XCTAssertEqual(env.channelUpdater?.createNewMessage_skipPush, skipPush)
+        XCTAssertEqual(env.channelUpdater?.createNewMessage_skipEnrichUrl, skipEnrichUrl)
         XCTAssertEqual(env.channelUpdater?.createNewMessage_pinning?.expirationDate, pin.expirationDate!)
 
         // Simulate successful update
@@ -4375,6 +4379,7 @@ extension ChannelController_Tests {
             quotedMessageId: nil,
             isSilent: false,
             skipPush: false,
+            skipEnrichUrl: false,
             attachments: [
                 .mockImage,
                 .mockFile,

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -980,6 +980,7 @@ final class MessageController_Tests: XCTestCase {
         let attachments: [AnyAttachmentPayload] = [.mockFile, .mockImage, .init(payload: TestAttachmentPayload.unique)]
         let pin = MessagePinning(expirationDate: .unique)
         let skipPush = true
+        let skipEnrichUrl = false
 
         // Simulate `createNewReply` calls and catch the completion
         var completionCalled = false
@@ -990,6 +991,7 @@ final class MessageController_Tests: XCTestCase {
             showReplyInChannel: showReplyInChannel,
             quotedMessageId: quotedMessageId,
             skipPush: skipPush,
+            skipEnrichUrl: skipEnrichUrl,
             extraData: extraData
         ) { [callbackQueueID] result in
             AssertTestQueue(withId: callbackQueueID)
@@ -1015,6 +1017,7 @@ final class MessageController_Tests: XCTestCase {
         XCTAssertEqual(env.messageUpdater.createNewReply_extraData, extraData)
         XCTAssertEqual(env.messageUpdater.createNewReply_attachments, attachments)
         XCTAssertEqual(env.messageUpdater.createNewReply_skipPush, skipPush)
+        XCTAssertEqual(env.messageUpdater.createNewReply_skipEnrichUrl, skipEnrichUrl)
         XCTAssertEqual(env.messageUpdater.createNewReply_quotedMessageId, quotedMessageId)
 
         // Simulate successful update

--- a/Tests/StreamChatTests/Database/DTOs/AttachmentDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/AttachmentDTO_Tests.swift
@@ -271,6 +271,7 @@ final class AttachmentDTO_Tests: XCTestCase {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: false,
+                skipEnrichUrl: false,
                 attachments: [.init(payload: TestAttachmentPayload.unique)],
                 extraData: [:]
             )

--- a/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
@@ -773,6 +773,7 @@ final class MessageDTO_Tests: XCTestCase {
                 quotedMessageId: nil,
                 createdAt: nil,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: messageExtraData
             ).id
         }
@@ -882,6 +883,7 @@ final class MessageDTO_Tests: XCTestCase {
                     quotedMessageId: nil,
                     createdAt: nil,
                     skipPush: false,
+                    skipEnrichUrl: false,
                     extraData: [:]
                 )
                 message1Id = message1DTO.id
@@ -902,6 +904,7 @@ final class MessageDTO_Tests: XCTestCase {
                     quotedMessageId: nil,
                     createdAt: nil,
                     skipPush: false,
+                    skipEnrichUrl: false,
                     extraData: [:]
                 )
                 // Reset the `locallyCreateAt` value of the second message to simulate the message was sent
@@ -996,6 +999,7 @@ final class MessageDTO_Tests: XCTestCase {
                 quotedMessageId: nil,
                 createdAt: nil,
                 skipPush: true,
+                skipEnrichUrl: true,
                 extraData: [:]
             )
             newMessageId = messageDTO.id
@@ -1005,6 +1009,7 @@ final class MessageDTO_Tests: XCTestCase {
 
         let messageDTO: MessageDTO = try XCTUnwrap(database.viewContext.message(id: newMessageId))
         XCTAssertEqual(messageDTO.skipPush, true)
+        XCTAssertEqual(messageDTO.skipEnrichUrl, true)
 
         let loadedMessage: ChatMessage = try messageDTO.asModel()
         XCTAssertEqual(loadedMessage.text, newMessageText)
@@ -1059,6 +1064,7 @@ final class MessageDTO_Tests: XCTestCase {
                 quotedMessageId: nil,
                 createdAt: nil,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             )
             messageId = messageDTO.id
@@ -1102,6 +1108,7 @@ final class MessageDTO_Tests: XCTestCase {
                 quotedMessageId: nil,
                 createdAt: nil,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             )
             threadReplyId = replyShownInChannelDTO.id
@@ -1158,6 +1165,7 @@ final class MessageDTO_Tests: XCTestCase {
                 quotedMessageId: nil,
                 createdAt: nil,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             )
         }
@@ -1183,6 +1191,7 @@ final class MessageDTO_Tests: XCTestCase {
                     quotedMessageId: nil,
                     createdAt: nil,
                     skipPush: false,
+                    skipEnrichUrl: false,
                     extraData: [:]
                 )
             }, completion: completion)
@@ -1222,6 +1231,7 @@ final class MessageDTO_Tests: XCTestCase {
                     quotedMessageId: nil,
                     createdAt: nil,
                     skipPush: false,
+                    skipEnrichUrl: false,
                     extraData: [:]
                 )
             }, completion: completion)
@@ -1259,6 +1269,7 @@ final class MessageDTO_Tests: XCTestCase {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             )
             newMessageId = messageDTO.id
@@ -1304,6 +1315,7 @@ final class MessageDTO_Tests: XCTestCase {
                 quotedMessageId: nil,
                 createdAt: nil,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             )
             // Get reply messageId

--- a/Tests/StreamChatTests/Database/DTOs/NSManagedObject+Validation_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/NSManagedObject+Validation_Tests.swift
@@ -79,7 +79,8 @@ private extension NSManagedObject_Validation_Tests {
                 text: "Hello",
                 pinning: nil,
                 quotedMessageId: nil,
-                skipPush: false
+                skipPush: false,
+                skipEnrichUrl: false
             )
         }
         return message

--- a/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
@@ -144,6 +144,27 @@ final class MessageRepositoryTests: XCTestCase {
         XCTAssertTrue(skipPush)
     }
 
+    func test_sendMessage_skipEnrichUrl() throws {
+        let id = MessageId.unique
+        try createMessage(id: id, localState: .pendingSend, skipEnrichUrl: true)
+        let expectation = self.expectation(description: "Send Message completes")
+        repository.sendMessage(with: id) { _ in
+            expectation.fulfill()
+        }
+
+        wait(for: [apiClient.request_expectation], timeout: defaultTimeout)
+
+        let payload = MessagePayload.Boxed(message: .dummy(messageId: id, authorUserId: .anonymous))
+        (apiClient.request_completion as? (Result<MessagePayload.Boxed, Error>) -> Void)?(.success(payload))
+
+        wait(for: [expectation], timeout: defaultTimeout)
+
+        let expectedEndpoint = try XCTUnwrap(apiClient.request_endpoint)
+        let requestBody = try expectedEndpoint.bodyAsDictionary()
+        let skipPush = try XCTUnwrap(requestBody["skip_enrich_url"] as? Bool)
+        XCTAssertTrue(skipPush)
+    }
+
     // MARK: saveSuccessfullySentMessage
 
     func test_saveSuccessfullySentMessage_noChannel() {
@@ -572,7 +593,12 @@ final class MessageRepositoryTests: XCTestCase {
 
 extension MessageRepositoryTests {
     @discardableResult
-    private func createMessage(id: MessageId, localState: LocalMessageState, skipPush: Bool = false) throws -> MessageDTO {
+    private func createMessage(
+        id: MessageId,
+        localState: LocalMessageState,
+        skipPush: Bool = false,
+        skipEnrichUrl: Bool = false
+    ) throws -> MessageDTO {
         try database.createCurrentUser()
         try database.createChannel(cid: cid)
         var message: MessageDTO!
@@ -584,6 +610,7 @@ extension MessageRepositoryTests {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: skipPush,
+                skipEnrichUrl: skipEnrichUrl,
                 extraData: [:]
             )
             message.id = id

--- a/Tests/StreamChatTests/Workers/Background/MessageSender_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/MessageSender_Tests.swift
@@ -71,6 +71,7 @@ final class MessageSender_Tests: XCTestCase {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             )
             message1.localMessageState = .pendingSend
@@ -83,6 +84,7 @@ final class MessageSender_Tests: XCTestCase {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: false,
+                skipEnrichUrl: false,
                 attachments: [
                     .mockFile,
                     .mockImage,
@@ -101,6 +103,7 @@ final class MessageSender_Tests: XCTestCase {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: false,
+                skipEnrichUrl: false,
                 attachments: [],
                 extraData: [:]
             )
@@ -142,6 +145,7 @@ final class MessageSender_Tests: XCTestCase {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: false,
+                skipEnrichUrl: false,
                 attachments: [
                     .init(payload: TestAttachmentPayload.unique),
                     .init(payload: TestAttachmentPayload.unique)
@@ -167,6 +171,7 @@ final class MessageSender_Tests: XCTestCase {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: false,
+                skipEnrichUrl: false,
                 attachments: [
                     .mockImage,
                     .init(payload: TestAttachmentPayload.unique)
@@ -205,6 +210,7 @@ final class MessageSender_Tests: XCTestCase {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             )
             message1.localMessageState = .pendingSend
@@ -217,6 +223,7 @@ final class MessageSender_Tests: XCTestCase {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             )
             message2.localMessageState = .pendingSend
@@ -229,6 +236,7 @@ final class MessageSender_Tests: XCTestCase {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             )
             message3.localMessageState = .pendingSend
@@ -276,6 +284,7 @@ final class MessageSender_Tests: XCTestCase {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             )
             messageA1.localMessageState = .pendingSend
@@ -288,6 +297,7 @@ final class MessageSender_Tests: XCTestCase {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             )
             messageA2.localMessageState = .pendingSend
@@ -300,6 +310,7 @@ final class MessageSender_Tests: XCTestCase {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             )
             messageB1.localMessageState = .pendingSend
@@ -312,6 +323,7 @@ final class MessageSender_Tests: XCTestCase {
                 quotedMessageId: nil,
                 isSilent: false,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             )
             messageB2.localMessageState = .pendingSend

--- a/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
@@ -480,6 +480,7 @@ final class ChannelUpdater_Tests: XCTestCase {
                 mentionedUserIds: [currentUserId],
                 quotedMessageId: nil,
                 skipPush: true,
+                skipEnrichUrl: true,
                 extraData: extraData
             ) { result in
                 do {
@@ -499,6 +500,7 @@ final class ChannelUpdater_Tests: XCTestCase {
             database.viewContext.message(id: newMessageId)
         )
         XCTAssertEqual(messageDTO.skipPush, true)
+        XCTAssertEqual(messageDTO.skipEnrichUrl, true)
 
         let message = try messageDTO.asModel()
         XCTAssertEqual(message.text, text)
@@ -553,6 +555,7 @@ final class ChannelUpdater_Tests: XCTestCase {
                 mentionedUserIds: [.unique],
                 quotedMessageId: nil,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             ) { completion($0) }
         }

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -838,6 +838,7 @@ final class MessageUpdater_Tests: XCTestCase {
                 isSilent: isSilent,
                 quotedMessageId: nil,
                 skipPush: true,
+                skipEnrichUrl: false,
                 extraData: extraData
             ) { result in
                 if let newMessageId = try? result.get() {
@@ -854,6 +855,7 @@ final class MessageUpdater_Tests: XCTestCase {
 
         let messageDTO: MessageDTO = try XCTUnwrap(database.viewContext.message(id: newMessageId))
         XCTAssertEqual(messageDTO.skipPush, true)
+        XCTAssertEqual(messageDTO.skipEnrichUrl, false)
 
         let message: ChatMessage = try messageDTO.asModel()
         XCTAssertEqual(message.text, text)
@@ -901,6 +903,7 @@ final class MessageUpdater_Tests: XCTestCase {
                 isSilent: false,
                 quotedMessageId: nil,
                 skipPush: false,
+                skipEnrichUrl: false,
                 extraData: [:]
             ) { completion($0) }
         }


### PR DESCRIPTION
### 🔗 Issue Links

-

### 🎯 Goal

Add support to skip url enrichment through the SDK

### 📝 Summary

Our backend allow us to send a flag to determine if the url sent in a message should be enriched or not. This PR allows this flag to be sent

### 🛠 Implementation

Both MessageController and ChannelController allow `skipEnrichUrl` parameter when sending a message/reply

### 🎨 Showcase
![Enrich](https://user-images.githubusercontent.com/7887319/220114699-7d68aece-b27a-4ac8-814e-29a23810d8ef.png)


### 🧪 Manual Testing Notes
- Open a Channel
- Tap the Debug Button
- Tap "Send message without url enriching" action
- Write a message
- Click "OK"

Should send a message without url enriching

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/l0MYylLtnC1ADCGys/giphy.gif)
