### PR TITLE
Add vale linting as a build step in Xcode

### DIFF
--- a/.styles/xcode-line.tmpl
+++ b/.styles/xcode-line.tmpl
@@ -1,0 +1,6 @@
+{{range .Files}}
+{{- $path := .Path -}}
+{{- range .Alerts -}}
+{{$path}}:{{.Line}}:{{index .Span 0}}: {{.Severity}}: {{.Check}}:{{.Message}}
+{{end -}}
+{{end -}}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -2444,6 +2444,7 @@
 		43F4750B26F4E4FF0009487D /* ChatMessageReactionItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageReactionItemView.swift; sourceTree = "<group>"; };
 		43F4750D26FB247C0009487D /* ChatReactionPickerReactionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatReactionPickerReactionsView.swift; sourceTree = "<group>"; };
 		4A4E184528D06CA30062378D /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
+		4A51230029D3170C005CEA9B /* docusaurus */ = {isa = PBXFileReference; lastKnownFileType = folder; path = docusaurus; sourceTree = "<group>"; };
 		640FE0D426A568C3006CE703 /* ListChangeIndexPathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListChangeIndexPathResolver.swift; sourceTree = "<group>"; };
 		640FE0F526A57903006CE703 /* ListChangeIndexPathResolver_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListChangeIndexPathResolver_Tests.swift; sourceTree = "<group>"; };
 		6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerShowingConnectionDelegate.swift; sourceTree = "<group>"; };
@@ -5232,6 +5233,7 @@
 		8AD5EC8522E9A3E8005CFAC9 = {
 			isa = PBXGroup;
 			children = (
+				4A51230029D3170C005CEA9B /* docusaurus */,
 				4A4E184528D06CA30062378D /* Documentation.docc */,
 				AD9BE32526680E4200A6D284 /* Stream.playground */,
 				792E3D6A25C97D920040B0C2 /* Package.swift */,
@@ -8141,6 +8143,7 @@
 				799C9418247D2F80001F1104 /* Frameworks */,
 				799C9419247D2F80001F1104 /* Resources */,
 				E3C7A0E42858BB10006133C3 /* SwiftLint */,
+				4A5122FF29D30BE0005CEA9B /* Run Vale */,
 			);
 			buildRules = (
 			);
@@ -8779,6 +8782,25 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		4A5122FF29D30BE0005CEA9B /* Run Vale */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Vale";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n./bin/vale-lint.sh\n";
+		};
 		88F0D6EB257E40B300F4B050 /* SwiftGen */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/bin/vale-lint.sh
+++ b/bin/vale-lint.sh
@@ -1,0 +1,17 @@
+if ! which vale >/dev/null; then
+    if ! which brew >/dev/null; then                    # If it's not found, check the Homebrew location and update PATH when needed
+        if test -e "/usr/local/bin/brew"; then          # Default Homebrew location (pre M1 era)
+            PATH="${PATH}:/usr/local/bin"
+        elif test -e "/opt/homebrew/bin/brew"; then     # Default Homebrew location (M1 era)
+            PATH="${PATH}:/opt/homebrew/bin"
+        else
+            echo "warning: Homebrew not found at default location"
+        fi
+    fi
+fi
+
+if which vale >/dev/null; then
+    vale --output=./.styles/xcode-line.tmpl docusaurus
+else
+    echo "warning: Vale not installed, download from https://vale.sh"
+fi


### PR DESCRIPTION
- Add script calling Vale. If vale is not available, pass successful.
- Add docusaurus as a folder tothe xcode project, making sure it is not part of any targets. This allows error reporting to be shown in Xcode
- Add a template file containing an output config that Xcode can interpret

### 🔗 Issue Links

_Provide all Jira tickets and/or Github issues related to this PR, if applicable._

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase


![](https://user-images.githubusercontent.com/39677/228255874-7bb75c8b-ab73-43df-b9ea-73b98c242b7f.mov)

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
