### PR TITLE
Fix shadow message making hidden channel reappear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fix not being able to send messages when jumping to message in newest page [#2647](https://github.com/GetStream/stream-chat-swift/pull/2647)
+- Fix shadow message making hidden channel reappear #2663(https://github.com/GetStream/stream-chat-swift/pull/2663)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelVisibilityEventMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelVisibilityEventMiddleware.swift
@@ -34,7 +34,9 @@ struct ChannelVisibilityEventMiddleware: EventMiddleware {
                     throw ClientError.ChannelDoesNotExist(cid: event.cid)
                 }
 
-                channelDTO.isHidden = false
+                if !event.message.isShadowed {
+                    channelDTO.isHidden = false
+                }
 
             // New Message will unhide the channel
             // but we won't get `ChannelVisibleEvent` for this case
@@ -43,7 +45,9 @@ struct ChannelVisibilityEventMiddleware: EventMiddleware {
                     throw ClientError.ChannelDoesNotExist(cid: event.channel.cid)
                 }
 
-                channelDTO.isHidden = false
+                if !event.message.isShadowed {
+                    channelDTO.isHidden = false
+                }
 
             default:
                 break

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/ChannelVisibilityEventMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/ChannelVisibilityEventMiddleware_Tests.swift
@@ -207,4 +207,93 @@ final class ChannelVisibilityEventMiddleware_Tests: XCTestCase {
         // Assert the `isHidden` value is reset
         XCTAssertFalse(channelDTO.isHidden)
     }
+
+    func test_messageNewEvent_whenShadowedMessage_doesNotResetsHiddenAtValue() throws {
+        let cid: ChannelId = .unique
+
+        // Create the event
+        let event = try MessageNewEventDTO(
+            from: .init(
+                eventType: .messageNew,
+                cid: cid,
+                user: .dummy(userId: .unique),
+                message: .dummy(messageId: .unique, authorUserId: .unique, isShadowed: true),
+                createdAt: .unique
+            ) as EventPayload
+        )
+
+        // Create a channel in the DB with `isHidden` set to true
+        try database.writeSynchronously { session in
+            let dto = try session.saveChannel(payload: XCTestCase().dummyPayload(with: cid))
+            dto.isHidden = true
+        }
+
+        // Simulate incoming event
+        _ = middleware.handle(event: event, session: database.viewContext)
+
+        let channelDTO = try XCTUnwrap(database.viewContext.channel(cid: cid))
+
+        // Assert the `isHidden` value is still true
+        XCTAssertTrue(channelDTO.isHidden)
+    }
+
+    func test_notificationMessageNewEvent_resetsHiddenAtValue() throws {
+        let cid: ChannelId = .unique
+
+        // Create the event
+        let event = try NotificationMessageNewEventDTO(
+            from: .init(
+                eventType: .notificationMessageNew,
+                cid: cid,
+                user: .dummy(userId: .unique),
+                channel: .dummy(cid: cid),
+                message: .dummy(messageId: .unique, authorUserId: .unique),
+                createdAt: .unique
+            )
+        )
+
+        // Create a channel in the DB with `isHidden` set to true
+        try database.writeSynchronously { session in
+            let dto = try session.saveChannel(payload: XCTestCase().dummyPayload(with: cid))
+            dto.isHidden = true
+        }
+
+        // Simulate incoming event
+        _ = middleware.handle(event: event, session: database.viewContext)
+
+        let channelDTO = try XCTUnwrap(database.viewContext.channel(cid: cid))
+
+        // Assert the `isHidden` value is reset
+        XCTAssertFalse(channelDTO.isHidden)
+    }
+
+    func test_notificationMessageNewEvent_whenShadowedMessage_doesNotResetsHiddenAtValue() throws {
+        let cid: ChannelId = .unique
+
+        // Create the event
+        let event = try NotificationMessageNewEventDTO(
+            from: .init(
+                eventType: .notificationMessageNew,
+                cid: cid,
+                user: .dummy(userId: .unique),
+                channel: .dummy(cid: cid),
+                message: .dummy(messageId: .unique, authorUserId: .unique, isShadowed: true),
+                createdAt: .unique
+            )
+        )
+
+        // Create a channel in the DB with `isHidden` set to true
+        try database.writeSynchronously { session in
+            let dto = try session.saveChannel(payload: XCTestCase().dummyPayload(with: cid))
+            dto.isHidden = true
+        }
+
+        // Simulate incoming event
+        _ = middleware.handle(event: event, session: database.viewContext)
+
+        let channelDTO = try XCTUnwrap(database.viewContext.channel(cid: cid))
+
+        // Assert the `isHidden` value is still true
+        XCTAssertTrue(channelDTO.isHidden)
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/425

### 🎯 Goal

Fix shadow message making hidden channel reappear. 

### 🧪 Manual Testing Notes
It is easier to test this with this PR merged: https://github.com/GetStream/stream-chat-swift/pull/2660

1. User A shadow bans User B
2. User A hides a channel
3. User B sends a message to the channel
4. Channel should still be hidden for User A


### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
