### PR TITLE
[Background Mapping] Do not use BG Mapping for CurrentUserController

### DIFF
--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -256,12 +256,11 @@ public extension CurrentChatUserController {
 extension CurrentChatUserController {
     struct Environment {
         var currentUserObserverBuilder: (
-            _ isBackgroundMappingEnabled: Bool,
-            _ databaseContainer: DatabaseContainer,
+            _ context: NSManagedObjectContext,
             _ fetchRequest: NSFetchRequest<CurrentUserDTO>,
             _ itemCreator: @escaping (CurrentUserDTO) throws -> CurrentChatUser,
             _ fetchedResultsControllerType: NSFetchedResultsController<CurrentUserDTO>.Type
-        ) -> EntityDatabaseObserverWrapper<CurrentChatUser, CurrentUserDTO> = EntityDatabaseObserverWrapper.init
+        ) -> EntityDatabaseObserver<CurrentChatUser, CurrentUserDTO> = EntityDatabaseObserver.init
 
         var currentUserUpdaterBuilder = CurrentUserUpdater.init
     }
@@ -283,10 +282,9 @@ private extension EntityChange where Item == UnreadCount {
 }
 
 private extension CurrentChatUserController {
-    func createUserObserver() -> EntityDatabaseObserverWrapper<CurrentChatUser, CurrentUserDTO> {
+    func createUserObserver() -> EntityDatabaseObserver<CurrentChatUser, CurrentUserDTO> {
         environment.currentUserObserverBuilder(
-            StreamRuntimeCheck._isBackgroundMappingEnabled,
-            client.databaseContainer,
+            client.databaseContainer.viewContext,
             CurrentUserDTO.defaultFetchRequest,
             { try $0.asModel() },
             NSFetchedResultsController<CurrentUserDTO>.self

--- a/Tests/StreamChatTests/Controllers/CurrentUserController/CurrentUserController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/CurrentUserController/CurrentUserController_Tests.swift
@@ -747,7 +747,7 @@ final class CurrentUserController_Tests: XCTestCase {
 }
 
 private class TestEnvironment {
-    var currentUserObserver: EntityDatabaseObserverWrapper_Mock<CurrentChatUser, CurrentUserDTO>!
+    var currentUserObserver: EntityDatabaseObserver_Mock<CurrentChatUser, CurrentUserDTO>!
     var currentUserObserverItem: CurrentChatUser?
     var currentUserObserverStartUpdatingError: Error?
 
@@ -755,7 +755,7 @@ private class TestEnvironment {
 
     lazy var currentUserControllerEnvironment: CurrentChatUserController
         .Environment = .init(currentUserObserverBuilder: { [unowned self] in
-            self.currentUserObserver = .init(isBackground: $0, database: $1, fetchRequest: $2, itemCreator: $3, fetchedResultsControllerType: $4)
+            self.currentUserObserver = .init(context: $0, fetchRequest: $1, itemCreator: $2, fetchedResultsControllerType: $3)
             self.currentUserObserver.synchronizeError = self.currentUserObserverStartUpdatingError
             self.currentUserObserver.item_mock = self.currentUserObserverItem
             return self.currentUserObserver!


### PR DESCRIPTION
### 🔗 Issue Links

N/A

### 🎯 Goal

Make sure `currentUser` data is available synchronously when accessing `client.currentUserController()`

### 📝 Summary

Based on the usage of certain clients, we see that they expect that accessing `client.currentUserController().currentUser` should synchronously return the object. This was, though, not true when BackgroundMapping was enabled.

This PR reverts this so that we can still honor this usage

### 🛠 Implementation

User `EntityDatabaseObserver` instead of `EntityDatabaseObserverWrapper` in `CurrentUserController`

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/ghVtt3BfMwYhi/giphy.gif)
