### PR TITLE
Add E2E tests for bi-directional-scrolling

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -362,6 +362,7 @@
 		826EF2B1291C01C1005A9EEF /* Authentication_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826EF2B0291C01C1005A9EEF /* Authentication_Tests.swift */; };
 		8279706F29689680006741A3 /* UserDetails_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8279706E29689680006741A3 /* UserDetails_Tests.swift */; };
 		827DD1A0289D5B3300910AC5 /* MessageActionsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827DD19F289D5B3300910AC5 /* MessageActionsVC.swift */; };
+		8292D6DB29B78476007A17D1 /* QuotedReply_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8292D6DA29B78476007A17D1 /* QuotedReply_Tests.swift */; };
 		829762E028C7587500B953E8 /* PushNotification_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829762DF28C7587500B953E8 /* PushNotification_Tests.swift */; };
 		829CD5C52848C2EA003C3877 /* ParticipantRobot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829CD5C32848C25F003C3877 /* ParticipantRobot.swift */; };
 		829CD5C72848C71B003C3877 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829CD5C62848C71B003C3877 /* Settings.swift */; };
@@ -2777,6 +2778,7 @@
 		826EF2B0291C01C1005A9EEF /* Authentication_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication_Tests.swift; sourceTree = "<group>"; };
 		8279706E29689680006741A3 /* UserDetails_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetails_Tests.swift; sourceTree = "<group>"; };
 		827DD19F289D5B3300910AC5 /* MessageActionsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageActionsVC.swift; sourceTree = "<group>"; };
+		8292D6DA29B78476007A17D1 /* QuotedReply_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotedReply_Tests.swift; sourceTree = "<group>"; };
 		829762DF28C7587500B953E8 /* PushNotification_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotification_Tests.swift; sourceTree = "<group>"; };
 		8298C8E827D22C3E004082D3 /* UserRobot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRobot.swift; sourceTree = "<group>"; };
 		829CD5C32848C25F003C3877 /* ParticipantRobot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantRobot.swift; sourceTree = "<group>"; };
@@ -4845,6 +4847,7 @@
 				829762DF28C7587500B953E8 /* PushNotification_Tests.swift */,
 				826EF2B0291C01C1005A9EEF /* Authentication_Tests.swift */,
 				8279706E29689680006741A3 /* UserDetails_Tests.swift */,
+				8292D6DA29B78476007A17D1 /* QuotedReply_Tests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -10101,6 +10104,7 @@
 			files = (
 				829CD5CC2848C8D6003C3877 /* BackendRobot.swift in Sources */,
 				82CED1C827DF492F006E967A /* ThreadPage.swift in Sources */,
+				8292D6DB29B78476007A17D1 /* QuotedReply_Tests.swift in Sources */,
 				8232B84F28635C4A0032C7DB /* Attachments_Tests.swift in Sources */,
 				822F266027D9FDB500E454FB /* URLProtocol_Mock.swift in Sources */,
 				82BA52EF27E1EF7B00951B87 /* MessageList_Tests.swift in Sources */,

