### PR TITLE
Background Mapping - Offline Fixes

### DIFF
--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -508,7 +508,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
         }
 
         guard !hasLoadedAllNextMessages && !isLoadingNextMessages else {
-            completion?(nil)
+            callback { completion?(nil) }
             return
         }
 

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1900,7 +1900,7 @@
 		C12297D62AC57F7C00C5FF04 /* ChatMessage+Equatable_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12297D52AC57F7C00C5FF04 /* ChatMessage+Equatable_Tests.swift */; };
 		C122B8812A02645200D27F41 /* ChannelReadPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C122B8802A02645200D27F41 /* ChannelReadPayload_Tests.swift */; };
 		C12D0A6028FD59B60099895A /* AuthenticationRepository_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12D0A5F28FD59B60099895A /* AuthenticationRepository_Mock.swift */; };
-		C12DBE5C2A614F310045D9F0 /* ListDatabaseObserver+Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12DBE5B2A614F310045D9F0 /* ListDatabaseObserver+Sorting.swift */; };
+		C12DBE5C2A614F310045D9F0 /* ListDatabaseObserver+Sorting_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12DBE5B2A614F310045D9F0 /* ListDatabaseObserver+Sorting_Tests.swift */; };
 		C12DBE5F2A67DFE80045D9F0 /* SortValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12DBE5D2A67DFC70045D9F0 /* SortValue.swift */; };
 		C12DBE612A67E2D60045D9F0 /* SortingValue_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12DBE602A67E2D60045D9F0 /* SortingValue_Tests.swift */; };
 		C1320E0A276B2E0F00A06B35 /* Array+SafeSubscript_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1320E07276B2E0800A06B35 /* Array+SafeSubscript_Tests.swift */; };
@@ -3832,7 +3832,7 @@
 		C12297D52AC57F7C00C5FF04 /* ChatMessage+Equatable_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatMessage+Equatable_Tests.swift"; sourceTree = "<group>"; };
 		C122B8802A02645200D27F41 /* ChannelReadPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelReadPayload_Tests.swift; sourceTree = "<group>"; };
 		C12D0A5F28FD59B60099895A /* AuthenticationRepository_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationRepository_Mock.swift; sourceTree = "<group>"; };
-		C12DBE5B2A614F310045D9F0 /* ListDatabaseObserver+Sorting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListDatabaseObserver+Sorting.swift"; sourceTree = "<group>"; };
+		C12DBE5B2A614F310045D9F0 /* ListDatabaseObserver+Sorting_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListDatabaseObserver+Sorting_Tests.swift"; sourceTree = "<group>"; };
 		C12DBE5D2A67DFC70045D9F0 /* SortValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortValue.swift; sourceTree = "<group>"; };
 		C12DBE602A67E2D60045D9F0 /* SortingValue_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortingValue_Tests.swift; sourceTree = "<group>"; };
 		C1320E07276B2E0800A06B35 /* Array+SafeSubscript_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeSubscript_Tests.swift"; sourceTree = "<group>"; };
@@ -6651,7 +6651,7 @@
 			children = (
 				79B8B648285B5ADD0059FB2D /* ChannelListSortingKey_Tests.swift */,
 				791D3D8F26776BE400E3A0F9 /* ChannelMemberListSortingKey_Tests.swift */,
-				C12DBE5B2A614F310045D9F0 /* ListDatabaseObserver+Sorting.swift */,
+				C12DBE5B2A614F310045D9F0 /* ListDatabaseObserver+Sorting_Tests.swift */,
 				DA958D5325309917005D23FA /* Sorting_Tests.swift */,
 				C12DBE602A67E2D60045D9F0 /* SortingValue_Tests.swift */,
 			);
@@ -10532,7 +10532,7 @@
 				4042969229FBF84B0089126D /* AudioSamplesProcessor_Tests.swift in Sources */,
 				A3F65E3627EB70E0003F6256 /* EventLogger.swift in Sources */,
 				DA8407332526003D005A0F62 /* UserListUpdater_Tests.swift in Sources */,
