### PR TITLE
Fix pinning messages with attachments not synced with server

### DIFF
--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -22,14 +22,15 @@ class AttachmentDTO: NSManagedObject {
     }
 
     /// An attachment local state.
-    @NSManaged private var localStateRaw: String
+    @NSManaged private var localStateRaw: String?
     @NSManaged private var localProgress: Double
     var localState: LocalAttachmentState? {
         get {
-            LocalAttachmentState(rawValue: localStateRaw, progress: localProgress)
+            guard let localStateRaw = self.localStateRaw else { return nil }
+            return LocalAttachmentState(rawValue: localStateRaw, progress: localProgress)
         }
         set {
-            localStateRaw = newValue?.rawValue ?? ""
+            localStateRaw = newValue?.rawValue
             localProgress = newValue?.progress ?? 0
         }
     }

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22D49" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22F66" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="localProgress" attributeType="Double" minValueString="0" maxValueString="1" defaultValueString="0.0" usesScalarValueType="YES"/>
-        <attribute name="localStateRaw" attributeType="String" defaultValueString=""/>
+        <attribute name="localStateRaw" optional="YES" attributeType="String"/>
         <attribute name="localURL" optional="YES" attributeType="URI"/>
         <attribute name="type" optional="YES" attributeType="String"/>
         <relationship name="message" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MessageDTO" inverseName="attachments" inverseEntity="MessageDTO"/>

