### PR TITLE
Fix issue where text view is not scrollable when pasting a long text

### DIFF
--- a/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
+++ b/Sources/StreamChatUI/CommonViews/InputTextView/InputTextView.swift
@@ -172,7 +172,17 @@ open class InputTextView: UITextView, AppearanceProvider {
 
     @objc open func handleTextChange() {
         placeholderLabel.isHidden = !text.isEmpty
-        setNeedsDisplay()
+        setNeedsLayout()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            // This is due to bug in UITextView where the scroll sometimes disables
+            // when a very long text is pasted in it.
+            // Doing this ensures that it doesn't happen
+            // Reference: https://stackoverflow.com/a/62386088/5493299
+
+            self?.isScrollEnabled = false
+            self?.layoutIfNeeded()
+            self?.isScrollEnabled = true
+        }
     }
 
     @objc func textDidEndEditing(notification: Notification) {


### PR DESCRIPTION
### 🔗 Issue Links

_Provide all Jira tickets and/or Github issues related to this PR, if applicable._

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
