### PR TITLE
Fix crash when getting unread count in invalid state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix channel disappearing when channel list auto-filtering is enabled and the user is not a member of the channel [#2557](https://github.com/GetStream/stream-chat-swift/pull/2557)
 - Fix an issues which was causing the app to terminate when using a filter with the `in` operator and `cid` values [#2561](https://github.com/GetStream/stream-chat-swift/pull/2561)
+- Fix crash when getting unread count in an invalid state [#2570](https://github.com/GetStream/stream-chat-swift/pull/2570)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -413,7 +413,13 @@ extension ChatChannel {
         let reads: [ChatChannelRead] = try dto.reads.map { try $0.asModel() }
 
         let unreadCount: () -> ChannelUnreadCount = {
-            guard dto.isValid, let currentUser = context.currentUser else { return .noUnread }
+            guard dto.isValid, let currentUser = context.currentUser else {
+                return .noUnread
+            }
+
+            guard currentUser.user.isValid else {
+                return .noUnread
+            }
 
             let currentUserRead = reads.first(where: { $0.user.id == currentUser.user.id })
 


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/271

### 🎯 Goal
It fixes a rare crash when getting an unread count from a logged-out/invalid user.

### 📝 Summary
- Fixes a crash when getting an unread count from an invalid user

### 🧪 Manual Testing Notes
Unit Tests have been added to cover this scenario. 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
