### PR TITLE
Set up the latest iOS version for macos-12

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - ios: 16.4
+          - ios: 16.2
             setup_runtime: false
             device: "iPhone 14 Pro Max"
             xcode: 14.2


### PR DESCRIPTION
Due to CI fail:
```
[03:30:10]: Simulator iPhone 14 Pro Max (16.4) not found 
Available simulators: 
["iPhone 8 (16.2)", "iPhone 8 Plus (16.2)", "iPhone 11 (16.2)", "iPhone 11 Pro (16.2)", "iPhone 11 Pro Max (16.2)", "iPhone SE (2nd generation) (16.2)", "iPhone 12 mini (16.2)", "iPhone 12 (16.2)", "iPhone 12 Pro (16.2)", "iPhone 12 Pro Max (16.2)", "iPhone 13 Pro (16.2)", "iPhone 13 Pro Max (16.2)", "iPhone 13 mini (16.2)", "iPhone 13 (16.2)", "iPhone SE (3rd generation) (16.2)", "iPhone 14 (16.2)", "iPhone 14 Plus (16.2)", "iPhone 14 Pro (16.2)", "iPhone 14 Pro Max (16.2)", "iPad Pro (9.7-inch) (16.2)", "iPad (9th generation) (16.2)", "iPad Air (4th generation) (16.2)", "iPad Pro (11-inch) (3rd generation) (16.2)", "iPad Pro (12.9-inch) (5th generation) (16.2)", "iPad Air (5th generation) (16.2)", "iPad (10th generation) (16.2)", "iPad mini (6th generation) (16.2)", "iPad Pro (11-inch) (4th generation) (16.2)", "iPad Pro (12.9-inch) (6th generation) (16.2)"]
```