### PR TITLE
Safer `connectUser()` by logging out the user first if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix crash when accessing FetchCache with an unexecuted NSFetchRequest [#2572](https://github.com/GetStream/stream-chat-swift/pull/2572)
 - Fix an issue which was blocking a Guest Authentication operation to retrieve a connection token [#2574](https://github.com/GetStream/stream-chat-swift/pull/2574)
 - Make connect/disconnect safer when network is offline [#2571](https://github.com/GetStream/stream-chat-swift/pull/2571)
+- Make connect by logging out the user first if needed [#2577](https://github.com/GetStream/stream-chat-swift/pull/2577)
 
 ## StreamChatUI
 ### ✅ Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix crash when accessing FetchCache with an unexecuted NSFetchRequest [#2572](https://github.com/GetStream/stream-chat-swift/pull/2572)
 - Fix an issue which was blocking a Guest Authentication operation to retrieve a connection token [#2574](https://github.com/GetStream/stream-chat-swift/pull/2574)
 - Make connect/disconnect safer when network is offline [#2571](https://github.com/GetStream/stream-chat-swift/pull/2571)
-- Make connect by logging out the user first if needed [#2577](https://github.com/GetStream/stream-chat-swift/pull/2577)
+- Make connect safer by logging out the user first if needed [#2577](https://github.com/GetStream/stream-chat-swift/pull/2577)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -473,21 +473,8 @@ public class ChatClient {
 }
 
 extension ChatClient: AuthenticationRepositoryDelegate {
-    /// Clears state related to the current user to leave the client ready for another user
-    /// Will clear:
-    ///     - Background workers
-    ///     - References to active controllers
-    ///     - Database
-    /// - Parameter completion: A block to be executed when the process is completed. Contains an error if something went wrong
-    func clearCurrentUserData(completion: @escaping (Error?) -> Void) {
-        createBackgroundWorkers()
-
-        // Stop tracking active components
-        activeChannelControllers.removeAllObjects()
-        activeChannelListControllers.removeAllObjects()
-
-        // Reset all existing local data.
-        databaseContainer.removeAllData(force: true, completion: completion)
+    func logoutUser(completion: @escaping () -> Void) {
+        logout(completion: completion)
     }
 
     func didFinishSettingUpAuthenticationEnvironment(for state: EnvironmentState) {

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -403,6 +403,10 @@ public class ChatClient {
     public func logout(completion: @escaping () -> Void) {
         authenticationRepository.logOutUser()
 
+        // Stop tracking active components
+        activeChannelControllers.removeAllObjects()
+        activeChannelListControllers.removeAllObjects()
+
         let group = DispatchGroup()
         group.enter()
         disconnect {

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -369,9 +369,7 @@ public class ChatClient {
     /// Connects anonymous user
     /// - Parameter completion: The completion that will be called once the **first** user session for the given token is setup.
     public func connectAnonymousUser(completion: ((Error?) -> Void)? = nil) {
-        authenticationRepository.connectUser(
-            userInfo: nil,
-            tokenProvider: { $0(.success(.anonymous)) },
+        authenticationRepository.connectAnonymousUser(
             completion: { completion?($0) }
         )
     }
@@ -477,7 +475,7 @@ public class ChatClient {
 }
 
 extension ChatClient: AuthenticationRepositoryDelegate {
-    func logoutUser(completion: @escaping () -> Void) {
+    func logOutUser(completion: @escaping () -> Void) {
         logout(completion: completion)
     }
 

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -11,7 +11,7 @@ enum EnvironmentState {
     case newToken
     case newUser
 
-    init(currentUserId: UserId?, newUserId: UserId?) {
+    init(currentUserId: UserId?, newUserId: UserId) {
         if currentUserId == nil {
             self = .firstConnection
         } else if currentUserId == newUserId {

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -307,6 +307,9 @@ class AuthenticationRepository {
 
         let onTokenReceived: (Token) -> Void = { [weak self, weak connectionRepository] token in
             self?.prepareEnvironment(userInfo: userInfo, newToken: token)
+            // We manually change the `connectionStatus` for passive client
+            // to `disconnected` when environment was prepared correctly
+            // (e.g. current user session is successfully restored).
             connectionRepository?.forceConnectionStatusForInactiveModeIfNeeded()
             connectionRepository?.connect(userInfo: userInfo, completion: onCompletion)
         }

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -10,11 +10,25 @@ enum EnvironmentState {
     case firstConnection
     case newToken
     case newUser
+
+    init(currentUserId: UserId?, newUserId: UserId?) {
+        if currentUserId == nil {
+            self = .firstConnection
+            return
+        }
+        
+        if currentUserId == newUserId {
+            self = .newToken
+            return
+        }
+
+        self = .newUser
+    }
 }
 
 protocol AuthenticationRepositoryDelegate: AnyObject {
     func didFinishSettingUpAuthenticationEnvironment(for state: EnvironmentState)
-    func clearCurrentUserData(completion: @escaping (Error?) -> Void)
+    func logoutUser(completion: @escaping () -> Void)
 }
 
 class AuthenticationRepository {
@@ -135,8 +149,23 @@ class AuthenticationRepository {
     ///   - userInfo:       The user information that will be created OR updated if it exists.
     ///   - tokenProvider:  The block to be used to get a token.
     func connectUser(userInfo: UserInfo?, tokenProvider: @escaping TokenProvider, completion: @escaping (Error?) -> Void) {
-        self.tokenProvider = tokenProvider
-        scheduleTokenFetch(isRetry: false, userInfo: userInfo, tokenProvider: tokenProvider, completion: completion)
+        log.assert(delegate != nil, "Delegate should not be nil at this point")
+
+        let handleTokenFetch = { [weak self] in
+            self?.tokenProvider = tokenProvider
+            self?.scheduleTokenFetch(isRetry: false, userInfo: userInfo, tokenProvider: tokenProvider, completion: completion)
+        }
+
+        let state = EnvironmentState(currentUserId: currentUserId, newUserId: userInfo?.id)
+
+        switch state {
+        case .firstConnection, .newToken:
+            handleTokenFetch()
+        case .newUser:
+            delegate?.logoutUser {
+                handleTokenFetch()
+            }
+        }
     }
 
     /// Establishes a connection for a guest user.
@@ -176,17 +205,12 @@ class AuthenticationRepository {
 
     func prepareEnvironment(
         userInfo: UserInfo?,
-        newToken: Token,
-        completion: @escaping (Error?) -> Void
+        newToken: Token
     ) {
-        let state: EnvironmentState
-        if currentUserId == nil {
-            state = .firstConnection
-        } else if newToken.userId == currentUserId {
-            state = .newToken
-        } else {
-            state = .newUser
-        }
+        let state = EnvironmentState(
+            currentUserId: currentUserId,
+            newUserId: newToken.userId
+        )
 
         log.assert(delegate != nil, "Delegate should not be nil at this point")
 
@@ -195,23 +219,11 @@ class AuthenticationRepository {
             connectionRepository.updateWebSocketEndpoint(with: newToken, userInfo: userInfo)
             setToken(token: newToken, completeTokenWaiters: true)
             delegate?.didFinishSettingUpAuthenticationEnvironment(for: state)
-            completion(nil)
 
         case .newUser:
             completeTokenWaiters(token: nil)
             setToken(token: newToken, completeTokenWaiters: false)
             delegate?.didFinishSettingUpAuthenticationEnvironment(for: state)
-
-            // Setting a new connection is not possible in connectionless mode.
-            guard connectionRepository.isClientInActiveMode else {
-                completion(ClientError.ClientIsNotInActiveMode())
-                return
-            }
-
-            connectionRepository.disconnect(source: .userInitiated) { [weak delegate, weak connectionRepository] in
-                connectionRepository?.updateWebSocketEndpoint(with: newToken, userInfo: userInfo)
-                delegate?.clearCurrentUserData(completion: completion)
-            }
         }
     }
 
@@ -294,19 +306,9 @@ class AuthenticationRepository {
         }
 
         let onTokenReceived: (Token) -> Void = { [weak self, weak connectionRepository] token in
-            self?.prepareEnvironment(userInfo: userInfo, newToken: token) { error in
-                // Errors thrown during `prepareEnvironment` cannot be recovered
-                if let error = error {
-                    onCompletion(error)
-                    return
-                }
-
-                // We manually change the `connectionStatus` for passive client
-                // to `disconnected` when environment was prepared correctly
-                // (e.g. current user session is successfully restored).
-                connectionRepository?.forceConnectionStatusForInactiveModeIfNeeded()
-                connectionRepository?.connect(userInfo: userInfo, completion: onCompletion)
-            }
+            self?.prepareEnvironment(userInfo: userInfo, newToken: token)
+            connectionRepository?.forceConnectionStatusForInactiveModeIfNeeded()
+            connectionRepository?.connect(userInfo: userInfo, completion: onCompletion)
         }
 
         let retryFetchIfPossible: (Error?) -> Void = { [weak self] error in

--- a/StreamChatUITestsApp/ViewController.swift
+++ b/StreamChatUITestsApp/ViewController.swift
@@ -205,10 +205,8 @@ extension StreamChatWrapper {
     }
 
     func connectGuestUser(completion: @escaping (Error?) -> Void) {
-        let userCredentials = UserCredentials.default
-        let tokenProvider = mockTokenProvider(for: userCredentials)
         client?.connectGuestUser(
-            userInfo: userCredentials.userInfo,
+            userInfo: .init(id: "123"),
             completion: completion
         )
     }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/AuthenticationRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/AuthenticationRepository_Mock.swift
@@ -10,6 +10,7 @@ class AuthenticationRepository_Mock: AuthenticationRepository, Spy {
     enum Signature {
         static let connectTokenProvider = "connectUser(userInfo:tokenProvider:completion:)"
         static let connectGuest = "connectGuestUser(userInfo:completion:)"
+        static let connectAnon = "connectAnonymousUser(completion:)"
         static let refreshToken = "refreshToken(completion:)"
         static let clearTokenProvider = "clearTokenProvider()"
         static let logOut = "logOutUser()"
@@ -24,6 +25,7 @@ class AuthenticationRepository_Mock: AuthenticationRepository, Spy {
 
     var connectUserResult: Result<Void, Error>?
     var connectGuestResult: Result<Void, Error>?
+    var connectAnonResult: Result<Void, Error>?
     var refreshTokenResult: Result<Void, Error>?
     var completeWaitersToken: Token?
 
@@ -69,6 +71,13 @@ class AuthenticationRepository_Mock: AuthenticationRepository, Spy {
     override func connectGuestUser(userInfo: UserInfo, completion: @escaping (Error?) -> Void) {
         record()
         if let result = connectGuestResult {
+            completion(result.error)
+        }
+    }
+
+    override func connectAnonymousUser(completion: @escaping (Error?) -> Void) {
+        record()
+        if let result = connectAnonResult {
             completion(result.error)
         }
     }

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/Logger_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/Logger_Spy.swift
@@ -8,6 +8,7 @@ import Foundation
 final class Logger_Spy: Logger, Spy {
     var originalLogger: Logger?
     var recordedFunctions: [String] = []
+    var failedAsserts: Int = 0
 
     func injectMock() {
         let logger = LogConfig.logger
@@ -39,6 +40,7 @@ final class Logger_Spy: Logger, Spy {
         lineNumber: UInt = #line
     ) {
         record()
+        failedAsserts += condition() ? 0 : 1
     }
 
     override func assertionFailure(
@@ -49,5 +51,6 @@ final class Logger_Spy: Logger, Spy {
         lineNumber: UInt = #line
     ) {
         record()
+        failedAsserts += 1
     }
 }

--- a/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
@@ -352,7 +352,6 @@ final class AuthenticationRepository_Tests: XCTestCase {
     }
 
     func test_connectUser_clearsTokenCompletionsQueueAfterSuccess() throws {
-        let userInfo = UserInfo(id: "123")
         XCTAssertNil(repository.tokenProvider)
 
         let delegate = AuthenticationRepositoryDelegateMock()
@@ -363,7 +362,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
 
         // First user
         var initialCompletionCalls = 0
-
+        let userInfo = UserInfo(id: "123")
         let originalTokenProvider: TokenProvider = { $0(.success(.unique())) }
         let expectation1 = expectation(description: "Completion call 1")
         repository.connectUser(userInfo: userInfo, tokenProvider: originalTokenProvider, completion: { _ in
@@ -380,6 +379,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
 
         // New token/user
         let newUserId = "user-id"
+        let newUserInfo = UserInfo(id: newUserId)
         var newTokenCompletionCalls = 0
         let expectation2 = expectation(description: "Completion call 2")
         let newTokenProvider: TokenProvider = { $0(.success(.unique(userId: newUserId))) }
@@ -400,7 +400,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         var refreshTokenCompletionCalls = 0
         let expectation3 = expectation(description: "Completion call 2")
         let refreshTokenProvider: TokenProvider = { $0(.success(.unique(userId: newUserId))) }
-        repository.connectUser(userInfo: userInfo, tokenProvider: refreshTokenProvider, completion: { _ in
+        repository.connectUser(userInfo: newUserInfo, tokenProvider: refreshTokenProvider, completion: { _ in
             refreshTokenCompletionCalls += 1
             expectation3.fulfill()
         })
@@ -412,7 +412,7 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertEqual(refreshTokenCompletionCalls, 1)
         XCTAssertEqual(delegate.newStateCalls, 3)
         XCTAssertEqual(delegate.newState, .newToken)
-        XCTAssertEqual(delegate.logoutCallCount, 2)
+        XCTAssertEqual(delegate.logoutCallCount, 1)
     }
 
     // Prepare environment on a successful token retrieval

--- a/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
@@ -303,6 +303,32 @@ final class ChatClient_Tests: XCTestCase {
         XCTAssertTrue(testEnv.databaseContainer!.removeAllData_called)
     }
 
+    func test_logout_clearsActiveControllers() throws {
+        // GIVEN
+        let client = ChatClient(
+            config: inMemoryStorageConfig,
+            environment: testEnv.environment
+        )
+        let connectionRepository = try XCTUnwrap(client.connectionRepository as? ConnectionRepository_Mock)
+        connectionRepository.disconnectResult = .success(())
+        client.trackChannelController(ChannelControllerSpy())
+        client.trackChannelListController(ChatChannelListController_Mock.mock())
+
+        XCTAssertEqual(client.activeChannelControllers.count, 1)
+        XCTAssertEqual(client.activeChannelListControllers.count, 1)
+
+        // WHEN
+        let expectation = self.expectation(description: "logout completes")
+        client.logout {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: defaultTimeout)
+
+        // THEN
+        XCTAssertEqual(client.activeChannelControllers.count, 0)
+        XCTAssertEqual(client.activeChannelListControllers.count, 0)
+    }
+
     // MARK: - Background workers tests
 
     func test_productionClientIsInitalizedWithAllMandatoryBackgroundWorkers() {

--- a/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
@@ -599,7 +599,7 @@ final class ChatClient_Tests: XCTestCase {
         let authenticationRepository = try XCTUnwrap(client.authenticationRepository as? AuthenticationRepository_Mock)
         let expectation = self.expectation(description: "Connect completes")
 
-        authenticationRepository.connectUserResult = .failure(testError)
+        authenticationRepository.connectAnonResult = .failure(testError)
         var receivedError: Error?
         client.connectAnonymousUser {
             receivedError = $0
@@ -607,7 +607,7 @@ final class ChatClient_Tests: XCTestCase {
         }
         waitForExpectations(timeout: defaultTimeout)
 
-        XCTAssertCall(AuthenticationRepository_Mock.Signature.connectTokenProvider, on: authenticationRepository)
+        XCTAssertCall(AuthenticationRepository_Mock.Signature.connectAnon, on: authenticationRepository)
         XCTAssertEqual(receivedError, testError)
     }
 
@@ -616,7 +616,7 @@ final class ChatClient_Tests: XCTestCase {
         let authenticationRepository = try XCTUnwrap(client.authenticationRepository as? AuthenticationRepository_Mock)
         let expectation = self.expectation(description: "Connect completes")
 
-        authenticationRepository.connectUserResult = .success(())
+        authenticationRepository.connectAnonResult = .success(())
         var receivedError: Error?
         client.connectAnonymousUser {
             receivedError = $0
@@ -624,7 +624,7 @@ final class ChatClient_Tests: XCTestCase {
         }
         waitForExpectations(timeout: defaultTimeout)
 
-        XCTAssertCall(AuthenticationRepository_Mock.Signature.connectTokenProvider, on: authenticationRepository)
+        XCTAssertCall(AuthenticationRepository_Mock.Signature.connectAnon, on: authenticationRepository)
         XCTAssertNil(receivedError)
     }
 


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/282

### 🎯 Goal
Make the `connectUser` call safer by logging out the user in case the user was not logged out. (If the user is a new user only)

### 🛠 Implementation
The implementation is done in the `AuthenticationRepository`, which delegates the logging out functionality to the `ChatClient`. This is useful because only in the `AuthenticationRepository` we have a centralized function to connect the user, whereas if we did it directly in the `ChatClient`, we would need to implement this in multiple places. Besides that, it would be harder to test. With the current approach, we just need to mock the delegate to check if we logged out. 

![fetch2](https://user-images.githubusercontent.com/7887319/234223258-46df61d8-8ec5-4427-b24d-247c6dde7828.png)


### 🎨 Showcase

https://user-images.githubusercontent.com/12814114/233457445-29aa52a8-c685-45e4-8fb0-fc224dab4fcb.mp4

### 🧪 Manual Testing Notes
Follow the steps in the showcase. The guest user should log in successfully, even after closing the app while logged in as a guest user. (This will log out the user without calling `chatClient.logout()`)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)