### PR TITLE
[CI] Add E2E tests for restarting attachment upload

### DIFF
--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -509,6 +509,10 @@
 		82BA52EF27E1EF7B00951B87 /* MessageList_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BA52EE27E1EF7B00951B87 /* MessageList_Tests.swift */; };
 		82CBE5682861BF300039C35C /* AttachmentResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CBE5672861BF300039C35C /* AttachmentResponses.swift */; };
 		82CED1C827DF492F006E967A /* ThreadPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CED1C727DF492F006E967A /* ThreadPage.swift */; };
+		82DCB3A92A4AE8FB00738933 /* StreamChat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 799C941B247D2F80001F1104 /* StreamChat.framework */; };
+		82DCB3AA2A4AE8FB00738933 /* StreamChat.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 799C941B247D2F80001F1104 /* StreamChat.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		82DCB3AD2A4AE8FB00738933 /* StreamChatUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; };
+		82DCB3AE2A4AE8FB00738933 /* StreamChatUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 790881FD25432B7200896F03 /* StreamChatUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		82E43AC128637651007BB6CD /* http_attachment.json in Resources */ = {isa = PBXBuildFile; fileRef = 82E43AC028637651007BB6CD /* http_attachment.json */; };
 		840B4FCF26A9E53100D5EFAB /* CustomEventRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840B4FCE26A9E53100D5EFAB /* CustomEventRequestBody.swift */; };
 		84196FA32805892500185E99 /* LocalMessageState+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84196FA22805892500185E99 /* LocalMessageState+Extensions.swift */; };
@@ -2288,6 +2292,20 @@
 			remoteGlobalIDString = 793060E525778896005CF846;
 			remoteInfo = StreamChatTestTools;
 		};
+		82DCB3AB2A4AE8FB00738933 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8AD5EC8622E9A3E8005CFAC9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 799C941A247D2F80001F1104;
+			remoteInfo = StreamChat;
+		};
+		82DCB3AF2A4AE8FB00738933 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8AD5EC8622E9A3E8005CFAC9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 790881FC25432B7200896F03;
+			remoteInfo = StreamChatUI;
+		};
 		A327D4B827E0D59300CFEC3F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8AD5EC8622E9A3E8005CFAC9 /* Project object */;
@@ -2468,6 +2486,18 @@
 				437FCA0B26D67BE40000223C /* DemoAppPush.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		82DCB3B12A4AE8FB00738933 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				82DCB3AE2A4AE8FB00738933 /* StreamChatUI.framework in Embed Frameworks */,
+				82DCB3AA2A4AE8FB00738933 /* StreamChat.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		C11B577A29D4403800D5A248 /* Embed Frameworks */ = {
@@ -4163,7 +4193,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				82DCB3A92A4AE8FB00738933 /* StreamChat.framework in Frameworks */,
 				A3BD486B281FD4500090D511 /* OHHTTPStubs in Frameworks */,
+				82DCB3AD2A4AE8FB00738933 /* StreamChatUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8602,12 +8634,15 @@
 				A34407B727D8C33F0044F150 /* Frameworks */,
 				A34407B827D8C33F0044F150 /* Resources */,
 				A3B78F1B282AB07100348AD1 /* SwiftLint */,
+				82DCB3B12A4AE8FB00738933 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				A34407F127D8C85E0044F150 /* PBXTargetDependency */,
 				A34407F327D8C85E0044F150 /* PBXTargetDependency */,
+				82DCB3AC2A4AE8FB00738933 /* PBXTargetDependency */,
+				82DCB3B02A4AE8FB00738933 /* PBXTargetDependency */,
 			);
 			name = StreamChatUITestsApp;
 			packageProductDependencies = (
@@ -11489,6 +11524,16 @@
 			isa = PBXTargetDependency;
 			target = 793060E525778896005CF846 /* StreamChatTestTools */;
 			targetProxy = 79F458A825E3B52900E63D67 /* PBXContainerItemProxy */;
+		};
+		82DCB3AC2A4AE8FB00738933 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 799C941A247D2F80001F1104 /* StreamChat */;
+			targetProxy = 82DCB3AB2A4AE8FB00738933 /* PBXContainerItemProxy */;
+		};
+		82DCB3B02A4AE8FB00738933 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 790881FC25432B7200896F03 /* StreamChatUI */;
+			targetProxy = 82DCB3AF2A4AE8FB00738933 /* PBXContainerItemProxy */;
 		};
 		A327D4B927E0D59300CFEC3F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
