### PR TITLE
Fixed typos in the UIKit docs

### DIFF
--- a/docusaurus/docs/iOS/uikit/components/channel-list.md
+++ b/docusaurus/docs/iOS/uikit/components/channel-list.md
@@ -26,7 +26,7 @@ let channelListVC = ChatChannelListVC.make(with: controller)
 
 When the `ChatChannelListVC` instance is created, there are multiple ways of showing it:
 1. modally
-1. inside existed `UINavigationController`
+1. inside an existing `UINavigationController`
 1. as a tab inside `UITabBarController`
 1. inside `UISplitViewController`
 1. as a child controller
@@ -38,7 +38,7 @@ let navigationVC = UINavigationController(rootViewController: channelListVC)
 present(navigationVC, animated: true)
 ```
 
-To push the channel list to existed navigation controller:
+To push the channel list to an existing navigation controller:
 ```swift
 navigationController?.pushViewController(channelListVC, animated: true)
 ```
@@ -215,7 +215,7 @@ The channel list component uses the `ChannelListController` to fetch the list of
 ## Channel List Query
 
 The `ChannelListQuery` is the structure used to specify the query parameters for fetching the list of channels from Stream backend.
-It has 4 parameters in it's `init`:
+It has 4 parameters in its `init`:
 
 ```swift
 public init(

--- a/docusaurus/docs/iOS/uikit/components/channel.md
+++ b/docusaurus/docs/iOS/uikit/components/channel.md
@@ -124,7 +124,7 @@ class CustomChatChannelVC: ChatChannelVC {
 | <img src={require("../../assets/channelvc-default.png").default} /> | <img src={require("../../assets/channelvc-livestream.png").default} /> |
 
 ## Channel Query
-When creating a `ChannelController` for the `ChatChannelVC` you can provide `ChannelQuery` different from one used by default. The `ChannelQuery` is the query parameters for fetching the channel from Stream's backend. It has the following initializer:
+When creating a `ChannelController` for the `ChatChannelVC` you can provide `ChannelQuery` different from the one used by default. The `ChannelQuery` contains the query parameters for fetching the channel from Stream's backend. It has the following initializer:
 
 ```swift
 public init(

--- a/docusaurus/docs/iOS/uikit/components/message.md
+++ b/docusaurus/docs/iOS/uikit/components/message.md
@@ -72,7 +72,7 @@ Components.default.messageBubbleView = CustomMessageSquaredBubbleView.self
 
 ### Simple Layout Changes
 
-The `ChatMessageLayoutOptions` are flags that the `ChatMessageLayoutOptionsResolver` injects in each message view depending on the message content (For example Does the message contains reactions? Is it coming from the same user? Etc...). When rendering the message view, the layout options will be used to know which views to show or hide, and if the message cell can be reused since different layout options combinations will produce different reuse identifiers.
+The `ChatMessageLayoutOptions` are flags that the `ChatMessageLayoutOptionsResolver` injects in each message view depending on the message content (For example: does the message contain reactions? Is it coming from the same user? Etc...). When rendering the message view, the layout options will be used to know which views to show or hide, and if the message cell can be reused since different layout options combinations will produce different reuse identifiers.
 
 By customizing the `ChatMessageLayoutOptionsResolver` it is possible to do simple layout changes, like for example always showing the timestamp (by default if the messages are sent in the same minute, only the last one shows the timestamp).
 

--- a/docusaurus/docs/iOS/uikit/custom-components.md
+++ b/docusaurus/docs/iOS/uikit/custom-components.md
@@ -16,14 +16,14 @@ To make customizations as easy as possible all view components share the same li
 component in most cases you only need to override methods from the `Customizable` protocol such as `updateContent()`, `setUpAppearance()` or `setUpLayout()`.
 
 :::note
-Most UI components are stateless view classes. Components like `MessageList`, `ChannelList` and `MessageComposer` are stateful and are view controllers. Customization for these components are described in detail in their own doc pages.
+Most UI components are stateless view classes. Components like `MessageList`, `ChannelList` and `MessageComposer` are stateful and are view controllers. Customizations for these components are described in detail in their own doc pages.
 :::
 
 ## The `Components` object
 
 You can provide your own component class via dependency injection. The SDK exposes this via the `Components` object and the `Components.default` singleton. You should provide all customizations as early as possible in your application.
 
-Let's say that you have your own component to render messages called `MyCustomMessageView`, this is how you register it to the SDK and replace the built-in one
+Let's say that you have your own component to render messages called `MyCustomMessageView`. Here's an example how to register it in the SDK and replace the built-in one:
 
 ```swift
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -57,16 +57,16 @@ func updateContent()
 ```
 
 ### `setUp()`
-You can see this lifecycle method as a custom constructor of the view since it is only called once in the lifecycle of the component. Here it is a good place for setting delegates, adding gesture recognizers or adding any kind of target action. Usually you want to call `super.setUp()` when overriding this lifecycle method, but you can chose not to if you want to configure all the delegates and actions from scratch.
+You can see this lifecycle method as a custom constructor of the view since it is only called once in the lifecycle of the component. This is a good place for setting delegates, adding gesture recognizers or adding any kind of target action. Usually you want to call `super.setUp()` when overriding this lifecycle method, but you can choose not to if you want to configure all the delegates and actions from scratch.
 
 ### `setUpAppearance()`
-This lifecycle is where you can customize the appearance of the component, like changing colors, corner radius, everything that changes the style of the UI but not the layout. You should call `super.setUpAppearance()` if you only want to override some of the view's appearance and not everything.
+This lifecycle method is where you can customize the appearance of the component, like changing colors, corner radius, everything that changes the style of the UI but not the layout. You should call `super.setUpAppearance()` if you only want to override part of the view's appearance and not everything.
 
 ### `setUpLayout()`
-Here is where you should do customize the layout of the component, for example, changing the position of the views, padding, margins or even remove some child views. All the UI Components of the SDK use **AutoLayout** to layout the views, but our SDK provides a `ContainerStackView` component to make the customization easier. The `ContainerStackView` works very much like a `UIStackView`, in fact, it has almost the same API, but it is better suitable for our needs in terms of customizability. Just like the other lifecycle methods, you can call `super.setUpLayout()` depending on if you want to make the layout of the component from scratch or just want to change some parts of the component.
+This method is where you should customize the layout of the component, for example, changing the position of the views, padding, margins or even remove some child views. All the UI Components of the SDK use **AutoLayout** to layout the views, but our SDK provides a `ContainerStackView` component to make the customization easier. The `ContainerStackView` works very much like a `UIStackView`, in fact, it has almost the same API, but it is better suitable for our needs in terms of customizability. Just like the other lifecycle methods, you can call `super.setUpLayout()` depending on if you want to make the layout of the component from scratch or just want to change some parts of the component.
 
 ### `updateContent()`
-Finally, this last lifecycle is called whenever the data of the component changes. Here is where you can change the logic of the component, change how the data is displayed or formatted. In the Stream SDK all of the components have a `content` property that represents the data of the component. The rule of thumb to use this lifecycle is that if the change you want to do depends on the data of the component, then you should use this lifecycle method, even, for example, to do layout changes that are impacted by the content.
+Finally, this method is called whenever the data of the component changes. Here you can change the logic of the component, change how the data is displayed or formatted. In the Stream SDK all of the components have a `content` property that represents the data of the component. This method should be used if the user interface depends on the data of the component.
 
 In addition to this, view components expose their content with the `content` property. For instance the `MessageContent` component `content`'s property holds the `ChatMessage` object.
 
@@ -102,7 +102,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 | ------------- | ------------- |
 | ![Default Avatars](../assets/default-avatars.png)  | ![Bordered Avatars](../assets/bordered-avatars.png)  |
 
-And that's it 🎉 as you can see all avatars across the UI are now with a border.
+And that's it 🎉, as you can see all avatars across the UI are now with a border.
 
 #### Change Avatar only in one view
 
@@ -133,7 +133,7 @@ As you can see, we override the `authorAvatarView` property of the `QuotedChatMe
 
 ## Example: Custom Unread Count Indicator
 
-Now, to show an example on how to use to other lifecycle methods, let's try to change the channel unread count indicator to look like the one in iMessage:
+Now, to show an example on how to use the other lifecycle methods, let's try to change the channel unread count indicator to look like the one in iMessage:
 
 | Default style  | Custom "iMessage" Style |
 | ------------- | ------------- |

--- a/docusaurus/docs/iOS/uikit/data-formatting.md
+++ b/docusaurus/docs/iOS/uikit/data-formatting.md
@@ -88,11 +88,11 @@ It supports the most common Markdown syntax:
 - headings and subheadings
 - links, etc.
 
-It uses [SwiftyMarkdown](https://github.com/SimonFairbairn/SwiftyMarkdown) library internally.
+It uses the [SwiftyMarkdown](https://github.com/SimonFairbairn/SwiftyMarkdown) library internally.
 
 <center><img src={require("../assets/markdown-formatting.png").default} width="60%" height="60%"/></center>
 
-Markdown support is enabled by default. You can disable it by setting the following flag to false in the `Appearance` configuration:
+Markdown support is enabled by default. You can disable it by setting the following flag to `false` in the `Appearance` configuration:
 
 ```swift
 Appearance.default.formatters.isMarkdownEnabled = false

--- a/docusaurus/docs/iOS/uikit/getting-started.md
+++ b/docusaurus/docs/iOS/uikit/getting-started.md
@@ -149,7 +149,7 @@ Your `ChannelId` has to be a unique ID and you can set this to anything, in this
 
 :::tip Using Synchronize
 
-After creating the channel `try ChatClient.shared.channelController(createChannelWithId: ChannelId(type: .livestream, id: UUID().uuidString), name: channelName)` it's important you call `synchronize()` after so the local and remote data is updated. You can read more about the importance of `synchronize()` [here](../../client/importance-of-synchronize)..
+After creating the channel `try ChatClient.shared.channelController(createChannelWithId: ChannelId(type: .livestream, id: UUID().uuidString), name: channelName)` it's important you call `synchronize()` after so the local and remote data is updated. You can read more about the importance of `synchronize()` [here](../../client/importance-of-synchronize).
 
 :::
 

--- a/docusaurus/docs/iOS/uikit/theming.md
+++ b/docusaurus/docs/iOS/uikit/theming.md
@@ -66,14 +66,14 @@ If the same image is used in multiple places, changing the image in the `Appeara
 
 Appearance style properties are organized in three groups:
 
-### `colorPalette`
+### colorPalette
 
-A color palette to provide basic set of colors for all UI components. The full reference can be found [here](../common-content/reference-docs/stream-chat-ui/appearance.color-palette.md)
+A color palette to provide basic set of colors for all UI components. The full reference can be found [here](../common-content/reference-docs/stream-chat-ui/appearance.color-palette.md).
 
 ### fonts
 
-The set of fonts used by UI components. The full reference can be found [here](../common-content/reference-docs/stream-chat-ui/appearance.fonts.md)
+The set of fonts used by UI components. The full reference can be found [here](../common-content/reference-docs/stream-chat-ui/appearance.fonts.md).
 
 ### images
 
-The set of images used by UI components. The full reference can be found [here](../common-content/reference-docs/stream-chat-ui/appearance.images.md)
+The set of images used by UI components. The full reference can be found [here](../common-content/reference-docs/stream-chat-ui/appearance.images.md).

--- a/docusaurus/docs/iOS/uikit/theming.md
+++ b/docusaurus/docs/iOS/uikit/theming.md
@@ -66,14 +66,14 @@ If the same image is used in multiple places, changing the image in the `Appeara
 
 Appearance style properties are organized in three groups:
 
-### colorPalette
+### `colorPalette`
 
 A color palette to provide basic set of colors for all UI components. The full reference can be found [here](../common-content/reference-docs/stream-chat-ui/appearance.color-palette.md).
 
-### fonts
+### `fonts`
 
 The set of fonts used by UI components. The full reference can be found [here](../common-content/reference-docs/stream-chat-ui/appearance.fonts.md).
 
-### images
+### `images`
 
 The set of images used by UI components. The full reference can be found [here](../common-content/reference-docs/stream-chat-ui/appearance.images.md).


### PR DESCRIPTION
### 🎯 Goal

Some typos I ran into while reading the UIKit docs.

### 🛠 Implementation

Updated the docusaurus files.

### 🧪 Manual Testing Notes

Run docusaurus locally.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)