### PR TITLE
Fix channel list states view when creating a channel and loading cached channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix showing channel outside of the channel list [#2819](https://github.com/GetStream/stream-chat-swift/pull/2819)
 
+## StreamChatUI
+### 🐞 Fixed
+- Fix showing empty view when creating a new channel [#2821](https://github.com/GetStream/stream-chat-swift/pull/2821)
+- Fix showing loading view for cached channels [#2821](https://github.com/GetStream/stream-chat-swift/pull/2821)
+
 # [4.38.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.38.0)
 _September 29, 2023_
 

--- a/DemoShare/DemoShareViewModel.swift
+++ b/DemoShare/DemoShareViewModel.swift
@@ -66,7 +66,7 @@ class DemoShareViewModel: ObservableObject, ChatChannelControllerDelegate {
             throw ClientError.Unexpected("Can't upload attachment")
         }
         channelController.delegate = self
-        loading = true        
+        loading = true
         try await channelController.synchronize()
         let remoteUrls = await withThrowingTaskGroup(of: URL.self) { taskGroup in
             for url in imageURLs {
@@ -107,7 +107,6 @@ class DemoShareViewModel: ObservableObject, ChatChannelControllerDelegate {
             selectedChannel = channel
         }
     }
-    
     
     func dismissShareSheet() {
         loading = false

--- a/Sources/StreamChat/APIClient/APIClient.swift
+++ b/Sources/StreamChat/APIClient/APIClient.swift
@@ -273,7 +273,7 @@ class APIClient {
 
         enterTokenFetchMode()
 
-        tokenRefresher?() { [weak self] in
+        tokenRefresher? { [weak self] in
             self?.exitTokenFetchMode()
             completion(ClientError.TokenRefreshed())
         }

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -430,10 +430,10 @@ open class ChatChannelListVC: _ViewController,
 
             switch controller.state {
             case .initialized, .localDataFetched:
-                isLoading = channels.isEmpty
+                isLoading = controller.channels.isEmpty
             case .remoteDataFetched:
                 isLoading = false
-                shouldHideEmptyView = !channels.isEmpty
+                shouldHideEmptyView = !controller.channels.isEmpty
             case .localDataFetchFailed, .remoteDataFetchFailed:
                 shouldHideEmptyView = emptyView.isHidden
                 isLoading = false
@@ -445,7 +445,7 @@ open class ChatChannelListVC: _ViewController,
         } else {
             switch controller.state {
             case .initialized, .localDataFetched:
-                if channels.isEmpty {
+                if controller.channels.isEmpty {
                     loadingIndicator.startAnimating()
                 } else {
                     loadingIndicator.stopAnimating()

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -402,7 +402,7 @@ open class ChatChannelListVC: _ViewController,
             return
         }
         reloadChannels()
-        handleChannelStateChanges()
+        handleStateChanges(controller.state)
     }
 
     @available(*, deprecated, message: "Please use `filter` when initializing a `ChatChannelListController`")
@@ -418,17 +418,17 @@ open class ChatChannelListVC: _ViewController,
     // MARK: - DataControllerStateDelegate
 
     open func controller(_ controller: DataController, didChangeState state: DataController.State) {
-        handleChannelStateChanges()
+        handleStateChanges(state)
     }
 
     /// Called whenever the channels data changes or the controller.state changes.
     /// It controls the visibility of the channel list state views.
-    open func handleChannelStateChanges() {
+    open func handleStateChanges(_ newState: DataController.State) {
         if isChatChannelListStatesEnabled {
             var shouldHideEmptyView = true
             var isLoading = true
 
-            switch controller.state {
+            switch newState {
             case .initialized, .localDataFetched:
                 isLoading = controller.channels.isEmpty
             case .remoteDataFetched:
@@ -443,7 +443,7 @@ open class ChatChannelListVC: _ViewController,
             emptyView.isHidden = shouldHideEmptyView
             chatChannelListLoadingView.isHidden = !isLoading
         } else {
-            switch controller.state {
+            switch newState {
             case .initialized, .localDataFetched:
                 if controller.channels.isEmpty {
                     loadingIndicator.startAnimating()

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -402,6 +402,7 @@ open class ChatChannelListVC: _ViewController,
             return
         }
         reloadChannels()
+        handleChannelStateChanges()
     }
 
     @available(*, deprecated, message: "Please use `filter` when initializing a `ChatChannelListController`")
@@ -417,11 +418,17 @@ open class ChatChannelListVC: _ViewController,
     // MARK: - DataControllerStateDelegate
 
     open func controller(_ controller: DataController, didChangeState state: DataController.State) {
+        handleChannelStateChanges()
+    }
+
+    /// Called whenever the channels data changes or the controller.state changes.
+    /// It controls the visibility of the channel list state views.
+    open func handleChannelStateChanges() {
         if isChatChannelListStatesEnabled {
             var shouldHideEmptyView = true
             var isLoading = true
 
-            switch state {
+            switch controller.state {
             case .initialized, .localDataFetched:
                 isLoading = channels.isEmpty
             case .remoteDataFetched:
@@ -436,7 +443,7 @@ open class ChatChannelListVC: _ViewController,
             emptyView.isHidden = shouldHideEmptyView
             chatChannelListLoadingView.isHidden = !isLoading
         } else {
-            switch state {
+            switch controller.state {
             case .initialized, .localDataFetched:
                 if channels.isEmpty {
                     loadingIndicator.startAnimating()

--- a/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
+++ b/Sources/StreamChatUI/ChatThread/ChatThreadVC.swift
@@ -438,7 +438,7 @@ open class ChatThreadVC: _ViewController,
         guard shouldRenderParentMessage else {
             return messageController.replies
         }
-        var messages = messageController.replies
+        let messages = messageController.replies
         let isFirstPage = messages.count < messageController.repliesPageSize
         let shouldAddRootMessageAtTheTop = isFirstPage || messageController.hasLoadedAllPreviousReplies
         if shouldAddRootMessageAtTheTop, let threadRootMessage = messageController.message {

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Controllers/Controllers/ChatChannelListController_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Controllers/Controllers/ChatChannelListController_Mock.swift
@@ -22,7 +22,7 @@ public class ChatChannelListController_Mock: ChatChannelListController, Spy {
         channels_mock.map { $0.lazyCachedMap { $0 } } ?? super.channels
     }
 
-    public private(set) var state_mock: State?
+    public var state_mock: State?
     override public var state: DataController.State {
         get { state_mock ?? super.state }
         set { super.state = newValue }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/WebSocketClient/WebSocketEngine_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/WebSocketClient/WebSocketEngine_Mock.swift
@@ -78,13 +78,13 @@ extension Dictionary {
                 "id": userId,
                 "banned": false,
                 "unread_channels": 0,
-                "mutes": [],
+                "mutes": [String](),
                 "last_active": "2020-05-02T13:21:03.849219Z",
                 "created_at": "2019-06-05T15:01:52.847807Z",
-                "devices": [],
+                "devices": [String](),
                 "invisible": false,
                 "unread_count": 0,
-                "channel_mutes": [],
+                "channel_mutes": [String](),
                 "image": "https://i.imgur.com/EgEPqWZ.jpg",
                 "updated_at": "2020-05-02T13:21:03.855468Z",
                 "role": "user",
@@ -92,7 +92,7 @@ extension Dictionary {
                 "online": true,
                 "name": "Steep Moon",
                 "test": 1
-            ],
+            ] as [String : Any],
             "type": "health.check",
             "connection_id": connectionId
         ]

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/ChannelReadPayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/ChannelReadPayload_Tests.swift
@@ -59,7 +59,7 @@ final class ChannelReadPayload_Tests: XCTestCase {
                 "total_unread_count": 0,
                 "online": true,
                 "name": "broken-waterfall-5"
-            ],
+            ] as [String: Any],
             "last_read": "2020-06-10T02:33:11.760244736Z",
             "last_read_message_id": "message-id-1"
         ]

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/CreateCallPayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/CreateCallPayload_Tests.swift
@@ -46,7 +46,7 @@ final class CreateCallPayload_Tests: XCTestCase {
                     "room_id": roomId,
                     "room_name": roomName
                 ]
-            ],
+            ] as [String: Any],
             "token": token,
             "agora_uid": agoraUid,
             "agora_app_id": agoraAppId

--- a/Tests/StreamChatTests/APIClient/Endpoints/Requests/ChannelTruncateRequestPayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Requests/ChannelTruncateRequestPayload_Tests.swift
@@ -38,7 +38,7 @@ final class ChannelTruncateRequestPayload_Tests: XCTestCase {
                 "pinned": false,
                 "show_in_channel": false,
                 "silent": false
-            ]
+            ] as [String: Any]
         ])
     }
 

--- a/Tests/StreamChatTests/APIClient/Endpoints/Requests/MessageReactionRequestPayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Requests/MessageReactionRequestPayload_Tests.swift
@@ -24,7 +24,7 @@ final class MessageReactionRequestPayload_Tests: XCTestCase {
                 "type": payload.reaction.type.rawValue,
                 "score": payload.reaction.score,
                 "mood": "good one"
-            ]
+            ] as [String: Any]
         ])
     }
 }

--- a/Tests/StreamChatTests/Query/ChannelListQuery_Tests.swift
+++ b/Tests/StreamChatTests/Query/ChannelListQuery_Tests.swift
@@ -29,7 +29,7 @@ final class ChannelListQuery_Tests: XCTestCase {
             "limit": pageSize,
             "message_limit": messagesLimit,
             "member_limit": membersLimit,
-            "sort": [["field": "cid", "direction": -1]],
+            "sort": [["field": "cid", "direction": -1] as [String: Any]],
             "filter_conditions": ["cid": ["$eq": cid.rawValue]],
             "watch": true
         ]

--- a/Tests/StreamChatTests/Query/ChannelMemberListQuery_Tests.swift
+++ b/Tests/StreamChatTests/Query/ChannelMemberListQuery_Tests.swift
@@ -23,7 +23,7 @@ final class ChannelMemberListQuery_Tests: XCTestCase {
         AssertJSONEqual(json, [
             "id": query.cid.id,
             "type": query.cid.type.rawValue,
-            "sort": [["field": "created_at", "direction": 1]] as NSArray,
+            "sort": [["field": "created_at", "direction": 1] as [String: Any]] as NSArray,
             "filter_conditions": ["id": ["$eq": "luke"]],
             "limit": 30
         ])

--- a/Tests/StreamChatTests/Query/ChannelQuery_Tests.swift
+++ b/Tests/StreamChatTests/Query/ChannelQuery_Tests.swift
@@ -26,7 +26,7 @@ final class ChannelQuery_Tests: XCTestCase {
             "presence": true,
             "watch": true,
             "state": true,
-            "messages": ["limit": 25, "id_lt": "testId"],
+            "messages": ["limit": 25, "id_lt": "testId"] as [String: Any],
             "members": ["limit": 10],
             "watchers": ["limit": 10]
         ]

--- a/Tests/StreamChatTests/Query/PinnedMessages/PinnedMessagesQuery_Tests.swift
+++ b/Tests/StreamChatTests/Query/PinnedMessages/PinnedMessagesQuery_Tests.swift
@@ -74,11 +74,11 @@ final class PinnedMessagesQuery_Tests: XCTestCase {
                 [
                     "field": "pinned_at",
                     "direction": 1
-                ],
+                ] as [String: Any],
                 [
                     "field": "custom",
                     "direction": -1
-                ]
+                ] as [String: Any]
             ] as NSArray
         ])
     }

--- a/Tests/StreamChatTests/StreamChatIntegrationTests/PinnedMessagesQuery_IntegrationTests.swift
+++ b/Tests/StreamChatTests/StreamChatIntegrationTests/PinnedMessagesQuery_IntegrationTests.swift
@@ -34,7 +34,7 @@ final class PinnedMessagesQuery_IntegrationTests: XCTestCase {
         // Create request encoder.
         let baseURL = BaseURL.dublin.restAPIBaseURL
         let apiKey = String.unique
-        var requestEncoder = DefaultRequestEncoder(
+        let requestEncoder = DefaultRequestEncoder(
             baseURL: baseURL,
             apiKey: .init(apiKey)
         )
@@ -68,7 +68,7 @@ final class PinnedMessagesQuery_IntegrationTests: XCTestCase {
                 [
                     "direction": 1,
                     "field": "pinned_at"
-                ]
+                ] as [String: Any]
             ] as NSArray
         ])
     }

--- a/Tests/StreamChatTests/WebSocketClient/WebSocketConnectPayload_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/WebSocketConnectPayload_Tests.swift
@@ -34,7 +34,7 @@ final class WebSocketConnectPayload_Tests: XCTestCase {
                 "image": "https://path/to/image",
                 "color": "blue",
                 "invisible": true
-            ]
+            ] as [String: Any]
         ]
         AssertJSONEqual(serialized, expected)
     }
@@ -54,7 +54,7 @@ final class WebSocketConnectPayload_Tests: XCTestCase {
                 "name": payload.userDetails.name!,
                 "color": "blue",
                 "invisible": false
-            ]
+            ] as [String: Any]
         ]
         AssertJSONEqual(serialized, expected)
     }

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -1388,7 +1388,7 @@ final class MessageUpdater_Tests: XCTestCase {
 
         // Delete the message from the database.
         try database.writeSynchronously {
-            let session = $0 as! NSManagedObjectContext
+            let session = try XCTUnwrap($0 as? NSManagedObjectContext)
             let messageDTO = try XCTUnwrap(session.message(id: messageId))
             session.delete(messageDTO)
         }

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannelList/ChatChannelListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannelList/ChatChannelListVC_Tests.swift
@@ -213,6 +213,46 @@ final class ChatChannelListVC_Tests: XCTestCase {
         XCTAssertEqual(errorViewHidden, vc.channelListErrorView.isHidden)
     }
 
+    func test_didChangeState_whenLocalDataFetched_whenChannelsNotEmpty_shouldHideLoadingView() {
+        vc.components.isChatChannelListStatesEnabled = true
+        mockedChannelListController.channels_mock = [.mock(cid: .unique)]
+        vc.chatChannelListLoadingView.isHidden = false
+
+        vc.controller(mockedChannelListController, didChangeState: .localDataFetched)
+
+        XCTAssertEqual(vc.chatChannelListLoadingView.isHidden, true)
+    }
+
+    func test_didChangeState_whenLocalDataFetched_whenChannelsEmpty_shouldShowLoadingView() {
+        vc.components.isChatChannelListStatesEnabled = true
+        mockedChannelListController.channels_mock = []
+        vc.chatChannelListLoadingView.isHidden = true
+
+        vc.controller(mockedChannelListController, didChangeState: .localDataFetched)
+
+        XCTAssertEqual(vc.chatChannelListLoadingView.isHidden, false)
+    }
+
+    func test_didChangeState_whenInitialized_whenChannelsNotEmpty_shouldHideLoadingView() {
+        vc.components.isChatChannelListStatesEnabled = true
+        mockedChannelListController.channels_mock = [.mock(cid: .unique)]
+        vc.chatChannelListLoadingView.isHidden = false
+
+        vc.controller(mockedChannelListController, didChangeState: .initialized)
+
+        XCTAssertEqual(vc.chatChannelListLoadingView.isHidden, true)
+    }
+
+    func test_didChangeState_whenInitialized_whenChannelsEmpty_shouldShowLoadingView() {
+        vc.components.isChatChannelListStatesEnabled = true
+        mockedChannelListController.channels_mock = []
+        vc.chatChannelListLoadingView.isHidden = true
+
+        vc.controller(mockedChannelListController, didChangeState: .initialized)
+
+        XCTAssertEqual(vc.chatChannelListLoadingView.isHidden, false)
+    }
+
     func test_shouldAddNewChannelToList_whenCurrentUserIsMember_shouldReturnTrue() {
         let channelListVC = FakeChatChannelListVC()
         channelListVC.controller = mockedChannelListController

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannelList/ChatChannelListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannelList/ChatChannelListVC_Tests.swift
@@ -258,6 +258,32 @@ final class ChatChannelListVC_Tests: XCTestCase {
         XCTAssertEqual(channelListVC.skippedRendering, true)
     }
 
+    func test_didChangeChannels_whenEmptyViewVisible_whenNewChannelsNotEmpty_shouldHideEmptyView() {
+        let channelListVC = FakeChatChannelListVC()
+        channelListVC.components.isChatChannelListStatesEnabled = true
+        channelListVC.controller = mockedChannelListController
+        mockedChannelListController.state_mock = .remoteDataFetched
+        mockedChannelListController.channels_mock = [.mock(cid: .unique)]
+        channelListVC.emptyView.isHidden = false
+
+        channelListVC.controller(mockedChannelListController, didChangeChannels: [])
+
+        XCTAssertEqual(channelListVC.emptyView.isHidden, true)
+    }
+
+    func test_didChangeChannels_whenEmptyViewHidden_whenNewChannelsIsEmpty_shouldShowEmptyView() {
+        let channelListVC = FakeChatChannelListVC()
+        channelListVC.components.isChatChannelListStatesEnabled = true
+        channelListVC.controller = mockedChannelListController
+        mockedChannelListController.state_mock = .remoteDataFetched
+        mockedChannelListController.channels_mock = []
+        channelListVC.emptyView.isHidden = true
+
+        channelListVC.controller(mockedChannelListController, didChangeChannels: [])
+
+        XCTAssertEqual(channelListVC.emptyView.isHidden, false)
+    }
+
     func test_viewWillAppear_whenSkippedRendering_shouldReloadData() {
         let channelListVC = FakeChatChannelListVC()
         channelListVC.controller = mockedChannelListController


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/546
Resolves https://github.com/GetStream/ios-issues-tracking/issues/576

### 🎯 Goal
- Fix showing empty view when creating a new channel
- Fix showing loading view for cached channels
- Bonus: Fixed some swiftlint warnings

Both are bundled in this PR since they are related.

### 🛠 Implementation
**Fix showing empty view when creating a new channel:**
This was happening because whenever the channels data was changed, we did not re-evaluate the state views. Now we also handle the state view changes whenever there are data changes.

**Fix showing loading view for cached channels:**
Because of the recent introduction of DIffKit in the Channel List, we had a race condition when determining if we should show the Loading View. The problem is that `ChatChannelListVC.channels` will be empty even if we have cached items when opening the channel. The reason is that the item observers are only started when we call `ChannelListController.channels`. So the `didChangeState` event will be called before the `ChatChannelListVC.channels` being populated, so the fix for now is to make sure we use the `controller.channels` directly.

### 🧪 Manual Testing Notes
**Fix showing empty view when creating a new channel:**
1. Open Demo App
2. Login with Jar Jar Binks (It has not channels already)
3. Create a new Channel
4. The channel should appear in the Channel List
5. Remove that same Channel
6. The empty view should reappear

**Fix showing loading view for cached channels:**
1. Open Demo App
2. Login with any user that has channels already
3. Kill the app
4. Open the App
5. Loading View should not appear

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
