### PR TITLE
Fix muted and joined channel list queries with empty data (Auto Filtering Enabled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix "to-many key not allowed here" error when using the `memberName` filter [#2604](https://github.com/GetStream/stream-chat-swift/pull/2604)
 - Fix memory leak in `ChannelListController` when loading more channels [#2624](https://github.com/GetStream/stream-chat-swift/pull/2624)
+- Fix muted and joined channel list queries with empty data (Auto Filtering Enabled) [#2634](https://github.com/GetStream/stream-chat-swift/pull/2634)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -113,8 +113,20 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
     static var team: FilterKey<Scope, TeamId?> { .init(rawValue: "team", keyPathString: #keyPath(ChannelDTO.team)) }
 
     /// Filter for checking whether current user is joined the channel or not (through invite or directly)
-    /// Supported operators: `equal`
-    static var joined: FilterKey<Scope, Bool> { .init(rawValue: "joined", keyPathString: #keyPath(ChannelDTO.membership)) }
+    /// Supported operators: `equal`.
+    static var joined: FilterKey<Scope, Bool> { .init(
+        rawValue: "joined",
+        keyPathString: #keyPath(ChannelDTO.membership),
+        predicateMapper: { op, joined in
+            let key = #keyPath(ChannelDTO.membership)
+            switch op {
+            case .equal:
+                return NSPredicate(format: joined ? "\(key) != nil" : "\(key) == nil")
+            default:
+                return nil
+            }
+        }
+    ) }
 
     /// Filter for checking whether current user has muted the channel
     /// Supported operators: `equal`.

--- a/Sources/StreamChat/Query/ChannelListQuery.swift
+++ b/Sources/StreamChat/Query/ChannelListQuery.swift
@@ -117,8 +117,20 @@ public extension FilterKey where Scope: AnyChannelListFilterScope {
     static var joined: FilterKey<Scope, Bool> { .init(rawValue: "joined", keyPathString: #keyPath(ChannelDTO.membership)) }
 
     /// Filter for checking whether current user has muted the channel
-    /// Supported operators: `equal`
-    static var muted: FilterKey<Scope, Bool> { .init(rawValue: "muted", keyPathString: #keyPath(ChannelDTO.mute)) }
+    /// Supported operators: `equal`.
+    static var muted: FilterKey<Scope, Bool> { .init(
+        rawValue: "muted",
+        keyPathString: #keyPath(ChannelDTO.mute),
+        predicateMapper: { op, muted in
+            let key = #keyPath(ChannelDTO.mute)
+            switch op {
+            case .equal:
+                return NSPredicate(format: muted ? "\(key) != nil" : "\(key) == nil")
+            default:
+                return nil
+            }
+        }
+    ) }
 
     /// Filter for checking the status of the invite
     /// Supported operators: `equal`

--- a/Sources/StreamChat/Query/Filter+ChatChannel.swift
+++ b/Sources/StreamChat/Query/Filter+ChatChannel.swift
@@ -46,6 +46,10 @@ extension Filter where Scope == ChannelListFilterScope {
             return nil
         }
 
+        if let overridePredicate = predicateMapper?(op, mappedValue) {
+            return overridePredicate
+        }
+
         switch op {
         case .equal, .notEqual, .greater, .greaterOrEqual, .less, .lessOrEqual:
             return comparingPredicate(op)

--- a/Sources/StreamChat/Query/Filter.swift
+++ b/Sources/StreamChat/Query/Filter.swift
@@ -111,13 +111,19 @@ public struct Filter<Scope: FilterScope> {
     /// Whether the `keyPathString` represents an array in the DTO entities.
     let isCollectionFilter: Bool
 
+    /// The mapper that will override the DB Predicate. This might be needed
+    /// for cases where our DB value is completely different from the server value.
+    typealias PredicateMapper = (FilterOperator, Any) -> NSPredicate?
+    let predicateMapper: PredicateMapper?
+
     init(
         operator: String,
         key: String?,
         value: FilterValue,
         valueMapper: ValueMapper?,
         keyPathString: String?,
-        isCollectionFilter: Bool
+        isCollectionFilter: Bool,
+        predicateMapper: PredicateMapper? = nil
     ) {
         log.assert(`operator`.hasPrefix("$"), "A filter operator must have `$` prefix.")
         self.operator = `operator`
@@ -126,6 +132,7 @@ public struct Filter<Scope: FilterScope> {
         self.valueMapper = valueMapper
         self.keyPathString = keyPathString
         self.isCollectionFilter = isCollectionFilter
+        self.predicateMapper = predicateMapper
     }
 
     /// Creates a new instance of `Filter`.
@@ -153,7 +160,8 @@ public struct Filter<Scope: FilterScope> {
             value: value,
             valueMapper: nil,
             keyPathString: nil,
-            isCollectionFilter: isCollectionFilter
+            isCollectionFilter: isCollectionFilter,
+            predicateMapper: nil
         )
     }
 }
@@ -174,7 +182,8 @@ extension Filter {
             value: value,
             valueMapper: valueMapper,
             keyPathString: keyPathString,
-            isCollectionFilter: key.isCollectionFilter
+            isCollectionFilter: key.isCollectionFilter,
+            predicateMapper: key.predicateMapper
         )
     }
 
@@ -228,6 +237,12 @@ public struct FilterKey<Scope: FilterScope, Value: FilterValue>: ExpressibleBySt
     typealias TypedValueMapper = (Value) -> FilterValue?
     let valueMapper: ValueMapper?
 
+    /// The mapper that will override the DB Predicate. This might be needed
+    /// for cases where our DB value is completely different from the server value.
+    typealias PredicateMapper = (FilterOperator, Any) -> NSPredicate?
+    typealias TypedPredicateMapper = (FilterOperator, Value) -> NSPredicate?
+    let predicateMapper: PredicateMapper?
+
     let isCollectionFilter: Bool
 
     public init(stringLiteral value: String) {
@@ -235,6 +250,7 @@ public struct FilterKey<Scope: FilterScope, Value: FilterValue>: ExpressibleBySt
         valueMapper = nil
         keyPathString = nil
         isCollectionFilter = false
+        predicateMapper = nil
     }
 
     public init(rawValue value: String) {
@@ -242,17 +258,26 @@ public struct FilterKey<Scope: FilterScope, Value: FilterValue>: ExpressibleBySt
         keyPathString = nil
         valueMapper = nil
         isCollectionFilter = false
+        predicateMapper = nil
     }
 
     init(
         rawValue value: String,
         keyPathString: String,
         valueMapper: TypedValueMapper? = nil,
-        isCollectionFilter: Bool = false
+        isCollectionFilter: Bool = false,
+        predicateMapper: TypedPredicateMapper? = nil
     ) {
         rawValue = value
         self.keyPathString = keyPathString
         self.isCollectionFilter = isCollectionFilter
+        self.predicateMapper = { op, value in
+            guard let predicateMapper = predicateMapper, let castInputValue = (value as? Value) else {
+                return nil
+            }
+            return predicateMapper(op, castInputValue)
+        }
+
         self.valueMapper = {
             guard let valueMapper = valueMapper, let castInputValue = ($0 as? Value) else {
                 return nil
@@ -485,13 +510,23 @@ extension Filter: Codable {
             if key.stringValue.hasPrefix("$") {
                 // The right side should be an array of other filters
                 let filters = try container.decode([Filter].self, forKey: key)
-                self.init(operator: key.stringValue, key: nil, value: filters, isCollectionFilter: false)
+                self.init(
+                    operator: key.stringValue,
+                    key: nil,
+                    value: filters,
+                    isCollectionFilter: false
+                )
                 return
 
             } else {
                 // The right side should be FilterRightSide
                 let rightSide = try container.decode(FilterRightSide.self, forKey: key)
-                self.init(operator: rightSide.operator, key: key.stringValue, value: rightSide.value, isCollectionFilter: false)
+                self.init(
+                    operator: rightSide.operator,
+                    key: key.stringValue,
+                    value: rightSide.value,
+                    isCollectionFilter: false
+                )
                 return
             }
         }


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/423

### 🎯 Goal
Fix the channel list query being empty when the `.muted` and `.joined` filters were used with auto filtering enabled.

### 🛠 Implementation
We currently have an issue with our Auto Filtering where the `.muted` and `.joined` filters do not properly map to our DB predicates.

After some analysis and discussion with @ipavlidakis, we opted for introducing a `PredicateMapper` so that a filter can override the default Predicate logic.

### 🧪 Manual Testing Notes
Unit tests were added to prove it works correctly.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
