### PR TITLE
Make sure that channel list states are disabled for Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChatUI
+### 🐞 Fixed
+- Explicitly disable channel list states for Search Components [#2725](https://github.com/GetStream/stream-chat-swift/pull/2725)
 
 # [4.35.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.35.1)
 _August 09, 2023_

--- a/Sources/StreamChatUI/ChatChannelList/Search/ChatChannelListSearchVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/Search/ChatChannelListSearchVC.swift
@@ -19,6 +19,10 @@ open class ChatChannelListSearchVC: ChatChannelListVC, UISearchResultsUpdating {
         ScrollViewPaginationHandler(scrollView: collectionView)
     }()
 
+    override open var isChatChannelListStatesEnabled: Bool {
+        false
+    }
+
     // MARK: - Lifecycle
 
     override open func setUpLayout() {

--- a/Sources/StreamChatUI/ChatChannelList/Search/ChatMessageSearchVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/Search/ChatMessageSearchVC.swift
@@ -19,10 +19,6 @@ open class ChatMessageSearchVC: ChatChannelListSearchVC, ChatMessageSearchContro
 
     private var isPaginatingMessages: Bool = false
 
-    override open var isChatChannelListStatesEnabled: Bool {
-        false
-    }
-
     // MARK: - Lifecycle
 
     override open func setUp() {

--- a/Sources/StreamChatUI/ChatChannelList/Search/ChatMessageSearchVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/Search/ChatMessageSearchVC.swift
@@ -19,6 +19,10 @@ open class ChatMessageSearchVC: ChatChannelListSearchVC, ChatMessageSearchContro
 
     private var isPaginatingMessages: Bool = false
 
+    override open var isChatChannelListStatesEnabled: Bool {
+        false
+    }
+
     // MARK: - Lifecycle
 
     override open func setUp() {


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Some customers had to disable this explicit to avoid some issues. This will make sure that for Search we don't use channel list states, and also that we don't add the empty view twice to the hierarchy.

### 🧪 Manual Testing Notes
N/A. There is no impact on the Demo App.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
