### PR TITLE
Fix channel list custom sorting for iOS 14 and below

### DIFF
--- a/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
+++ b/Sources/StreamChat/Query/Sorting/ChannelListSortingKey.swift
@@ -7,38 +7,78 @@ import Foundation
 /// `ChannelListSortingKey` is keys by which you can get sorted channels after query.
 public struct ChannelListSortingKey: SortingKey, Equatable {
     /// The default sorting is by the last massage date or a channel created date. The same as by `updatedDate`.
-    public static let `default` = Self(keyPath: \.defaultSortingAt, localKey: "defaultSortingAt", remoteKey: "updated_at", requiresRuntimeSorting: false)
+    public static let `default` = Self(
+        keyPath: \.defaultSortingAt,
+        localKey: #keyPath(ChannelDTO.defaultSortingAt),
+        remoteKey: ChannelCodingKeys.updatedAt.rawValue
+    )
+
     /// Sort channels by date they were created.
-    public static let createdAt = Self(keyPath: \.createdAt, remoteKey: "created_at", requiresRuntimeSorting: false)
+    public static let createdAt = Self(
+        keyPath: \.createdAt,
+        localKey: #keyPath(ChannelDTO.createdAt),
+        remoteKey: ChannelCodingKeys.createdAt.rawValue
+    )
+
     /// Sort channels by date they were updated.
-    public static let updatedAt = Self(keyPath: \.updatedAt, remoteKey: "updated_at", requiresRuntimeSorting: false)
+    public static let updatedAt = Self(
+        keyPath: \.updatedAt,
+        localKey: #keyPath(ChannelDTO.updatedAt),
+        remoteKey: ChannelCodingKeys.updatedAt.rawValue
+    )
+
     /// Sort channels by the last message date..
-    public static let lastMessageAt = Self(keyPath: \.lastMessageAt, remoteKey: "last_message_at", requiresRuntimeSorting: false)
+    public static let lastMessageAt = Self(
+        keyPath: \.lastMessageAt,
+        localKey: #keyPath(ChannelDTO.lastMessageAt),
+        remoteKey: ChannelCodingKeys.lastMessageAt.rawValue
+    )
+
     /// Sort channels by number of members.
-    public static let memberCount = Self(keyPath: \.memberCount, remoteKey: "member_count", requiresRuntimeSorting: false)
+    public static let memberCount = Self(
+        keyPath: \.memberCount,
+        localKey: #keyPath(ChannelDTO.memberCount),
+        remoteKey: ChannelCodingKeys.memberCount.rawValue
+    )
+
     /// Sort channels by `cid`.
     /// **Note**: This sorting option can extend your response waiting time if used as primary one.
-    public static let cid = Self(keyPath: \.cid, remoteKey: "cid", requiresRuntimeSorting: false)
+    public static let cid = Self(
+        keyPath: \.cid,
+        localKey: #keyPath(ChannelDTO.cid),
+        remoteKey: ChannelCodingKeys.cid.rawValue
+    )
+
     /// Sort channels by unread state. When using this sorting key, every unread channel weighs the same,
     /// so they're sorted by `updatedAt`
-    public static let hasUnread = Self(keyPath: \.hasUnread, remoteKey: "has_unread", requiresRuntimeSorting: true)
+    public static let hasUnread = Self(
+        keyPath: \.hasUnread,
+        localKey: nil,
+        remoteKey: "has_unread"
+    )
+
     /// Sort channels by their unread count.
-    public static let unreadCount = Self(keyPath: \.unreadCount, remoteKey: "unread_count", requiresRuntimeSorting: true)
+    public static let unreadCount = Self(
+        keyPath: \.unreadCount,
+        localKey: nil,
+        remoteKey: "unread_count"
+    )
 
     public static func custom<T>(keyPath: KeyPath<ChatChannel, T>, key: String) -> Self {
-        .init(keyPath: keyPath, remoteKey: key, requiresRuntimeSorting: true)
+        .init(keyPath: keyPath, localKey: nil, remoteKey: key)
     }
 
     let keyPath: PartialKeyPath<ChatChannel>
-    let localKey: String
+    let localKey: String?
     let remoteKey: String
-    let requiresRuntimeSorting: Bool
+    var requiresRuntimeSorting: Bool {
+        localKey == nil
+    }
 
-    init<T>(keyPath: KeyPath<ChatChannel, T>, localKey: String? = nil, remoteKey: String, requiresRuntimeSorting: Bool) {
+    init<T>(keyPath: KeyPath<ChatChannel, T>, localKey: String?, remoteKey: String) {
         self.keyPath = keyPath
-        self.localKey = localKey ?? keyPath.stringValue
+        self.localKey = localKey
         self.remoteKey = remoteKey
-        self.requiresRuntimeSorting = requiresRuntimeSorting
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -49,7 +89,7 @@ public struct ChannelListSortingKey: SortingKey, Equatable {
 
 extension ChannelListSortingKey: CustomDebugStringConvertible {
     public var debugDescription: String {
-        localKey
+        remoteKey
     }
 }
 
@@ -60,7 +100,10 @@ extension ChannelListSortingKey {
     }()
 
     func sortDescriptor(isAscending: Bool) -> NSSortDescriptor? {
-        requiresRuntimeSorting ? nil : .init(key: localKey, ascending: isAscending)
+        guard let localKey = self.localKey else {
+            return nil
+        }
+        return .init(key: localKey, ascending: isAscending)
     }
 }
 
@@ -81,18 +124,6 @@ extension Array where Element == Sorting<ChannelListSortingKey> {
 private extension Sorting where Key == ChannelListSortingKey {
     var sortValue: SortValue<ChatChannel>? {
         SortValue(keyPath: key.keyPath, isAscending: isAscending)
-    }
-}
-
-private extension KeyPath where Root == ChatChannel {
-    /// The keyPath key has a string.
-    ///
-    /// Example:
-    /// `\ChatChannel.createdAt` returns `"createdAt"`.
-    var stringValue: String {
-        let value = String(describing: self)
-        let root = String(describing: Self.rootType)
-        return value.replacingOccurrences(of: "\\\(root).", with: "")
     }
 }
 

--- a/Tests/StreamChatTests/Query/ChannelListFilterScope_Tests.swift
+++ b/Tests/StreamChatTests/Query/ChannelListFilterScope_Tests.swift
@@ -93,7 +93,7 @@ final class ChannelListFilterScope_Tests: XCTestCase {
         let id = "theid"
         let query = ChannelListQuery(
             filter: .containMembers(userIds: [id]),
-            sort: [Sorting<ChannelListSortingKey>(key: .cid)],
+            sort: [.init(key: .cid)],
             pageSize: 1,
             messagesLimit: 2,
             membersLimit: 3

--- a/Tests/StreamChatTests/Query/Sorting/ChannelListSortingKey_Tests.swift
+++ b/Tests/StreamChatTests/Query/Sorting/ChannelListSortingKey_Tests.swift
@@ -90,7 +90,7 @@ final class ChannelListSortingKey_Tests: XCTestCase {
     func test_runtimeSortingKey_keyPath_isValid() throws {
         let key = ChannelListSortingKey.custom(keyPath: \.customScore, key: "score")
         XCTAssertTrue(key.requiresRuntimeSorting)
-        XCTAssertEqual(key.localKey, "customScore")
+        XCTAssertEqual(key.localKey, nil)
         XCTAssertEqual(key.remoteKey, "score")
         XCTAssertNil(key.sortDescriptor(isAscending: true))
         XCTAssertTrue(key.requiresRuntimeSorting)
@@ -100,7 +100,7 @@ final class ChannelListSortingKey_Tests: XCTestCase {
     func test_customNestedSortingKey_keyPath_isValid() throws {
         let key = ChannelListSortingKey.custom(keyPath: \.customNestedName, key: "employee.name")
         XCTAssertTrue(key.requiresRuntimeSorting)
-        XCTAssertEqual(key.localKey, "customNestedName")
+        XCTAssertEqual(key.localKey, nil)
         XCTAssertEqual(key.remoteKey, "employee.name")
         XCTAssertNil(key.sortDescriptor(isAscending: true))
         XCTAssertTrue(key.requiresRuntimeSorting)


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Fix channel list custom sorting for iOS 14 due to the fact that KeyPath's String Convertible works differently depending on iOS version.

### 🛠 Implementation
The `localKey` used for the Sort Descriptor is now built with a `#keyPath` of a `ChannelDTO` property. As a result, the `requiresRuntimeSorting` now calculated based on if we have a localKey or not. 

### 🧪 Manual Testing Notes
- Run Demo App with Channel Pinning Enabled on iOS 14
- It should not crash or block the app

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)