### PR TITLE
[BW] Use Xcode 14.2 and macOS 12 for Snapshot tests

### DIFF
--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -89,7 +89,7 @@ jobs:
 
   build-and-test-ui-debug:
     name: Test UI (Debug)
-    runs-on: macos-13
+    runs-on: macos-12
     if: ${{ github.event_name != 'push' }}
     steps:
     - uses: actions/checkout@v3.1.0
@@ -102,6 +102,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_PR_NUM: ${{ github.event.number }}
+        XCODE_VERSION: "14.2.0"                      # TODO: delete these two lines
+        IOS_SIMULATOR_DEVICE: "iPhone 14 Pro (16.2)" # when Xcode 14.3.1 is released
     - name: Parse xcresult
       if: failure()
       run: xcparse screenshots fastlane/test_output/StreamChatUI.xcresult fastlane/test_output/snapshots --test


### PR DESCRIPTION
Xcode 13 and macOS 13 raise some weird issues on CI for E2E and Snapshot tests. For now, we decided to stick with Xcode 14.2 for these tests and with macOS 12 for Snapshot tests only.

Test:
- https://github.com/GetStream/stream-chat-swift/actions/runs/5122487122/jobs/9211654099?pr=2657