### PR TITLE
Add missing keypathMapper for ChannelId auto-filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix channel disappearing when channel list auto-filtering is enabled and the user is not a member of the channel [#2557](https://github.com/GetStream/stream-chat-swift/pull/2557)
+- Fix and issues which was causing the app to terminate when using a filter with the `in` operator and `cid` values [#2561](https://github.com/GetStream/stream-chat-swift/pull/2561)
 
 ### 🔄 Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix channel disappearing when channel list auto-filtering is enabled and the user is not a member of the channel [#2557](https://github.com/GetStream/stream-chat-swift/pull/2557)
-- Fix and issues which was causing the app to terminate when using a filter with the `in` operator and `cid` values [#2561](https://github.com/GetStream/stream-chat-swift/pull/2561)
+- Fix an issues which was causing the app to terminate when using a filter with the `in` operator and `cid` values [#2561](https://github.com/GetStream/stream-chat-swift/pull/2561)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -58,7 +58,7 @@ public enum InviteFilterValue: String, FilterValue {
 public extension FilterKey where Scope: AnyChannelListFilterScope {
     /// A filter key for matching the `cid` value.
     /// Supported operators: `in`, `equal`
-    static var cid: FilterKey<Scope, ChannelId> { .init(rawValue: "cid", keyPathString: #keyPath(ChannelDTO.cid)) }
+    static var cid: FilterKey<Scope, ChannelId> { .init(rawValue: "cid", keyPathString: #keyPath(ChannelDTO.cid), valueMapper: { $0.rawValue }) }
 
     /// A filter key for matching the `id` value.
     /// Supported operators: `in`, `equal`

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -1575,6 +1575,50 @@ final class ChannelListController_Tests: XCTestCase {
         )
     }
 
+    func test_filterPredicate_inWithArrayOfChannelIds_returnsExpectedResults() throws {
+        let chatIds: [String] = [
+            "suggestions-63986de56549624f314b75cb",
+            "suggestions-6ukh3986de56549624f314b75cjkhagfdkjhab",
+            "suggestions-sdfdsfsad",
+            "suggestions-234263986desadfsadf56549624f314b75cb"
+        ]
+
+        let channelIds = chatIds.map { ChannelId(type: .custom("daisy-dashboard"), id: $0) }
+
+        try assertFilterPredicate(
+            .in(.cid, values: channelIds),
+            channelsInDB: [
+                .dummy(channel: .dummy(cid: channelIds[0])),
+                .dummy(channel: .dummy(cid: channelIds[1])),
+                .dummy(),
+                .dummy()
+            ],
+            expectedResult: [channelIds[0], channelIds[1]]
+        )
+    }
+
+    func test_filterPredicate_inWithArrayOfIds_returnsExpectedResults() throws {
+        let chatIds: [String] = [
+            "suggestions-63986de56549624f314b75cb",
+            "suggestions-6ukh3986de56549624f314b75cjkhagfdkjhab",
+            "suggestions-sdfdsfsad",
+            "suggestions-234263986desadfsadf56549624f314b75cb"
+        ]
+
+        let channelIds = chatIds.map { ChannelId(type: .custom("daisy-dashboard"), id: $0) }
+
+        try assertFilterPredicate(
+            .in(.id, values: channelIds.map(\.rawValue)),
+            channelsInDB: [
+                .dummy(channel: .dummy(cid: channelIds[0])),
+                .dummy(channel: .dummy(cid: channelIds[1])),
+                .dummy(),
+                .dummy()
+            ],
+            expectedResult: [channelIds[0], channelIds[1]]
+        )
+    }
+
     // MARK: - Private Helpers
 
     private func setUpChatClientWithoutAutoFiltering() {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/375

### 🎯 Goal

Improve auto-filtering when using ChannelId (cid) with the `in` operator.

### 🛠 Implementation

Due to a missing keypathMapper the comparison was unable to complete on CoreData layer.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
