### PR TITLE
Fix channel capabilities logic when channel is empty

### DIFF
--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -368,146 +368,146 @@ public struct ChannelCapability: RawRepresentable, ExpressibleByStringLiteral, H
 public extension ChatChannel {
     /// Can the current user ban members from this channel.
     var canBanChannelMembers: Bool {
-        ownCapabilities.contains(.banChannelMembers) == true
+        ownCapabilities.contains(.banChannelMembers)
     }
 
     /// Can the current user receive connect events from this channel.
     var canReceiveConnectEvents: Bool {
-        ownCapabilities.contains(.connectEvents) == true
+        ownCapabilities.contains(.connectEvents)
     }
 
     /// Can the current user delete any message from this channel.
     var canDeleteAnyMessage: Bool {
-        ownCapabilities.contains(.deleteAnyMessage) == true
+        ownCapabilities.contains(.deleteAnyMessage)
     }
 
     /// Can the current user delete the channel.
     var canDeleteChannel: Bool {
-        ownCapabilities.contains(.deleteChannel) == true
+        ownCapabilities.contains(.deleteChannel)
     }
 
     /// Can the current user delete own messages from the channel.
     var canDeleteOwnMessage: Bool {
-        ownCapabilities.contains(.deleteOwnMessage) == true
+        ownCapabilities.contains(.deleteOwnMessage)
     }
 
     /// Can the current user flag a message in this channel.
     var canFlagMessage: Bool {
-        ownCapabilities.contains(.flagMessage) == true
+        ownCapabilities.contains(.flagMessage)
     }
 
     /// Can the current user freeze or unfreeze the channel.
     var canFreezeChannel: Bool {
-        ownCapabilities.contains(.freezeChannel) == true
+        ownCapabilities.contains(.freezeChannel)
     }
 
     /// Can the current user leave the channel (remove own membership).
     var canLeaveChannel: Bool {
-        ownCapabilities.contains(.leaveChannel) == true
+        ownCapabilities.contains(.leaveChannel)
     }
 
     /// Can the current user join the channel (add own membership).
     var canJoinChannel: Bool {
-        ownCapabilities.contains(.joinChannel) == true
+        ownCapabilities.contains(.joinChannel)
     }
 
     /// Can the current user mute the channel.
     var canMuteChannel: Bool {
-        ownCapabilities.contains(.muteChannel) == true
+        ownCapabilities.contains(.muteChannel)
     }
 
     /// Can the current user pin a message in this channel.
     var canPinMessage: Bool {
-        ownCapabilities.contains(.pinMessage) == true
+        ownCapabilities.contains(.pinMessage)
     }
 
     /// Can the current user quote a message in this channel.
     var canQuoteMessage: Bool {
-        ownCapabilities.contains(.quoteMessage) == true
+        ownCapabilities.contains(.quoteMessage)
     }
 
     /// Can the current user receive read events from this channel.
     var canReceiveReadEvents: Bool {
-        ownCapabilities.contains(.readEvents) == true
+        ownCapabilities.contains(.readEvents)
     }
 
     /// Can the current user use message search in this channel.
     var canSearchMessages: Bool {
-        ownCapabilities.contains(.searchMessages) == true
+        ownCapabilities.contains(.searchMessages)
     }
 
     /// Can the current user send custom events in this channel.
     var canSendCustomEvents: Bool {
-        ownCapabilities.contains(.sendCustomEvents) == true
+        ownCapabilities.contains(.sendCustomEvents)
     }
 
     /// Can the current user attach links to messages in this channel.
     var canSendLinks: Bool {
-        ownCapabilities.contains(.sendLinks) == true
+        ownCapabilities.contains(.sendLinks)
     }
 
     /// Can the current user send a message in this channel.
     var canSendMessage: Bool {
-        ownCapabilities.contains(.sendMessage) == true
+        ownCapabilities.contains(.sendMessage)
     }
 
     /// Can the current user send reactions in this channel.
     var canSendReaction: Bool {
-        ownCapabilities.contains(.sendReaction) == true
+        ownCapabilities.contains(.sendReaction)
     }
 
     /// Can the current user thread reply to a message in this channel.
     var canSendReply: Bool {
-        ownCapabilities.contains(.sendReply) == true
+        ownCapabilities.contains(.sendReply)
     }
 
     /// Can the current user enable or disable slow mode in this channel.
     var canSetChannelCooldown: Bool {
-        ownCapabilities.contains(.setChannelCooldown) == true
+        ownCapabilities.contains(.setChannelCooldown)
     }
 
     /// Can the current user send and receive typing events in this channel.
     var canSendTypingEvents: Bool {
-        ownCapabilities.contains(.sendTypingEvents) == true
+        ownCapabilities.contains(.sendTypingEvents)
     }
 
     /// Can the current user update any message in this channel.
     var canUpdateAnyMessage: Bool {
-        ownCapabilities.contains(.updateAnyMessage) == true
+        ownCapabilities.contains(.updateAnyMessage)
     }
 
     /// Can the current user update channel data.
     var canUpdateChannel: Bool {
-        ownCapabilities.contains(.updateChannel) == true
+        ownCapabilities.contains(.updateChannel)
     }
 
     /// Can the current user update channel members.
     var canUpdateChannelMembers: Bool {
-        ownCapabilities.contains(.updateChannelMembers) == true
+        ownCapabilities.contains(.updateChannelMembers)
     }
 
     /// Can the current user update own messages in this channel.
     var canUpdateOwnMessage: Bool {
-        ownCapabilities.contains(.updateOwnMessage) == true
+        ownCapabilities.contains(.updateOwnMessage)
     }
 
     /// Can the current user upload message attachments in this channel.
     var canUploadFile: Bool {
-        ownCapabilities.contains(.uploadFile) == true
+        ownCapabilities.contains(.uploadFile)
     }
 
     /// Can the current user join a call in this channel.
     var canJoinCall: Bool {
-        ownCapabilities.contains(.joinCall) == true
+        ownCapabilities.contains(.joinCall)
     }
 
     /// Can the current user create a call in this channel.
     var canCreateCall: Bool {
-        ownCapabilities.contains(.createCall) == true
+        ownCapabilities.contains(.createCall)
     }
 
     /// Is slow mode active in this channel.
     var isSlowMode: Bool {
-        ownCapabilities.contains(.slowMode) == true
+        ownCapabilities.contains(.slowMode)
     }
 }

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -289,11 +289,17 @@ open class ComposerVC: _ViewController,
 
     /// A Boolean value indicating whether the attachments are enabled.
     open var isAttachmentsEnabled: Bool {
-        channelController?.channel?.canUploadFile == true
+        channelController?.channel?.canUploadFile ?? true
     }
 
