### PR TITLE
Don't mark as read if not onscreen

### DIFF
--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -63,6 +63,7 @@ open class ChatChannelVC: _ViewController,
 
     /// A boolean value indicating whether the last message is fully visible or not.
     open var isLastMessageFullyVisible: Bool {
+        guard viewIfLoaded?.window != nil else { return false }
         messageListVC.listView.isLastCellFullyVisible
     }
 


### PR DESCRIPTION
### 🔗 Issue Links

_Provide all Jira tickets and/or Github issues related to this PR, if applicable._

### 🎯 Goal

Bug:
1. put chat thread in a UITabBarController
2. switch tabs away from thread
3. receive a message on that thread

Expected: new messages not marked read until you switch back to the chat tab
Actual: new messages marked read without being seen

### 📝 Summary

Check if thread is onscreen before marking as read

### 🛠 Implementation

Window is nil when view is not part of the view hierarchy, so we can check this.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

Performed in my app.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

<img src="https://media0.giphy.com/media/LR6XGI9qzX8KW4pZx7/giphy.gif?cid=ecf05e47hiqhciatxo9nndek2dor8kerb86zkl6voqcbyr2s&rid=giphy.gif&ct=g"/>