### PR TITLE
Fix blank channel name in Message Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChatUI
 ### 🐞 Fixed
 - Explicitly disable channel list states for Search Components [#2725](https://github.com/GetStream/stream-chat-swift/pull/2725)
+- Fix blank channel name in Message Search [#2726](https://github.com/GetStream/stream-chat-swift/pull/2726)
 
 # [4.35.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.35.1)
 _August 09, 2023_

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -128,7 +128,7 @@ open class ChatChannelListItemView: _View, ThemeProvider, SwiftUIRepresentable {
     open var titleText: String? {
         if let searchedMessage = content?.searchedMessage {
             var title = "\(searchedMessage.author.name ?? searchedMessage.author.id)"
-            if let channelName = content?.channel.name {
+            if let channelName = content?.channel.name, !channelName.isEmpty {
                 title += L10n.Channel.Item.Search.in(channelName)
             }
             return title

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannelList/ChatChannelListItemView_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannelList/ChatChannelListItemView_Tests.swift
@@ -496,6 +496,25 @@ final class ChatChannelListItemView_Tests: XCTestCase {
         XCTAssertEqual(itemView.titleText, "Yoda")
     }
 
+    func test_titleText_whenSearchingMessage_whenChannelNameIsEmpty() {
+        let userId: UserId = .unique
+
+        let channel: ChatChannel = .mock(
+            cid: .unique,
+            name: "",
+            membership: .mock(id: userId)
+        )
+
+        let itemView = ChatChannelListItemView()
+        itemView.content = .init(
+            channel: channel,
+            currentUserId: nil,
+            searchResult: .init(text: "Dummy", message: .mock(author: .mock(id: .unique, name: "Yoda")))
+        )
+
+        XCTAssertEqual(itemView.titleText, "Yoda")
+    }
+
     // MARK: - Subtitle
 
     func test_subtitleText_isNil_whenChannelIsNil() {


### PR DESCRIPTION
### 🔗 Issue Links
N/A

### 🎯 Goal
Fix the channel name being blank in Message Search when the channel name exists but is empty.

### 🧪 Manual Testing Notes
N/A. A test was added to prove it works.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
