### PR TITLE
Fix channel marking read when view is not visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Allow the message list to start at the top if `Components.shouldMessagesStartAtTheTop` is enabled [#2537](https://github.com/GetStream/stream-chat-swift/pull/2537)
 
+### 🐞 Fixed
+- Fix channel marking read when view is not visible [#2544](https://github.com/GetStream/stream-chat-swift/pull/2544)
+
 # [4.29.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.29.0)
 _March 17, 2023_
 ## StreamChat

--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -52,8 +52,12 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
             vc.channelController = rootViewController.controller.client.channelController(for: cid)
             vc.tabBarItem = .init(title: "Chat", image: nil, tag: 0)
 
+            let dummyViewController = UIViewController()
+            dummyViewController.tabBarItem = .init(title: "Dummy", image: nil, tag: 1)
+
             let tabBarController = UITabBarController()
-            tabBarController.viewControllers = [vc]
+            tabBarController.view.backgroundColor = .systemBackground
+            tabBarController.viewControllers = [vc, dummyViewController]
             // Make the tab bar not translucent to make sure the
             // keyboard handling works in all conditions.
             tabBarController.tabBar.isTranslucent = false

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -67,9 +67,16 @@ open class ChatChannelVC: _ViewController,
         messageListVC.listView.isLastCellFullyVisible
     }
 
+    internal var isViewVisible: ((ChatChannelVC) -> Bool) = { channelVC in
+        channelVC.viewIfLoaded?.window != nil
+    }
+
     /// A boolean value indicating whether it should mark the channel read.
     public var shouldMarkChannelRead: Bool {
-        isLastMessageFullyVisible && channelController.hasLoadedAllNextMessages && !hasMarkedMessageAsUnread
+        guard isViewVisible(self) else {
+            return false
+        }
+        return isLastMessageFullyVisible && channelController.hasLoadedAllNextMessages && !hasMarkedMessageAsUnread
     }
 
     /// A component responsible to handle when to load new or old messages.

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
@@ -19,6 +19,7 @@ final class ChatChannelVC_Tests: XCTestCase {
         components.messageComposerVC = ComposerVC_Mock.self
         components.messageListView = ChatMessageListView_Mock.self
         vc = ChatChannelVC()
+        vc.isViewVisible = { _ in true }
         vc.components = components
         channelControllerMock = ChatChannelController_Mock.mock()
         vc.channelController = channelControllerMock
@@ -650,6 +651,15 @@ final class ChatChannelVC_Tests: XCTestCase {
         channelControllerMock.hasLoadedAllNextMessages_mock = true
 
         XCTAssertTrue(vc.shouldMarkChannelRead)
+    }
+
+    func test_shouldMarkChannelRead_whenViewIsNotVisible_thenReturnsFalse() {
+        let mockedListView = makeMockMessageListView()
+        mockedListView.mockIsLastCellFullyVisible = true
+        channelControllerMock.hasLoadedAllNextMessages_mock = true
+        vc.isViewVisible = { _ in false }
+
+        XCTAssertFalse(vc.shouldMarkChannelRead)
     }
 
     func test_shouldMarkChannelRead_whenNotLastMessageFullyVisible_thenReturnsFalse() {


### PR DESCRIPTION
### 🔗 Issue Links
https://github.com/GetStream/stream-chat-swift/pull/2532
https://github.com/GetStream/ios-issues-tracking/issues/357

### 🎯 Goal
Fixes channel being marked read when the view is not visible

### 🧪 Manual Testing Notes
- Login as User A
- In the channel list, slide the channel row and change the presentation style to TabBar
- Make sure to remain at the bottom of the channel
- Then select the dummy view (right view)
- With User B, send messages to the channel
- With User A, tap on the top left arrow to return to the Channel List
- User A should see the unread counter in the channel row

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)