--- a/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
+++ b/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
@@ -26,6 +26,10 @@ class MessageListPage {
     static var scrollToBottomButton: XCUIElement {
         app.buttons["ScrollToLatestMessageButton"]
     }
+    
+    static var scrollToBottomButtonUnreadCount: XCUIElement {
+        app.staticTexts["unreadCountLabel"]
+    }
 
     enum NavigationBar {
 

--- a/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
@@ -662,7 +662,7 @@ extension UserRobot {
 
     @discardableResult
     func assertQuotedMessage(
-        replyText: String = "",
+        replyText: String = "", // empty text by default for attachment messages
         quotedText: String,
         at messageCellIndex: Int? = nil,
         file: StaticString = #filePath,

--- a/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
@@ -367,6 +367,40 @@ extension UserRobot {
         XCTAssertEqual(author, actualAuthor, file: file, line: line)
         return self
     }
+    
+    @discardableResult
+    func assertScrollToBottomButton(
+        isVisible: Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        var btn = MessageListPage.scrollToBottomButton
+        btn = isVisible ? btn.wait() : btn.waitForDisappearance()
+        XCTAssertEqual(isVisible,
+                       btn.exists,
+                       "Scroll to bottom button should be \(isVisible ? "visible" : "hidden")",
+                       file: file,
+                       line: line)
+        return self
+    }
+    
+    @discardableResult
+    func assertScrollToBottomButtonUnreadCount(
+        _ expectedCount: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        let unreadCount = MessageListPage.scrollToBottomButtonUnreadCount
+        let unreadCountShouldBeVisible = expectedCount > 0
+        if unreadCountShouldBeVisible {
+            XCTAssertEqual("\(expectedCount)", unreadCount.wait().label)
+        } else {
+            if unreadCount.exists {
+                XCTAssertEqual("\(expectedCount)", unreadCount.label)
+            }
+        }
+        return self
+    }
 
     @discardableResult
     func assertTypingIndicatorShown(
@@ -615,6 +649,12 @@ extension UserRobot {
         XCTAssertTrue(link.isHittable, "Link itself is not clickable")
         return self
     }
+    
+    @discardableResult
+    func waitForMessageVisibility(at messageCellIndex: Int) -> Self {
+        _ = messageCell(withIndex: messageCellIndex).waitForHitPoint()
+        return self
+    }
 }
 
 // MARK: Quoted Messages
@@ -633,6 +673,22 @@ extension UserRobot {
         let quotedMessage = attributes.quotedText(quotedText, in: messageCell).wait()
         XCTAssertTrue(quotedMessage.exists, "Quoted message was not showed", file: file, line: line)
         XCTAssertFalse(quotedMessage.isEnabled, "Quoted message should be disabled", file: file, line: line)
+        XCTAssertTrue(quotedMessage.isHittable, "Quoted message is not visible", file: file, line: line)
+        return self
+    }
+    
+    @discardableResult
+    func assertQuotedMessageWithAttachment(
+        quotedText: String,
+        at messageCellIndex: Int? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        let messageCell = messageCell(withIndex: messageCellIndex, file: file, line: line)
+        let quotedMessage = attributes.quotedText(quotedText, in: messageCell).wait()
+        XCTAssertTrue(quotedMessage.exists, "Quoted message was not showed", file: file, line: line)
+        XCTAssertFalse(quotedMessage.isEnabled, "Quoted message should be disabled", file: file, line: line)
+        XCTAssertTrue(quotedMessage.isHittable, "Quoted message is not visible", file: file, line: line)
         return self
     }
 }

--- a/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
@@ -662,18 +662,25 @@ extension UserRobot {
 
     @discardableResult
     func assertQuotedMessage(
-        replyText: String,
+        replyText: String = "",
         quotedText: String,
         at messageCellIndex: Int? = nil,
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> Self {
-        assertQuotedMessage(replyText, file: file, line: line)
         let messageCell = messageCell(withIndex: messageCellIndex, file: file, line: line)
-        let quotedMessage = attributes.quotedText(quotedText, in: messageCell).wait()
-        XCTAssertTrue(quotedMessage.exists, "Quoted message was not showed", file: file, line: line)
-        XCTAssertFalse(quotedMessage.isEnabled, "Quoted message should be disabled", file: file, line: line)
-        XCTAssertTrue(quotedMessage.isHittable, "Quoted message is not visible", file: file, line: line)
+        let message = attributes.quotedText(quotedText, in: messageCell).wait()
+        let actualText = message.waitForText(quotedText).text
+        XCTAssertEqual(quotedText, actualText)
+        XCTAssertTrue(message.exists, "Quoted message was not showed")
+        XCTAssertFalse(message.isEnabled, "Quoted message should be disabled")
+        XCTAssertTrue(message.isHittable, "Quoted message is not visible")
+        
+        if !replyText.isEmpty {
+            let message = attributes.text(replyText, in: messageCell).wait()
+            let actualText = message.waitForText(replyText).text
+            XCTAssertEqual(replyText, actualText)
+        }
         return self
     }
     

--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -207,7 +207,6 @@ extension UserRobot {
                         line: UInt = #line) -> Self {
         selectOptionFromContextMenu(option: .reply, forMessageAtIndex: messageCellIndex)
         sendMessage(text,
-                    at: messageCellIndex,
                     waitForAppearance: waitForAppearance,
                     file: file,
                     line: line)
@@ -231,6 +230,13 @@ extension UserRobot {
     func tapOnMessage(at messageCellIndex: Int? = 0) -> Self {
         let messageCell = messageCell(withIndex: messageCellIndex)
         return tapOnMessage(messageCell)
+    }
+    
+    @discardableResult
+    func tapOnRepliedMessage(_ text: String, at messageCellIndex: Int? = 0) -> Self {
+        let messageCell = messageCell(withIndex: messageCellIndex)
+        MessageListPage.Attributes.quotedText(text, in: messageCell).waitForHitPoint().safeTap()
+        return self
     }
 
     @discardableResult
@@ -301,20 +307,26 @@ extension UserRobot {
     }
 
     @discardableResult
-    func scrollMessageListDown() -> Self {
-        MessageListPage.list.swipeUp()
+    func scrollMessageListDown(times: Int = 1) -> Self {
+        for _ in 1...times {
+            MessageListPage.list.swipeUp()
+        }
         return self
     }
 
     @discardableResult
-    func scrollMessageListUp() -> Self {
-        MessageListPage.list.swipeDown()
+    func scrollMessageListUp(times: Int = 1) -> Self {
+        for _ in 1...times {
+            MessageListPage.list.swipeDown()
+        }
         return self
     }
 
     @discardableResult
-    func scrollMessageListUpSlow() -> Self {
-        MessageListPage.list.swipeDown(velocity: .slow)
+    func scrollMessageListUpSlow(times: Int = 1) -> Self {
+        for _ in 1...times {
+            MessageListPage.list.swipeDown(velocity: .slow)
+        }
         return self
     }
 

--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -235,7 +235,12 @@ extension UserRobot {
     @discardableResult
     func tapOnRepliedMessage(_ text: String, at messageCellIndex: Int? = 0) -> Self {
         let messageCell = messageCell(withIndex: messageCellIndex)
-        MessageListPage.Attributes.quotedText(text, in: messageCell).waitForHitPoint().safeTap()
+        MessageListPage
+            .Attributes
+            .quotedText(text, in: messageCell)
+            .wait()
+            .waitForHitPoint()
+            .safeTap()
         return self
     }
 

--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -200,11 +200,11 @@ extension UserRobot {
     }
 
     @discardableResult
-    func replyToMessage(_ text: String,
-                        messageCellIndex: Int = 0,
-                        waitForAppearance: Bool = true,
-                        file: StaticString = #filePath,
-                        line: UInt = #line) -> Self {
+    func quoteMessage(_ text: String,
+                      messageCellIndex: Int = 0,
+                      waitForAppearance: Bool = true,
+                      file: StaticString = #filePath,
+                      line: UInt = #line) -> Self {
         selectOptionFromContextMenu(option: .reply, forMessageAtIndex: messageCellIndex)
         sendMessage(text,
                     waitForAppearance: waitForAppearance,
@@ -233,7 +233,7 @@ extension UserRobot {
     }
     
     @discardableResult
-    func tapOnRepliedMessage(_ text: String, at messageCellIndex: Int? = 0) -> Self {
+    func tapOnQuotedMessage(_ text: String, at messageCellIndex: Int? = 0) -> Self {
         let messageCell = messageCell(withIndex: messageCellIndex)
         MessageListPage
             .Attributes

--- a/StreamChatUITestsAppUITests/Tests/ChannelList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/ChannelList_Tests.swift
@@ -248,10 +248,11 @@ extension ChannelList_Tests {
             userRobot.truncateChannel(withMessage: true)
         }
         THEN("user observes only the system message") {
-            userRobot.assertMessage(message)
-        }
-        AND("previous messages are no longer visible") {
-            userRobot.assertMessageCount(1)
+            userRobot
+                .assertMessage(message)
+                .assertMessageCount(1)
+                .assertScrollToBottomButton(isVisible: false)
+                .assertScrollToBottomButtonUnreadCount(0)
         }
         WHEN("user goes to channel list") {
             userRobot.tapOnBackButton()

--- a/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
@@ -232,119 +232,6 @@ final class MessageList_Tests: StreamTestCase {
         }
     }
 
-    func test_messageListScrollsDown_whenMessageListIsScrolledUp_andUserSendsNewMessage() throws {
-        linkToScenario(withId: 193)
-
-        try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12,
-                      "[CIS-2020] Scroll on message list does not work well enough")
-
-        let newMessage = "New message"
-
-        GIVEN("user opens the channel") {
-            backendRobot.generateChannels(count: 1, messagesCount: 30)
-            userRobot.login().openChannel()
-        }
-        WHEN("user scrolls up") {
-            userRobot.scrollMessageListUp()
-        }
-        AND("user sends a new message") {
-            userRobot.sendMessage(newMessage)
-        }
-        THEN("message list is scrolled down") {
-            userRobot.assertMessageIsVisible(newMessage)
-        }
-    }
-
-    func test_messageListScrollsDown_whenMessageListIsScrolledDown_andUserReceivesNewMessage() throws {
-        linkToScenario(withId: 75)
-
-        try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12,
-                      "[CIS-2020] Scroll on message list does not work well enough")
-
-        let newMessage = "New message"
-
-        GIVEN("user opens the channel") {
-            backendRobot.generateChannels(count: 1, messagesCount: 30)
-            userRobot.login().openChannel()
-        }
-        WHEN("participant sends a message") {
-            participantRobot.sendMessage(newMessage)
-        }
-        THEN("message list is scrolled down") {
-            userRobot.assertMessageIsVisible(newMessage)
-        }
-    }
-
-    func test_messageListDoesNotScrollDown_whenMessageListIsScrolledUp_andUserReceivesNewMessage() {
-        linkToScenario(withId: 194)
-
-        let newMessage = "New message"
-
-        GIVEN("user opens the channel") {
-            backendRobot.generateChannels(count: 1, messagesCount: 30)
-            userRobot.login().openChannel()
-        }
-        WHEN("user scrolls up") {
-            userRobot.scrollMessageListUp()
-        }
-        AND("participant sends a message") {
-            participantRobot.sendMessage(newMessage)
-        }
-        THEN("message list is scrolled up") {
-            userRobot.assertMessageIsNotVisible(newMessage)
-        }
-    }
-
-    func test_messageListScrollsDown_whenUserTapsOnScrollToBottomButton() throws {
-        linkToScenario(withId: 196)
-
-        try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12,
-                      "[CIS-2020] Scroll on message list does not work well enough")
-
-        let newMessage = "New message"
-
-        GIVEN("user opens the channel") {
-            backendRobot.generateChannels(count: 1, messagesCount: 30)
-            userRobot.login().openChannel()
-        }
-        AND("user sends a new message") {
-            userRobot.sendMessage(newMessage)
-        }
-        WHEN("user scrolls up") {
-            userRobot.scrollMessageListUp()
-        }
-        AND("user taps on 'scroll to bottom' button") {
-            userRobot.tapOnScrollToBottomButton()
-        }
-        THEN("message list is scrolled down") {
-            userRobot.assertMessageIsVisible(newMessage)
-        }
-    }
-
-    func test_reloadsSkippedMessages_whenScrolledToTheBottom() throws {
-        linkToScenario(withId: 289)
-
-        try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12,
-                      "[CIS-2020] Scroll on message list does not work well enough")
-
-        GIVEN("user opens the channel") {
-            backendRobot.generateChannels(count: 1, messagesCount: 30)
-            userRobot.login().openChannel()
-        }
-        AND("user scrolls up") {
-            userRobot.scrollMessageListUpSlow()
-        }
-        AND("participant sends some messages") {
-            participantRobot.sendMultipleMessages(repeatingText: "Some message", count: 16)
-        }
-        WHEN("user scrolls to the bottom") {
-            userRobot.tapOnScrollToBottomButton()
-        }
-        THEN("skipped messages are reloaded") {
-            userRobot.assertMessageIsVisible("Some message-16")
-        }
-    }
-
     func test_commandsPopupDisappear_whenUserTapsOnMessageList() {
         linkToScenario(withId: 98)
 
@@ -450,59 +337,182 @@ final class MessageList_Tests: StreamTestCase {
     }
 }
 
-// MARK: Quoted messages
-
+// MARK: Scroll to bottom
+    
 extension MessageList_Tests {
-
-    func test_quotedReplyInList_whenUserAddsQuotedReply() {
-        linkToScenario(withId: 51)
-
-        let messageCount = 1
-        let message = String(messageCount)
-        let quotedMessage = "quoted reply"
-
-        GIVEN("user opens the channel") {
-            backendRobot.generateChannels(count: 1, messagesCount: messageCount)
-            userRobot.login().openChannel()
-        }
-        AND("participant sends a message") {
-            participantRobot.sendMessage(message)
-        }
-        WHEN("user adds a quoted reply to participant message") {
-            userRobot.replyToMessage(quotedMessage)
-        }
-        THEN("user observes the reply in message list") {
-            userRobot.assertQuotedMessage(replyText: quotedMessage, quotedText: message)
-        }
-    }
-
-    func test_quotedReplyInList_whenParticipantAddsQuotedReply() {
-        linkToScenario(withId: 52)
-
-        let messageCount = 1
-        let message = String(messageCount)
-        let quotedMessage = "quoted reply"
-
-        GIVEN("user opens the channel") {
-            backendRobot.generateChannels(count: 1, messagesCount: messageCount)
-            userRobot.login().openChannel()
-        }
-        WHEN("participant adds a quoted reply to users message") {
-            participantRobot.replyToMessage(quotedMessage)
-        }
-        THEN("user observes the reply in message list") {
-            userRobot.assertQuotedMessage(replyText: quotedMessage, quotedText: message)
-        }
-    }
-
-    func test_paginationOnMessageList() throws {
-        linkToScenario(withId: 56)
+    
+    func test_messageListScrollsDown_whenMessageListIsScrolledUp_andUserSendsNewMessage() throws {
+        linkToScenario(withId: 193)
 
         try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12,
                       "[CIS-2020] Scroll on message list does not work well enough")
 
-        let messagesCount = 60
+        let newMessage = "New message"
 
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: 30)
+            userRobot.login().openChannel()
+        }
+        WHEN("user scrolls up") {
+            userRobot.scrollMessageListUp()
+        }
+        AND("user sends a new message") {
+            userRobot.sendMessage(newMessage)
+        }
+        THEN("message list is scrolled down") {
+            userRobot
+                .assertMessageIsVisible(newMessage)
+                .assertScrollToBottomButton(isVisible: false)
+        }
+    }
+
+    func test_messageListScrollsDown_whenMessageListIsScrolledDown_andUserReceivesNewMessage() throws {
+        linkToScenario(withId: 75)
+
+        try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12,
+                      "[CIS-2020] Scroll on message list does not work well enough")
+
+        let newMessage = "New message"
+
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: 30)
+            userRobot.login().openChannel()
+        }
+        WHEN("participant sends a message") {
+            participantRobot.sendMessage(newMessage)
+        }
+        THEN("message list is scrolled down") {
+            userRobot
+                .assertMessageIsVisible(newMessage)
+                .assertScrollToBottomButton(isVisible: false)
+        }
+    }
+
+    func test_messageListDoesNotScrollDown_whenMessageListIsScrolledUp_andUserReceivesNewMessage() {
+        linkToScenario(withId: 194)
+
+        let newMessage = "New message"
+
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: 30)
+            userRobot.login().openChannel()
+        }
+        WHEN("user scrolls up") {
+            userRobot.scrollMessageListUp()
+        }
+        AND("participant sends a message") {
+            participantRobot.sendMessage(newMessage)
+        }
+        THEN("message list is not scrolled down") {
+            userRobot
+                .assertMessageIsNotVisible(newMessage)
+                .assertScrollToBottomButton(isVisible: true)
+        }
+    }
+
+    func test_messageListScrollsDown_whenUserTapsOnScrollToBottomButton() throws {
+        linkToScenario(withId: 196)
+
+        try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12,
+                      "[CIS-2020] Scroll on message list does not work well enough")
+
+        let newMessage = "New message"
+
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: 30)
+            userRobot.login().openChannel()
+        }
+        AND("user sends a new message") {
+            userRobot.sendMessage(newMessage)
+        }
+        WHEN("user scrolls up") {
+            userRobot.scrollMessageListUp()
+        }
+        AND("user taps on 'scroll to bottom' button") {
+            userRobot.tapOnScrollToBottomButton()
+        }
+        THEN("message list is scrolled down") {
+            userRobot
+                .assertMessageIsVisible(newMessage)
+                .assertScrollToBottomButton(isVisible: false)
+        }
+    }
+
+    func test_reloadsSkippedMessages_whenScrolledToTheBottom() throws {
+        linkToScenario(withId: 289)
+
+        try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12,
+                      "[CIS-2020] Scroll on message list does not work well enough")
+
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: 30)
+            userRobot.login().openChannel()
+        }
+        AND("user scrolls up") {
+            userRobot.scrollMessageListUpSlow()
+        }
+        AND("participant sends some messages") {
+            participantRobot.sendMultipleMessages(repeatingText: "Some message", count: 16)
+        }
+        WHEN("user scrolls to the bottom") {
+            userRobot.tapOnScrollToBottomButton()
+        }
+        THEN("skipped messages are reloaded") {
+            userRobot
+                .assertMessageIsVisible("Some message-16")
+                .assertScrollToBottomButton(isVisible: false)
+        }
+    }
+    
+    func test_scrollToBottom_unreadCount() throws {
+        linkToScenario(withId: 1669)
+        
+        try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12,
+                      "This test does not work well enough on iOS 12")
+
+        let newMessage = "New message"
+
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: 30)
+            userRobot.login().openChannel()
+        }
+        WHEN("user scrolls up") {
+            userRobot.scrollMessageListUp(times: 2)
+        }
+        AND("participant sends a message") {
+            participantRobot.sendMessage(newMessage)
+        }
+        THEN("message list is not scrolled down") {
+            userRobot
+                .assertMessageIsNotVisible(newMessage)
+                .assertScrollToBottomButton(isVisible: true)
+                .assertScrollToBottomButtonUnreadCount(1)
+        }
+        WHEN("user taps on scroll to bottom button") {
+            userRobot.tapOnScrollToBottomButton()
+        }
+        AND("user scrolls up") {
+            userRobot.scrollMessageListUp(times: 2)
+        }
+        THEN("unread count is not displayed") {
+            userRobot
+                .assertScrollToBottomButton(isVisible: true)
+                .assertScrollToBottomButtonUnreadCount(0)
+        }
+    }
+}
+    
+// MARK: Pagination
+    
+extension MessageList_Tests {
+    func test_paginationOnMessageList() throws {
+        linkToScenario(withId: 56)
+        
+        try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12,
+                      "[CIS-2020] Scroll on message list does not work well enough")
+        
+        let messagesCount = 60
+        
         WHEN("user opens the channel") {
             backendRobot.generateChannels(count: 1, messagesCount: messagesCount)
             userRobot.login().openChannel()
@@ -511,15 +521,15 @@ extension MessageList_Tests {
             userRobot.assertMessageListPagination(messagesCount: messagesCount)
         }
     }
-
+    
     func test_paginationOnThread() throws {
         linkToScenario(withId: 55)
-
+        
         try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12,
                       "[CIS-2020] Scroll on message list does not work well enough")
-
+        
         let replyCount = 60
-
+        
         GIVEN("user opens the channel") {
             backendRobot.generateChannels(count: 1, messagesCount: 1, replyCount: replyCount)
             userRobot.login().openChannel()
@@ -531,10 +541,15 @@ extension MessageList_Tests {
             userRobot.assertMessageListPagination(messagesCount: replyCount + 1)
         }
     }
+}
 
