### PR TITLE
[Background Mapping] Fix Mark as unread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChatUI
 ### 🐞 Fixed
 - Fix skip slow mode capability not handled [#2904](https://github.com/GetStream/stream-chat-swift/pull/2904)
+
+### 🔄 Changed
+- `ChannelController.markUnread`'s `completion`'s argument is now a `(Result<ChatChannel, Error>` instead of `Error?`
 
 # [4.43.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.43.0)
 _November 17, 2023_

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -120,7 +120,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
     /// This is because we cannot calculate the accurate value until we have all he messages in memory.
     /// Paginate to get the most accurate value.
     public var firstUnreadMessageId: MessageId? {
-        getFirstUnreadMessageId(for: channel)
+        channel.flatMap { getFirstUnreadMessageId(for: $0) }
     }
 
     /// The id of the message which the current user last read.
@@ -1217,7 +1217,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
         updater.deleteImage(in: cid, url: url, completion: completion)
     }
 
-    public func getFirstUnreadMessageId(for channel: ChatChannel?) -> MessageId? {
+    public func getFirstUnreadMessageId(for channel: ChatChannel) -> MessageId? {
         // Return the oldest regular message if all messages are unread in the message list.
         let oldestRegularMessage: () -> MessageId? = { [weak self] in
             guard self?.hasLoadedAllPreviousMessages == true else {
@@ -1226,7 +1226,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
             return self?.messages.last(where: { $0.type == .regular || $0.type == .reply })?.id
         }
 
-        guard let currentUserRead = channel?.reads.first(where: {
+        guard let currentUserRead = channel.reads.first(where: {
             $0.user.id == client.currentUserId
         }) else {
             return oldestRegularMessage()

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -125,7 +125,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
 
     /// The id of the message which the current user last read.
     public var lastReadMessageId: MessageId? {
-        channel?.lastReadMessageId(userId: client.currentUserId)
+        client.currentUserId.flatMap { channel?.lastReadMessageId(userId: $0) }
     }
 
     /// A boolean indicating if the user marked the channel as unread in the current session
@@ -1678,7 +1678,7 @@ public extension ChatChannelController {
 }
 
 public extension ChatChannel {
-    func lastReadMessageId(userId: UserId?) -> MessageId? {
+    func lastReadMessageId(userId: UserId) -> MessageId? {
         guard let currentUserRead = reads.first(where: {
             $0.user.id == userId
         }) else {

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -441,7 +441,7 @@ class ChannelUpdater: Worker {
         userId: UserId,
         from messageId: MessageId,
         lastReadMessageId: MessageId?,
-        completion: ((Error?) -> Void)? = nil
+        completion: ((Result<ChatChannel, Error>) -> Void)? = nil
     ) {
         channelRepository.markUnread(
             for: cid,

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -590,7 +590,7 @@ private extension ChatChannelVC {
     }
 
     func updateJumpToUnreadRelatedComponents(channel: ChatChannel? = nil) {
-        let firstUnreadMessageId = channelController.getFirstUnreadMessageId(for: channel) ?? channelController.firstUnreadMessageId
+        let firstUnreadMessageId = channel.flatMap { channelController.getFirstUnreadMessageId(for: $0) } ?? channelController.firstUnreadMessageId
         let lastReadMessageId = client.currentUserId.flatMap { channel?.lastReadMessageId(userId: $0) } ?? channelController.lastReadMessageId
 
         messageListVC.updateJumpToUnreadMessageId(
@@ -601,7 +601,7 @@ private extension ChatChannelVC {
     }
 
     func updateUnreadMessagesBannerRelatedComponents(channel: ChatChannel? = nil) {
-        let firstUnreadMessageId = channelController.getFirstUnreadMessageId(for: channel) ?? channelController.firstUnreadMessageId
+        let firstUnreadMessageId = channel.flatMap { channelController.getFirstUnreadMessageId(for: $0) } ?? channelController.firstUnreadMessageId
         self.firstUnreadMessageId = firstUnreadMessageId
         messageListVC.updateUnreadMessagesSeparator(at: firstUnreadMessageId)
     }

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -391,8 +391,10 @@ open class ChatChannelVC: _ViewController,
             }
         case is MarkUnreadActionItem:
             dismiss(animated: true) { [weak self] in
-                self?.channelController.markUnread(from: message.id) { _ in
-                    self?.updateAllUnreadMessagesRelatedComponents()
+                self?.channelController.markUnread(from: message.id) { result in
+                    if case let .success(channel) = result {
+                        self?.updateAllUnreadMessagesRelatedComponents(channel: channel)
+                    }
                 }
             }
         default:
@@ -576,27 +578,32 @@ private extension ChatChannelVC {
         )
     }
 
-    func updateAllUnreadMessagesRelatedComponents() {
-        updateScrollToBottomButtonCount()
-        updateJumpToUnreadRelatedComponents()
-        updateUnreadMessagesBannerRelatedComponents()
+    func updateAllUnreadMessagesRelatedComponents(channel: ChatChannel? = nil) {
+        let firstUnreadMessageId = channelController.getFirstUnreadMessageId(for: channel)
+        updateScrollToBottomButtonCount(channel: channel)
+        updateJumpToUnreadRelatedComponents(channel: channel)
+        updateUnreadMessagesBannerRelatedComponents(channel: channel)
     }
 
-    func updateScrollToBottomButtonCount() {
-        let channelUnreadCount = channelController.channel?.unreadCount ?? .noUnread
+    func updateScrollToBottomButtonCount(channel: ChatChannel? = nil) {
+        let channelUnreadCount = (channel ?? channelController.channel)?.unreadCount ?? .noUnread
         messageListVC.scrollToBottomButton.content = channelUnreadCount
     }
 
-    func updateJumpToUnreadRelatedComponents() {
+    func updateJumpToUnreadRelatedComponents(channel: ChatChannel? = nil) {
+        let firstUnreadMessageId = channelController.getFirstUnreadMessageId(for: channel) ?? channelController.firstUnreadMessageId
+        let lastReadMessageId = channel?.lastReadMessageId(userId: client.currentUserId) ?? channelController.lastReadMessageId
+
         messageListVC.updateJumpToUnreadMessageId(
-            channelController.firstUnreadMessageId,
-            lastReadMessageId: channelController.lastReadMessageId
+            firstUnreadMessageId,
+            lastReadMessageId: lastReadMessageId
         )
         messageListVC.updateJumpToUnreadButtonVisibility()
     }
 
-    func updateUnreadMessagesBannerRelatedComponents() {
-        firstUnreadMessageId = channelController.firstUnreadMessageId
+    func updateUnreadMessagesBannerRelatedComponents(channel: ChatChannel? = nil) {
+        let firstUnreadMessageId = channelController.getFirstUnreadMessageId(for: channel) ?? channelController.firstUnreadMessageId
+        self.firstUnreadMessageId = firstUnreadMessageId
         messageListVC.updateUnreadMessagesSeparator(at: firstUnreadMessageId)
     }
 }

--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -579,7 +579,6 @@ private extension ChatChannelVC {
     }
 
     func updateAllUnreadMessagesRelatedComponents(channel: ChatChannel? = nil) {
-        let firstUnreadMessageId = channelController.getFirstUnreadMessageId(for: channel)
         updateScrollToBottomButtonCount(channel: channel)
         updateJumpToUnreadRelatedComponents(channel: channel)
         updateUnreadMessagesBannerRelatedComponents(channel: channel)
@@ -592,7 +591,7 @@ private extension ChatChannelVC {
 
     func updateJumpToUnreadRelatedComponents(channel: ChatChannel? = nil) {
         let firstUnreadMessageId = channelController.getFirstUnreadMessageId(for: channel) ?? channelController.firstUnreadMessageId
-        let lastReadMessageId = channel?.lastReadMessageId(userId: client.currentUserId) ?? channelController.lastReadMessageId
+        let lastReadMessageId = client.currentUserId.flatMap { channel?.lastReadMessageId(userId: $0) } ?? channelController.lastReadMessageId
 
         messageListVC.updateJumpToUnreadMessageId(
             firstUnreadMessageId,

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/ChannelRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/ChannelRepository_Mock.swift
@@ -18,7 +18,7 @@ class ChannelRepository_Mock: ChannelRepository {
     var markUnreadUserId: UserId?
     var markUnreadMessageId: UserId?
     var markUnreadLastReadMessageId: UserId?
-    var markUnreadResult: Result<Void, Error>?
+    var markUnreadResult: Result<ChatChannel, Error>?
 
     override func markRead(cid: ChannelId, userId: UserId, completion: ((Error?) -> Void)? = nil) {
         markReadCid = cid
@@ -29,14 +29,14 @@ class ChannelRepository_Mock: ChannelRepository {
         }
     }
 
-    override func markUnread(for cid: ChannelId, userId: UserId, from messageId: MessageId, lastReadMessageId: MessageId?, completion: ((Error?) -> Void)? = nil) {
+    override func markUnread(for cid: ChannelId, userId: UserId, from messageId: MessageId, lastReadMessageId: MessageId?, completion: ((Result<ChatChannel, Error>) -> Void)? = nil) {
         markUnreadCid = cid
         markUnreadUserId = userId
         markUnreadMessageId = messageId
         markUnreadLastReadMessageId = lastReadMessageId
 
         markUnreadResult.map {
-            completion?($0.error)
+            completion?($0)
         }
     }
 }

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ChannelUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/ChannelUpdater_Mock.swift
@@ -81,7 +81,7 @@ final class ChannelUpdater_Mock: ChannelUpdater {
     @Atomic var markUnread_userId: UserId?
     @Atomic var markUnread_messageId: MessageId?
     @Atomic var markUnread_lastReadMessageId: MessageId?
-    @Atomic var markUnread_completion: ((Error?) -> Void)?
+    @Atomic var markUnread_completion: ((Result<ChatChannel, Error>) -> Void)?
 
     @Atomic var enableSlowMode_cid: ChannelId?
     @Atomic var enableSlowMode_cooldownDuration: Int?
@@ -359,7 +359,7 @@ final class ChannelUpdater_Mock: ChannelUpdater {
         markRead_completion = completion
     }
 
-    override func markUnread(cid: ChannelId, userId: UserId, from messageId: MessageId, lastReadMessageId: MessageId?, completion: ((Error?) -> Void)? = nil) {
+    override func markUnread(cid: ChannelId, userId: UserId, from messageId: MessageId, lastReadMessageId: MessageId?, completion: ((Result<ChatChannel, Error>) -> Void)? = nil) {
         markUnread_cid = cid
         markUnread_userId = userId
         markUnread_messageId = messageId

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -440,7 +440,7 @@ final class ChannelController_Tests: XCTestCase {
         let token = Token(rawValue: "", userId: userId, expiration: nil)
         controller.client.authenticationRepository.setMockToken(token)
 
-        try createChannel(oldestMessageId: oldestMessageId, newestMessageId: newestMessageId, channelReads: [channelRead])
+        createChannel(oldestMessageId: oldestMessageId, newestMessageId: newestMessageId, channelReads: [channelRead])
 
         try client.databaseContainer.writeSynchronously {
             try $0.saveCurrentUser(payload: .dummy(userId: userId, role: .user))
@@ -3958,8 +3958,8 @@ final class ChannelController_Tests: XCTestCase {
     func test_markUnread_whenChannelDoesNotExist() {
         var receivedError: Error?
         let expectation = self.expectation(description: "Mark Unread completes")
-        controller.markUnread(from: .unique) { error in
-            receivedError = error
+        controller.markUnread(from: .unique) { result in
+            receivedError = result.error
             expectation.fulfill()
         }
 
@@ -3979,8 +3979,8 @@ final class ChannelController_Tests: XCTestCase {
 
         var receivedError: Error?
         let expectation = self.expectation(description: "Mark Unread completes")
-        controller.markUnread(from: .unique) { error in
-            receivedError = error
+        controller.markUnread(from: .unique) { result in
+            receivedError = result.error
             expectation.fulfill()
         }
 
@@ -4034,8 +4034,8 @@ final class ChannelController_Tests: XCTestCase {
 
         var receivedError: Error?
         let expectation = self.expectation(description: "Mark Unread completes")
-        controller.markUnread(from: .unique) { error in
-            receivedError = error
+        controller.markUnread(from: .unique) { result in
+            receivedError = result.error
             expectation.fulfill()
         }
 
@@ -4055,8 +4055,8 @@ final class ChannelController_Tests: XCTestCase {
 
         var receivedError: Error?
         let expectation = self.expectation(description: "Mark Unread completes")
-        controller.markUnread(from: .unique) { error in
-            receivedError = error
+        controller.markUnread(from: .unique) { result in
+            receivedError = result.error
             expectation.fulfill()
         }
 
@@ -4076,12 +4076,12 @@ final class ChannelController_Tests: XCTestCase {
 
         var receivedError: Error?
         let expectation = self.expectation(description: "Mark Unread completes")
-        controller.markUnread(from: .unique) { error in
-            receivedError = error
+        controller.markUnread(from: .unique) { result in
+            receivedError = result.error
             expectation.fulfill()
         }
         let mockedError = TestError()
-        env.channelUpdater?.markUnread_completion?(mockedError)
+        env.channelUpdater?.markUnread_completion?(.failure(mockedError))
 
         waitForExpectations(timeout: defaultTimeout)
 
@@ -4100,13 +4100,13 @@ final class ChannelController_Tests: XCTestCase {
         var receivedError: Error?
         let messageId = MessageId.unique
         let expectation = self.expectation(description: "Mark Unread completes")
-        controller.markUnread(from: messageId) { error in
-            receivedError = error
+        controller.markUnread(from: messageId) { result in
+            receivedError = result.error
             expectation.fulfill()
         }
         let updater = try XCTUnwrap(env.channelUpdater)
 
-        updater.markUnread_completion?(nil)
+        updater.markUnread_completion?(.success(ChatChannel.mock(cid: .unique)))
 
         waitForExpectations(timeout: defaultTimeout)
 
@@ -4130,13 +4130,13 @@ final class ChannelController_Tests: XCTestCase {
 
         var receivedError: Error?
         let expectation = self.expectation(description: "Mark Unread completes")
-        controller.markUnread(from: messageId) { error in
-            receivedError = error
+        controller.markUnread(from: messageId) { result in
+            receivedError = result.error
             expectation.fulfill()
         }
         let updater = try XCTUnwrap(env.channelUpdater)
 
-        updater.markUnread_completion?(nil)
+        updater.markUnread_completion?(.success(ChatChannel.mock(cid: .unique)))
 
         waitForExpectations(timeout: defaultTimeout)
 

--- a/Tests/StreamChatTests/Models/ChatChannel_Tests.swift
+++ b/Tests/StreamChatTests/Models/ChatChannel_Tests.swift
@@ -285,6 +285,36 @@ final class ChatChannel_Tests: XCTestCase {
         XCTAssertEqual(channelWithoutCapability.isSlowMode, false)
     }
 
+    func test_lastReadMessageId_readsDontContainUser() {
+        let userId: UserId = "current"
+        let channel = ChatChannel.mock(cid: .unique, reads: [
+            .init(lastReadAt: Date(), lastReadMessageId: .unique, unreadMessagesCount: 3, user: .mock(id: "other"))
+        ])
+
+        XCTAssertNil(channel.lastReadMessageId(userId: userId))
+    }
+
+    func test_lastReadMessageId_userReadDoesNotHaveLastRead() {
+        let userId: UserId = "current"
+        let channel = ChatChannel.mock(cid: .unique, reads: [
+            .init(lastReadAt: Date(), lastReadMessageId: nil, unreadMessagesCount: 3, user: .mock(id: userId)),
+            .init(lastReadAt: Date(), lastReadMessageId: .unique, unreadMessagesCount: 3, user: .mock(id: "other"))
+        ])
+
+        XCTAssertNil(channel.lastReadMessageId(userId: userId))
+    }
+
+    func test_lastReadMessageId_userReadHasLastRead() {
+        let userId: UserId = "current"
+        let lastReadId = MessageId.unique
+        let channel = ChatChannel.mock(cid: .unique, reads: [
+            .init(lastReadAt: Date(), lastReadMessageId: lastReadId, unreadMessagesCount: 3, user: .mock(id: userId)),
+            .init(lastReadAt: Date(), lastReadMessageId: .unique, unreadMessagesCount: 3, user: .mock(id: "other"))
+        ])
+
+        XCTAssertEqual(channel.lastReadMessageId(userId: userId), lastReadId)
+    }
+
     private func setupChannel(withCapabilities capabilities: Set<ChannelCapability>) -> ChatChannel {
         .mock(
             cid: .unique,

--- a/Tests/StreamChatTests/Repositories/ChannelRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/ChannelRepository_Tests.swift
@@ -72,15 +72,21 @@ final class ChannelRepository_Tests: XCTestCase {
 
     // MARK: - Mark as unread
 
-    func test_markUnread_successfulResponse() {
+    func test_markUnread_successfulResponse() throws {
         let cid = ChannelId.unique
         let userId = UserId.unique
         let messageId = MessageId.unique
 
+        try database.createCurrentUser()
+        try database.writeSynchronously {
+            try $0.saveChannel(payload: .dummy(channel: .dummy(cid: cid)))
+        }
+        database.writeSessionCounter = 0
+
         let expectation = self.expectation(description: "markUnread completes")
         var receivedError: Error?
-        repository.markUnread(for: cid, userId: userId, from: messageId, lastReadMessageId: .unique) { error in
-            receivedError = error
+        repository.markUnread(for: cid, userId: userId, from: messageId, lastReadMessageId: .unique) { result in
+            receivedError = result.error
             expectation.fulfill()
         }
 
@@ -100,8 +106,8 @@ final class ChannelRepository_Tests: XCTestCase {
 
         let expectation = self.expectation(description: "markUnread completes")
         var receivedError: Error?
-        repository.markUnread(for: cid, userId: userId, from: messageId, lastReadMessageId: .unique) { error in
-            receivedError = error
+        repository.markUnread(for: cid, userId: userId, from: messageId, lastReadMessageId: .unique) { result in
+            receivedError = result.error
             expectation.fulfill()
         }
 

--- a/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
@@ -1472,9 +1472,9 @@ final class ChannelUpdater_Tests: XCTestCase {
         let expectation = self.expectation(description: "markUnread completes")
         var receivedError: Error?
 
-        channelRepository.markUnreadResult = .success(())
-        channelUpdater.markUnread(cid: .unique, userId: .unique, from: .unique, lastReadMessageId: .unique) { error in
-            receivedError = error
+        channelRepository.markUnreadResult = .success(.mock(cid: .unique))
+        channelUpdater.markUnread(cid: .unique, userId: .unique, from: .unique, lastReadMessageId: .unique) { result in
+            receivedError = result.error
             expectation.fulfill()
         }
 
@@ -1488,8 +1488,8 @@ final class ChannelUpdater_Tests: XCTestCase {
         var receivedError: Error?
 
         channelRepository.markUnreadResult = .failure(mockedError)
-        channelUpdater.markUnread(cid: .unique, userId: .unique, from: .unique, lastReadMessageId: .unique) { error in
-            receivedError = error
+        channelUpdater.markUnread(cid: .unique, userId: .unique, from: .unique, lastReadMessageId: .unique) { result in
+            receivedError = result.error
             expectation.fulfill()
         }
 


### PR DESCRIPTION
### 🔗 Issue Links

Closes https://github.com/GetStream/ios-issues-tracking/issues/652

### 🎯 Goal

Fix Mark as unread when Background Mapping is enabled

### 📝 Summary

We need to use the data that the API Request returns to us, instead of waiting for the delegate calls.
The most important thing here is that we cannot use the delegate calls because we cannot know if the update is from a “mark as unread” action or a different thing. If we just update the unread banner on the delegate call, we lose all the context as the channel will be marked as read, and the views would then disappear.

### 🛠 Implementation

- The completion of `markUnread(from:completion:)` moves from just returning the `Error` to returning a `Result` object with the data.
- `ChannelController.getFirstUnreadMessageId(for:)` is now public
- `Channel` exposes now a convenience function to get the lastReadMessageId based on a user id (`lastReadMessageId(userId:)`)

### 🧪 Manual Testing Notes

Precondition: BG Mapping Enabled

1. Open a channel with many messages
2. Mark a message as unread

Expected result:
- It should update the "Unread messages" banner to the right location

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/8dYmJ6Buo3lYY/giphy.gif)
