### PR TITLE
Resend failed attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Expose Extra Data for Giphy Attachment Payloads [#2678](https://github.com/GetStream/stream-chat-swift/pull/2678)
 
+### 🐞 Fixed
+- Fix not being able to resend failed attachments [#2680](https://github.com/GetStream/stream-chat-swift/pull/2680)
+
 # [4.33.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.33.0)
 _June 08, 2023_
 

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -146,7 +146,7 @@ private extension AttachmentDTO {
             )
         } catch {
             log.error("""
-                Failed to build uploading state for attachment with id: \(attachmentID).
+                Failed to build uploading state for attachment with id: \(attachmentID) at \(localURL)
                 Error: \(error.localizedDescription)
             """)
             return nil

--- a/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
+++ b/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift
@@ -171,11 +171,11 @@ public struct AttachmentFile: Codable, Hashable {
         }
 
         let fileType = AttachmentFileType(ext: url.pathExtension)
-        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
 
         self.init(
             type: fileType,
-            size: attributes[.size] as? Int64 ?? 0,
+            size: attributes?[.size] as? Int64 ?? 0,
             mimeType: fileType.mimeType
         )
     }

--- a/Sources/StreamChat/Workers/Background/AttachmentQueueUploader.swift
+++ b/Sources/StreamChat/Workers/Background/AttachmentQueueUploader.swift
@@ -226,7 +226,7 @@ private class AttachmentStorage {
 
     private let fileManager: FileManager
     private lazy var baseURL: URL = {
-        let base = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first ?? FileManager.default.temporaryDirectory
+        let base = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first ?? fileManager.temporaryDirectory
         return base.appendingPathComponent(Constants.path)
     }()
 

--- a/Sources/StreamChat/Workers/Background/AttachmentQueueUploader.swift
+++ b/Sources/StreamChat/Workers/Background/AttachmentQueueUploader.swift
@@ -25,6 +25,7 @@ class AttachmentQueueUploader: Worker {
     private let observer: ListDatabaseObserver<AttachmentDTO, AttachmentDTO>
     private let attachmentPostProcessor: UploadedAttachmentPostProcessor?
     private let attachmentUpdater = AnyAttachmentUpdater()
+    private let attachmentStorage = AttachmentStorage()
 
     var minSignificantUploadingProgressChange: Double = 0.05
 
@@ -69,12 +70,10 @@ class AttachmentQueueUploader: Worker {
     }
 
     private func uploadNextAttachment() {
-        database.write { [weak self] session in
-            guard let attachmentID = self?.pendingAttachmentIDs.first else {
-                return
-            }
+        guard let attachmentID = pendingAttachmentIDs.first else { return }
 
-            guard let attachment = session.attachment(id: attachmentID)?.asAnyModel() else {
+        prepareAttachmentForUpload(with: attachmentID) { [weak self] attachment in
+            guard let attachment = attachment else {
                 self?.removeAttachmentIDAndContinue(attachmentID)
                 return
             }
@@ -100,6 +99,28 @@ class AttachmentQueueUploader: Worker {
                     )
                 }
             )
+        }
+    }
+
+    private func prepareAttachmentForUpload(with id: AttachmentId, completion: @escaping (AnyChatMessageAttachment?) -> Void) {
+        let attachmentStorage = self.attachmentStorage
+        database.write { session in
+            guard let attachment = session.attachment(id: id) else { return }
+
+            if let temporaryURL = attachment.localURL {
+                do {
+                    let localURL = try attachmentStorage.storeAttachment(at: temporaryURL)
+                    attachment.localURL = localURL
+                } catch {
+                    log.error("Could not copy attachment to local storage: \(error.localizedDescription)", subsystems: .offlineSupport)
+                }
+            }
+
+            let model = attachment.asAnyModel()
+
+            DispatchQueue.main.async {
+                completion(model)
+            }
         }
     }
 
@@ -139,6 +160,7 @@ class AttachmentQueueUploader: Worker {
                     uploadedAttachment = processedAttachment
                 }
                 attachmentDTO.data = uploadedAttachment.attachment.payload
+                self?.removeDataFromLocalStorage(for: attachmentId)
             }
         }, completion: {
             if let error = $0 {
@@ -175,6 +197,13 @@ class AttachmentQueueUploader: Worker {
 
         uploadedAttachment.attachment = attachment
     }
+
+    private func removeDataFromLocalStorage(for attachmentId: AttachmentId) {
+        database.write { [weak attachmentStorage] session in
+            guard let attachmentLocalURL = session.attachment(id: attachmentId)?.localURL else { return }
+            attachmentStorage?.removeAttachment(at: attachmentLocalURL)
+        }
+    }
 }
 
 private extension Array where Element == ListChange<AttachmentDTO> {
@@ -187,5 +216,55 @@ private extension Array where Element == ListChange<AttachmentDTO> {
                 return nil
             }
         }
+    }
+}
+
+private class AttachmentStorage {
+    enum Constants {
+        static let path = "LocalAttachments"
+    }
+
+    private let fileManager: FileManager
+    private lazy var baseURL: URL = {
+        let base = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first ?? FileManager.default.temporaryDirectory
+        return base.appendingPathComponent(Constants.path)
+    }()
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        do {
+            try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        } catch {
+            log.error("Could not create a directory to store attachments: \(error.localizedDescription)")
+        }
+    }
+
+    /// Since iOS 8, we cannot use absolute paths to access resources because the intermediate folders can change between sessions/app runs. The content of it, when
+    /// using `.documentsDirectory` is stable.
+    /// Because of that, if the file is already in our storage, the only thing we will do is to give a fresh and valid url to access it.
+    func storeAttachment(at temporaryURL: URL) throws -> URL {
+        let id = temporaryURL.lastPathComponent
+        let sandboxedURL = baseURL.appendingPathComponent(id)
+
+        guard !fileExists(at: sandboxedURL) else {
+            return sandboxedURL
+        }
+
+        // Copy data to local path
+        try Data(contentsOf: temporaryURL).write(to: sandboxedURL)
+        return sandboxedURL
+    }
+
+    func removeAttachment(at localURL: URL) {
+        guard fileExists(at: localURL) else { return }
+        do {
+            try fileManager.removeItem(at: localURL)
+        } catch {
+            log.info("Unable to remove attachment at \(localURL): \(error.localizedDescription)")
+        }
+    }
+
+    private func fileExists(at url: URL) -> Bool {
+        fileManager.fileExists(atPath: url.path)
     }
 }

