### PR TITLE
Delete file and image endpoints

### DIFF
--- a/Sources/StreamChat/APIClient/Endpoints/EndpointPath+OfflineRequest.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/EndpointPath+OfflineRequest.swift
@@ -13,7 +13,7 @@ extension EndpointPath {
              .deleteChannel, .channelUpdate, .muteChannel, .showChannel, .truncateChannel, .markChannelRead, .markChannelUnread,
              .markAllChannelsRead, .channelEvent, .stopWatchingChannel, .pinnedMessages, .uploadAttachment, .message,
              .replies, .reactions, .messageAction, .banMember, .flagUser, .flagMessage, .muteUser, .translateMessage,
-             .callToken, .createCall:
+             .callToken, .createCall, .deleteFile, .deleteImage:
             return false
         }
     }

--- a/Sources/StreamChat/APIClient/Endpoints/EndpointPath.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/EndpointPath.swift
@@ -47,6 +47,9 @@ enum EndpointPath: Codable {
 
     case callToken(String)
     case createCall(String)
+    
+    case deleteFile(String)
+    case deleteImage(String)
 
     var value: String {
         switch self {
@@ -91,6 +94,8 @@ enum EndpointPath: Codable {
         case let .muteUser(mute): return "moderation/\(mute ? "mute" : "unmute")"
         case let .callToken(callId): return "calls/\(callId)"
         case let .createCall(queryString): return "channels/\(queryString)/call"
+        case let .deleteFile(channelId): return "channels/\(channelId)/file"
+        case let .deleteImage(channelId): return "channels/\(channelId)/image"
         }
     }
 
@@ -100,7 +105,7 @@ enum EndpointPath: Codable {
         case connect, sync, users, guest, members, search, devices, channels, createChannel, updateChannel, deleteChannel,
              channelUpdate, muteChannel, showChannel, truncateChannel, markChannelRead, markAllChannelsRead, channelEvent,
              stopWatchingChannel, pinnedMessages, uploadAttachment, sendMessage, message, editMessage, deleteMessage, replies,
-             reactions, addReaction, deleteReaction, messageAction, translate, banMember, flagUser, flagMessage, muteUser
+             reactions, addReaction, deleteReaction, messageAction, translate, banMember, flagUser, flagMessage, muteUser, deleteFile, deleteImage, markChannelUnread, callToken, createCall
     }
 
     init(from decoder: Decoder) throws {
@@ -165,6 +170,10 @@ enum EndpointPath: Codable {
                 channelId: nestedContainer.decode(String.self),
                 type: nestedContainer.decode(String.self)
             )
+        case .deleteFile:
+            self = try .deleteFile(container.decode(String.self, forKey: key))
+        case .deleteImage:
+            self = try .deleteImage(container.decode(String.self, forKey: key))
         case .sendMessage:
             self = try .sendMessage(container.decode(ChannelId.self, forKey: key))
         case .message:
@@ -197,6 +206,12 @@ enum EndpointPath: Codable {
             self = try .flagMessage(container.decode(Bool.self, forKey: key))
         case .muteUser:
             self = try .muteUser(container.decode(Bool.self, forKey: key))
+        case .markChannelUnread:
+            self = try .markChannelUnread(container.decode(String.self, forKey: key))
+        case .callToken:
+            self = try .callToken(container.decode(String.self, forKey: key))
+        case .createCall:
+            self = try .createCall(container.decode(String.self, forKey: key))
         }
     }
 
@@ -250,6 +265,10 @@ enum EndpointPath: Codable {
             var nestedContainer = container.nestedUnkeyedContainer(forKey: .uploadAttachment)
             try nestedContainer.encode(channelId)
             try nestedContainer.encode(type)
+        case let .deleteFile(channelId):
+            try container.encode(channelId, forKey: .deleteFile)
+        case let .deleteImage(channelId):
+            try container.encode(channelId, forKey: .deleteImage)
         case let .sendMessage(channelId):
             try container.encode(channelId, forKey: .sendMessage)
         case let .message(messageId):
@@ -280,6 +299,12 @@ enum EndpointPath: Codable {
             try container.encode(bool, forKey: .flagMessage)
         case let .muteUser(bool):
             try container.encode(bool, forKey: .muteUser)
+        case let .markChannelUnread(channelId):
+            try container.encode(channelId, forKey: .markChannelUnread)
+        case let .callToken(callToken):
+            try container.encode(callToken, forKey: .callToken)
+        case let .createCall(callId):
+            try container.encode(callId, forKey: .createCall)
         }
     }
     #endif

--- a/Sources/StreamChat/APIClient/Endpoints/FilesEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/FilesEndpoints.swift
@@ -1,0 +1,27 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension Endpoint {
+    static func deleteFile(cid: ChannelId, url: String) -> Endpoint<EmptyResponse> {
+        .init(
+            path: .deleteFile(cid.apiPath),
+            method: .delete,
+            queryItems: ["url": url],
+            requiresConnectionId: false,
+            body: nil
+        )
+    }
+
+    static func deleteImage(cid: ChannelId, url: String) -> Endpoint<EmptyResponse> {
+        .init(
+            path: .deleteImage(cid.apiPath),
+            method: .delete,
+            queryItems: ["url": url],
+            requiresConnectionId: false,
+            body: nil
+        )
+    }
+}

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1143,6 +1143,11 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
         }
     }
     
