### PR TITLE
Handle `user.updated` events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `isJumpingToMessage` being `true` after jumping to message on the first page [#2608](https://github.com/GetStream/stream-chat-swift/pull/2608)
 - Fix `noTeam` filter that was causing an error [#2632](https://github.com/GetStream/stream-chat-swift/pull/2632)
 - Fix muted and joined channel list queries with empty data (Auto Filtering Enabled) [#2634](https://github.com/GetStream/stream-chat-swift/pull/2634)
+- Fix user information not being updated when receiving `user.updated` [#2643](https://github.com/GetStream/stream-chat-swift/pull/2643)
 
 ## StreamChatUI
 ### ✅ Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `isJumpingToMessage` being `true` after jumping to message on the first page [#2608](https://github.com/GetStream/stream-chat-swift/pull/2608)
 - Fix `noTeam` filter that was causing an error [#2632](https://github.com/GetStream/stream-chat-swift/pull/2632)
 - Fix muted and joined channel list queries with empty data (Auto Filtering Enabled) [#2634](https://github.com/GetStream/stream-chat-swift/pull/2634)
-- Fix user information not being updated when receiving `user.updated` [#2643](https://github.com/GetStream/stream-chat-swift/pull/2643)
+- Fix user information not being updated when receiving updated information from backend [#2643](https://github.com/GetStream/stream-chat-swift/pull/2643)
 
 ## StreamChatUI
 ### ✅ Added

--- a/DemoApp/DemoAppConfiguration.swift
+++ b/DemoApp/DemoAppConfiguration.swift
@@ -21,7 +21,7 @@ enum DemoAppConfiguration {
 
     // MARK: Internal configuration
 
-    private static var isStreamInternalConfiguration: Bool {
+    static var isStreamInternalConfiguration: Bool {
         ProcessInfo.processInfo.environment["STREAM_DEV"] != nil
     }
 

--- a/DemoApp/Screens/UserProfileViewController/UserProfileViewController.swift
+++ b/DemoApp/Screens/UserProfileViewController/UserProfileViewController.swift
@@ -36,7 +36,9 @@ class UserProfileViewController: UIViewController, CurrentChatUserControllerDele
         imageView.layer.cornerRadius = 30
         imageView.layer.masksToBounds = true
         updateButton.setTitle("Update", for: .normal)
-        updateButton.backgroundColor = .blue
+        updateButton.layer.cornerRadius = 4
+        updateButton.backgroundColor = .systemBlue
+        updateButton.contentEdgeInsets = UIEdgeInsets(top: 0.0, left: 15, bottom: 0.0, right: 15)
         updateButton.addTarget(self, action: #selector(didTapUpdateButton), for: .touchUpInside)
         updateButton.isHidden = !DemoAppConfiguration.isStreamInternalConfiguration
 
@@ -49,7 +51,7 @@ class UserProfileViewController: UIViewController, CurrentChatUserControllerDele
             nameTextField.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 20),
             updateButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             updateButton.topAnchor.constraint(equalTo: nameTextField.bottomAnchor, constant: 20),
-            updateButton.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor)
+            updateButton.heightAnchor.constraint(equalToConstant: 35)
         ])
 
         currentUserController.delegate = self

--- a/DemoApp/Screens/UserProfileViewController/UserProfileViewController.swift
+++ b/DemoApp/Screens/UserProfileViewController/UserProfileViewController.swift
@@ -1,0 +1,88 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import UIKit
+
+class UserProfileViewController: UIViewController, CurrentChatUserControllerDelegate {
+    private let imageView = UIImageView()
+    private let nameTextField = UITextField()
+    private let updateButton = UIButton()
+
+    let currentUserController: CurrentChatUserController
+
+    init(currentUserController: CurrentChatUserController) {
+        self.currentUserController = currentUserController
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .white
+
+        [imageView, nameTextField, updateButton].forEach {
+            view.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 30
+        imageView.layer.masksToBounds = true
+        updateButton.setTitle("Update", for: .normal)
+        updateButton.backgroundColor = .blue
+        updateButton.addTarget(self, action: #selector(didTapUpdateButton), for: .touchUpInside)
+        updateButton.isHidden = !DemoAppConfiguration.isStreamInternalConfiguration
+
+        NSLayoutConstraint.activate([
+            imageView.widthAnchor.constraint(equalToConstant: 60),
+            imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor),
+            imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            imageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+            nameTextField.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            nameTextField.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 20),
+            updateButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            updateButton.topAnchor.constraint(equalTo: nameTextField.bottomAnchor, constant: 20),
+            updateButton.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor)
+        ])
+
+        currentUserController.delegate = self
+        synchronizeAndUpdateData()
+    }
+
+    private func synchronizeAndUpdateData() {
+        currentUserController.synchronize { [weak self] _ in
+            self?.updateUserData()
+        }
+    }
+
+    private func updateUserData() {
+        nameTextField.text = currentUserController.currentUser?.name ?? "Unknown"
+
+        guard let imageURL = currentUserController.currentUser?.imageURL else { return }
+
+        DispatchQueue.global().async { [weak self] in
+            guard let data = try? Data(contentsOf: imageURL), let image = UIImage(data: data) else { return }
+            DispatchQueue.main.async {
+                self?.imageView.image = image
+            }
+        }
+    }
+
+    @objc private func didTapUpdateButton() {
+        guard let newName = nameTextField.text, newName != currentUserController.currentUser?.name else { return }
+        currentUserController.updateUserData(name: newName) { [weak self] _ in
+            self?.synchronizeAndUpdateData()
+        }
+    }
+
+    func currentUserController(_ controller: CurrentChatUserController, didChangeCurrentUser: EntityChange<CurrentChatUser>) {
+        updateUserData()
+    }
+}

--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -28,6 +28,12 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
 
     override func showCurrentUserProfile() {
         rootViewController.presentAlert(title: nil, actions: [
+            .init(title: "Show Profile", style: .default, handler: { [weak self] _ in
+                guard let self = self else { return }
+                let client = self.rootViewController.controller.client
+                let viewController = UserProfileViewController(currentUserController: client.currentUserController())
+                self.rootNavigationController?.pushViewController(viewController, animated: true)
+            }),
             .init(title: "Logout", style: .destructive, handler: { [weak self] _ in
                 self?.onLogout?()
             })

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -66,6 +66,7 @@ public class ChatClient {
             MemberEventMiddleware(),
             UserChannelBanEventsMiddleware(),
             UserWatchingEventMiddleware(),
+            UserUpdateMiddleware(),
             ChannelVisibilityEventMiddleware(),
             EventDTOConverterMiddleware()
         ]

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -328,7 +328,7 @@ class AuthenticationRepository {
             // to `disconnected` when environment was prepared correctly
             // (e.g. current user session is successfully restored).
             connectionRepository?.forceConnectionStatusForInactiveModeIfNeeded()
-            connectionRepository?.connect(userInfo: userInfo, completion: onCompletion)
+            connectionRepository?.connect(completion: onCompletion)
         }
 
         let retryFetchIfPossible: (Error?) -> Void = { [weak self] error in

--- a/Sources/StreamChat/Repositories/ConnectionRepository.swift
+++ b/Sources/StreamChat/Repositories/ConnectionRepository.swift
@@ -52,13 +52,9 @@ class ConnectionRepository {
     /// When the connection is established, `ChatClient` starts receiving chat updates, and `currentUser` variable is available.
     ///
     /// - Parameters:
-    ///   - userInfo:       The user information that will be created OR updated if it exists.
     ///   - completion: Called when the connection is established. If the connection fails, the completion is called with an error.
     ///
-    func connect(
-        userInfo: UserInfo? = nil,
-        completion: ((Error?) -> Void)? = nil
-    ) {
+    func connect(completion: ((Error?) -> Void)? = nil) {
         // Connecting is not possible in connectionless mode (duh)
         guard isClientInActiveMode else {
             completion?(ClientError.ClientIsNotInActiveMode())

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/UserUpdateMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/UserUpdateMiddleware.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// The middleware listens for `UserUpdatedEvent`s and updates `CurrentChatUserDTO` accordingly.
+/// The middleware listens for `UserUpdatedEvent`s and updates the database accordingly.
 struct UserUpdateMiddleware: EventMiddleware {
     func handle(event: Event, session: DatabaseSession) -> Event? {
         guard let userUpdatedEvent = event as? UserUpdatedEventDTO else { return event }

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/UserUpdateMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/UserUpdateMiddleware.swift
@@ -1,0 +1,5 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import Foundation

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/UserUpdateMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/UserUpdateMiddleware.swift
@@ -3,3 +3,16 @@
 //
 
 import Foundation
+
+/// The middleware listens for `UserUpdatedEvent`s and updates `CurrentChatUserDTO` accordingly.
+struct UserUpdateMiddleware: EventMiddleware {
+    func handle(event: Event, session: DatabaseSession) -> Event? {
+        guard let userUpdatedEvent = event as? UserUpdatedEventDTO else { return event }
+        do {
+            try session.saveUser(payload: userUpdatedEvent.user)
+        } catch {
+            log.error("Failed to update user in the database, error: \(error)")
+        }
+        return event
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1758,6 +1758,7 @@
 		C1CEF9072A1BC4E800414931 /* UserProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1CEF9062A1BC4E800414931 /* UserProfileViewController.swift */; };
 		C1CEF9092A1CDF7600414931 /* UserUpdateMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1CEF9082A1CDF7600414931 /* UserUpdateMiddleware.swift */; };
 		C1CEF90A2A1CDF7600414931 /* UserUpdateMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1CEF9082A1CDF7600414931 /* UserUpdateMiddleware.swift */; };
+		C1CEF90C2A1CF8A900414931 /* UserUpdateMiddleware_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1CEF90B2A1CF8A900414931 /* UserUpdateMiddleware_Tests.swift */; };
 		C1E8AD57278C8A6E0041B775 /* SyncRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E8AD55278C8A440041B775 /* SyncRepository.swift */; };
 		C1E8AD58278C8A6F0041B775 /* SyncRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E8AD55278C8A440041B775 /* SyncRepository.swift */; };
 		C1E8AD5E278EF5F30041B775 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E8AD5B278DDEC70041B775 /* AsyncOperation.swift */; };
@@ -3540,6 +3541,7 @@
 		C1CE8EFD27F20C3A0091097B /* MissingEventsPayload-IncompleteChannel.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "MissingEventsPayload-IncompleteChannel.json"; sourceTree = "<group>"; };
 		C1CEF9062A1BC4E800414931 /* UserProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewController.swift; sourceTree = "<group>"; };
 		C1CEF9082A1CDF7600414931 /* UserUpdateMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdateMiddleware.swift; sourceTree = "<group>"; };
+		C1CEF90B2A1CF8A900414931 /* UserUpdateMiddleware_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdateMiddleware_Tests.swift; sourceTree = "<group>"; };
 		C1E8AD55278C8A440041B775 /* SyncRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncRepository.swift; sourceTree = "<group>"; };
 		C1E8AD5B278DDEC70041B775 /* AsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOperation.swift; sourceTree = "<group>"; };
 		C1EE53A627BA53F300B1A6CA /* Endpoint_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint_Tests.swift; sourceTree = "<group>"; };
@@ -5473,6 +5475,7 @@
 				796CBC1B25F7CD58003299B0 /* UserChannelBanEventsMiddleware_Tests.swift */,
 				F6CCA24E2512491B004C1859 /* UserTypingStateUpdaterMiddleware_Tests.swift */,
 				79617CB925F23AA400D54E61 /* UserWatchingEventMiddleware_Tests.swift */,
+				C1CEF90B2A1CF8A900414931 /* UserUpdateMiddleware_Tests.swift */,
 			);
 			path = EventMiddlewares;
 			sourceTree = "<group>";
@@ -9737,6 +9740,7 @@
 				A382131E2805C8AC0068D30E /* TestsEnvironmentSetup.swift in Sources */,
 				A34ECB4C27F5CA5E00A804C1 /* ReactionEvents_IntegrationTests.swift in Sources */,
 				882C5766252C7F7000E60C44 /* ChannelMemberListUpdater_Tests.swift in Sources */,
+				C1CEF90C2A1CF8A900414931 /* UserUpdateMiddleware_Tests.swift in Sources */,
 				DA4EE5A1252B443400CB26D4 /* NewUserQueryUpdater_Tests.swift in Sources */,
 				C1EFF3F828633B5D0057B91B /* IdentifiableModel_Tests.swift in Sources */,
 				C143789727BE6D4800E23965 /* OfflineRequestsRepository_Tests.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1755,6 +1755,7 @@
 		C1BFBAC129CC42CE00FC82A2 /* JumpToUnreadMessagesButton_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1BFBAC029CC42CE00FC82A2 /* JumpToUnreadMessagesButton_Tests.swift */; };
 		C1C5345A29AFDDAE006F9AF4 /* ChannelRepository_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C5345929AFDDAE006F9AF4 /* ChannelRepository_Mock.swift */; };
 		C1C5345D29AFE526006F9AF4 /* ChannelRepository_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C5345B29AFE4C9006F9AF4 /* ChannelRepository_Tests.swift */; };
+		C1CEF9072A1BC4E800414931 /* UserProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1CEF9062A1BC4E800414931 /* UserProfileViewController.swift */; };
 		C1E8AD57278C8A6E0041B775 /* SyncRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E8AD55278C8A440041B775 /* SyncRepository.swift */; };
 		C1E8AD58278C8A6F0041B775 /* SyncRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E8AD55278C8A440041B775 /* SyncRepository.swift */; };
 		C1E8AD5E278EF5F30041B775 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E8AD5B278DDEC70041B775 /* AsyncOperation.swift */; };
@@ -3535,6 +3536,7 @@
 		C1C5345929AFDDAE006F9AF4 /* ChannelRepository_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelRepository_Mock.swift; sourceTree = "<group>"; };
 		C1C5345B29AFE4C9006F9AF4 /* ChannelRepository_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelRepository_Tests.swift; sourceTree = "<group>"; };
 		C1CE8EFD27F20C3A0091097B /* MissingEventsPayload-IncompleteChannel.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "MissingEventsPayload-IncompleteChannel.json"; sourceTree = "<group>"; };
+		C1CEF9062A1BC4E800414931 /* UserProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewController.swift; sourceTree = "<group>"; };
 		C1E8AD55278C8A440041B775 /* SyncRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncRepository.swift; sourceTree = "<group>"; };
 		C1E8AD5B278DDEC70041B775 /* AsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOperation.swift; sourceTree = "<group>"; };
 		C1EE53A627BA53F300B1A6CA /* Endpoint_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint_Tests.swift; sourceTree = "<group>"; };
@@ -5238,6 +5240,7 @@
 		A3227ECA284A607D00EBE6CC /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				C1CEF9052A1BC4CD00414931 /* UserProfileViewController */,
 				79330603256FEBE600FBB586 /* AdvancedOptionsViewController.swift */,
 				AD6BEFF42786474A00E184B4 /* AppConfigViewController */,
 				A3227E5D284A494000EBE6CC /* Create Chat */,
@@ -7490,6 +7493,14 @@
 			path = Tasks;
 			sourceTree = "<group>";
 		};
+		C1CEF9052A1BC4CD00414931 /* UserProfileViewController */ = {
+			isa = PBXGroup;
+			children = (
+				C1CEF9062A1BC4E800414931 /* UserProfileViewController.swift */,
+			);
+			path = UserProfileViewController;
+			sourceTree = "<group>";
+		};
 		C1E8AD59278DDC500041B775 /* Repositories */ = {
 			isa = PBXGroup;
 			children = (
@@ -9149,6 +9160,7 @@
 				A3227E7E284A511200EBE6CC /* DemoAppConfiguration.swift in Sources */,
 				AD6BEFF227862F9300E184B4 /* AppConfigViewController.swift in Sources */,
 				792DDA5C256FB69E001DB91B /* SceneDelegate.swift in Sources */,
+				C1CEF9072A1BC4E800414931 /* UserProfileViewController.swift in Sources */,
 				A3227E62284A499500EBE6CC /* SearchUserCell.swift in Sources */,
 				A3227E76284A4C6400EBE6CC /* MessageReactionType+Position.swift in Sources */,
 				A3227E74284A4C3300EBE6CC /* DemoChatMessageActionsVC.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1756,6 +1756,8 @@
 		C1C5345A29AFDDAE006F9AF4 /* ChannelRepository_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C5345929AFDDAE006F9AF4 /* ChannelRepository_Mock.swift */; };
 		C1C5345D29AFE526006F9AF4 /* ChannelRepository_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C5345B29AFE4C9006F9AF4 /* ChannelRepository_Tests.swift */; };
 		C1CEF9072A1BC4E800414931 /* UserProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1CEF9062A1BC4E800414931 /* UserProfileViewController.swift */; };
+		C1CEF9092A1CDF7600414931 /* UserUpdateMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1CEF9082A1CDF7600414931 /* UserUpdateMiddleware.swift */; };
+		C1CEF90A2A1CDF7600414931 /* UserUpdateMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1CEF9082A1CDF7600414931 /* UserUpdateMiddleware.swift */; };
 		C1E8AD57278C8A6E0041B775 /* SyncRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E8AD55278C8A440041B775 /* SyncRepository.swift */; };
 		C1E8AD58278C8A6F0041B775 /* SyncRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E8AD55278C8A440041B775 /* SyncRepository.swift */; };
 		C1E8AD5E278EF5F30041B775 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E8AD5B278DDEC70041B775 /* AsyncOperation.swift */; };
