### PR TITLE
Remove [URLQueryItem] public conformance of ExpressibleByDictionaryLiteral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🔄 Changed
+- Remove [URLQueryItem] public conformance of ExpressibleByDictionaryLiteral [#2505](https://github.com/GetStream/stream-chat-swift/pull/2505)
 
 # [4.27.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.27.1)
 _February 20, 2023_

--- a/Sources/StreamChat/APIClient/RequestEncoder.swift
+++ b/Sources/StreamChat/APIClient/RequestEncoder.swift
@@ -261,6 +261,11 @@ struct DefaultRequestEncoder: RequestEncoder {
 }
 
 private extension URL {
+    func appendingQueryItems(_ items: [String: String]) throws -> URL {
+        let queryItems = items.map { URLQueryItem(name: $0.key, value: $0.value) }
+        return try appendingQueryItems(queryItems)
+    }
+
     func appendingQueryItems(_ items: [URLQueryItem]) throws -> URL {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
             throw ClientError.InvalidURL("Can't create `URLComponents` from the url: \(self).")
@@ -290,14 +295,4 @@ extension ClientError {
     class InvalidURL: ClientError {}
     class InvalidJSON: ClientError {}
     class MissingConnectionId: ClientError {}
-}
-
-/// A helper extension allowing to create `URLQueryItems` using a dictionary literal like:
-/// ```
-/// let queryItems = ["item1": "Luke", "item2": nil, "item3": "Leia"]
-/// ```
-extension Array: ExpressibleByDictionaryLiteral where Element == URLQueryItem {
-    public init(dictionaryLiteral elements: (String, String?)...) {
-        self = elements.map(URLQueryItem.init)
-    }
 }


### PR DESCRIPTION
### 🎯 Goal

We had a public extension on `[URLQueryItem]` that was supposed to only be internal

### 📝 Summary

ExpressibleByDictionaryLiteral's conformance requires its methods to be public, which was exposing this extension to our integrators

### 🛠 Implementation

Removed the conformance of ExpressibleByDictionaryLiteral and created an extension over `URL` to allow passing in query parameters as dictionary, which will internally be converted into `URLQueryItem`

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/KchJVIsJcjdzBNQqaE/giphy.gif)
