### PR TITLE
Fixed pasting images from browser when isPastingImagesEnabled is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix not able to mark channel read after clearing history [#2867](https://github.com/GetStream/stream-chat-swift/pull/2867)
 - Fix pasting images from browser when isPastingImagesEnabled is false [#2874](https://github.com/GetStream/stream-chat-swift/pull/2874)
+- Fix not being able to paste images when multiple attachments are present [#2874](https://github.com/GetStream/stream-chat-swift/pull/2874)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fix not able to mark channel read after clearing history [#2867](https://github.com/GetStream/stream-chat-swift/pull/2867)
+- Fix pasting images from browser when isPastingImagesEnabled is false [#2874](https://github.com/GetStream/stream-chat-swift/pull/2874)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
+++ b/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
@@ -171,7 +171,7 @@ open class InputTextView: UITextView, AppearanceProvider {
     }
 
     override open func paste(_ sender: Any?) {
-        if let pasteboardImage = UIPasteboard.general.image {
+        if isPastingImagesEnabled, let pasteboardImage = UIPasteboard.general.image {
             clipboardAttachmentDelegate?.inputTextView(self, didPasteImage: pasteboardImage)
         } else {
             super.paste(sender)

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -567,11 +567,6 @@ open class ComposerVC: _ViewController,
             return
         }
 
-        // If we have files in attachments, do not allow images to be pasted in the text view.
-        // This is due to the limitation of UI(files and images cannot be shown together)
-        let filesExistInAttachments = content.attachments.contains(where: { $0.type == .file })
-        composerView.inputMessageView.textView.isPastingImagesEnabled = !filesExistInAttachments
-
         if !isSendMessageEnabled {
             composerView.inputMessageView.textView.placeholderLabel.text = L10n.Composer.Placeholder.messageDisabled
             composerView.recordButton.isHidden = true


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/597.

### 🎯 Goal

This is fixing the issue where you can fix pasting images from the browser, when isPastingImagesEnabled is false.

### 📝 Summary

- Added a check when we perform the paste action
- Bonus: fixed changing this value to prevent files and images being in the composer at the same time (leftover)

### 🧪 Manual Testing Notes

- Disable isPastingImagesEnabled
- Go to the browser and copy an image
- Paste it in the composer - the link as a text should be pasted, instead of an image.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![ALT_TEXT](https://media.giphy.com/media/kjpKQ8wXVVocN5IIyK/giphy.gif)