### PR TITLE
Fix `_dispatch_lane_resume` crash in RepeatingTimer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### 🐞 Fixed
 - Fix duplicated Runpath Search Paths [#2937](https://github.com/GetStream/stream-chat-swift/pull/2937)
+- Fix `_dispatch_lane_resume` crash in `RepeatingTimer` [#2938](https://github.com/GetStream/stream-chat-swift/pull/2938)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChat/Utils/Timers.swift
+++ b/Sources/StreamChat/Utils/Timers.swift
@@ -98,7 +98,9 @@ private class RepeatingTimer: RepeatingTimerControl {
         timer.cancel()
         // If the timer is suspended, calling cancel without resuming
         // triggers a crash. This is documented here https://forums.developer.apple.com/thread/15902
-        timer.resume()
+        if state == .suspended {
+            timer.resume()
+        }
     }
 
     func resume() {

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1407,6 +1407,7 @@
 		ADE40043291B1A510000C98B /* AttachmentUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE40042291B1A510000C98B /* AttachmentUploader.swift */; };
 		ADE40044291B1A510000C98B /* AttachmentUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE40042291B1A510000C98B /* AttachmentUploader.swift */; };
 		ADE88A142949453200C0F084 /* ChatMessageListRouter_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE88A132949453200C0F084 /* ChatMessageListRouter_Mock.swift */; };
+		ADEDA1FA2B2BC46C00020460 /* RepeatingTimer_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEDA1F92B2BC46C00020460 /* RepeatingTimer_Tests.swift */; };
 		ADEE651829BF712D00186129 /* ChatMessageListView_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEE651429BF711200186129 /* ChatMessageListView_Mock.swift */; };
 		ADEE651929BF713200186129 /* ChatMessageCell_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEE651629BF712500186129 /* ChatMessageCell_Mock.swift */; };
 		ADEE651E29BF715600186129 /* ChatMessageListVCDelegate_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEE651C29BF715300186129 /* ChatMessageListVCDelegate_Mock.swift */; };
@@ -3872,6 +3873,7 @@
 		ADE88A132949453200C0F084 /* ChatMessageListRouter_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListRouter_Mock.swift; sourceTree = "<group>"; };
 		ADEA7F21261D2F8C00CA2289 /* chewbacca.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = chewbacca.jpg; sourceTree = "<group>"; };
 		ADEA7F22261D2F8C00CA2289 /* r2.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = r2.jpg; sourceTree = "<group>"; };
+		ADEDA1F92B2BC46C00020460 /* RepeatingTimer_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatingTimer_Tests.swift; sourceTree = "<group>"; };
 		ADEE651429BF711200186129 /* ChatMessageListView_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListView_Mock.swift; sourceTree = "<group>"; };
 		ADEE651629BF712500186129 /* ChatMessageCell_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageCell_Mock.swift; sourceTree = "<group>"; };
 		ADEE651A29BF714300186129 /* ChatMessageListVCDataSource_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListVCDataSource_Mock.swift; sourceTree = "<group>"; };
@@ -6833,6 +6835,7 @@
 		A364D0BB27D12AD50029857A /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				ADEDA1F92B2BC46C00020460 /* RepeatingTimer_Tests.swift */,
 				40D3962B2A0910CF0020DDC9 /* ArraySampling_Tests.swift */,
 				CF1F1D442824243F002E2977 /* CooldownTracker_Tests.swift */,
 				40789D3E29F6AFC40018C2BB /* Debouncer_Tests.swift */,
@@ -10806,6 +10809,7 @@
 				AD45333A25D153CF00CD9D47 /* ConnectionController+SwiftUI_Tests.swift in Sources */,
 				8A0D64AE24E5853F0017A3C0 /* DataController_Tests.swift in Sources */,
 				8486CAF926FA51EE00A9AD96 /* EventDTOConverterMiddleware_Tests.swift in Sources */,