+    /// Deletes a file associated with the given URL in the channel.
+    /// - Parameters:
+    ///   - url: The URL of the file to be deleted.
+    ///   - completion: An optional closure to be called when the delete operation is complete.
+    ///                 If an error occurs during deletion, the error will be passed to this closure.
     public func deleteFile(url: String, completion: ((Error?) -> Void)? = nil) {
         guard let cid = cid, isChannelAlreadyCreated else {
             channelModificationFailed(completion)
@@ -1152,6 +1157,11 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
         updater.deleteFile(in: cid, url: url, completion: completion)
     }
     
+    /// Deletes an image associated with the given URL in the channel.
+    /// - Parameters:
+    ///   - url: The URL of the image to be deleted.
+    ///   - completion: An optional closure to be called when the delete operation is complete.
+    ///                 If an error occurs during deletion, the error will be passed to this closure.
     public func deleteImage(url: String, completion: ((Error?) -> Void)? = nil) {
         guard let cid = cid, isChannelAlreadyCreated else {
             channelModificationFailed(completion)

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1142,6 +1142,24 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
             }
         }
     }
+    
+    public func deleteFile(url: String, completion: ((Error?) -> Void)? = nil) {
+        guard let cid = cid, isChannelAlreadyCreated else {
+            channelModificationFailed(completion)
+            return
+        }
+        
+        updater.deleteFile(in: cid, url: url, completion: completion)
+    }
+    
+    public func deleteImage(url: String, completion: ((Error?) -> Void)? = nil) {
+        guard let cid = cid, isChannelAlreadyCreated else {
+            channelModificationFailed(completion)
+            return
+        }
+        
+        updater.deleteImage(in: cid, url: url, completion: completion)
+    }
 
     // MARK: - Internal
 

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -576,4 +576,16 @@ class ChannelUpdater: Worker {
     func createCall(in cid: ChannelId, callId: String, type: String, completion: @escaping (Result<CallWithToken, Error>) -> Void) {
         callRepository.createCall(in: cid, callId: callId, type: type, completion: completion)
     }
+    
+    func deleteFile(in cid: ChannelId, url: String, completion: ((Error?) -> Void)? = nil) {
+        apiClient.request(endpoint: .deleteFile(cid: cid, url: url), completion: {
+            completion?($0.error)
+        })
+    }
+    
+    func deleteImage(in cid: ChannelId, url: String, completion: ((Error?) -> Void)? = nil) {
+        apiClient.request(endpoint: .deleteImage(cid: cid, url: url), completion: {
+            completion?($0.error)
+        })
+    }
 }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -520,6 +520,9 @@
 		842F9746277A09B10060A489 /* PinnedMessagesQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842F9744277A09B10060A489 /* PinnedMessagesQuery.swift */; };
 		842F9749277A1CCF0060A489 /* PinnedMessagesPagination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842F9748277A1CCF0060A489 /* PinnedMessagesPagination.swift */; };
 		842F974A277A1CCF0060A489 /* PinnedMessagesPagination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842F9748277A1CCF0060A489 /* PinnedMessagesPagination.swift */; };