-				C12DBE5C2A614F310045D9F0 /* ListDatabaseObserver+Sorting.swift in Sources */,
+				C12DBE5C2A614F310045D9F0 /* ListDatabaseObserver+Sorting_Tests.swift in Sources */,
 				F69E7F7D24ED7562000F5252 /* CurrentUserController_Tests.swift in Sources */,
 				A30C3F22276B4F8800DA5968 /* UnknownUserEvent_Tests.swift in Sources */,
 				7922F30A24DAE3B600C364BC /* EntityDatabaseObserver_Tests.swift in Sources */,

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Controllers/ListDatabaseObserver_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Controllers/ListDatabaseObserver_Mock.swift
@@ -22,3 +22,19 @@ final class ListDatabaseObserver_Mock<Item, DTO: NSManagedObject>: ListDatabaseO
         items_mock ?? super.items
     }
 }
+
+extension ListDatabaseObserverWrapper {
+    func startObservingAndWaitForInitialUpdate(on testCase: XCTestCase, file: StaticString = #file, line: UInt = #line) throws {
+        guard isBackground else {
+            try startObserving()
+            return
+        }
+
+        let expectation = testCase.expectation(description: "Messages update")
+        onDidChange = { _ in
+            expectation.fulfill()
+        }
+        try startObserving()
+        testCase.wait(for: [expectation], timeout: defaultTimeout)
+    }
+}

