### PR TITLE
Allow editing messages with attachments

### DIFF
--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -245,12 +245,23 @@ public extension ChatMessageController {
     ///
     /// - Parameters:
     ///   - text: The updated message text.
+    ///   - attachments: An array of the attachments for the message.
     ///   - extraData: Custom extra data. When `nil` is passed the message custom fields stay the same. Equals `nil` by default.
     ///   - completion: The completion. Will be called on a **callbackQueue** when the network request is finished.
     ///                 If request fails, the completion will be called with an error.
     ///
-    func editMessage(text: String, extraData: [String: RawJSON]? = nil, completion: ((Error?) -> Void)? = nil) {
-        messageUpdater.editMessage(messageId: messageId, text: text, extraData: extraData) { error in
+    func editMessage(
+        text: String,
+        attachments: [AnyAttachmentPayload] = [],
+        extraData: [String: RawJSON]? = nil,
+        completion: ((Error?) -> Void)? = nil
+    ) {
+        messageUpdater.editMessage(
+            messageId: messageId,
+            text: text,
+            attachments: attachments,
+            extraData: extraData
+        ) { error in
             self.callback {
                 completion?(error)
             }

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -125,6 +125,10 @@ extension NSManagedObjectContext: AttachmentDatabaseSession {
 
         return dto
     }
+
+    func delete(attachment: AttachmentDTO) {
+        delete(attachment)
+    }
 }
 
 private extension AttachmentDTO {

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -363,6 +363,10 @@ protocol AttachmentDatabaseSession {
         attachment: AnyAttachmentPayload,
         id: AttachmentId
     ) throws -> AttachmentDTO
+
+    /// Deletes the provided dto from a database
+    /// - Parameter attachment: The DTO to be deleted
+    func delete(attachment: AttachmentDTO)
 }
 
 protocol QueuedRequestDatabaseSession {

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -110,36 +110,50 @@ class MessageUpdater: Worker {
     ///  - Parameters:
     ///   - messageId: The message identifier.
     ///   - text: The updated message text.
+    ///   - attachments: An array of the attachments for the message.
     ///   - extraData: Extra Data for the message.
     ///   - completion: The completion. Will be called with an error if smth goes wrong, otherwise - will be called with `nil`.
     func editMessage(
         messageId: MessageId,
         text: String,
+        attachments: [AnyAttachmentPayload] = [],
         extraData: [String: RawJSON]? = nil,
         completion: ((Error?) -> Void)? = nil
     ) {
         database.write({ session in
             let messageDTO = try session.messageEditableByCurrentUser(messageId)
 
-            let encodedExtraData = extraData.map { try? JSONEncoder.default.encode($0) } ?? messageDTO.extraData
+            func updateMessage(localState: LocalMessageState) throws {
+                messageDTO.text = text
+                let encodedExtraData = extraData.map { try? JSONEncoder.default.encode($0) } ?? messageDTO.extraData
+                messageDTO.extraData = encodedExtraData
 
-            let updateQuotingMessages = {
+                messageDTO.localMessageState = localState
+
                 messageDTO.quotedBy.forEach { message in
                     message.updatedAt = messageDTO.updatedAt
                 }
+
+                guard let cid = try? messageDTO.channel.map({ try ChannelId(cid: $0.cid) }) else { return }
+                let messageId = messageDTO.id
+
+                messageDTO.attachments.forEach {
+                    session.delete(attachment: $0)
+                }
+
+                messageDTO.attachments = Set(
+                    try attachments.enumerated().map { index, attachment in
+                        let id = AttachmentId(cid: cid, messageId: messageId, index: index)
+                        return try session.createNewAttachment(attachment: attachment, id: id)
+                    }
+                )
             }
 
             switch messageDTO.localMessageState {
             case nil, .pendingSync, .syncingFailed, .deletingFailed:
-                messageDTO.text = text
-                messageDTO.extraData = encodedExtraData
-                messageDTO.localMessageState = .pendingSync
-                updateQuotingMessages()
+                try updateMessage(localState: .pendingSync)
             case .pendingSend, .sendingFailed:
-                messageDTO.text = text
-                messageDTO.extraData = encodedExtraData
-                messageDTO.localMessageState = .pendingSend
-                updateQuotingMessages()
+                try updateMessage(localState: .pendingSend)
             case .sending, .syncing, .deleting:
                 throw ClientError.MessageEditing(
                     messageId: messageId,

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -487,7 +487,7 @@ open class ComposerVC: _ViewController,
             Animate {
                 self.composerView.confirmButton.isHidden = false
                 self.composerView.sendButton.isHidden = true
-                self.composerView.recordButton.isHidden = self.composerView.sendButton.isHidden
+                self.composerView.recordButton.isHidden = self.composerView.confirmButton.isHidden
                 self.composerView.headerView.isHidden = false
                 self.composerView.cooldownView.isHidden = true
                 self.composerView.leadingContainer.isHidden = false
@@ -1292,7 +1292,10 @@ private extension Array where Element == ChatMessageAttachment<Data> {
             case .video: type = VideoAttachmentPayload.self
             case .audio: type = AudioAttachmentPayload.self
             case .file: type = FileAttachmentPayload.self
-            default: return nil
+            case .voiceRecording: type = VoiceRecordingAttachmentPayload.self
+            default:
+                log.assertionFailure("Unsupported attachment")
+                return nil
             }
 
             guard let payload = try? decoder.decode(type, from: attachment.payload) else { return nil }

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -156,6 +156,36 @@ open class ComposerVC: _ViewController,
         ///
         /// - Parameter message: The message that the composer will edit.
         public mutating func editMessage(_ message: ChatMessage) {
+            #warning("This process does not belong here probably!")
+            let attachments: [AnyAttachmentPayload] = message.allAttachments.compactMap { attachment in
+                let payload: AttachmentPayload?
+
+                let decoder = JSONDecoder()
+
+                let type: AttachmentPayload.Type
+
+                switch attachment.type {
+                case .image:
+                    type = ImageAttachmentPayload.self
+                case .video:
+                    type = VideoAttachmentPayload.self
+                case .audio:
+                    type = AudioAttachmentPayload.self
+                case .file:
+                    type = FileAttachmentPayload.self
+                default:
+                    return nil
+                }
+
+                payload = try? decoder.decode(type, from: attachment.payload)
+
+                guard let payload = payload else {
+                    return nil
+                }
+
+                return AnyAttachmentPayload(payload: payload)
+            }
+
             self = .init(
                 text: message.text,
                 state: .edit,

--- a/Sources/StreamChatUI/Composer/ComposerView.swift
+++ b/Sources/StreamChatUI/Composer/ComposerView.swift
@@ -162,13 +162,13 @@ open class ComposerView: _View, ThemeProvider {
         trailingContainer.distribution = .equal
         trailingContainer.directionalLayoutMargins = .zero
         trailingContainer.addArrangedSubview(sendButton)
-        if components.isVoiceRecordingEnabled {
-            trailingContainer.addArrangedSubview(recordButton)
-        }
         trailingContainer.addArrangedSubview(cooldownView)
         trailingContainer.addArrangedSubview(confirmButton)
         cooldownView.isHidden = true
         confirmButton.isHidden = true
+        if components.isVoiceRecordingEnabled {
+            trailingContainer.addArrangedSubview(recordButton)
+        }
 
         leadingContainer.axis = .horizontal
         leadingContainer.alignment = .center


### PR DESCRIPTION
### 🔗 Issue Links

https://github.com/GetStream/ios-issues-tracking/issues/14

### 🎯 Goal

Allow editing messages that contain any type of attachments

### 📝 Summary

As of now, it is not possible to edit the attachments of an already sent message.

### 🛠 Implementation

Dislpays currently attached messages in ComposerVC when editing a message, and updates the model accordingly.
Removed attachments are deleted, and new ones are uploaded and added to the message

### 🧪 Manual Testing Notes

1. Send a message with attachment(s)
2. Edit the message altering the attachments

Expected results:
- The message should only contain the attachments that were sent in the message edition

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/du9tUy0lntYsqGF2Ye/giphy.gif)