### PR TITLE
Expose Extra Data for Giphy Attachment Payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Expose Extra Data for Giphy Attachment Payloads [#2678](https://github.com/GetStream/stream-chat-swift/pull/2678)
 
 # [4.33.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.33.0)
 _June 08, 2023_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ## StreamChat
-### 🐞 Fixed
+### ✅ Added
 - Expose Extra Data for Giphy Attachment Payloads [#2678](https://github.com/GetStream/stream-chat-swift/pull/2678)
 
 # [4.33.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.33.0)

--- a/Tests/StreamChatTests/Models/Attachments/GiphyAttachmentPayload_Tests.swift
+++ b/Tests/StreamChatTests/Models/Attachments/GiphyAttachmentPayload_Tests.swift
@@ -43,4 +43,42 @@ final class GiphyAttachmentPayload_Tests: XCTestCase {
         XCTAssertEqual(sut?.previewURL, giphyURL)
         XCTAssertEqual(sut?.actions, [])
     }
+
+    func test_decodingExtraData() throws {
+        let title: String = .unique
+        let thumbURL: URL = .unique()
+        let comment: String = .unique
+
+        let json = """
+        {
+            "title": "\(title)",
+            "thumb_url": "\(thumbURL.absoluteString)",
+            "comment": "\(comment)"
+        }
+        """.data(using: .utf8)!
+        let payload = try JSONDecoder.stream.decode(GiphyAttachmentPayload.self, from: json)
+
+        XCTAssertEqual(payload.title, title)
+        XCTAssertEqual(payload.previewURL, thumbURL)
+        XCTAssertEqual(payload.extraData?["comment"]?.stringValue, comment)
+    }
+
+    func test_encodingExtraData() throws {
+        let payload = GiphyAttachmentPayload(
+            title: "Giphy 1",
+            previewURL: URL(string: "dummyURL")!,
+            actions: [],
+            extraData: ["comment": .string("Some comment")]
+        )
+        let json = try JSONEncoder.stream.encode(payload)
+
+        let expectedJsonObject: [String: Any] = [
+            "title": "Giphy 1",
+            "thumb_url": "dummyURL",
+            "comment": "Some comment",
+            "actions": NSArray()
+        ]
+
+        AssertJSONEqual(json, expectedJsonObject)
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links
https://github.com/GetStream/stream-chat-swift/issues/2629

### 🎯 Goal
Expose the Extra Data field in the Giphy Attachment Payload.

### 🧪 Manual Testing Notes
N/A for manual QA.

Unit Tests where added to proof it works.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
