### PR TITLE
Fix gap between the composer and the keyboard when parent view’s frame origin is not zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,25 +4,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ## StreamChat
-
 ### ✅ Added
 - Add XCPrivacy manifest [#2740](https://github.com/GetStream/stream-chat-swift/pull/2740)
 - Add digital signature to StreamChat XCFramework [#2740](https://github.com/GetStream/stream-chat-swift/pull/2740)
-
 ### 🐞 Fixed
 - Fix Message List not updating when user info changes [#2738](https://github.com/GetStream/stream-chat-swift/pull/2738)
 - Fix Channel List items online presence not updating when user info changes [#2742](https://github.com/GetStream/stream-chat-swift/pull/2742)
 - Fix Channel name not updating when member name changes [#2742](https://github.com/GetStream/stream-chat-swift/pull/2742)
 
 ## StreamChatUI
-
 ### ✅ Added
 - Add XCPrivacy manifest [#2740](https://github.com/GetStream/stream-chat-swift/pull/2740)
 - Add digital signature to StreamChatUI XCFramework [#2740](https://github.com/GetStream/stream-chat-swift/pull/2740)
-
 ### 🐞 Fixed
 - Fix Channel Header View not updating when user info changes [#2742](https://github.com/GetStream/stream-chat-swift/pull/2742)
 - Fix Channel List rendering user name on subtitle text in 1:1 channel [#2737](https://github.com/GetStream/stream-chat-swift/pull/2737)
+- Fix gap between the composer and the keyboard when parent view’s frame origin is not zero [#2743](https://github.com/GetStream/stream-chat-swift/pull/2743)
 ### 🔄 Changed
 - Change timestamp formatting in Channel List according to the default design and other SDKs [#2736](https://github.com/GetStream/stream-chat-swift/pull/2736)
 

--- a/Sources/StreamChatUI/Composer/ComposerKeyboardHandler.swift
+++ b/Sources/StreamChatUI/Composer/ComposerKeyboardHandler.swift
@@ -83,7 +83,7 @@ open class ComposerKeyboardHandler: KeyboardHandler {
             composerBottomConstraint?.constant = originalBottomConstraintValue
         } else {
             let convertedKeyboardFrame = composerParentView.convert(frame, from: UIScreen.main.coordinateSpace)
-            let intersectedKeyboardHeight = composerParentView.frame.intersection(convertedKeyboardFrame).height
+            let intersectedKeyboardHeight = composerParentView.bounds.intersection(convertedKeyboardFrame).height
 
             let rootTabBar = composerParentView.window?.rootViewController?.tabBarController?.tabBar
             let shouldAddTabBarHeight = rootTabBar != nil && rootTabBar!.isTranslucent == false


### PR DESCRIPTION
### 🔗 Issue Links
if the message composer’s parent view’s frame origin is not zero, there is a gap between the composer and the keyboard by that amount:
<img src="https://github.com/GetStream/stream-chat-swift/assets/8378384/5b47b07c-0919-4f24-87c4-aed91459895e" width=320>

### 🎯 Goal
to fix this glitch

### 📝 Summary
to find where the keyboard intersects the composer’s parent view, I think you need bounds, not frame. frame is in the coordinate space of composerParentView’s superview, and convertedKeyboardFrame is in the coordinate space of composerParentView.

### 🛠 Implementation
changed frame to bounds

### 🎨 Showcase
| Before | After |
| ------ | ----- |
| <img width="608" alt="Screenshot 2023-08-21 at 3 53 20 PM" src="https://github.com/GetStream/stream-chat-swift/assets/8378384/5d9b5289-a96e-45d3-bb6f-cdfdb704438d"> | <img width="608" alt="Screenshot 2023-08-21 at 3 52 16 PM" src="https://github.com/GetStream/stream-chat-swift/assets/8378384/82c73b6d-4aa3-4cc0-aff1-a8d54474b57f"> |

### 🧪 Manual Testing Notes
- [x] tested in a message list where composerParentView’s frame’s origin’s y is 0 and one where it is non-zero

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)