### PR TITLE
Reuse logic to get message text content

### DIFF
--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -124,6 +124,9 @@ open class ChatChannelListItemView: _View, ThemeProvider, SwiftUIRepresentable {
         .withoutAutoresizingMaskConstraints
         .withAccessibilityIdentifier(identifier: "unreadCountView")
 
+    /// The component responsible for getting the text content of a message.
+    let messageTextRenderer = ChatMessageTextRenderer()
+
     /// Text of `titleLabel` which contains the channel name.
     open var titleText: String? {
         if let searchedMessage = content?.searchedMessage {
@@ -160,12 +163,7 @@ open class ChatChannelListItemView: _View, ThemeProvider, SwiftUIRepresentable {
                 return previewMessage.text
             }
 
-            var text = previewMessage.textContent ?? previewMessage.text
-
-            if let currentUserLang = content.channel.membership?.language,
-               let translatedText = previewMessage.translatedText(for: currentUserLang) {
-                text = translatedText
-            }
+            var text = messageTextRenderer.text(for: previewMessage, channel: content.channel)
 
             if let attachmentPreviewText = attachmentPreviewText(
                 for: previewMessage,

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageLayoutOptionsResolver.swift
@@ -77,7 +77,7 @@ open class ChatMessageLayoutOptionsResolver {
         if showOnlyVisibleToYouIndicator(for: message) {
             options.insert(.onlyVisibleToYouIndicator)
         }
-        if message.textContent?.isEmpty == false {
+        if !message.text.isEmpty && message.type != .ephemeral {
             options.insert(.text)
         }
         if isLastInSequence && !message.isSentByCurrentUser {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageTextRenderer.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageTextRenderer.swift
@@ -1,0 +1,26 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamChat
+
+/// The component responsible for getting the text content of a message text.
+struct ChatMessageTextRenderer {
+    func text(for message: ChatMessage, channel: ChatChannel) -> String {
+        if message.type == .ephemeral {
+            return message.text
+        }
+
+        if message.isDeleted {
+            return L10n.Message.deletedMessagePlaceholder
+        }
+
+        if let currentUserLang = channel.membership?.language,
+           let translatedText = message.translatedText(for: currentUserLang) {
+            return translatedText
+        }
+
+        return message.text
+    }
+}

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
@@ -36,6 +36,9 @@ open class ChatMessageActionsVC: _ViewController, ThemeProvider {
         messageController.message
     }
 
+    /// The component responsible for getting the text content of a message.
+    let messageTextRenderer = ChatMessageTextRenderer()
+
     /// The `AlertsRouter` instance responsible for presenting alerts.
     open lazy var alertsRouter = components
         .alertsRouter
@@ -283,16 +286,13 @@ open class ChatMessageActionsVC: _ViewController, ThemeProvider {
         CopyActionItem(
             action: { [weak self] _ in
                 guard let self = self else { return }
-
-                let text: String?
-                if let currentUserLang = self.channel?.membership?.language,
-                   let translatedText = self.message?.translatedText(for: currentUserLang) {
-                    text = translatedText
-                } else {
-                    text = self.message?.text
+                guard let message = self.message, let channel = self.channel else {
+                    return
                 }
 
+                let text = messageTextRenderer.text(for: message, channel: channel)
                 UIPasteboard.general.string = text
+
                 self.delegate?.chatMessageActionsVCDidFinish(self)
             },
             appearance: appearance

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
@@ -290,7 +290,7 @@ open class ChatMessageActionsVC: _ViewController, ThemeProvider {
                     return
                 }
 
-                let text = messageTextRenderer.text(for: message, channel: channel)
+                let text = self.messageTextRenderer.text(for: message, channel: channel)
                 UIPasteboard.general.string = text
 
                 self.delegate?.chatMessageActionsVCDidFinish(self)

--- a/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
@@ -38,7 +38,7 @@ public extension ChatMessage {
         parentMessageId != nil
     }
 
-    /// The text which should be shown in a text view inside the message bubble.
+    @available(*, deprecated, message: "this has now been replaced by ChatMessageTextRenderer()")
     var textContent: String? {
         guard type != .ephemeral else {
             return nil
@@ -69,8 +69,8 @@ public extension ChatMessage {
     ///
     /// Note that for messages sent with attachments, large emojis aren's rendered
     var shouldRenderAsJumbomoji: Bool {
-        guard attachmentCounts.isEmpty, let textContent = textContent, !textContent.isEmpty else { return false }
-        return textContent.count <= 3 && textContent.containsOnlyEmoji
+        guard attachmentCounts.isEmpty, !text.isEmpty else { return false }
+        return text.count <= 3 && text.containsOnlyEmoji
     }
 
     /// When a message that has been synced gets edited but is bounced by the moderation API it will return true to this state.

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1166,6 +1166,8 @@
 		AD1D7A8526A2131D00494CA5 /* ChatChannelVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1D7A8326A212D000494CA5 /* ChatChannelVC.swift */; };
 		AD25070D272C0C8D00BC14C4 /* ChatMessageReactionAuthorsVC_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD25070B272C0C8800BC14C4 /* ChatMessageReactionAuthorsVC_Tests.swift */; };
 		AD2525212ACB3C0800F1433C /* ChatClientFactory_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD2525202ACB3C0800F1433C /* ChatClientFactory_Tests.swift */; };
+		AD2891AF2AE991D2004CC3E0 /* ChatMessageTextRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD2891AE2AE991D2004CC3E0 /* ChatMessageTextRenderer.swift */; };
+		AD2891B02AE991D2004CC3E0 /* ChatMessageTextRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD2891AE2AE991D2004CC3E0 /* ChatMessageTextRenderer.swift */; };
 		AD29395D2A2E36FE00533CA7 /* SwipeToReplyGestureHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD29395C2A2E36FE00533CA7 /* SwipeToReplyGestureHandler.swift */; };
 		AD29395E2A2E36FE00533CA7 /* SwipeToReplyGestureHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD29395C2A2E36FE00533CA7 /* SwipeToReplyGestureHandler.swift */; };
 		AD2C94DC29CB8CC40096DCA1 /* PartiallyFailingChannelListPayload.json in Sources */ = {isa = PBXBuildFile; fileRef = AD2C94DB29CB8CC40096DCA1 /* PartiallyFailingChannelListPayload.json */; };
@@ -3644,6 +3646,7 @@
 		AD1D7A8326A212D000494CA5 /* ChatChannelVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatChannelVC.swift; sourceTree = "<group>"; };
 		AD25070B272C0C8800BC14C4 /* ChatMessageReactionAuthorsVC_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageReactionAuthorsVC_Tests.swift; sourceTree = "<group>"; };
 		AD2525202ACB3C0800F1433C /* ChatClientFactory_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatClientFactory_Tests.swift; sourceTree = "<group>"; };
+		AD2891AE2AE991D2004CC3E0 /* ChatMessageTextRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageTextRenderer.swift; sourceTree = "<group>"; };
 		AD29395C2A2E36FE00533CA7 /* SwipeToReplyGestureHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeToReplyGestureHandler.swift; sourceTree = "<group>"; };
 		AD2C94DB29CB8CC40096DCA1 /* PartiallyFailingChannelListPayload.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PartiallyFailingChannelListPayload.json; sourceTree = "<group>"; };
 		AD2C94DE29CB93C40096DCA1 /* FailingChannelListPayload.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FailingChannelListPayload.json; sourceTree = "<group>"; };
@@ -8355,6 +8358,7 @@
 				A39A8AE6263825F4003453D9 /* ChatMessageLayoutOptionsResolver.swift */,
 				8830518D263038190069D731 /* ChatReactionsBubbleView.swift */,
 				883051C72630579D0069D731 /* ChatThreadArrowView.swift */,
+				AD2891AE2AE991D2004CC3E0 /* ChatMessageTextRenderer.swift */,
 			);
 			path = ChatMessage;
 			sourceTree = "<group>";
@@ -9675,6 +9679,7 @@
 				40FA4DD72A12A0C300DA21D2 /* RecordingIndicatorView.swift in Sources */,
 				C1FC2F6727416E150062530F /* ResumableData.swift in Sources */,
 				BD4016362638411D00F09774 /* Deprecations.swift in Sources */,
+				AD2891AF2AE991D2004CC3E0 /* ChatMessageTextRenderer.swift in Sources */,
 				7844B14E25EF9F5700B87E89 /* ChatChannelAvatarView+SwiftUI.swift in Sources */,
 				ADA5A0F8276790C100E1C465 /* ChatMessageListDateSeparatorView.swift in Sources */,
 				BDC80CB5265CF4B800F62CE2 /* ImageCDN.swift in Sources */,
@@ -11571,6 +11576,7 @@
 				C121EC2F2746A1ED00023E4C /* Deprecated.swift in Sources */,
 				C121EC302746A1ED00023E4C /* Combine.swift in Sources */,
 				C121EC312746A1ED00023E4C /* Operation.swift in Sources */,
+				AD2891B02AE991D2004CC3E0 /* ChatMessageTextRenderer.swift in Sources */,
 				C121EC322746A1ED00023E4C /* ImageRequestKeys.swift in Sources */,
 				C121EC332746A1ED00023E4C /* LinkedList.swift in Sources */,
 				ADCB577E28A42D7700B81AE8 /* UIKitExtension.swift in Sources */,

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessage/ChatMessageContentView_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessage/ChatMessageContentView_Tests.swift
@@ -541,7 +541,6 @@ final class ChatMessageContentView_Tests: XCTestCase {
             message: message,
             channel: .mock(cid: .unique, membership: .mock(id: .unique, language: .portuguese))
         )
-        view.layoutOptions?.insert(.translation)
 
         AssertSnapshot(view, variants: [.defaultLight])
     }
@@ -945,7 +944,7 @@ extension ChatMessage {
         if isLastInGroup, isSentByCurrentUser, type == .deleted || type == .ephemeral {
             options.insert(.onlyVisibleToYouIndicator)
         }
-        if textContent?.isEmpty == false {
+        if text.isEmpty == false {
             options.insert(.text)
         }
 


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Reuse the logic to get the message content of a message. 

### 📝 Summary
Right now, this logic is spread across multiple places in the UI SDK. We should aim to make this logic reusable so that it is easier to maintain. For example, when implementing auto translations, it was pretty difficult to track where we should update this logic. 

### 🛠 Implementation
The proposed solution is to extract this logic to a component like `ChatMessageTextRenderer` or `ChatMessageTextPresenter`, which will basically reuse the UI logic of rendering the message text content. Since we don't have presenters or view models, this is a simple solution that could help us for now.

This component replaces the `message.textContent` that had a similar goal, but it lacked information in order to handle all scenarios.

For now, we could make this component internal, and then if we see customers finding it useful to expose it, we can expose it and make it customizable.

### 🎨 Showcase
N/A

### 🧪 Manual Testing Notes
N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)