### PR TITLE
Fix quoted chat empty attachments handling and localization

### DIFF
--- a/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.swift
+++ b/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.swift
@@ -53,12 +53,7 @@ open class QuotedChatMessageView: _View, ThemeProvider, SwiftUIRepresentable {
     /// A Boolean value that checks if all attachments are empty.
     open var isAttachmentsEmpty: Bool {
         guard let content = self.content else { return true }
-        return content.message.fileAttachments.isEmpty
-            && content.message.imageAttachments.isEmpty
-            && content.message.linkAttachments.isEmpty
-            && content.message.giphyAttachments.isEmpty
-            && content.message.videoAttachments.isEmpty
-            && content.message.voiceRecordingAttachments.isEmpty
+        return content.message.allAttachments.isEmpty
     }
 
     /// The container view that holds the `authorAvatarView` and the `contentContainerView`.
@@ -244,7 +239,7 @@ open class QuotedChatMessageView: _View, ThemeProvider, SwiftUIRepresentable {
             attachmentPreviewView.contentMode = .scaleAspectFill
             setAttachmentPreviewImage(url: imagePayload.imageURL)
             if textView.text.isEmpty {
-                textView.text = "Photo"
+                textView.text = L10n.Composer.QuotedMessage.photo
             }
         } else if let linkPayload = message.linkAttachments.first?.payload {
             attachmentPreviewView.contentMode = .scaleAspectFill
@@ -254,7 +249,7 @@ open class QuotedChatMessageView: _View, ThemeProvider, SwiftUIRepresentable {
             attachmentPreviewView.contentMode = .scaleAspectFill
             setAttachmentPreviewImage(url: giphyPayload.previewURL)
             if textView.text.isEmpty {
-                textView.text = "Giphy"
+                textView.text = L10n.Composer.QuotedMessage.giphy
             }
         } else if let videoPayload = message.videoAttachments.first?.payload {
             attachmentPreviewView.contentMode = .scaleAspectFill

--- a/Sources/StreamChatUI/Generated/L10n.swift
+++ b/Sources/StreamChatUI/Generated/L10n.swift
@@ -143,6 +143,12 @@ internal enum L10n {
       /// Slow mode ON
       internal static var slowMode: String { L10n.tr("Localizable", "composer.placeholder.slowMode") }
     }
+    internal enum QuotedMessage {
+      /// Giphy
+      internal static var giphy: String { L10n.tr("Localizable", "composer.quoted-message.giphy") }
+      /// Photo
+      internal static var photo: String { L10n.tr("Localizable", "composer.quoted-message.photo") }
+    }
     internal enum Suggestions {
       internal enum Commands {
         /// Instant Commands

--- a/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatUI/Resources/en.lproj/Localizable.strings
@@ -75,6 +75,9 @@
 "composer.links-disabled.title" = "Links are disabled";
 "composer.links-disabled.subtitle" = "Sending links is not allowed in this conversation.";
 
+"composer.quoted-message.photo" = "Photo";
+"composer.quoted-message.giphy" = "Giphy";
+
 "composer.suggestions.commands.header" = "Instant Commands";
 "message.sending.attachment-uploading-failed" = "UPLOADING FAILED";
 

--- a/docusaurus/docs/iOS/uikit/guides/working-with-attachments.md
+++ b/docusaurus/docs/iOS/uikit/guides/working-with-attachments.md
@@ -325,6 +325,38 @@ Finally, don't forget to assign the custom message list if you haven't yet:
 Components.default.messageListVC = CustomChatMessageListVC.self
 ```
 
+### Quoted Message View Preview
+
+A preview of the custom attachment view while a message containing such attachment is being quoted, needs to be provided as well.
+
+In order to do this, you need to subclass the `QuotedChatMessageView` and provide your own implementation for the custom attachment type.
+
+For example, let's create a `CustomQuotedMessageView` with the following implementation.
+
+```swift
+class CustomQuotedMessageView: QuotedChatMessageView {
+    
+    override func setAttachmentPreview(for message: ChatMessage) {
+        if let customPayload = message.attachments(payloadType: WorkoutAttachmentPayload.self).first?.payload {
+            attachmentPreviewView.contentMode = .scaleAspectFit
+            attachmentPreviewView.image = appearance.images.fileFallback
+            if textView.text.isEmpty {
+                textView.text = customPayload.workoutType
+            }
+        }
+        return super.setAttachmentPreview(for: message)
+    }
+}
+```
+
+In the subclass, we are overriding the implementation of the `setAttachmentPreview` method. We are checking if the message contains a custom attachment of type `WorkoutAttachmentPayload`. If it does, we are providing an image and a text available from the message payload.
+
+Finally, you need to inject your custom implementation of the `CustomQuotedMessageView` in our `Components`'s property `quotedMessageView`.
+
+```
+Components.default.quotedMessageView = CustomQuotedMessageView.self
+```
+
 ### Tracking custom attachment upload progress
 In the previous examples, we assumed that you already have the custom attachment remote URL available. But, you can also upload the custom attachment through the Stream's SDK and observe the uploading progress.
 


### PR DESCRIPTION
### 🎯 Goal

- Fix empty attachments handling in quoted message view
- Fix localization in quoted message view

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![ALT_TEXT](https://media.giphy.com/media/qs6ev2pm8g9dS/giphy.gif)