### PR TITLE
Release fix: Truncation related fixes for mark as/jump to unread

### DIFF
--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -861,6 +861,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
         updater.markRead(cid: channel.cid, userId: currentUserId) { error in
             self.callback {
                 self.markingRead = false
+                self.isMarkedAsUnread = false
                 completion?(error)
             }
         }

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelTruncatedEventMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/ChannelTruncatedEventMiddleware.swift
@@ -14,10 +14,18 @@ struct ChannelTruncatedEventMiddleware: EventMiddleware {
         }
 
         do {
-            if let channelDTO = session.channel(cid: truncatedEvent.channel.cid) {
-                channelDTO.truncatedAt = truncatedEvent.channel.truncatedAt?.bridgeDate
-            } else {
-                throw ClientError.ChannelDoesNotExist(cid: truncatedEvent.channel.cid)
+            let cid = truncatedEvent.channel.cid
+            guard let channelDTO = session.channel(cid: cid) else {
+                throw ClientError.ChannelDoesNotExist(cid: cid)
+            }
+
+            channelDTO.truncatedAt = truncatedEvent.channel.truncatedAt?.bridgeDate
+
+            // Until BE returns valid values for user's read after truncation, we are clearing them.
+            if let userId = truncatedEvent.user?.id, let read = session.loadChannelRead(cid: cid, userId: userId) {
+                read.lastReadMessageId = nil
+                read.lastReadAt = truncatedEvent.channel.truncatedAt?.bridgeDate ?? DBDate()
+                read.unreadMessageCount = 0
             }
         } catch {
             log.error("Failed to write the `truncatedAt` field update in the database, error: \(error)")

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -90,7 +90,11 @@ open class ChatChannelVC: _ViewController,
             return false
         }
 
-        return hasSeenLastMessage && hasSeenFirstUnreadMessage && channelController.hasLoadedAllNextMessages && !hasMarkedMessageAsUnread
+        return isLastMessageVisibleOrSeen && hasSeenFirstUnreadMessage && channelController.hasLoadedAllNextMessages && !hasMarkedMessageAsUnread
+    }
+
+    private var isLastMessageVisibleOrSeen: Bool {
+        hasSeenLastMessage || isLastMessageFullyVisible
     }
 
     /// A component responsible to handle when to load new or old messages.
@@ -106,7 +110,7 @@ open class ChatChannelVC: _ViewController,
     /// Determines whether first unread message has been seen
     private var hasSeenFirstUnreadMessage: Bool = false
 
-    /// Determines whether last cell has been seen
+    /// Determines whether last cell has been seen since the last time it was marked as read
     private var hasSeenLastMessage: Bool = false
 
     /// The id of the first unread message

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -1039,8 +1039,6 @@ private extension ChatMessageListVC {
                 self?.adjustContentOffset(oldContentOffset: oldContentOffset, oldContentSize: oldContentSize)
             }
 
-            self?.updateScrollDependentButtonsVisibility()
-
             UIView.performWithoutAnimation {
                 self?.scrollToBottomIfNeeded(with: changes, newestChange: newestChange)
                 self?.reloadMovedMessage(newestChange: newestChange)


### PR DESCRIPTION
### 🔗 Issue Links

### 🎯 Goal

Fix issues around Mark as/Jump to unread for scenarios around truncation

### 📝 Summary

There were some issues found when trying with truncated messages.

### 🛠 Implementation

- When checking if the last message was seen, we are now checking if it was seen or it is currently on screen
- Truncation events now clear the state for current user's read
- When discarding messages using the unread messages pill, we are resetting the state that determines if the channel was marked as unread in the current session

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Scenarios

** Truncation **
- Create a channel
- Add some messages with 2 users
- While in the channel, truncate it
- Receive new messages

Expected result:
- The unread message pill should not be displayed (It can be displayed as there is an issue on the backend)

** Mark as read when scrolled to bottom **
- Open a channel with quite some unread messages (We don't want the first one to be visible when opening)
- Scroll to the first unread
- Receive 2 messages
    - You should see in the scroll to bottom counter 2 new messages
 - Scroll to bottom
    - 2 previous messages should be seen as read from the other device
- Receive new messages

Expected result:
- When receiving new messages, they should instantly be marked as read

** Do not mark as read when scrolled to top **
- Open a channel with quite some unread messages (We don't want the first one to be visible when opening)
- Scroll to the first unread
- Receive 2 messages
    - You should see in the scroll to bottom counter 2 new messages

Expected result:
- The 2 messages should not be seen as read from the other device

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://giphy.com/clips/buzzfeed-mothers-day-3bG6XxjjZDrIEmm4tZ)
