### PR TITLE
Fix InputTextView not scrolling to caret when pasting long text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
-### 🔄 Changed
 
 ## StreamChat
 ### 🐞 Fixed
 - Fix "to-many key not allowed here" error when using the `memberName` filter [#2604](https://github.com/GetStream/stream-chat-swift/pull/2604)
+
+## StreamChatUI
+### 🐞 Fixed
+- Fix InputTextView not scrolling to caret when pasting long text [#2609](https://github.com/GetStream/stream-chat-swift/pull/2609)
 
 # [4.31.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.31.0)
 _April 25, 2023_

--- a/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
+++ b/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
@@ -172,5 +172,13 @@ open class InputTextView: UITextView, AppearanceProvider {
             // so we must call this function
             setTextViewHeight()
         }
+
+        // When pasting text, we should scroll to the bottom, so that if the text
+        // is very long, it correctly scrolls to the input caret.
+        if let pasteboardText = UIPasteboard.general.string {
+            let padding = directionalLayoutMargins.leading
+            let bottomOffset = contentSize.height - padding
+            setContentOffset(.init(x: 0, y: contentSize.height - padding), animated: true)
+        }
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links
https://github.com/GetStream/stream-chat-swift/issues/2590

### 🎯 Goal
Fix InputTextView not scrolling to caret when pasting long text

### 🎨 Showcase

https://github.com/GetStream/stream-chat-swift/assets/12814114/e91f2cff-1840-473b-b8a2-942af211de38

### 🧪 Manual Testing Notes
This is a small issue with low impact, so there is a need for Manual QA or Automated tests. 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
