### PR TITLE
Fix custom `ImageLoading` functions with default arguments not being called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### ✅ Added
 - Expose Extra Data for Giphy Attachment Payloads [#2678](https://github.com/GetStream/stream-chat-swift/pull/2678)
-
 ### 🐞 Fixed
 - Rescue messages that are stuck in `.sending` state [#2676](https://github.com/GetStream/stream-chat-swift/pull/2676)
 - Fix not being able to resend failed attachments [#2680](https://github.com/GetStream/stream-chat-swift/pull/2680)
+
+## StreamChatUI
+### 🐞 Fixed
 - Fix custom `ImageLoading` functions with default arguments not being called [#2695](https://github.com/GetStream/stream-chat-swift/pull/2695)
 
 # [4.33.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.33.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Rescue messages that are stuck in `.sending` state [#2676](https://github.com/GetStream/stream-chat-swift/pull/2676)
 - Fix not being able to resend failed attachments [#2680](https://github.com/GetStream/stream-chat-swift/pull/2680)
+- Fix custom `ImageLoading` functions with default arguments not being called [#2695](https://github.com/GetStream/stream-chat-swift/pull/2695)
 
 # [4.33.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.33.0)
 _June 08, 2023_

--- a/Sources/StreamChatUI/Utils/ImageLoading/ImageLoading.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/ImageLoading.swift
@@ -99,7 +99,7 @@ public extension ImageLoading {
         into imageView: UIImageView,
         from attachmentPayload: ImageAttachmentPayload?,
         maxResolutionInPixels: Double,
-        completion: ((_ result: Result<UIImage, Error>) -> Void)? = nil
+        completion: ((_ result: Result<UIImage, Error>) -> Void)?
     ) -> Cancellable? {
         guard let originalWidth = attachmentPayload?.originalWidth,
               let originalHeight = attachmentPayload?.originalHeight else {
@@ -125,20 +125,40 @@ public extension ImageLoading {
             completion: completion
         )
     }
+
+    @discardableResult
+    func loadImage(
+        into imageView: UIImageView,
+        from attachmentPayload: ImageAttachmentPayload?,
+        maxResolutionInPixels: Double
+    ) -> Cancellable? {
+        loadImage(
+            into: imageView,
+            from: attachmentPayload,
+            maxResolutionInPixels: maxResolutionInPixels,
+            completion: nil
+        )
+    }
 }
 
 // MARK: - Default Parameters
 
 public extension ImageLoading {
-    // Default empty completion block.
+    @discardableResult
+    func loadImage(
+        into imageView: UIImageView,
+        from url: URL?
+    ) -> Cancellable? {
+        loadImage(into: imageView, from: url, with: ImageLoaderOptions(), completion: nil)
+    }
+
     @discardableResult
     func loadImage(
         into imageView: UIImageView,
         from url: URL?,
-        with options: ImageLoaderOptions = ImageLoaderOptions(),
-        completion: ((_ result: Result<UIImage, Error>) -> Void)? = nil
+        with options: ImageLoaderOptions
     ) -> Cancellable? {
-        loadImage(into: imageView, from: url, with: options, completion: completion)
+        loadImage(into: imageView, from: url, with: options, completion: nil)
     }
 }
 

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1176,6 +1176,7 @@
 		AD472EF825C425FB00A96E70 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = AD472EF725C425FB00A96E70 /* SnapshotTesting */; };
 		AD483B962A2658970004B406 /* ChannelMemberUnbanRequestPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD483B952A2658970004B406 /* ChannelMemberUnbanRequestPayload.swift */; };
 		AD483B972A2658970004B406 /* ChannelMemberUnbanRequestPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD483B952A2658970004B406 /* ChannelMemberUnbanRequestPayload.swift */; };
+		AD4C15562A55874700A32955 /* ImageLoading_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD4C15552A55874700A32955 /* ImageLoading_Tests.swift */; };
 		AD4CDD85296499160057BC8A /* ScrollViewPaginationHandler_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD4CDD81296498D20057BC8A /* ScrollViewPaginationHandler_Tests.swift */; };
 		AD4CDD862964991A0057BC8A /* InvertedScrollViewPaginationHandler_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD4CDD83296498EB0057BC8A /* InvertedScrollViewPaginationHandler_Tests.swift */; };
 		AD52A2192804850700D0157E /* ChannelConfigDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD52A2182804850700D0157E /* ChannelConfigDTO.swift */; };
@@ -3599,6 +3600,7 @@
 		AD470C9B26C6D8C60090759A /* ChatMessageListVCDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListVCDataSource.swift; sourceTree = "<group>"; };
 		AD470C9D26C6D9030090759A /* ChatMessageListVCDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListVCDelegate.swift; sourceTree = "<group>"; };
 		AD483B952A2658970004B406 /* ChannelMemberUnbanRequestPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelMemberUnbanRequestPayload.swift; sourceTree = "<group>"; };
+		AD4C15552A55874700A32955 /* ImageLoading_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageLoading_Tests.swift; sourceTree = "<group>"; };
 		AD4CDD81296498D20057BC8A /* ScrollViewPaginationHandler_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewPaginationHandler_Tests.swift; sourceTree = "<group>"; };
 		AD4CDD83296498EB0057BC8A /* InvertedScrollViewPaginationHandler_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvertedScrollViewPaginationHandler_Tests.swift; sourceTree = "<group>"; };
 		AD52A2182804850700D0157E /* ChannelConfigDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelConfigDTO.swift; sourceTree = "<group>"; };
@@ -6928,6 +6930,7 @@
 		A3960E0427DA5512003AB2B0 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				AD4C15552A55874700A32955 /* ImageLoading_Tests.swift */,
 				640FE0F526A57903006CE703 /* ListChangeIndexPathResolver_Tests.swift */,
 				BDDD1EAB2632E32000BA007B /* AppearanceProvider_Tests.swift */,
 				C1320E07276B2E0800A06B35 /* Array+SafeSubscript_Tests.swift */,
