### PR TITLE
Fix auto filtering issue with collection operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix ephemeral message disappearing after leaving channel [#2464](https://github.com/GetStream/stream-chat-swift/pull/2464)
 - Fix ephemeral message appearing in channel preview [#2464](https://github.com/GetStream/stream-chat-swift/pull/2464)
-- Fix an issue when auto-filtering is enabled and using the `in` operator with the `ChannelType` FilterKey. [#2531](https://github.com/GetStream/stream-chat-swift/pull/2531)
+- Fix issue when using `in` or `notIn` operators with auto-filtering enabled. [#2531](https://github.com/GetStream/stream-chat-swift/pull/2531)
 
 ## StreamChatUI
 ### 🔄 Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix ephemeral message disappearing after leaving channel [#2464](https://github.com/GetStream/stream-chat-swift/pull/2464)
 - Fix ephemeral message appearing in channel preview [#2464](https://github.com/GetStream/stream-chat-swift/pull/2464)
+- Fix an issue when auto-filtering is enabled and using the `in` operator with the ChannelType key. [#2531](https://github.com/GetStream/stream-chat-swift/pull/2531)
 
 ## StreamChatUI
 ### 🔄 Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix ephemeral message disappearing after leaving channel [#2464](https://github.com/GetStream/stream-chat-swift/pull/2464)
 - Fix ephemeral message appearing in channel preview [#2464](https://github.com/GetStream/stream-chat-swift/pull/2464)
-- Fix an issue when auto-filtering is enabled and using the `in` operator with the ChannelType key. [#2531](https://github.com/GetStream/stream-chat-swift/pull/2531)
+- Fix an issue when auto-filtering is enabled and using the `in` operator with the `ChannelType` FilterKey. [#2531](https://github.com/GetStream/stream-chat-swift/pull/2531)
 
 ## StreamChatUI
 ### 🔄 Changed

--- a/Sources/StreamChat/Query/Filter+ChatChannel.swift
+++ b/Sources/StreamChat/Query/Filter+ChatChannel.swift
@@ -9,7 +9,22 @@ extension Filter where Scope == ChannelListFilterScope {
     /// using the mapper.
     ///
     /// If the mapper returns nil, the original value will be returned
-    var mappedValue: FilterValue { valueMapper?(value) ?? value }
+    var mappedValue: FilterValue {
+        valueMapper?(value) ?? value
+    }
+
+    /// If the mappedValues is an array of FilterValues, we will try to transform them using the valueMapper
+    /// to ensure that both parts of the comparison are of the same type.
+    ///
+    /// If the value is not an array, this value will return nil.
+    /// If the valueMapper isn't provided or the value mapper returns nil, the original value will be included
+    /// in the array.
+    var mappedArrayValue: [FilterValue]? {
+        guard let filterArray = mappedValue as? [FilterValue] else {
+            return nil
+        }
+        return filterArray.map { valueMapper?($0) ?? $0 }
+    }
 
     /// If it can be translated, this will return
     /// an NSPredicate instance that is equivalent
@@ -133,7 +148,7 @@ extension Filter where Scope == ChannelListFilterScope {
 
         switch op {
         case .in where mappedValue is [FilterValue]:
-            guard let filterArray = (mappedValue as? [FilterValue]) else {
+            guard let filterArray = mappedArrayValue else {
                 return nil
             }
             return NSCompoundPredicate(

--- a/Sources/StreamChat/Query/Filter+ChatChannel.swift
+++ b/Sources/StreamChat/Query/Filter+ChatChannel.swift
@@ -161,7 +161,7 @@ extension Filter where Scope == ChannelListFilterScope {
             )
 
         case .notIn where mappedValue is [FilterValue]:
-            guard let filterArray = (mappedValue as? [FilterValue]) else {
+            guard let filterArray = mappedArrayValue else {
                 return nil
             }
             return NSCompoundPredicate(

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -1454,6 +1454,36 @@ final class ChannelListController_Tests: XCTestCase {
             expectedResult: [cid]
         )
     }
+
+    func test_filterPredicate_inWithArrayOfChannelTypes_returnsExpectedResults() throws {
+        let streamChannelTypes: [ChannelType] = [
+            .custom("private_messaging"),
+            .custom("messaging"),
+            .custom("location_group"),
+            .custom("department_group"),
+            .custom("role_group")
+        ]
+
+        let teamId = TeamId.unique
+        let cid = ChannelId(type: .custom("private_messaging"), id: .unique)
+        let memberId = UserId.unique
+
+        try assertFilterPredicate(
+            .and([
+                .in(.type, values: streamChannelTypes),
+                .equal(.team, to: teamId),
+                .containMembers(userIds: [memberId])
+            ]),
+            channelsInDB: [
+                .dummy(channel: .dummy(cid: cid, team: teamId), members: [.dummy(user: .dummy(userId: memberId))]),
+                .dummy(channel: .dummy(cid: .init(type: .custom("private_messaging"), id: .unique)), members: [.dummy(user: .dummy(userId: memberId))]),
+                .dummy(channel: .dummy(cid: .init(type: .custom("messaging"), id: .unique), team: teamId), members: [.dummy()]),
+                .dummy(channel: .dummy(cid: .init(type: .custom("location_group"), id: .unique), team: teamId), members: []),
+                .dummy(channel: .dummy(cid: .init(type: .custom("role_group"), id: .unique)), members: [.dummy()])
+            ],
+            expectedResult: [cid]
+        )
+    }
 }
 
 private class TestEnvironment {


### PR DESCRIPTION
### 🔗 Issue Links

_Provide all Jira tickets and/or Github issues related to this PR, if applicable._

### 🎯 Goal

Fix an issue when using auto-filtering with collection operators where the array of values, contains items of types that are not directly comparably for CoreData.

### 📝 Summary

The crash is caused because the values array contains items of type ChannelType which is not directly comparable for CoreData.

### 🛠 Implementation

We are using the same approach we used to resolve the problem with the FilterKey value. We are using the valueMapper provided by the FilterKey to map the values into a CoreData comparable format.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
