### PR TITLE
Re-enable test

### DIFF
--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/MessageRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/MessageRepository_Mock.swift
@@ -12,11 +12,10 @@ final class MessageRepository_Mock: MessageRepository, Spy {
     }
 
     var sendMessageResult: Result<ChatMessage, MessageRepositoryError>?
-    var sendMessageCalls: [MessageId: (Result<ChatMessage, MessageRepositoryError>) -> Void] = [:]
+    @Atomic var sendMessageCalls: [MessageId: (Result<ChatMessage, MessageRepositoryError>) -> Void] = [:]
     var getMessageResult: Result<ChatMessage, Error>?
     var receivedGetMessageStore: Bool?
     var saveSuccessfullyDeletedMessageError: Error?
-    let lock = NSLock()
     var updatedMessageLocalState: LocalMessageState?
 
     override func sendMessage(
@@ -24,11 +23,11 @@ final class MessageRepository_Mock: MessageRepository, Spy {
         completion: @escaping (Result<ChatMessage, MessageRepositoryError>) -> Void
     ) {
         record()
-        lock.lock()
-        sendMessageCalls[messageId] = { result in
-            completion(result)
+        _sendMessageCalls.mutate { dictionary in
+            dictionary[messageId] = { result in
+                completion(result)
+            }
         }
-        lock.unlock()
 
         if let sendMessageResult = sendMessageResult {
             completion(sendMessageResult)

--- a/Tests/StreamChatTests/Workers/Background/MessageSender_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/MessageSender_Tests.swift
@@ -197,8 +197,6 @@ final class MessageSender_Tests: XCTestCase {
     }
 
     func test_senderSendsMessage_inTheOrderTheyWereCreatedLocally() throws {
-        throw XCTSkip("https://github.com/GetStream/ios-issues-tracking/issues/330")
-        
         var message1Id: MessageId!
         var message2Id: MessageId!
         var message3Id: MessageId!


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/330

### 🎯 Goal

Run the test without crashing

### 📝 Summary

The test is crashing due to a race condition in accessing the `sendMessageCalls`. We are using atomic writes but not reads. 

### 🛠 Implementation

Change the access to `sendMessageCalls` to be Atomic for both writes and reads

### 🧪 Manual Testing Notes

We are going to use the Repeatable test execution on Xcode:
1. Right click on the status diamond on the left side of the test case
2. Select Run test "test_senderSendsMessage_inTheOrderTheyWereCreatedLocally" Repeatedly...
![Screenshot 2023-02-21 at 2 26 51 PM](https://user-images.githubusercontent.com/472467/220344970-821f8587-382d-469c-a513-034c0d4f3444.png)
3. Set the stop after to Failure and the maximum repetitions to 1000

Execute on develop and then on this branch.

### ☑️ Contributor Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![meme](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExMmYwYTkwMDExZjNkMzIyOGQ3NjU0MGMxMzA5NTYwYzRmNDIwZmQ5NSZjdD1n/6Z3D5t31ZdoNW/giphy.gif)
