### PR TITLE
Fix empty channel list when querying both hidden or shown channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix not being able to delete local-only messages [#2846](https://github.com/GetStream/stream-chat-swift/pull/2846)
 - Fix bounced message displayed as a system message instead of an error [#2846](https://github.com/GetStream/stream-chat-swift/pull/2846)
 - Fix not showing bounced actions when long pressing bounced message [#2846](https://github.com/GetStream/stream-chat-swift/pull/2846)
+- Fix empty channel list when querying both hidden or shown channels [#2865](https://github.com/GetStream/stream-chat-swift/pull/2865)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -1360,6 +1360,73 @@ final class ChannelListController_Tests: XCTestCase {
         )
     }
 
+    func test_filterPredicate_whenHiddenTrueOrFalse_containsExpectedItems() throws {
+        let cid1 = ChannelId(type: .messaging, id: "1")
+        let cid2 = ChannelId(type: .messaging, id: "2")
+        let cid3 = ChannelId(type: .messaging, id: "3")
+
+        try assertFilterPredicate(
+            .or([
+                .equal(.hidden, to: true),
+                .equal(.hidden, to: false)
+            ]),
+            channelsInDB: [
+                .dummy(channel: .dummy(cid: cid1, name: "streamOriginal", isHidden: true)),
+                .dummy(channel: .dummy(cid: cid2, name: "teamDream", isHidden: true)),
+                .dummy(channel: .dummy(cid: cid3, name: "team", isHidden: false))
+            ],
+            expectedResult: [cid1, cid2, cid3]
+        )
+    }
+
+    func test_filterPredicate_whenHiddenTrue_containsExpectedItems() throws {
+        let cid1 = ChannelId(type: .messaging, id: "1")
+        let cid2 = ChannelId(type: .messaging, id: "2")
+        let cid3 = ChannelId(type: .messaging, id: "3")
+
+        try assertFilterPredicate(
+            .equal(.hidden, to: true),
+            channelsInDB: [
+                .dummy(channel: .dummy(cid: cid1, name: "streamOriginal", isHidden: true)),
+                .dummy(channel: .dummy(cid: cid2, name: "teamDream", isHidden: true)),
+                .dummy(channel: .dummy(cid: cid3, name: "team", isHidden: false))
+            ],
+            expectedResult: [cid1, cid2]
+        )
+    }
+
+    func test_filterPredicate_whenHiddenFalse_containsExpectedItems() throws {
+        let cid1 = ChannelId(type: .messaging, id: "1")
+        let cid2 = ChannelId(type: .messaging, id: "2")
+        let cid3 = ChannelId(type: .messaging, id: "3")
+
+        try assertFilterPredicate(
+            .equal(.hidden, to: false),
+            channelsInDB: [
+                .dummy(channel: .dummy(cid: cid1, name: "streamOriginal", isHidden: true)),
+                .dummy(channel: .dummy(cid: cid2, name: "teamDream", isHidden: true)),
+                .dummy(channel: .dummy(cid: cid3, name: "team", isHidden: false))
+            ],
+            expectedResult: [cid3]
+        )
+    }
+
+    func test_filterPredicate_whenHiddenNotSpecified_containsExpectedItems() throws {
+        let cid1 = ChannelId(type: .messaging, id: "1")
+        let cid2 = ChannelId(type: .messaging, id: "2")
+        let cid3 = ChannelId(type: .messaging, id: "3")
+
+        try assertFilterPredicate(
+            .noTeam,
+            channelsInDB: [
+                .dummy(channel: .dummy(cid: cid1, name: "streamOriginal", isHidden: true)),
+                .dummy(channel: .dummy(cid: cid2, name: "teamDream", isHidden: true)),
+                .dummy(channel: .dummy(cid: cid3, name: "team", isHidden: false))
+            ],
+            expectedResult: [cid3]
+        )
+    }
+
     func test_filterPredicate_nor_containsExpectedItems() throws {
         let memberId1 = UserId.unique
         let memberId2 = UserId.unique


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/619

### 🎯 Goal
Fix empty channel list when querying channels like so:
```swift
.or([
   .equal(.hidden, to: true),
   .equal(.hidden, to: false)
])
```

### 🛠 Implementation
We were always adding a hidden filter by default. This filter assumed that the customer could only provide 1 filter for hidden, but that is actually not true. So this default hidden filter was overriding the logic provided by the customer. Now, we only add the hidden filter if the customer does not provide their own hidden filter.

### 🎨 Showcase
N/A

### 🧪 Manual Testing Notes
N/A. 

Integration tests were added to prove it works.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)