### PR TITLE
Fix memory leak in ChannelListController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fix "to-many key not allowed here" error when using the `memberName` filter [#2604](https://github.com/GetStream/stream-chat-swift/pull/2604)
+- Fix memory leak in `ChannelListController` when loading more channels [#2624](https://github.com/GetStream/stream-chat-swift/pull/2624)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -167,15 +167,15 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
         let limit = query.pagination.pageSize
         worker.update(
             channelListQuery: query
-        ) { result in
+        ) { [weak self] result in
             switch result {
             case let .success(channels):
-                self.state = .remoteDataFetched
-                self.hasLoadedAllPreviousChannels = channels.count < limit
-                self.callback { completion?(nil) }
+                self?.state = .remoteDataFetched
+                self?.hasLoadedAllPreviousChannels = channels.count < limit
+                self?.callback { completion?(nil) }
             case let .failure(error):
-                self.state = .remoteDataFetchFailed(ClientError(with: error))
-                self.callback { completion?(error) }
+                self?.state = .remoteDataFetchFailed(ClientError(with: error))
+                self?.callback { completion?(error) }
             }
         }
     }

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -133,12 +133,17 @@ final class ChannelListController_Tests: XCTestCase {
         controller.callbackQueue = .testQueue(withId: queueId)
 
         // Simulate `synchronize` calls and catch the completion
-        var completionCalled = false
+        let exp = expectation(description: "sync call should complete")
         controller.synchronize { error in
             XCTAssertNil(error)
             AssertTestQueue(withId: queueId)
-            completionCalled = true
+            exp.fulfill()
         }
+
+        // Simulate successful update
+        env.channelListUpdater?.update_completion?(.success([]))
+
+        waitForExpectations(timeout: defaultTimeout)
 
         // Keep a weak ref so we can check if it's actually deallocated
         weak var weakController = controller
@@ -149,16 +154,7 @@ final class ChannelListController_Tests: XCTestCase {
 
         // Assert the updater is called with the query
         XCTAssertEqual(env.channelListUpdater!.update_queries.first?.filter.filterHash, query.filter.filterHash)
-        // Completion shouldn't be called yet
-        XCTAssertFalse(completionCalled)
 
-        // Simulate successful update
-        env.channelListUpdater?.update_completion?(.success([]))
-        // Release reference of completion so we can deallocate stuff
-        env.channelListUpdater?.update_completion = nil
-
-        // Completion should be called
-        AssertAsync.willBeTrue(completionCalled)
         // `weakController` should be deallocated too
         AssertAsync.canBeReleased(&weakController)
     }
@@ -171,12 +167,17 @@ final class ChannelListController_Tests: XCTestCase {
         controller.callbackQueue = .testQueue(withId: queueId)
 
         // Simulate `synchronize` calls and catch the completion
-        var completionCalled = false
+        let exp = expectation(description: "sync call should complete")
         controller.synchronize { error in
             XCTAssertNil(error)
             AssertTestQueue(withId: queueId)
-            completionCalled = true
+            exp.fulfill()
         }
+
+        // Simulate successful update
+        env.channelListUpdater?.update_completion?(.success([]))
+
+        waitForExpectations(timeout: defaultTimeout)
 
         // Keep a weak ref so we can check if it's actually deallocated
         weak var weakController = controller
@@ -185,18 +186,6 @@ final class ChannelListController_Tests: XCTestCase {
         // by not keeping any references to it
         controller = nil
 
-        // Assert the updater is called with the correct pageSize
-        XCTAssertEqual(env.channelListUpdater!.update_queries.first?.pagination.pageSize, pageSize)
-        // Completion shouldn't be called yet
-        XCTAssertFalse(completionCalled)
-
-        // Simulate successful update
-        env.channelListUpdater!.update_completion?(.success([]))
-        // Release reference of completion so we can deallocate stuff
-        env.channelListUpdater!.update_completion = nil
-
-        // Completion should be called
-        AssertAsync.willBeTrue(completionCalled)
         // `weakController` should be deallocated too
         AssertAsync.canBeReleased(&weakController)
     }
@@ -206,12 +195,17 @@ final class ChannelListController_Tests: XCTestCase {
         controller.callbackQueue = .testQueue(withId: queueId)
 
         // Simulate `synchronize` calls and catch the completion
-        var completionCalled = false
+        let exp = expectation(description: "sync call should complete")
         controller.synchronize { error in
             XCTAssertNil(error)
             AssertTestQueue(withId: queueId)
-            completionCalled = true
+            exp.fulfill()
         }
+
+        // Simulate successful update
+        env.channelListUpdater?.update_completion?(.success([]))
+
+        waitForExpectations(timeout: defaultTimeout)
 
         // Keep a weak ref so we can check if it's actually deallocated
         weak var weakController = controller
@@ -222,16 +216,7 @@ final class ChannelListController_Tests: XCTestCase {
 
         // Assert the updater is called with the query
         XCTAssertEqual(env.channelListUpdater?.update_queries.first?.filter.filterHash, query.filter.filterHash)
-        // Completion shouldn't be called yet
-        XCTAssertFalse(completionCalled)
 
-        // Simulate successful update
-        env.channelListUpdater?.update_completion?(.success([]))
-        // Release reference of completion so we can deallocate stuff
-        env.channelListUpdater?.update_completion = nil
-
-        // Completion should be called
-        AssertAsync.willBeTrue(completionCalled)
         // `weakController` should be deallocated too
         AssertAsync.canBeReleased(&weakController)
     }


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/420

### 🎯 Goal
Fix a memory leak when loading more channels in `ChatChannelListController` caused strongly capturing self when calling the `ChannelListUpdater.update` completion block. This memory leak was recently introduced because of `AsyncOperation` retaining the completion blocks of the updaters. 

### 🧪 Manual Testing Notes
Tests were changed to make sure there are no regressions in this memory leak.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
