### PR TITLE
[Fix]Guest Authentication Flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix unexpected 401s produced at launch while the chat is not yet fully connected [#2559](https://github.com/GetStream/stream-chat-swift/pull/2559)
 - Fix crash when getting unread count in an invalid state [#2570](https://github.com/GetStream/stream-chat-swift/pull/2570)
 - Fix crash when accessing FetchCache with an unexecuted NSFetchRequest [#2572](https://github.com/GetStream/stream-chat-swift/pull/2572)
+- Fix an issue which was blocking a Guest Authentication operation to retrieve a connection token [#2574](https://github.com/GetStream/stream-chat-swift/pull/2574)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/APIClient/APIClient.swift
+++ b/Sources/StreamChat/APIClient/APIClient.swift
@@ -102,18 +102,16 @@ class APIClient {
     }
 
     /// Performs a network request and retries in case of network failures. The network operation
-    /// won't be managed by the APIClient instance. Instead it will be added on the provided operationQueue.
+    /// won't be managed by the APIClient instance. Instead it will be added on the `OperationQueue.main`
     ///
     /// - Parameters:
     ///   - endpoint: The `Endpoint` used to create the network request.
-    ///   - operationQueue: The queue that will be responsible for executing the network operation
     ///   - completion: Called when the networking request is finished.
     func unmanagedRequest<Response: Decodable>(
         endpoint: Endpoint<Response>,
-        operationQueue: OperationQueue,
         completion: @escaping (Result<Response, Error>) -> Void
     ) {
-        operationQueue.addOperation(
+        OperationQueue.main.addOperation(
             unmanagedOperation(endpoint: endpoint, completion: completion)
         )
     }

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -121,16 +121,6 @@ class AuthenticationRepository {
         self.currentUserId = currentUserId
     }
 
-    /// Fetches the user saved in the database, if exists
-    func deleteCurrentUser() {
-        if let currentUserId = currentUserId {
-            let context = databaseContainer.writableContext
-            context.performAndWait {
-                context.deleteQuery(.user(withID: currentUserId))
-            }
-        }
-    }
-
     /// Sets the user token. This method is only needed to perform API calls without connecting as a user.
     /// You should only use this in special cases like a notification service or other background process
     /// - Parameters:
@@ -171,7 +161,6 @@ class AuthenticationRepository {
         clearTokenProvider()
         currentToken = nil
         currentUserId = nil
-        deleteCurrentUser()
     }
 
     func refreshToken(completion: @escaping (Error?) -> Void) {

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -361,7 +361,7 @@ class AuthenticationRepository {
         /// We need to ensure that the request to fetch the userToken will be executed. As APIClient's
         /// operationQueue may be suspended (due to the getToken operation) we are firing an
         /// unmanagedRequest/Operation that will be added on the `OperationQueue.main`
-        apiClient.unmanagedRequest(endpoint: endpoint, operationQueue: .main) {
+        apiClient.unmanagedRequest(endpoint: endpoint) {
             switch $0 {
             case let .success(payload):
                 let token = payload.token

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -346,7 +346,11 @@ class AuthenticationRepository {
             imageURL: userInfo.imageURL,
             extraData: userInfo.extraData
         )
-        apiClient.request(endpoint: endpoint) {
+
+        /// We need to ensure that the request to fetch the userToken will be executed. As APIClient's
+        /// operationQueue may be suspended (due to the getToken operation) we are firing an
+        /// unmanagedRequest/Operation that will be added on the `OperationQueue.main`
+        apiClient.unmanagedRequest(endpoint: endpoint, operationQueue: .main) {
             switch $0 {
             case let .success(payload):
                 let token = payload.token

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -121,6 +121,16 @@ class AuthenticationRepository {
         self.currentUserId = currentUserId
     }
 
+    /// Fetches the user saved in the database, if exists
+    func deleteCurrentUser() {
+        if let currentUserId = currentUserId {
+            let context = databaseContainer.writableContext
+            context.performAndWait {
+                context.deleteQuery(.user(withID: currentUserId))
+            }
+        }
+    }
+
     /// Sets the user token. This method is only needed to perform API calls without connecting as a user.
     /// You should only use this in special cases like a notification service or other background process
     /// - Parameters:
@@ -161,6 +171,7 @@ class AuthenticationRepository {
         clearTokenProvider()
         currentToken = nil
         currentUserId = nil
+        deleteCurrentUser()
     }
 
     func refreshToken(completion: @escaping (Error?) -> Void) {

--- a/Sources/StreamChat/Utils/Operations/AsyncOperation.swift
+++ b/Sources/StreamChat/Utils/Operations/AsyncOperation.swift
@@ -9,36 +9,36 @@ class AsyncOperation: BaseOperation {
         case retry
         case `continue`
     }
-    
+
     private let maxRetries: Int
     private(set) var executionBlock: (AsyncOperation, @escaping (_ output: Output) -> Void) -> Void
     private var executedRetries = 0
-    
+
     var canRetry: Bool {
         executedRetries < maxRetries && !isCancelled && !isFinished
     }
-    
+
     init(maxRetries: Int = 0, executionBlock: @escaping (AsyncOperation, @escaping (_ output: Output) -> Void) -> Void) {
         self.maxRetries = maxRetries
         self.executionBlock = executionBlock
     }
-    
+
     override func start() {
         if isCancelled {
             isFinished = true
             return
         }
-        
+
         isExecuting = true
         execute()
     }
-    
+
     private func execute() {
         executionBlock(self) { [weak self] in
             self?.handleResult($0)
         }
     }
-    
+
     private func handleResult(_ output: Output) {
         let shouldRetry = output == .retry && canRetry
         guard shouldRetry else {
@@ -46,11 +46,11 @@ class AsyncOperation: BaseOperation {
             isFinished = true
             return
         }
-        
+
         executedRetries += 1
         execute()
     }
-    
+
     func resetRetries() {
         executedRetries = 0
     }

--- a/Sources/StreamChat/Utils/Operations/AsyncOperation.swift
+++ b/Sources/StreamChat/Utils/Operations/AsyncOperation.swift
@@ -56,6 +56,8 @@ class AsyncOperation: BaseOperation {
     }
 }
 
+class UnmanagedAsyncOperation: AsyncOperation {}
+
 class BaseOperation: Operation {
     private var _finished = false
     private var _executing = false

--- a/StreamChatUITestsApp/ViewController.swift
+++ b/StreamChatUITestsApp/ViewController.swift
@@ -26,6 +26,7 @@ final class ViewController: UIViewController {
         stackView.distribution = .fillProportionally
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.addArrangedSubview(createStartButton())
+        stackView.addArrangedSubview(createConnectGuestButton())
         view.addSubview(stackView)
         NSLayoutConstraint.activate([
             stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
@@ -37,6 +38,13 @@ final class ViewController: UIViewController {
         // Setup chat client
         streamChat.setUpChat()
         streamChat.connectUser(completion: { _ in })
+        showChannelList()
+    }
+
+    @objc func didTapConnectGuest() {
+        // Setup chat client
+        streamChat.setUpChat()
+        streamChat.connectGuestUser(completion: { _ in })
         showChannelList()
     }
 
@@ -163,6 +171,15 @@ extension ViewController {
         return startButton
     }
 
+    func createConnectGuestButton() -> UIButton {
+        let startButton = UIButton(type: .system)
+        startButton.translatesAutoresizingMaskIntoConstraints = false
+        startButton.setTitle("Connect Guest", for: .normal)
+        startButton.accessibilityIdentifier = "TestApp.ConnectGuest"
+        startButton.addTarget(self, action: #selector(didTapConnectGuest), for: .touchUpInside)
+        return startButton
+    }
+
     func createDebugButton() -> UIBarButtonItem {
         let item = UIBarButtonItem(
             image: UIImage(named: "pencil")!,
@@ -183,6 +200,15 @@ extension StreamChatWrapper {
         client?.connectUser(
             userInfo: userCredentials.userInfo,
             tokenProvider: tokenProvider,
+            completion: completion
+        )
+    }
+
+    func connectGuestUser(completion: @escaping (Error?) -> Void) {
+        let userCredentials = UserCredentials.default
+        let tokenProvider = mockTokenProvider(for: userCredentials)
+        client?.connectGuestUser(
+            userInfo: userCredentials.userInfo,
             completion: completion
         )
     }

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
@@ -27,9 +27,8 @@ final class APIClient_Spy: APIClient, Spy {
     /// The last endpoint `unmanagedRequest` function was called with.
     @Atomic private var unmanagedRequest_result: Any?
     @Atomic var unmanagedRequest_endpoint: AnyEndpoint?
-    @Atomic var unmanagedRequest_operationQueue: OperationQueue?
     @Atomic var unmanagedRequest_completion: Any?
-    @Atomic var unmanagedRequest_allRecordedCalls: [(endpoint: AnyEndpoint, operationQueue: OperationQueue, completion: Any?)] = []
+    @Atomic var unmanagedRequest_allRecordedCalls: [(endpoint: AnyEndpoint, completion: Any?)] = []
 
     /// The last endpoint `uploadFile` function was called with.
     @Atomic var uploadFile_attachment: AnyChatMessageAttachment?
@@ -130,13 +129,11 @@ final class APIClient_Spy: APIClient, Spy {
 
     override func unmanagedRequest<Response>(
         endpoint: Endpoint<Response>,
-        operationQueue: OperationQueue,
         completion: @escaping (Result<Response, Error>) -> Void
     ) where Response : Decodable {
         unmanagedRequest_endpoint = AnyEndpoint(endpoint)
-        unmanagedRequest_operationQueue = operationQueue
         unmanagedRequest_completion = completion
-        _unmanagedRequest_allRecordedCalls.mutate { $0.append((unmanagedRequest_endpoint!, unmanagedRequest_operationQueue!, unmanagedRequest_completion!)) }
+        _unmanagedRequest_allRecordedCalls.mutate { $0.append((unmanagedRequest_endpoint!, unmanagedRequest_completion!)) }
         if let result = unmanagedRequest_result as? Result<Response, Error> {
             completion(result)
         }

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
@@ -24,6 +24,13 @@ final class APIClient_Spy: APIClient, Spy {
     @Atomic var recoveryRequest_completion: Any?
     @Atomic var recoveryRequest_allRecordedCalls: [(endpoint: AnyEndpoint, completion: Any?)] = []
 
+    /// The last endpoint `unmanagedRequest` function was called with.
+    @Atomic private var unmanagedRequest_result: Any?
+    @Atomic var unmanagedRequest_endpoint: AnyEndpoint?
+    @Atomic var unmanagedRequest_operationQueue: OperationQueue?
+    @Atomic var unmanagedRequest_completion: Any?
+    @Atomic var unmanagedRequest_allRecordedCalls: [(endpoint: AnyEndpoint, operationQueue: OperationQueue, completion: Any?)] = []
+
     /// The last endpoint `uploadFile` function was called with.
     @Atomic var uploadFile_attachment: AnyChatMessageAttachment?
     @Atomic var uploadFile_progress: ((Double) -> Void)?
@@ -95,6 +102,10 @@ final class APIClient_Spy: APIClient, Spy {
         request_result = responseResult
     }
 
+    func test_mockUnmanagedResponseResult<Response: Decodable>(_ responseResult: Result<Response, Error>) {
+        unmanagedRequest_result = responseResult
+    }
+
     override func request<Response>(
         endpoint: Endpoint<Response>,
         completion: @escaping (Result<Response, Error>) -> Void
@@ -115,6 +126,20 @@ final class APIClient_Spy: APIClient, Spy {
         recoveryRequest_endpoint = AnyEndpoint(endpoint)
         recoveryRequest_completion = completion
         _recoveryRequest_allRecordedCalls.mutate { $0.append((recoveryRequest_endpoint!, recoveryRequest_completion!)) }
+    }
+
+    override func unmanagedRequest<Response>(
+        endpoint: Endpoint<Response>,
+        operationQueue: OperationQueue,
+        completion: @escaping (Result<Response, Error>) -> Void
+    ) where Response : Decodable {
+        unmanagedRequest_endpoint = AnyEndpoint(endpoint)
+        unmanagedRequest_operationQueue = operationQueue
+        unmanagedRequest_completion = completion
+        _unmanagedRequest_allRecordedCalls.mutate { $0.append((unmanagedRequest_endpoint!, unmanagedRequest_operationQueue!, unmanagedRequest_completion!)) }
+        if let result = unmanagedRequest_result as? Result<Response, Error> {
+            completion(result)
+        }
     }
 
     override func uploadAttachment(

--- a/Tests/StreamChatTests/APIClient/APIClient_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/APIClient_Tests.swift
@@ -667,7 +667,7 @@ final class APIClient_Tests: XCTestCase {
         )
 
         XCTAssertEqual(operationQueue.operationCount, 1)
-        _ = try XCTUnwrap(operationQueue.operations.first as? UnmanagedAsyncOperation)
+        _ = try XCTUnwrap(operationQueue.operations.first as? AsyncOperation)
     }
 
     func test_unmanagedRequest_noRecoveryNoTokenFetching_requestSucceeds() throws {

--- a/Tests/StreamChatTests/APIClient/APIClient_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/APIClient_Tests.swift
@@ -653,6 +653,56 @@ final class APIClient_Tests: XCTestCase {
         XCTAssertEqual(totalRequests.count, 8)
         XCTAssertEqual(Set(totalRequests).count, 5)
     }
+
+    // MARK: - Unmanaged Requests
+
+    func test_unmanagedRequest_addsAnOperationOnTheProvidedOperationQueue() throws {
+        let operationQueue = OperationQueue()
+        operationQueue.isSuspended = true
+
+        apiClient.unmanagedRequest(
+            endpoint: Endpoint<TestUser>.mock(),
+            operationQueue: operationQueue,
+            completion: { _ in }
+        )
+
+        XCTAssertEqual(operationQueue.operationCount, 1)
+        _ = try XCTUnwrap(operationQueue.operations.first as? UnmanagedAsyncOperation)
+    }
+
+    func test_unmanagedRequest_noRecoveryNoTokenFetching_requestSucceeds() throws {
+        try executeUnmanagedRequestThatSucceeds()
+    }
+
+    func test_unmanagedRequest_recoveryNoTokenFetching_requestSucceeds() throws {
+        apiClient.enterRecoveryMode()
+        try executeUnmanagedRequestThatSucceeds()
+    }
+
+    func test_unmanagedRequest_recoveryAndTokenFetching_requestSucceeds() throws {
+        apiClient.enterRecoveryMode()
+        apiClient.enterTokenFetchMode()
+        try executeUnmanagedRequestThatSucceeds()
+    }
+
+    func test_unmanagedRequest_noRecoveryButInTokenFetching_requestSucceeds() throws {
+        apiClient.enterTokenFetchMode()
+        try executeUnmanagedRequestThatSucceeds()
+    }
+
+    func test_unmanagedRequest_retriesOnConnectionFailure() throws {
+        let networkError = NSError(domain: "", code: NSURLErrorNotConnectedToInternet, userInfo: nil)
+        decoder.decodeRequestResponse = .failure(networkError)
+
+        let expectation = self.expectation(description: "Request completes")
+        apiClient.unmanagedRequest(endpoint: Endpoint<TestUser>.mock(), operationQueue: .main) { _ in
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
+
+        // Retries until the maximum amount
+        XCTEnsureRequestsWereExecuted(times: 4)
+    }
 }
 
 // MARK: Helpers
@@ -676,6 +726,36 @@ extension APIClient_Tests {
             tokenRefresher: self.tokenRefresher,
             queueOfflineRequest: self.queueOfflineRequest
         )
+    }
+
+    private func executeUnmanagedRequestThatSucceeds() throws {
+        // Create a test request and set it as a response from the encoder
+        let testRequest = URLRequest(url: .unique())
+        encoder.encodeRequest = .success(testRequest)
+
+        // Set up a successful mock network response for the request
+        let mockNetworkResponseData = try JSONEncoder.stream.encode(TestUser(name: "Network Response"))
+        URLProtocol_Mock.mockResponse(request: testRequest, statusCode: 234, responseBody: mockNetworkResponseData)
+
+        // Set up a decoder response
+        // ⚠️ Watch out: the user is different there, so we can distinguish between the incoming data
+        // to the encoder, and the outgoing data).
+        let mockDecoderResponseData = TestUser(name: "Decoder Response")
+        decoder.decodeRequestResponse = .success(mockDecoderResponseData)
+
+        // Create a test endpoint (it's actually ignored, because APIClient uses the testRequest returned from the encoder)
+        let testEndpoint = Endpoint<TestUser>.mock()
+
+        // Create a request and wait for the completion block
+        let result = try waitFor { apiClient.unmanagedRequest(endpoint: testEndpoint, operationQueue: .main, completion: $0) }
+
+        // Check the incoming data to the encoder is the URLResponse and data from the network
+        XCTAssertEqual(decoder.decodeRequestResponse_data, mockNetworkResponseData)
+        XCTAssertEqual(decoder.decodeRequestResponse_response?.statusCode, 234)
+
+        // Check the outgoing data from the encoder is the result data
+        AssertResultSuccess(result, mockDecoderResponseData)
+        XCTEnsureRequestsWereExecuted(times: 1)
     }
 
     // MARK: - Helpers

--- a/Tests/StreamChatTests/APIClient/APIClient_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/APIClient_Tests.swift
@@ -656,20 +656,6 @@ final class APIClient_Tests: XCTestCase {
 
     // MARK: - Unmanaged Requests
 
-    func test_unmanagedRequest_addsAnOperationOnTheProvidedOperationQueue() throws {
-        let operationQueue = OperationQueue()
-        operationQueue.isSuspended = true
-
-        apiClient.unmanagedRequest(
-            endpoint: Endpoint<TestUser>.mock(),
-            operationQueue: operationQueue,
-            completion: { _ in }
-        )
-
-        XCTAssertEqual(operationQueue.operationCount, 1)
-        _ = try XCTUnwrap(operationQueue.operations.first as? AsyncOperation)
-    }
-
     func test_unmanagedRequest_noRecoveryNoTokenFetching_requestSucceeds() throws {
         try executeUnmanagedRequestThatSucceeds()
     }
@@ -695,7 +681,7 @@ final class APIClient_Tests: XCTestCase {
         decoder.decodeRequestResponse = .failure(networkError)
 
         let expectation = self.expectation(description: "Request completes")
-        apiClient.unmanagedRequest(endpoint: Endpoint<TestUser>.mock(), operationQueue: .main) { _ in
+        apiClient.unmanagedRequest(endpoint: Endpoint<TestUser>.mock()) { _ in
             expectation.fulfill()
         }
         waitForExpectations(timeout: defaultTimeout, handler: nil)
@@ -747,7 +733,7 @@ extension APIClient_Tests {
         let testEndpoint = Endpoint<TestUser>.mock()
 
         // Create a request and wait for the completion block
-        let result = try waitFor { apiClient.unmanagedRequest(endpoint: testEndpoint, operationQueue: .main, completion: $0) }
+        let result = try waitFor { apiClient.unmanagedRequest(endpoint: testEndpoint, completion: $0) }
 
         // Check the incoming data to the encoder is the URLResponse and data from the network
         XCTAssertEqual(decoder.decodeRequestResponse_data, mockNetworkResponseData)

--- a/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
@@ -570,7 +570,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
 
         // Token Provider Failure
         let apiError = TestError()
-        apiClient.test_mockResponseResult(Result<GuestUserTokenPayload, Error>.failure(apiError))
+        apiClient.test_mockUnmanagedResponseResult(Result<GuestUserTokenPayload, Error>.failure(apiError))
 
         let completionExpectation = expectation(description: "Connect completion")
         var receivedError: Error?
@@ -585,7 +585,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         waitForExpectations(timeout: defaultTimeout)
         XCTAssertNil(repository.currentToken)
         XCTAssertEqual(receivedError, apiError)
-        let request = try XCTUnwrap(apiClient.request_endpoint)
+        let request = try XCTUnwrap(apiClient.unmanagedRequest_endpoint)
         XCTAssertEqual(request.path, .guest)
         XCTAssertNotCall(ConnectionRepository_Mock.Signature.connect, on: connectionRepository)
         XCTAssertNotCall(ConnectionRepository_Mock.Signature.forceConnectionInactiveMode, on: connectionRepository)
@@ -602,7 +602,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         connectionRepository.connectResult = .failure(testError)
 
         // API Result
-        apiClient.test_mockResponseResult(
+        apiClient.test_mockUnmanagedResponseResult(
             Result<GuestUserTokenPayload, Error>.success(GuestUserTokenPayload(
                 user: CurrentUserPayload.dummy(userId: "", role: .user),
                 token: apiToken
@@ -622,7 +622,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertNotNil(repository.tokenProvider)
         waitForExpectations(timeout: defaultTimeout)
         XCTAssertEqual(repository.currentToken, apiToken)
-        let request = try XCTUnwrap(apiClient.request_endpoint)
+        let request = try XCTUnwrap(apiClient.unmanagedRequest_endpoint)
         XCTAssertEqual(request.path, .guest)
         XCTAssertEqual(connectionRepository.updateWebSocketEndpointToken, apiToken)
         XCTAssertEqual(connectionRepository.updateWebSocketEndpointUserInfo, userInfo)
@@ -641,7 +641,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         connectionRepository.connectResult = .success(())
 
         // API Result
-        apiClient.test_mockResponseResult(
+        apiClient.test_mockUnmanagedResponseResult(
             Result<GuestUserTokenPayload, Error>.success(GuestUserTokenPayload(
                 user: CurrentUserPayload.dummy(userId: "", role: .user),
                 token: apiToken
@@ -661,7 +661,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertNotNil(repository.tokenProvider)
         waitForExpectations(timeout: defaultTimeout)
         XCTAssertEqual(repository.currentToken, apiToken)
-        let request = try XCTUnwrap(apiClient.request_endpoint)
+        let request = try XCTUnwrap(apiClient.unmanagedRequest_endpoint)
         XCTAssertEqual(request.path, .guest)
         XCTAssertEqual(connectionRepository.updateWebSocketEndpointToken, apiToken)
         XCTAssertEqual(connectionRepository.updateWebSocketEndpointUserInfo, userInfo)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/389

### 🎯 Goal

Fix the Guest authentication

### 📝 Summary

Since the SDK version 4.25.0 the Guest Authentication was failing. This PR resolves the underlying issue and ensures Guest Authentication works again as expected.

### 🛠 Implementation

During Guest Authentication, the APIClient's operationQueue is getting suspended as it enters tokenFetching mode. Then we using APIClient to fetch the Guest Authentication Token. The request never gets executed due to the suspended operationQueue.

To overcome the issue but also provide a mechanism for similar use-cases, we are introducing a new request/operation combination on APIClient. The new request will be translated to an AsyncOperation which will be added for execution to user-provided operationQueue. The APIClient will not be responsible for the execution of the new UnmanagedOperation.

### 🧪 Manual Testing Notes

From the DemoApp, try to connect with a Guest User

### ☑️ Contributor Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [X] Changelog is updated with client-facing changes
- [X] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
