### PR TITLE
Release fix: Do not mark as read new unseen messages

### DIFF
--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -345,12 +345,11 @@ open class ChatChannelVC: _ViewController,
         _ vc: ChatMessageListVC,
         willDisplayMessageAt indexPath: IndexPath
     ) {
+        guard !hasSeenFirstUnreadMessage else { return }
+
         let message = chatMessageListVC(vc, messageAt: indexPath)
         if message?.id == firstUnreadMessageId {
             hasSeenFirstUnreadMessage = true
-        }
-        if isLastMessageFullyVisible {
-            hasSeenLastMessage = true
         }
     }
 
@@ -396,6 +395,9 @@ open class ChatChannelVC: _ViewController,
         _ vc: ChatMessageListVC,
         scrollViewDidScroll scrollView: UIScrollView
     ) {
+        if !hasSeenLastMessage && isLastMessageFullyVisible {
+            hasSeenLastMessage = true
+        }
         if shouldMarkChannelRead {
             markRead()
         }

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -90,7 +90,7 @@ open class ChatChannelVC: _ViewController,
             return false
         }
 
-        return hasSeenLastMessage && hasSeenAllUnreadMessages && channelController.hasLoadedAllNextMessages && !hasMarkedMessageAsUnread
+        return hasSeenLastMessage && hasSeenFirstUnreadMessage && channelController.hasLoadedAllNextMessages && !hasMarkedMessageAsUnread
     }
 
     /// A component responsible to handle when to load new or old messages.
@@ -103,8 +103,8 @@ open class ChatChannelVC: _ViewController,
         channelController.isMarkedAsUnread
     }
 
-    /// Determines whether all unread messages have been seen
-    private var hasSeenAllUnreadMessages: Bool = false
+    /// Determines whether first unread message has been seen
+    private var hasSeenFirstUnreadMessage: Bool = false
 
     /// Determines whether last cell has been seen
     private var hasSeenLastMessage: Bool = false
@@ -254,7 +254,10 @@ open class ChatChannelVC: _ViewController,
 
     /// Marks the channel read and updates the UI optimistically.
     public func markRead() {
-        channelController.markRead { [weak self] _ in
+        channelController.markRead { [weak self] error in
+            if error == nil {
+                self?.hasSeenLastMessage = false
+            }
             self?.updateJumpToUnreadRelatedComponents()
             self?.updateScrollToBottomButtonCount()
         }
@@ -344,7 +347,7 @@ open class ChatChannelVC: _ViewController,
     ) {
         let message = chatMessageListVC(vc, messageAt: indexPath)
         if message?.id == firstUnreadMessageId {
-            hasSeenAllUnreadMessages = true
+            hasSeenFirstUnreadMessage = true
         }
         if isLastMessageFullyVisible {
             hasSeenLastMessage = true
@@ -449,13 +452,13 @@ open class ChatChannelVC: _ViewController,
             guard let self = self else { return }
 
             if let unreadCount = channelController.channel?.unreadCount.messages, channelController.firstUnreadMessageId == nil && unreadCount == 0 {
-                self.hasSeenAllUnreadMessages = true
+                self.hasSeenFirstUnreadMessage = true
             }
 
             self.updateJumpToUnreadRelatedComponents()
             if self.shouldMarkChannelRead {
                 self.markRead()
-            } else if !self.hasSeenAllUnreadMessages {
+            } else if !self.hasSeenFirstUnreadMessage {
                 self.updateUnreadMessagesBannerRelatedComponents()
             }
         }

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
@@ -766,8 +766,9 @@ final class ChatChannelVC_Tests: XCTestCase {
         channelControllerMock.hasLoadedAllNextMessages_mock = true
         channelControllerMock.markedAsUnread_mock = false
 
-        // Simulate display to update hasSeenLastMessage
+        // Simulate display to update hasSeenLastMessage && hasSeenFirstUnreadMessage
         vc.chatMessageListVC(ChatMessageListVC_Mock(), willDisplayMessageAt: IndexPath(item: 0, section: 0))
+        vc.chatMessageListVC(ChatMessageListVC_Mock(), scrollViewDidScroll: UIScrollView())
 
         XCTAssertTrue(vc.shouldMarkChannelRead)
     }
@@ -826,8 +827,10 @@ final class ChatChannelVC_Tests: XCTestCase {
         channelControllerMock.markedAsUnread_mock = false
         channelControllerMock.state_mock = .remoteDataFetched
 
-        // Simulate display to update hasSeenLastMessage
+        // Simulate display to update hasSeenLastMessage && hasSeenFirstUnreadMessage
         vc.chatMessageListVC(ChatMessageListVC_Mock(), willDisplayMessageAt: IndexPath(item: 0, section: 0))
+        vc.chatMessageListVC(ChatMessageListVC_Mock(), scrollViewDidScroll: UIScrollView())
+        channelControllerMock.markReadCallCount = 0
 
         vc.viewDidAppear(false)
         XCTAssertEqual(channelControllerMock.markReadCallCount, 1)
@@ -882,8 +885,10 @@ final class ChatChannelVC_Tests: XCTestCase {
         channelControllerMock.markedAsUnread_mock = false
         channelControllerMock.state_mock = .remoteDataFetched
 
-        // Simulate display to update hasSeenLastMessage
+        // Simulate display to update hasSeenLastMessage && hasSeenFirstUnreadMessage
         vc.chatMessageListVC(ChatMessageListVC_Mock(), willDisplayMessageAt: IndexPath(item: 0, section: 0))
+        vc.chatMessageListVC(ChatMessageListVC_Mock(), scrollViewDidScroll: UIScrollView())
+        channelControllerMock.markReadCallCount = 0
 
         vc.channelController(channelControllerMock, didUpdateMessages: [])
         mockedListView.updateMessagesCompletion?()


### PR DESCRIPTION
### 🔗 Issue Links

_Provide all Jira tickets and/or Github issues related to this PR, if applicable._

### 🎯 Goal

Do not mark unseen new messages as read. Wait until they are seen

### 📝 Summary

When a user was in a chat, but scrolled up, new messages were being marked as read, even though those were not seen

### 🛠 Implementation

Since 4.37.0, we have been using local flags to keep track of whether the first unread message and the newest message in the history were seen. For the latter, we need to make sure we reset the local flag to false after marking the channel as read, so that we don't mistakenly mark messages as read when they are not seen.

### 🧪 Manual Testing Notes

1. Open a channel
2. Make sure it is marked as read
3. Scroll up so the newest message is not visible on screen
4. Send a message from another device

Expected result:
- The new message should not be marked as read until it is seen

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/ihwsHf00ljMOwGhuVA/giphy.gif)