### PR TITLE
Make `ChannelListLoadingView` Customizable + Fix UI Glitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix connecting user from background thread [#2762](https://github.com/GetStream/stream-chat-swift/pull/2762)
 
 ## StreamChatUI
+### ✅ Added
+- Add customization support for `ChannelListLoadingView` [#2772](https://github.com/GetStream/stream-chat-swift/pull/2772)
 ### 🐞 Fixed
 - Fix tapping on the status bar scrolling to the bottom instead of the top [#2763](https://github.com/GetStream/stream-chat-swift/pull/2763)
 - Fix empty channel header view for new DM Channels [#2764](https://github.com/GetStream/stream-chat-swift/pull/2764)
 - Fix showing copy message action when text is empty [#2765](https://github.com/GetStream/stream-chat-swift/pull/2765)
+- Fix dummy texts UI Glitch in `ChannelListLoadingView` [#2772](https://github.com/GetStream/stream-chat-swift/pull/2772)
 ### 🔄 Changed
 - Make record button in composer, visible depending on the channel's capabilities. [#2758](https://github.com/GetStream/stream-chat-swift/pull/2758)
+- Rename`Components.chatChannelListLoadingView` -> `Components.channelListLoadingView` [#2772](https://github.com/GetStream/stream-chat-swift/pull/2772)
 
 # [4.36.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.36.0)
 _August 28, 2023_

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListLoadingView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListLoadingView.swift
@@ -19,10 +19,7 @@ open class ChatChannelListLoadingView: _View, ThemeProvider, UITableViewDataSour
 
         tableView.dataSource = self
         tableView.isScrollEnabled = false
-        tableView.register(
-            ChatChannelListLoadingViewCell.self,
-            forCellReuseIdentifier: ChatChannelListLoadingViewCell.reuseIdentifier
-        )
+        tableView.register(components.channelListLoadingViewCell)
     }
 
     override open func setUpLayout() {
@@ -44,6 +41,6 @@ open class ChatChannelListLoadingView: _View, ThemeProvider, UITableViewDataSour
     }
 
     open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        tableView.dequeueReusableCell(with: ChatChannelListLoadingViewCell.self, for: indexPath)
+        tableView.dequeueReusableCell(with: components.channelListLoadingViewCell, for: indexPath)
     }
 }

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListLoadingViewCell.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListLoadingViewCell.swift
@@ -6,7 +6,8 @@ import UIKit
 
 open class ChatChannelListLoadingViewCell: _TableViewCell, ThemeProvider, SkeletonLoadable {
     /// The `ChatChannelListLoadingViewCellContentView` instance used as content view.
-    open private(set) lazy var chatChannelListLoadingViewCellContentView: ChatChannelListLoadingViewCellContentView = .init()
+    open private(set) lazy var chatChannelListLoadingViewCellContentView: ChatChannelListLoadingViewCellContentView = components
+        .channelListLoadingContentViewCell.init()
         .withoutAutoresizingMaskConstraints
 
     override open func setUp() {

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListLoadingViewCell.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListLoadingViewCell.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-open class ChatChannelListLoadingViewCell: _TableViewCell, ThemeProvider, SkeletonLoadable {
+open class ChatChannelListLoadingViewCell: _TableViewCell, ThemeProvider {
     /// The `ChatChannelListLoadingViewCellContentView` instance used as content view.
     open private(set) lazy var chatChannelListLoadingViewCellContentView: ChatChannelListLoadingViewCellContentView = components
         .channelListLoadingContentViewCell.init()

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -212,8 +212,8 @@ open class ChatChannelListVC: _ViewController,
         }
     }
 
-    override open func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+    override open func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
 
         chatChannelListLoadingView.updateContent()
     }

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -64,7 +64,7 @@ open class ChatChannelListVC: _ViewController,
 
     /// View that shows when loading the Channel list.
     open private(set) lazy var chatChannelListLoadingView: ChatChannelListLoadingView = components
-        .chatChannelListLoadingView
+        .channelListLoadingView
         .init()
         .withoutAutoresizingMaskConstraints
 

--- a/Sources/StreamChatUI/CommonViews/SkeletonLoadable.swift
+++ b/Sources/StreamChatUI/CommonViews/SkeletonLoadable.swift
@@ -4,20 +4,22 @@
 
 import UIKit
 
-protocol SkeletonLoadable {}
+protocol SkeletonLoadable {
+    func makeAnimationGroup(previousGroup: CAAnimationGroup?) -> CAAnimationGroup
+}
 
-extension SkeletonLoadable {
+extension SkeletonLoadable where Self: AppearanceProvider {
     func makeAnimationGroup(previousGroup: CAAnimationGroup? = nil) -> CAAnimationGroup {
         let animDuration: CFTimeInterval = 1.5
         let animation1 = CABasicAnimation(keyPath: #keyPath(CAGradientLayer.backgroundColor))
-        animation1.fromValue = Appearance.ColorPalette().background2.cgColor
-        animation1.toValue = Appearance.ColorPalette().background7.cgColor
+        animation1.fromValue = appearance.colorPalette.background2.cgColor
+        animation1.toValue = appearance.colorPalette.background7.cgColor
         animation1.duration = animDuration
         animation1.beginTime = 0.0
 
         let animation2 = CABasicAnimation(keyPath: #keyPath(CAGradientLayer.backgroundColor))
-        animation2.fromValue = Appearance.ColorPalette().background7.cgColor
-        animation2.toValue = Appearance.ColorPalette().background2.cgColor
+        animation2.fromValue = appearance.colorPalette.background7.cgColor
+        animation2.toValue = appearance.colorPalette.background2.cgColor
         animation2.duration = animDuration
         animation2.beginTime = animation1.beginTime + animation1.duration
 

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -372,6 +372,12 @@ public struct Components {
     /// View that shows when loading the Channel list.
     public var channelListLoadingView: ChatChannelListLoadingView.Type = ChatChannelListLoadingView.self
 
+    /// The `UITableViewCell` responsible to display a skeleton loading view.
+    public var channelListLoadingViewCell: ChatChannelListLoadingViewCell.Type = ChatChannelListLoadingViewCell.self
+
+    /// The content view inside the `UITableViewCell` responsible to display a skeleton loading view.
+    public var channelListLoadingContentViewCell: ChatChannelListLoadingViewCellContentView.Type = ChatChannelListLoadingViewCellContentView.self
+
     /// A boolean value that determines whether the Channel list default loading states (empty, error and loading views) are handled by the Stream SDK. It is false by default.
     /// If it is false, it does not show empty or error views and just shows a spinner indicator for the loading state. If set to true, the empty, error and shimmer loading views are shown instead.
     public var isChatChannelListStatesEnabled = false

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -370,7 +370,7 @@ public struct Components {
     public var channelListErrorView: ChatChannelListErrorView.Type = ChatChannelListErrorView.self
 
     /// View that shows when loading the Channel list.
-    public var chatChannelListLoadingView: ChatChannelListLoadingView.Type = ChatChannelListLoadingView.self
+    public var channelListLoadingView: ChatChannelListLoadingView.Type = ChatChannelListLoadingView.self
 
     /// A boolean value that determines whether the Channel list default loading states (empty, error and loading views) are handled by the Stream SDK. It is false by default.
     /// If it is false, it does not show empty or error views and just shows a spinner indicator for the loading state. If set to true, the empty, error and shimmer loading views are shown instead.
@@ -554,6 +554,16 @@ public extension Components {
         }
         set {
             userAvatarView = newValue
+        }
+    }
+
+    @available(*, deprecated, renamed: "channelListLoadingView")
+    var chatChannelListLoadingView: ChatChannelListLoadingView.Type {
+        get {
+            channelListLoadingView
+        }
+        set {
+            channelListLoadingView = newValue
         }
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/512
Resolves https://github.com/GetStream/ios-issues-tracking/issues/537

### 🎯 Goal
Make `ChannelListLoadingView` Customizable.
Fix a UI Glitch that sometimes would appear as dummy text for a split second.

### 📝 Summary
- Add customization support for `ChannelListLoadingView`
- Fix dummy texts UI Glitch in `ChannelListLoadingView`
- Rename`Components.chatChannelListLoadingView` -> `Components.channelListLoadingView`

### 🛠 Implementation
Currently, our Skeleton View is not very flexible, and ideally, we should have a generic Skeleton View, which would adapt independently of the Channel List Cell layout. Something similar to what we had in a previous WIP PR: https://github.com/GetStream/stream-chat-swift/blob/CIS-1010-Add_States_to_ChannelList/Sources/StreamChatUI/Utils/LoaderView.swift

Either way, some customers complained that the current Channel List Loading View is not customizable at all, and it is not possible to override views or colours. So this PR fixes that and makes sure that this view is now overridable.

In terms of the glitch, it was a quick fix. The layout subviews of the loading cell were being called in the incorrect lifecycle method, and so the bounds of the views at that stage were empty/zero. 

### 🎨 Showcase

### Glitch Fix Showcase 
| Before | After |
| ------ | ----- |
|  <video src="https://github.com/GetStream/stream-chat-swift/assets/12814114/a72e9f4d-f0e4-4864-8b6b-51b389cd5972"/>   |  <video src="https://github.com/GetStream/stream-chat-swift/assets/12814114/e427ff32-b221-4543-80e9-c7492250c86a"/>  |

### 🧪 Manual Testing Notes
This is easier to reproduce by launching the app in Debug mode, and with a real device. By just launching the app, the glitch would always appear. 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)