--- a/Tests/StreamChatTests/BackgroundListDatabaseObserver_Tests.swift
+++ b/Tests/StreamChatTests/BackgroundListDatabaseObserver_Tests.swift
@@ -54,20 +54,18 @@ final class BackgroundListDatabaseObserver_Tests: XCTestCase {
     }
 
     func test_changeAggregatorSetup() throws {
-        // Start observing to ensure everything is set up
-        try observer.startObserving()
-
-        let onDidChangeExpectation = expectation(description: "onDidChange")
-        observer.onDidChange = { _ in
-            onDidChangeExpectation.fulfill()
+        let expectation1 = expectation(description: "onWillChange is called")
+        observer.onWillChange = {
+            expectation1.fulfill()
         }
 
-        let onWillChangeExpectation = expectation(description: "onWillChange")
-        observer.onWillChange = { onWillChangeExpectation.fulfill() }
+        let expectation2 = expectation(description: "onDidChange is called")
+        observer.onDidChange = { _ in
+            expectation2.fulfill()
+        }
 
-        // Simulate callbacks from the aggregator
-        observer.changeAggregator.onWillChange?()
-        observer.changeAggregator.onDidChange?([])
+        // Start observing to ensure everything is set up
+        try observer.startObserving()
 
         waitForExpectations(timeout: defaultTimeout)
 
@@ -115,49 +113,6 @@ final class BackgroundListDatabaseObserver_Tests: XCTestCase {
         XCTAssertFalse(testFRC.test_performFetchCalled)
     }
 
-    func test_updateStillReported_whenSamePropertyAssigned() throws {
-        // For this test, we need an actual NSFetchedResultsController, not the test one
-        let observer = BackgroundListDatabaseObserver<String, TestManagedObject>(
-            context: database.backgroundReadOnlyContext,
-            fetchRequest: fetchRequest,
-            itemCreator: { $0.testId },
-            sorting: []
-        )
-
-        // We call startObserving
-        try observer.startObserving()
-
-        let onDidChangeExpectation = expectation(description: "onDidChange")
-        onDidChangeExpectation.expectedFulfillmentCount = 2
-
-        var receivedChanges: [ListChange<String>] = []
-        observer.onDidChange = {
-            receivedChanges.append(contentsOf: $0)
-            onDidChangeExpectation.fulfill()
-        }
-
-        // Insert the test object
-        let testValue = String.unique
-        var item: TestManagedObject!
-        try database.writeSynchronously { _ in
-            let context = self.database.writableContext
-            item = NSEntityDescription.insertNewObject(forEntityName: "TestManagedObject", into: context) as? TestManagedObject
-            item.testId = testValue
-            item.testValue = testValue
-        }
-
-        // Assign the same testValue to the same entity
-        try database.writeSynchronously { _ in
-            item.testValue = testValue
-        }
-
-        waitForExpectations(timeout: defaultTimeout)
-
-        XCTAssertEqual(receivedChanges.count, 2)
-        XCTAssertEqual(receivedChanges.first?.isInsertion, true)
-        XCTAssertEqual(receivedChanges.last?.isUpdate, true)
-    }
-
     func test_allItemsAreRemoved_whenDatabaseContainerRemovesAllData() throws {
         // Simulate objects fetched by FRC
         let objects = [
@@ -182,7 +137,11 @@ final class BackgroundListDatabaseObserver_Tests: XCTestCase {
 
         let startObservingDidChangeExpectation = expectation(description: "onDidChange")
         var changes: [ListChange<String>] = []
+        // When sending `DatabaseContainer.DidRemoveAllDataNotification` we call `startObserving`, which will call again `onDidChange` with 0 changes. We are not interested in this later part for this test.
+        var callsCount = 0
         observer.onDidChange = { incomingChanges in
+            guard callsCount == 0 else { return }
+            callsCount += 1
             changes = incomingChanges
             changes.forEach {
                 switch $0 {
@@ -209,28 +168,28 @@ final class BackgroundListDatabaseObserver_Tests: XCTestCase {
     }
 
     private func startObservingAndWaitForInitialResults() throws {
-        // Start observing to ensure everything is set up
-        try observer.startObserving()
-
-        waitForItemsUpdate()
+        try waitForItemsUpdate {
+            // Start observing to ensure everything is set up
+            try observer.startObserving()
+        }
     }
 
     private func assertItemsAfterUpdate(_ items: [String], file: StaticString = #file, line: UInt = #line) {
-        waitForItemsUpdate()
+        try? waitForItemsUpdate {
+            let changeAggregator = observer.frc.delegate as? ListChangeAggregator<TestManagedObject, String>
+            changeAggregator?.onDidChange?([])
+        }
         let sutItems = Array(observer.items)
         XCTAssertEqual(sutItems, items, file: file, line: line)
     }
 
-    private func waitForItemsUpdate() {
+    private func waitForItemsUpdate(block: () throws -> Void) throws {
         let expectation = self.expectation(description: "Get items")
         observer.onDidChange = { _ in
             expectation.fulfill()
         }
 
-        let changeAggregator = observer.frc.delegate as? ListChangeAggregator<TestManagedObject, String>
-
-        changeAggregator?.onDidChange?([])
-
+        try block()
         waitForExpectations(timeout: defaultTimeout)
     }
 }

--- a/Tests/StreamChatTests/BackgroundListDatabaseObserver_Tests.swift
+++ b/Tests/StreamChatTests/BackgroundListDatabaseObserver_Tests.swift
@@ -113,6 +113,49 @@ final class BackgroundListDatabaseObserver_Tests: XCTestCase {
         XCTAssertFalse(testFRC.test_performFetchCalled)
     }
 
+    func test_updateStillReported_whenSamePropertyAssigned() throws {
+        // For this test, we need an actual NSFetchedResultsController, not the test one
+        observer = BackgroundListDatabaseObserver<String, TestManagedObject>(
+            context: database.backgroundReadOnlyContext,
+            fetchRequest: fetchRequest,
+            itemCreator: { $0.testId },
+            sorting: []
+        )
+
+        // We call startObserving
+        try startObservingAndWaitForInitialResults()
+
+        let onDidChangeExpectation = expectation(description: "onDidChange")
+        onDidChangeExpectation.expectedFulfillmentCount = 2
+
+        var receivedChanges: [ListChange<String>] = []
+        observer.onDidChange = {
+            receivedChanges.append(contentsOf: $0)
+            onDidChangeExpectation.fulfill()
+        }
+
+        // Insert the test object
+        let testValue = String.unique
+        var item: TestManagedObject!
+        try database.writeSynchronously { _ in
+            let context = self.database.writableContext
+            item = NSEntityDescription.insertNewObject(forEntityName: "TestManagedObject", into: context) as? TestManagedObject
+            item.testId = testValue
+            item.testValue = testValue
+        }
+
+        // Assign the same testValue to the same entity
+        try database.writeSynchronously { _ in
+            item.testValue = testValue
+        }
+
+        waitForExpectations(timeout: defaultTimeout)
+
+        XCTAssertEqual(receivedChanges.count, 2)
+        XCTAssertEqual(receivedChanges.first?.isInsertion, true)
+        XCTAssertEqual(receivedChanges.last?.isUpdate, true)
+    }
+
     func test_allItemsAreRemoved_whenDatabaseContainerRemovesAllData() throws {
         // Simulate objects fetched by FRC
         let objects = [

--- a/Tests/StreamChatTests/ListDatabaseObserverWrapper_Tests.swift
+++ b/Tests/StreamChatTests/ListDatabaseObserverWrapper_Tests.swift
@@ -247,20 +247,8 @@ extension ListDatabaseObserverWrapper_Tests {
         )
     }
 
-    private func startObservingWaitingForInitialResults() throws {
-        guard observer.isBackground else {
-            try observer.startObserving()
-            return
-        }
-
-        // Because when in background initial results are not returned instantly, we need to
-        // wait for the first call to `onDidChange` to have the initial results.
-        let expectation = self.expectation(description: "Get items")
-        observer.onDidChange = { _ in
-            expectation.fulfill()
-        }
-        try observer.startObserving()
-        waitForExpectations(timeout: defaultTimeout)
+    private func startObservingWaitingForInitialResults(file: StaticString = #file, line: UInt = #line) throws {
+        try observer.startObservingAndWaitForInitialUpdate(on: self, file: file, line: line)
     }
 
     private func assertItemsAfterUpdate(_ items: [String], isBackground: Bool, file: StaticString = #file, line: UInt = #line) {

--- a/Tests/StreamChatTests/ListDatabaseObserverWrapper_Tests.swift
+++ b/Tests/StreamChatTests/ListDatabaseObserverWrapper_Tests.swift
@@ -95,7 +95,7 @@ final class ListDatabaseObserverWrapper_Tests: XCTestCase {
         prepare(isBackground: isBackground)
         
         // Call startObserving to set everything up
-        try observer.startObserving()
+        try startObservingWaitingForInitialResults()
 
         // Simulate objects fetched by FRC
         let reference1 = [
@@ -187,7 +187,7 @@ final class ListDatabaseObserverWrapper_Tests: XCTestCase {
         prepare(isBackground: isBackground)
 
         // Call startObserving to set everything up
-        try observer.startObserving()
+        try startObservingWaitingForInitialResults()
         let frc = try XCTUnwrap(frc)
 
         // Simulate objects fetched by FRC
@@ -199,8 +199,16 @@ final class ListDatabaseObserverWrapper_Tests: XCTestCase {
         assertItemsAfterUpdate(objects.map(\.uniqueValue), isBackground: isBackground)
 
         // Listen to callbacks
+        let onDidChangeExpectation = expectation(description: "onDidChange is called")
         var receivedChanges: [ListChange<String>]?
-        observer.onDidChange = { receivedChanges = $0 }
+        // When sending `DatabaseContainer.DidRemoveAllDataNotification` we call `startObserving`, which will call again `onDidChange` with 0 changes. We are not interested in this later part for this test.
+        var callsCount = 0
+        observer.onDidChange = {
+            guard callsCount == 0 else { return }
+            callsCount += 1
+            receivedChanges = $0
+            onDidChangeExpectation.fulfill()
+        }
 
         // Reset test FRC's `performFetch` called flag
         frc.performFetchCalled = false
@@ -219,8 +227,9 @@ final class ListDatabaseObserverWrapper_Tests: XCTestCase {
         // Assert `performFetch` was called again on the FRC
         XCTAssertTrue(frc.performFetchCalled)
 
+        waitForExpectations(timeout: defaultTimeout)
         // Assert callback is called with removed entities
-        AssertAsync.willBeEqual(
+        XCTAssertEqual(
             receivedChanges,
             [.remove(objects[0].uniqueValue, index: [0, 0]), .remove(objects[1].uniqueValue, index: [0, 1])]
         )
@@ -236,6 +245,22 @@ extension ListDatabaseObserverWrapper_Tests {
             itemCreator: { $0.uniqueValue },
             fetchedResultsControllerType: FRC.self
         )
+    }
+
+    private func startObservingWaitingForInitialResults() throws {
+        guard observer.isBackground else {
+            try observer.startObserving()
+            return
+        }
+
+        // Because when in background initial results are not returned instantly, we need to
+        // wait for the first call to `onDidChange` to have the initial results.
+        let expectation = self.expectation(description: "Get items")
+        observer.onDidChange = { _ in
+            expectation.fulfill()
+        }
+        try observer.startObserving()
+        waitForExpectations(timeout: defaultTimeout)
     }
 
     private func assertItemsAfterUpdate(_ items: [String], isBackground: Bool, file: StaticString = #file, line: UInt = #line) {

--- a/Tests/StreamChatTests/Query/Sorting/ListDatabaseObserver+Sorting.swift
+++ b/Tests/StreamChatTests/Query/Sorting/ListDatabaseObserver+Sorting.swift
@@ -29,6 +29,18 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
     var query: ChannelListQuery!
     var observer: ListDatabaseObserverWrapper<ChatChannel, ChannelDTO>!
 
+    private static var originalIsBackgroundMappingEnabled = StreamRuntimeCheck._isBackgroundMappingEnabled
+
+    override class func setUp() {
+        super.setUp()
+        originalIsBackgroundMappingEnabled = StreamRuntimeCheck._isBackgroundMappingEnabled
+    }
+
+    override class func tearDown() {
+        super.tearDown()
+        StreamRuntimeCheck._isBackgroundMappingEnabled = originalIsBackgroundMappingEnabled
+    }
+
     override func tearDown() {
         super.tearDown()
         database = nil
@@ -44,12 +56,12 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
         try assert_channelsAreSortedAccordingToDefaultSorting(isBackground: true)
     }
 
-    func assert_channelsAreSortedAccordingToDefaultSorting(isBackground: Bool, file: StaticString = #filePath, line: UInt = #line) throws {
+    func assert_channelsAreSortedAccordingToDefaultSorting(isBackground: Bool) throws {
         createObserver(with: [
             .init(key: .default, isAscending: false)
         ], isBackground: isBackground)
 
-        try observer.startObserving()
+        try startObservingAndWaitForInitialUpdate(isBackground: isBackground)
 
         let expectation = self.expectation(description: "Observer notifies")
         observer.onDidChange = { changes in
@@ -87,7 +99,7 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
             .init(key: .custom(keyPath: \.defaultSortingAt, key: "defaultSortingAt"), isAscending: false)
         ], isBackground: isBackground)
 
-        try observer.startObserving()
+        try startObservingAndWaitForInitialUpdate(isBackground: isBackground)
 
         let expectation = self.expectation(description: "Observer notifies")
         observer.onDidChange = { changes in
@@ -123,7 +135,7 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
         createObserver(with: [
             .init(key: .custom(keyPath: \.name, key: "name"), isAscending: false)
         ], isBackground: isBackground)
-        try observer.startObserving()
+        try startObservingAndWaitForInitialUpdate(isBackground: isBackground)
 
         let expectation = self.expectation(description: "Observer notifies")
         observer.onDidChange = { changes in
@@ -152,7 +164,7 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
             .init(key: .custom(keyPath: \.isPinned, key: "is_pinned"), isAscending: true),
             .init(key: .custom(keyPath: \.name, key: "name"), isAscending: true)
         ], isBackground: isBackground)
-        try observer.startObserving()
+        try startObservingAndWaitForInitialUpdate(isBackground: isBackground)
 
         let expectation = self.expectation(description: "Observer notifies")
         expectation.expectedFulfillmentCount = 2
@@ -194,7 +206,7 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
             .init(key: .createdAt, isAscending: false),
             .init(key: .custom(keyPath: \.name, key: "name"), isAscending: false)
         ], isBackground: isBackground)
-        try observer.startObserving()
+        try startObservingAndWaitForInitialUpdate(isBackground: isBackground)
 
         let expectation = self.expectation(description: "Observer notifies")
         observer.onDidChange = { changes in
@@ -249,7 +261,7 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
         ]
 
         createObserver(with: sorting, isBackground: isBackground)
-        try observer.startObserving()
+        try startObservingAndWaitForInitialUpdate(isBackground: isBackground)
 
         observer.onDidChange = { changes in
             expectation.fulfill()
@@ -302,7 +314,7 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
         ]
 
         createObserver(with: sorting, isBackground: isBackground)
-        try observer.startObserving()
+        try startObservingAndWaitForInitialUpdate(isBackground: isBackground)
 
         observer.onDidChange = { changes in
             expectation.fulfill()
@@ -320,6 +332,7 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
     // MARK: - Helpers
 
     private func createObserver(with sorting: [Sorting<ChannelListSortingKey>], isBackground: Bool) {
+        StreamRuntimeCheck._isBackgroundMappingEnabled = isBackground
         database = DatabaseContainer_Spy(
             kind: .onDisk(databaseFileURL: .newTemporaryFileURL()),
             modelName: "StreamChatModel",
@@ -370,6 +383,20 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
         try createChannels(mapping: mapping.map {
             ($0, $1, $1)
         })
+    }
+
+    private func startObservingAndWaitForInitialUpdate(isBackground: Bool, file: StaticString = #file, line: UInt = #line) throws {
+        guard isBackground else {
+            try observer.startObserving()
+            return
+        }
+
+        let expectation = self.expectation(description: "Messages update")
+        observer.onDidChange = { _ in
+            expectation.fulfill()
+        }
+        try observer.startObserving()
+        wait(for: [expectation], timeout: defaultTimeout)
     }
 }
 

--- a/Tests/StreamChatTests/Query/Sorting/ListDatabaseObserver+Sorting_Tests.swift
+++ b/Tests/StreamChatTests/Query/Sorting/ListDatabaseObserver+Sorting_Tests.swift
@@ -7,7 +7,7 @@ import CoreData
 @testable import StreamChatTestTools
 import XCTest
 
-final class ListDatabaseObserver_Sorting: XCTestCase {
+final class ListDatabaseObserver_Sorting_Tests: XCTestCase {
     let dateNow = Date()
     let datePast = Date().addingTimeInterval(-60 * 60 * 3)
     let dateWayPast = Date().addingTimeInterval(-60 * 60 * 100)
@@ -61,7 +61,7 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
             .init(key: .default, isAscending: false)
         ], isBackground: isBackground)
 
-        try startObservingAndWaitForInitialUpdate(isBackground: isBackground)
+        try startObservingAndWaitForInitialUpdate()
 
         let expectation = self.expectation(description: "Observer notifies")
         observer.onDidChange = { changes in
@@ -99,7 +99,7 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
             .init(key: .custom(keyPath: \.defaultSortingAt, key: "defaultSortingAt"), isAscending: false)
         ], isBackground: isBackground)
 
-        try startObservingAndWaitForInitialUpdate(isBackground: isBackground)
+        try startObservingAndWaitForInitialUpdate()
 
         let expectation = self.expectation(description: "Observer notifies")
         observer.onDidChange = { changes in
@@ -135,7 +135,7 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
         createObserver(with: [
             .init(key: .custom(keyPath: \.name, key: "name"), isAscending: false)
         ], isBackground: isBackground)
-        try startObservingAndWaitForInitialUpdate(isBackground: isBackground)
+        try startObservingAndWaitForInitialUpdate()
 
         let expectation = self.expectation(description: "Observer notifies")
         observer.onDidChange = { changes in
@@ -164,7 +164,7 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
             .init(key: .custom(keyPath: \.isPinned, key: "is_pinned"), isAscending: true),
             .init(key: .custom(keyPath: \.name, key: "name"), isAscending: true)
         ], isBackground: isBackground)
-        try startObservingAndWaitForInitialUpdate(isBackground: isBackground)
+        try startObservingAndWaitForInitialUpdate()
 
         let expectation = self.expectation(description: "Observer notifies")
         expectation.expectedFulfillmentCount = 2
@@ -206,7 +206,7 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
             .init(key: .createdAt, isAscending: false),
             .init(key: .custom(keyPath: \.name, key: "name"), isAscending: false)
         ], isBackground: isBackground)
-        try startObservingAndWaitForInitialUpdate(isBackground: isBackground)
+        try startObservingAndWaitForInitialUpdate()
 
         let expectation = self.expectation(description: "Observer notifies")
         observer.onDidChange = { changes in
@@ -261,7 +261,7 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
         ]
 
         createObserver(with: sorting, isBackground: isBackground)
-        try startObservingAndWaitForInitialUpdate(isBackground: isBackground)
+        try startObservingAndWaitForInitialUpdate()
 
         observer.onDidChange = { changes in
             expectation.fulfill()
@@ -314,7 +314,7 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
         ]
 
         createObserver(with: sorting, isBackground: isBackground)
-        try startObservingAndWaitForInitialUpdate(isBackground: isBackground)
+        try startObservingAndWaitForInitialUpdate()
 
         observer.onDidChange = { changes in
             expectation.fulfill()
@@ -385,18 +385,8 @@ final class ListDatabaseObserver_Sorting: XCTestCase {
         })
     }
 
-    private func startObservingAndWaitForInitialUpdate(isBackground: Bool, file: StaticString = #file, line: UInt = #line) throws {
-        guard isBackground else {
-            try observer.startObserving()
-            return
-        }
-
-        let expectation = self.expectation(description: "Messages update")
-        observer.onDidChange = { _ in
-            expectation.fulfill()
-        }
-        try observer.startObserving()
-        wait(for: [expectation], timeout: defaultTimeout)
+    private func startObservingAndWaitForInitialUpdate(file: StaticString = #file, line: UInt = #line) throws {
+        try observer.startObservingAndWaitForInitialUpdate(on: self, file: file, line: line)
     }
 }
 


### PR DESCRIPTION
### 🔗 Issue Links

Continuation of https://github.com/GetStream/stream-chat-swift/pull/2831

### 🎯 Goal

The goal of this PR was to fix some deficiencies BG Mapping had when being Offline

### 📝 Summary

There was an assumption that for the initial fetch we would not need to notify the listeners. This was not a problem when being online, given that any interaction with the network would trigger updates, and therefore the listeners would be notified.

This is, though, a big problem when in offline mode, where we depend on the initial data.

### 🛠 Implementation

This PR makes sure the listener is always notified with the initial fetch

### 🧪 Manual Testing Notes

1. Open the app
2. Close the app
3. Disable internet
4. Open the app while offline (should have some content fetched in another session)

Expected result:
- The data in the channel list should be displayed
- Opening a channel results in a message list filled with the messages fetched in a previous session

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/avOd4dltPp9fIDm5P3/giphy.gif)