--- a/Tests/StreamChatTests/Database/DTOs/AttachmentDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/AttachmentDTO_Tests.swift
@@ -38,7 +38,7 @@ final class AttachmentDTO_Tests: XCTestCase {
 
         // Assert attachment has correct values.
         XCTAssertEqual(loadedAttachment.attachmentID, attachmentId)
-        XCTAssertEqual(loadedAttachment.localState, .unknown)
+        XCTAssertEqual(loadedAttachment.localState, nil)
         XCTAssertEqual(loadedAttachment.attachmentType, attachment.type)
         XCTAssertEqual(loadedAttachment.message.id, messageId)
 
@@ -72,7 +72,7 @@ final class AttachmentDTO_Tests: XCTestCase {
 
         // Assert attachment has correct values.
         XCTAssertEqual(loadedAttachment.attachmentID, attachmentId)
-        XCTAssertEqual(loadedAttachment.localState, .unknown)
+        XCTAssertEqual(loadedAttachment.localState, nil)
         XCTAssertEqual(loadedAttachment.attachmentType, attachment.type)
         XCTAssertEqual(loadedAttachment.message.id, messageId)
 
@@ -109,7 +109,7 @@ final class AttachmentDTO_Tests: XCTestCase {
 
         // Assert attachment has correct values.
         XCTAssertEqual(loadedAttachment.attachmentID, attachmentId)
-        XCTAssertEqual(loadedAttachment.localState, .unknown)
+        XCTAssertEqual(loadedAttachment.localState, nil)
         XCTAssertEqual(loadedAttachment.attachmentType, attachment.type)
         XCTAssertEqual(loadedAttachment.message.id, messageId)
 
@@ -250,7 +250,34 @@ final class AttachmentDTO_Tests: XCTestCase {
 
         // Assert attachment local file URL and state are nil.
         XCTAssertNil(loadedAttachment?.localURL)
-        XCTAssertEqual(loadedAttachment?.localState, .unknown)
+        XCTAssertEqual(loadedAttachment?.localState, nil)
+    }
+
+    func test_localStateRaw_whenSetToNil_shouldReturnNil() throws {
+        let cid: ChannelId = .unique
+        let messageId: MessageId = .unique
+        let attachmentId = AttachmentId(cid: cid, messageId: messageId, index: 0)
+        let attachmentEnvelope = AnyAttachmentPayload.mockFile
+
+        // Create channel in the database.
+        try database.createChannel(cid: cid, withMessages: false)
+
+        // Create message in the database.
+        try database.createMessage(id: messageId, cid: cid)
+
+        // Seed message attachment with localState == nil.
+        try database.writeSynchronously { session in
+            let attachmentDTO = try session.createNewAttachment(attachment: attachmentEnvelope, id: attachmentId)
+            attachmentDTO.localState = nil
+        }
+
+        // Load the attachment from the database.
+        var loadedAttachment: AttachmentDTO? {
+            database.viewContext.attachment(id: attachmentId)
+        }
+
+        // Assert attachment has localState == nil, which means the attachment comes from the server.
+        XCTAssertEqual(loadedAttachment?.localState, nil)
     }
 
     func test_attachmentChange_triggerMessageUpdate() throws {

--- a/Tests/StreamChatTests/Workers/Background/MessageEditor_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/MessageEditor_Tests.swift
@@ -81,6 +81,42 @@ final class MessageEditor_Tests: XCTestCase {
         XCTAssertCall("updateMessage(withID:localState:isBounced:completion:)", on: messageRepository, times: 1)
     }
 
+    func test_editorSyncsMessage_whenMessageChangesToPendingSyncAndHasAttachmentsUploadedFromServer() throws {
+        let currentUserId: UserId = .unique
+        let messageId: MessageId = .unique
+        let cid: ChannelId = .unique
+
+        // We create a message with an attachment from the server.
+        try database.createCurrentUser(id: currentUserId)
+        try database.createMessage(id: messageId, authorId: currentUserId, cid: cid, localState: nil)
+        try database.writeSynchronously { session in
+            let attachmentDTO = try session.saveAttachment(
+                payload: .dummy(),
+                id: .init(cid: cid, messageId: messageId, index: 0)
+            )
+            let messageDTO = session.message(id: messageId)
+            messageDTO?.attachments.insert(attachmentDTO)
+        }
+
+        // When we update the message local state to pending sync
+        try database.writeSynchronously { session in
+            let messageDTO = session.message(id: messageId)
+            messageDTO?.localMessageState = .pendingSync
+        }
+
+        // Then the message editor updates the message.
+        let message1Payload: MessageRequestBody = try XCTUnwrap(
+            database.viewContext.message(id: messageId)?
+                .asRequestBody()
+        )
+        AssertAsync {
+            Assert.willBeEqual(self.apiClient.request_allRecordedCalls.filter {
+                $0.endpoint == AnyEndpoint(.editMessage(payload: message1Payload))
+            }.count, 1)
+        }
+        XCTAssertCall("updateMessage(withID:localState:isBounced:completion:)", on: messageRepository, times: 1)
+    }
+
     func test_editorSyncsMessage_withPendingSyncLocalState_withPendingAttachments() throws {
         let currentUserId: UserId = .unique
         let messageId: MessageId = .unique
@@ -96,9 +132,9 @@ final class MessageEditor_Tests: XCTestCase {
         let messageDTO = try XCTUnwrap(database.viewContext.message(id: messageId))
         XCTAssertEqual(messageDTO.attachments.count, 1)
 
-        let attachmentId = try XCTUnwrap(messageDTO.attachments.first?.attachmentID)
-        XCTAssertEqual(apiClient.request_allRecordedCalls.count, 0)
+        apiClient.request_allRecordedCalls = []
 
+        let attachmentId = try XCTUnwrap(messageDTO.attachments.first?.attachmentID)
         try database.writeSynchronously { session in
             let attachment = try XCTUnwrap(session.attachment(id: attachmentId))
             attachment.localState = .uploaded


### PR DESCRIPTION
### 🔗 Issue Links
https://github.com/GetStream/stream-chat-swift/issues/2697

### 🎯 Goal
Fixes pinned messages with attachments not synced with the server.

### 📝 Summary
After this PR: https://github.com/GetStream/stream-chat-swift/pull/2659, the MessageEditor was changed to that only messages that had no attachments or had all attachments uploaded were considered to be updated by the MessageEditor. The thing is that a while back ([here](https://github.com/GetStream/stream-chat-swift/pull/1646)) we changed the attachment's local state would be `unknown` in case they are uploaded and came from the server response. This is incorrect, and it should actually be `nil`. 

With this, the MessageEditor will correctly observe the messages which have all attachments uploaded or all attachments with local state to `nil`. 

### 🧪 Manual Testing Notes
- Open Channel
- Pin a message with attachments
- Logout
- Login
- Check if the pin message with attachments is still pinned

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
