### PR TITLE
Allow easier customisation of the `ChatChannelListItemView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### ⚠️ Important
+## StreamChatUI
+### ✅ Added
+- Allow easier customisation of the `ChatChannelListItemView` [#2855](https://github.com/GetStream/stream-chat-swift/pull/2855)
 
-- From now on, our XCFrameworks are built with Swift 5.7. In order to use them you need Xcode 14 or above.
+## ⚠️ Important
+- From now on, our XCFrameworks will be built with Swift 5.7. In order to use them, you need Xcode 14 or above.
 
 # [4.40.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.40.0)
 _October 25, 2023_

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListItemView.swift
@@ -127,17 +127,11 @@ open class ChatChannelListItemView: _View, ThemeProvider, SwiftUIRepresentable {
     /// Text of `titleLabel` which contains the channel name.
     open var titleText: String? {
         if let searchedMessage = content?.searchedMessage {
-            var title = "\(searchedMessage.author.name ?? searchedMessage.author.id)"
-            if let channelName = content?.channel.name, !channelName.isEmpty {
-                title += L10n.Channel.Item.Search.in(channelName)
-            }
-            return title
+            return channelTitleTextForSearchedMessage(searchedMessage)
         }
 
         if let channel = content?.channel {
-            return appearance.formatters
-                .channelName
-                .format(channel: channel, forCurrentUserId: channel.membership?.id)
+            return channelTitleText(for: channel)
         }
 
         return nil
@@ -355,6 +349,24 @@ open class ChatChannelListItemView: _View, ThemeProvider, SwiftUIRepresentable {
                 at: status == .pending || status == .failed ? 0 : 1
             )
         }
+    }
+
+    // MARK: - Channel title rendering
+
+    /// The channel title text in case the channel is part of a search result.
+    open func channelTitleTextForSearchedMessage(_ message: ChatMessage) -> String {
+        var title = "\(message.author.name ?? message.author.id)"
+        if let channelName = content?.channel.name, !channelName.isEmpty {
+            title += L10n.Channel.Item.Search.in(channelName)
+        }
+        return title
+    }
+
+    /// The default channel title text.
+    open func channelTitleText(for channel: ChatChannel) -> String? {
+        appearance.formatters
+            .channelName
+            .format(channel: channel, forCurrentUserId: channel.membership?.id)
     }
 
     // MARK: - Preview message text rendering


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/610

### 🎯 Goal
Some customers complained that it was difficult to override the `subtitleText: String` in the `ChatChannelListItemView`. There is quite a lot of logical branching inside this property which made it difficult to override the rendering of the subtitle without duplicating logic on the App side.

### 📝 Summary
The following functions were added to make it easier to customize the channel item view without duplicating logic:
- Added `open func channelTitleTextForSearchedMessage()`
- Added `open func channelTitleText()`
- Added `open func previewMessageTextForEmptyMessage()`
- Added `open func previewMessageForAudioRecordingMessage()`
- Added `open func previewMessageTextForSystemMessage()`
- Added `open func previewMessageTextForSearchedMessage()`
- Added `open func previewMessageTextForCurrentUser()`
- Added `open func previewMessageTextFor1on1Channel()`
- Added `open func previewMessageTextFromAnotherUser()`
- Added `open func attachmentPreviewText()`
- Added `open func translatedPreviewText()`
- Added `open var typingUserString: String?`

### 🎨 Showcase
N/A

### 🧪 Manual Testing Notes
N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)