### PR TITLE
Allow replies to soft-deleted messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix Composer's keyboard not adjusted when presenting alert controllers [#2610](https://github.com/GetStream/stream-chat-swift/pull/2610)
 - Fix InputTextView not scrolling to caret when pasting long text [#2609](https://github.com/GetStream/stream-chat-swift/pull/2609)
 - Fix scrollToBottomButton visible when jumping to message on the first page [#2608](https://github.com/GetStream/stream-chat-swift/pull/2608)
-- Allow replies to soft-deleted messages [#2633](https://github.com/GetStream/stream-chat-swift/pull/2633)
+- Allow sending replies to soft-deleted parent messages [#2633](https://github.com/GetStream/stream-chat-swift/pull/2633)
 
 # [4.31.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.31.0)
 _April 25, 2023_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix Composer's keyboard not adjusted when presenting alert controllers [#2610](https://github.com/GetStream/stream-chat-swift/pull/2610)
 - Fix InputTextView not scrolling to caret when pasting long text [#2609](https://github.com/GetStream/stream-chat-swift/pull/2609)
 - Fix scrollToBottomButton visible when jumping to message on the first page [#2608](https://github.com/GetStream/stream-chat-swift/pull/2608)
+- Allow replies to soft-deleted messages [#2633](https://github.com/GetStream/stream-chat-swift/pull/2633)
 
 # [4.31.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.31.0)
 _April 25, 2023_

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
@@ -84,6 +84,11 @@ open class ChatMessageLayoutOptionsResolver {
         if isLastInSequence && !message.isSentByCurrentUser && channel.memberCount > 2 {
             options.insert(.authorName)
         }
+        if channel.config.repliesEnabled && (message.isRootOfThread || message.isPartOfThread) {
+            options.insert(.threadInfo)
+            // The bubbles with thread look like continuous bubbles
+            options.insert(.continuousBubble)
+        }
 
         guard message.isDeleted == false else {
             return options
@@ -91,11 +96,6 @@ open class ChatMessageLayoutOptionsResolver {
 
         if hasQuotedMessage(message) {
             options.insert(.quotedMessage)
-        }
-        if channel.config.repliesEnabled && (message.isRootOfThread || message.isPartOfThread) {
-            options.insert(.threadInfo)
-            // The bubbles with thread look like continuous bubbles
-            options.insert(.continuousBubble)
         }
         if hasReactions(channel, message, appearance) {
             options.insert(.reactions)
@@ -114,7 +114,7 @@ open class ChatMessageLayoutOptionsResolver {
         message.quotedMessage?.id != nil
     }
 
-    func hasReactions(_ channel: ChatChannel, _ message: ChatMessage, _ appareance: Appearance) -> Bool {
+    func hasReactions(_ channel: ChatChannel, _ message: ChatMessage, _ appearance: Appearance) -> Bool {
         if !channel.config.reactionsEnabled {
             return false
         }
@@ -123,14 +123,14 @@ open class ChatMessageLayoutOptionsResolver {
             return false
         }
 
-        let unhandledReactionTypes = message.latestReactions.filter { appareance.images.availableReactions[$0.type] == nil }
+        let unhandledReactionTypes = message.latestReactions.filter { appearance.images.availableReactions[$0.type] == nil }
             .map(\.type)
 
         if !unhandledReactionTypes.isEmpty {
             log.warning("message contains unhandled reaction types \(unhandledReactionTypes)")
         }
 
-        return !message.latestReactions.filter { appareance.images.availableReactions[$0.type] != nil }.isEmpty
+        return !message.latestReactions.filter { appearance.images.availableReactions[$0.type] != nil }.isEmpty
     }
 
     /// Says whether the message at given `indexPath` is the last one in a sequence of messages

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver_Tests.swift
@@ -929,7 +929,7 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
         }
     }
 
-    func test_optionsForMessage_whenMessageIsDeleted_doesNotIncludeThreadInfo() {
+    func test_optionsForMessage_whenMessageIsDeleted_includesThreadInfo() {
         let sut = createOptionsResolver()
 
         // Create deleted thread root message
@@ -965,7 +965,7 @@ final class ChatMessageLayoutOptionsResolver_Tests: XCTestCase {
             )
 
             // Assert `.threadInfo` is not included since message is deleted
-            XCTAssertFalse(layoutOptions.contains(.threadInfo))
+            XCTAssertTrue(layoutOptions.contains(.threadInfo))
         }
     }
 


### PR DESCRIPTION
### 🔗 Issue Links

https://github.com/GetStream/ios-issues-tracking/issues/407

### 🎯 Goal

Allow replies for soft-deleted messages

### 📝 Summary

Up until now, we were not showing the UI to access thread replies for soft deleted messages. This was not allowing a UX flow to add more replies to it.
This PR aims to allow access to a thread when there are replies to a soft deleted message

### 🎨 Showcase

![Uploading Screenshot 2023-05-19 at 17.52.40.png…]()

### 🧪 Manual Testing Notes

1. Send a message
2. Add a thread reply to it
3. Remove root message

Expected results:
1. The deleted message cell should indicate that there are replies to it
2. You should be able to access the thread
3. You should be able to send new replies to it

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/9QHjubgztG1eO6sEVy/giphy.gif)
