### PR TITLE
Fix critical issue causing a query channel call for every new message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix core data warnings when logging with different user [#2759](https://github.com/GetStream/stream-chat-swift/pull/2759)
 - Fix connecting user from background thread [#2762](https://github.com/GetStream/stream-chat-swift/pull/2762)
 - Improve `addDevice()` and `removeDevice()` with optimistic updates [#2778](https://github.com/GetStream/stream-chat-swift/pull/2778)
+- Fix critical issue causing a query channel call for every new message [#2781](https://github.com/GetStream/stream-chat-swift/tree/fix/calling-watch-channel-on-every-new-message)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -275,16 +275,16 @@ extension ChatChannelListController: EventsControllerDelegate {
 
     /// Handles if a channel should be linked to the current query or not.
     private func linkChannelIfNeeded(_ channel: ChatChannel) {
-        if shouldChannelBelongToCurrentQuery(channel) {
-            link(channel: channel)
-        }
+        guard !channels.contains(channel) else { return }
+        guard shouldChannelBelongToCurrentQuery(channel) else { return }
+        link(channel: channel)
     }
 
     /// Handles if a channel should be unlinked from the current query or not.
     private func unlinkChannelIfNeeded(_ channel: ChatChannel) {
-        if !shouldChannelBelongToCurrentQuery(channel) {
-            worker.unlink(channel: channel, with: query)
-        }
+        guard channels.contains(channel) else { return }
+        guard !shouldChannelBelongToCurrentQuery(channel) else { return }
+        worker.unlink(channel: channel, with: query)
     }
 
     /// Checks if the given channel should belong to the current query or not.


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Fix critical issues causing a query channel call for every new message.

### 🛠 Implementation
Whenever we link a channel, we do a call to start watching that channel. This makes a request to the channels query endpoint. Because now we check for linking a channel on every new message, we need to first verify if this channel is already linked or not, otherwise, we will be making unnecessary requests. 

### 🧪 Manual Testing Notes
- Proxyman is needed to verify that the requests are not being sent anymore for every new message.
- Unit tests were added as well to cover these scenarios.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme
<img src="https://media4.giphy.com/media/lTkT3Np4tKeZRdlY8z/giphy.gif"/>
