### PR TITLE
Fix compilation issues on NSEs when using Cocoapods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChatUI
 ### 🐞 Fixed
 - Fix the unread messages banner showing on system messages [#2793](https://github.com/GetStream/stream-chat-swift/pull/2793)
+- Fix compilation issues on NSEs when using Cocoapods [#2798](https://github.com/GetStream/stream-chat-swift/pull/2798)
 
 # [4.37.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.37.0)
 _September 18, 2023_

--- a/Sources/StreamChatUI/ChatChannelList/Search/ChatChannelListSearchVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/Search/ChatChannelListSearchVC.swift
@@ -7,6 +7,7 @@ import UIKit
 
 /// An abstract class responsible to handle the channel list search logic.
 /// It is a subclass of the Channel List since most of the logic is reused from the original Channel List.
+@available(iOSApplicationExtension, unavailable)
 open class ChatChannelListSearchVC: ChatChannelListVC, UISearchResultsUpdating {
     /// The component responsible to debounce search requests.
     public var debouncer = Debouncer(0.3, queue: .main)

--- a/Sources/StreamChatUI/ChatChannelList/Search/ChatChannelSearchVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/Search/ChatChannelSearchVC.swift
@@ -7,6 +7,7 @@ import UIKit
 
 /// The view controller responsible to search channels.
 /// It implements the required functions of the `ChatChannelListSearchVC` abstract class.
+@available(iOSApplicationExtension, unavailable)
 open class ChatChannelSearchVC: ChatChannelListSearchVC {
     /// The closure that is triggered whenever a channel is selected from the search result.
     public var didSelectChannel: ((ChatChannel) -> Void)?

--- a/Sources/StreamChatUI/ChatChannelList/Search/ChatMessageSearchVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/Search/ChatMessageSearchVC.swift
@@ -7,6 +7,7 @@ import UIKit
 
 /// The view controller responsible to search messages.
 /// It implements the required functions of the `ChatChannelListSearchVC` abstract class.
+@available(iOSApplicationExtension, unavailable)
 open class ChatMessageSearchVC: ChatChannelListSearchVC, ChatMessageSearchControllerDelegate {
     /// The data of the message list.
     public private(set) var messages: [ChatMessage] = []


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Fix compilation issues introduced in the 4.37.0 release. 

### 📝 Summary
Somehow for some customers that use Cocoapods, the `@available(iOSApplicationExtension, unavailable)` is required. 

### 🧪 Manual Testing Notes
N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)