### PR TITLE
Fix jumping to bottom when loading new messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix duplicated Runpath Search Paths [#2937](https://github.com/GetStream/stream-chat-swift/pull/2937)
 - Fix file attachments not rendering file size [#2941](https://github.com/GetStream/stream-chat-swift/pull/2941)
+- Fix jumping to bottom when loading new messages [#2945](https://github.com/GetStream/stream-chat-swift/pull/2945)
 
 # [4.45.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.45.0)
 _December 11, 2023_

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -1177,12 +1177,14 @@ private extension ChatMessageListVC {
     }
 
     // Scroll to the bottom if the new message was sent by
-    // the current user, or moved by the current user, and the first page is loaded.
+    // the current user, or moved by the current user (ex: Giphy publish),
+    // and the first page is loaded.
     func scrollToBottomIfNeeded(with changes: [ListChange<ChatMessage>], newestChange: ListChange<ChatMessage>?) {
         guard isFirstPageLoaded else { return }
         guard let newMessage = newestChange?.item else { return }
-        let newestChangeIsInsertionOrMove = newestChange?.isInsertion == true || newestChange?.isMove == true
-        if newestChangeIsInsertionOrMove && newMessage.isSentByCurrentUser {
+        let numberOfInsertions = changes.filter(\.isInsertion).count
+        let isNewMessage = newestChange?.isInsertion == true && numberOfInsertions == 1
+        if (isNewMessage || newestChange?.isMove == true) && newMessage.isSentByCurrentUser {
             scrollToBottom()
         }
     }

--- a/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatMessageList/ChatMessageListVC_Tests.swift
@@ -475,7 +475,21 @@ final class ChatMessageListVC_Tests: XCTestCase {
         XCTAssertEqual(mockedListView.scrollToBottomCallCount, 1)
     }
 
-    func test_updateMessages_whenNewestMessageMovedByCurrentUser_whenFistPageNotLoaded_shouldScrollToBottom() {
+    func test_updateMessages_whenNewestMessageInsertedByCurrentUser_whenMultipleInsertions_shouldScrollToBottom() {
+        mockedDataSource.mockedIsFirstPageLoaded = true
+        mockedListView.mockIsLastCellFullyVisible = true
+
+        sut.updateMessages(with: [
+            .insert(.mock(isSentByCurrentUser: false), index: .init(item: 0, section: 0)),
+            .insert(.mock(isSentByCurrentUser: false), index: .init(item: 0, section: 0)),
+            .insert(.mock(isSentByCurrentUser: true), index: .init(item: 0, section: 0))
+        ])
+        mockedListView.updateMessagesCompletion?()
+
+        XCTAssertEqual(mockedListView.scrollToBottomCallCount, 0)
+    }
+
+    func test_updateMessages_whenNewestMessageMovedByCurrentUser_whenFistPageNotLoaded_shouldNotScrollToBottom() {
         mockedDataSource.mockedIsFirstPageLoaded = false
         mockedListView.mockIsLastCellFullyVisible = true
 


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/682

### 🎯 Goal
Fix the message list jumping to the bottom when loading new messages.

 Before, whenever the newest message inserted was from the current user, we would scroll to the bottom. This is incorrect, since when loading new messages, if the last message author, is the current user, it will scroll to it. Now, it will only scroll if there is one insertion, which is what happens when the current user creates a new message. 

### 🧪 Manual Testing Notes

1. Jump to a mid-page
2. Load new pages (Scroll to the bottom)
3. When loading the newest page the newest message is by the current logged-in user
4. The message list should not scroll to the bottom automatically

**Note:** The difference is not very noticeable sometimes. This issue also fixes another case where sometimes if a channel was opened and then quickly scrolling to the top, would unwillingly scroll to the bottom. 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)