### PR TITLE
Bugfix: Do not mark channel as read for new members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,14 @@ _November 17, 2023_
 ### ✅ Added
 - Add new `NewMessageErrorEvent` when observing `EventsController` [#2885](https://github.com/GetStream/stream-chat-swift/pull/2885)
 
+### 🐞 Fixed
+- Fix channel history being marked as read for new members [#2905](https://github.com/GetStream/stream-chat-swift/pull/2905)
+
 ## StreamChatUI
 ### ✅ Added
 - Add jump to unread messages interaction [#2894](https://github.com/GetStream/stream-chat-swift/pull/2894)
 - Add support for opening a channel in the unread messages page with `Components.shouldJumpToUnreadWhenOpeningChannel` [#2894](https://github.com/GetStream/stream-chat-swift/pull/2894)
 
-## StreamChatUI
 ### 🐞 Fixed
 - Fix Message List UI not updated when message.updatedAt changes [#2884](https://github.com/GetStream/stream-chat-swift/pull/2884)
 - Fix jump to unread button showing "0" unread counts [#2894](https://github.com/GetStream/stream-chat-swift/pull/2894)

--- a/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware.swift
+++ b/Sources/StreamChat/WebSocketClient/EventMiddlewares/MemberEventMiddleware.swift
@@ -16,9 +16,6 @@ struct MemberEventMiddleware: EventMiddleware {
                 if let channel = session.channel(cid: event.cid) {
                     let member = try session.saveMember(payload: event.member, channelId: event.cid)
 
-                    // Mark all messages in channel as read
-                    session.markChannelAsRead(cid: event.cid, userId: event.member.userId, at: event.createdAt)
-
                     insertMemberToMemberListQueries(channel, member)
                 }
 

--- a/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus_Tests.swift
+++ b/StreamChatUITestsAppUITests/Tests/Message Delivery Status/MessageDeliveryStatus_Tests.swift
@@ -101,7 +101,7 @@ final class MessageDeliveryStatus_Tests: StreamTestCase {
         }
     }
 
-    func test_doubleCheckmarkShown_whenNewParticipantAdded() {
+    func test_noDoubleCheckmarkShown_whenNewParticipantAdded() {
         linkToScenario(withId: 143)
 
         GIVEN("user opens the channel") {
@@ -124,8 +124,8 @@ final class MessageDeliveryStatus_Tests: StreamTestCase {
         THEN("user spots double checkmark below the message") {
             userRobot.assertMessageDeliveryStatus(.read)
         }
-        AND("user see read count 2 below the message") {
-            userRobot.assertMessageReadCount(readBy: 2)
+        AND("user see read count 1 below the message") {
+            userRobot.assertMessageReadCount(readBy: 1)
         }
     }
 
@@ -358,7 +358,7 @@ extension MessageDeliveryStatus_Tests {
         }
     }
 
-    func test_doubleCheckmarkShownInThreadReply_whenNewParticipantAdded() throws {
+    func test_noDoubleCheckmarkShownInThreadReply_whenNewParticipantAdded() throws {
         linkToScenario(withId: 154)
         
         try XCTSkipIf(ProcessInfo().operatingSystemVersion.majorVersion == 12, "Flaky on iOS 12")
@@ -378,10 +378,10 @@ extension MessageDeliveryStatus_Tests {
             userRobot.addParticipant()
         }
         THEN("user spots double checkmark below the thread reply") {
-            userRobot.assertMessageDeliveryStatus(.read)
+            userRobot.assertMessageDeliveryStatus(.sent)
         }
         AND("user see read count 2 below the message") {
-            userRobot.assertMessageReadCount(readBy: 1)
+            userRobot.assertMessageReadCount(readBy: 0)
         }
     }
 

--- a/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/MemberEventMiddleware_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/EventMiddlewares/MemberEventMiddleware_Tests.swift
@@ -151,7 +151,7 @@ final class MemberEventMiddleware_Tests: XCTestCase {
         XCTAssertEqual(memberListQueryDTO?.members.map(\.user.id).sorted(), [existingMember.user!.id, newMemberId].sorted())
     }
 
-    func test_memberAddedEvent_marksChannelAsRead() throws {
+    func test_memberAddedEvent_doesNotMarkChannelAsRead() throws {
         let mockSession = DatabaseSession_Mock(underlyingSession: database.viewContext)
 
         // GIVEN
@@ -175,9 +175,7 @@ final class MemberEventMiddleware_Tests: XCTestCase {
         _ = middleware.handle(event: event, session: mockSession)
 
         // THEN
-        XCTAssertEqual(mockSession.markChannelAsReadParams?.cid, event.cid)
-        XCTAssertEqual(mockSession.markChannelAsReadParams?.userId, event.member.userId)
-        XCTAssertEqual(mockSession.markChannelAsReadParams?.at, event.createdAt)
+        XCTAssertNil(mockSession.markChannelAsReadParams?.cid)
     }
 
     // MARK: - MemberRemovedEvent


### PR DESCRIPTION
### 🔗 Issue Links

https://github.com/GetStream/ios-issues-tracking/issues/653

### 🎯 Goal

Stop marking channels as read for new members

### 📝 Summary

Seems like we were marking the chat history as read for new channel members. This created a situation where on adding a member, all the messages in the history would increase their read count by one.

### 🛠 Implementation

Stop marking as read for a new member in MemberEventMiddleware

### 🧪 Manual Testing Notes

1. Create a group
2. Send a message
3. Add a new member

Expected result:
- Read counts on messages should not increase

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/xpX7EFdRVczD9avaHo/giphy.gif)