+		84355D882AB2FCAC00FD5838 /* FilesEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84355D872AB2FCAC00FD5838 /* FilesEndpoints.swift */; };
+		84355D892AB2FCAC00FD5838 /* FilesEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84355D872AB2FCAC00FD5838 /* FilesEndpoints.swift */; };
+		84355D8B2AB3440E00FD5838 /* FileEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84355D8A2AB3440E00FD5838 /* FileEndpoints_Tests.swift */; };
 		843C53AB269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843C53AA269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift */; };
 		843C53AD269373EA00C7D8EA /* VideoAttachmentPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843C53AC269373EA00C7D8EA /* VideoAttachmentPayload_Tests.swift */; };
 		843C53AF2693759E00C7D8EA /* FileAttachmentPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843C53AE2693759E00C7D8EA /* FileAttachmentPayload_Tests.swift */; };
@@ -3088,6 +3091,8 @@
 		842F9748277A1CCF0060A489 /* PinnedMessagesPagination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedMessagesPagination.swift; sourceTree = "<group>"; };
 		8431843A26FB53B400B5B25E /* NotificationMessageNew+MissingFields.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "NotificationMessageNew+MissingFields.json"; sourceTree = "<group>"; };
 		8431843C26FB54F400B5B25E /* NotificationAddedToChannel+MissingFields.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "NotificationAddedToChannel+MissingFields.json"; sourceTree = "<group>"; };
+		84355D872AB2FCAC00FD5838 /* FilesEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesEndpoints.swift; sourceTree = "<group>"; };
+		84355D8A2AB3440E00FD5838 /* FileEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEndpoints_Tests.swift; sourceTree = "<group>"; };
 		843C53AA269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentPayload_Tests.swift; sourceTree = "<group>"; };
 		843C53AC269373EA00C7D8EA /* VideoAttachmentPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentPayload_Tests.swift; sourceTree = "<group>"; };
 		843C53AE2693759E00C7D8EA /* FileAttachmentPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileAttachmentPayload_Tests.swift; sourceTree = "<group>"; };
@@ -5028,6 +5033,7 @@
 				F6ED5F75250278D7005D7327 /* SyncEndpoint.swift */,
 				DA84070825250528005A0F62 /* UserEndpoints.swift */,
 				F65D9090250A5989000B8CEB /* WebSocketConnectEndpoint.swift */,
+				84355D872AB2FCAC00FD5838 /* FilesEndpoints.swift */,
 				79682C4724BF37550071578E /* Payloads */,
 				DAEAF4B624DADA990015FB28 /* Requests */,
 			);
@@ -6142,6 +6148,7 @@
 				F62BE78225062FC400D13B86 /* SyncEndpoint_Tests.swift */,
 				DA84072C2525EF8D005A0F62 /* UserEndpoints_Tests.swift */,
 				F65D9092250A5CD4000B8CEB /* WebSocketConnectEndpoint_Tests.swift */,
+				84355D8A2AB3440E00FD5838 /* FileEndpoints_Tests.swift */,
 				A364D09427D0BF3A0029857A /* Payloads */,
 				A364D09527D0C4C40029857A /* Requests */,
 			);
@@ -10139,6 +10146,7 @@
 				79A9EB4D2625793000F2A72D /* CoreDataLazy.swift in Sources */,
 				DABC6AC22546FFB600A8FC78 /* AttachmentTypes.swift in Sources */,
 				4042968329FACA0E0089126D /* AudioSamplesProcessor.swift in Sources */,
