### PR TITLE
Background Mapping - Disable CoreDataLazy

### DIFF
--- a/DemoApp/DemoAppConfiguration.swift
+++ b/DemoApp/DemoAppConfiguration.swift
@@ -28,7 +28,7 @@ enum DemoAppConfiguration {
     // This function is called from `DemoAppCoordinator` before the Chat UI is created
     static func setInternalConfiguration() {
         StreamRuntimeCheck.assertionsEnabled = isStreamInternalConfiguration
-        StreamRuntimeCheck._isBackgroundMappingEnabled = false
+        StreamRuntimeCheck._isBackgroundMappingEnabled = isStreamInternalConfiguration
         AppConfig.shared.demoAppConfig.isTokenRefreshEnabled = isStreamInternalConfiguration
 
         configureAtlantisIfNeeded()

--- a/Sources/StreamChat/Config/StreamRuntimeCheck.swift
+++ b/Sources/StreamChat/Config/StreamRuntimeCheck.swift
@@ -14,4 +14,9 @@ public enum StreamRuntimeCheck {
     ///
     ///  Enables background mapping of DB models
     public static var _isBackgroundMappingEnabled = false
+
+    /// For *internal use* only
+    ///
+    ///  Established the maximum depth of relationships to fetch when performing a mapping
+    public static var _backgroundMappingRelationshipsMaxDepth = 2
 }

--- a/Sources/StreamChat/Config/StreamRuntimeCheck.swift
+++ b/Sources/StreamChat/Config/StreamRuntimeCheck.swift
@@ -18,5 +18,9 @@ public enum StreamRuntimeCheck {
     /// For *internal use* only
     ///
     ///  Established the maximum depth of relationships to fetch when performing a mapping
+    ///
+    ///  Eg.
+    ///  Relationship:    Message ---> QuotedMessage ---> Channel ---X---
+    ///  Depth:                     0                         1                           2
     public static var _backgroundMappingRelationshipsMaxDepth = 2
 }

--- a/Sources/StreamChat/Config/StreamRuntimeCheck.swift
+++ b/Sources/StreamChat/Config/StreamRuntimeCheck.swift
@@ -20,7 +20,17 @@ public enum StreamRuntimeCheck {
     ///  Established the maximum depth of relationships to fetch when performing a mapping
     ///
     ///  Eg.
-    ///  Relationship:    Message ---> QuotedMessage ---> Channel ---X---
-    ///  Depth:                     0                         1                           2
+    ///  Relationship:    Message --->  QuotedMessage --->    QuotedMessage   ---X---     NIL
+    ///  Relationship:    Channel  --->      Message         --->     QuotedMessage  ---X---     NIL
+    ///  Depth:                     0                         1                                     2                               3
     public static var _backgroundMappingRelationshipsMaxDepth = 2
+
+    /// For *internal use* only
+    ///
+    ///  Returns true if the maximum depth of relationships to fetch when performing a mapping is not yet met
+    public static func _canFetchRelationship(currentDepth: Int) -> Bool {
+        guard _isBackgroundMappingEnabled else { return true }
+
+        return currentDepth <= _backgroundMappingRelationshipsMaxDepth
+    }
 }

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -377,12 +377,26 @@ extension ChannelDTO {
 
 extension ChannelDTO {
     /// Snapshots the current state of `ChannelDTO` and returns an immutable model object from it.
-    func asModel() throws -> ChatChannel { try .create(fromDTO: self) }
+    func asModel() throws -> ChatChannel { try .create(fromDTO: self, depth: 0) }
+
+    /// Snapshots the current state of `ChannelDTO` and returns an immutable model object from it if the dependency depth
+    /// limit has not been reached
+    func relationshipAsModel(depth: Int) throws -> ChatChannel? {
+        do {
+            return try .create(fromDTO: self, depth: depth)
+        } catch {
+            if error is RecursionLimitError { return nil }
+            throw error
+        }
+    }
 }
 
 extension ChatChannel {
     /// Create a ChannelModel struct from its DTO
-    fileprivate static func create(fromDTO dto: ChannelDTO) throws -> ChatChannel {
+    fileprivate static func create(fromDTO dto: ChannelDTO, depth: Int) throws -> ChatChannel {
+        guard depth <= StreamRuntimeCheck._backgroundMappingRelationshipsMaxDepth else {
+            throw RecursionLimitError()
+        }
         guard dto.isValid, let cid = try? ChannelId(cid: dto.cid), let context = dto.managedObjectContext else {
             throw InvalidModel(dto)
         }
@@ -447,7 +461,7 @@ extension ChatChannel {
                     shouldShowShadowedMessages: dto.managedObjectContext?.shouldShowShadowedMessages ?? false,
                     context: context
                 )
-                .compactMap { try? $0.asModel() }
+                .compactMap { try? $0.relationshipAsModel(depth: depth) }
         }
 
         let fetchLatestMessageFromUser: () -> ChatMessage? = {
@@ -459,7 +473,7 @@ extension ChatChannel {
                     in: dto.cid,
                     context: context
                 )?
-                .asModel()
+                .relationshipAsModel(depth: depth)
         }
 
         let fetchWatchers: () -> [ChatUser] = {
@@ -511,9 +525,9 @@ extension ChatChannel {
             //            invitedMembers: [],
             latestMessages: { fetchMessages() },
             lastMessageFromCurrentUser: { fetchLatestMessageFromUser() },
-            pinnedMessages: { dto.pinnedMessages.compactMap { try? $0.asModel() } },
+            pinnedMessages: { dto.pinnedMessages.compactMap { try? $0.relationshipAsModel(depth: depth) } },
             muteDetails: fetchMuteDetails,
-            previewMessage: { try? dto.previewMessage?.asModel() },
+            previewMessage: { try? dto.previewMessage?.relationshipAsModel(depth: depth) },
             underlyingContext: dto.managedObjectContext
         )
     }

--- a/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/ChannelDTO.swift
@@ -383,7 +383,7 @@ extension ChannelDTO {
     /// limit has not been reached
     func relationshipAsModel(depth: Int) throws -> ChatChannel? {
         do {
-            return try .create(fromDTO: self, depth: depth)
+            return try .create(fromDTO: self, depth: depth + 1)
         } catch {
             if error is RecursionLimitError { return nil }
             throw error
@@ -394,7 +394,7 @@ extension ChannelDTO {
 extension ChatChannel {
     /// Create a ChannelModel struct from its DTO
     fileprivate static func create(fromDTO dto: ChannelDTO, depth: Int) throws -> ChatChannel {
-        guard depth <= StreamRuntimeCheck._backgroundMappingRelationshipsMaxDepth else {
+        guard StreamRuntimeCheck._canFetchRelationship(currentDepth: depth) else {
             throw RecursionLimitError()
         }
         guard dto.isValid, let cid = try? ChannelId(cid: dto.cid), let context = dto.managedObjectContext else {

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -1015,7 +1015,18 @@ extension NSManagedObjectContext: MessageDatabaseSession {
 
 extension MessageDTO {
     /// Snapshots the current state of `MessageDTO` and returns an immutable model object from it.
-    func asModel() throws -> ChatMessage { try .init(fromDTO: self) }
+    func asModel() throws -> ChatMessage { try .init(fromDTO: self, depth: 0) }
+
+    /// Snapshots the current state of `MessageDTO` and returns an immutable model object from it if the dependency depth
+    /// limit has not been reached
+    func relationshipAsModel(depth: Int) throws -> ChatMessage? {
+        do {
+            return try ChatMessage(fromDTO: self, depth: depth)
+        } catch {
+            if error is RecursionLimitError { return nil }
+            throw error
+        }
+    }
 
     /// Snapshots the current state of `MessageDTO` and returns its representation for the use in API calls.
     func asRequestBody() -> MessageRequestBody {
@@ -1057,7 +1068,10 @@ extension MessageDTO {
 }
 
 private extension ChatMessage {
-    init(fromDTO dto: MessageDTO) throws {
+    init(fromDTO dto: MessageDTO, depth: Int) throws {
+        guard depth <= StreamRuntimeCheck._backgroundMappingRelationshipsMaxDepth else {
+            throw RecursionLimitError()
+        }
         guard dto.isValid, let context = dto.managedObjectContext else {
             throw InvalidModel(dto)
         }
@@ -1164,11 +1178,11 @@ private extension ChatMessage {
             $_latestReplies = ({
                 MessageDTO
                     .loadReplies(for: dto.id, limit: 5, context: context)
-                    .compactMap { try? ChatMessage(fromDTO: $0) }
+                    .compactMap { try? ChatMessage(fromDTO: $0, depth: depth) }
             }, dto.managedObjectContext)
         }
 
-        $_quotedMessage = ({ try? dto.quotedMessage?.asModel() }, dto.managedObjectContext)
+        $_quotedMessage = ({ try? dto.quotedMessage?.relationshipAsModel(depth: depth) }, dto.managedObjectContext)
 
         let readBy = {
             Set(dto.reads.compactMap { try? $0.user.asModel() })

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -1021,7 +1021,7 @@ extension MessageDTO {
     /// limit has not been reached
     func relationshipAsModel(depth: Int) throws -> ChatMessage? {
         do {
-            return try ChatMessage(fromDTO: self, depth: depth)
+            return try ChatMessage(fromDTO: self, depth: depth + 1)
         } catch {
             if error is RecursionLimitError { return nil }
             throw error
@@ -1069,7 +1069,7 @@ extension MessageDTO {
 
 private extension ChatMessage {
     init(fromDTO dto: MessageDTO, depth: Int) throws {
-        guard depth <= StreamRuntimeCheck._backgroundMappingRelationshipsMaxDepth else {
+        guard StreamRuntimeCheck._canFetchRelationship(currentDepth: depth) else {
             throw RecursionLimitError()
         }
         guard dto.isValid, let context = dto.managedObjectContext else {

--- a/Sources/StreamChat/Database/DTOs/NSManagedObject+Validation.swift
+++ b/Sources/StreamChat/Database/DTOs/NSManagedObject+Validation.swift
@@ -30,3 +30,5 @@ struct InvalidModel: LocalizedError {
         "\(entityName ?? "Unknown") object with ID \(id) is invalid"
     }
 }
+
+struct RecursionLimitError: LocalizedError {}

--- a/Sources/StreamChat/Models/Channel.swift
+++ b/Sources/StreamChat/Models/Channel.swift
@@ -111,7 +111,7 @@ public struct ChatChannel {
     /// - Important: The `latestMessages` property is loaded and evaluated lazily to maintain high performance.
     public var latestMessages: [ChatMessage] { _latestMessages }
     // stream:annotation "Move to async"
-    @CoreDataLazy(forceLazy: true) private var _latestMessages: [ChatMessage]
+    @CoreDataLazy private var _latestMessages: [ChatMessage]
 
     /// Latest message present on the channel sent by current user even if sent on a thread.
     ///
@@ -127,7 +127,7 @@ public struct ChatChannel {
     /// - Important: The `pinnedMessages` property is loaded and evaluated lazily to maintain high performance.
     public var pinnedMessages: [ChatMessage] { _pinnedMessages }
     // stream:annotation "Move to async"
-    @CoreDataLazy(forceLazy: true) private var _pinnedMessages: [ChatMessage]
+    @CoreDataLazy private var _pinnedMessages: [ChatMessage]
 
     /// Read states of the users for this channel.
     ///
@@ -162,7 +162,7 @@ public struct ChatChannel {
     /// because the preview message is the last `non-deleted` message sent to the channel.
     public var previewMessage: ChatMessage? { _previewMessage }
     // stream:annotation "Move to async?"
-    @CoreDataLazy(forceLazy: true) private var _previewMessage: ChatMessage?
+    @CoreDataLazy private var _previewMessage: ChatMessage?
 
     // MARK: - Internal
 

--- a/Sources/StreamChat/Models/ChatMessage.swift
+++ b/Sources/StreamChat/Models/ChatMessage.swift
@@ -179,7 +179,7 @@ public struct ChatMessage {
     /// - Note: For the message authored by other channel members this field always returns `0`.
     public var readByCount: Int { _readByCount }
 
-    @CoreDataLazy(forceLazy: true) internal var _readByCount: Int
+    @CoreDataLazy internal var _readByCount: Int
 
     internal init(
         id: MessageId,

--- a/Sources/StreamChat/Models/ChatMessage.swift
+++ b/Sources/StreamChat/Models/ChatMessage.swift
@@ -59,7 +59,7 @@ public struct ChatMessage {
     /// If message is inline reply this property will contain the message quoted by this reply.
     ///
     public var quotedMessage: ChatMessage? { _quotedMessage }
-    @CoreDataLazy(forceLazy: true) internal var _quotedMessage: ChatMessage?
+    @CoreDataLazy internal var _quotedMessage: ChatMessage?
 
     /// A flag indicating whether the message was bounced due to moderation.
     public let isBounced: Bool
@@ -120,7 +120,7 @@ public struct ChatMessage {
     /// - Important: The `latestReplies` property is loaded and evaluated lazily to maintain high performance.
     public var latestReplies: [ChatMessage] { _latestReplies }
     // stream:annotation "Move to async"
-    @CoreDataLazy(forceLazy: true) internal var _latestReplies: [ChatMessage]
+    @CoreDataLazy internal var _latestReplies: [ChatMessage]
 
     /// A possible additional local state of the message. Applies only for the messages of the current user.
     ///
@@ -171,7 +171,7 @@ public struct ChatMessage {
     /// it's recommended to use `readByCount` instead of `readBy.count` for better performance.
     public var readBy: Set<ChatUser> { _readBy }
 
-    @CoreDataLazy(forceLazy: true) internal var _readBy: Set<ChatUser>
+    @CoreDataLazy internal var _readBy: Set<ChatUser>
 
     /// For the message authored by the current user this field contains number of channel members
     /// who has read this message (excluding the current user).

--- a/Sources/StreamChat/Utils/CoreDataLazy.swift
+++ b/Sources/StreamChat/Utils/CoreDataLazy.swift
@@ -22,12 +22,6 @@ class CoreDataLazy<T> {
     /// This is used to detect when there are lingering models in the memory, which will cause a crash when tried to materialize.
     var persistentStoreIdentifier: String?
 
-    let forceLazy: Bool
-
-    init(forceLazy: Bool = false) {
-        self.forceLazy = forceLazy
-    }
-
     var wrappedValue: T {
         var returnValue: T!
 
@@ -77,7 +71,7 @@ class CoreDataLazy<T> {
             computeValue = newValue.0
             context = newValue.1
             persistentStoreIdentifier = context?.persistentStoreCoordinator?.persistentStores.first?.identifier
-            if StreamRuntimeCheck._isBackgroundMappingEnabled && !forceLazy {
+            if StreamRuntimeCheck._isBackgroundMappingEnabled {
                 _cached = computeValue()
             } else {
                 _cached = nil

--- a/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/ChannelDTO_Tests.swift
@@ -1479,6 +1479,69 @@ final class ChannelDTO_Tests: XCTestCase {
             Set([message1.id, deletedMessageFromCurrentUser.id, shadowedMessageFromAnotherUser.id])
         )
     }
+
+    // MARK: Max depth
+
+    func test_asModel_onlyFetchesUntilCertainRelationship() throws {
+        let originalIsBackgroundMappingEnabled = StreamRuntimeCheck._isBackgroundMappingEnabled
+        try test_asModel_onlyFetchesUntilCertainRelationship(isBackgroundMappingEnabled: false)
+        try test_asModel_onlyFetchesUntilCertainRelationship(isBackgroundMappingEnabled: true)
+        StreamRuntimeCheck._isBackgroundMappingEnabled = originalIsBackgroundMappingEnabled
+    }
+
+    private func test_asModel_onlyFetchesUntilCertainRelationship(isBackgroundMappingEnabled: Bool) throws {
+        StreamRuntimeCheck._isBackgroundMappingEnabled = isBackgroundMappingEnabled
+        let cid = ChannelId.unique
+
+        // GIVEN
+        let quoted3MessagePayload: MessagePayload = .dummy(
+            messageId: .unique,
+            cid: cid
+        )
+
+        let quoted2MessagePayload: MessagePayload = .dummy(
+            messageId: .unique,
+            quotedMessageId: quoted3MessagePayload.id,
+            quotedMessage: quoted3MessagePayload,
+            cid: cid
+        )
+
+        let message1Payload: MessagePayload = .dummy(
+            messageId: .unique,
+            quotedMessageId: quoted2MessagePayload.id,
+            quotedMessage: quoted2MessagePayload,
+            cid: cid
+        )
+
+        let channelPayload: ChannelPayload = .dummy(
+            channel: .dummy(cid: cid),
+            messages: [
+                message1Payload
+            ]
+        )
+        let userId = UserId.unique
+
+        try database.writeSynchronously { session in
+            try session.saveCurrentUser(payload: .dummy(userId: userId, role: .user))
+            try session.saveChannel(payload: channelPayload)
+        }
+
+        // WHEN
+        let channel = try XCTUnwrap(database.viewContext.channel(cid: cid)?.asModel())
+
+        // THEN
+        let message1 = try XCTUnwrap(channel.latestMessages.first { $0.id == message1Payload.id })
+        let quoted2Message = try XCTUnwrap(message1.quotedMessage)
+        XCTAssertEqual(quoted2Message.id, quoted2MessagePayload.id)
+
+        let quoted3Message = quoted2Message.quotedMessage
+        if isBackgroundMappingEnabled {
+            // 3rd level of depth is not mapped
+            XCTAssertNil(quoted3Message)
+        } else {
+            XCTAssertEqual(quoted3Message?.id, quoted3MessagePayload.id)
+        }
+    }
 }
 
 private extension ChannelDTO_Tests {

--- a/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
+++ b/Tests/StreamChatTests/Database/DTOs/MessageDTO_Tests.swift
@@ -3380,6 +3380,75 @@ final class MessageDTO_Tests: XCTestCase {
         XCTAssertNotNil(messageModel.cid)
     }
 
+    // MARK: Max depth
+
+    func test_asModel_onlyFetchesUntilCertainRelationship() throws {
+        let originalIsBackgroundMappingEnabled = StreamRuntimeCheck._isBackgroundMappingEnabled
+        try test_asModel_onlyFetchesUntilCertainRelationship(isBackgroundMappingEnabled: false)
+        try test_asModel_onlyFetchesUntilCertainRelationship(isBackgroundMappingEnabled: true)
+        StreamRuntimeCheck._isBackgroundMappingEnabled = originalIsBackgroundMappingEnabled
+    }
+
+    private func test_asModel_onlyFetchesUntilCertainRelationship(isBackgroundMappingEnabled: Bool) throws {
+        StreamRuntimeCheck._isBackgroundMappingEnabled = isBackgroundMappingEnabled
+        let cid = ChannelId.unique
+
+        // GIVEN
+        let quoted3MessagePayload: MessagePayload = .dummy(messageId: .unique, cid: cid)
+        let quoted2MessagePayload: MessagePayload = .dummy(
+            messageId: .unique,
+            quotedMessageId: quoted3MessagePayload.id,
+            quotedMessage: quoted3MessagePayload,
+            cid: cid
+        )
+
+        let quoted1MessagePayload: MessagePayload = .dummy(
+            messageId: .unique,
+            quotedMessageId: quoted2MessagePayload.id,
+            quotedMessage: quoted2MessagePayload,
+            cid: cid
+        )
+
+        let messagePayload: MessagePayload = .dummy(
+            messageId: .unique,
+            quotedMessageId: quoted1MessagePayload.id,
+            quotedMessage: quoted1MessagePayload,
+            cid: cid
+        )
+
+        let channelPayload: ChannelPayload = .dummy(
+            channel: .dummy(cid: cid),
+            messages: [
+                messagePayload
+            ]
+        )
+        let userId = UserId.unique
+
+        try database.writeSynchronously { session in
+            try session.saveCurrentUser(payload: .dummy(userId: userId, role: .user))
+            try session.saveChannel(payload: channelPayload)
+        }
+
+        // WHEN
+        let message = try XCTUnwrap(
+            database.viewContext.message(id: messagePayload.id)?.asModel()
+        )
+
+        // THEN
+        let quoted1Message = try XCTUnwrap(message.quotedMessage)
+        XCTAssertEqual(quoted1Message.id, quoted1MessagePayload.id)
+        let quoted2Message = try XCTUnwrap(quoted1Message.quotedMessage)
+        XCTAssertEqual(quoted2Message.id, quoted2MessagePayload.id)
+
+        let quoted3Message = quoted2Message.quotedMessage
+        if isBackgroundMappingEnabled {
+            // 3rd level of depth is not mapped
+            XCTAssertNil(quoted3Message)
+        } else {
+            XCTAssertEqual(quoted3Message?.id, quoted3MessagePayload.id)
+        }
+    }
+
     // MARK: - Helpers:
 
     private func createMessage(with message: MessagePayload) throws -> MessageDTO {


### PR DESCRIPTION
### 🔗 Issue Links

https://github.com/GetStream/ios-issues-tracking/issues/2

### 🎯 Goal

Allow fetching the needed relationships of models when mapping from DTO to Model without the performance degradation CoreDataLazy adds

### 📝 Summary

When mapping the objects without `CoreDataLazy`, there was an infinite loop of fetches dues to circular relationships. This forced us to keep the laziness of `CoreDataLazy` for some mappings even when background mapping was enabled. Moreover, it was adding performance degradation due to its locking mechanisms.

### 🛠 Implementation

- The logic around `CoreDataLazy` has been disabled for Background Mapping:
   - Lazyness
   - Locks
- Remove loops when fetching relationships
   - When mapping relationships, a `depth` parameter is passed in order to stop fetching when a threshold is reached.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/QTrfggoDA5zcWJc2C0/giphy-downsized-large.gif)
