### PR TITLE
[Background Mapping] Avoid crash when accessing DTOs while DB is being recreated

### DIFF
--- a/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
@@ -191,7 +191,8 @@ class BackgroundDatabaseObserver<Item, DTO: NSManagedObject> {
 
         var items: [Item?] = []
         items = objects.map { [weak self] in
-            try? self?.itemCreator($0)
+            guard $0.isValid else { return nil }
+            return try? self?.itemCreator($0)
         }
 
         let sorting = self.sorting

--- a/Sources/StreamChat/Controllers/DatabaseObserver/DatabaseObserverRemovalListener.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/DatabaseObserverRemovalListener.swift
@@ -11,6 +11,7 @@ protocol DatabaseObserverRemovalListener: AnyObject {
 
 extension DatabaseObserverRemovalListener {
     func listenForRemoveAllDataNotifications<Item, DTO: NSManagedObject>(
+        updateIsDeleting: @escaping (Bool) -> Void,
         isBackground: Bool,
         frc: NSFetchedResultsController<DTO>,
         changeAggregator: ListChangeAggregator<DTO, Item>,
@@ -28,6 +29,7 @@ extension DatabaseObserverRemovalListener {
             object: context,
             queue: .main
         ) { [weak frc, weak context, weak changeAggregator] _ in
+            updateIsDeleting(true)
             guard let frc = frc, let context = context, let changeAggregator = changeAggregator else { return }
             guard let fetchResultsController = frc as? NSFetchedResultsController<NSFetchRequestResult> else { return }
 
@@ -68,6 +70,7 @@ extension DatabaseObserverRemovalListener {
             object: context,
             queue: .main
         ) { _ in
+            updateIsDeleting(false)
             onCompletion()
         }
 
@@ -75,5 +78,22 @@ extension DatabaseObserverRemovalListener {
             notificationCenter?.removeObserver(willRemoveAllDataNotificationObserver)
             notificationCenter?.removeObserver(didRemoveAllDataNotificationObserver)
         }
+    }
+
+    func listenForRemoveAllDataNotifications<Item, DTO: NSManagedObject>(
+        isBackground: Bool,
+        frc: NSFetchedResultsController<DTO>,
+        changeAggregator: ListChangeAggregator<DTO, Item>,
+        onItemsRemoval: @escaping (@escaping () -> Void) -> Void,
+        onCompletion: @escaping () -> Void
+    ) {
+        listenForRemoveAllDataNotifications(
+            updateIsDeleting: { _ in },
+            isBackground: isBackground,
+            frc: frc,
+            changeAggregator: changeAggregator,
+            onItemsRemoval: onItemsRemoval,
+            onCompletion: onCompletion
+        )
     }
 }

--- a/Sources/StreamChat/Controllers/DatabaseObserver/DatabaseObserverRemovalListener.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/DatabaseObserverRemovalListener.swift
@@ -11,10 +11,10 @@ protocol DatabaseObserverRemovalListener: AnyObject {
 
 extension DatabaseObserverRemovalListener {
     func listenForRemoveAllDataNotifications<Item, DTO: NSManagedObject>(
-        updateIsDeleting: @escaping (Bool) -> Void,
         isBackground: Bool,
         frc: NSFetchedResultsController<DTO>,
         changeAggregator: ListChangeAggregator<DTO, Item>,
+        onStart: @escaping () -> Void,
         onItemsRemoval: @escaping (@escaping () -> Void) -> Void,
         onCompletion: @escaping () -> Void
     ) {
@@ -29,9 +29,9 @@ extension DatabaseObserverRemovalListener {
             object: context,
             queue: .main
         ) { [weak frc, weak context, weak changeAggregator] _ in
-            updateIsDeleting(true)
             guard let frc = frc, let context = context, let changeAggregator = changeAggregator else { return }
             guard let fetchResultsController = frc as? NSFetchedResultsController<NSFetchRequestResult> else { return }
+            onStart()
 
             let removeItems = {
                 // Simulate ChangeObserver callbacks like all data are being removed
@@ -70,7 +70,6 @@ extension DatabaseObserverRemovalListener {
             object: context,
             queue: .main
         ) { _ in
-            updateIsDeleting(false)
             onCompletion()
         }
 
@@ -88,10 +87,10 @@ extension DatabaseObserverRemovalListener {
         onCompletion: @escaping () -> Void
     ) {
         listenForRemoveAllDataNotifications(
-            updateIsDeleting: { _ in },
             isBackground: isBackground,
             frc: frc,
             changeAggregator: changeAggregator,
+            onStart: {},
             onItemsRemoval: onItemsRemoval,
             onCompletion: onCompletion
         )


### PR DESCRIPTION
### 🔗 Issue Links

https://github.com/GetStream/ios-issues-tracking/issues/625

### 🎯 Goal

Avoid crash when accessing DTOs from BackgroundDatabaseObserver while DB is being recreated

### 📝 Summary

There can be cases in which, because of the async nature of BackgroundDatabaseObserver, we can access a DTO that is no longer part of the DB if this one is being recreated. This can be reproduced in some cases when logging in and out pretty fast multiple times.

### 🛠 Implementation

This PR adds a thread guarded property (isDeletingDatabase) to BackgroundDatabaseObserver which will block any access to DTOs while the DB is being recreated.

### 🧪 Manual Testing Notes

Log in and out pretty fast multiple times

Expected result:
No crashes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![](https://media.giphy.com/media/10Mn81By5JVRnO/giphy.gif)