### PR TITLE
Fix messages not updated when user name and image changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add support for custom HTTP headers in `ChatClientConfig.urlSessionConfiguration` [#2818](https://github.com/GetStream/stream-chat-swift/pull/2818)
 ### 🐞 Fixed
 - Fix showing channel outside of the channel list [#2819](https://github.com/GetStream/stream-chat-swift/pull/2819)
+- Fix messages not updated when user name and image change [#2822](https://github.com/GetStream/stream-chat-swift/pull/2822)
 
 # [4.38.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.38.0)
 _September 29, 2023_

--- a/Sources/StreamChat/Database/DTOs/UserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/UserDTO.swift
@@ -57,6 +57,16 @@ class UserDTO: NSManagedObject {
                     member.channel.cid = fakeNewCid
                 }
             }
+
+            let hasNameChanged = changedValues().keys.contains(#keyPath(UserDTO.name))
+            let hasImageUrlChanged = changedValues().keys.contains(#keyPath(UserDTO.imageURL))
+            if hasNameChanged || hasImageUrlChanged {
+                for message in messages ?? [] {
+                    if !message.hasChanges && !message.isDeleted {
+                        message.user = self
+                    }
+                }
+            }
         }
     }
 }

--- a/Sources/StreamChat/Database/DTOs/UserDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/UserDTO.swift
@@ -58,6 +58,10 @@ class UserDTO: NSManagedObject {
                 }
             }
 
+            /// When a user updates, we want to trigger message updates, so that changes
+            /// are reflected in the UI and the message authors are updated.
+            /// It is important we only do this for name and images changes since this
+            /// will trigger an event for every message that this user owns.
             let hasNameChanged = changedValues().keys.contains(#keyPath(UserDTO.name))
             let hasImageUrlChanged = changedValues().keys.contains(#keyPath(UserDTO.imageURL))
             if hasNameChanged || hasImageUrlChanged {

--- a/Tests/StreamChatTests/Database/DTOs/UserDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/UserDTO_Tests.swift
@@ -397,4 +397,60 @@ final class UserDTO_Tests: XCTestCase {
         // Assert: Channel should be updated
         XCTAssertNotNil(receivedChange)
     }
+
+    func test_userChange_whenNameOrImageUpdates_triggerMessagesUpdate() throws {
+        // Arrange: Store messages in database
+        let userId: UserId = .unique
+        let channelId: ChannelId = .unique
+
+        let userPayload: UserPayload = .dummy(userId: userId)
+        let channelPayload: ChannelPayload = .dummy(channel: .dummy(cid: channelId))
+        let payload: MessagePayload = .dummy(
+            showReplyInChannel: false,
+            authorUserId: userId,
+            text: "Yo"
+        )
+
+        try database.writeSynchronously { session in
+            try session.saveChannel(payload: channelPayload)
+            try session.saveUser(payload: userPayload)
+            try session.saveMessage(payload: payload, for: channelId, syncOwnReactions: false, cache: nil)
+        }
+
+        // Arrange: Observe changes on messages
+        let observer = EntityDatabaseObserver<MessageDTO, MessageDTO>(
+            context: database.viewContext,
+            fetchRequest: MessageDTO.messagesFetchRequest(
+                for: channelId,
+                pageSize: 20,
+                deletedMessagesVisibility: .alwaysVisible,
+                shouldShowShadowedMessages: false
+            ),
+            itemCreator: { $0 }
+        )
+        try observer.startObserving()
+
+        var receivedChange: EntityChange<MessageDTO>?
+        observer.onChange { receivedChange = $0 }
+
+        // Act: Update user name
+        try database.writeSynchronously { session in
+            let loadedUser: UserDTO = try XCTUnwrap(session.user(id: userId))
+            loadedUser.name = "Jo Jo"
+        }
+
+        // Assert: Messages should be updated
+        XCTAssertNotNil(receivedChange)
+
+        // Act: Update user image
+        try database.writeSynchronously { session in
+            let loadedUser: UserDTO = try XCTUnwrap(session.user(id: userId))
+            loadedUser.imageURL = .localYodaImage
+        }
+
+        receivedChange = nil
+
+        // Assert: Messages should be updated
+        XCTAssertNotNil(receivedChange)
+    }
 }

--- a/Tests/StreamChatTests/Database/DTOs/UserDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/UserDTO_Tests.swift
@@ -442,15 +442,28 @@ final class UserDTO_Tests: XCTestCase {
         // Assert: Messages should be updated
         XCTAssertNotNil(receivedChange)
 
+        // Reset
+        receivedChange = nil
+
         // Act: Update user image
         try database.writeSynchronously { session in
             let loadedUser: UserDTO = try XCTUnwrap(session.user(id: userId))
             loadedUser.imageURL = .localYodaImage
         }
 
-        receivedChange = nil
-
         // Assert: Messages should be updated
         XCTAssertNotNil(receivedChange)
+
+        // Reset
+        receivedChange = nil
+
+        // Act: Update user lastActivityAt
+        try database.writeSynchronously { session in
+            let loadedUser: UserDTO = try XCTUnwrap(session.user(id: userId))
+            loadedUser.lastActivityAt = .unique
+        }
+
+        // Assert: Messages should not update
+        XCTAssertNil(receivedChange)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/520

### 🎯 Goal
Fix message list not updated when user name and image changes.

### 📝 Summary
This one fixes the issue reverted here: https://github.com/GetStream/stream-chat-swift/pull/2810

The original fix caused big performance issues. The reason is that we did this change for every user update, even if there were no actual real user changes, and so this caused way too many message updates for no reason.

This new approach will only update the message when user names and images change. Since these rarely happen, it is safe to make this change. 

### 🧪 Manual Testing Notes

### Performance
Perform a stress test in the Message List

### User changes
1. Open a Channel
2. Update the user data of one of the members.
    ```bash
    stream-cli chat upsert-user --properties "{\"id\":\"leia_organa\",\"name\":\"Leia\", \"image\":\"https://www.themarysue.com/wp-content/uploads/2017/08/leiatop1.jpg?resize=650%2C574\"}"
    ```
3. Should update all the messages with the new user info
4. Change the user info back to the original
    ```bash
    stream-cli chat upsert-user --properties "{\"id\":\"leia_organa\",\"name\":\"Leia Organa\", \"image\":\"https://vignette.wikia.nocookie.net/starwars/images/f/fc/Leia_Organa_TLJ.png\"}"
    ```

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)