### PR TITLE
Fix quoted chat message view with wrong text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix duplicated Runpath Search Paths [#2937](https://github.com/GetStream/stream-chat-swift/pull/2937)
 - Fix file attachments not rendering file size [#2941](https://github.com/GetStream/stream-chat-swift/pull/2941)
+- Fix quoted chat message view with wrong text [#2946](https://github.com/GetStream/ios-issues-tracking/issues/683)
 
 # [4.45.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.45.0)
 _December 11, 2023_

--- a/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.swift
+++ b/Sources/StreamChatUI/CommonViews/QuotedChatMessageView/QuotedChatMessageView.swift
@@ -163,17 +163,11 @@ open class QuotedChatMessageView: _View, ThemeProvider, SwiftUIRepresentable {
         guard let message = content?.message else { return }
         guard let avatarAlignment = content?.avatarAlignment else { return }
 
-        if let currentUserLang = content?.channel?.membership?.language,
-           let translatedText = content?.message.translatedText(for: currentUserLang) {
-            textView.text = translatedText
-        } else {
-            textView.text = message.text
-        }
-
         contentContainerView.backgroundColor = message.linkAttachments.isEmpty
             ? appearance.colorPalette.popoverBackground
             : appearance.colorPalette.highlightedAccentBackground1
-
+        
+        textView.text = message.text
         setAvatar(imageUrl: message.author.imageURL)
         setAvatarAlignment(avatarAlignment)
 
@@ -182,6 +176,11 @@ open class QuotedChatMessageView: _View, ThemeProvider, SwiftUIRepresentable {
         } else {
             setAttachmentPreview(for: message)
             showAttachmentPreview()
+        }
+
+        if let currentUserLang = content?.channel?.membership?.language,
+           let translatedText = content?.message.translatedText(for: currentUserLang) {
+            textView.text = translatedText
         }
     }
 
@@ -232,15 +231,11 @@ open class QuotedChatMessageView: _View, ThemeProvider, SwiftUIRepresentable {
         if let filePayload = message.fileAttachments.first?.payload {
             attachmentPreviewView.contentMode = .scaleAspectFit
             attachmentPreviewView.image = appearance.images.fileIcons[filePayload.file.type] ?? appearance.images.fileFallback
-            if textView.text.isEmpty {
-                textView.text = filePayload.title
-            }
+            textView.text = message.text.isEmpty ? filePayload.title : message.text
         } else if let imagePayload = message.imageAttachments.first?.payload {
             attachmentPreviewView.contentMode = .scaleAspectFill
             setAttachmentPreviewImage(url: imagePayload.imageURL)
-            if textView.text.isEmpty {
-                textView.text = L10n.Composer.QuotedMessage.photo
-            }
+            textView.text = message.text.isEmpty ? L10n.Composer.QuotedMessage.photo : message.text
         } else if let linkPayload = message.linkAttachments.first?.payload {
             attachmentPreviewView.contentMode = .scaleAspectFill
             setAttachmentPreviewImage(url: linkPayload.previewURL)
@@ -248,18 +243,14 @@ open class QuotedChatMessageView: _View, ThemeProvider, SwiftUIRepresentable {
         } else if let giphyPayload = message.giphyAttachments.first?.payload {
             attachmentPreviewView.contentMode = .scaleAspectFill
             setAttachmentPreviewImage(url: giphyPayload.previewURL)
-            if textView.text.isEmpty {
-                textView.text = L10n.Composer.QuotedMessage.giphy
-            }
+            textView.text = message.text.isEmpty ? L10n.Composer.QuotedMessage.giphy : message.text
         } else if let videoPayload = message.videoAttachments.first?.payload {
             attachmentPreviewView.contentMode = .scaleAspectFill
+            textView.text = message.text.isEmpty ? videoPayload.title : message.text
             if let thumbnailURL = videoPayload.thumbnailURL {
                 setVideoAttachmentThumbnail(url: thumbnailURL)
             } else {
                 setVideoAttachmentPreviewImage(url: videoPayload.videoURL)
-            }
-            if textView.text.isEmpty {
-                textView.text = videoPayload.title
             }
         } else if let voiceRecordingPayload = message.voiceRecordingAttachments.first?.payload {
             voiceRecordingAttachmentQuotedPreview.content = .init(
@@ -272,6 +263,7 @@ open class QuotedChatMessageView: _View, ThemeProvider, SwiftUIRepresentable {
         } else {
             voiceRecordingAttachmentQuotedPreview.isHidden = true
             contentContainerView.isHidden = false
+            textView.text = nil
         }
     }
 


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/683

### 🎯 Goal

Fix quoted chat message view with wrong text.

The quoted chat message was using the `textView.text.isEmpty` to determine how to render text. Since this is used in a reusable cell, it would sometimes reproduce unexpected results.

### 🧪 Manual Testing Notes
This one was a bit hard to reproduce since it only happens when the cell is reused. 
Either way, we have plenty of snapshot testing covering the quoted messages. If the tests are green, it should not have any regressions. 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)