### PR TITLE
Fix SwiftLint regular_constraints_forbidden rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -83,7 +83,7 @@ custom_rules:
     capture_group: 1
     match_kinds:
       - identifier
-    message: "Plain constraints methods are forbidden. Use `pin(...)` alternative"
+    message: "Regular constraint methods are forbidden. Use `.pin()` instead."
 
   coredata_date_forbidden:
     included: "Sources/StreamChat/Database/DTOs"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -78,14 +78,14 @@ cyclomatic_complexity:
   error: 30
 
 custom_rules:
-  constraints_forbidden:
-    included: ".*StreamChatUI" # Matches all StreamChatUI files
-    excluded: ".*(?:_Tests)" # Doesn't apply to tests
-    regex: "Anchor(.constraint)\\("
+  regular_constraints_forbidden:
+    included: "Sources/StreamChatUI"
+    regex: "(.constraint)\\("
     capture_group: 1
     match_kinds:
       - identifier
     message: "Plain constraints methods are forbidden. Use `pin(...)` alternative"
+
   coredata_date_forbidden:
     included: "Sources/StreamChat/Database/DTOs"
     regex: "@NSManaged(| \\S*)* var \\S*: (NS)?Date"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -28,7 +28,6 @@ disabled_rules:
   - type_body_length
   - opening_brace
   - line_length
-  - constraints_forbidden
 
 opt_in_rules:
   - convenience_type

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListDateSeparatorView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListDateSeparatorView.swift
@@ -32,11 +32,11 @@ open class ChatMessageListDateSeparatorView: ChatMessageDecorationView, Appearan
         container.embed(textLabel, insets: .init(top: 3, leading: 9, bottom: 3, trailing: 9))
 
         NSLayoutConstraint.activate([
-            container.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
-            container.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
-            container.topAnchor.constraint(equalTo: topAnchor),
-            container.bottomAnchor.constraint(equalTo: bottomAnchor),
-            container.centerXAnchor.constraint(equalTo: centerXAnchor)
+            container.leadingAnchor.pin(greaterThanOrEqualTo: leadingAnchor),
+            container.trailingAnchor.pin(lessThanOrEqualTo: trailingAnchor),
+            container.topAnchor.pin(equalTo: topAnchor),
+            container.bottomAnchor.pin(equalTo: bottomAnchor),
+            container.centerXAnchor.pin(equalTo: centerXAnchor)
         ])
     }
 

--- a/Sources/StreamChatUI/CommonViews/ContainerStackView.swift
+++ b/Sources/StreamChatUI/CommonViews/ContainerStackView.swift
@@ -5,6 +5,8 @@
 import StreamChat
 import UIKit
 
+// swiftlint:disable regular_constraints_forbidden
+
 extension ContainerStackView {
     /// Describes the size distribution of the arranged subviews in a container stack view.
     public struct Distribution: Equatable {

--- a/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
+++ b/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
@@ -102,7 +102,7 @@ open class InputTextView: UITextView, AppearanceProvider {
         placeholderLabel.pin(anchors: [.centerY], to: self)
         placeholderLabel.widthAnchor.pin(equalTo: widthAnchor, multiplier: 0.95).isActive = true
 
-        heightConstraint = heightAnchor.constraint(equalToConstant: minimumHeight)
+        heightConstraint = heightAnchor.pin(equalToConstant: minimumHeight)
         isScrollEnabled = false
     }
 

--- a/Sources/StreamChatUI/Gallery/GalleryVC.swift
+++ b/Sources/StreamChatUI/Gallery/GalleryVC.swift
@@ -195,7 +195,7 @@ open class GalleryVC: _ViewController,
 
         view.addSubview(topBarView)
         topBarView.pin(anchors: [.leading, .trailing], to: view)
-        topBarTopConstraint = topBarView.topAnchor.constraint(equalTo: view.topAnchor)
+        topBarTopConstraint = topBarView.topAnchor.pin(equalTo: view.topAnchor)
         topBarTopConstraint?.isActive = true
 
         topBarView.embed(topBarContainerStackView)
@@ -219,7 +219,7 @@ open class GalleryVC: _ViewController,
 
         view.addSubview(bottomBarView)
         bottomBarView.pin(anchors: [.leading, .trailing], to: view)
-        bottomBarBottomConstraint = bottomBarView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        bottomBarBottomConstraint = bottomBarView.bottomAnchor.pin(equalTo: view.bottomAnchor)
         bottomBarBottomConstraint?.isActive = true
 
         bottomBarContainerStackView.preservesSuperviewLayoutMargins = true
@@ -238,7 +238,7 @@ open class GalleryVC: _ViewController,
 
         view.addSubview(videoPlaybackBar)
         videoPlaybackBar.pin(anchors: [.leading, .trailing], to: view)
-        videoPlaybackBar.bottomAnchor.constraint(equalTo: bottomBarView.topAnchor).isActive = true
+        videoPlaybackBar.bottomAnchor.pin(equalTo: bottomBarView.topAnchor).isActive = true
     }
 
     override open func viewDidLoad() {

--- a/Sources/StreamChatUI/Utils/Extensions/NSLayoutConstraint+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/Extensions/NSLayoutConstraint+Extensions.swift
@@ -4,6 +4,8 @@
 
 import UIKit
 
+// swiftlint:disable regular_constraints_forbidden
+
 extension UILayoutPriority {
     /// Having our default priority lower than `.required(1000)` allow user easily
     /// override any default constraints and customize layout

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -8002,7 +8002,6 @@
 				790881F925432B7200896F03 /* Sources */,
 				790881FA25432B7200896F03 /* Frameworks */,
 				790881FB25432B7200896F03 /* Resources */,
-				E3C7A0E52858BB2A006133C3 /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -8840,25 +8839,6 @@
 			shellScript = "# Adds support for Apple Silicon brew directory\nexport PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which mint; then\n  echo \"Runnning SwiftLint\"\n  mkdir -p reports && mint run swiftlint | tee reports/swiftlint.txt\nelse\n  echo \"Warning: Mint not installed\"\nfi\n";
 		};
 		E3C7A0E42858BB10006133C3 /* SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = SwiftLint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Adds support for Apple Silicon brew directory\nexport PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which mint; then\n  echo \"Runnning SwiftLint\"\n  mkdir -p reports && mint run swiftlint | tee reports/swiftlint.txt\nelse\n  echo \"Warning: Mint not installed\"\nfi\n";
-		};
-		E3C7A0E52858BB2A006133C3 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;

--- a/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/MessageList_Tests.swift
@@ -601,8 +601,7 @@ extension MessageList_Tests {
         }
     }
 }
-    
-    
+
 // MARK: Links preview
 
 extension MessageList_Tests {


### PR DESCRIPTION
### 🔗 Issue Links
N/A

### 🎯 Goal
Fix our custom swiftlint rule to ensure we write UI Components only using `.pin()` instead of the `.constraint()` so customers can override our constraints.

Bonus: Fixes swiftlint from running twice

### 🎨 Showcase

<img width="1152" alt="image" src="https://user-images.githubusercontent.com/12814114/229856497-62cda93a-93a9-4c63-8c30-fbbdfa9e5649.png">

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)