### PR TITLE
Add support for disabling jumping to message animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix connecting user from background thread [#2762](https://github.com/GetStream/stream-chat-swift/pull/2762)
 
 ## StreamChatUI
+### ✅ Added
+- Add support for disabling jumping to message animation [#2770](https://github.com/GetStream/stream-chat-swift/pull/2770)
 ### 🐞 Fixed
 - Fix tapping on the status bar scrolling to the bottom instead of the top [#2763](https://github.com/GetStream/stream-chat-swift/pull/2763)
 - Fix empty channel header view for new DM Channels [#2764](https://github.com/GetStream/stream-chat-swift/pull/2764)

--- a/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
+++ b/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
@@ -141,6 +141,7 @@ class AppConfigViewController: UITableViewController {
     enum ComponentsConfigOption: String, CaseIterable {
         case isUniqueReactionsEnabled
         case shouldMessagesStartAtTheTop
+        case shouldAnimateJumpToMessageWhenOpeningChannel
         case threadRepliesStartFromOldest
         case threadRendersParentMessageEnabled
         case isVoiceRecordingEnabled
@@ -351,6 +352,10 @@ class AppConfigViewController: UITableViewController {
         case .shouldMessagesStartAtTheTop:
             cell.accessoryView = makeSwitchButton(Components.default.shouldMessagesStartAtTheTop) { newValue in
                 Components.default.shouldMessagesStartAtTheTop = newValue
+            }
+        case .shouldAnimateJumpToMessageWhenOpeningChannel:
+            cell.accessoryView = makeSwitchButton(Components.default.shouldAnimateJumpToMessageWhenOpeningChannel) { newValue in
+                Components.default.shouldAnimateJumpToMessageWhenOpeningChannel = newValue
             }
         case .threadRepliesStartFromOldest:
             cell.accessoryView = makeSwitchButton(Components.default.threadRepliesStartFromOldest) { newValue in

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -244,16 +244,17 @@ open class ChatChannelVC: _ViewController,
     ///
     /// - Parameters:
     ///   - id: The id of message which the message list should go to.
+    ///   - animated: `true` if you want to animate the change in position; `false` if it should be immediate.
     ///   - shouldHighlight: Whether the message should be highlighted when jumping to it. By default it is highlighted.
-    public func jumpToMessage(id: MessageId, shouldHighlight: Bool = true) {
+    public func jumpToMessage(id: MessageId, animated: Bool = true, shouldHighlight: Bool = true) {
         if shouldHighlight {
-            messageListVC.jumpToMessage(id: id) { [weak self] indexPath in
+            messageListVC.jumpToMessage(id: id, animated: animated) { [weak self] indexPath in
                 self?.messageListVC.highlightCell(at: indexPath)
             }
             return
         }
 
-        messageListVC.jumpToMessage(id: id)
+        messageListVC.jumpToMessage(id: id, animated: animated)
     }
 
     // MARK: - ChatMessageListVCDataSource

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -211,16 +211,17 @@ open class ChatThreadVC: _ViewController,
     ///
     /// - Parameters:
     ///   - id: The id of message which the message list should go to.
+    ///   - animated: `true` if you want to animate the change in position; `false` if it should be immediate.
     ///   - shouldHighlight: Whether the message should be highlighted when jumping to it. By default it is highlighted.
-    public func jumpToMessage(id: MessageId, shouldHighlight: Bool = true) {
+    public func jumpToMessage(id: MessageId, animated: Bool = true, shouldHighlight: Bool = true) {
         if shouldHighlight {
-            messageListVC.jumpToMessage(id: id) { [weak self] indexPath in
+            messageListVC.jumpToMessage(id: id, animated: animated) { [weak self] indexPath in
                 self?.messageListVC.highlightCell(at: indexPath)
             }
             return
         }
 
-        messageListVC.jumpToMessage(id: id)
+        messageListVC.jumpToMessage(id: id, animated: animated)
     }
 
     // MARK: - ChatMessageListVCDataSource

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -89,7 +89,7 @@ open class ChatThreadVC: _ViewController,
     open var shouldStartFromOldestReplies: Bool {
         components.threadRepliesStartFromOldest
     }
-
+    
     override open func setUp() {
         super.setUp()
 
@@ -128,42 +128,13 @@ open class ChatThreadVC: _ViewController,
         // Set the initial data
         messages = getReplies(from: messageController)
 
-        let completeSetUp: (ChatMessage?) -> Void = { [messageController, messageComposerVC] message in
-            if messageComposerVC.content.threadMessage == nil,
-               let message = messageController?.message {
-                messageComposerVC.content.threadMessage = message
-            }
-
-            // If there is an initial reply id, we should jump to it
-            if let initialReplyId = self.initialReplyId {
-                self.messageController.loadPageAroundReplyId(initialReplyId) { [weak self] error in
-                    guard error == nil else {
-                        return
-                    }
-
-                    self?.jumpToMessage(id: initialReplyId)
-                }
-                return
-            }
-
-            // When we tap on the parent message and start from oldest replies is enabled
-            if self.shouldStartFromOldestReplies, let parentMessage = self.messageController.message {
-                self.messageController.loadPageAroundReplyId(parentMessage.id) { [weak self] _ in
-                    self?.messageListVC.scrollToTop(animated: false)
-                }
-                return
-            }
-
-            self.messageController.loadPreviousReplies()
-        }
-
-        if let message = messageController.message {
-            completeSetUp(message)
+        if messageController.message != nil {
+            didFinishSynchronizing(with: nil)
             return
         }
 
-        messageController.synchronize { [weak self] _ in
-            completeSetUp(self?.messageController.message)
+        messageController.synchronize { [weak self] error in
+            self?.didFinishSynchronizing(with: error)
         }
     }
 
@@ -201,6 +172,38 @@ open class ChatThreadVC: _ViewController,
         resignFirstResponder()
 
         keyboardHandler.stop()
+    }
+
+    /// Called when the syncing of the `messageController` is finished.
+    /// - Parameter error: An `error` if the syncing failed; `nil` if it was successful.
+    open func didFinishSynchronizing(with error: Error?) {
+        if messageComposerVC.content.threadMessage == nil,
+           let message = messageController?.message {
+            messageComposerVC.content.threadMessage = message
+        }
+
+        // If there is an initial reply id, we should jump to it
+        if let initialReplyId = self.initialReplyId {
+            messageController.loadPageAroundReplyId(initialReplyId) { [weak self] error in
+                guard error == nil else {
+                    return
+                }
+
+                let shouldAnimate = self?.components.shouldAnimateJumpToMessageWhenOpeningChannel == true
+                self?.jumpToMessage(id: initialReplyId, animated: shouldAnimate)
+            }
+            return
+        }
+
+        // When we tap on the parent message and start from oldest replies is enabled
+        if shouldStartFromOldestReplies, let parentMessage = messageController.message {
+            messageController.loadPageAroundReplyId(parentMessage.id) { [weak self] _ in
+                self?.messageListVC.scrollToTop(animated: false)
+            }
+            return
+        }
+
+        messageController.loadPreviousReplies()
     }
 
     /// Jump to a given message.

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -118,6 +118,10 @@ public struct Components {
     /// of the list  when there are few messages. By default it is `false`.
     public var shouldMessagesStartAtTheTop: Bool = false
 
+    /// Wether it should animate when opening the channel with a given message around id.
+    /// Ex: When opening a channel from a push notification with a given message id.
+    public var shouldAnimateJumpToMessageWhenOpeningChannel: Bool = true
+
     /// The view that shows the date for currently visible messages on top of message list.
     public var messageListScrollOverlayView: ChatMessageListScrollOverlayView.Type =
         ChatMessageListScrollOverlayView.self

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -118,7 +118,7 @@ public struct Components {
     /// of the list  when there are few messages. By default it is `false`.
     public var shouldMessagesStartAtTheTop: Bool = false
 
-    /// Wether it should animate when opening the channel with a given message around id.
+    /// Whether it should animate when opening the channel with a given message around id.
     /// Ex: When opening a channel from a push notification with a given message id.
     public var shouldAnimateJumpToMessageWhenOpeningChannel: Bool = true
 

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Controllers/Controllers/ChatChannelController_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Controllers/Controllers/ChatChannelController_Mock.swift
@@ -67,6 +67,11 @@ public class ChatChannelController_Mock: ChatChannelController {
         channel_mock ?? super.channel
     }
 
+    public var channelQuery_mock: ChannelQuery?
+    public override var channelQuery: ChannelQuery {
+        channelQuery_mock ?? super.channelQuery
+    }
+
     public var messages_mock: [ChatMessage]?
     override public var messages: LazyCachedMapCollection<ChatMessage> {
         messages_mock.map { $0.lazyCachedMap { $0 } } ?? super.messages

--- a/Tests/StreamChatUITests/Mocks/ChatMessageList/ChatMessageListVC_Mock.swift
+++ b/Tests/StreamChatUITests/Mocks/ChatMessageList/ChatMessageListVC_Mock.swift
@@ -13,7 +13,9 @@ class ChatMessageListVC_Mock: ChatMessageListVC {
     }
 
     var jumpToMessageCallCount = 0
-    override func jumpToMessage(id: MessageId, onHighlight: ((IndexPath) -> Void)? = nil) {
+    var jumpToMessageCalledWith: (id: MessageId, animated: Bool, onHighlight: ((IndexPath) -> Void)?)?
+    override func jumpToMessage(id: MessageId, animated: Bool, onHighlight: ((IndexPath) -> Void)? = nil) {
         jumpToMessageCallCount += 1
+        jumpToMessageCalledWith = (id: id, animated: animated, onHighlight: onHighlight)
     }
 }

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
@@ -903,6 +903,48 @@ final class ChatChannelVC_Tests: XCTestCase {
         XCTAssertEqual(vc.messageComposerVC.content.quotingMessage?.id, expectMessage.id)
     }
 
+    func test_setUp_whenGivenMessageAroundId_whenShouldAnimateJumpToMessageWhenOpeningChannelIsTrue_thenAnimate() {
+        var components = Components.mock
+        components.shouldAnimateJumpToMessageWhenOpeningChannel = true
+        components.messageListVC = ChatMessageListVC_Mock.self
+        vc.components = components
+        let messageListVCMock = vc.messageListVC as? ChatMessageListVC_Mock
+
+        channelControllerMock.channelQuery_mock = .init(
+            cid: .unique,
+            pageSize: 10,
+            paginationParameter: .around(.newUniqueId)
+        )
+
+        vc.setUp()
+
+        channelControllerMock.synchronize_completion?(nil)
+
+        XCTAssertEqual(messageListVCMock?.jumpToMessageCallCount, 1)
+        XCTAssertEqual(messageListVCMock?.jumpToMessageCalledWith?.animated, true)
+    }
+
+    func test_setUp_whenGivenMessageAroundId_whenShouldAnimateJumpToMessageWhenOpeningChannelIsFalse_thenDoNotAnimate() {
+        var components = Components.mock
+        components.shouldAnimateJumpToMessageWhenOpeningChannel = false
+        components.messageListVC = ChatMessageListVC_Mock.self
+        vc.components = components
+        let messageListVCMock = vc.messageListVC as? ChatMessageListVC_Mock
+
+        channelControllerMock.channelQuery_mock = .init(
+            cid: .unique,
+            pageSize: 10,
+            paginationParameter: .around(.newUniqueId)
+        )
+
+        vc.setUp()
+
+        channelControllerMock.synchronize_completion?(nil)
+
+        XCTAssertEqual(messageListVCMock?.jumpToMessageCallCount, 1)
+        XCTAssertEqual(messageListVCMock?.jumpToMessageCalledWith?.animated, false)
+    }
+
     // MARK: - audioQueuePlayerNextAssetURL
 
     func test_audioQueuePlayerNextAssetURL_callsNextAvailableVoiceRecordingProvideWithExpectedInputAndReturnsValue() throws {

--- a/Tests/StreamChatUITests/SnapshotTests/ChatThread/ChatThreadVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatThread/ChatThreadVC_Tests.swift
@@ -259,6 +259,44 @@ final class ChatThreadVC_Tests: XCTestCase {
         XCTAssertEqual(messageListVCMock?.scrollToTopCallCount, 0)
     }
 
+    func test_setUp_whenInitialReply_whenShouldAnimateJumpToMessageWhenOpeningChannelIsTrue_thenAnimate() {
+        var components = Components.mock
+        components.shouldAnimateJumpToMessageWhenOpeningChannel = true
+        components.messageListVC = ChatMessageListVC_Mock.self
+        vc.components = components
+        messageControllerMock.message_mock = .mock()
+        let messageListVCMock = vc.messageListVC as? ChatMessageListVC_Mock
+        vc.initialReplyId = .unique
+
+        vc.setUp()
+
+        messageControllerMock.synchronize_completion?(nil)
+        messageControllerMock.loadPageAroundReplyId_completion?(nil)
+
+        XCTAssertEqual(messageControllerMock.loadPageAroundReplyId_callCount, 1)
+        XCTAssertEqual(messageListVCMock?.jumpToMessageCallCount, 1)
+        XCTAssertEqual(messageListVCMock?.jumpToMessageCalledWith?.animated, true)
+    }
+
+    func test_setUp_whenInitialReply_whenShouldAnimateJumpToMessageWhenOpeningChannelIsFalse_thenDoesNotAnimate() {
+        var components = Components.mock
+        components.shouldAnimateJumpToMessageWhenOpeningChannel = false
+        components.messageListVC = ChatMessageListVC_Mock.self
+        vc.components = components
+        messageControllerMock.message_mock = .mock()
+        let messageListVCMock = vc.messageListVC as? ChatMessageListVC_Mock
+        vc.initialReplyId = .unique
+
+        vc.setUp()
+
+        messageControllerMock.synchronize_completion?(nil)
+        messageControllerMock.loadPageAroundReplyId_completion?(nil)
+
+        XCTAssertEqual(messageControllerMock.loadPageAroundReplyId_callCount, 1)
+        XCTAssertEqual(messageListVCMock?.jumpToMessageCallCount, 1)
+        XCTAssertEqual(messageListVCMock?.jumpToMessageCalledWith?.animated, false)
+    }
+
     // MARK: - audioQueuePlayerNextAssetURL
 
     func test_audioQueuePlayerNextAssetURL_callsNextAvailableVoiceRecordingProvideWithExpectedInputAndReturnsValue() throws {


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/533

### 🎯 Goal
Possibility to skip the animation when jumping to a message.

### 📝 Summary
- Added a new `animated: Bool` to `jumpToMessage()`
- Added a new `Components.shouldAnimateJumpToMessageWhenOpeningChannel`

### 🧪 Manual Testing Notes
- Open DemoApp Configuration
- Disabled `shouldAnimateJumpToMessageWhenOpeningChannel`
- Enable Message Debugger
- Open a channel
- Long tap a message
- Tap on message debugger
- copy message id
- Leave the channel
- Swipe and tap on "..."
- Tap on "show channel with id"
- Should jump to the message without animation

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)