+    /// A Boolean value indicating whether sending message is enabled.
     open var isSendMessageEnabled: Bool {
-        channelController?.channel?.canSendMessage == true
+        channelController?.channel?.canSendMessage ?? true
+    }
+
+    /// A Boolean value indicating whether if the message being sent can contain links.
+    open var canSendLinks: Bool {
+        channelController?.channel?.canSendLinks ?? true
     }
 
     /// A Boolean value indicating whether the current input text contains links.
@@ -593,7 +599,7 @@ open class ComposerVC: _ViewController,
     // MARK: - Actions
 
     @objc open func publishMessage(sender: UIButton) {
-        if channelController?.channel?.canSendLinks == false && inputContainsLinks {
+        if !canSendLinks && inputContainsLinks {
             presentAlert(title: L10n.Composer.LinksDisabled.title, message: L10n.Composer.LinksDisabled.subtitle)
             return
         }

--- a/Tests/StreamChatUITests/SnapshotTests/Composer/ComposerVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/Composer/ComposerVC_Tests.swift
@@ -348,6 +348,13 @@ final class ComposerVC_Tests: XCTestCase {
         XCTAssertEqual(composerVC.composerView.attachmentButton.isHidden, true)
     }
 
+    func test_isAttachmentsEnabled_whenChannelIsEmpty_thenReturnsTrue() {
+        let mock = ChatChannelController_Mock.mock()
+        mock.channel_mock = nil
+        composerVC.channelController = mock
+        XCTAssertEqual(composerVC.isAttachmentsEnabled, true)
+    }
+
     func test_canNotSendMessage() {
         composerVC.appearance = Appearance.default
         composerVC.content = .initial()
@@ -357,6 +364,13 @@ final class ComposerVC_Tests: XCTestCase {
         composerVC.channelController = mock
 
         AssertSnapshot(composerVC)
+    }
+
+    func test_isSendMessageEnabled_whenChannelIsEmpty_thenReturnsTrue() {
+        let mock = ChatChannelController_Mock.mock()
+        mock.channel_mock = nil
+        composerVC.channelController = mock
+        XCTAssertEqual(composerVC.isSendMessageEnabled, true)
     }
 
     func test_canNotSendLinks() {
@@ -375,6 +389,7 @@ final class ComposerVC_Tests: XCTestCase {
         composerVC.publishMessage(sender: composerVC.composerView.sendButton)
 
         XCTAssertEqual(mock.createNewMessageCallCount, 1)
+        XCTAssertEqual(composerVC.canSendLinks, false)
     }
 
     func test_canSendLinks() {
@@ -388,6 +403,14 @@ final class ComposerVC_Tests: XCTestCase {
         composerVC.publishMessage(sender: composerVC.composerView.sendButton)
 
         XCTAssertEqual(mock.createNewMessageCallCount, 1)
+        XCTAssertEqual(composerVC.canSendLinks, true)
+    }
+
+    func test_canSendLinks_whenChannelIsEmpty() {
+        let mock = ChatChannelController_Mock.mock()
+        mock.channel_mock = nil
+        composerVC.channelController = mock
+        XCTAssertEqual(composerVC.canSendLinks, true)
     }
     
     // MARK: - audioPlayer


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Fix not being able to send messages when channel is empty. Also it should not be possible to send attachments initially, only after the channel is created.

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  <video src="https://github.com/GetStream/stream-chat-swift/assets/12814114/32531197-84bc-40ed-9e53-1ff41e13e77e"/>   |  <video src="https://github.com/GetStream/stream-chat-swift/assets/12814114/4cb25e7f-fb22-4e05-8df5-bba23b8ba9cc"/> |

### 🧪 Manual Testing Notes
Check the video

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
