### PR TITLE
[339] Make title optional in GiphyAttachmentPayload

### DIFF
--- a/Sources/StreamChat/Models/Attachments/ChatMessageGiphyAttachment.swift
+++ b/Sources/StreamChat/Models/Attachments/ChatMessageGiphyAttachment.swift
@@ -16,7 +16,7 @@ public struct GiphyAttachmentPayload: AttachmentPayload {
     public static let type: AttachmentType = .giphy
 
     /// A  title, usually the search request used to find the gif.
-    public var title: String
+    public var title: String?
     /// A link to gif file.
     public var previewURL: URL
     /// Actions when gif is not sent yet. (e.g. `Shuffle`)
@@ -26,7 +26,7 @@ public struct GiphyAttachmentPayload: AttachmentPayload {
     ///   - title: Title of the giphy
     ///   - previewURL: thumb url of the giphy
     ///   - actions: Leave empty
-    public init(title: String, previewURL: URL, actions: [AttachmentAction] = []) {
+    public init(title: String?, previewURL: URL, actions: [AttachmentAction] = []) {
         self.title = title
         self.previewURL = previewURL
         self.actions = actions
@@ -63,7 +63,7 @@ extension GiphyAttachmentPayload: Decodable {
         let giphyAttachmentContainer = try decoder.container(keyedBy: GiphyAttachmentSpecificCodingKeys.self)
 
         self.init(
-            title: try container.decode(String.self, forKey: .title),
+            title: try container.decodeIfPresent(String.self, forKey: .title),
             previewURL: try container.decode(URL.self, forKey: .thumbURL),
             actions: try giphyAttachmentContainer.decodeIfPresent([AttachmentAction].self, forKey: .actions) ?? []
         )

--- a/Tests/StreamChatTests/Models/Attachments/GiphyAttachmentPayload_Tests.swift
+++ b/Tests/StreamChatTests/Models/Attachments/GiphyAttachmentPayload_Tests.swift
@@ -32,15 +32,14 @@ final class GiphyAttachmentPayload_Tests: XCTestCase {
     
     func test_ItInitializesPayloadWithoutTitle() {
         // WHEN
-        let title: String? = nil
         sut = GiphyAttachmentPayload(
-            title: title,
+            title: nil,
             previewURL: giphyURL,
             actions: []
         )
 
         // THEN
-        XCTAssertEqual(sut?.title, title)
+        XCTAssertNil(sut?.title)
         XCTAssertEqual(sut?.previewURL, giphyURL)
         XCTAssertEqual(sut?.actions, [])
     }

--- a/Tests/StreamChatTests/Models/Attachments/GiphyAttachmentPayload_Tests.swift
+++ b/Tests/StreamChatTests/Models/Attachments/GiphyAttachmentPayload_Tests.swift
@@ -29,4 +29,19 @@ final class GiphyAttachmentPayload_Tests: XCTestCase {
         XCTAssertEqual(sut?.previewURL, giphyURL)
         XCTAssertEqual(sut?.actions, [])
     }
+    
+    func test_ItInitializesPayloadWithoutTitle() {
+        // WHEN
+        let title: String? = nil
+        sut = GiphyAttachmentPayload(
+            title: title,
+            previewURL: giphyURL,
+            actions: []
+        )
+
+        // THEN
+        XCTAssertEqual(sut?.title, title)
+        XCTAssertEqual(sut?.previewURL, giphyURL)
+        XCTAssertEqual(sut?.actions, [])
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/339

### 🎯 Goal

Make title optional in `GiphyAttachmentPayload`

### 📝 Summary

Currently, `GiphyAttachmentPayload` is the only attachment payload that unjustifiably requires `title` to be provided. This PR intends to fix this.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/Od0QRnzwRBYmDU3eEO/giphy.gif)