+				84355D882AB2FCAC00FD5838 /* FilesEndpoints.swift in Sources */,
 				7964F3B9249A314D002A09EC /* BaseLogDestination.swift in Sources */,
 				C1FC2F942742579D0062530F /* Security.swift in Sources */,
 				AD52A21C2804851600D0157E /* CommandDTO.swift in Sources */,
@@ -10497,6 +10505,7 @@
 				C1EFF3F828633B5D0057B91B /* IdentifiableModel_Tests.swift in Sources */,
 				40789D4829F6C1DC0018C2BB /* StreamAppStateObserver_Tests.swift in Sources */,
 				C143789727BE6D4800E23965 /* OfflineRequestsRepository_Tests.swift in Sources */,
+				84355D8B2AB3440E00FD5838 /* FileEndpoints_Tests.swift in Sources */,
 				84D5BC5B277B18AF00A65C75 /* PinnedMessagesQuery_Tests.swift in Sources */,
 				DA4EE5BB252B69FD00CB26D4 /* UserListController+Combine_Tests.swift in Sources */,
 				84DCB84F269F46BE006CDF32 /* EventsController_Tests.swift in Sources */,
@@ -10946,6 +10955,7 @@
 				C121E86D274544AF00023E4C /* DatabaseContainer.swift in Sources */,
 				C121E86E274544AF00023E4C /* DatabaseSession.swift in Sources */,
 				C121E86F274544AF00023E4C /* DataStore.swift in Sources */,
+				84355D892AB2FCAC00FD5838 /* FilesEndpoints.swift in Sources */,
 				C121E870274544AF00023E4C /* MessageReactionDTO.swift in Sources */,
 				C121E871274544AF00023E4C /* MessageDTO.swift in Sources */,
 				40789D3629F6AC500018C2BB /* AudioAnalysisEngine.swift in Sources */,

--- a/Tests/StreamChatTests/APIClient/Endpoints/FileEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/FileEndpoints_Tests.swift
@@ -1,0 +1,51 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class FileEndpoints_Tests: XCTestCase {
+
+    func test_deleteFile_buildsCorrectly() {
+        // Given
+        let channelId: ChannelId = .unique
+        let url = "https://example.com/someimage.pdf"
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: .deleteFile(channelId.apiPath),
+            method: .delete,
+            queryItems: ["url": url],
+            requiresConnectionId: false,
+            requiresToken: true
+        )
+        
+        // When
+        let endpoint: Endpoint<EmptyResponse> = .deleteFile(cid: channelId, url: url)
+        
+        // Then
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        XCTAssertEqual("channels/\(channelId.apiPath)/file", endpoint.path.value)
+    }
+    
+    func test_deleteImage_buildsCorrectly() {
+        // Given
+        let channelId: ChannelId = .unique
+        let url = "https://example.com/someimage.pdf"
+        let expectedEndpoint = Endpoint<EmptyResponse>(
+            path: .deleteImage(channelId.apiPath),
+            method: .delete,
+            queryItems: ["url": url],
+            requiresConnectionId: false,
+            requiresToken: true
+        )
+        
+        // When
+        let endpoint: Endpoint<EmptyResponse> = .deleteImage(cid: channelId, url: url)
+        
+        // Then
+        XCTAssertEqual(AnyEndpoint(expectedEndpoint), AnyEndpoint(endpoint))
+        XCTAssertEqual("channels/\(channelId.apiPath)/image", endpoint.path.value)
+    }
+
+}


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/19

### 🎯 Goal

To allow customers delete files and images by url.

### 📝 Summary

Exposed two additional methods on the channel controller.

### 🧪 Manual Testing Notes

You would need to manually extract a URL, call the method and make sure the file is not there anymore.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![Alt Text](https://media.giphy.com/media/3o7524cGvd7gNWf3mo/giphy.gif)