### PR TITLE
Rescue messages stuck in .sending state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Expose Extra Data for Giphy Attachment Payloads [#2678](https://github.com/GetStream/stream-chat-swift/pull/2678)
 
+### 🐞 Fixed
+- Rescue messages that are stuck in `.sending` state [#2676](https://github.com/GetStream/stream-chat-swift/pull/2676)
+
 # [4.33.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.33.0)
 _June 08, 2023_
 
@@ -18,7 +21,7 @@ _June 08, 2023_
 
 ### 🐞 Fixed
 - Fix not being able to send messages when jumping to message in newest page [#2647](https://github.com/GetStream/stream-chat-swift/pull/2647)
-- Fix shadow message making hidden channel reappear #2663(https://github.com/GetStream/stream-chat-swift/pull/2663)
+- Fix shadow message making hidden channel reappear [#2663](https://github.com/GetStream/stream-chat-swift/pull/2663)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/Database/DatabaseSession.swift
+++ b/Sources/StreamChat/Database/DatabaseSession.swift
@@ -181,6 +181,11 @@ protocol MessageDatabaseSession {
     /// Ignores messages that could not be saved
     @discardableResult
     func saveMessageSearch(payload: MessageSearchResultsPayload, for query: MessageSearchQuery) -> [MessageDTO]
+
+    /// Changes the state to `.pendingSend` for all messages in `.sending` state. This method is expected to be used at the beginning of the session
+    /// to avoid those from being stuck there in limbo.
+    /// Messages can get stuck in `.sending` state if the network request to send them takes to much, and the app is backgrounded or killed.
+    func rescueMessagesStuckInSending()
 }
 
 extension MessageDatabaseSession {

--- a/Sources/StreamChat/Workers/Background/MessageSender.swift
+++ b/Sources/StreamChat/Workers/Background/MessageSender.swift
@@ -56,6 +56,9 @@ class MessageSender: Worker {
                 if let changes = self?.observer.items.map({ ListChange.insert($0, index: .init(item: 0, section: 0)) }) {
                     self?.handleChanges(changes: changes)
                 }
+                self?.database.write {
+                    $0.rescueMessagesStuckInSending()
+                }
             } catch {
                 log.error("Failed to start MessageSender worker. \(error)")
             }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -6,7 +6,7 @@ import Foundation
 @testable import StreamChat
 
 /// This class allows you to wrap an existing `DatabaseSession` and adjust the behavior of its methods.
-final class DatabaseSession_Mock: DatabaseSession {
+class DatabaseSession_Mock: DatabaseSession {
     /// The wrapped session
     let underlyingSession: DatabaseSession
 
@@ -19,11 +19,7 @@ final class DatabaseSession_Mock: DatabaseSession {
 
     var markChannelAsReadParams: (cid: ChannelId, userId: UserId, at: Date)?
     var markChannelAsUnreadParams: (cid: ChannelId, userId: UserId)?
-}
 
-// Here start the boilerplate that forwards and intercepts the session calls if needed
-
-extension DatabaseSession_Mock {
     func addReaction(
         to messageId: MessageId,
         type: MessageReactionType,

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Database/DatabaseSession_Mock.swift
@@ -209,6 +209,10 @@ extension DatabaseSession_Mock {
         underlyingSession.preview(for: cid)
     }
 
+    func rescueMessagesStuckInSending() {
+        underlyingSession.rescueMessagesStuckInSending()
+    }
+
     func reaction(messageId: MessageId, userId: UserId, type: MessageReactionType) -> MessageReactionDTO? {
         underlyingSession.reaction(messageId: messageId, userId: userId, type: type)
     }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/471

### 🎯 Goal

Messages could enter in a limbo state if they were stuck in .sending

### 📝 Summary

There was an edge case where if the app is killed while messages are being sent, they are stuck in `.sending` state. MessageSender was not trying to send them in the following session as it only looks for message is `.pendingSend` state.

### 🛠 Implementation

This PR adds a mechanism to move those messages in `.sending` state to `.pendingState` on start up, so those can be rescued.

### 🧪 Manual Testing Notes

1. Simulate a really bad network
2. Send a message
3. Kill the app
4. Open the app again

Expected result:
- The message should initially not be sent (showing the clock)
- The message should be immediately sent after startup, and show the "tick" icon

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/Uuk2KuEcSWQ984DPoQ/giphy.gif)
