### PR TITLE
[BW] Update test plans

### DIFF
--- a/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
+++ b/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
@@ -29,6 +29,7 @@
         "MessageUpdater_Tests\/test_unpinMessage_propogatesMessageEditingError_ifLocalStateIsInvalidForUnpinning()",
         "MessageUpdater_Tests\/test_deleteBouncedMessage_isDeletedLocally_whenLocalStateIsSendingFailed()",
         "MessageUpdater_Tests\/test_deleteMessage_updatesMessageStateCorrectly()",
+        "MessageUpdater_Tests\/test_loadReplies_whenIsJumpingToMessage_shouldClearCurrentMessagesExcludingLocalOnly()",
         "SyncRepository_Tests\/test_cancelRecoveryFlow_cancelsAllOperations()",
         "SyncRepository_Tests\/test_syncExistingChannelsEvents_someChannels_apiSuccess_shouldStoreEvents()",
         "WebSocketClient_Tests\/test_changingConnectEndpointAndReconnecting()",

--- a/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
+++ b/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
@@ -29,7 +29,6 @@
         "MessageUpdater_Tests\/test_unpinMessage_propogatesMessageEditingError_ifLocalStateIsInvalidForUnpinning()",
         "MessageUpdater_Tests\/test_deleteBouncedMessage_isDeletedLocally_whenLocalStateIsSendingFailed()",
         "MessageUpdater_Tests\/test_deleteMessage_updatesMessageStateCorrectly()",
-        "MessageUpdater_Tests\/test_loadReplies_whenIsJumpingToMessage_shouldClearCurrentMessagesExcludingLocalOnly()",
         "SyncRepository_Tests\/test_cancelRecoveryFlow_cancelsAllOperations()",
         "SyncRepository_Tests\/test_syncExistingChannelsEvents_someChannels_apiSuccess_shouldStoreEvents()",
         "WebSocketClient_Tests\/test_changingConnectEndpointAndReconnecting()",

--- a/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
+++ b/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
@@ -30,8 +30,9 @@
         "MessageUpdater_Tests\/test_deleteBouncedMessage_isDeletedLocally_whenLocalStateIsSendingFailed()",
         "MessageUpdater_Tests\/test_deleteMessage_updatesMessageStateCorrectly()",
         "SyncRepository_Tests\/test_cancelRecoveryFlow_cancelsAllOperations()",
-        "WebSocketClient_Tests\/test_whenHealthCheckEventComes_itGetProcessedSilentlyWithoutBatching()",
-        "WebSocketClient_Tests\/test_changingConnectEndpointAndReconnecting()"
+        "SyncRepository_Tests\/test_syncExistingChannelsEvents_someChannels_apiSuccess_shouldStoreEvents()",
+        "WebSocketClient_Tests\/test_changingConnectEndpointAndReconnecting()",
+        "WebSocketClient_Tests\/test_whenHealthCheckEventComes_itGetProcessedSilentlyWithoutBatching()"
       ],
       "target" : {
         "containerPath" : "container:StreamChat.xcodeproj",

--- a/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
@@ -48,6 +48,7 @@
         "MessageUpdater_Tests\/test_deleteBouncedMessage_isDeletedLocally_whenLocalStateIsSendingFailed()",
         "MessageUpdater_Tests\/test_deleteMessage_updatesMessageStateCorrectly()",
         "SyncRepository_Tests\/test_cancelRecoveryFlow_cancelsAllOperations()",
+        "SyncRepository_Tests\/test_syncExistingChannelsEvents_someChannels_apiSuccess_shouldStoreEvents()",
         "WebSocketClient_Tests\/test_changingConnectEndpointAndReconnecting()",
         "WebSocketClient_Tests\/test_whenHealthCheckEventComes_itGetProcessedSilentlyWithoutBatching()"
       ],

--- a/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
@@ -47,7 +47,6 @@
         "MessageUpdater_Tests\/test_unpinMessage_propogatesMessageEditingError_ifLocalStateIsInvalidForUnpinning()",
         "MessageUpdater_Tests\/test_deleteBouncedMessage_isDeletedLocally_whenLocalStateIsSendingFailed()",
         "MessageUpdater_Tests\/test_deleteMessage_updatesMessageStateCorrectly()",
-        "MessageUpdater_Tests\/test_loadReplies_whenIsJumpingToMessage_shouldClearCurrentMessagesExcludingLocalOnly()",
         "SyncRepository_Tests\/test_cancelRecoveryFlow_cancelsAllOperations()",
         "SyncRepository_Tests\/test_syncExistingChannelsEvents_someChannels_apiSuccess_shouldStoreEvents()",
         "WebSocketClient_Tests\/test_changingConnectEndpointAndReconnecting()",

--- a/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
@@ -47,6 +47,7 @@
         "MessageUpdater_Tests\/test_unpinMessage_propogatesMessageEditingError_ifLocalStateIsInvalidForUnpinning()",
         "MessageUpdater_Tests\/test_deleteBouncedMessage_isDeletedLocally_whenLocalStateIsSendingFailed()",
         "MessageUpdater_Tests\/test_deleteMessage_updatesMessageStateCorrectly()",
+        "MessageUpdater_Tests\/test_loadReplies_whenIsJumpingToMessage_shouldClearCurrentMessagesExcludingLocalOnly()",
         "SyncRepository_Tests\/test_cancelRecoveryFlow_cancelsAllOperations()",
         "SyncRepository_Tests\/test_syncExistingChannelsEvents_someChannels_apiSuccess_shouldStoreEvents()",
         "WebSocketClient_Tests\/test_changingConnectEndpointAndReconnecting()",

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -2771,7 +2771,7 @@ extension MessageUpdater_Tests {
 
         if shouldClear {
             // Previous current messages are not shown (excluding local messages).
-            XCTAssertEqual(currentMessageDTOs.map(\.showInsideThread), [true, false, false], file: file, line: line)
+            XCTAssertEqual(currentMessageDTOs.filter { $0.showInsideThread }.count, 1, file: file, line: line)
         } else {
             // Previous current messages are not discarded.
             XCTAssertEqual(currentMessageDTOs.map(\.showInsideThread), [true, true, true], file: file, line: line)


### PR DESCRIPTION
`SyncRepository_Tests.test_syncExistingChannelsEvents_someChannels_apiSuccess_shouldStoreEvents` has failed multiple times on CI during the month.

Moving it to the flaky test suite if there are no objections.

Fixing `MessageUpdater_Tests.test_loadReplies_whenIsJumpingToMessage_shouldClearCurrentMessagesExcludingLocalOnly` 