### PR TITLE
Add jump to unread interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### ✅ Added
 - Add new `NewMessageErrorEvent` when observing `EventsController` [#2885](https://github.com/GetStream/stream-chat-swift/pull/2885)
+- Add support for jump to unread messages interaction [#2894](https://github.com/GetStream/stream-chat-swift/pull/2894)
+- Add support for opening a channel in the unread messages page with `Components.shouldJumpToUnreadWhenOpeningChannel` [#2894](https://github.com/GetStream/stream-chat-swift/pull/2894)
 
 ## StreamChatUI
 ### 🐞 Fixed
 - Fix Message List UI not updated when message.updatedAt changes [#2884](https://github.com/GetStream/stream-chat-swift/pull/2884)
+- Fix jump to unread button showing "0" unread counts [#2894](https://github.com/GetStream/stream-chat-swift/pull/2894)
 
 # [4.42.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.42.0)
 _November 14, 2023_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### ✅ Added
 - Add new `NewMessageErrorEvent` when observing `EventsController` [#2885](https://github.com/GetStream/stream-chat-swift/pull/2885)
+
+## StreamChatUI
+### ✅ Added
 - Add jump to unread messages interaction [#2894](https://github.com/GetStream/stream-chat-swift/pull/2894)
 - Add support for opening a channel in the unread messages page with `Components.shouldJumpToUnreadWhenOpeningChannel` [#2894](https://github.com/GetStream/stream-chat-swift/pull/2894)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### ✅ Added
 - Add new `NewMessageErrorEvent` when observing `EventsController` [#2885](https://github.com/GetStream/stream-chat-swift/pull/2885)
-- Add support for jump to unread messages interaction [#2894](https://github.com/GetStream/stream-chat-swift/pull/2894)
+- Add jump to unread messages interaction [#2894](https://github.com/GetStream/stream-chat-swift/pull/2894)
 - Add support for opening a channel in the unread messages page with `Components.shouldJumpToUnreadWhenOpeningChannel` [#2894](https://github.com/GetStream/stream-chat-swift/pull/2894)
 
 ## StreamChatUI

--- a/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
+++ b/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
@@ -143,6 +143,7 @@ class AppConfigViewController: UITableViewController {
         case isUniqueReactionsEnabled
         case shouldMessagesStartAtTheTop
         case shouldAnimateJumpToMessageWhenOpeningChannel
+        case shouldJumpToUnreadWhenOpeningChannel
         case threadRepliesStartFromOldest
         case threadRendersParentMessageEnabled
         case isVoiceRecordingEnabled
@@ -363,6 +364,10 @@ class AppConfigViewController: UITableViewController {
         case .shouldAnimateJumpToMessageWhenOpeningChannel:
             cell.accessoryView = makeSwitchButton(Components.default.shouldAnimateJumpToMessageWhenOpeningChannel) { newValue in
                 Components.default.shouldAnimateJumpToMessageWhenOpeningChannel = newValue
+            }
+        case .shouldJumpToUnreadWhenOpeningChannel:
+            cell.accessoryView = makeSwitchButton(Components.default.shouldJumpToUnreadWhenOpeningChannel) { newValue in
+                Components.default.shouldJumpToUnreadWhenOpeningChannel = newValue
             }
         case .threadRepliesStartFromOldest:
             cell.accessoryView = makeSwitchButton(Components.default.threadRepliesStartFromOldest) { newValue in

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -123,6 +123,21 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
         getFirstUnreadMessageId()
     }
 
+    /// The id of the message which the current user last read.
+    public var lastReadMessageId: MessageId? {
+        guard let currentUserRead = channel?.reads.first(where: {
+            $0.user.id == client.currentUserId
+        }) else {
+            return nil
+        }
+
+        guard let lastReadMessageId = currentUserRead.lastReadMessageId else {
+            return nil
+        }
+
+        return lastReadMessageId
+    }
+
     /// A boolean indicating if the user marked the channel as unread in the current session
     public private(set) var isMarkedAsUnread: Bool = false
 

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -241,11 +241,13 @@ open class ChatChannelVC: _ViewController,
         setChannelControllerToComposerIfNeeded(cid: channelController.cid)
         messageComposerVC.updateContent()
 
-        if let messageId = channelController.channelQuery.pagination?.parameter?.aroundMessageId {
-            jumpToMessage(id: messageId, animated: components.shouldAnimateJumpToMessageWhenOpeningChannel)
-        }
+        updateAllUnreadMessagesRelatedComponents()
 
-        if let replyId = initialReplyId {
+        if let messageId = channelController.channelQuery.pagination?.parameter?.aroundMessageId {
+            // Jump to a message when opening the channel.
+            jumpToMessage(id: messageId, animated: components.shouldAnimateJumpToMessageWhenOpeningChannel)
+        } else if let replyId = initialReplyId {
+            // Jump to a parent message when opening the channel, and then to the reply.
             // The delay is necessary so that the animation does not happen to quickly.
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.jumpToMessage(
@@ -253,12 +255,10 @@ open class ChatChannelVC: _ViewController,
                     animated: self.components.shouldAnimateJumpToMessageWhenOpeningChannel
                 )
             }
+        } else if components.shouldJumpToUnreadWhenOpeningChannel {
+            // Jump to the unread message.
+            messageListVC.jumpToUnreadMessage(animated: components.shouldAnimateJumpToMessageWhenOpeningChannel)
         }
-
-        updateAllUnreadMessagesRelatedComponents()
-        
-        // TODO: Add flag
-        // messageListVC.jumpToUnreadMessage()
     }
 
     // MARK: - Actions

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -472,7 +472,7 @@ open class ChatChannelVC: _ViewController,
 
             self.updateJumpToUnreadRelatedComponents()
             if self.shouldMarkChannelRead {
-                throttler.execute {
+                self.throttler.execute {
                     self.markRead()
                 }
             } else if !self.hasSeenFirstUnreadMessage {

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -486,6 +486,7 @@ open class ChatChannelVC: _ViewController,
         didUpdateChannel channel: EntityChange<ChatChannel>
     ) {
         updateScrollToBottomButtonCount()
+        updateJumpToUnreadRelatedComponents()
 
         if headerView.channelController == nil, let cid = channelController.cid {
             headerView.channelController = client.channelController(for: cid)

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -119,7 +119,7 @@ open class ChatChannelVC: _ViewController,
     /// The id of the first unread message
     private var firstUnreadMessageId: MessageId?
 
-    /// In case the given  around message id is from a thread, we need to jump to the parent message and then the reply.
+    /// In case the given around message id is from a thread, we need to jump to the parent message and then the reply.
     private var initialReplyId: MessageId?
 
     override open func setUp() {
@@ -254,7 +254,11 @@ open class ChatChannelVC: _ViewController,
                 )
             }
         }
+
         updateAllUnreadMessagesRelatedComponents()
+        
+        // TODO: Add flag
+        // messageListVC.jumpToUnreadMessage()
     }
 
     // MARK: - Actions
@@ -339,7 +343,10 @@ open class ChatChannelVC: _ViewController,
             return
         }
 
-        channelController.loadPageAroundMessageId(messageId, completion: completion)
+        channelController.loadPageAroundMessageId(messageId) { [weak self] error in
+            self?.updateJumpToUnreadRelatedComponents()
+            completion(error)
+        }
     }
 
     open func chatMessageListVCShouldLoadFirstPage(
@@ -565,7 +572,10 @@ private extension ChatChannelVC {
     }
 
     func updateJumpToUnreadRelatedComponents() {
-        messageListVC.updateJumpToUnreadMessageId(channelController.firstUnreadMessageId)
+        messageListVC.updateJumpToUnreadMessageId(
+            channelController.firstUnreadMessageId,
+            lastReadMessageId: channelController.lastReadMessageId
+        )
         messageListVC.updateJumpToUnreadButtonVisibility()
     }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -116,6 +116,7 @@ open class ChatMessageListVC: _ViewController,
     }
 
     private var unreadSeparatorMessageId: MessageId?
+    private var lastReadMessageId: MessageId?
     private var jumpToUnreadMessageId: MessageId?
     private var jumpToUnreadMessageIndexPath: IndexPath? {
         jumpToUnreadMessageId.flatMap(getIndexPath)
@@ -190,8 +191,8 @@ open class ChatMessageListVC: _ViewController,
         listView.addGestureRecognizer(panGestureRecognizer)
 
         scrollToBottomButton.addTarget(self, action: #selector(didTapScrollToBottomButton), for: .touchUpInside)
-        jumpToUnreadMessagesButton.addTarget(self, action: #selector(jumpToUnreadMessages))
-        jumpToUnreadMessagesButton.addDiscardButtonTarget(self, action: #selector(discardUnreadMessages))
+        jumpToUnreadMessagesButton.addTarget(self, action: #selector(didTapJumpToUnreadButton))
+        jumpToUnreadMessagesButton.addDiscardButtonTarget(self, action: #selector(didTapDiscardJumpToUnreadButton))
     }
 
     override open func setUpLayout() {
@@ -363,8 +364,9 @@ open class ChatMessageListVC: _ViewController,
         listView.reloadRows(at: indexPathsToReload, with: .automatic)
     }
 
-    func updateJumpToUnreadMessageId(_ jumpToUnreadMessageId: MessageId?) {
+    func updateJumpToUnreadMessageId(_ jumpToUnreadMessageId: MessageId?, lastReadMessageId: MessageId?) {
         self.jumpToUnreadMessageId = jumpToUnreadMessageId
+        self.lastReadMessageId = lastReadMessageId
     }
 
     private func isMessageVisible(at indexPath: IndexPath) -> Bool {
@@ -372,12 +374,11 @@ open class ChatMessageListVC: _ViewController,
         return visibleIndexPaths.contains(indexPath)
     }
 
-    @objc func jumpToUnreadMessages() {
-        guard let firstUnreadMessageId = unreadSeparatorMessageId else { return }
-        jumpToMessage(id: firstUnreadMessageId)
+    @objc func didTapJumpToUnreadButton() {
+        jumpToUnreadMessage()
     }
 
-    @objc func discardUnreadMessages() {
+    @objc func didTapDiscardJumpToUnreadButton() {
         delegate?.chatMessageListDidDiscardUnreadMessages(self)
     }
 
@@ -609,6 +610,19 @@ open class ChatMessageListVC: _ViewController,
         ]
     }
 
+    /// Jump to the current unread message if there is one.
+    /// - Parameter onHighlight: An optional closure to provide highlighting style when the message appears on screen.
+    open func jumpToUnreadMessage(onHighlight: ((IndexPath) -> Void)? = nil) {
+        getCurrentUnreadMessageId { [weak self] messageId in
+            guard let jumpToUnreadMessageId = messageId else { return }
+
+            // The delay helps having a smoother scrolling animation.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                self?.jumpToMessage(id: jumpToUnreadMessageId, onHighlight: onHighlight)
+            }
+        }
+    }
+
     /// Jump to a given message.
     /// In case the message is already loaded, it directly goes to it.
     /// If not, it will load the messages around it and go to that page.
@@ -691,6 +705,36 @@ open class ChatMessageListVC: _ViewController,
         delegate?.chatMessageListVCShouldLoadFirstPage(self)
         scrollToBottomButton.isHidden = true
         listView.reloadSkippedMessages()
+    }
+
+    /// Fetch the current unread message id.
+    ///
+    /// If the message is available locally, we get it instantly.
+    /// If not, we need to fetch the page of messages where the `lastReadMessageId` is,
+    /// so that we can find the first unread message id next to it.
+    ///
+    /// Note: This is a current backend limitation. Ideally, in the future,
+    /// we will get the `unreadMessageId` directly from the backend.
+    private func getCurrentUnreadMessageId(completion: @escaping (MessageId?) -> Void) {
+        if let jumpToUnreadMessageId = self.jumpToUnreadMessageId {
+            return completion(jumpToUnreadMessageId)
+        }
+
+        guard let lastReadMessageId = self.lastReadMessageId else {
+            return completion(nil)
+        }
+
+        delegate?.chatMessageListVC(self, shouldLoadPageAroundMessageId: lastReadMessageId) { error in
+            guard error == nil else {
+                return completion(nil)
+            }
+
+            guard let jumpToUnreadMessageId = self.jumpToUnreadMessageId else {
+                return completion(nil)
+            }
+
+            completion(jumpToUnreadMessageId)
+        }
     }
 
     // MARK: - UITableViewDataSource & UITableViewDelegate

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -612,14 +612,15 @@ open class ChatMessageListVC: _ViewController,
     }
 
     /// Jump to the current unread message if there is one.
+    /// - Parameter animated: `true` if you want to animate the change in position; `false` if it should be immediate.
     /// - Parameter onHighlight: An optional closure to provide highlighting style when the message appears on screen.
-    open func jumpToUnreadMessage(onHighlight: ((IndexPath) -> Void)? = nil) {
+    open func jumpToUnreadMessage(animated: Bool = true, onHighlight: ((IndexPath) -> Void)? = nil) {
         getCurrentUnreadMessageId { [weak self] messageId in
             guard let jumpToUnreadMessageId = messageId else { return }
 
             // The delay helps having a smoother scrolling animation.
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                self?.jumpToMessage(id: jumpToUnreadMessageId, onHighlight: onHighlight)
+                self?.jumpToMessage(id: jumpToUnreadMessageId, animated: animated, onHighlight: onHighlight)
             }
         }
     }
@@ -629,8 +630,8 @@ open class ChatMessageListVC: _ViewController,
     /// If not, it will load the messages around it and go to that page.
     ///
     /// - Parameter id: The id of message which the message list should go to.
-    /// - Parameter onHighlight: An optional closure to provide highlighting style when the message appears on screen.
     /// - Parameter animated: `true` if you want to animate the change in position; `false` if it should be immediate.
+    /// - Parameter onHighlight: An optional closure to provide highlighting style when the message appears on screen.
     public func jumpToMessage(id: MessageId, animated: Bool = true, onHighlight: ((IndexPath) -> Void)? = nil) {
         if let indexPath = getIndexPath(forMessageId: id) {
             messagePendingScrolling = (id, animated)

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -309,7 +309,8 @@ open class ChatMessageListVC: _ViewController,
         guard isJumpToUnreadEnabled else { return }
 
         if let unreadCount = dataSource?.channel(for: self)?.unreadCount,
-           unreadCount != jumpToUnreadMessagesButton.content {
+           unreadCount != jumpToUnreadMessagesButton.content,
+           unreadCount.messages > 0 {
             jumpToUnreadMessagesButton.content = unreadCount
         }
 

--- a/Sources/StreamChatUI/ChatMessageList/JumpToUnreadMessagesButton.swift
+++ b/Sources/StreamChatUI/ChatMessageList/JumpToUnreadMessagesButton.swift
@@ -64,8 +64,7 @@ open class JumpToUnreadMessagesButton: _Button, ThemeProvider {
     }
 
     open func addTarget(_ target: Any?, action: Selector) {
-        // TODO: https://github.com/GetStream/ios-issues-tracking/issues/529
-        // addTarget(target, action: action, for: .touchUpInside)
+        addTarget(target, action: action, for: .touchUpInside)
     }
 
     open func addDiscardButtonTarget(_ target: Any?, action: Selector) {

--- a/Sources/StreamChatUI/Components.swift
+++ b/Sources/StreamChatUI/Components.swift
@@ -122,6 +122,10 @@ public struct Components {
     /// Ex: When opening a channel from a push notification with a given message id.
     public var shouldAnimateJumpToMessageWhenOpeningChannel: Bool = true
 
+    /// Whether it should jump to the unread message when the channel is initially opened.
+    /// By default it is disabled.
+    public var shouldJumpToUnreadWhenOpeningChannel: Bool = false
+
     /// The view that shows the date for currently visible messages on top of message list.
     public var messageListScrollOverlayView: ChatMessageListScrollOverlayView.Type =
         ChatMessageListScrollOverlayView.self

--- a/Sources/StreamChatUI/Utils/Throttler.swift
+++ b/Sources/StreamChatUI/Utils/Throttler.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Based on the implementation from Apple: https://developer.apple.com/documentation/combine/anypublisher/throttle(for:scheduler:latest:)
 class Throttler {
     private var workItem: DispatchWorkItem?
-    private let queue = DispatchQueue(label: "com.stream.throttler", qos: .background)
+    private let queue: DispatchQueue
     private var previousRun: Date = Date.distantPast
     let interval: TimeInterval
     let broadcastLatestEvent: Bool
@@ -16,16 +16,22 @@ class Throttler {
     /// - Parameters:
     ///   - interval: The interval that an action can be executed.
     ///   - broadcastLatestEvent: A Boolean value that indicates whether we should be using the first or last event of the ones that are being throttled.
+    ///   - queue: The queue where the work will be executed.
     ///   This last action will have a delay of the provided interval until it is executed.
-    init(interval: TimeInterval, broadcastLatestEvent: Bool = true) {
+    init(
+        interval: TimeInterval,
+        broadcastLatestEvent: Bool = true,
+        queue: DispatchQueue = .init(label: "com.stream.throttler", qos: .background)
+    ) {
         self.interval = interval
         self.broadcastLatestEvent = broadcastLatestEvent
+        self.queue = queue
     }
 
     /// Throttle an action. It will cancel the previous action if exists, and it will execute the action immediately
     /// if the last action executed was past the interval provided. If not, it will only be executed after a delay.
     /// - Parameter action: The closure to be performed.
-    func throttle(_ action: @escaping () -> Void) {
+    func execute(_ action: @escaping () -> Void) {
         workItem?.cancel()
 
         let workItem = DispatchWorkItem { [weak self] in

--- a/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
+++ b/Tests/StreamChatTests/StreamChatFlakyTests.xctestplan
@@ -25,6 +25,7 @@
         "MessageSender_Tests\/test_sender_doesNotRetainItself()",
         "MessageSender_Tests\/test_sender_sendsMessage_withBothNotUploadableAttachmentAndUploadedAttachments()",
         "MessageSender_Tests\/test_sender_sendsMessage_withUploadedAttachments()",
+        "MessageSender_Tests\/test_sender_sendsMessage_whenError_sendsEvent()",
         "MessageUpdater_Tests\/test_flagMessage_happyPath()",
         "MessageUpdater_Tests\/test_unpinMessage_propogatesMessageEditingError_ifLocalStateIsInvalidForUnpinning()",
         "MessageUpdater_Tests\/test_deleteBouncedMessage_isDeletedLocally_whenLocalStateIsSendingFailed()",

--- a/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
+++ b/Tests/StreamChatTests/StreamChatTestPlan.xctestplan
@@ -43,6 +43,7 @@
         "MessageSender_Tests\/test_sender_doesNotRetainItself()",
         "MessageSender_Tests\/test_sender_sendsMessage_withBothNotUploadableAttachmentAndUploadedAttachments()",
         "MessageSender_Tests\/test_sender_sendsMessage_withUploadedAttachments()",
+        "MessageSender_Tests\/test_sender_sendsMessage_whenError_sendsEvent()",
         "MessageUpdater_Tests\/test_flagMessage_happyPath()",
         "MessageUpdater_Tests\/test_unpinMessage_propogatesMessageEditingError_ifLocalStateIsInvalidForUnpinning()",
         "MessageUpdater_Tests\/test_deleteBouncedMessage_isDeletedLocally_whenLocalStateIsSendingFailed()",

--- a/Tests/StreamChatUITests/Mocks/ChatMessageList/ChatMessageListVCDelegate_Mock.swift
+++ b/Tests/StreamChatUITests/Mocks/ChatMessageList/ChatMessageListVCDelegate_Mock.swift
@@ -21,7 +21,8 @@ class ChatMessageListVCDelegate_Mock: ChatMessageListVCDelegate {
 
     var shouldLoadPageAroundMessageCallCount = 0
     var shouldLoadPageAroundMessageResult: Error?
-    func chatMessageListVC(_ vc: ChatMessageListVC, shouldLoadPageAroundMessage message: ChatMessage, _ completion: @escaping ((Error?) -> Void)) {
+
+    func chatMessageListVC(_ vc: ChatMessageListVC, shouldLoadPageAroundMessageId messageId: MessageId, _ completion: @escaping ((Error?) -> Void)) {
         shouldLoadPageAroundMessageCallCount += 1
         if let result = shouldLoadPageAroundMessageResult {
             completion(result)

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannel/ChatChannelVC_Tests.swift
@@ -1269,7 +1269,7 @@ class ThrottlerMock: Throttler {
         super.init(interval: 0)
     }
 
-    override func throttle(_ action: @escaping () -> Void) {
+    override func execute(_ action: @escaping () -> Void) {
         action()
     }
 }

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
@@ -633,6 +633,66 @@ final class ChatMessageListVC_Tests: XCTestCase {
         XCTAssertEqual(mockedListView.scrollToRowCallCount, 0)
     }
 
+    // MARK: jumpToUnreadMessage()
+
+    func test_jumpToUnreadMessage_whenUnreadMessageIsLocallyAvailable() {
+        // Given
+        mockedDataSource.messages = [
+            .mock(id: "0"),
+            .mock(id: "1"),
+            .mock(id: "2"),
+            .mock(id: "3"),
+            .mock(id: "4")
+        ]
+
+        // When
+        sut.updateJumpToUnreadMessageId("2", lastReadMessageId: nil)
+
+        // Then
+        sut.jumpToUnreadMessage()
+        AssertAsync.willBeEqual(mockedListView.scrollToRowCallCount, 1)
+        AssertAsync.willBeEqual(mockedListView.scrollToRowCalledWith?.row, 2)
+        AssertAsync.willBeEqual(mockedDelegate.shouldLoadPageAroundMessageCallCount, 0)
+    }
+
+    func test_jumpToUnreadMessage_whenUnreadMessageIsRemotelyAvailable() {
+        // Given
+        mockedDataSource.messages = [
+            .mock(id: "0"),
+            .mock(id: "1"),
+            .mock(id: "2"),
+            .mock(id: "3"),
+            .mock(id: "4")
+        ]
+
+        // When
+        sut.updateJumpToUnreadMessageId(nil, lastReadMessageId: "5")
+
+        // Then
+        sut.jumpToUnreadMessage()
+        AssertAsync.willBeEqual(mockedListView.scrollToRowCallCount, 0)
+        AssertAsync.willBeEqual(mockedDelegate.shouldLoadPageAroundMessageCallCount, 1)
+    }
+
+    func test_jumpToUnreadMessage_whenNoUnreadMessage() {
+        // Given
+        mockedDataSource.messages = [
+            .mock(id: "0"),
+            .mock(id: "1"),
+            .mock(id: "2"),
+            .mock(id: "3"),
+            .mock(id: "4")
+        ]
+
+        // When
+        sut.updateJumpToUnreadMessageId(nil, lastReadMessageId: nil)
+
+        // Then
+        sut.jumpToUnreadMessage()
+        AssertAsync.willBeEqual(mockedListView.scrollToRowCallCount, 0)
+        AssertAsync.willBeEqual(mockedDelegate.shouldLoadPageAroundMessageCallCount, 0)
+    }
+
     // MARK: isJumpToUnreadMessagesButtonVisible
 
     func test_isJumpToUnreadMessagesButtonVisible_whenFeatureIsDisabled() {
@@ -663,7 +723,7 @@ final class ChatMessageListVC_Tests: XCTestCase {
         mockedDelegate.mockedShouldShowJumpToUnread = true
         mockedDataSource.mockedChannel = .mock(cid: .unique, unreadCount: .mock(messages: 0))
         let unreadMessageId = MessageId.unique
-        sut.updateJumpToUnreadMessageId(unreadMessageId)
+        sut.updateJumpToUnreadMessageId(unreadMessageId, lastReadMessageId: nil)
         mockedDataSource.messages = []
 
         XCTAssertFalse(sut.isJumpToUnreadMessagesButtonVisible)
@@ -674,7 +734,7 @@ final class ChatMessageListVC_Tests: XCTestCase {
         mockedDelegate.mockedShouldShowJumpToUnread = true
         mockedDataSource.mockedChannel = .mock(cid: .unique, unreadCount: .mock(messages: 1))
         let unreadMessageId = MessageId.unique
-        sut.updateJumpToUnreadMessageId(unreadMessageId)
+        sut.updateJumpToUnreadMessageId(unreadMessageId, lastReadMessageId: nil)
         mockedDataSource.messages = []
 
         XCTAssertTrue(sut.isJumpToUnreadMessagesButtonVisible)
@@ -685,7 +745,7 @@ final class ChatMessageListVC_Tests: XCTestCase {
         mockedDelegate.mockedShouldShowJumpToUnread = true
         mockedDataSource.mockedChannel = .mock(cid: .unique, unreadCount: .mock(messages: 1))
         let unreadMessageId = MessageId.unique
-        sut.updateJumpToUnreadMessageId(unreadMessageId)
+        sut.updateJumpToUnreadMessageId(unreadMessageId, lastReadMessageId: nil)
         mockedDataSource.messages = [
             ChatMessage.mock(id: unreadMessageId) // IndexPath: 0 - 0
         ]
@@ -701,7 +761,7 @@ final class ChatMessageListVC_Tests: XCTestCase {
         mockedDelegate.mockedShouldShowJumpToUnread = true
         mockedDataSource.mockedChannel = .mock(cid: .unique, unreadCount: .mock(messages: 1))
         let unreadMessageId = MessageId.unique
-        sut.updateJumpToUnreadMessageId(unreadMessageId)
+        sut.updateJumpToUnreadMessageId(unreadMessageId, lastReadMessageId: nil)
         mockedDataSource.messages = [
             ChatMessage.mock(id: unreadMessageId) // IndexPath: 0 - 0
         ]


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/529

### 🎯 Goal
Enables the Jump to Unread button so that it jumps to the unread message when tapping it. 

### 📝 Summary
- Adds support for jumping to unread messages through `ChatMessageListVC.jumpToUnreadMessage()`
- Adds a flag `Components.default.shouldJumpToUnreadWhenOpeningChannel` that if enabled the channel will open always in the unread message location
- Fixes a bug where "0 Unread Count" would show on the Jump To Unread Button

### 🛠 Implementation
Because we don't yet get the `firstUnreadMessageId` from the backend, the current solution is to jump directly to the `firstUnreadMessageId` if it is already locally available. If not, we fetch the page where the `lastReadMessageId` is; since the `firstUnreadMessageId` will be located on that page, we then jump to it. 

### 🧪 Manual Testing Notes
**Jump to Local Unread Message:**
1. Login
2. Open a Channel
3. Mark a message unread
4. Tap on the JumpToUnread Button
5. Should directly scroll to it

**Jump to Old/Remote Unread Message:**
1. Login
2. Open a Channel
3. Mark a message unread on an old page
4. Go back to the Channel List
5. Open the channel again
6. Tap on the jumpToUnread Button
7. Should jump to the page where the unread message is

**Enabling `shouldJumpToUnreadWhenOpeningChannel`:**
1. Enable `shouldJumpToUnreadWhenOpeningChannel` in the Demo App Configuration
2. Login
3. Open a Channel with unreads
4. It should open the channel in the unread messages (Either on the current page or an old page)

**0 Unread counts bug:**
1. Open a channel with unreads
2. Close the Jump To Unread Button (Tap on the "X")
3. You should see the button disappear without showing "0" unreads for a split second

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)