### PR TITLE
Fix completion blocks not called when loading more messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix channel list parsing failing completely if one channel fails parsing [#2541](https://github.com/GetStream/stream-chat-swift/pull/2541)
+- Fix completion blocks not called when loading more messages [#2553](https://github.com/GetStream/stream-chat-swift/pull/2553)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -407,11 +407,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
         }
 
         guard !hasLoadedAllPreviousMessages && !isLoadingPreviousMessages else {
-            log.debug("""
-                Skipped loading more previous messages.
-                    - hasLoadedAllPreviousMessages:\(hasLoadedAllPreviousMessages)
-                    - isLoadingPreviousMessages: \(isLoadingPreviousMessages)
-            """)
+            completion?(nil)
             return
         }
 
@@ -465,11 +461,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
         }
 
         guard !hasLoadedAllNextMessages && !isLoadingNextMessages else {
-            log.debug("""
-                Skipped loading more next messages.
-                    - hasLoadedAllNextMessages:\(hasLoadedAllNextMessages)
-                    - isLoadingNextMessages: \(isLoadingNextMessages)
-            """)
+            completion?(nil)
             return
         }
 
@@ -518,10 +510,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
         }
 
         guard !isLoadingMiddleMessages else {
-            log.debug("""
-                Skipped loading middle messages.
-                    - isLoadingMiddleMessages: \(isLoadingMiddleMessages)
-            """)
+            completion?(nil)
             return
         }
 

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -2038,8 +2038,14 @@ final class ChannelController_Tests: XCTestCase {
             )))
 
         // Since the messages have been all loaded already, the second call
-        // to load the previous message should not make any request
-        controller.loadPreviousMessages(before: messageId, limit: pageSize)
+        // to load the previous message should not make any request but should call the completion block
+        let exp = expectation(description: "should still call the completion block")
+        controller.loadPreviousMessages(before: messageId, limit: pageSize) { error in
+            XCTAssertNil(error)
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: defaultTimeout)
 
         // Wait for the first load to be completed
         AssertAsync.willBeTrue(firstLoadCompletionCalled)
@@ -2055,8 +2061,14 @@ final class ChannelController_Tests: XCTestCase {
         XCTAssertEqual(controller.isLoadingPreviousMessages, true)
 
         // Since the messages have been all loaded already, the second call
-        // to load the previous message should not make any request
-        controller.loadPreviousMessages(before: .unique)
+        // to load the previous message should not make any request but should call the completion block
+        let exp = expectation(description: "should still call the completion block")
+        controller.loadPreviousMessages(before: .unique) { error in
+            XCTAssertNil(error)
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: defaultTimeout)
 
         // Make sure the channel updater is only called the first time
         AssertAsync.willBeEqual(env.channelUpdater?.update_callCount, 1)
@@ -2359,7 +2371,13 @@ final class ChannelController_Tests: XCTestCase {
             withAllNextMessagesLoaded: true
         )
 
-        controller.loadNextMessages()
+        let exp = expectation(description: "should still call the completion block")
+        controller.loadNextMessages() { error in
+            XCTAssertNil(error)
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: defaultTimeout)
 
         XCTAssertEqual(env.channelUpdater?.update_callCount, 0)
     }
@@ -2374,7 +2392,12 @@ final class ChannelController_Tests: XCTestCase {
         XCTAssertEqual(env.channelUpdater?.update_callCount, 1)
 
         // Second call should not increment the call count
-        controller.loadNextMessages(after: .unique)
+        let exp = expectation(description: "should still call the completion block")
+        controller.loadNextMessages(after: .unique) { error in
+            XCTAssertNil(error)
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: defaultTimeout)
         XCTAssertEqual(env.channelUpdater?.update_callCount, 1)
     }
 
@@ -2546,7 +2569,12 @@ final class ChannelController_Tests: XCTestCase {
         XCTAssertEqual(controller.isLoadingMiddleMessages, true)
         XCTAssertEqual(env.channelUpdater?.update_callCount, 1)
 
-        controller.loadPageAroundMessageId(.unique)
+        let exp = expectation(description: "should still call the completion block")
+        controller.loadPageAroundMessageId(.unique) { error in
+            XCTAssertNil(error)
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: defaultTimeout)
         XCTAssertEqual(controller.isLoadingMiddleMessages, true)
         XCTAssertEqual(env.channelUpdater?.update_callCount, 1)
     }


### PR DESCRIPTION
### 🔗 Issue Links
https://github.com/GetStream/stream-chat-swift/issues/2545

### 🎯 Goal

Calls missing completion blocks when `loadPreviousMessages`, `loadingNextMessages` and `loadingPageAroundMessageId`.

### 🧪 Manual Testing Notes
N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
