### PR TITLE
Fix "In" Filter only returning results when all values match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix messages appearing sooner in Thread pagination [#2470](https://github.com/GetStream/stream-chat-swift/pull/2470)
 - Fix messages disappearing from the Message List when quoting a message [#2470](https://github.com/GetStream/stream-chat-swift/pull/2470)
+- Fix "In" Filter only returning results when all values match [#2514][https://github.com/GetStream/stream-chat-swift/pull/2514]
 
 # [4.27.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.27.1)
 _February 20, 2023_

--- a/Sources/StreamChat/Query/Filter+ChatChannel.swift
+++ b/Sources/StreamChat/Query/Filter+ChatChannel.swift
@@ -137,7 +137,7 @@ extension Filter where Scope == ChannelListFilterScope {
                 return nil
             }
             return NSCompoundPredicate(
-                andPredicateWithSubpredicates: filterArray.map { subValue in
+                orPredicateWithSubpredicates: filterArray.map { subValue in
                     NSPredicate(
                         format: "%@ IN %K",
                         argumentArray: [subValue, keyPathString]

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -1346,19 +1346,23 @@ final class ChannelListController_Tests: XCTestCase {
 
     func test_filterPredicate_and_containsExpectedItems() throws {
         let memberId1 = UserId.unique
-        let memberId2 = UserId.unique
         let cid = ChannelId.unique
 
         try assertFilterPredicate(
             .and([
-                .in(.members, values: [memberId1, memberId2]),
+                .in(.members, values: [memberId1]),
                 .contains(.name, value: "team")
             ]),
             channelsInDB: [
                 .dummy(channel: .dummy(name: "streamtEam")),
                 .dummy(channel: .dummy(name: "originalTeam")),
-                .dummy(channel: .dummy(name: "basketball_team", members: [.dummy(user: .dummy(userId: memberId2))])),
-                .dummy(channel: .dummy(cid: cid, name: "teamDream", members: [.dummy(user: .dummy(userId: memberId1)), .dummy(user: .dummy(userId: memberId2))])),
+                .dummy(channel: .dummy(name: "basketball_team", members: [
+                    .dummy(user: .dummy(userId: .unique))
+                ])),
+                .dummy(channel: .dummy(cid: cid, name: "teamDream", members: [
+                    .dummy(user: .dummy(userId: memberId1)),
+                    .dummy(user: .dummy(userId: .unique))
+                ])),
                 .dummy(channel: .dummy(name: "TEAM"))
             ],
             expectedResult: [cid]


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/333

### 🎯 Goal
Fix "In" Filter only returning results when all values match.

### 📝 Summary
The Mongoose style "in" operator, used by our backend API is actually an "or" operation, meaning that only one of the given values need to match, and not all of them. So this was a simple change in our side.

### 🧪 Manual Testing Notes
Unit tests were provided to cover regression.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
