### PR TITLE
Bump Xcode version

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -22,21 +22,32 @@ jobs:
         include:
           - ios: latest
             device: "iPhone 14 Pro Max"
+            xcode: 14.3
+            os: macos-13
           - ios: 15.4
             device: "iPhone 8"
+            xcode: 14.2
+            os: macos-12
           - ios: 14.5
             device: "iPhone SE (2nd generation)"
+            xcode: 14.2
+            os: macos-12
           - ios: 13.7
             device: "iPad Air (3rd generation)"
+            xcode: 14.2
+            os: macos-12
           - ios: 12.4
             device: "iPhone X"
+            xcode: 14.2
+            os: macos-12
       fail-fast: false
-    runs-on: macos-12
+    runs-on: ${{ matrix.os }}
     env:
       GITHUB_EVENT: ${{ toJson(github.event) }}
       GITHUB_PR_NUM: ${{ github.event.number }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ALLURE_TOKEN: ${{ secrets.ALLURE_TOKEN }}
+      XCODE_VERSION: ${{ matrix.xcode }}
       STREAM_DEMO_APP_SECRET: ${{ secrets.STREAM_DEMO_APP_SECRET }}
       IOS_SIMULATOR_DEVICE: "${{ matrix.device }} (${{ matrix.ios }})"
     steps:
@@ -86,8 +97,15 @@ jobs:
     name: Test LLC (Debug)
     strategy:
       matrix:
-        xcode: [13.1, 13.4.1, 14.2]
-        os: [macos-12]
+        include:
+          - xcode: 14.3
+            os: macos-13
+          - xcode: 14.2
+            os: macos-12
+          - xcode: 13.4.1
+            os: macos-12
+          - xcode: 13.1
+            os: macos-12
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -113,7 +131,7 @@ jobs:
 
   automated-code-review:
     name: Automated Code Review
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v3.1.0
     - uses: ./.github/actions/bootstrap

--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -22,8 +22,8 @@ jobs:
         include:
           - ios: latest
             device: "iPhone 14 Pro Max"
-            xcode: 14.3
-            os: macos-13
+            xcode: 14.2
+            os: macos-12
           - ios: 15.4
             device: "iPhone 8"
             xcode: 14.2
@@ -80,7 +80,7 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
-      if: failure()
+      if: failure() && github.event_name == 'schedule'
     - name: Parse xcresult
       if: failure()
       run: xcparse logs fastlane/test_output/StreamChatUITestsApp.xcresult fastlane/test_output/logs/
@@ -127,7 +127,7 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
-      if: failure()
+      if: failure() && github.event_name == 'schedule'
 
   automated-code-review:
     name: Automated Code Review

--- a/.github/workflows/emerge.yml
+++ b/.github/workflows/emerge.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   upload--build:
     name: Upload Build to Emerge
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Install Bot SSH Key
         uses: webfactory/ssh-agent@v0.7.0

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -114,11 +114,13 @@ jobs:
 
   build-and-test-e2e-debug:
     name: Test E2E UI (Debug)
-    runs-on: macos-13
+    runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     needs: allure_testops_launch
     env:
       LAUNCH_ID: ${{ needs.allure_testops_launch.outputs.launch_id }}
+      XCODE_VERSION: "14.2.0"                      # TODO: delete these two lines
+      IOS_SIMULATOR_DEVICE: "iPhone 14 Pro (16.2)" # when Xcode 14.3.1 is released
     strategy:
       matrix:
         batch: [0, 1, 2]
@@ -186,7 +188,7 @@ jobs:
 
   build-xcode13:
     name: Build LLC + UI (Xcode 13)
-    runs-on: macos-13
+    runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     env:
       XCODE_VERSION: "13.4.1"

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   automated-code-review:
     name: Automated Code Review
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_PR_NUM: ${{ github.event.number }}
@@ -48,7 +48,7 @@ jobs:
 
   build-and-test-debug:
     name: Test LLC (Debug)
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_PR_NUM: ${{ github.event.number }}
@@ -89,7 +89,7 @@ jobs:
 
   build-and-test-ui-debug:
     name: Test UI (Debug)
-    runs-on: macos-12
+    runs-on: macos-13
     if: ${{ github.event_name != 'push' }}
     steps:
     - uses: actions/checkout@v3.1.0
@@ -114,7 +114,7 @@ jobs:
 
   build-and-test-e2e-debug:
     name: Test E2E UI (Debug)
-    runs-on: macos-12
+    runs-on: macos-13
     if: ${{ github.event_name != 'push' }}
     needs: allure_testops_launch
     env:
@@ -165,7 +165,7 @@ jobs:
 
   allure_testops_launch:
     name: Launch Allure TestOps
-    runs-on: macos-12
+    runs-on: macos-13
     if: ${{ github.event_name != 'push' }}
     outputs:
       launch_id: ${{ steps.get_launch_id.outputs.launch_id }}
@@ -186,7 +186,7 @@ jobs:
 
   build-xcode13:
     name: Build LLC + UI (Xcode 13)
-    runs-on: macos-12
+    runs-on: macos-13
     if: ${{ github.event_name != 'push' }}
     env:
       XCODE_VERSION: "13.4.1"
@@ -206,7 +206,7 @@ jobs:
 
   build-apps:
     name: Build Demo App + Example Apps
-    runs-on: macos-12
+    runs-on: macos-13
     if: ${{ github.event_name != 'push' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -232,7 +232,7 @@ jobs:
 
   spm-integration:
     name: Test Integration (SPM)
-    runs-on: macos-12
+    runs-on: macos-13
     if: ${{ github.event_name != 'push' }}
     steps:
     - uses: actions/checkout@v3.1.0
@@ -246,7 +246,7 @@ jobs:
 
   cocoapods-integration:
     name: Test Integration (CocoaPods)
-    runs-on: macos-12
+    runs-on: macos-13
     if: ${{ github.event_name != 'push' }}
     steps:
     - uses: actions/checkout@v3.1.0

--- a/.github/workflows/sync-mock-server.yml
+++ b/.github/workflows/sync-mock-server.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   sync:
     name: Sync
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v3.1.0
     - uses: actions/setup-python@v4.3.0

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   deploy:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - name: Install Bot SSH Key
       uses: webfactory/ssh-agent@v0.7.0

--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -258,7 +258,7 @@ extension UserRobot {
 
     @discardableResult
     func tapOnScrollToBottomButton() -> Self {
-        MessageListPage.scrollToBottomButton.safeTap()
+        MessageListPage.scrollToBottomButton.tapFrameCenter()
         return self
     }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,7 @@ require 'net/http'
 import 'Sonarfile'
 import 'Allurefile'
 
-xcode_version = ENV['XCODE_VERSION'] || '14.2'
+xcode_version = ENV['XCODE_VERSION'] || '14.3'
 xcode_project = 'StreamChat.xcodeproj'
 sdk_names = ['StreamChat', 'StreamChatUI']
 github_repo = ENV['GITHUB_REPOSITORY'] || 'GetStream/stream-chat-swift'


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/443

### 🎯 Goal

Bump Xcode version to 14.3 on GitHub Actions

### 📝 Summary

- All jobs on GitHub Actions now use `Xcode 14.3`
- Except E2E tests which still use `Xcode 14.2` because, for some reason, authentication tests do now work on GitHub Actions on `Xcode 14.3`. Will try to run them on Xcode 14.3.1 as soon as it's released.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/x2edi9sI9KkfjJZnyw/giphy.gif)