@@ -3537,6 +3539,7 @@
 		C1C5345B29AFE4C9006F9AF4 /* ChannelRepository_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelRepository_Tests.swift; sourceTree = "<group>"; };
 		C1CE8EFD27F20C3A0091097B /* MissingEventsPayload-IncompleteChannel.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "MissingEventsPayload-IncompleteChannel.json"; sourceTree = "<group>"; };
 		C1CEF9062A1BC4E800414931 /* UserProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewController.swift; sourceTree = "<group>"; };
+		C1CEF9082A1CDF7600414931 /* UserUpdateMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUpdateMiddleware.swift; sourceTree = "<group>"; };
 		C1E8AD55278C8A440041B775 /* SyncRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncRepository.swift; sourceTree = "<group>"; };
 		C1E8AD5B278DDEC70041B775 /* AsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOperation.swift; sourceTree = "<group>"; };
 		C1EE53A627BA53F300B1A6CA /* Endpoint_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint_Tests.swift; sourceTree = "<group>"; };
@@ -4360,6 +4363,7 @@
 				79A0E9B92498C31300E9BD50 /* TypingStartCleanupMiddleware.swift */,
 				796CBC1225F7CD48003299B0 /* UserChannelBanEventsMiddleware.swift */,
 				F6CCA24C251235F7004C1859 /* UserTypingStateUpdaterMiddleware.swift */,
