### PR TITLE
[Enhancement]Expose audioSessionConfiguration for the AudioPlayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### ✅ Added
+- A way to configure the object that configures the AudioSession when using VoiceRecordings. [#2919](https://github.com/GetStream/stream-chat-swift/pull/2919)
+
 ## StreamChatUI
 ### 🐞 Fixed
 - Fix date separator decoration view showing in the last message of the current page [#2899](https://github.com/GetStream/stream-chat-swift/pull/2899)

--- a/Sources/StreamChat/Audio/AudioPlayer/AudioPlaying.swift
+++ b/Sources/StreamChat/Audio/AudioPlayer/AudioPlaying.swift
@@ -61,7 +61,7 @@ open class StreamAudioPlayer: AudioPlaying, AppStateObserverDelegate {
     /// The player that will be used for the playback of the audio files
     fileprivate let player: AVPlayer
 
-    private let audioSessionConfigurator: AudioSessionConfiguring
+    private var audioSessionConfigurator: AudioSessionConfiguring
 
     /// The assetPropertyLoader is being used during the loading of an asset with non-nil URL, to provide
     /// async information about the asset's properties. Currently, we are only loading the `duration`
@@ -78,6 +78,7 @@ open class StreamAudioPlayer: AudioPlaying, AppStateObserverDelegate {
 
     // MARK: - Lifecycle
 
+    @available(*, deprecated, message: "You can use the Builder API to create a new instance of the player.")
     public required convenience init() {
         self.init(
             assetPropertyLoader: StreamAssetPropertyLoader(),
@@ -102,6 +103,15 @@ open class StreamAudioPlayer: AudioPlaying, AppStateObserverDelegate {
         self.appStateObserver = appStateObserver
 
         setUp()
+    }
+
+    /// Provides a way to customise of the underline audioSessionConfiguration, in order to allow extension
+    /// on the logic that handles the `AVAudioSession.shared`.
+    /// - Parameters:
+    ///     - audioSessionConfiguration: The new instance of the audioSessionConfigurator that will
+    ///     be used whenever the player needs to interact with the `AVAudioSession.shared`.
+    public func configure(_ audioSessionConfigurator: AudioSessionConfiguring) {
+        self.audioSessionConfigurator = audioSessionConfigurator
     }
 
     // MARK: - AudioPlaying

--- a/Sources/StreamChat/Audio/AudioPlayer/AudioPlaying.swift
+++ b/Sources/StreamChat/Audio/AudioPlayer/AudioPlaying.swift
@@ -78,7 +78,6 @@ open class StreamAudioPlayer: AudioPlaying, AppStateObserverDelegate {
 
     // MARK: - Lifecycle
 
-    @available(*, deprecated, message: "You can use the Builder API to create a new instance of the player.")
     public required convenience init() {
         self.init(
             assetPropertyLoader: StreamAssetPropertyLoader(),

--- a/Sources/StreamChat/Audio/AudioRecorder/AudioRecording.swift
+++ b/Sources/StreamChat/Audio/AudioRecorder/AudioRecording.swift
@@ -99,7 +99,7 @@ open class StreamAudioRecorder: NSObject, AudioRecording, AVAudioRecorderDelegat
 
     /// The `audioSessionConfigurator` will be called when the recorder needs to request or resign
     /// the permission to record from the current `AudioSession`
-    private let audioSessionConfigurator: AudioSessionConfiguring
+    private var audioSessionConfigurator: AudioSessionConfiguring
 
     /// A normaliser that will be responsible to polish the powering meters as they will be send by
     /// the AVAudioRecorder
@@ -181,6 +181,15 @@ open class StreamAudioRecorder: NSObject, AudioRecording, AVAudioRecorderDelegat
         super.init()
 
         setUp()
+    }
+
+    /// Provides a way to customise of the underline audioSessionConfiguration, in order to allow extension
+    /// on the logic that handles the `AVAudioSession.shared`.
+    /// - Parameters:
+    ///     - audioSessionConfiguration: The new instance of the audioSessionConfigurator that will
+    ///     be used whenever the player needs to interact with the `AVAudioSession.shared`.
+    public func configure(_ audioSessionConfigurator: AudioSessionConfiguring) {
+        self.audioSessionConfigurator = audioSessionConfigurator
     }
 
     // MARK: - AudioRecording

--- a/Sources/StreamChat/Audio/AudioSessionConfiguring.swift
+++ b/Sources/StreamChat/Audio/AudioSessionConfiguring.swift
@@ -86,14 +86,15 @@ open class StreamAudioSessionConfigurator: AudioSessionConfiguring {
         try deactivateSession()
     }
 
-    /// Calling this method should activate the provided `AVAudioSession` for playback.
+    /// Calling this method should activate the provided `AVAudioSession` for playback and record.
     ///
-    /// - Note: The method will check if the audioSession's category contains the `playback` capability
-    /// and if it doesn't it will activate it using the `.playback` category and `.default` for both mode
-    /// and policy.  OverrideOutputAudioPort is set to `.speaker`.
+    /// - Note: The method will check if the audioSession's category contains the `playAndRecord` capability
+    /// and if it doesn't it will activate it using the `.playbackAndRecord` category and `.default` for both mode
+    /// and policy.  OverrideOutputAudioPort is set to `.speaker`. The `record` capability is required
+    /// ensure that the output port can be set to `.speaker`.
     open func activatePlaybackSession() throws {
         try audioSession.setCategory(
-            .playback,
+            .playAndRecord,
             mode: .default,
             policy: .default,
             options: []

--- a/Sources/StreamChat/Audio/AudioSessionConfiguring.swift
+++ b/Sources/StreamChat/Audio/AudioSessionConfiguring.swift
@@ -7,7 +7,7 @@ import AVFoundation
 // MARK: - Protocol
 
 /// A protocol describing an object that can configure/interact with `AVAudioSession`
-protocol AudioSessionConfiguring {
+public protocol AudioSessionConfiguring {
     /// The required initialiser
     init()
 
@@ -35,19 +35,19 @@ protocol AudioSessionConfiguring {
 
 #if os(macOS) && !targetEnvironment(macCatalyst)
 /// An implementation where for macOS we don't have interactions with AVAudioSession as it's not available.
-final class StreamAudioSessionConfigurator: AudioSessionConfiguring {
-    func activateRecordingSession() throws { /* No-op */ }
+open class StreamAudioSessionConfigurator: AudioSessionConfiguring {
+    public func activateRecordingSession() throws { /* No-op */ }
 
-    func deactivateRecordingSession() throws { /* No-op */ }
+    public func deactivateRecordingSession() throws { /* No-op */ }
 
-    func activatePlaybackSession() throws { /* No-op */ }
+    public func activatePlaybackSession() throws { /* No-op */ }
 
-    func deactivatePlaybackSession() throws { /* No-op */ }
+    public func deactivatePlaybackSession() throws { /* No-op */ }
 
-    func requestRecordPermission(_ completionHandler: @escaping (Bool) -> Void) { completionHandler(true) }
+    public func requestRecordPermission(_ completionHandler: @escaping (Bool) -> Void) { completionHandler(true) }
 }
 #else
-final class StreamAudioSessionConfigurator: AudioSessionConfiguring {
+open class StreamAudioSessionConfigurator: AudioSessionConfiguring {
     /// The audioSession with which the configurator will interact.
     private let audioSession: AudioSessionProtocol
 
@@ -59,13 +59,13 @@ final class StreamAudioSessionConfigurator: AudioSessionConfiguring {
 
     // MARK: - AudioSessionConfigurator
 
-    required convenience init() {
+    public required convenience init() {
         self.init(AVAudioSession.sharedInstance())
     }
 
     /// - Note: This method is using the `.playAndRecord` category with the `.spokenAudio` mode.
     /// The preferredInput will be set to `.buildInMic` and overrideOutputAudioPort to `.speaker`.
-    func activateRecordingSession() throws {
+    open func activateRecordingSession() throws {
         try audioSession.setCategory(
             .playAndRecord,
             mode: .spokenAudio,
@@ -78,14 +78,14 @@ final class StreamAudioSessionConfigurator: AudioSessionConfiguring {
 
     /// - Note: The method will check if the audioSession's category contains the `record` capability
     /// and if it does it will deactivate it. Otherwise, no action will be performed.
-    func deactivateRecordingSession() throws {
+    open func deactivateRecordingSession() throws {
         try deactivateSession()
     }
 
     /// - Note: The method will check if the audioSession's category contains the `playback` capability
     /// and if it doesn't it will activate it using the `.playback` category and `.default` for both mode
     /// and policy.  OverrideOutputAudioPort is set to `.speaker`.
-    func activatePlaybackSession() throws {
+    open func activatePlaybackSession() throws {
         try audioSession.setCategory(
             .playAndRecord,
             mode: .default,
@@ -97,11 +97,11 @@ final class StreamAudioSessionConfigurator: AudioSessionConfiguring {
 
     /// - Note: The method will check if the audioSession's category contains the `playback` capability
     /// and if it does it will deactivate it. Otherwise, no action will be performed.
-    func deactivatePlaybackSession() throws {
+    open func deactivatePlaybackSession() throws {
         try deactivateSession()
     }
 
-    func requestRecordPermission(
+    open func requestRecordPermission(
         _ completionHandler: @escaping (Bool) -> Void
     ) {
         audioSession.requestRecordPermission { [weak self] in

--- a/Sources/StreamChat/Audio/AudioSessionConfiguring.swift
+++ b/Sources/StreamChat/Audio/AudioSessionConfiguring.swift
@@ -63,6 +63,8 @@ open class StreamAudioSessionConfigurator: AudioSessionConfiguring {
         self.init(AVAudioSession.sharedInstance())
     }
 
+    /// Calling this method should activate the provided `AVAudioSession` for recording and playback.
+    ///
     /// - Note: This method is using the `.playAndRecord` category with the `.spokenAudio` mode.
     /// The preferredInput will be set to `.buildInMic` and overrideOutputAudioPort to `.speaker`.
     open func activateRecordingSession() throws {
@@ -76,18 +78,22 @@ open class StreamAudioSessionConfigurator: AudioSessionConfiguring {
         try activateSession()
     }
 
+    /// Calling this method should deactivate the provided `AVAudioSession`.
+    ///
     /// - Note: The method will check if the audioSession's category contains the `record` capability
     /// and if it does it will deactivate it. Otherwise, no action will be performed.
     open func deactivateRecordingSession() throws {
         try deactivateSession()
     }
 
+    /// Calling this method should activate the provided `AVAudioSession` for playback.
+    ///
     /// - Note: The method will check if the audioSession's category contains the `playback` capability
     /// and if it doesn't it will activate it using the `.playback` category and `.default` for both mode
     /// and policy.  OverrideOutputAudioPort is set to `.speaker`.
     open func activatePlaybackSession() throws {
         try audioSession.setCategory(
-            .playAndRecord,
+            .playback,
             mode: .default,
             policy: .default,
             options: []
@@ -95,12 +101,21 @@ open class StreamAudioSessionConfigurator: AudioSessionConfiguring {
         try activateSession()
     }
 
+    /// Calling this method should deactivate the provided `AVAudioSession`.
+    ///
     /// - Note: The method will check if the audioSession's category contains the `playback` capability
     /// and if it does it will deactivate it. Otherwise, no action will be performed.
     open func deactivatePlaybackSession() throws {
         try deactivateSession()
     }
 
+    /// Requests recording permission from the underline `AVAudioSession` and invokes the provided
+    /// completionHandler whenever there is an available response.
+    ///
+    /// - Parameters:
+    ///     - completionHandler: The closure to call on the the `AVAudioSession` request returns
+    ///     with a response.
+    ///     - Note: The closure's invocation will be dispatched on the MainThread.
     open func requestRecordPermission(
         _ completionHandler: @escaping (Bool) -> Void
     ) {

--- a/Sources/StreamChat/Audio/AudioSessionConfiguring.swift
+++ b/Sources/StreamChat/Audio/AudioSessionConfiguring.swift
@@ -36,6 +36,8 @@ public protocol AudioSessionConfiguring {
 #if os(macOS) && !targetEnvironment(macCatalyst)
 /// An implementation where for macOS we don't have interactions with AVAudioSession as it's not available.
 open class StreamAudioSessionConfigurator: AudioSessionConfiguring {
+    public required init() {}
+
     public func activateRecordingSession() throws { /* No-op */ }
 
     public func deactivateRecordingSession() throws { /* No-op */ }

--- a/Tests/StreamChatTests/Audio/StreamAudioPlayer_Tests.swift
+++ b/Tests/StreamChatTests/Audio/StreamAudioPlayer_Tests.swift
@@ -80,6 +80,18 @@ final class StreamAudioPlayer_Tests: XCTestCase {
         XCTAssertNil(playerObserver.addStoppedPlaybackObserverWasCalledWithQueue)
     }
 
+    // MARK: - configureAudioSessionConfigurator
+
+    func test_configureAudioSessionConfigurator_onlyNewInstanceIsInvoked() {
+        let newAudioSessionConfigurator = MockAudioSessionConfigurator()
+        subject.configure(newAudioSessionConfigurator)
+
+        subject.play()
+
+        XCTAssertEqual(newAudioSessionConfigurator.recordedFunctions, ["activatePlaybackSession()"])
+        XCTAssertTrue(audioSessionConfigurator.recordedFunctions.isEmpty)
+    }
+
     // MARK: - periodicTimerObserver
 
     func test_periodicTimerObserver_isSeekingIsFalse_delegateWasUpdatedWithExpectedContext() {

--- a/Tests/StreamChatTests/Audio/StreamAudioRecorder_Tests.swift
+++ b/Tests/StreamChatTests/Audio/StreamAudioRecorder_Tests.swift
@@ -37,6 +37,22 @@ final class StreamAudioRecorder_Tests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - configureAudioSessionConfigurator
+
+    func test_configureAudioSessionConfigurator_onlyNewInstanceIsInvoked() {
+        setAudioRecorder()
+        let newAudioSessionConfigurator = MockAudioSessionConfigurator()
+        subject.configure(newAudioSessionConfigurator)
+
+        subject.beginRecording {}
+
+        XCTAssertEqual(newAudioSessionConfigurator.recordedFunctions, [
+            "activateRecordingSession()",
+            "requestRecordPermission(_:)"
+        ])
+        XCTAssertTrue(audioSessionConfigurator.recordedFunctions.isEmpty)
+    }
+
     // MARK: - beginRecording
 
     func test_beginRecording_audioSessionConfiguratorThrowsAnError_callsDidFailWithErrorOnDelegate() throws {

--- a/Tests/StreamChatTests/Audio/StreamAudioSessionConfigurator_Tests.swift
+++ b/Tests/StreamChatTests/Audio/StreamAudioSessionConfigurator_Tests.swift
@@ -171,7 +171,7 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
 
         try subject.activatePlaybackSession()
 
-        XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithCategory, .playback)
+        XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithCategory, .playAndRecord)
         XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithMode, .default)
         XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithPolicy, .default)
         XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithOptions, [])

--- a/Tests/StreamChatTests/Audio/StreamAudioSessionConfigurator_Tests.swift
+++ b/Tests/StreamChatTests/Audio/StreamAudioSessionConfigurator_Tests.swift
@@ -171,7 +171,7 @@ final class StreamAudioSessionConfigurator_Tests: XCTestCase {
 
         try subject.activatePlaybackSession()
 
-        XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithCategory, .playAndRecord)
+        XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithCategory, .playback)
         XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithMode, .default)
         XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithPolicy, .default)
         XCTAssertEqual(stubAudioSession.setCategoryWasCalledWithOptions, [])

--- a/docusaurus/docs/iOS/client/audio-support/audio-playback.md
+++ b/docusaurus/docs/iOS/client/audio-support/audio-playback.md
@@ -42,6 +42,10 @@ Updates the loaded asset's playback rate to the provided one.
 #### `func seek(to:)`
 Performs a seek in the loaded asset's timeline at the provided time.
 
+#### `configure(_ audioSessionConfigurator: AudioSessionConfiguring)`
+
+The default object that interacts with the `AVAudioSession`, assumes that it's the only one that manages the `AVAudioSession` shared instance. In scenarios where that's not the case (for example, you have an active audio session going on because of audio/video call), you can use this method to provide a another instance that will be aware of all related features and will act as the central point of `AVAudioSession` configuration between Stream VoiceRecording feature and any other feature that uses the `AVAudioSession`.
+
 ### Receiving updates
 
 By calling `subscribe(_ subscriber: AudioPlayingDelegate)` we are subscribing to receive updates from the `AudioPlaying` instance. Those updates include information about:

--- a/docusaurus/docs/iOS/client/audio-support/audio-recording.md
+++ b/docusaurus/docs/iOS/client/audio-support/audio-recording.md
@@ -62,6 +62,10 @@ It will stop the current recording and inform the `AVAudioSession` that recordin
 
 They will pause and resume respectively, the current recording.
 
+#### `configure(_ audioSessionConfigurator: AudioSessionConfiguring)`
+
+The default object that interacts with the `AVAudioSession`, assumes that it's the only one that manages the `AVAudioSession` shared instance. In scenarios where that's not the case (for example, you have an active audio session going on because of audio/video call), you can use this method to provide a another instance that will be aware of all related features and will act as the central point of `AVAudioSession` configuration between Stream VoiceRecording feature and any other feature that uses the `AVAudioSession`.
+
 ### Receiving updates
 By calling `subscribe(_ subscriber: AudioRecordingDelegate)` we are subscribing to receive updates from the `AudioRecording` instance. Those updates include information about:
 - Active recording and its properties (for example its duration, state and [average power](https://developer.apple.com/documentation/avfaudio/avaudiorecorder/1387176-averagepowerforchannel))


### PR DESCRIPTION
### 🎯 Goal

Allow VoiceRecording feature to work aside with any other stack that also uses/manipulates the shared AVAudioSession instace.

### 📝 Summary

In a WebRTC stack (which controls the AVAudioSession) if the user tries to send a VoiceRecording (chat during a voice/video call), once the message recording finishes, our AudioPlayer & AudioRecorder will try to mark the shared AVAudioSession as deactivated. That causes a conflict with the WebRTC stack which still requires the session to be activated.

### 🛠 Implementation

The AudioSession handling as an implementation of our StreamAudioPlayer and StreamAudioRecorder (and not of them conforming protocols, AudioPlaying and AudioRecording). For this reason, we added a public method which can be used to update the underline `audioSessionConfigurator` on both classes. 

### 🎨 Showcase

An example of usage is the following:
#### Step 1. Create our custom AudioSessionConfigurator
```swift
final class DemoAudioSessionConfigurator: AudioSessionConfiguring {

    private let audioSessionConfigurator: StreamAudioSessionConfigurator

    init() {
        self.audioSessionConfigurator = StreamAudioSessionConfigurator()
    }

    func activateRecordingSession() throws {
        try audioSessionConfigurator.activateRecordingSession()
    }
    
    func deactivateRecordingSession() throws {
//        guard !WebRTCSessionIsActive else {
//            return
//        }
        try audioSessionConfigurator.deactivateRecordingSession()
    }
    
    func activatePlaybackSession() throws {
        try audioSessionConfigurator.activatePlaybackSession()
    }
    
    func deactivatePlaybackSession() throws {
//        guard !WebRTCSessionIsActive else {
//            return
//        }
        try audioSessionConfigurator.deactivatePlaybackSession()
    }
    
    func requestRecordPermission(_ completionHandler: @escaping (Bool) -> Void) {
        audioSessionConfigurator.requestRecordPermission(completionHandler)
    }
}
```

#### Step 2. Update the AudioPlayer instance with our AudioSessionConfigurator
For this step we need to add the following line in our subclass of `ChatChannelVC`
```swift
final class MyChatChannelVC: ChatChannelVC {
...

override func viewDidLoad() {
    ...
    let audioSessionConfigurator = DemoAudioSessionConfigurator()
    // Update the audioPlayer
    (audioPlayer as? StreamAudioPlayer)?.configure(audioSessionConfigurator)
    // Update the audioRecorder
    (messageComposerVC.voiceRecordingVC.audioRecorder as? StreamAudioRecorder).configure(audioSessionConfigurator)
}

...
}
```

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
