### PR TITLE
Fix composer not intractable after enabling send-message capability

### DIFF
--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -574,11 +574,11 @@ open class ComposerVC: _ViewController,
 
         if !isSendMessageEnabled {
             composerView.inputMessageView.textView.placeholderLabel.text = L10n.Composer.Placeholder.messageDisabled
-            composerView.inputMessageView.isUserInteractionEnabled = false
             composerView.recordButton.isHidden = true
             composerView.attachmentButton.isHidden = true
             composerView.commandsButton.isHidden = true
         }
+        composerView.inputMessageView.isUserInteractionEnabled = isSendMessageEnabled
 
         dismissSuggestions()
     }

--- a/Tests/StreamChatUITests/SnapshotTests/Composer/ComposerVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/Composer/ComposerVC_Tests.swift
@@ -413,6 +413,31 @@ final class ComposerVC_Tests: XCTestCase {
         XCTAssertEqual(composerVC.isSendMessageEnabled, true)
     }
 
+    func test_updateContent_whenSendMessageEnabledAfterBeingDisabled_thenComposerViewIsInteractable() {
+        let mock = ChatChannelController_Mock.mock()
+        composerVC.components.isVoiceRecordingEnabled = true
+
+        // When disabled
+        mock.channel_mock = .mock(cid: .unique, ownCapabilities: [.uploadFile])
+        composerVC.channelController = mock
+        composerVC.updateContent()
+        XCTAssertEqual(composerVC.isSendMessageEnabled, false)
+        XCTAssertEqual(composerVC.composerView.inputMessageView.isUserInteractionEnabled, false)
+        XCTAssertEqual(composerVC.composerView.recordButton.isHidden, true)
+        XCTAssertEqual(composerVC.composerView.attachmentButton.isHidden, true)
+        XCTAssertEqual(composerVC.composerView.commandsButton.isHidden, true)
+
+        // After enabling it
+        mock.channel_mock = .mock(cid: .unique, ownCapabilities: [.uploadFile, .sendMessage])
+        composerVC.channelController = mock
+        composerVC.updateContent()
+        XCTAssertEqual(composerVC.isSendMessageEnabled, true)
+        XCTAssertEqual(composerVC.composerView.inputMessageView.isUserInteractionEnabled, true)
+        XCTAssertEqual(composerVC.composerView.recordButton.isHidden, false)
+        XCTAssertEqual(composerVC.composerView.attachmentButton.isHidden, false)
+        XCTAssertEqual(composerVC.composerView.commandsButton.isHidden, false)
+    }
+
     func test_quotedTranslatedMessage() {
         composerVC.appearance = Appearance.default
         composerVC.content = .initial()


### PR DESCRIPTION
### 🔗 Issue Links

_Provide all Jira tickets and/or Github issues related to this PR, if applicable._

### 🎯 Goal

Fix composer not intractable after enabling send-message capability.

### 📝 Summary
After the composer was disabled by `send-message` capability being disabled, when it was re-enabled, we forgot to reset the `isUserInteractionEnabled` value of `inputMessageView`. Although, all the other values are set before the `if !isSendMessageEnabled`, this one was not, so it didn't change after being enabled. 

### 🧪 Manual Testing Notes
Integration tests were added to prove it works.

### ☑️ Contributor Checklist
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)