--- a/Sources/StreamChat/Workers/Background/AttachmentQueueUploader.swift
+++ b/Sources/StreamChat/Workers/Background/AttachmentQueueUploader.swift
@@ -240,8 +240,8 @@ private class AttachmentStorage {
     }
 
     /// Since iOS 8, we cannot use absolute paths to access resources because the intermediate folders can change between sessions/app runs. The content of it, when
-    /// using `.documentsDirectory` is stable.
-    /// Because of that, if the file is already in our storage, the only thing we will do is to give a fresh and valid url to access it.
+    /// using `.documentsDirectory`, is stable though.
+    /// Because of that, if the file is already in our storage, the only thing we will do is to return a fresh and valid url to access it.
     func storeAttachment(at temporaryURL: URL) throws -> URL {
         let id = temporaryURL.lastPathComponent
         let sandboxedURL = baseURL.appendingPathComponent(id)

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
@@ -41,6 +41,7 @@ final class APIClient_Spy: APIClient, Spy {
     @Atomic var init_attachmentUploader: AttachmentUploader
     @Atomic var request_expectation: XCTestExpectation
     @Atomic var recoveryRequest_expectation: XCTestExpectation
+    @Atomic var uploadRequest_expectation: XCTestExpectation
 
     // Cleans up all recorded values
     func cleanUp() {
@@ -49,6 +50,7 @@ final class APIClient_Spy: APIClient, Spy {
         request_completion = nil
         request_expectation = .init()
         recoveryRequest_expectation = .init()
+        uploadRequest_expectation = .init()
 
         recoveryRequest_endpoint = nil
         recoveryRequest_allRecordedCalls = []
@@ -75,6 +77,7 @@ final class APIClient_Spy: APIClient, Spy {
         init_attachmentUploader = attachmentUploader
         request_expectation = .init()
         recoveryRequest_expectation = .init()
+        uploadRequest_expectation = .init()
 
         super.init(
             sessionConfiguration: sessionConfiguration,
@@ -147,6 +150,7 @@ final class APIClient_Spy: APIClient, Spy {
         uploadFile_attachment = attachment
         uploadFile_progress = progress
         uploadFile_completion = completion
+        uploadRequest_expectation.fulfill()
     }
 
     override func flushRequestsQueue() {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: https://github.com/GetStream/stream-chat-swift/issues/2326
Resolves: https://github.com/GetStream/ios-issues-tracking/issues/208

### 🎯 Goal

Allow resending attachments when those fail

### 📝 Summary

Up until now, when sending a resource as part of a message attachment, we would face an issue trying to resend them if those were not successfully sent at first. This is because the resources could not be found using the references that were given when initially fetching them from the SDK.

When importing resources (using Files, Photo Album or Camera) into the SDK we are given temporary URLs. Those URLs are meant to be used within the session in which those are provided, but not persisted. Those resources will not be available in subsequent launches of the app, and therefore we cannot keep those URLs as a reference.

Because of that, we need to copy those resources into a safe place, and use that safe storage to keep them until they are successfully sent.

### 🛠 Implementation

This PR introduces AttachmentStorage, which takes care of saving resources in a folder of the Documents directory of the app. When those are sent, they are removed from there.

### 🧪 Manual Testing Notes

1. Simulate a bad internet connection
2. Send a message with an attachment
3. Kill the app while uploading it
4. Reopen the app

Expected result:
- The attachment should be in failure state, and tapping on retry should successfully send it.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/G1ypMuTabhPwRXRgRE/giphy.gif)