+++ b/StreamChatUITestsAppUITests/Pages/MessageListPage.swift
@@ -261,6 +261,14 @@ class MessageListPage {
         static func videoPlayer() -> XCUIElement {
             app.otherElements["PlayerView"]
         }
+        
+        static func restartAttachmentUploadIcon(in messageCell: XCUIElement) -> XCUIElement {
+            messageCell.buttons["AttachmentActionButton"]
+        }
+        
+        static func uploadingProgressLabel(in messageCell: XCUIElement) -> XCUIElement {
+            messageCell.staticTexts["uploadingProgressLabel"]
+        }
 
         enum LinkPreview {
             static func link(in messageCell: XCUIElement) -> XCUIElement {

--- a/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot+Asserts.swift
@@ -987,6 +987,9 @@ extension UserRobot {
     ) -> Self {
         let messageCell = messageCell(withIndex: messageCellIndex)
         MessageListPage.Attributes.time(in: messageCell).wait()
+        let uploadingProgressLabel = MessageListPage.Attributes.uploadingProgressLabel(in: messageCell).waitForDisappearance()
+        XCTAssertFalse(uploadingProgressLabel.exists, "Image uploading failed", file: file, line: line)
+        
         tapOnMessage(messageCell)
         let fullscreenImage = attributes.fullscreenImage().wait()
         let errMessage = isPresent ? "There is no image" : "Image is presented"

--- a/StreamChatUITestsAppUITests/Robots/UserRobot.swift
+++ b/StreamChatUITestsAppUITests/Robots/UserRobot.swift
@@ -403,6 +403,13 @@ extension UserRobot {
         if send { sendMessage("", waitForAppearance: false) }
         return self
     }
+    
+    @discardableResult
+    func restartImageUpload(messageCellIndex: Int = 0) -> Self {
+        let messageCell = messageCell(withIndex: messageCellIndex)
+        MessageListPage.Attributes.restartAttachmentUploadIcon(in: messageCell).wait().safeTap()
+        return self
+    }
 
     @discardableResult
     func mentionParticipant(manually: Bool = false) -> Self {

--- a/StreamChatUITestsAppUITests/Tests/Attachments_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Attachments_Tests.swift
@@ -64,4 +64,68 @@ final class Attachments_Tests: StreamTestCase {
             userRobot.assertVideo(isPresent: true)
         }
     }
+    
+    func test_restartImageUpload() throws {
+        linkToScenario(withId: 2195)
+
+        try XCTSkipIf(
+            UIDevice.current.userInterfaceIdiom == .pad || ProcessInfo().operatingSystemVersion.majorVersion == 12,
+            "Flaky on iPad and iOS 12"
+        )
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .setConnectivitySwitchVisibility(to: .on)
+                .login()
+                .openChannel()
+        }
+        WHEN("user sends an image beeing offline") {
+            userRobot
+                .setConnectivity(to: .off)
+                .uploadImage()
+        }
+        AND("user restarts an image upload being online") {
+            userRobot
+                .setConnectivity(to: .on)
+                .restartImageUpload()
+        }
+        THEN("user can see uploaded image") {
+            userRobot.assertImage(isPresent: true)
+        }
+    }
+    
+    func test_restartImageUploadAfterRestartingTheApp() throws {
+        linkToScenario(withId: 2196)
+
+        try XCTSkipIf(
+            UIDevice.current.userInterfaceIdiom == .pad || ProcessInfo().operatingSystemVersion.majorVersion == 12,
+            "Flaky on iPad and iOS 12"
+        )
+
+        GIVEN("user opens the channel") {
+            userRobot
+                .setIsLocalStorageEnabled(to: .on)
+                .setConnectivitySwitchVisibility(to: .on)
+                .login()
+                .openChannel()
+        }
+        WHEN("user sends an image being offline") {
+            userRobot
+                .setConnectivity(to: .off)
+                .uploadImage()
+        }
+        AND("user restarts the app") {
+            app.restart()
+        }
+        AND("user restarts an image being online") {
+            userRobot
+                .setIsLocalStorageEnabled(to: .on)
+                .login()
+                .openChannel()
+                .restartImageUpload()
+        }
+        THEN("user can see uploaded image") {
+            userRobot.assertImage(isPresent: true)
+        }
+    }
 }


### PR DESCRIPTION
Relates to https://github.com/GetStream/stream-chat-swift/pull/2680

PS: I also added `StreamChat` and `StreamChatUI` frameworks to the TestApp's embedded frameworks to be able to start the app on the device/simulator without Xcode.