### PR TITLE
Fix skipping messages logic + performance improvements

### DIFF
--- a/Sources/StreamChat/Utils/LazyCachedMapCollection.swift
+++ b/Sources/StreamChat/Utils/LazyCachedMapCollection.swift
@@ -70,6 +70,10 @@ public struct LazyCachedMapCollection<Element>: RandomAccessCollection {
             return value
         }
     }
+
+    public func append(_ element: Element) {
+        cache.values.append(element)
+    }
 }
 
 extension LazyCachedMapCollection: ExpressibleByArrayLiteral {

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -453,7 +453,7 @@ open class ChatChannelVC: _ViewController,
         didUpdateMessages changes: [ListChange<ChatMessage>]
     ) {
         messageListVC.setPreviousMessagesSnapshot(messages)
-        messageListVC.setNewMessagesSnapshot(Array(channelController.messages))
+        messageListVC.setNewMessagesSnapshot(channelController.messages)
         messageListVC.updateMessages(with: changes) { [weak self] in
             guard let self = self else { return }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC+DiffKit.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC+DiffKit.swift
@@ -12,7 +12,7 @@ extension ChatMessageListVC {
     }
 
     /// Set the new message snapshot reported by the data controller.
-    internal func setNewMessagesSnapshot(_ messages: [ChatMessage]) {
+    internal func setNewMessagesSnapshot(_ messages: LazyCachedMapCollection<ChatMessage>) {
         listView.currentMessagesFromDataSource = messages
         listView.newMessagesSnapshot = messages
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -1059,13 +1059,13 @@ private extension ChatMessageListVC {
         let isNewestChangeInsertion = newestChange?.isInsertion == true
         let isNewestChangeNotByCurrentUser = newestChange?.item.isSentByCurrentUser == false
         let isNewestChangeNotVisible = !listView.isLastCellFullyVisible && !listView.previousMessagesSnapshot.isEmpty
-        let isNewPageLoading = insertions.count > 1 && insertions.count == changes.count
+        let isLoadingNewPage = insertions.count > 1 && insertions.count == changes.count
         let shouldSkipMessages =
             isFirstPageLoaded
                 && isNewestChangeNotVisible
                 && isNewestChangeInsertion
                 && isNewestChangeNotByCurrentUser
-                && !isNewPageLoading
+                && !isLoadingNewPage
 
         guard shouldSkipMessages else {
             return false

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -386,7 +386,7 @@ open class ChatMessageListVC: _ViewController,
         // the UI is not updated for the next inserted messages.
         guard #available(iOS 13.0, *) else {
             if listView.previousMessagesSnapshot.count < 2 {
-                dataSource?.messages = listView.newMessagesSnapshot
+                dataSource?.messages = Array(listView.newMessagesSnapshot)
                 listView.reloadData()
                 completion?()
                 return
@@ -1026,7 +1026,9 @@ private extension ChatMessageListVC {
     func handleMessageUpdates(with changes: [ListChange<ChatMessage>], completion: (() -> Void)?) {
         let newestChange = changes.first(where: { $0.indexPath.item == 0 })
 
-        addSkippedMessagesIfNeeded(with: changes, newestChange: newestChange)
+        if shouldSkipMessages(with: changes, newestChange: newestChange) {
+            return
+        }
 
         // The old content offset and size should be stored before updating the list view.
         let oldContentOffset = listView.contentOffset
@@ -1052,31 +1054,28 @@ private extension ChatMessageListVC {
         }
     }
 
-    func addSkippedMessagesIfNeeded(with changes: [ListChange<ChatMessage>], newestChange: ListChange<ChatMessage>?) {
+    func shouldSkipMessages(with changes: [ListChange<ChatMessage>], newestChange: ListChange<ChatMessage>?) -> Bool {
         let insertions = changes.filter(\.isInsertion)
         let isNewestChangeInsertion = newestChange?.isInsertion == true
         let isNewestChangeNotByCurrentUser = newestChange?.item.isSentByCurrentUser == false
         let isNewestChangeNotVisible = !listView.isLastCellFullyVisible && !listView.previousMessagesSnapshot.isEmpty
-        let hasMultipleInsertions = insertions.count > 1
+        let isNewPageLoading = insertions.count > 1 && insertions.count == changes.count
         let shouldSkipMessages =
             isFirstPageLoaded
                 && isNewestChangeNotVisible
                 && isNewestChangeInsertion
                 && isNewestChangeNotByCurrentUser
-                && !hasMultipleInsertions
+                && !isNewPageLoading
 
         guard shouldSkipMessages else {
-            return
+            return false
         }
 
         changes.filter(\.isInsertion).forEach {
             listView.skippedMessages.insert($0.item.id)
         }
 
-        // By setting the new snapshots to itself, it will
-        // trigger didSet and remove the newly skipped messages.
-        let newMessageSnapshot = listView.newMessagesSnapshot
-        listView.newMessagesSnapshot = newMessageSnapshot
+        return true
     }
 
     func scrollPendingMessageIfNeeded() {

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -125,6 +125,9 @@ open class ChatThreadVC: _ViewController,
             queueAudioPlayer.dataSource = self
         }
 
+        // Set the initial data
+        messages = Array(getReplies(from: messageController))
+
         if messageController.message != nil {
             didFinishSynchronizing(with: nil)
             return
@@ -439,7 +442,9 @@ open class ChatThreadVC: _ViewController,
         let isFirstPage = messages.count < messageController.repliesPageSize
         let shouldAddRootMessageAtTheTop = isFirstPage || messageController.hasLoadedAllPreviousReplies
         if shouldAddRootMessageAtTheTop, let threadRootMessage = messageController.message {
-            messages.append(threadRootMessage)
+            if messages.last?.id != threadRootMessage.id {
+                messages.append(threadRootMessage)
+            }
         }
         return messages
     }

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -125,9 +125,6 @@ open class ChatThreadVC: _ViewController,
             queueAudioPlayer.dataSource = self
         }
 
-        // Set the initial data
-        messages = getReplies(from: messageController)
-
         if messageController.message != nil {
             didFinishSynchronizing(with: nil)
             return
@@ -434,11 +431,11 @@ open class ChatThreadVC: _ViewController,
         messageListVC.updateMessages(with: changes)
     }
 
-    private func getReplies(from messageController: ChatMessageController) -> [ChatMessage] {
+    private func getReplies(from messageController: ChatMessageController) -> LazyCachedMapCollection<ChatMessage> {
         guard shouldRenderParentMessage else {
-            return Array(messageController.replies)
+            return messageController.replies
         }
-        var messages = Array(messageController.replies)
+        var messages = messageController.replies
         let isFirstPage = messages.count < messageController.repliesPageSize
         let shouldAddRootMessageAtTheTop = isFirstPage || messageController.hasLoadedAllPreviousReplies
         if shouldAddRootMessageAtTheTop, let threadRootMessage = messageController.message {


### PR DESCRIPTION
### 🎯 Goal
Fixes the logic around skipping messages when receiving messages and scrolling at the top.
It also improves the efficiency of skipping messages by transforming the `LazyCachedMapCollection` to `Array` only when there are message list UI changes.

### 🎨 Showcase
To be filled when merged to develop

### 🧪 Manual Testing Notes
Run the performance load script while scrolling the message list to the top. The message list should not jump + performance should be good.

### ☑️ Contributor Checklist
To be filled when merged to develop