+// MARK: Mentions
+
+extension MessageList_Tests {
+    
     func test_addingCommandHidesLeftButtons() {
         linkToScenario(withId: 104)
-
+        
         GIVEN("user opens the channel") {
             userRobot.login().openChannel()
         }
@@ -551,10 +566,10 @@ extension MessageList_Tests {
             userRobot.assertComposerLeftButtons(shouldBeVisible: true)
         }
     }
-
+    
     func test_mentionsView() {
         linkToScenario(withId: 61)
-
+        
         GIVEN("user opens the channel") {
             userRobot.login().openChannel()
         }
@@ -571,10 +586,10 @@ extension MessageList_Tests {
             userRobot.assertComposerMentions(shouldBeVisible: false)
         }
     }
-
+    
     func test_userFillsTheComposerMentioningParticipantThroughMentionsView() {
         linkToScenario(withId: 62)
-
+        
         GIVEN("user opens the channel") {
             userRobot.login().openChannel()
         }
@@ -585,6 +600,12 @@ extension MessageList_Tests {
             userRobot.assertMentionWasApplied()
         }
     }
+}
+    
+    
+// MARK: Links preview
+
+extension MessageList_Tests {
 
     func test_addMessageWithLinkToUnsplash() {
         linkToScenario(withId: 59)
@@ -795,10 +816,14 @@ extension MessageList_Tests {
             userRobot.assertMessageHasTimestamp()
         }
         WHEN("user sends an ephemeral message") {
-            userRobot.sendGiphy(send: false)
+            userRobot
+                .sendGiphy(send: false)
+                .scrollMessageListDown() // to hide the keyboard
         }
         THEN("messages are not grouped, 1st message shows the timestamp") {
-            userRobot.assertMessageHasTimestamp(at: 1)
+            userRobot
+                .assertMessageCount(2)
+                .assertMessageHasTimestamp(at: 1)
         }
     }
 
@@ -864,46 +889,6 @@ extension MessageList_Tests {
             participantRobot.deleteMessage()
         }
         THEN("the message is deleted") {
-            userRobot.assertDeletedMessage()
-        }
-    }
-
-    func test_quotedReplyIsDeletedByParticipant_deletedMessageIsShown() {
-        linkToScenario(withId: 108)
-
-        let quotedMessage = "quoted reply"
-
-        GIVEN("user opens the channel") {
-            backendRobot.generateChannels(count: 1, messagesCount: 1)
-            userRobot.login().openChannel()
-        }
-        AND("participant adds a quoted reply") {
-            participantRobot.replyToMessage(quotedMessage)
-        }
-        WHEN("participant deletes a quoted message") {
-            participantRobot.deleteMessage()
-        }
-        THEN("user observes Message deleted") {
-            userRobot.assertDeletedMessage()
-        }
-    }
-
-    func test_quotedReplyIsDeletedByUser_deletedMessageIsShown() {
-        linkToScenario(withId: 109)
-
-        let quotedMessage = "quoted reply"
-
-        GIVEN("user opens the channel") {
-            backendRobot.generateChannels(count: 1, messagesCount: 1)
-            userRobot.login().openChannel()
-        }
-        AND("user adds a quoted reply") {
-            userRobot.replyToMessage(quotedMessage)
-        }
-        WHEN("user deletes a quoted message") {
-            userRobot.deleteMessage()
-        }
-        THEN("deleted message is shown") {
             userRobot.assertDeletedMessage()
         }
     }

