### PR TITLE
Fix channel header and user online presence not updated when user changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fix Message List not updating when user info changes [#2738](https://github.com/GetStream/stream-chat-swift/pull/2738)
+- Fix Channel List items online presence not updating when user info changes [#2742](https://github.com/GetStream/stream-chat-swift/pull/2742)
+- Fix Channel name not updating when member name changes [#2742](https://github.com/GetStream/stream-chat-swift/pull/2742)
 
 ## StreamChatUI
 ### 🐞 Fixed
-- Fix channel list rendering user name on subtitle text in 1:1 channel [#2737](https://github.com/GetStream/stream-chat-swift/pull/2737)
+- Fix Channel Header View not updating when user info changes [#2742](https://github.com/GetStream/stream-chat-swift/pull/2742)
+- Fix Channel List rendering user name on subtitle text in 1:1 channel [#2737](https://github.com/GetStream/stream-chat-swift/pull/2737)
 ### 🔄 Changed
 - Change timestamp formatting in Channel List according to the default design and other SDKs [#2736](https://github.com/GetStream/stream-chat-swift/pull/2736)
 

--- a/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MemberModelDTO.swift
@@ -27,6 +27,7 @@ class MemberDTO: NSManagedObject {
 
     @NSManaged var user: UserDTO
     @NSManaged var queries: Set<ChannelMemberListQueryDTO>
+    @NSManaged var channel: ChannelDTO
 
     private static func createId(userId: String, channeldId: ChannelId) -> String {
         channeldId.rawValue + userId

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -417,14 +417,16 @@ open class ChatChannelVC: _ViewController,
         let channelUnreadCount = channelController.channel?.unreadCount ?? .noUnread
         messageListVC.scrollToBottomButton.content = channelUnreadCount
 
-        guard channelController.firstUnreadMessageId != firstUnreadMessageId else { return }
-        let previousUnreadMessageId = firstUnreadMessageId
-        firstUnreadMessageId = channelController.firstUnreadMessageId
-        
-        messageListVC.updateUnreadMessagesSeparator(
-            at: firstUnreadMessageId,
-            previousId: previousUnreadMessageId
-        )
+        if channelController.firstUnreadMessageId != firstUnreadMessageId {
+            let previousUnreadMessageId = firstUnreadMessageId
+            firstUnreadMessageId = channelController.firstUnreadMessageId
+            messageListVC.updateUnreadMessagesSeparator(
+                at: firstUnreadMessageId,
+                previousId: previousUnreadMessageId
+            )
+        }
+
+        channelAvatarView.content = (channelController.channel, client.currentUserId)
     }
 
     open func channelController(

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
@@ -841,6 +841,19 @@ final class ChatChannelVC_Tests: XCTestCase {
         AssertSnapshot(vc, variants: [.defaultLight])
     }
 
+    func test_didUpdateChannel_shouldUpdateChannelAvatarView() {
+        vc.setUp()
+
+        let previousChannel = ChatChannel.mockNonDMChannel(name: "Previous")
+        vc.channelAvatarView.content = (previousChannel, .unique)
+
+        let newChannel = ChatChannel.mockNonDMChannel(name: "New")
+        channelControllerMock.channel_mock = newChannel
+        vc.channelController(vc.channelController, didUpdateChannel: .update(newChannel))
+
+        XCTAssertEqual(vc.channelAvatarView.content.channel?.name, "New")
+    }
+
     // MARK: - setUp
 
     func test_setUp_messagesListVCAndMessageComposerVCHaveTheExpectedAudioPlayerInstance() {


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/269

### 🎯 Goal
Fixes multiple issues related to user changes not being reflected in UI components.

### 📝 Summary
- Fixes channel header view not updating when there are user changes
- Fixes user online presence UI not updated in the Channel Header View
- Fixes user online presence not updated in the Channel List items

### 🛠 Implementation
Whenever there is a user update, now we not only trigger updates to the members but also to the channel to which that member belongs.

### 🎨 Showcase

| Channel Header Updates | Online Presence Updates |
| ------ | ----- |
|  <video src="https://github.com/GetStream/stream-chat-swift/assets/12814114/33c7ba95-7312-49bf-9fe1-e26ff0431036"/>   |  <video src="https://github.com/GetStream/stream-chat-swift/assets/12814114/74e07f4a-fde5-4194-881f-cd49113e7642"/>   |

### 🧪 Manual Testing Notes
**ACs:**
GIVEN I'm in the Channel View
WHEN the user updates it's name or image
THEN the channel header should update the title and avatar

GIVEN I'm in the Channel View
WHEN the user logins/logouts
THEN the channel header avatar should update the online indicator

GIVEN I'm in the Channel List
WHEN the user logins/logouts
THEN the online indicator of the channel items should update

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)