### PR TITLE
Fix tapping on status bar scrolling to bottom instead of top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow injecting a custom URLSessionConfiguration in ChatClientConfig [#2756](https://github.com/GetStream/stream-chat-swift/pull/2756)
 
 ## StreamChatUI
+### 🐞 Fixed
+- Fix tapping on the status bar scrolling to the bottom instead of the top [#2763](https://github.com/GetStream/stream-chat-swift/pull/2763)
 ### 🔄 Changed
 - Make record button in composer, visible depending on the channel's capabilities. [#2758](https://github.com/GetStream/stream-chat-swift/pull/2758)
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -634,6 +634,17 @@ open class ChatMessageListVC: _ViewController,
         }
     }
 
+    /// Since our message list view is an inverted table view, when the user taps the status bar
+    /// our message list will be scrolled to the bottom instead of the top. This implementation makes sure
+    /// we to the top. The only caveat is that when the list is fully scrolled to the bottom, this method
+    /// won't be triggered because UIKit thinks we are already at the "top" which in our case is not true.
+    /// If this caveat is a concern for you, we recommend turning off the scrollToTop behaviour.
+    /// You can do this by setting `listView.scrollsToTop = false` in the `setUp()` lifecycle.
+    open func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
+        scrollToTop()
+        return false
+    }
+
     open func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
         updateScrollToBottomButtonVisibility()
 


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/1

### 🎯 Goal
Fixes scrolling to the bottom when tapping in the status bar.

### 🧪 Manual Testing Notes
1. Tap on the status bar
2. Should scroll to the top (In the current page)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)