### PR TITLE
Fix broken composer input view scrolling after shrinking input

### DIFF
--- a/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
+++ b/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
@@ -122,12 +122,6 @@ open class InputTextView: UITextView, AppearanceProvider {
         replace(selectedRange, withText: text)
     }
 
-    override open func layoutSubviews() {
-        super.layoutSubviews()
-        handleTextChange()
-        scrollToCaretPosition(animated: false)
-    }
-
     open func textDidChangeProgrammatically() {
         delegate?.textViewDidChange?(self)
         handleTextChange()
@@ -193,7 +187,8 @@ open class InputTextView: UITextView, AppearanceProvider {
         }
     }
 
-    private func scrollToCaretPosition(animated: Bool) {
+    /// Scrolls the text view to to the caret's position.
+    public func scrollToCaretPosition(animated: Bool) {
         guard let selectedTextRange = self.selectedTextRange else { return }
         let caret = caretRect(for: selectedTextRange.start)
         scrollRectToVisible(caret, animated: animated)

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -701,6 +701,10 @@ open class ComposerVC: _ViewController,
                 self.composerView.attachmentButton.isHidden = true
             }
         }
+
+        // Makes sure the text view remains in the same position when it changes size.
+        composerView.inputMessageView.textView.setTextViewHeight()
+        composerView.inputMessageView.textView.scrollToCaretPosition(animated: false)
     }
 
     @objc open func showAvailableCommands(sender: UIButton) {


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Fix regression while testing Release 4.37.0

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)