+				C1CEF9082A1CDF7600414931 /* UserUpdateMiddleware.swift */,
 				79617CB025F236B600D54E61 /* UserWatchingEventMiddleware.swift */,
 			);
 			path = EventMiddlewares;
@@ -9609,6 +9613,7 @@
 				79A0E9BB2498C31300E9BD50 /* TypingStartCleanupMiddleware.swift in Sources */,
 				C1EE53A927BA662B00B1A6CA /* QueuedRequestDTO.swift in Sources */,
 				790A4C42252DD377001F4A23 /* DeviceEndpoints.swift in Sources */,
+				C1CEF9092A1CDF7600414931 /* UserUpdateMiddleware.swift in Sources */,
 				797A756424814E7A003CF16D /* WebSocketConnectPayload.swift in Sources */,
 				F6FF1DA624FD17B400151735 /* MessageController.swift in Sources */,
 				E7AD954F25D536AA00076DC3 /* SystemEnvironment+Version.swift in Sources */,
@@ -10292,6 +10297,7 @@
 				C121E8E0274544B100023E4C /* Atomic.swift in Sources */,
 				ADB951A2291BD7CC00800554 /* UploadedAttachment.swift in Sources */,
 				C121E8E1274544B100023E4C /* OptionalDecodable.swift in Sources */,
