### PR TITLE
Make sure loud speaker is always used for playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fix video attachments not being sent with `thumb_url`, which caused issues in other platforms [#2720](https://github.com/GetStream/stream-chat-swift/pull/2720)
+- Make sure loud speaker is always used for playback in voice messages [#2734](https://github.com/GetStream/stream-chat-swift/pull/2734)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChat/Audio/AudioPlayer/AudioPlaying.swift
+++ b/Sources/StreamChat/Audio/AudioPlayer/AudioPlaying.swift
@@ -121,13 +121,13 @@ open class StreamAudioPlayer: AudioPlaying, AppStateObserverDelegate {
             /// If the currentItem is paused, we want to continue the playback
             /// Otherwise, no action is required
             if context.state == .paused {
-                player.play()
+                play()
             } else if context.state == .stopped {
                 /// If the currentItem has stopped, we want to restart the playback. We are replacing
                 /// the currentItem with the same one to trigger the player's observers on the updated
                 /// currentItem.
                 player.replaceCurrentItem(with: .init(asset: currentItem))
-                player.play()
+                play()
             }
 
             /// This case may be triggered if we call ``loadAsset`` on a player that is currently
@@ -173,7 +173,7 @@ open class StreamAudioPlayer: AudioPlaying, AppStateObserverDelegate {
         do {
             /// As the AVPlayer doesn't provide an API to actually stop the playback, we are simulating it
             /// by calling pause
-            player.pause()
+            pause()
 
             try audioSessionConfigurator.deactivatePlaybackSession()
 
@@ -211,13 +211,13 @@ open class StreamAudioPlayer: AudioPlaying, AppStateObserverDelegate {
     func applicationDidMoveToBackground() {
         guard context.state == .playing else { return }
         shouldPlayWhenComeToForeground = true
-        player.pause()
+        pause()
     }
 
     func applicationDidMoveToForeground() {
         guard shouldPlayWhenComeToForeground else { return }
         shouldPlayWhenComeToForeground = false
-        player.play()
+        play()
     }
 
     // MARK: - Helpers

--- a/Sources/StreamChat/Audio/AudioSessionConfiguring.swift
+++ b/Sources/StreamChat/Audio/AudioSessionConfiguring.swift
@@ -48,9 +48,6 @@ final class StreamAudioSessionConfigurator: AudioSessionConfiguring {
 }
 #else
 final class StreamAudioSessionConfigurator: AudioSessionConfiguring {
-    private static let recordingCategories: Set<AVAudioSession.Category> = [.record, .playAndRecord]
-    private static let playbackCategories: Set<AVAudioSession.Category> = [.playback, .playAndRecord]
-
     /// The audioSession with which the configurator will interact.
     private let audioSession: AudioSessionProtocol
 

--- a/Sources/StreamChat/Audio/AudioSessionConfiguring.swift
+++ b/Sources/StreamChat/Audio/AudioSessionConfiguring.swift
@@ -69,9 +69,6 @@ final class StreamAudioSessionConfigurator: AudioSessionConfiguring {
     /// - Note: This method is using the `.playAndRecord` category with the `.spokenAudio` mode.
     /// The preferredInput will be set to `.buildInMic` and overrideOutputAudioPort to `.speaker`.
     func activateRecordingSession() throws {
-        guard !Self.recordingCategories.contains(audioSession.category) else {
-            return
-        }
         try audioSession.setCategory(
             .playAndRecord,
             mode: .spokenAudio,
@@ -79,45 +76,32 @@ final class StreamAudioSessionConfigurator: AudioSessionConfiguring {
             options: []
         )
         try setUpPreferredInput(.builtInMic)
-        try audioSession.overrideOutputAudioPort(.speaker)
-        try audioSession.setActive(true, options: [])
+        try activateSession()
     }
 
     /// - Note: The method will check if the audioSession's category contains the `record` capability
     /// and if it does it will deactivate it. Otherwise, no action will be performed.
     func deactivateRecordingSession() throws {
-        guard Self.recordingCategories.contains(audioSession.category) else {
-            return
-        }
-        try audioSession.overrideOutputAudioPort(.none)
-        try audioSession.setActive(false, options: [])
+        try deactivateSession()
     }
 
     /// - Note: The method will check if the audioSession's category contains the `playback` capability
     /// and if it doesn't it will activate it using the `.playback` category and `.default` for both mode
     /// and policy.  OverrideOutputAudioPort is set to `.speaker`.
     func activatePlaybackSession() throws {
-        guard !Self.playbackCategories.contains(audioSession.category) else {
-            return
-        }
         try audioSession.setCategory(
-            .playback,
+            .playAndRecord,
             mode: .default,
             policy: .default,
             options: []
         )
-        try audioSession.overrideOutputAudioPort(.speaker)
-        try audioSession.setActive(true, options: [])
+        try activateSession()
     }
 
     /// - Note: The method will check if the audioSession's category contains the `playback` capability
     /// and if it does it will deactivate it. Otherwise, no action will be performed.
     func deactivatePlaybackSession() throws {
-        guard Self.playbackCategories.contains(audioSession.category) else {
-            return
-        }
-        try audioSession.overrideOutputAudioPort(.none)
-        try audioSession.setActive(false, options: [])
+        try deactivateSession()
     }
 
     func requestRecordPermission(
@@ -129,6 +113,16 @@ final class StreamAudioSessionConfigurator: AudioSessionConfiguring {
     }
 
     // MARK: - Helpers
+
+    private func activateSession() throws {
+        try audioSession.overrideOutputAudioPort(.speaker)
+        try audioSession.setActive(true, options: [])
+    }
+
+    private func deactivateSession() throws {
+        try audioSession.overrideOutputAudioPort(.none)
+        try audioSession.setActive(false, options: [])
+    }
 
     private func handleRecordPermissionResponse(
         _ permissionGranted: Bool,

--- a/Tests/StreamChatTests/Audio/StreamAudioSessionConfigurator_Tests.swift
+++ b/Tests/StreamChatTests/Audio/StreamAudioSessionConfigurator_Tests.swift
@@ -21,23 +21,7 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
 
     // MARK: - activateRecordingSession
 
-    func test_activateRecordingSession_categoryIsRecord_nothingHappens() throws {
-        stubAudioSession.stubProperty(\.category, with: .record)
-
-        try subject.activateRecordingSession()
-
-        XCTAssertNil(stubAudioSession.setActiveWasCalledWithActive)
-    }
-
-    func test_activateRecordingSession_categoryIsPlayAndRecord_nothingHappens() throws {
-        stubAudioSession.stubProperty(\.category, with: .playAndRecord)
-
-        try subject.activateRecordingSession()
-
-        XCTAssertNil(stubAudioSession.setActiveWasCalledWithActive)
-    }
-
-    func test_activateRecordingSession_categoryIsNotRecording_setCategoryFailedToComplete() {
+    func test_activateRecordingSession_setCategoryFailedToComplete() {
         stubAudioSession.stubProperty(\.category, with: .soloAmbient)
         stubAudioSession.stubProperty(\.availableInputs, with: [makeAvailableInput(with: .builtInMic)])
         stubAudioSession.setCategoryResult = .failure(genericError)
@@ -45,7 +29,7 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
         XCTAssertThrowsError(try subject.activateRecordingSession(), genericError)
     }
 
-    func test_activateRecordingSession_categoryIsNotRecording_setCategoryCompletedSuccessfully() throws {
+    func test_activateRecordingSession_setCategoryCompletedSuccessfully() throws {
         stubAudioSession.stubProperty(\.category, with: .soloAmbient)
         stubAudioSession.stubProperty(\.availableInputs, with: [makeAvailableInput(with: .builtInMic)])
 
@@ -57,7 +41,7 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
         XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithOptions, [])
     }
 
-    func test_activateRecordingSession_categoryIsNotRecording_setUpPreferredInputFailedToCompleteDueToNoAvailableInput() {
+    func test_activateRecordingSession_setUpPreferredInputFailedToCompleteDueToNoAvailableInput() {
         stubAudioSession.stubProperty(\.category, with: .soloAmbient)
         stubAudioSession.stubProperty(\.availableInputs, with: [])
 
@@ -66,14 +50,14 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
         }
     }
 
-    func test_activateRecordingSession_categoryIsNotRecording_setUpPreferredInputCompletedSuccessfully() throws {
+    func test_activateRecordingSession_setUpPreferredInputCompletedSuccessfully() throws {
         stubAudioSession.stubProperty(\.category, with: .soloAmbient)
         stubAudioSession.stubProperty(\.availableInputs, with: [makeAvailableInput(with: .builtInMic)])
 
         try subject.activateRecordingSession()
     }
 
-    func test_activateRecordingSession_categoryIsNotRecording_setOverrideOutputFailed() {
+    func test_activateRecordingSession_setOverrideOutputFailed() {
         stubAudioSession.stubProperty(\.category, with: .soloAmbient)
         stubAudioSession.stubProperty(\.availableInputs, with: [makeAvailableInput(with: .builtInMic)])
         stubAudioSession.overrideOutputAudioPortResult = .failure(genericError)
@@ -82,7 +66,7 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
         XCTAssertEqual(stubAudioSession.overrideOutputAudioPortWasCalledWithPortOverride, .speaker)
     }
 
-    func test_activateRecordingSession_categoryIsNotRecording_setOverrideOutputCompletedSuccessfully() throws {
+    func test_activateRecordingSession_setOverrideOutputCompletedSuccessfully() throws {
         stubAudioSession.stubProperty(\.category, with: .soloAmbient)
         stubAudioSession.stubProperty(\.availableInputs, with: [makeAvailableInput(with: .builtInMic)])
 
@@ -90,7 +74,7 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
         XCTAssertEqual(stubAudioSession.overrideOutputAudioPortWasCalledWithPortOverride, .speaker)
     }
 
-    func test_activateRecordingSession_categoryIsNotRecording_setActiveFailed() {
+    func test_activateRecordingSession_setActiveFailed() {
         stubAudioSession.stubProperty(\.category, with: .soloAmbient)
         stubAudioSession.stubProperty(\.availableInputs, with: [makeAvailableInput(with: .builtInMic)])
         stubAudioSession.setActiveResult = .failure(genericError)
@@ -99,7 +83,7 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
         XCTAssertTrue(stubAudioSession.setActiveWasCalledWithActive ?? false)
     }
 
-    func test_activateRecordingSession_categoryIsNotRecording_setActiveCompletedSuccessfully() throws {
+    func test_activateRecordingSession_setActiveCompletedSuccessfully() throws {
         stubAudioSession.stubProperty(\.category, with: .soloAmbient)
         stubAudioSession.stubProperty(\.availableInputs, with: [makeAvailableInput(with: .builtInMic)])
 
@@ -108,14 +92,6 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
     }
 
     // MARK: - deactivateRecordingSession
-
-    func test_deactivateRecordingSession_categoryIsNotRecordOrPlayAndRecord_nothingHappens() throws {
-        stubAudioSession.stubProperty(\.category, with: .soloAmbient)
-
-        try subject.deactivatePlaybackSession()
-
-        XCTAssertNil(stubAudioSession.setActiveWasCalledWithActive)
-    }
 
     func test_deactivateRecordingSession_categoryIsRecord_setOverrideOutputFailed() {
         stubAudioSession.stubProperty(\.category, with: .record)
@@ -183,41 +159,25 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
 
     // MARK: - activatePlaybackSession
 
-    func test_activatePlaybackSession_categoryIsRecord_nothingHappens() throws {
-        stubAudioSession.stubProperty(\.category, with: .playback)
-
-        try subject.activatePlaybackSession()
-
-        XCTAssertNil(stubAudioSession.setActiveWasCalledWithActive)
-    }
-
-    func test_activatePlaybackSession_categoryIsPlayAndRecord_nothingHappens() throws {
-        stubAudioSession.stubProperty(\.category, with: .playAndRecord)
-
-        try subject.activatePlaybackSession()
-
-        XCTAssertNil(stubAudioSession.setActiveWasCalledWithActive)
-    }
-
-    func test_activatePlaybackSession_categoryIsNotPlayback_setCategoryFailedToComplete() {
+    func test_activatePlaybackSession_setCategoryFailedToComplete() {
         stubAudioSession.stubProperty(\.category, with: .soloAmbient)
         stubAudioSession.setCategoryResult = .failure(genericError)
 
         XCTAssertThrowsError(try subject.activatePlaybackSession(), genericError)
     }
 
-    func test_activatePlaybackSession_categoryIsNotRecording_setCategoryCompletedSuccessfully() throws {
+    func test_activatePlaybackSession_setCategoryCompletedSuccessfully() throws {
         stubAudioSession.stubProperty(\.category, with: .soloAmbient)
 
         try subject.activatePlaybackSession()
 
-        XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithCategory, .playback)
+        XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithCategory, .playAndRecord)
         XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithMode, .default)
         XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithPolicy, .default)
         XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithOptions, [])
     }
 
-    func test_activatePlaybackSession_categoryIsNotPlayback_setOverrideOutputFailed() {
+    func test_activatePlaybackSession_setOverrideOutputFailed() {
         stubAudioSession.stubProperty(\.category, with: .soloAmbient)
         stubAudioSession.overrideOutputAudioPortResult = .failure(genericError)
 
@@ -225,7 +185,7 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
         XCTAssertEqual(stubAudioSession.overrideOutputAudioPortWasCalledWithPortOverride, .speaker)
     }
 
-    func test_activatePlaybackSession_categoryIsNotPlayback_setOverrideOutputCompletedSuccessfully() throws {
+    func test_activatePlaybackSession_setOverrideOutputCompletedSuccessfully() throws {
         stubAudioSession.stubProperty(\.category, with: .soloAmbient)
 
         try subject.activatePlaybackSession()
@@ -233,7 +193,7 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
         XCTAssertEqual(stubAudioSession.overrideOutputAudioPortWasCalledWithPortOverride, .speaker)
     }
 
-    func test_activatePlaybackSession_categoryIsNotPlayback_setActiveFailed() {
+    func test_activatePlaybackSession_setActiveFailed() {
         stubAudioSession.stubProperty(\.category, with: .soloAmbient)
         stubAudioSession.setActiveResult = .failure(genericError)
 
@@ -241,7 +201,7 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
         XCTAssertTrue(stubAudioSession.setActiveWasCalledWithActive ?? false)
     }
 
-    func test_activatePlaybackSession_categoryIsNotPlayback_setActiveCompletedSuccessfully() throws {
+    func test_activatePlaybackSession_setActiveCompletedSuccessfully() throws {
         stubAudioSession.stubProperty(\.category, with: .soloAmbient)
 
         try subject.activatePlaybackSession()
@@ -249,14 +209,6 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
     }
 
     // MARK: - deactivatePlaybackSession
-
-    func test_deactivatePlaybackSession_categoryIsNotPlaybackOrPlayAndRecord_nothingHappens() throws {
-        stubAudioSession.stubProperty(\.category, with: .soloAmbient)
-
-        try subject.deactivatePlaybackSession()
-
-        XCTAssertNil(stubAudioSession.setActiveWasCalledWithActive)
-    }
 
     func test_deactivatePlaybackSession_categoryIsPlayback_setActiveCompletedSuccesfully() throws {
         stubAudioSession.stubProperty(\.category, with: .playback)


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/441

### 🎯 Goal

Make sure all voice messages are played using the loud speaker

### 📝 Summary

AudioSession does not allow overriding the speaker output unless the category is set to `.playAndRecord`. When we were tying to do so, an error was triggered, leaving the whole Audio Player in an inconsistent state which would result in all the voice messages being played from the earpiece.

### 🛠 Implementation

- Changed the category to `.playAndRecord` for playback.
- Removed unnecessary guards 

### 🧪 Manual Testing Notes

- Open message list
- Play audio
- Audio plays from Loud Speaker
- Record Audio Message
- Play any audio

Expected result:
- All audio is coming from the loud speaker


### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/cYaBD8kxE4PZudHBRA/giphy.gif)
