### PR TITLE
Fix messages disappearing in search query after entering a channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix messages disappearing in search query after entering a channel [#2700](https://github.com/GetStream/stream-chat-swift/pull/2700)
 
 # [4.34.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.34.0)
 _July 05, 2023_

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -22,6 +22,7 @@ class MessageDTO: NSManagedObject {
     @NSManaged fileprivate var localMessageStateRaw: String?
 
     @NSManaged var id: String
+    @NSManaged var cid: String?
     @NSManaged var text: String
     @NSManaged var type: String
     @NSManaged var command: String?
@@ -95,6 +96,10 @@ class MessageDTO: NSManagedObject {
 
         guard !isDeleted else {
             return
+        }
+
+        if let channel = channel, self.cid != channel.cid {
+            self.cid = channel.cid
         }
 
         // Manually mark the channel as dirty to trigger the entity update and give the UI a chance
@@ -650,6 +655,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
             return dto
         }
 
+        dto.cid = payload.cid?.rawValue
         dto.text = payload.text
         dto.createdAt = payload.createdAt.bridgeDate
         dto.updatedAt = payload.updatedAt.bridgeDate
@@ -1054,7 +1060,7 @@ private extension ChatMessage {
         }
 
         id = dto.id
-        cid = try? dto.channel.map { try ChannelId(cid: $0.cid) }
+        cid = try? dto.cid.map { try ChannelId(cid: $0) }
         text = dto.text
         type = MessageType(rawValue: dto.type) ?? .regular
         command = dto.command

--- a/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
+++ b/Sources/StreamChat/Database/StreamChatModel.xcdatamodeld/StreamChatModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22D49" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22F66" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AttachmentDTO" representedClassName="AttachmentDTO" syncable="YES">
         <attribute name="data" attributeType="Binary"/>
         <attribute name="id" attributeType="String"/>
@@ -184,6 +184,7 @@
     </entity>
     <entity name="MessageDTO" representedClassName="MessageDTO" syncable="YES">
         <attribute name="args" optional="YES" attributeType="String"/>
+        <attribute name="cid" optional="YES" attributeType="String"/>
         <attribute name="command" optional="YES" attributeType="String"/>
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="defaultSortingKey" optional="YES" attributeType="Date" usesScalarValueType="NO"/>

--- a/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
@@ -1218,7 +1218,8 @@ final class MessageDTO_Tests: XCTestCase {
         let messagePayload: MessagePayload = .dummy(
             messageId: .unique,
             authorUserId: .unique,
-            channel: ChannelDetailPayload.dummy(cid: channelId)
+            channel: ChannelDetailPayload.dummy(cid: channelId),
+            cid: channelId
         )
 
         try database.writeSynchronously { session in

--- a/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
@@ -3350,7 +3350,30 @@ final class MessageDTO_Tests: XCTestCase {
         XCTAssertEqual(message.isLocalOnly, false)
     }
 
-    // MARK: Helpers:
+    // MARK: - message.cid
+
+    func test_cid_whenChannelIsDeleted_thenCidNotNil() throws {
+        // GIVEN
+        let messagePayload = MessagePayload.dummy(cid: .unique)
+        let channelId = ChannelId.unique
+        try database.writeSynchronously { session in
+            let channelDTO = try session.saveChannel(payload: .dummy(channel: .dummy(cid: channelId)))
+            try session.saveMessage(payload: messagePayload, channelDTO: channelDTO, syncOwnReactions: false, cache: nil)
+        }
+
+        // WHEN
+        try database.writeSynchronously { session in
+            session.removeChannels(cids: Set([channelId]))
+        }
+
+        // THEN
+        let messageDTO = try XCTUnwrap(database.viewContext.message(id: messagePayload.id))
+        let messageModel = try messageDTO.asModel()
+        XCTAssertNotNil(messageDTO.cid)
+        XCTAssertNotNil(messageModel.cid)
+    }
+
+    // MARK: - Helpers:
 
     private func createMessage(with message: MessagePayload) throws -> MessageDTO {
         let context = database.viewContext


### PR DESCRIPTION
### 🔗 Issue Links
https://github.com/GetStream/stream-chat-swift/issues/2699

### 🎯 Goal
Fix messages disappearing while searching messages. This would happen after entering a channel and coming back to the search. 

### 🛠 Implementation

We fix this by separating the `message.cid` and the `message.channel.cid`. Before, the `message.cid` was populated through the `channel.cid`, the thing is that in some scenarios we might not have the channel in the local DB. For example, when jumping to messages we sometimes delete or unlink the channel from the local DB. This PR changes this, so now the `message.cid` is populated whether we have a channel locally or not.

### 🧪 Manual Testing Notes
This was tested in a local branch through SwiftUI.
Integration tests were also added to proof it works.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
