### PR TITLE
Add replace query function in the Channel List + Fix muted channels query displaying empty data

### DIFF
--- a/DemoApp/Extensions/UIViewController+Alert.swift
+++ b/DemoApp/Extensions/UIViewController+Alert.swift
@@ -63,12 +63,13 @@ extension UIViewController {
         title: String?,
         message: String? = nil,
         actions: [UIAlertAction],
-        cancelHandler: (() -> Void)? = nil
+        cancelHandler: (() -> Void)? = nil,
+        preferredStyle: UIAlertController.Style = .alert
     ) {
         let alert = UIAlertController(
             title: title,
             message: message,
-            preferredStyle: .alert
+            preferredStyle: preferredStyle
         )
 
         actions.forEach { alert.addAction($0) }

--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -419,19 +419,4 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
             }
         }
     }
-
-    func showHiddenChannels() {
-        let client = rootViewController.controller.client
-
-        let vc = HiddenChannelListVC()
-        vc.router = self
-        vc.controller = client.channelListController(
-            query: .init(filter: .and([
-                .containMembers(userIds: [client.currentUserId!]),
-                .equal(.hidden, to: true)
-            ]))
-        )
-
-        rootNavigationController?.pushViewController(vc, animated: true)
-    }
 }

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -118,7 +118,16 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
 
     /// Filter for checking whether current user has muted the channel
     /// Supported operators: `equal`
-    static var muted: FilterKey<Scope, Bool> { .init(rawValue: "muted", keyPathString: #keyPath(ChannelDTO.mute)) }
+    static var muted: FilterKey<Scope, Bool> { .init(
+        rawValue: "muted",
+        keyPathString: #keyPath(ChannelDTO.mute),
+        predicateMapper: { muted in
+            if muted {
+                return NSPredicate(format: "mute != nil")
+            }
+            return NSPredicate(format: "mute == nil")
+        }
+    ) }
 
     /// Filter for checking the status of the invite
     /// Supported operators: `equal`

--- a/Sources/StreamChat/Query/Filter+ChatChannel.swift
+++ b/Sources/StreamChat/Query/Filter+ChatChannel.swift
@@ -46,6 +46,10 @@ extension Filter where Scope == ChannelListFilterScope {
             return nil
         }
 
+        if let overridePredicate = predicateMapper?(mappedValue) {
+            return overridePredicate
+        }
+
         switch op {
         case .equal, .notEqual, .greater, .greaterOrEqual, .less, .lessOrEqual:
             return comparingPredicate(op)

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -214,6 +214,25 @@ open class ChatChannelListVC: _ViewController,
         chatChannelListLoadingView.updateContent()
     }
 
+    /// Replaces the channel list query and loads the new data.
+    ///
+    /// - Parameter query: The new channel list query.
+    public func replaceQuery(_ query: ChannelListQuery) {
+        let newController = controller.client.channelListController(
+            query: query
+        )
+        replaceChannelListController(newController)
+    }
+
+    /// Replaces the channel list controller and loads the new data.
+    /// - Parameter controller: The new channel list controller.
+    public func replaceChannelListController(_ controller: ChatChannelListController) {
+        self.controller = controller
+        self.controller.delegate = self
+        collectionView.reloadData()
+        self.controller.synchronize()
+    }
+
     open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         controller.channels.count
     }


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/421

### 🎯 Goal
A lot of customers ask how to change the channel list query at runtime to support channel list filters or even channel searching.

The goal of this task is to provide a function to do this easily. 

### 📝 Summary

While doing this I found an issue with our Automatic Filtering. The muted channels query wouldn't show any data, because in our DB we store mutes as an actual type, instead of a Boolean. This required a "predicateMapper" to solve this, but feel free to suggest other ideas on how to fix this.

### 🎨 Showcase
TODO

### 🧪 Manual Testing Notes
TODO

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