+				C1CEF90A2A1CDF7600414931 /* UserUpdateMiddleware.swift in Sources */,
 				C121E8E2274544B200023E4C /* Codable+Extensions.swift in Sources */,
 				C121E8E3274544B200023E4C /* Data+Gzip.swift in Sources */,
 				C121E8E4274544B200023E4C /* LazyCachedMapCollection.swift in Sources */,

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/ConnectionRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/ConnectionRepository_Mock.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Mock implementation of `ChatClientUpdater`
 final class ConnectionRepository_Mock: ConnectionRepository, Spy {
     enum Signature {
-        static let connect = "connect(userInfo:completion:)"
+        static let connect = "connect(completion:)"
         static let disconnect = "disconnect(source:completion:)"
         static let forceConnectionInactiveMode = "forceConnectionStatusForInactiveModeIfNeeded()"
         static let updateWebSocketEndpointTokenInfo = "updateWebSocketEndpoint(with:userInfo:)"
@@ -58,10 +58,7 @@ final class ConnectionRepository_Mock: ConnectionRepository, Spy {
 
     // MARK: - Overrides
 
-    override func connect(
-        userInfo: UserInfo?,
-        completion: ((Error?) -> Void)? = nil
-    ) {
+    override func connect(completion: ((Error?) -> Void)? = nil) {
         record()
         if let result = connectResult {
             completion?(result.error)

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/UserUpdateMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/UserUpdateMiddleware_Tests.swift
@@ -16,11 +16,12 @@ final class UserUpdateMiddleware_Tests: XCTestCase {
         super.setUp()
 
         database = DatabaseContainer_Spy()
-        middleware = .init()
+        middleware = UserUpdateMiddleware()
     }
 
     override func tearDown() {
         database = nil
+        middleware = nil
         AssertAsync.canBeReleased(&database)
         super.tearDown()
     }

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/UserUpdateMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/UserUpdateMiddleware_Tests.swift
@@ -1,0 +1,118 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class UserUpdateMiddleware_Tests: XCTestCase {
+    var database: DatabaseContainer_Spy!
+    var middleware: UserUpdateMiddleware!
+
+    // MARK: - Set up
+
+    override func setUp() {
+        super.setUp()
+
+        database = DatabaseContainer_Spy()
+        middleware = .init()
+    }
+
+    override func tearDown() {
+        database = nil
+        AssertAsync.canBeReleased(&database)
+        super.tearDown()
+    }
+
+    func test_forwardsOtherEvents() throws {
+        let event = TestEvent()
+
+        // Handle non-reaction event
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
+
+        // Assert event is forwarded as it is
+        let unwrappedForwardedEvent = try XCTUnwrap(forwardedEvent as? TestEvent)
+        XCTAssertEqual(unwrappedForwardedEvent, event)
+    }
+
+    func test_whenDatabaseWriteFails_eventIsForwarded() throws {
+        let eventPayload: EventPayload = .init(
+            eventType: .userUpdated,
+            user: .dummy(userId: .unique),
+            createdAt: Date.unique
+        )
+
+        // Set error to be thrown on write.
+        let session = DatabaseSession_Mock(underlyingSession: database.viewContext)
+        let error = TestError()
+        session.errorToReturn = error
+
+        // Simulate and handle user watching event.
+        let event = try UserUpdatedEventDTO(from: eventPayload)
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
+
+        // Assert `UserWatchingEvent` is forwarded even though database error happened.
+        XCTAssertTrue(forwardedEvent is UserWatchingEventDTO)
+    }
+
+    func test_whenDatabaseWriteDoesNotFail_userInformationIsUpdated() throws {
+        // Given
+        let userId = UserId.unique
+        let initialUserPayload = UserPayload.dummy(userId: userId, name: "Initial name")
+        try database.writeSynchronously {
+            try $0.saveUser(payload: initialUserPayload)
+        }
+        XCTAssertEqual(database.viewContext.user(id: userId)?.name, "Initial name")
+
+        // When
+        let updatedUserPayload = UserPayload.dummy(userId: userId, name: "Updated name")
+        let eventPayload: EventPayload = .init(
+            eventType: .userUpdated,
+            user: updatedUserPayload,
+            createdAt: Date.unique
+        )
+
+        // Simulate and handle user watching event.
+        let event = try UserUpdatedEventDTO(from: eventPayload)
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
+
+        // Then
+        // Assert `UserWatchingEvent` is forwarded even if all succeeded
+        XCTAssertTrue(forwardedEvent is UserUpdatedEventDTO)
+        XCTAssertEqual(database.viewContext.user(id: userId)?.name, "Updated name")
+        XCTAssertEqual(database.writeSessionCounter, 1)
+    }
+
+    func test_whenDatabaseWriteDoesNotFail_whenEventIsForCurrentUser_currentUserInformationIsUpdated() throws {
+        // Given
+        let currentUserId = UserId.unique
+        let initialCurrentUserPayload = CurrentUserPayload.dummy(
+            userPayload: .dummy(userId: currentUserId, name: "Name 1")
+        )
+        try database.writeSynchronously {
+            try $0.saveCurrentUser(payload: initialCurrentUserPayload)
+        }
+        XCTAssertEqual(database.viewContext.user(id: currentUserId)?.name, "Name 1")
+        XCTAssertEqual(database.viewContext.currentUser?.user.name, "Name 1")
+
+        // When
+        let updatedUserPayload = UserPayload.dummy(userId: currentUserId, name: "Name 2")
+        let eventPayload: EventPayload = .init(
+            eventType: .userUpdated,
+            user: updatedUserPayload,
+            createdAt: Date.unique
+        )
+
+        // Simulate and handle user watching event.
+        let event = try UserUpdatedEventDTO(from: eventPayload)
+        let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
+
+        // Then
+        // Assert `UserWatchingEvent` is forwarded even if all succeeded
+        XCTAssertTrue(forwardedEvent is UserUpdatedEventDTO)
+        XCTAssertEqual(database.viewContext.user(id: currentUserId)?.name, "Name 2")
+        XCTAssertEqual(database.viewContext.currentUser?.user.name, "Name 2")
+        XCTAssertEqual(database.writeSessionCounter, 1)
+    }
+}

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/UserUpdateMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/UserUpdateMiddleware_Tests.swift
@@ -54,7 +54,7 @@ final class UserUpdateMiddleware_Tests: XCTestCase {
         let forwardedEvent = middleware.handle(event: event, session: database.viewContext)
 
         // Assert `UserWatchingEvent` is forwarded even though database error happened.
-        XCTAssertTrue(forwardedEvent is UserWatchingEventDTO)
+        XCTAssertTrue(forwardedEvent is UserUpdatedEventDTO)
     }
 
     func test_whenDatabaseWriteDoesNotFail_userInformationIsUpdated() throws {


### PR DESCRIPTION
### 🔗 Issue Links

https://github.com/GetStream/ios-issues-tracking/issues/426

### 🎯 Goal

Handle `user.updated` events and reflect such changes in the database

### 📝 Summary

We were not yet handling those events, which was resulting in changes to users information (including the current user) not being reflected during the lifecycle of the app

### 🛠 Implementation

This PR adds `UserUpdatedMiddleware`, which updates the user in the Database according to the data received.
It also adds a new screen in the DemoApp that shows the profile, and reacts to changes to it.

### 🎨 Showcase


https://github.com/GetStream/stream-chat-swift/assets/7887319/00e8510a-db5a-479c-9e0a-22dc8130e381


### 🧪 Manual Testing Notes

1. Open the demo app, and go to the profile.
2. From another device update the information of this user

Expected result:
3. The updates should be reflected on screen


### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/Q848HhiZLpYQeOHky1/giphy.gif)