--- a/StreamChatUITestsAppUITests/Tests/QuotedReply_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/QuotedReply_Tests.swift
@@ -149,7 +149,7 @@ final class QuotedReply_Tests: StreamTestCase {
         THEN("user observes the reply in message list") {
             userRobot
                 .assertFile(isPresent: true)
-                .assertQuotedMessageWithAttachment(quotedText: parentMessage)
+                .assertQuotedMessage(quotedText: parentMessage)
                 .assertScrollToBottomButton(isVisible: false)
         }
         WHEN("user taps on a replied message") {
@@ -176,7 +176,7 @@ final class QuotedReply_Tests: StreamTestCase {
         THEN("user observes the reply in message list") {
             userRobot
                 .assertGiphyImage()
-                .assertQuotedMessageWithAttachment(quotedText: parentMessage)
+                .assertQuotedMessage(quotedText: parentMessage)
                 .assertScrollToBottomButton(isVisible: false)
         }
         WHEN("user taps on a replied message") {

--- a/StreamChatUITestsAppUITests/Tests/QuotedReply_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/QuotedReply_Tests.swift
@@ -1,0 +1,254 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import XCTest
+
+final class QuotedReply_Tests: StreamTestCase {
+    
+    let messageCount = 30
+    let parentMessage = "1"
+    let quotedMessage = "quoted reply"
+    
+    override func setUpWithError() throws {
+        try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12,
+                      "Quoted Reply automated tests do not work well on iOS 12")
+        try super.setUpWithError()
+        addTags([.coreFeatures])
+    }
+    
+    override func tearDownWithError() throws {
+        if ProcessInfo().operatingSystemVersion.majorVersion > 12 {
+            try super.tearDownWithError()
+        }
+    }
+    
+    func test_quotedReplyInList_whenUserAddsQuotedReply() {
+        linkToScenario(withId: 1667)
+        
+        let messageCount = 20
+        
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: 20)
+            userRobot.login().openChannel()
+        }
+        WHEN("user adds a quoted reply to participant message") {
+            userRobot
+                .scrollMessageListUp(times: 4)
+                .replyToMessage(quotedMessage, messageCellIndex: messageCount - 1)
+                .waitForMessageVisibility(at: 0)
+        }
+        THEN("user observes the reply in message list") {
+            userRobot
+                .assertQuotedMessage(replyText: quotedMessage, quotedText: parentMessage)
+                .assertScrollToBottomButton(isVisible: false)
+        }
+        WHEN("user taps on a replied message") {
+            userRobot.tapOnRepliedMessage(parentMessage, at: 0)
+        }
+        THEN("user is scrolled up to the parent message") {
+            userRobot
+                .assertMessageIsVisible(at: messageCount)
+                .assertScrollToBottomButton(isVisible: true)
+        }
+    }
+    
+    func test_quotedReplyInList_whenParticipantAddsQuotedReply_Message() {
+        linkToScenario(withId: 1668)
+        
+        let messageCount = 20
+        
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: messageCount)
+            userRobot.login().openChannel()
+        }
+        WHEN("participant adds a quoted reply") {
+            participantRobot.replyToMessage(quotedMessage, toLastMessage: false)
+            userRobot.waitForMessageVisibility(at: 0)
+        }
+        THEN("user observes the reply in message list") {
+            userRobot
+                .assertQuotedMessage(replyText: quotedMessage, quotedText: parentMessage)
+                .assertScrollToBottomButton(isVisible: false)
+        }
+        WHEN("user taps on a replied message") {
+            userRobot.tapOnRepliedMessage(parentMessage, at: 0)
+        }
+        THEN("user is scrolled up to the parent message") {
+            userRobot
+                .assertMessageIsVisible(at: messageCount)
+                .assertScrollToBottomButton(isVisible: true)
+        }
+    }
+    
+    func test_quotedReplyNotInList_whenUserAddsQuotedReply() {
+        linkToScenario(withId: 51)
+        
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: messageCount)
+            userRobot.login().openChannel()
+        }
+        WHEN("user adds a quoted reply to participant message") {
+            userRobot
+                .scrollMessageListUp(times: 4)
+                .replyToMessage(quotedMessage, messageCellIndex: messageCount - 1)
+                .waitForMessageVisibility(at: 0)
+        }
+        THEN("user observes the reply in message list") {
+            userRobot
+                .assertQuotedMessage(replyText: quotedMessage, quotedText: parentMessage)
+                .assertScrollToBottomButton(isVisible: false)
+        }
+        WHEN("user taps on a replied message") {
+            userRobot.tapOnRepliedMessage(parentMessage, at: 0)
+        }
+        THEN("user is scrolled up to the parent message") {
+            userRobot
+                .assertMessageIsVisible(at: messageCount)
+                .assertScrollToBottomButton(isVisible: true)
+        }
+    }
+    
+    func test_quotedReplyNotInList_whenParticipantAddsQuotedReply_Message() {
+        linkToScenario(withId: 52)
+        
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: messageCount)
+            userRobot.login().openChannel()
+        }
+        WHEN("participant adds a quoted reply") {
+            participantRobot.replyToMessage(quotedMessage, toLastMessage: false)
+            userRobot.waitForMessageVisibility(at: 0)
+        }
+        THEN("user observes the reply in message list") {
+            userRobot
+                .assertQuotedMessage(replyText: quotedMessage, quotedText: parentMessage)
+                .assertScrollToBottomButton(isVisible: false)
+        }
+        WHEN("user taps on a replied message") {
+            userRobot.tapOnRepliedMessage(parentMessage, at: 0)
+        }
+        THEN("user is scrolled up to the parent message") {
+            userRobot
+                .assertMessageIsVisible(at: messageCount)
+                .assertScrollToBottomButton(isVisible: true)
+        }
+    }
+    
+    func test_quotedReplyNotInList_whenParticipantAddsQuotedReply_File() {
+        linkToScenario(withId: 1568)
+        
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: messageCount)
+            userRobot.login().openChannel()
+        }
+        WHEN("participant sends file as a quoted reply") {
+            participantRobot.uploadAttachment(type: .file, asReplyToFirstMessage: true)
+            userRobot.waitForMessageVisibility(at: 0)
+        }
+        THEN("user observes the reply in message list") {
+            userRobot
+                .assertFile(isPresent: true)
+                .assertQuotedMessageWithAttachment(quotedText: parentMessage)
+                .assertScrollToBottomButton(isVisible: false)
+        }
+        WHEN("user taps on a replied message") {
+            userRobot.tapOnRepliedMessage(parentMessage, at: 0)
+        }
+        THEN("user is scrolled up to the parent message") {
+            userRobot
+                .assertMessageIsVisible(at: messageCount)
+                .assertScrollToBottomButton(isVisible: true)
+        }
+    }
+    
+    func test_quotedReplyNotInList_whenParticipantAddsQuotedReply_Giphy() {
+        linkToScenario(withId: 1571)
+        
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: messageCount)
+            userRobot.login().openChannel()
+        }
+        WHEN("participant sends giphy as a quoted reply") {
+            participantRobot.replyWithGiphy(toLastMessage: false)
+            userRobot.waitForMessageVisibility(at: 0)
+        }
+        THEN("user observes the reply in message list") {
+            userRobot
+                .assertGiphyImage()
+                .assertQuotedMessageWithAttachment(quotedText: parentMessage)
+                .assertScrollToBottomButton(isVisible: false)
+        }
+        WHEN("user taps on a replied message") {
+            userRobot.tapOnRepliedMessage(parentMessage, at: 0)
+        }
+        THEN("user is scrolled up to the parent message") {
+            userRobot
+                .assertMessageIsVisible(at: messageCount)
+                .assertScrollToBottomButton(isVisible: true)
+        }
+    }
+
+    func test_quotedReplyIsDeletedByParticipant_deletedMessageIsShown() {
+        linkToScenario(withId: 108)
+
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: 1)
+            userRobot.login().openChannel()
+        }
+        AND("participant adds a quoted reply") {
+            participantRobot.replyToMessage(quotedMessage)
+        }
+        WHEN("participant deletes a quoted message") {
+            participantRobot.deleteMessage()
+        }
+        THEN("user observes Message deleted") {
+            userRobot.assertDeletedMessage()
+        }
+    }
+
+    func test_quotedReplyIsDeletedByUser_deletedMessageIsShown() {
+        linkToScenario(withId: 109)
+
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: 1)
+            userRobot.login().openChannel()
+        }
+        AND("user adds a quoted reply") {
+            userRobot.replyToMessage(quotedMessage)
+        }
+        WHEN("user deletes a quoted message") {
+            userRobot.deleteMessage()
+        }
+        THEN("deleted message is shown") {
+            userRobot.assertDeletedMessage()
+        }
+    }
+    
+    func test_unreadCount_whenUserSendsInvalidCommand_and_jumpingOnQuotedMessage() {
+        linkToScenario(withId: 1676)
+
+        let invalidCommand = "invalid command"
+        
+        GIVEN("user opens the channel") {
+            backendRobot.generateChannels(count: 1, messagesCount: messageCount)
+            userRobot.login().openChannel()
+        }
+        WHEN("user adds a quoted reply to participant message") {
+            userRobot
+                .scrollMessageListUp(times: 4)
+                .replyToMessage(quotedMessage, messageCellIndex: messageCount - 1)
+        }
+        AND("user sends a message with invalid command") {
+            userRobot.sendMessage("/\(invalidCommand)", waitForAppearance: false)
+        }
+        AND("user taps on a replied message") {
+            userRobot.tapOnRepliedMessage(parentMessage, at: 0)
+        }
+        THEN("user observes error message") {
+            userRobot
+                .assertScrollToBottomButton(isVisible: true)
+                .assertScrollToBottomButtonUnreadCount(0)
+        }
+    }
+}

