### PR TITLE
Fix thread-safety of connection waiter when timing out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### 🐞 Fixed
+- Fix thread-safety issues when connection waiters time out [#2814](https://github.com/GetStream/stream-chat-swift/pull/2814)
+
+## StreamChatUI
 ### ✅ Added
 - Message parameter in adding/removing members methods
 

--- a/Sources/StreamChat/Repositories/ConnectionRepository.swift
+++ b/Sources/StreamChat/Repositories/ConnectionRepository.swift
@@ -183,9 +183,9 @@ class ConnectionRepository {
         connectionIdWaiters[waiterToken] = completion
 
         timerType.schedule(timeInterval: timeout, queue: connectionQueue) { [weak self] in
-            guard let completion = self?._connectionIdWaiters[waiterToken] else { return }
+            guard let completion = self?.connectionIdWaiters[waiterToken] else { return }
             completion(.failure(ClientError.WaiterTimeout()))
-            self?._connectionIdWaiters[waiterToken] = nil
+            self?.connectionIdWaiters[waiterToken] = nil
         }
     }
 

--- a/Tests/StreamChatTests/Repositories/ConnectionRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/ConnectionRepository_Tests.swift
@@ -425,6 +425,18 @@ final class ConnectionRepository_Tests: XCTestCase {
         XCTAssertTrue(result?.error is ClientError.WaiterTimeout)
     }
 
+    func test_connectionId_returnsErrorOnTimeout_threadSafe() {
+        let expectation = self.expectation(description: "Provide Token Completion")
+        expectation.expectedFulfillmentCount = 100
+
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            expectation.fulfill()
+            repository.provideConnectionId(timeout: 0.1) { _ in }
+        }
+
+        waitForExpectations(timeout: defaultTimeout)
+    }
+
     func test_connectionId_returnsErrorOnMissingValue() {
         var result: Result<ConnectionId, Error>?
         let expectation = self.expectation(description: "Provide Token Completion")


### PR DESCRIPTION
### 🔗 Issue Links
N/A

### 🎯 Goal
Fix thread-safety issues when connection waiters time out.

### 🧪 Manual Testing Notes
Unit tests were added to proof it does not crash anymore.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)