### PR TITLE
Make connect/disconnect safer when network is offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix an issues which was causing the app to terminate when using a filter with the `in` operator and `cid` values [#2561](https://github.com/GetStream/stream-chat-swift/pull/2561)
 - Fix unexpected 401s produced at launch while the chat is not yet fully connected [#2559](https://github.com/GetStream/stream-chat-swift/pull/2559)
 - Fix crash when getting unread count in an invalid state [#2570](https://github.com/GetStream/stream-chat-swift/pull/2570)
+- Make connect/disconnect safer when network is offline [#2571](https://github.com/GetStream/stream-chat-swift/pull/2571)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/APIClient/RequestEncoder.swift
+++ b/Sources/StreamChat/APIClient/RequestEncoder.swift
@@ -56,12 +56,16 @@ extension RequestEncoder {
             dispatchGroup.leave()
         }
 
-        let waitResult = dispatchGroup.wait(timeout: .now() + 5)
+        let waitResult = dispatchGroup.wait(timeout: .now() + returningResultTimeout)
         if waitResult == .timedOut {
             result = .failure(ClientError("Encoding request timed out. Endpoint: \(endpoint)"))
         }
 
         return try result.get()
+    }
+
+    private var returningResultTimeout: TimeInterval {
+        5
     }
 }
 

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -70,8 +70,8 @@ class WebSocketClient {
         do {
             request = try requestEncoder.encodeRequest(for: connectEndpoint)
         } catch {
-            log.log(.debug, message: error.localizedDescription)
-            throw ClientError(error.localizedDescription)
+            log.log(.error, message: error.localizedDescription)
+            throw error
         }
 
         if let existedEngine = engine, existedEngine.request == request {

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -65,12 +65,13 @@ class WebSocketClient {
         return pingController
     }()
 
-    private func createEngineIfNeeded(for connectEndpoint: Endpoint<EmptyResponse>) -> WebSocketEngine {
+    private func createEngineIfNeeded(for connectEndpoint: Endpoint<EmptyResponse>) throws -> WebSocketEngine {
         let request: URLRequest
         do {
             request = try requestEncoder.encodeRequest(for: connectEndpoint)
         } catch {
-            fatalError("Failed to create WebSocketEngine with error: \(error)")
+            log.log(.debug, message: error.localizedDescription)
+            throw ClientError(error.localizedDescription)
         }
 
         if let existedEngine = engine, existedEngine.request == request {
@@ -113,7 +114,11 @@ class WebSocketClient {
         default: break
         }
 
-        engine = createEngineIfNeeded(for: endpoint)
+        do {
+            engine = try createEngineIfNeeded(for: endpoint)
+        } catch {
+            return
+        }
 
         connectionState = .connecting
 

--- a/Tests/StreamChatTests/APIClient/RequestEncoder_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/RequestEncoder_Tests.swift
@@ -279,6 +279,36 @@ final class RequestEncoder_Tests: XCTestCase {
         XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], token.rawValue)
     }
 
+    func test_encodeRequest_syncVersion_whenEndpointRequiresConnectionId_shouldReturnRequest() {
+        let endpoint = Endpoint<Data>(
+            path: .guest,
+            method: .get,
+            queryItems: nil,
+            requiresConnectionId: true,
+            requiresToken: false,
+            body: nil
+        )
+
+        connectionDetailsProvider.provideConnectionIdResult = .success(.unique)
+
+        XCTAssertNoThrow(try encoder.encodeRequest(for: endpoint))
+    }
+
+    func test_encodeRequest_syncVersion_whenEndpointRequiresConnectionId_whenConnectionFails_shouldThrow() {
+        let endpoint = Endpoint<Data>(
+            path: .guest,
+            method: .get,
+            queryItems: nil,
+            requiresConnectionId: true,
+            requiresToken: false,
+            body: nil
+        )
+
+        connectionDetailsProvider.provideConnectionIdResult = .failure(TestError())
+        
+        XCTAssertThrowsError(try encoder.encodeRequest(for: endpoint))
+    }
+
     func test_encodingRequestURL() throws {
         let testStringValue = String.unique
 

--- a/Tests/StreamChatTests/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/WebSocketClient_Tests.swift
@@ -128,6 +128,20 @@ final class WebSocketClient_Tests: XCTestCase {
         XCTAssertFalse(oldEngine === webSocketClient.engine)
     }
 
+    func test_engine_whenRequestEncoderFails_engineIsNil() {
+        // Setup endpoint.
+        webSocketClient.connectEndpoint = endpoint
+
+        // Update request encode to provide different request.
+        requestEncoder.encodeRequest = .failure(ClientError("Dummy"))
+
+        // Simulate connect to trigger engine creation or reuse.
+        webSocketClient.connect()
+
+        // Assert engine is recreated since the connect request is changed.
+        XCTAssertNil(webSocketClient.engine)
+    }
+
     // MARK: - Connection tests
 
     func test_connectionFlow() {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/386

### 🎯 Goal
Fixes a crash only in the develop branch, which happens when logging out and in with an unstable network connection or the network is offline.

### 🧪 Manual Testing Notes
1. Open channel list
2. Turn off Wi-fi
3. Log out
4. Log in
5. Channel List will display an error to re-fetch the channel list
6. Turn on Wi-fi and at the same time, tap to re-fetch the channel list

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
