### PR TITLE
Fix Markdown hanging forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🔄 Changed
 - Remove [URLQueryItem] public conformance of ExpressibleByDictionaryLiteral [#2505](https://github.com/GetStream/stream-chat-swift/pull/2505)
+
 ### 🐞 Fixed
 - Fix messages appearing sooner in Thread pagination [#2470](https://github.com/GetStream/stream-chat-swift/pull/2470)
 - Fix messages disappearing from the Message List when quoting a message [#2470](https://github.com/GetStream/stream-chat-swift/pull/2470)
+- Fix Markdown formatting hanging with edge case pattern [#2513](https://github.com/GetStream/stream-chat-swift/pull/2513)
 
 # [4.27.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.27.1)
 _February 20, 2023_

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ update_dependencies:
 	echo "👉 Updating SwiftyGif"
 	make update_swiftygif version=5.4.2
 	echo "👉 Updating SwiftyMarkdown"
-	make update_swiftymarkdown version=1.2.4
+	make update_swiftymarkdown version=master
 	echo "👉 Updating DifferenceKit"
 	make update_differencekit version=1.3.0
 

--- a/Scripts/removePublicDeclarations.sh
+++ b/Scripts/removePublicDeclarations.sh
@@ -62,10 +62,8 @@ do
 		'public func isContentEqual(to source: Wrapped?) -> Bool {' \
 		$f
 
-		# This replacement is not actually working, and I don't know why,
-		# for now, I did this change manually.
-		replaceDeclaration 'func isContentEqual(to source: [Element]) -> Bool' \
-		'public func isContentEqual(to source: [Element]) -> Bool' \
+		replaceDeclaration 'func isContentEqual(to source: \[Element\]) -> Bool' \
+		'public func isContentEqual(to source: \[Element\]) -> Bool' \
 		$f
 
 		replaceDeclaration 'extension ContentIdentifiable where Self: Hashable {' \

--- a/Scripts/updateDependency.sh
+++ b/Scripts/updateDependency.sh
@@ -28,7 +28,7 @@ elif [[ $dependency_directory == *"SwiftyGif"* ]]; then
 elif [[ $dependency_directory == *"Starscream"* ]]; then
 	dependency_url="git@github.com:daltoniam/Starscream.git"
 elif [[ $dependency_directory == *"SwiftyMarkdown"* ]]; then
-    dependency_url="git@github.com:SimonFairbairn/SwiftyMarkdown.git"
+    dependency_url="git@github.com:GetStream/SwiftyMarkdown.git"
 elif [[ $dependency_directory == *"DifferenceKit"* ]]; then
 	dependency_url="git@github.com:ra1028/DifferenceKit.git"
 else

--- a/Sources/StreamChatUI/StreamSwiftyMarkdown/SwiftyMarkdown/SwiftyScanner.swift
+++ b/Sources/StreamChatUI/StreamSwiftyMarkdown/SwiftyMarkdown/SwiftyScanner.swift
@@ -259,7 +259,8 @@ class SwiftyScanner {
 		} else {
 			var remainingTags = min(openRange.upperBound - openRange.lowerBound, closeRange.upperBound - closeRange.lowerBound) + 1
 			while remainingTags > 0 {
-				if remainingTags >= self.rule.maxTags {
+				let shouldAppendStyle = remainingTags >= self.rule.maxTags
+				if shouldAppendStyle {
 					remainingTags -= self.rule.maxTags
 					if let style = self.rule.styles[ self.rule.maxTags ] {
 						if !styles.contains(where: { $0.isEqualTo(style)}) {
@@ -267,11 +268,17 @@ class SwiftyScanner {
 						}
 					}
 				}
-				if let style = self.rule.styles[remainingTags] {
+
+				let remainingTagsStyle = self.rule.styles[remainingTags]
+				if let style = remainingTagsStyle {
 					remainingTags -= remainingTags
 					if !styles.contains(where: { $0.isEqualTo(style)}) {
 						styles.append(style)
 					}
+				}
+
+				if !shouldAppendStyle && remainingTagsStyle == nil {
+					break
 				}
 			}
 			

--- a/Tests/StreamChatUITests/Utils/DefaultMarkdownFormatter_Tests.swift
+++ b/Tests/StreamChatUITests/Utils/DefaultMarkdownFormatter_Tests.swift
@@ -249,4 +249,10 @@ final class DefaultMarkdownFormatter_Tests: XCTestCase {
             }
         }
     }
+
+    func test_complexMarkdownPattern_doesNotHangForever() {
+        let string = "**~*~~~*~*~**~*~* h e a r d ***~*~*~**~*~~~*"
+        let result = sut.format(string)
+        XCTAssertEqual(result.string, "**~~*~**~~ h e a r d ***~~~**~")
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/334

### 🎯 Goal

Fix issue where an unexpected Markdown pattern was hanging forever due to an issue in SwiftyMarkdown

### 🛠 Implementation

Forked SwiftyMarkdown, and added a defensive measure so that this scenario does not happen again.
https://github.com/GetStream/SwiftyMarkdown/commit/16b4de5804977bfb3da3b61e8443d1a180f5d2d5

Updated embedded dependencies so that our SDK has this change.

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://giphy.com/clips/parksandrec-parks-and-recreation-rec-peacock-tv-2y5bZ44bYRpPvycXsO)
