### PR TITLE
Add "Cool Channels" to test extra data queries in the Demo App

### DIFF
--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -291,6 +291,20 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
                     }
                 }
             }),
+            .init(title: "Cool channel", isEnabled: canMuteChannel, handler: { [unowned self] _ in
+                channelController.partialChannelUpdate(extraData: ["is_cool": true]) { error in
+                    if let error = error {
+                        self.rootViewController.presentAlert(title: "Couldn't make a channel \(cid) cool", message: "\(error)")
+                    }
+                }
+            }),
+            .init(title: "Uncool channel", isEnabled: canMuteChannel, handler: { [unowned self] _ in
+                channelController.partialChannelUpdate(extraData: ["is_cool": false]) { error in
+                    if let error = error {
+                        self.rootViewController.presentAlert(title: "Couldn't make a channel \(cid) uncool", message: "\(error)")
+                    }
+                }
+            }),
             .init(title: "Unmute channel", isEnabled: canMuteChannel, handler: { [unowned self] _ in
                 channelController.unmuteChannel { error in
                     if let error = error {

--- a/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
@@ -46,6 +46,11 @@ final class DemoChatChannelListVC: ChatChannelListVC, EventsControllerDelegate {
         .equal(.muted, to: true)
     ]))
 
+    lazy var coolChannelsQuery: ChannelListQuery = .init(filter: .and([
+        .containMembers(userIds: [currentUserId]),
+        .equal("is_cool", to: true)
+    ]))
+
     var demoRouter: DemoChatChannelListRouter? {
         router as? DemoChatChannelListRouter
     }
@@ -96,6 +101,15 @@ final class DemoChatChannelListVC: ChatChannelListVC, EventsControllerDelegate {
             }
         )
 
+        let coolChannelsAction = UIAlertAction(
+            title: "Cool Channels",
+            style: .default,
+            handler: { [weak self] _ in
+                self?.title = "Cool Channels"
+                self?.setCoolChannelsQuery()
+            }
+        )
+
         let mutedChannelsAction = UIAlertAction(
             title: "Muted Channels",
             style: .default,
@@ -107,7 +121,7 @@ final class DemoChatChannelListVC: ChatChannelListVC, EventsControllerDelegate {
 
         presentAlert(
             title: "Filter Channels",
-            actions: [defaultChannelsAction, hiddenChannelsAction, mutedChannelsAction],
+            actions: [defaultChannelsAction, hiddenChannelsAction, mutedChannelsAction, coolChannelsAction],
             preferredStyle: .actionSheet,
             sourceView: filterChannelsButton
         )
@@ -119,6 +133,16 @@ final class DemoChatChannelListVC: ChatChannelListVC, EventsControllerDelegate {
 
     func setMutedChannelsQuery() {
         replaceQuery(mutedChannelsQuery)
+    }
+
+    func setCoolChannelsQuery() {
+        let controller = self.controller.client.channelListController(
+            query: coolChannelsQuery,
+            filter: { channel in
+                channel.extraData["is_cool"]?.boolValue ?? false
+            }
+        )
+        replaceChannelListController(controller)
     }
 
     func setInitialChannelsQuery() {


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Add a "Cool Channels" query in the Demo App to test extra data queries that involve a filter block.

### 🎨 Showcase
TODO

### 🧪 Manual Testing Notes
1. Open the Channel List
2. Swipe a channel
3. Tap on "Cool channel"
4. Tap on the right top corner filter button
5. Tap on "Cool Channels"
6. The channel should be there
7. Swipe the channel
8. "Uncool the channel"
9. It should be removed from the list

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)