### PR TITLE
Add support for editing custom attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix not being able to paste images when multiple attachments are present [#2874](https://github.com/GetStream/stream-chat-swift/pull/2874)
 
 ## StreamChatUI
+### ✅ Added
+- Add support for editing custom attachments [#2879](https://github.com/GetStream/stream-chat-swift/pull/2879)
 ### 🐞 Fixed
 - Fix composer not interactable after enabling send-message capability [#2866](https://github.com/GetStream/stream-chat-swift/pull/2866)
 

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -51,7 +51,7 @@ public class ChatClient {
     /// The notification center used to send and receive notifications about incoming events.
     private(set) var eventNotificationCenter: EventNotificationCenter
 
-    /// The register that contains all the attachment payloads associated with their attachment types.
+    /// The registry that contains all the attachment payloads associated with their attachment types.
     /// For the meantime this is a static property to avoid breaking changes. On v5, this can be changed.
     private(set) static var customAttachmentTypes: [AttachmentType: AttachmentPayload.Type] = [:]
 

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -51,6 +51,10 @@ public class ChatClient {
     /// The notification center used to send and receive notifications about incoming events.
     private(set) var eventNotificationCenter: EventNotificationCenter
 
+    /// The register that contains all the attachment payloads associated with their attachment types.
+    /// For the meantime this is a static property to avoid breaking changes. On v5, this can be changed.
+    private(set) static var customAttachmentTypes: [AttachmentType: AttachmentPayload.Type] = [:]
+
     let connectionRepository: ConnectionRepository
 
     let authenticationRepository: AuthenticationRepository
@@ -233,6 +237,18 @@ public class ChatClient {
             environment.internetConnection(eventNotificationCenter, environment.internetMonitor),
             config.staysConnectedInBackground
         )
+    }
+
+    /// Register a custom attachment payload.
+    ///
+    /// Example:
+    /// ```
+    /// registerCustomAttachment(CustomAttachmentPayload.self)
+    /// ```
+    ///
+    /// - Parameter payloadType: The payload type of the attachment.
+    public func registerCustomAttachment<Payload: AttachmentPayload>(_ payloadType: Payload.Type) {
+        Self.customAttachmentTypes[Payload.type] = payloadType
     }
 
     /// Connects the client with the given user.

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -53,7 +53,13 @@ public class ChatClient {
 
     /// The registry that contains all the attachment payloads associated with their attachment types.
     /// For the meantime this is a static property to avoid breaking changes. On v5, this can be changed.
-    private(set) static var customAttachmentTypes: [AttachmentType: AttachmentPayload.Type] = [:]
+    private(set) static var attachmentTypesRegistry: [AttachmentType: AttachmentPayload.Type] = [
+        .image: ImageAttachmentPayload.self,
+        .video: VideoAttachmentPayload.self,
+        .audio: AudioAttachmentPayload.self,
+        .file: FileAttachmentPayload.self,
+        .voiceRecording: VideoAttachmentPayload.self
+    ]
 
     let connectionRepository: ConnectionRepository
 
@@ -243,12 +249,12 @@ public class ChatClient {
     ///
     /// Example:
     /// ```
-    /// registerCustomAttachment(CustomAttachmentPayload.self)
+    /// registerAttachment(CustomAttachmentPayload.self)
     /// ```
     ///
     /// - Parameter payloadType: The payload type of the attachment.
-    public func registerCustomAttachment<Payload: AttachmentPayload>(_ payloadType: Payload.Type) {
-        Self.customAttachmentTypes[Payload.type] = payloadType
+    public func registerAttachment<Payload: AttachmentPayload>(_ payloadType: Payload.Type) {
+        Self.attachmentTypesRegistry[Payload.type] = payloadType
     }
 
     /// Connects the client with the given user.

--- a/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload.swift
+++ b/Sources/StreamChat/Models/Attachments/AnyAttachmentPayload.swift
@@ -193,18 +193,7 @@ extension AttachmentPayload {
 public extension Array where Element == ChatMessageAttachment<Data> {
     func toAnyAttachmentPayload() -> [AnyAttachmentPayload] {
         compactMap { attachment in
-            /// Currently supported editable attachments
-            let types: [AttachmentType: AttachmentPayload.Type] = [
-                .image: ImageAttachmentPayload.self,
-                .video: VideoAttachmentPayload.self,
-                .audio: AudioAttachmentPayload.self,
-                .file: FileAttachmentPayload.self,
-                .voiceRecording: VideoAttachmentPayload.self
-            ].merging(
-                ChatClient.customAttachmentTypes,
-                uniquingKeysWith: { defaultType, _ in defaultType }
-            ) // Merge editable attachments with custom types
-
+            let types = ChatClient.attachmentTypesRegistry
             guard let payloadType = types[attachment.type] else { return nil }
             guard let payload = try? JSONDecoder.default.decode(
                 payloadType,

--- a/docusaurus/docs/iOS/uikit/guides/working-with-attachments.md
+++ b/docusaurus/docs/iOS/uikit/guides/working-with-attachments.md
@@ -94,10 +94,11 @@ Components.default.filesAttachmentInjector = MyCustomAttachmentViewInjector.self
 Stream chat allows you to create your own types of attachments as well. The steps to follow to add support for a custom attachment type are the following:
 
 1. Extend `AttachmentType` to include the custom type
-1. Create a new `AttachmentPayload` struct to handle your custom attachment data
-1. Create a `typealias` for `ChatMessageAttachment<AttachmentPayload>` which will be used for the content of the view
-1. Create a new `AttachmentViewInjector`
-1. Configure the SDK to use your view injector class to render custom attachments
+2. Create a new `AttachmentPayload` struct to handle your custom attachment data
+3. Register the new attachment payload type in `ChatClient`
+4. Create a `typealias` for `ChatMessageAttachment<AttachmentPayload>` which will be used for the content of the view
+5. Create a new `AttachmentViewInjector`
+6. Configure the SDK to use your view injector class to render custom attachments
 
 Let's assume we want to attach a workout session to a message, the payload of the attachment will look like this:
 
@@ -113,7 +114,7 @@ Let's assume we want to attach a workout session to a message, the payload of th
 }
 ```
 
-Here's how we get around the first three steps:
+Here's how we get around the first four steps:
 
 ```swift
 public extension AttachmentType {
@@ -144,10 +145,21 @@ public struct WorkoutAttachmentPayload: AttachmentPayload {
 Here we extended `AttachmentType` to include the `workout` type and afterwards we introduced a new struct to match the payload data that we expect.
 
 1. `WorkoutAttachmentPayload.type` is used to match message attachments to this struct
-1. All attachment fields are optional, this is highly recommended for all custom data
-1. We use `CodingKeys` to map JSON field names to struct fields
+2. All attachment fields are optional, this is highly recommended for all custom data
+3. We use `CodingKeys` to map JSON field names to struct fields
 
-Let's now create a custom view injector to handle the workout attachment.
+Then, you should register your custom attachment type when creating the `ChatClient`, example:
+
+```swift
+let client = ChatClient(config: config)
+let client.registerCustomAttachment(WorkoutAttachmentPayload.self)
+```
+
+:::note
+The `ChatClient.registerCustomAttachment()` is only available after the 4.42.0 release. This one was added to make sure that editing custom attachments is also supported.
+:::
+
+Let's now create a custom view injector to handle the workout attachment view.
 
 ```swift
 import StreamChat

--- a/docusaurus/docs/iOS/uikit/guides/working-with-attachments.md
+++ b/docusaurus/docs/iOS/uikit/guides/working-with-attachments.md
@@ -152,11 +152,11 @@ Then, you should register your custom attachment type when creating the `ChatCli
 
 ```swift
 let client = ChatClient(config: config)
-let client.registerCustomAttachment(WorkoutAttachmentPayload.self)
+let client.registerAttachment(WorkoutAttachmentPayload.self)
 ```
 
 :::note
-The `ChatClient.registerCustomAttachment()` is only available after the 4.42.0 release. This one was added to make sure that editing custom attachments is also supported.
+The `ChatClient.registerAttachment()` is only available after the 4.42.0 release. This one was added to make sure that editing custom attachments is also supported.
 :::
 
 Let's now create a custom view injector to handle the workout attachment view.

--- a/docusaurus/docs/iOS/uikit/guides/working-with-attachments.md
+++ b/docusaurus/docs/iOS/uikit/guides/working-with-attachments.md
@@ -114,7 +114,7 @@ Let's assume we want to attach a workout session to a message, the payload of th
 }
 ```
 
-Here's how we get around the first four steps:
+In the code, the payload and attachment type should look something like this:
 
 ```swift
 public extension AttachmentType {
@@ -152,7 +152,7 @@ Then, you should register your custom attachment type when creating the `ChatCli
 
 ```swift
 let client = ChatClient(config: config)
-let client.registerAttachment(WorkoutAttachmentPayload.self)
+client.registerAttachment(WorkoutAttachmentPayload.self)
 ```
 
 :::note


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/463

### 🎯 Goal
Adds support for editing custom attachments. 

### 📝 Summary
A new API was added as part of the custom attachments flow. When creating the `ChatClient` it is now required to register the custom attachment payload through `ChatClient.registerAttachment(payloadType:)`.

Internally, we are currently using a static property because we can't afford having breaking changes. For StreamChat v5, we will most likely improve the attachments experience based on this WIP PR: https://github.com/GetStream/stream-chat-swift/pull/2879

### 🎨 Showcase
N/A. We will eventually add a custom attachment in the Demo App out-of-the-box once we refresh the docs around custom attachments.

### 🧪 Manual Testing Notes
N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS)