### PR TITLE
Add support for jumping to message inside threads from channel view

### DIFF
--- a/Sources/StreamChat/Query/Pagination.swift
+++ b/Sources/StreamChat/Query/Pagination.swift
@@ -62,7 +62,7 @@ public struct MessagesPagination: Encodable, Equatable {
     /// Parameter for pagination.
     public let parameter: PaginationParameter?
 
-    init(pageSize: Int, parameter: PaginationParameter? = nil) {
+    public init(pageSize: Int, parameter: PaginationParameter? = nil) {
         self.pageSize = pageSize
         self.parameter = parameter
     }
@@ -119,14 +119,19 @@ public enum PaginationParameter: Encodable, Hashable {
         }
     }
 
+    /// A String value that returns the message id if the pagination will jump to a message around a given id.
+    public var aroundMessageId: String? {
+        switch self {
+        case let .around(messageId):
+            return messageId
+        default:
+            return nil
+        }
+    }
+
     /// A Boolean value that returns true if the pagination will jump to a message around a given id.
     public var isJumpingToMessage: Bool {
-        switch self {
-        case .around:
-            return true
-        default:
-            return false
-        }
+        aroundMessageId != nil
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -653,7 +653,14 @@ open class ChatMessageListVC: _ViewController,
             return log.error("DataSource not found for the message list.")
         }
 
-        showThread(messageId: message.parentMessageId ?? message.id)
+        // If the parent message id exists, it means we open the thread from a reply
+        if let parentMessageId = message.parentMessageId {
+            showThread(messageId: parentMessageId, at: message.id)
+            return
+        }
+
+        // If the parentMessageId does not exist, it means the message is the root of the thread
+        showThread(messageId: message.id)
     }
 
     open func messageContentViewDidTapOnQuotedMessage(_ quotedMessage: ChatMessage) {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -493,6 +493,14 @@ open class ChatMessageListVC: _ViewController,
         listView.scrollToRow(at: indexPath, at: .middle, animated: true)
         messageIdPendingHighlight = messageIdPendingScrolling
         messageIdPendingScrolling = nil
+
+        // If the list view does not scroll, because the message is too close
+        // we need to instantly highlight the message.
+        if listView.indexPathsForVisibleRows?.contains(indexPath) == true {
+            DispatchQueue.main.async {
+                onHighlight?(indexPath)
+            }
+        }
     }
 
     /// Highlight the the message cell, for example, when jumping to a message.

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -345,11 +345,15 @@ open class ChatMessageListVC: _ViewController,
         )
     }
 
-    /// Opens thread detail for given `MessageId`.
-    open func showThread(messageId: MessageId) {
+    /// Opens the thread for the given parent `MessageId`.
+    /// - Parameters:
+    ///   - messageId: The parent message id.
+    ///   - replyId: An optional reply id to where the thread will jump to when opening the thread.
+    open func showThread(messageId: MessageId, at replyId: MessageId? = nil) {
         guard let cid = dataSource?.channel(for: self)?.cid else { log.error("Channel is not available"); return }
         router.showThread(
             messageId: messageId,
+            at: replyId,
             cid: cid,
             client: client
         )

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -19,6 +19,9 @@ open class ChatThreadVC: _ViewController,
     /// Controller for observing data changes within the parent thread message.
     open var messageController: ChatMessageController!
 
+    /// An optional message id to where the thread should jump to when opening the thread.
+    public var initialReplyId: MessageId?
+
     /// Controller for observing typing events for this thread.
     open lazy var channelEventsController: ChannelEventsController = client.channelEventsController(for: messageController.cid)
 
@@ -103,7 +106,23 @@ open class ChatThreadVC: _ViewController,
                 messageComposerVC.content.threadMessage = message
             }
 
+            if let initialReplyId = self.initialReplyId {
+                self.messageController.loadPageAroundReplyId(initialReplyId) { error in
+                    guard error == nil else {
+                        return
+                    }
+
+                    self.jumpToMessage(id: initialReplyId)
+                }
+                return
+            }
+
             self.messageController.loadPreviousReplies()
+        }
+
+        if let message = messageController.message {
+            completeSetUp(message)
+            return
         }
 
         messageController.synchronize { [weak self] _ in
@@ -145,6 +164,26 @@ open class ChatThreadVC: _ViewController,
         resignFirstResponder()
 
         keyboardHandler.stop()
+    }
+
+    /// Jump to a given message.
+    /// In case the message is already loaded, it directly goes to it.
+    /// If not, it will load the messages around it and go to that page.
+    ///
+    /// This function is an high-level abstraction of `messageListVC.jumpToMessage(id:onHighlight:)`.
+    ///
+    /// - Parameters:
+    ///   - id: The id of message which the message list should go to.
+    ///   - shouldHighlight: Whether the message should be highlighted when jumping to it. By default it is highlighted.
+    public func jumpToMessage(id: MessageId, shouldHighlight: Bool = true) {
+        if shouldHighlight {
+            messageListVC.jumpToMessage(id: id) { [weak self] indexPath in
+                self?.messageListVC.highlightCell(at: indexPath)
+            }
+            return
+        }
+
+        messageListVC.jumpToMessage(id: id)
     }
 
     // MARK: - ChatMessageListVCDataSource

--- a/Sources/StreamChatUI/Navigation/ChatMessageListRouter.swift
+++ b/Sources/StreamChatUI/Navigation/ChatMessageListRouter.swift
@@ -129,7 +129,7 @@ open class ChatMessageListRouter:
     /// Shows the detail View Controller of a message thread.
     ///
     /// - Parameters:
-    ///   - messageId: The id if the parent message of the thread.
+    ///   - messageId: The id of the parent message of the thread.
     ///   - cid: The `cid` of the channel the message belongs to.
     ///   - client: The current `ChatClient` instance.
     ///
@@ -140,6 +140,28 @@ open class ChatMessageListRouter:
         client: ChatClient
     ) {
         let threadVC = components.threadVC.init()
+        threadVC.channelController = client.channelController(for: cid)
+        threadVC.messageController = client.messageController(
+            cid: cid,
+            messageId: messageId
+        )
+        rootNavigationController?.show(threadVC, sender: self)
+    }
+
+    /// Shows the view controller with messages for the provided cid and jumps to the given message id.
+    /// - Parameters:
+    ///   - messageId: The id of the parent message of the thread.
+    ///   - replyId: The reply id to where the thread should jump to when opening the thread.
+    ///   - cid: The `ChannelId` of the channel the should be presented.
+    ///   - client: The current `ChatClient` instance.
+    open func showThread(
+        messageId: MessageId,
+        at replyId: MessageId?,
+        cid: ChannelId,
+        client: ChatClient
+    ) {
+        let threadVC = components.threadVC.init()
+        threadVC.initialReplyId = replyId
         threadVC.channelController = client.channelController(for: cid)
         threadVC.messageController = client.messageController(
             cid: cid,

--- a/StreamChatUITestsApp/StreamChat/CustomChatMessageListRouter.swift
+++ b/StreamChatUITestsApp/StreamChat/CustomChatMessageListRouter.swift
@@ -26,4 +26,21 @@ final class CustomMessageListRouter: ChatMessageListRouter {
         rootNavigationController?.show(threadVC, sender: self)
     }
 
+    override func showThread(messageId: MessageId, at replyId: MessageId?, cid: ChannelId, client: ChatClient) {
+        let threadVC = components.threadVC.init()
+        threadVC.initialReplyId = replyId
+        threadVC.channelController = client.channelController(for: cid)
+        threadVC.messageController = client.messageController(
+            cid: cid,
+            messageId: messageId
+        )
+
+        if let vc = threadVC as? ThreadVC {
+            vc.onViewWillAppear = { [weak self] _ in
+                self?.onThreadViewWillAppear?(vc)
+            }
+        }
+        rootNavigationController?.show(threadVC, sender: self)
+    }
+
 }

--- a/TestTools/StreamChatTestMockServer/MockServer/MessageList.swift
+++ b/TestTools/StreamChatTestMockServer/MockServer/MessageList.swift
@@ -170,14 +170,16 @@ public extension StreamMockServer {
         around: String?
     ) -> [[String: Any]] {
         var newMessageList: [[String: Any]] = []
+        var startWith: Int?
+        var endWith: Int?
+
         if let idLt = idLt {
             let messageIndex = messageList.firstIndex {
                 idLt == $0[messageKey.id.rawValue] as? String
             }
             if let messageIndex = messageIndex {
-                let startWith = messageIndex - limit > 0 ? messageIndex - limit : 0
-                let endWith = messageIndex - 1 > 0 ? messageIndex - 1 : 0
-                newMessageList = Array(messageList[startWith...endWith])
+                startWith = messageIndex - limit > 0 ? messageIndex - limit : 0
+                endWith = messageIndex - 1 > 0 ? messageIndex - 1 : 0
             }
         } else if let idGt = idGt {
             let messageIndex = messageList.firstIndex {
@@ -186,8 +188,8 @@ public extension StreamMockServer {
             if let messageIndex = messageIndex {
                 let messageCount = messageList.count - 1
                 let plusLimit = messageIndex + limit
-                let endWith = plusLimit < messageCount ? plusLimit : messageCount
-                newMessageList = Array(messageList[messageIndex + 1...endWith])
+                startWith = messageIndex
+                endWith = plusLimit < messageCount ? plusLimit : messageCount
             }
         } else if let idLte = idLte {
             let messageIndex = messageList.firstIndex {
@@ -195,8 +197,8 @@ public extension StreamMockServer {
             }
             if let messageIndex = messageIndex {
                 let minusLimit = messageIndex - limit
-                let startWith = minusLimit > 0 ? minusLimit : 0
-                newMessageList = Array(messageList[startWith + 1...messageIndex])
+                startWith = minusLimit > 0 ? minusLimit : 0
+                endWith = messageIndex
             }
         } else if let idGte = idGte {
             let messageIndex = messageList.firstIndex {
@@ -205,21 +207,26 @@ public extension StreamMockServer {
             if let messageIndex = messageIndex {
                 let messageCount = messageList.count - 1
                 let plusLimit = messageIndex + limit
-                let endWith = plusLimit < messageCount ? plusLimit - 1 : messageCount
-                newMessageList = Array(messageList[messageIndex...endWith])
+                startWith = messageIndex
+                endWith = plusLimit < messageCount ? plusLimit - 1 : messageCount
             }
         } else if let around = around {
             let messageIndex = messageList.firstIndex {
                 around == $0[messageKey.id.rawValue] as? String
             }
             if let messageIndex = messageIndex {
-                let startWith = messageIndex
-                let endWith = messageIndex + limit
-                newMessageList = Array(messageList[startWith...endWith])
+                startWith = messageIndex
+                endWith = min(messageIndex + limit, messageList.count - 1)
             }
+        }
+
+        if let startWith = startWith, let endWith = endWith {
+            let endWith = min(endWith, messageList.count - 1)
+            newMessageList = Array(messageList[startWith...endWith])
         } else {
             newMessageList = Array(messageList.suffix(limit))
         }
+
         return newMessageList
     }
 }

--- a/Tests/StreamChatTests/Query/Pagination_Tests.swift
+++ b/Tests/StreamChatTests/Query/Pagination_Tests.swift
@@ -67,4 +67,12 @@ final class Pagination_Tests: XCTestCase {
         // Assert `MessagesPagination` encoded correctly
         AssertJSONEqual(encodedJSON, expectedJSON)
     }
+
+    func test_aroundMessageId() {
+        let aroundPagination = MessagesPagination(pageSize: 25, parameter: .around("someId"))
+        XCTAssertEqual(aroundPagination.parameter?.aroundMessageId, "someId")
+
+        let greaterPagination = MessagesPagination(pageSize: 25, parameter: .greaterThan("someId"))
+        XCTAssertEqual(greaterPagination.parameter?.aroundMessageId, nil)
+    }
 }

--- a/Tests/StreamChatUITests/Mocks/Navigation/ChatMessageListRouter_Mock.swift
+++ b/Tests/StreamChatUITests/Mocks/Navigation/ChatMessageListRouter_Mock.swift
@@ -16,4 +16,17 @@ class ChatMessageListRouter_Mock: ChatMessageListRouter {
     ) {
         showMessageActionsPopUpCallCount += 1
     }
+
+    var showThreadCallCount = 0
+    var showThreadCalledWith: (parentMessageId: MessageId, replyId: MessageId?, cid: ChannelId)?
+
+    override func showThread(messageId: MessageId, cid: ChannelId, client: ChatClient) {
+        showThreadCallCount += 1
+        showThreadCalledWith = (messageId, nil, cid)
+    }
+
+    override func showThread(messageId: MessageId, at replyId: MessageId?, cid: ChannelId, client: ChatClient) {
+        showThreadCallCount += 1
+        showThreadCalledWith = (messageId, replyId, cid)
+    }
 }

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
@@ -14,6 +14,8 @@ final class ChatMessageListVC_Tests: XCTestCase {
         sut.listView as! ChatMessageListView_Mock
     }
 
+    var mockedRouter: ChatMessageListRouter_Mock { sut.router as! ChatMessageListRouter_Mock }
+
     var mockedDataSource: ChatMessageListVCDataSource_Mock!
     var mockedDelegate: ChatMessageListVCDelegate_Mock!
 
@@ -28,6 +30,7 @@ final class ChatMessageListVC_Tests: XCTestCase {
         sut.client = ChatClient_Mock(config: config)
         sut.components = .mock
         sut.components.messageListView = ChatMessageListView_Mock.self
+        sut.components.messageListRouter = ChatMessageListRouter_Mock.self
 
         mockedDataSource = ChatMessageListVCDataSource_Mock()
         sut.dataSource = mockedDataSource
@@ -687,5 +690,36 @@ final class ChatMessageListVC_Tests: XCTestCase {
 
         XCTAssertNotNil(cell.headerContainerView.superview)
         XCTAssertNotNil(cell.headerContainerView.subviews.first as? ChatMessageListDateSeparatorView)
+    }
+
+    // MARK: - messageContentViewDidTapOnThread
+
+    func test_messageContentViewDidTapOnThread_whenParentMessageExists_showThreadAtReplyId() {
+        let expectedParentMessageId = MessageId.unique
+        let messageWithParentMessage = ChatMessage.mock(parentMessageId: expectedParentMessageId)
+        let expectedCid = ChannelId.unique
+        mockedDataSource.messages = [messageWithParentMessage]
+        mockedDataSource.mockedChannel = .mock(cid: expectedCid)
+
+        sut.messageContentViewDidTapOnThread(.init(item: 0, section: 0))
+
+        XCTAssertEqual(mockedRouter.showThreadCallCount, 1)
+        XCTAssertEqual(mockedRouter.showThreadCalledWith?.parentMessageId, expectedParentMessageId)
+        XCTAssertEqual(mockedRouter.showThreadCalledWith?.replyId, messageWithParentMessage.id)
+        XCTAssertEqual(mockedRouter.showThreadCalledWith?.cid, expectedCid)
+    }
+
+    func test_messageContentViewDidTapOnThread_whenParentMessageDoesNotExist_showThreadWithoutJumpingToReply() {
+        let messageWithParentMessage = ChatMessage.mock(parentMessageId: nil)
+        let expectedCid = ChannelId.unique
+        mockedDataSource.messages = [messageWithParentMessage]
+        mockedDataSource.mockedChannel = .mock(cid: expectedCid)
+
+        sut.messageContentViewDidTapOnThread(.init(item: 0, section: 0))
+
+        XCTAssertEqual(mockedRouter.showThreadCallCount, 1)
+        XCTAssertEqual(mockedRouter.showThreadCalledWith?.parentMessageId, messageWithParentMessage.id)
+        XCTAssertNil(mockedRouter.showThreadCalledWith?.replyId)
+        XCTAssertEqual(mockedRouter.showThreadCalledWith?.cid, expectedCid)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links
https://github.com/GetStream/ios-issues-tracking/issues/384

### 🎯 Goal

Jump to reply inside a thread from the channel view.

### 📝 Summary

- Adds jumping to a reply inside a thread when tapping a quoted message which is inside a thread
- Adds jumping to the reply inside a thread when opening a thread from a thread reply in the channel view
- Adds jumping to a reply inside a thread when opening a channel with pagination of `.around`  and the given message is a replyId

### 🧪 Manual Testing Notes
**New ACs:**
1. When I tap on quoted message, which is inside a thread reply, it should open the thread and jump to the thread reply
2. When opening a thread from a thread reply which was also sent to the channel, it should open the thread and jump to the reply
3. When I open a channel where the initial pagination is .around(replyId), it should open the channel in the parent message location, open the thread and jump to the reply id

### 🎨 Showcase

| AC.1 | AC.2 | AC.3 |
|--------|--------|--------|
| <video src="https://github.com/GetStream/stream-chat-swift/assets/12814114/2f907f3c-eba5-462b-8048-e7c1f3f76cbc" >  | <video src="https://github.com/GetStream/stream-chat-swift/assets/12814114/56bd12f9-2536-478d-a82e-37b8b9182287"> | <video src="https://github.com/GetStream/stream-chat-swift/assets/12814114/79e6da81-7a5c-4d83-9411-feb8229a87fc"> |

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