@@ -9777,6 +9780,7 @@
 				795296C12582494000435B2E /* ComponentsProvider_Tests.swift in Sources */,
 				225503B825DC59FD00A5A65A /* UIView+Helpers.swift in Sources */,
 				7865705825FB6DF300974045 /* UIViewController+Extensions_Tests.swift in Sources */,
+				AD4C15562A55874700A32955 /* ImageLoading_Tests.swift in Sources */,
 				40FA4E012A12A85E00DA21D2 /* VoiceRecordingVC_Tests.swift in Sources */,
 				400F063C29A6632F00242A86 /* ChatMessageListDateSeparatorView_Tests.swift in Sources */,
 				792057AC264168A6002B145B /* UITestsEnvironmentSetup.swift in Sources */,

--- a/Tests/StreamChatUITests/Utils/ImageLoading_Tests.swift
+++ b/Tests/StreamChatUITests/Utils/ImageLoading_Tests.swift
@@ -1,0 +1,94 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatUI
+import XCTest
+
+final class ImageLoading_Tests: XCTestCase {
+    var sut: ImageLoading!
+    var spy: ImageLoaderSpy!
+
+    override func setUp() {
+        super.setUp()
+        spy = ImageLoaderSpy()
+        sut = spy
+    }
+
+    override func tearDown() {
+        sut = nil
+        spy = nil
+        super.tearDown()
+    }
+
+    func test_loadImageIntoWithOptions_isCalled() {
+        sut.loadImage(into: .init(image: nil), from: nil, with: .init(), completion: nil)
+
+        XCTAssertEqual(spy.loadImageIntoWithOptionsCallCount, 1)
+    }
+
+    func test_loadImageIntoWithOptions_whenDefaultArgumentsUsed_isCalled() {
+        sut.loadImage(into: .init(image: nil), from: nil, with: .init(), completion: nil)
+        sut.loadImage(into: .init(image: nil), from: nil, with: .init())
+
+        XCTAssertEqual(spy.loadImageIntoWithOptionsCallCount, 2)
+    }
+
+    func test_downloadImage_isCalled() {
+        sut.downloadImage(with: .init(url: .localYodaImage, options: .init()), completion: { _ in })
+
+        XCTAssertEqual(spy.downloadImageCallCount, 1)
+    }
+
+    func test_downloadMultipleImages_isCalled() {
+        sut.downloadMultipleImages(with: [.init(url: .localYodaImage, options: .init())], completion: { _ in })
+
+        XCTAssertEqual(spy.downloadMultipleImagesCallCount, 1)
+    }
+
+    class ImageLoaderSpy: ImageLoading {
+        var loadImageIntoWithOptionsCallCount = 0
+        var loadImageIntoWithAttachmentPayloadCallCount = 0
+        var downloadImageCallCount = 0
+        var downloadMultipleImagesCallCount = 0
+
+        @discardableResult
+        func loadImage(
+            into imageView: UIImageView,
+            from url: URL?,
+            with options: ImageLoaderOptions,
+            completion: ((_ result: Result<UIImage, Error>) -> Void)?
+        ) -> Cancellable? {
+            loadImageIntoWithOptionsCallCount += 1
+            return nil
+        }
+
+        @discardableResult
+        func loadImage(
+            into imageView: UIImageView,
+            from attachmentPayload: ImageAttachmentPayload?,
+            maxResolutionInPixels: Double,
+            completion: ((_ result: Result<UIImage, Error>) -> Void)?
+        ) -> Cancellable? {
+            loadImageIntoWithAttachmentPayloadCallCount += 1
+            return nil
+        }
+
+        @discardableResult
+        func downloadImage(
+            with request: ImageDownloadRequest,
+            completion: @escaping ((_ result: Result<UIImage, Error>) -> Void)
+        ) -> Cancellable? {
+            downloadImageCallCount += 1
+            return nil
+        }
+
+        func downloadMultipleImages(
+            with requests: [ImageDownloadRequest],
+            completion: @escaping (([Result<UIImage, Error>]) -> Void)
+        ) {
+            downloadMultipleImagesCallCount += 1
+        }
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links
https://github.com/GetStream/stream-chat-swift/issues/2692

### 📝 Summary
When providing a custom `ImageLoading` implementation, some of the functions were not being called. This is because the default implementations provided through the extension in the protocol were using default arguments in the declaration, and this makes Swift think that it is a different function. So the solution is to provide additional declarations without the arguments, which can have default values.

### 🧪 Manual Testing Notes
N/A for manual QA. Unit Tests were added to proof it works.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
