### PR TITLE
Prevent unauthorized requests from reaching the backend

### DIFF
--- a/Sources/StreamChat/APIClient/APIClient.swift
+++ b/Sources/StreamChat/APIClient/APIClient.swift
@@ -117,6 +117,14 @@ class APIClient {
                     // Retry request. Expired token has been refreshed
                     operation.resetRetries()
                     done(.retry)
+                case .failure(_ as ClientError.WaiterTimeout):
+                    // When waiters timeout, chances are that we are still connecting. We are going to retry until we reach max retries
+                    if operation.canRetry {
+                        done(.retry)
+                    } else {
+                        completion(result)
+                        done(.continue)
+                    }
                 case let .failure(error) where self?.isConnectionError(error) == true:
                     // If a non recovery request comes in while we are in recovery mode, we want to queue if still has
                     // retries left

--- a/Sources/StreamChat/APIClient/RequestEncoder.swift
+++ b/Sources/StreamChat/APIClient/RequestEncoder.swift
@@ -152,7 +152,8 @@ struct DefaultRequestEncoder: RequestEncoder {
                 }
                 completion(.success(updatedRequest))
             case let .failure(error as ClientError.WaiterTimeout):
-                // The APIClient will treat a waiter timeout differently than the other ones
+                // The receiver will treat a waiter timeout differently than the other ones, and that's why we are not
+                // masking it under missing token. The receiver should retry based on their own logic
                 completion(.failure(error))
             case .failure:
                 completion(.failure(missingTokenError))
@@ -188,7 +189,8 @@ struct DefaultRequestEncoder: RequestEncoder {
                     updatedRequest.url = try updatedRequest.url?.appendingQueryItems(["connection_id": connectionId])
                     completion(.success(updatedRequest))
                 case let .failure(error as ClientError.WaiterTimeout):
-                    // The APIClient will treat a waiter timeout differently than the other ones
+                    // The receiver will treat a waiter timeout differently than the other ones, and that's why we are not
+                    // masking it under missing token. The receiver should retry based on their own logic
                     throw error
                 case .failure:
                     throw missingConnectionIdError

--- a/Sources/StreamChat/APIClient/RequestEncoder.swift
+++ b/Sources/StreamChat/APIClient/RequestEncoder.swift
@@ -151,10 +151,9 @@ struct DefaultRequestEncoder: RequestEncoder {
                     updatedRequest.setHTTPHeaders(.jwtStreamAuth, .authorization(token.rawValue))
                 }
                 completion(.success(updatedRequest))
-            case .failure(_ as ClientError.WaiterTimeout):
-                // We complete with a success to account for the most probable case for the timeout: No connection.
-                // That way, when reaching the APIClient, we would properly report a connection error.
-                completion(.success(request))
+            case let .failure(error as ClientError.WaiterTimeout):
+                // The APIClient will treat a waiter timeout differently than the other ones
+                completion(.failure(error))
             case .failure:
                 completion(.failure(missingTokenError))
             }
@@ -188,10 +187,9 @@ struct DefaultRequestEncoder: RequestEncoder {
                     var updatedRequest = request
                     updatedRequest.url = try updatedRequest.url?.appendingQueryItems(["connection_id": connectionId])
                     completion(.success(updatedRequest))
-                case .failure(_ as ClientError.WaiterTimeout):
-                    // We complete with a success to account for the most probable case for the timeout: No connection.
-                    // That way, when reaching the APIClient, we would properly report a connection error.
-                    completion(.success(request))
+                case let .failure(error as ClientError.WaiterTimeout):
+                    // The APIClient will treat a waiter timeout differently than the other ones
+                    throw error
                 case .failure:
                     throw missingConnectionIdError
                 }

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/ConnectionDetailsProviderDelegate_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/ConnectionDetailsProviderDelegate_Spy.swift
@@ -9,10 +9,10 @@ import Foundation
 final class ConnectionDetailsProviderDelegate_Spy: ConnectionDetailsProviderDelegate, Spy {
     var recordedFunctions: [String] = []
 
-    @Atomic var token: Token?
+    var provideTokenResult: Result<Token, Error>?
     @Atomic var tokenWaiters: [String: (Token?) -> Void] = [:]
 
-    @Atomic var connectionId: ConnectionId?
+    var provideConnectionIdResult: Result<ConnectionId, Error>?
     @Atomic var connectionWaiters: [String: (ConnectionId?) -> Void] = [:]
 
     func clear() {
@@ -29,8 +29,8 @@ final class ConnectionDetailsProviderDelegate_Spy: ConnectionDetailsProviderDele
             $0[waiterToken] = valueCompletion
         }
 
-        if let connectionId = connectionId {
-            completion(.success(connectionId))
+        if let connectionIdResult = provideConnectionIdResult {
+            completion(connectionIdResult)
         }
     }
 
@@ -43,8 +43,8 @@ final class ConnectionDetailsProviderDelegate_Spy: ConnectionDetailsProviderDele
             $0[waiterToken] = valueCompletion
         }
 
-        if let token = token {
-            completion(.success(token))
+        if let tokenResult = provideTokenResult {
+            completion(tokenResult)
         }
     }
 

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/RequestEncoder_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/RequestEncoder_Spy.swift
@@ -23,13 +23,13 @@ final class RequestEncoder_Spy: RequestEncoder, Spy {
         completion: @escaping (Result<URLRequest, Error>) -> Void
     ) where ResponsePayload: Decodable {
         record()
-        onEncodeRequestCall?()
         encodeRequest_endpoints.append(AnyEndpoint(endpoint))
         encodeRequest_completion = completion
 
         if let result = encodeRequest {
             completion(result)
         }
+        onEncodeRequestCall?()
     }
 
     required init(baseURL: URL, apiKey: APIKey) {

--- a/Tests/StreamChatTests/StreamChatIntegrationTests/PinnedMessagesQuery_IntegrationTests.swift
+++ b/Tests/StreamChatTests/StreamChatIntegrationTests/PinnedMessagesQuery_IntegrationTests.swift
@@ -29,7 +29,7 @@ final class PinnedMessagesQuery_IntegrationTests: XCTestCase {
 
         // Create token provider
         let tokenProvider = ConnectionDetailsProviderDelegate_Spy()
-        tokenProvider.token = .unique(userId: .unique)
+        tokenProvider.provideTokenResult = .success(.unique(userId: .unique))
 
         // Create request encoder.
         let baseURL = BaseURL.dublin.restAPIBaseURL


### PR DESCRIPTION
### 🔗 Issue Links

Relates to #2431 

### 🎯 Goal

Fix unexpected 401s produced at launch, while the chat is not yet fully connected.

### 📝 Summary

The issue was produce when trying to load resources, while  connecting to the chat. 
When that happened, and if the internet connection is not ideal, it might happen that while waiting for the token to be retrieved, we end up timeout'ing. 
In that case, we were mistakenly sending the request without authentication headers and that's returning an expected 401. 

### 🛠 Implementation

This PR forwards timeouts to the APIClient for it to handle it, instead of just returning a request without authorization that gets sent to the backend.
The APIClient will retry the request (up to a max retries limit), giving time for the connection to be fully stablished

### 🧪 Manual Testing Notes

TBD

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/l0HlxBaX9oJ24YT7i/giphy.gif)
