### PR TITLE
Fix deprecatedFallback getting called when auto-filtering is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 
 ### 🐞 Fixed
-- Fix channel list auto-filtering issue in cases where we are querying for channels that the user may not be a member [#2557](https://github.com/GetStream/stream-chat-swift/pull/2557)
+- Fix channel disappearing when channel list auto-filtering is enabled and the user is not a member of the channel [#2557](https://github.com/GetStream/stream-chat-swift/pull/2557)
 
 ### 🔄 Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
+## StreamChat
+
+### 🐞 Fixed
+- Fix channel list auto-filtering issue in cases where we are querying for channels that the user may not be a member [#2557](https://github.com/GetStream/stream-chat-swift/pull/2557)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -203,6 +203,13 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
             return filter(channel)
         }
 
+        guard !client.config.isChannelAutomaticFilteringEnabled else {
+            // When auto-filtering is enabled this will be called with channels
+            // that already have been matched against the provided filter. For
+            // this reason, we provide no additional logic and simply return true.
+            return true
+        }
+
         // Given that at the moment some delegate methods are not yet removed, but some integrators are still using
         // those, we need to keep using them for now.
         // This block should be removed once `shouldAddNewChannelToList` and `shouldListUpdatedChannel` methods are


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/369

### 📝 Summary

With the auto-filtering implementation the filtering priorities were set to (higher to lower):
- `filter` closure
- auto-filtering
- `deprecatedFallback`, which is using the controller's delegate to determine if channel should be linked or not with a controller.
 
When auto-linking is enabled and no filter closure is used, we should return immediately and skip calling the controller's delegate.

### 🛠 Implementation

Implemented the filtering hierarchy that was described in Summary.

### 🧪 Manual Testing Notes

- (with auto-filtering on) Test with a user that is not part of a public livestream that they can still access the channel.
- - (with auto-filtering off) Test with a user that is not part of a public livestream that they cannot access the channel.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
