### PR TITLE
Fix singular and plural form of online members in header view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix crash when accessing FetchCache with an unexecuted NSFetchRequest [#2572](https://github.com/GetStream/stream-chat-swift/pull/2572)
 - Fix an issue which was blocking a Guest Authentication operation to retrieve a connection token [#2574](https://github.com/GetStream/stream-chat-swift/pull/2574)
 - Make connect/disconnect safer when network is offline [#2571](https://github.com/GetStream/stream-chat-swift/pull/2571)
+- Fix singular and plural form of online members in `ChatChannelHeaderView`
 
 ## StreamChatUI
 ### ✅ Added

--- a/DemoApp/Resources/en.lproj/Localizable.strings
+++ b/DemoApp/Resources/en.lproj/Localizable.strings
@@ -52,7 +52,7 @@
 
 "message.title.online" = "Online";
 "message.title.offline" = "Offline";
-"message.title.group" = "%d members, %d online";
+"message.title.members.online" = "%d online";
 
 "message.moderation.title" = "This message has been moderated";
 "message.moderation.message" = "Please select any of the following options to proceed";

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelHeaderView.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelHeaderView.swift
@@ -90,7 +90,7 @@ open class ChatChannelHeaderView: _View,
             }
         }
 
-        return L10n.Message.Title.group(channel.memberCount, channel.watcherCount)
+        return "\(L10n.Message.Title.Members.count(channel.memberCount)), \(L10n.Message.Title.Members.online(channel.watcherCount))"
     }
 
     /// Create the timer to repeatedly update the online status of the members.

--- a/Sources/StreamChatUI/Generated/L10n.swift
+++ b/Sources/StreamChatUI/Generated/L10n.swift
@@ -225,14 +225,20 @@ internal enum L10n {
       }
     }
     internal enum Title {
-      /// %d members, %d online
-      internal static func group(_ p1: Int, _ p2: Int) -> String {
-        return L10n.tr("Localizable", "message.title.group", p1, p2)
-      }
       /// Offline
       internal static var offline: String { L10n.tr("Localizable", "message.title.offline") }
       /// Online
       internal static var online: String { L10n.tr("Localizable", "message.title.online") }
+      internal enum Members {
+        /// Plural format key: "%#@members@"
+        internal static func count(_ p1: Int) -> String {
+          return L10n.tr("Localizable", "message.title.members.count", p1)
+        }
+        /// %d online
+        internal static func online(_ p1: Int) -> String {
+          return L10n.tr("Localizable", "message.title.members.online", p1)
+        }
+      }
     }
     internal enum Unread {
       /// Plural format key: "%#@unread@"

--- a/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
@@ -63,7 +63,7 @@
 
 "message.title.online" = "Online";
 "message.title.offline" = "Offline";
-"message.title.group" = "%d members, %d online";
+"message.title.members.online" = "%d online";
 
 "message.moderation.title" = "This message has been moderated";
 "message.moderation.message" = "Please select any of the following options to proceed";

--- a/Sources/StreamChatUI/Resources/en.lproj/Localizable.stringsdict
+++ b/Sources/StreamChatUI/Resources/en.lproj/Localizable.stringsdict
@@ -2,6 +2,24 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>message.title.members.count</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@members@</string>
+		<key>members</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>no members</string>
+			<key>one</key>
+			<string>1 member</string>
+			<key>other</key>
+			<string>%d members</string>
+		</dict>
+	</dict>
 	<key>messageList.typingIndicator.users</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Tests/StreamChatUITests/SnapshotTests/CommonViews/ChatChannelHeaderView/ChatChannelHeaderView_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/CommonViews/ChatChannelHeaderView/ChatChannelHeaderView_Tests.swift
@@ -95,6 +95,34 @@ final class ChatChannelHeaderView_Tests: XCTestCase {
         XCTAssertEqual(subtitleText, expectedSubtitleText)
     }
 
+    func test_isNotDirectMessageChannel_OneMemberOnline_SubtitleText_containsSingularMemberCount() {
+        // GIVEN
+        let expectedSubtitleText = "\(L10n.Message.Title.Members.count(1)), \(L10n.Message.Title.Members.online(1))"
+        let mockChannel: ChatChannel = .mockNonDMChannel(watcherCount: 1, memberCount: 1)
+        mockChannelController.channel_mock = mockChannel
+        sut.setUpLayout()
+
+        // WHEN
+        let subtitleText = sut.subtitleText
+
+        // THEN
+        XCTAssertEqual(subtitleText, expectedSubtitleText)
+    }
+
+    func test_isNotDirectMessageChannel_MultipleMembersOnline_SubtitleText_containsPluralMemberCount() {
+        // GIVEN
+        let expectedSubtitleText = "\(L10n.Message.Title.Members.count(2)), \(L10n.Message.Title.Members.online(2))"
+        let mockChannel: ChatChannel = .mockNonDMChannel(watcherCount: 2, memberCount: 2)
+        mockChannelController.channel_mock = mockChannel
+        sut.setUpLayout()
+
+        // WHEN
+        let subtitleText = sut.subtitleText
+
+        // THEN
+        XCTAssertEqual(subtitleText, expectedSubtitleText)
+    }
+
     func test_channelNameSet() {
         let newChannelName = "New Channel Name"
 

--- a/Tests/StreamChatUITests/en.lproj/TestLocalizable.strings
+++ b/Tests/StreamChatUITests/en.lproj/TestLocalizable.strings
@@ -50,7 +50,7 @@
 
 "message.title.online" = "Online";
 "message.title.offline" = "Offline";
-"message.title.group" = "%d members, %d online";
+"message.title.members.online" = "%d online";
 
 "message.moderation.title" = "This message has been moderated";
 "message.moderation.message" = "Please select any of the following options to proceed";


### PR DESCRIPTION
### 🎯 Goal

The goal of this pull-request is to update the label for the members list count to correctly display singular and plural forms based on the number of members in the channel.

### 🛠 Implementation

To achieve this goal, the static locale was replaced with a locale dictionary that supports plural forms. This allows the label to display correctly regardless of the number of members in the channel.

### 🎨 Showcase

The following table demonstrates the updated label for both singular and plural forms:

| Singular | Plural |
| ------ | ----- |
| <img width="565" alt="Screenshot 2023-04-21 at 11 46 19" src="https://user-images.githubusercontent.com/5214134/233638687-f11ada1e-b254-4760-9f88-7917e1435218.png"> |  <img width="565" alt="Screenshot 2023-04-21 at 11 46 00" src="https://user-images.githubusercontent.com/5214134/233638737-ec573058-bbbc-44a8-9965-a22bb942aa61.png"> |

### 🧪 Manual Testing Notes

To test the updated label:
- Open a non-DM channel with one member and verify that the label displays as "1 member".
- Open a non-DM channel with multiple members and verify that the label displays as "X members", where X is the total number of members.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)