### PR TITLE
Fix Demo App crash when tapping filter channels on iPad

### DIFF
--- a/DemoApp/Extensions/UIViewController+Alert.swift
+++ b/DemoApp/Extensions/UIViewController+Alert.swift
@@ -64,13 +64,15 @@ extension UIViewController {
         message: String? = nil,
         actions: [UIAlertAction],
         cancelHandler: (() -> Void)? = nil,
-        preferredStyle: UIAlertController.Style = .alert
+        preferredStyle: UIAlertController.Style = .alert,
+        sourceView: UIView? = nil
     ) {
         let alert = UIAlertController(
             title: title,
             message: message,
             preferredStyle: preferredStyle
         )
+        alert.popoverPresentationController?.sourceView = sourceView
 
         actions.forEach { alert.addAction($0) }
         alert.addAction(.init(title: "Cancel", style: .destructive, handler: { _ in

--- a/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
@@ -108,7 +108,8 @@ final class DemoChatChannelListVC: ChatChannelListVC, EventsControllerDelegate {
         presentAlert(
             title: "Filter Channels",
             actions: [defaultChannelsAction, hiddenChannelsAction, mutedChannelsAction],
-            preferredStyle: .actionSheet
+            preferredStyle: .actionSheet,
+            sourceView: filterChannelsButton
         )
     }
 


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Fix demo app crash when tapping filter channels on iPad.

### 🧪 Manual Testing Notes
- Open Demo App with iPad
- Tap on Channel Filters (right top corner icon)
- Should not crash

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