--- a/StreamChatUITestsAppUITests/Tests/QuotedReply_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/QuotedReply_Tests.swift
@@ -35,18 +35,18 @@ final class QuotedReply_Tests: StreamTestCase {
         WHEN("user adds a quoted reply to participant message") {
             userRobot
                 .scrollMessageListUp(times: 4)
-                .replyToMessage(quotedMessage, messageCellIndex: messageCount - 1)
+                .quoteMessage(quotedMessage, messageCellIndex: messageCount - 1)
                 .waitForMessageVisibility(at: 0)
         }
-        THEN("user observes the reply in message list") {
+        THEN("user observes the quote reply in message list") {
             userRobot
                 .assertQuotedMessage(replyText: quotedMessage, quotedText: parentMessage)
                 .assertScrollToBottomButton(isVisible: false)
         }
-        WHEN("user taps on a replied message") {
-            userRobot.tapOnRepliedMessage(parentMessage, at: 0)
+        WHEN("user taps on a quoted message") {
+            userRobot.tapOnQuotedMessage(parentMessage, at: 0)
         }
-        THEN("user is scrolled up to the parent message") {
+        THEN("user is scrolled up to the quoted message") {
             userRobot
                 .assertMessageIsVisible(at: messageCount)
                 .assertScrollToBottomButton(isVisible: true)
@@ -63,18 +63,18 @@ final class QuotedReply_Tests: StreamTestCase {
             userRobot.login().openChannel()
         }
         WHEN("participant adds a quoted reply") {
-            participantRobot.replyToMessage(quotedMessage, toLastMessage: false)
+            participantRobot.quoteMessage(quotedMessage, toLastMessage: false)
             userRobot.waitForMessageVisibility(at: 0)
         }
-        THEN("user observes the reply in message list") {
+        THEN("user observes the quote reply in message list") {
             userRobot
                 .assertQuotedMessage(replyText: quotedMessage, quotedText: parentMessage)
                 .assertScrollToBottomButton(isVisible: false)
         }
-        WHEN("user taps on a replied message") {
-            userRobot.tapOnRepliedMessage(parentMessage, at: 0)
+        WHEN("user taps on a quoted message") {
+            userRobot.tapOnQuotedMessage(parentMessage, at: 0)
         }
-        THEN("user is scrolled up to the parent message") {
+        THEN("user is scrolled up to the quoted message") {
             userRobot
                 .assertMessageIsVisible(at: messageCount)
                 .assertScrollToBottomButton(isVisible: true)
@@ -91,18 +91,18 @@ final class QuotedReply_Tests: StreamTestCase {
         WHEN("user adds a quoted reply to participant message") {
             userRobot
                 .scrollMessageListUp(times: 4)
-                .replyToMessage(quotedMessage, messageCellIndex: messageCount - 1)
+                .quoteMessage(quotedMessage, messageCellIndex: messageCount - 1)
                 .waitForMessageVisibility(at: 0)
         }
-        THEN("user observes the reply in message list") {
+        THEN("user observes the quote reply in message list") {
             userRobot
                 .assertQuotedMessage(replyText: quotedMessage, quotedText: parentMessage)
                 .assertScrollToBottomButton(isVisible: false)
         }
-        WHEN("user taps on a replied message") {
-            userRobot.tapOnRepliedMessage(parentMessage, at: 0)
+        WHEN("user taps on a quoted message") {
+            userRobot.tapOnQuotedMessage(parentMessage, at: 0)
         }
-        THEN("user is scrolled up to the parent message") {
+        THEN("user is scrolled up to the quoted message") {
             userRobot
                 .assertMessageIsVisible(at: messageCount)
                 .assertScrollToBottomButton(isVisible: true)
@@ -117,18 +117,18 @@ final class QuotedReply_Tests: StreamTestCase {
             userRobot.login().openChannel()
         }
         WHEN("participant adds a quoted reply") {
-            participantRobot.replyToMessage(quotedMessage, toLastMessage: false)
+            participantRobot.quoteMessage(quotedMessage, toLastMessage: false)
             userRobot.waitForMessageVisibility(at: 0)
         }
-        THEN("user observes the reply in message list") {
+        THEN("user observes the quote reply in message list") {
             userRobot
                 .assertQuotedMessage(replyText: quotedMessage, quotedText: parentMessage)
                 .assertScrollToBottomButton(isVisible: false)
         }
-        WHEN("user taps on a replied message") {
-            userRobot.tapOnRepliedMessage(parentMessage, at: 0)
+        WHEN("user taps on a quoted message") {
+            userRobot.tapOnQuotedMessage(parentMessage, at: 0)
         }
-        THEN("user is scrolled up to the parent message") {
+        THEN("user is scrolled up to the quoted message") {
             userRobot
                 .assertMessageIsVisible(at: messageCount)
                 .assertScrollToBottomButton(isVisible: true)
@@ -146,16 +146,16 @@ final class QuotedReply_Tests: StreamTestCase {
             participantRobot.uploadAttachment(type: .file, asReplyToFirstMessage: true)
             userRobot.waitForMessageVisibility(at: 0)
         }
-        THEN("user observes the reply in message list") {
+        THEN("user observes the quote reply in message list") {
             userRobot
                 .assertFile(isPresent: true)
                 .assertQuotedMessage(quotedText: parentMessage)
                 .assertScrollToBottomButton(isVisible: false)
         }
-        WHEN("user taps on a replied message") {
-            userRobot.tapOnRepliedMessage(parentMessage, at: 0)
+        WHEN("user taps on a quoted message") {
+            userRobot.tapOnQuotedMessage(parentMessage, at: 0)
         }
-        THEN("user is scrolled up to the parent message") {
+        THEN("user is scrolled up to the quoted message") {
             userRobot
                 .assertMessageIsVisible(at: messageCount)
                 .assertScrollToBottomButton(isVisible: true)
@@ -173,16 +173,16 @@ final class QuotedReply_Tests: StreamTestCase {
             participantRobot.replyWithGiphy(toLastMessage: false)
             userRobot.waitForMessageVisibility(at: 0)
         }
-        THEN("user observes the reply in message list") {
+        THEN("user observes the quote reply in message list") {
             userRobot
                 .assertGiphyImage()
                 .assertQuotedMessage(quotedText: parentMessage)
                 .assertScrollToBottomButton(isVisible: false)
         }
-        WHEN("user taps on a replied message") {
-            userRobot.tapOnRepliedMessage(parentMessage, at: 0)
+        WHEN("user taps on a quoted message") {
+            userRobot.tapOnQuotedMessage(parentMessage, at: 0)
         }
-        THEN("user is scrolled up to the parent message") {
+        THEN("user is scrolled up to the quoted message") {
             userRobot
                 .assertMessageIsVisible(at: messageCount)
                 .assertScrollToBottomButton(isVisible: true)
@@ -197,7 +197,7 @@ final class QuotedReply_Tests: StreamTestCase {
             userRobot.login().openChannel()
         }
         AND("participant adds a quoted reply") {
-            participantRobot.replyToMessage(quotedMessage)
+            participantRobot.quoteMessage(quotedMessage)
         }
         WHEN("participant deletes a quoted message") {
             participantRobot.deleteMessage()
@@ -215,7 +215,7 @@ final class QuotedReply_Tests: StreamTestCase {
             userRobot.login().openChannel()
         }
         AND("user adds a quoted reply") {
-            userRobot.replyToMessage(quotedMessage)
+            userRobot.quoteMessage(quotedMessage)
         }
         WHEN("user deletes a quoted message") {
             userRobot.deleteMessage()
@@ -237,13 +237,13 @@ final class QuotedReply_Tests: StreamTestCase {
         WHEN("user adds a quoted reply to participant message") {
             userRobot
                 .scrollMessageListUp(times: 4)
-                .replyToMessage(quotedMessage, messageCellIndex: messageCount - 1)
+                .quoteMessage(quotedMessage, messageCellIndex: messageCount - 1)
         }
         AND("user sends a message with invalid command") {
             userRobot.sendMessage("/\(invalidCommand)", waitForAppearance: false)
         }
-        AND("user taps on a replied message") {
-            userRobot.tapOnRepliedMessage(parentMessage, at: 0)
+        AND("user taps on a quoted message") {
+            userRobot.tapOnQuotedMessage(parentMessage, at: 0)
         }
         THEN("user observes error message") {
             userRobot

--- a/TestTools/StreamChatTestMockServer/Robots/ParticipantRobot.swift
+++ b/TestTools/StreamChatTestMockServer/Robots/ParticipantRobot.swift
@@ -224,7 +224,7 @@ public class ParticipantRobot {
     }
 
     @discardableResult
-    public func replyToMessage(_ text: String, toLastMessage: Bool = true) -> Self {
+    public func quoteMessage(_ text: String, toLastMessage: Bool = true) -> Self {
         startTyping()
         stopTyping()
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/361

### 🎯 Goal

- Add E2E tests for bi-directional-scrolling

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMjRhYjQxOWQ1YzQzNDI2ZjJkMjc3YTY5MDk2ZDkwM2ZmYTc4ZjhhZCZjdD1n/gw3IWyGkC0rsazTi/giphy.gif)
