### PR TITLE
Fix connectionStatus observing documentation

### DIFF
--- a/docusaurus/docs/iOS/common-content/reference-docs/stream-chat/chat-client.md
+++ b/docusaurus/docs/iOS/common-content/reference-docs/stream-chat/chat-client.md
@@ -51,7 +51,7 @@ The current connection status of the client.
 public internal(set) var connectionStatus: ConnectionStatus = .initialized
 ```
 
-To observe changes in the connection status, create an instance of `CurrentChatUserController`, and use it to receive
+To observe changes in the connection status, create an instance of `ChatConnectionController`, and use it to receive
 callbacks when the connection status changes.
 
 ### `config`


### PR DESCRIPTION
### 🔗 Issue Links

https://getstream.zendesk.com/agent/tickets/34723

### 📝 Summary

There was a mistake in the documentation around `connectionStatus` that was suggesting to use `CurrentChatUserController` instead of `ChatConnectionController` to observe changes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/l0IydbsUbimmcv2yQ/giphy.gif)