### PR TITLE
Avoid deadlock when acessing connectionIdWaiters

### DIFF
--- a/Sources/StreamChat/Repositories/ConnectionRepository.swift
+++ b/Sources/StreamChat/Repositories/ConnectionRepository.swift
@@ -182,7 +182,8 @@ class ConnectionRepository {
         let waiterToken = String.newUniqueId
         connectionIdWaiters[waiterToken] = completion
 
-        timerType.schedule(timeInterval: timeout, queue: .global()) { [weak self] in
+        let globalQueue = DispatchQueue.global()
+        timerType.schedule(timeInterval: timeout, queue: globalQueue) { [weak self] in
             guard let self = self else { return }
 
             // Not the nicest, but we need to ensure the read and write below are treated as an atomic operation,
@@ -192,7 +193,7 @@ class ConnectionRepository {
             self.connectionQueue.async(flags: .barrier) {
                 guard let completion = self._connectionIdWaiters[waiterToken] else { return }
 
-                self.connectionQueue.async {
+                globalQueue.async {
                     completion(.failure(ClientError.WaiterTimeout()))
                 }
 

--- a/Sources/StreamChat/Repositories/ConnectionRepository.swift
+++ b/Sources/StreamChat/Repositories/ConnectionRepository.swift
@@ -182,11 +182,21 @@ class ConnectionRepository {
         let waiterToken = String.newUniqueId
         connectionIdWaiters[waiterToken] = completion
 
-        timerType.schedule(timeInterval: timeout, queue: connectionQueue) { [weak self] in
-            self?.connectionQueue.async(flags: .barrier) {
-                guard let completion = self?._connectionIdWaiters[waiterToken] else { return }
-                completion(.failure(ClientError.WaiterTimeout()))
-                self?._connectionIdWaiters[waiterToken] = nil
+        timerType.schedule(timeInterval: timeout, queue: .global()) { [weak self] in
+            guard let self = self else { return }
+
+            // Not the nicest, but we need to ensure the read and write below are treated as an atomic operation,
+            // in a queue that is concurrent, whilst the completion needs to be called outside of the barrier'ed operation.
+            // If we call the block as part of the barrier'ed operation, and by any chance this ends up synchronously
+            // calling any queue protected property in this class before the operation is completed, we can potentially crash the app.
+            self.connectionQueue.async(flags: .barrier) {
+                guard let completion = self._connectionIdWaiters[waiterToken] else { return }
+
+                self.connectionQueue.async {
+                    completion(.failure(ClientError.WaiterTimeout()))
+                }
+
+                self._connectionIdWaiters[waiterToken] = nil
             }
         }
     }

--- a/Tests/StreamChatTests/Repositories/ConnectionRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/ConnectionRepository_Tests.swift
@@ -470,6 +470,16 @@ final class ConnectionRepository_Tests: XCTestCase {
         XCTAssertEqual(result?.value, connectionId)
     }
 
+    func test_connectionId_doesNotDeadlock() {
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            repository.provideConnectionId(timeout: 0) { _ in }
+        }
+
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            repository.connectionIdWaiters.forEach { _ in }
+        }
+    }
+
     // MARK: Complete ConnectionId Waiters
 
     func test_completeConnectionIdWaiters_nil_connectionId() {


### PR DESCRIPTION
### 🎯 Goal

Fix deadlock introduced by: https://github.com/GetStream/stream-chat-swift/pull/2814

### 📝 Summary

When timing out on `provideConnectionId`, a deadlock happens because of a `sync` dispatch to the same queue where we are already performing the work.

### 🛠 Implementation

`connectionQueue` is a concurrent queue, and therefore multiple threads might be reading/writing `connectionIdWaiters`. This is not what we want. To fix that, we will dispatch writes using a `.barrier` flag, so that there are no race conditions there.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
