### PR TITLE
Avoid Crash when accessing FetchCache with an unexecuted NSFetchRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### ✅ Added
 - Add `ChatMessageController.loadPageAroundReplyId()` to load mid-page inside threads [#2566](https://github.com/GetStream/stream-chat-swift/pull/2566)
+
 ### 🐞 Fixed
 - Fix channel disappearing when channel list auto-filtering is enabled and the user is not a member of the channel [#2557](https://github.com/GetStream/stream-chat-swift/pull/2557)
 - Fix an issues which was causing the app to terminate when using a filter with the `in` operator and `cid` values [#2561](https://github.com/GetStream/stream-chat-swift/pull/2561)
 - Fix unexpected 401s produced at launch while the chat is not yet fully connected [#2559](https://github.com/GetStream/stream-chat-swift/pull/2559)
 - Fix crash when getting unread count in an invalid state [#2570](https://github.com/GetStream/stream-chat-swift/pull/2570)
+- Fix crash when accessing FetchCache with an unexecuted NSFetchRequest [#2572](https://github.com/GetStream/stream-chat-swift/pull/2572)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/Utils/Database/NSManagedObject+Extensions.swift
+++ b/Sources/StreamChat/Utils/Database/NSManagedObject+Extensions.swift
@@ -63,28 +63,73 @@ extension NSManagedObject {
 }
 
 class FetchCache {
+    /// We use this wrapper to have a custom implementation of both Equatable and Hashable.
+    /// This is because when using NSFetchRequest directly, its implementation of `hash` uses `entity`, which is a property that crashes on access
+    /// when it is not yet set
+    struct FetchRequestWrapper<T: NSFetchRequestResult>: Equatable, Hashable {
+        let request: NSFetchRequest<T>
+
+        static func == (lhs: FetchRequestWrapper<T>, rhs: FetchRequestWrapper<T>) -> Bool {
+            switch (lhs.request.predicate, rhs.request.predicate) {
+            case let (.some(lhsPredicate), .some(rhsPredicate)) where lhsPredicate == rhsPredicate:
+                break
+            case (.none, .none):
+                break
+            default:
+                return false
+            }
+
+            return lhs.request.sortDescriptors == rhs.request.sortDescriptors
+                && lhs.request.entityName == rhs.request.entityName
+                && lhs.request.fetchLimit == rhs.request.fetchLimit
+        }
+
+        func hash(into hasher: inout Hasher) {
+            if let predicate = request.predicate {
+                hasher.combine(predicate)
+            }
+            if let sortDescriptors = request.sortDescriptors {
+                sortDescriptors.forEach {
+                    hasher.combine($0.key)
+                    hasher.combine($0.ascending)
+                }
+            }
+            if let entityName = request.entityName {
+                hasher.combine(entityName)
+            }
+            hasher.combine(request.fetchLimit)
+        }
+    }
+
     fileprivate static let shared = FetchCache()
     private let queue = DispatchQueue(label: "io.stream.com.fetch-cache", qos: .userInitiated, attributes: .concurrent)
-    private var cache = [NSFetchRequest<NSFetchRequestResult>: [NSManagedObjectID]]()
+    private var cache = [FetchRequestWrapper<NSFetchRequestResult>: [NSManagedObjectID]]()
 
-    fileprivate func set<T>(_ request: NSFetchRequest<T>, objectIds: [NSManagedObjectID]) where T: NSFetchRequestResult {
+    var cacheEntriesCount: Int {
+        queue.sync { cache.count }
+    }
+
+    func set<T>(_ request: NSFetchRequest<T>, objectIds: [NSManagedObjectID]) where T: NSFetchRequestResult {
         guard let request = request as? NSFetchRequest<NSFetchRequestResult> else {
             log.assertionFailure("Request should have a generic type conforming to NSFetchRequestResult")
             return
         }
+
+        let wrapper = FetchRequestWrapper(request: request)
         queue.async(flags: .barrier) {
-            self.cache[request] = objectIds
+            self.cache[wrapper] = objectIds
         }
     }
 
-    fileprivate func get<T>(_ request: NSFetchRequest<T>) -> [NSManagedObjectID]? where T: NSFetchRequestResult {
+    func get<T>(_ request: NSFetchRequest<T>) -> [NSManagedObjectID]? where T: NSFetchRequestResult {
         guard let request = request as? NSFetchRequest<NSFetchRequestResult> else {
             log.assertionFailure("Request should have a generic type conforming to NSFetchRequestResult")
             return nil
         }
+        let wrapper = FetchRequestWrapper(request: request)
         var objectIDs: [NSManagedObjectID]?
         queue.sync {
-            objectIDs = cache[request]
+            objectIDs = cache[wrapper]
         }
         return objectIDs
     }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1778,6 +1778,7 @@
 		C18F5B522840BD2C00527915 /* DBDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18F5B512840BD2C00527915 /* DBDate.swift */; };
 		C18F5B532840BD2C00527915 /* DBDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18F5B512840BD2C00527915 /* DBDate.swift */; };
 		C19B9C3227D0FB0800D308C0 /* EndpointPath_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19B9C3127D0FB0800D308C0 /* EndpointPath_Tests.swift */; };
+		C1A25D6029E70DEB00DAE933 /* FetchCache_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A25D5F29E70DEB00DAE933 /* FetchCache_Tests.swift */; };
 		C1B0B38327BFC08900C8207D /* EndpointPath+OfflineRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B0B38227BFC08800C8207D /* EndpointPath+OfflineRequest.swift */; };
 		C1B0B38427BFC08900C8207D /* EndpointPath+OfflineRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B0B38227BFC08800C8207D /* EndpointPath+OfflineRequest.swift */; };
 		C1B0B38627BFE8AB00C8207D /* MessageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B0B38527BFE8AB00C8207D /* MessageRepository.swift */; };
@@ -3598,6 +3599,7 @@
 		C186BFB527AAFDAB0099CCA6 /* SyncOperations_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncOperations_Tests.swift; sourceTree = "<group>"; };
 		C18F5B512840BD2C00527915 /* DBDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBDate.swift; sourceTree = "<group>"; };
 		C19B9C3127D0FB0800D308C0 /* EndpointPath_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndpointPath_Tests.swift; sourceTree = "<group>"; };
+		C1A25D5F29E70DEB00DAE933 /* FetchCache_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchCache_Tests.swift; sourceTree = "<group>"; };
 		C1B0B38227BFC08800C8207D /* EndpointPath+OfflineRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EndpointPath+OfflineRequest.swift"; sourceTree = "<group>"; };
 		C1B0B38527BFE8AB00C8207D /* MessageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRepository.swift; sourceTree = "<group>"; };
 		C1B15A1329115E8D00C9CD80 /* Token+Development.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Token+Development.swift"; sourceTree = "<group>"; };
@@ -5874,6 +5876,7 @@
 				799C945F247D77D6001F1104 /* DatabaseContainer_Tests.swift */,
 				792FCB4C24A3D56D000290C7 /* DatabaseSession_Tests.swift */,
 				797EEA4724FFB4C200C81203 /* DataStore_Tests.swift */,
+				C1A25D5F29E70DEB00DAE933 /* FetchCache_Tests.swift */,
 				A364D09D27D0C6D30029857A /* DTOs */,
 			);
 			path = Database;
@@ -10109,6 +10112,7 @@
 				A3C7BAE527E4EABC00BBF4FA /* ChannelEvents_IntegrationTests.swift in Sources */,
 				7952B3B324D4560E00AC53D4 /* ChannelController_Tests.swift in Sources */,
 				8A0CC9EB24C601F600705CF9 /* MemberEvents_Tests.swift in Sources */,
+				C1A25D6029E70DEB00DAE933 /* FetchCache_Tests.swift in Sources */,
 				A32D55142860B40B00E66AF9 /* ChatMessageLinkAttachment_Tests.swift in Sources */,
 				792B805224D95D4300C2963E /* Cached_StressTests.swift in Sources */,
 				A34ECB4A27F5CA1B00A804C1 /* TypingEvents_IntegrationTests.swift in Sources */,

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
@@ -34,6 +34,7 @@ final class APIClient_Spy: APIClient, Spy {
     @Atomic var init_requestDecoder: RequestDecoder
     @Atomic var init_attachmentUploader: AttachmentUploader
     @Atomic var request_expectation: XCTestExpectation
+    @Atomic var recoveryRequest_expectation: XCTestExpectation
 
     // Cleans up all recorded values
     func cleanUp() {
@@ -41,6 +42,7 @@ final class APIClient_Spy: APIClient, Spy {
         request_endpoint = nil
         request_completion = nil
         request_expectation = .init()
+        recoveryRequest_expectation = .init()
 
         recoveryRequest_endpoint = nil
         recoveryRequest_allRecordedCalls = []
@@ -66,6 +68,7 @@ final class APIClient_Spy: APIClient, Spy {
         init_requestDecoder = requestDecoder
         init_attachmentUploader = attachmentUploader
         request_expectation = .init()
+        recoveryRequest_expectation = .init()
 
         super.init(
             sessionConfiguration: sessionConfiguration,
@@ -132,6 +135,12 @@ final class APIClient_Spy: APIClient, Spy {
     func waitForRequest(timeout: Double = defaultTimeout) -> AnyEndpoint? {
         XCTWaiter().wait(for: [request_expectation], timeout: timeout)
         return request_endpoint
+    }
+
+    @discardableResult
+    func waitForRecoveryRequest(timeout: Double = defaultTimeout) -> AnyEndpoint? {
+        XCTWaiter().wait(for: [recoveryRequest_expectation], timeout: timeout)
+        return recoveryRequest_endpoint
     }
 
     override func enterRecoveryMode() {

--- a/Tests/StreamChatTests/Database/FetchCache_Tests.swift
+++ b/Tests/StreamChatTests/Database/FetchCache_Tests.swift
@@ -1,0 +1,80 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import CoreData
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class FetchCache_Tests: XCTestCase {
+    func test_canBeAccessedFromMultipleThreads_sameRequest_sameInstance_shouldOnlyKeepOne() throws {
+        let cache = FetchCache()
+        let request = createRequest()
+
+        DispatchQueue.concurrentPerform(iterations: 10) { _ in
+            let objectIDs = tenIds
+            cache.set(request, objectIds: objectIDs)
+        }
+
+        XCTAssertEqual(cache.cacheEntriesCount, 1)
+    }
+
+    func test_fetchRequestWrapper_sameRequest_differentInstance_shouldOnlyKeepOne() {
+        let cache = FetchCache()
+
+        DispatchQueue.concurrentPerform(iterations: 10) { _ in
+            let objectIDs = tenIds
+            let request = createRequest()
+
+            XCTAssertTrue(!(request.entityName ?? "").isEmpty)
+
+            cache.set(request, objectIds: objectIDs)
+        }
+
+        XCTAssertEqual(cache.cacheEntriesCount, 1)
+    }
+
+    func test_fetchRequestWrapper_sameRequest_differentSortDescriptorOrder_shouldHaveDifferentHashValue() {
+        let cache = FetchCache()
+        let objectIDs = tenIds
+        let request = createRequest(sortDescriptors: [
+            NSSortDescriptor(keyPath: \QueuedRequestDTO.date, ascending: false),
+            NSSortDescriptor(keyPath: \QueuedRequestDTO.date, ascending: true)
+        ])
+        let request2 = createRequest(sortDescriptors: [
+            NSSortDescriptor(keyPath: \QueuedRequestDTO.date, ascending: true),
+            NSSortDescriptor(keyPath: \QueuedRequestDTO.date, ascending: false)
+        ])
+        let request3 = createRequest(sortDescriptors: [
+            NSSortDescriptor(keyPath: \QueuedRequestDTO.date, ascending: true)
+        ])
+
+        cache.set(request, objectIds: objectIDs)
+        cache.set(request2, objectIds: objectIDs)
+        cache.set(request3, objectIds: objectIDs)
+
+        XCTAssertEqual(cache.cacheEntriesCount, 3)
+    }
+
+    private var tenIds: [TestId] {
+        (1...10).map { _ in TestId() }
+    }
+
+    private func createRequest(sortDescriptors: [NSSortDescriptor]? = nil) -> NSFetchRequest<QueuedRequestDTO> {
+        let request = NSFetchRequest<QueuedRequestDTO>(entityName: QueuedRequestDTO.entityName)
+        request.sortDescriptors = sortDescriptors ?? [
+            NSSortDescriptor(keyPath: \QueuedRequestDTO.date, ascending: false),
+            NSSortDescriptor(keyPath: \QueuedRequestDTO.date, ascending: true)
+        ]
+        request.predicate = NSPredicate(format: "id == 1")
+        request.fetchLimit = 3
+        return request
+    }
+}
+
+class TestId: NSManagedObjectID {
+    override func uriRepresentation() -> URL {
+        URL(string: "file://a")!
+    }
+}

--- a/Tests/StreamChatTests/Repositories/OfflineRequestsRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/OfflineRequestsRepository_Tests.swift
@@ -176,6 +176,8 @@ final class OfflineRequestsRepository_Tests: XCTestCase {
             expectation.fulfill()
         }
 
+        apiClient.waitForRecoveryRequest()
+
         XCTAssertEqual(apiClient.recoveryRequest_allRecordedCalls.count, 5)
         // We make all the requests succeed
         apiClient.recoveryRequest_allRecordedCalls.forEach { _, completion in
@@ -199,6 +201,8 @@ final class OfflineRequestsRepository_Tests: XCTestCase {
         repository.runQueuedRequests {
             expectation.fulfill()
         }
+
+        apiClient.waitForRecoveryRequest()
 
         XCTAssertEqual(apiClient.recoveryRequest_allRecordedCalls.count, 5)
 
@@ -228,6 +232,8 @@ final class OfflineRequestsRepository_Tests: XCTestCase {
         repository.runQueuedRequests {
             expectation.fulfill()
         }
+
+        apiClient.waitForRecoveryRequest()
 
         XCTAssertEqual(apiClient.recoveryRequest_allRecordedCalls.count, 5)
 


### PR DESCRIPTION
### 🔗 Issue Links

https://github.com/GetStream/ios-issues-tracking/issues/385

### 🎯 Goal

Fix a crash where accessing FetchCache internal storage would crash

### 📝 Summary

```
This fetch request (0x60000263cb60) was created with a string name (QueuedRequestDTO), and cannot respond to -entity until used by an NSManagedObjectContext
```
You cannot access NSFetchRequest’s `entity` property unless the request has been executed.
Because setting it as a key for a dictionary will access its hash value, and it internally uses `entity` to compute it, it crashes.
Same goes for the other crash we've seen, where it is calling isEqual and its internal implementation makes it crash.

### 🛠 Implementation

NSFetchRequest is wrapped before adding it to the internal storage of FetchCache. This wrapper has its own implementation of Hashable and Equatable, which makes it safer.

### 🧪 Manual Testing Notes

We could not find a way to reproduce it aside from Unit tests.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/qmtZWoxt5jYvEi9ovV/giphy.gif)