+				ADEDA1FA2B2BC46C00020460 /* RepeatingTimer_Tests.swift in Sources */,
 				C14A46562845064E00EF498E /* ThreadSafeWeakCollection_Tests.swift in Sources */,
 				ADC40C3226E26E9F005B616C /* UserSearchController_Tests.swift in Sources */,
 				40D3962C2A0910CF0020DDC9 /* ArraySampling_Tests.swift in Sources */,

--- a/Tests/StreamChatTests/Utils/RepeatingTimer_Tests.swift
+++ b/Tests/StreamChatTests/Utils/RepeatingTimer_Tests.swift
@@ -1,0 +1,40 @@
+//
+// Copyright © 2023 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class RepeatingTimer_Tests: XCTestCase {
+    func test_state_isThreadSafe() {
+        DispatchQueue.concurrentPerform(iterations: 10000) { _ in
+            let repeatingTimer: RepeatingTimerControl? = DefaultTimer.scheduleRepeating(
+                timeInterval: 0.4,
+                queue: .main,
+                onFire: {}
+            )
+            repeatingTimer?.resume()
+            repeatingTimer?.suspend()
+        }
+    }
+
+    func test_deinit_whenResumed_doesNotCrash() {
+        var repeatingTimer: RepeatingTimerControl? = DefaultTimer.scheduleRepeating(
+            timeInterval: 0.4,
+            queue: .main,
+            onFire: {}
+        )
+        repeatingTimer?.resume()
+        repeatingTimer = nil
+    }
+    
+    func test_deinit_whenSuspended_doesNotCrash() {
+        var repeatingTimer: RepeatingTimerControl? = DefaultTimer.scheduleRepeating(
+            timeInterval: 0.4,
+            queue: .main,
+            onFire: {}
+        )
+        repeatingTimer?.suspend()
+        repeatingTimer = nil
+    }
+}

--- a/Tests/StreamChatTests/WebSocketClient/WebSocketPingController_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/WebSocketPingController_Tests.swift
@@ -51,6 +51,16 @@ final class WebSocketPingController_Tests: XCTestCase {
         XCTAssertEqual(delegate.sendPing_calledCount, oldPingCount)
     }
 
+    func test_concurrent() {
+        DispatchQueue.concurrentPerform(iterations: 20000) { _ in
+            let repeatingTimer: RepeatingTimerControl? = DefaultTimer.scheduleRepeating(timeInterval: 0.4, queue: .main) {
+                print("test")
+            }
+            repeatingTimer?.resume()
+            repeatingTimer?.suspend()
+        }
+    }
+
     func test_disconnectOnNoPongReceived_called_whenNoPongReceived() throws {
         // Set the connection state as connected
         pingController.connectionStateDidChange(.connected(connectionId: .unique))

--- a/Tests/StreamChatTests/WebSocketClient/WebSocketPingController_Tests.swift
+++ b/Tests/StreamChatTests/WebSocketClient/WebSocketPingController_Tests.swift
@@ -51,16 +51,6 @@ final class WebSocketPingController_Tests: XCTestCase {
         XCTAssertEqual(delegate.sendPing_calledCount, oldPingCount)
     }
 
-    func test_concurrent() {
-        DispatchQueue.concurrentPerform(iterations: 20000) { _ in
-            let repeatingTimer: RepeatingTimerControl? = DefaultTimer.scheduleRepeating(timeInterval: 0.4, queue: .main) {
-                print("test")
-            }
-            repeatingTimer?.resume()
-            repeatingTimer?.suspend()
-        }
-    }
-
     func test_disconnectOnNoPongReceived_called_whenNoPongReceived() throws {
         // Set the connection state as connected
         pingController.connectionStateDidChange(.connected(connectionId: .unique))


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/676

### 🎯 Goal
Fixes a crash in `RepeatingTimer`. The root cause is because of a double `resume()` call. Although we had protections against this, the reason this still happens very rarely is because this class is called from multiple threads, and so the way to fix it is to make sure the state is accessed in a serial queue.

### 🧪 Manual Testing Notes
N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)