### PR TITLE
Avoid edge case deadlock in AuthenticationRepository

### DIFF
--- a/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
@@ -981,6 +981,18 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertEqual(result?.value, token)
     }
 
+    func test_provideToken_doesNotDeadlock() {
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            repository.provideToken(timeout: 0) { _ in
+                self.repository.tokenWaiters.forEach { _ in }
+            }
+        }
+
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            repository.tokenWaiters.forEach { _ in }
+        }
+    }
+
     // MARK: EnvironmentState
 
     func test_environmentState_nilCurrentUserId() {

--- a/Tests/StreamChatTests/Repositories/ConnectionRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/ConnectionRepository_Tests.swift
@@ -472,7 +472,9 @@ final class ConnectionRepository_Tests: XCTestCase {
 
     func test_connectionId_doesNotDeadlock() {
         DispatchQueue.concurrentPerform(iterations: 100) { _ in
-            repository.provideConnectionId(timeout: 0) { _ in }
+            repository.provideConnectionId(timeout: 0) { _ in
+                self.repository.connectionIdWaiters.forEach { _ in }
+            }
         }
 
         DispatchQueue.concurrentPerform(iterations: 100) { _ in


### PR DESCRIPTION
### 🔗 Issue Links

Closes https://github.com/GetStream/stream-chat-swift/issues/2840

### 📝 Summary

When timing out on `provideConnectionId`, a deadlock can happen because of a `sync` dispatch to the same queue where we are already performing the work. If that ends up calling a property on the class that requires a `sync` dispatch, it would deadlock.

### 🛠 Implementation

`tokenQueue` is a concurrent queue, and therefore multiple threads might be reading/writing `tokenWaiters`. This is not what we want. To fix that, we will dispatch writes using a `.barrier` flag, so that there are no race conditions there.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
