### PR TITLE
Fix jump to thread reply when opening channel

### DIFF
--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -246,14 +246,16 @@ open class ChatChannelVC: _ViewController,
         if let messageId = channelController.channelQuery.pagination?.parameter?.aroundMessageId {
             // Jump to a message when opening the channel.
             jumpToMessage(id: messageId, animated: components.shouldAnimateJumpToMessageWhenOpeningChannel)
-        } else if let replyId = initialReplyId {
-            // Jump to a parent message when opening the channel, and then to the reply.
-            // The delay is necessary so that the animation does not happen to quickly.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                self.jumpToMessage(
-                    id: replyId,
-                    animated: self.components.shouldAnimateJumpToMessageWhenOpeningChannel
-                )
+
+            if let replyId = initialReplyId {
+                // Jump to a parent message when opening the channel, and then to the reply.
+                // The delay is necessary so that the animation does not happen to quickly.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    self.jumpToMessage(
+                        id: replyId,
+                        animated: self.components.shouldAnimateJumpToMessageWhenOpeningChannel
+                    )
+                }
             }
         } else if components.shouldJumpToUnreadWhenOpeningChannel {
             // Jump to the unread message.

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -120,7 +120,7 @@ open class ChatChannelVC: _ViewController,
     private var firstUnreadMessageId: MessageId?
 
     /// In case the given around message id is from a thread, we need to jump to the parent message and then the reply.
-    private var initialReplyId: MessageId?
+    internal var initialReplyId: MessageId?
 
     override open func setUp() {
         super.setUp()

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/EventNotificationCenter_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/EventNotificationCenter_Mock.swift
@@ -15,6 +15,7 @@ final class EventNotificationCenter_Mock: EventNotificationCenter {
     var newMessageIdsMock: Set<MessageId>?
 
     lazy var mock_process = MockFunc<([Event], Bool, (() -> Void)?), Void>.mock(for: process)
+    var mock_processCalledWithEvents: [Event] = []
 
     override func process(
         _ events: [Event],
@@ -22,7 +23,8 @@ final class EventNotificationCenter_Mock: EventNotificationCenter {
         completion: (() -> Void)? = nil
     ) {
         super.process(events, postNotifications: postNotifications, completion: completion)
-
+        
+        mock_processCalledWithEvents = events
         mock_process.call(with: (events, postNotifications, completion))
     }
 }

--- a/Tests/StreamChatUITests/Mocks/ChatMessageList/ChatMessageListVC_Mock.swift
+++ b/Tests/StreamChatUITests/Mocks/ChatMessageList/ChatMessageListVC_Mock.swift
@@ -18,4 +18,9 @@ class ChatMessageListVC_Mock: ChatMessageListVC {
         jumpToMessageCallCount += 1
         jumpToMessageCalledWith = (id: id, animated: animated, onHighlight: onHighlight)
     }
+
+    var jumpToUnreadMessageCallCount = 0
+    override func jumpToUnreadMessage(animated: Bool = true, onHighlight: ((IndexPath) -> Void)? = nil) {
+        jumpToUnreadMessageCallCount += 1
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links
Regression found in 4.43.0

### 🎯 Goal
Fix broken jump to thread reply when opening channel.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)