### PR TITLE
Revert message updates whenever user info changes

### DIFF
--- a/Sources/StreamChat/Database/DTOs/UserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/UserDTO.swift
@@ -57,12 +57,6 @@ class UserDTO: NSManagedObject {
                     member.channel.cid = fakeNewCid
                 }
             }
-            for message in messages ?? [] {
-                if !message.hasChanges, !message.isDeleted {
-                    let fakeNewText = message.text
-                    message.text = fakeNewText
-                }
-            }
         }
     }
 }

--- a/Tests/StreamChatTests/Database/DTOs/UserDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/UserDTO_Tests.swift
@@ -358,51 +358,6 @@ final class UserDTO_Tests: XCTestCase {
         XCTAssertNotNil(receivedChange)
     }
 
-    func test_userChange_triggerMessagesUpdate() throws {
-        // Arrange: Store messages in database
-        let userId: UserId = .unique
-        let channelId: ChannelId = .unique
-
-        let userPayload: UserPayload = .dummy(userId: userId)
-        let channelPayload: ChannelPayload = .dummy(channel: .dummy(cid: channelId))
-        let payload: MessagePayload = .dummy(
-            showReplyInChannel: false,
-            authorUserId: userId,
-            text: "Yo"
-        )
-
-        try database.writeSynchronously { session in
-            try session.saveChannel(payload: channelPayload)
-            try session.saveUser(payload: userPayload)
-            try session.saveMessage(payload: payload, for: channelId, syncOwnReactions: false, cache: nil)
-        }
-
-        // Arrange: Observe changes on messages
-        let observer = EntityDatabaseObserver<MessageDTO, MessageDTO>(
-            context: database.viewContext,
-            fetchRequest: MessageDTO.messagesFetchRequest(
-                for: channelId,
-                pageSize: 20,
-                deletedMessagesVisibility: .alwaysVisible,
-                shouldShowShadowedMessages: false
-            ),
-            itemCreator: { $0 }
-        )
-        try observer.startObserving()
-
-        var receivedChange: EntityChange<MessageDTO>?
-        observer.onChange { receivedChange = $0 }
-
-        // Act: Update user
-        try database.writeSynchronously { session in
-            let loadedUser: UserDTO = try XCTUnwrap(session.user(id: userId))
-            loadedUser.name = "Jo Jo"
-        }
-
-        // Assert: Messages should be updated
-        XCTAssertNotNil(receivedChange)
-    }
-
     func test_userChange_triggerChannelUpdateForMembers() throws {
         // Arrange: Store messages in database
         let userId: UserId = .unique


### PR DESCRIPTION
### 🎯 Goal
Reverts updating every message whenever the user info changes since this causes a lot of performance issues.