### PR TITLE
Allow editing pending messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### ✅ Added
+- Allow restarting pending attachments [#2958](https://github.com/GetStream/stream-chat-swift/pull/2958)
+
 ## StreamChatUI
 ### ✅ Added
 - Better support for custom mixed attachments rendering [#2947](https://github.com/GetStream/stream-chat-swift/pull/2947)
 - Add default rendering for unsupported attachments [#2948](https://github.com/GetStream/stream-chat-swift/pull/2948)
+- Allow editing pending messages [#2958](https://github.com/GetStream/stream-chat-swift/pull/2958)
 ### 🐞 Fixed
 - Fix deleted messages showing custom attachments [#2947](https://github.com/GetStream/stream-chat-swift/pull/2947)
 - Fix blocked messages showing attachments [#2947](https://github.com/GetStream/stream-chat-swift/pull/2947)

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -663,7 +663,7 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
         with id: AttachmentId,
         completion: ((Error?) -> Void)? = nil
     ) {
-        messageUpdater.restartFailedAttachmentUploading(with: id) { error in
+        messageUpdater.restartAttachmentUploading(with: id) { error in
             self.callback {
                 completion?(error)
             }

--- a/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/AttachmentDTO.swift
@@ -231,12 +231,6 @@ extension ClientError {
         }
     }
 
-    class AttachmentEditing: ClientError {
-        init(id: AttachmentId, reason: String) {
-            super.init("`AttachmentDTO` with id: \(id) can't be edited (\(reason))")
-        }
-    }
-
     class AttachmentDecoding: ClientError {}
 
     class AttachmentUploading: ClientError {

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -511,20 +511,13 @@ class MessageUpdater: Worker {
     /// - Parameters:
     ///   - id: The attachment identifier.
     ///   - completion: Called when the attachment database entity is updated. Called with `Error` if update fails.
-    func restartFailedAttachmentUploading(
+    func restartAttachmentUploading(
         with id: AttachmentId,
         completion: @escaping (Error?) -> Void
     ) {
         database.write({
             guard let attachmentDTO = $0.attachment(id: id) else {
                 throw ClientError.AttachmentDoesNotExist(id: id)
-            }
-
-            guard case .uploadingFailed = attachmentDTO.localState else {
-                throw ClientError.AttachmentEditing(
-                    id: id,
-                    reason: "uploading can be restarted for attachments in `.uploadingFailed` state only"
-                )
             }
 
             attachmentDTO.localState = .pendingUpload

--- a/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
+++ b/Sources/StreamChatUI/Utils/ChatMessage+Extensions.swift
@@ -12,7 +12,7 @@ public extension ChatMessage {
             return false
         }
 
-        return localState == nil || isLastActionFailed
+        return true
     }
 
     /// A boolean value that checks if the last action (`send`, `edit` or `delete`) on the message failed.

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/MessageUpdater_Mock.swift
@@ -320,7 +320,7 @@ final class MessageUpdater_Mock: MessageUpdater {
         unpinMessage_completion = completion
     }
 
-    override func restartFailedAttachmentUploading(
+    override func restartAttachmentUploading(
         with id: AttachmentId,
         completion: @escaping (Error?) -> Void
     ) {

--- a/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/MessageUpdater_Tests.swift
@@ -1989,59 +1989,18 @@ final class MessageUpdater_Tests: XCTestCase {
         }
     }
 
-    // MARK: - Restart failed attachment uploading
+    // MARK: - Restart attachment uploading
 
-    func test_restartFailedAttachmentUploading_propagatesAttachmentDoesNotExistError() throws {
+    func test_restartAttachmentUploading_propagatesAttachmentDoesNotExistError() throws {
         let error = try waitFor {
-            messageUpdater.restartFailedAttachmentUploading(with: .unique, completion: $0)
+            messageUpdater.restartAttachmentUploading(with: .unique, completion: $0)
         }
 
         // Assert `ClientError.AttachmentDoesNotExist` is propagated.
         XCTAssertTrue(error is ClientError.AttachmentDoesNotExist)
     }
 
-    func test_restartFailedAttachmentUploading_propagatesAttachmentEditingError() throws {
-        let cid: ChannelId = .unique
-        let messageId: MessageId = .unique
-        let attachmentId: AttachmentId = .init(cid: cid, messageId: messageId, index: 0)
-
-        // Create channel in database.
-        try database.createChannel(cid: cid, withMessages: false)
-        // Create message in database.
-        try database.createMessage(id: messageId, cid: cid)
-        // Create attachment in database.
-        try database.writeSynchronously {
-            try $0.createNewAttachment(
-                attachment: .mockFile,
-                id: attachmentId
-            )
-        }
-
-        let rejectedStates: [LocalAttachmentState?] = [
-            .pendingUpload,
-            .uploading(progress: .random(in: 0...1)),
-            .uploaded,
-            nil
-        ]
-
-        // Iterate through rejected for uploading restart states.
-        for state in rejectedStates {
-            // Apply rejected state.
-            try database.writeSynchronously {
-                $0.attachment(id: attachmentId)?.localState = state
-            }
-
-            // Try to restart uploading and catch the error.
-            let error = try waitFor {
-                messageUpdater.restartFailedAttachmentUploading(with: attachmentId, completion: $0)
-            }
-
-            // Assert `ClientError.AttachmentEditing` is propagated.
-            XCTAssertTrue(error is ClientError.AttachmentEditing)
-        }
-    }
-
-    func test_restartFailedAttachmentUploading_propagatesDatabaseError() throws {
+    func test_restartAttachmentUploading_propagatesDatabaseError() throws {
         let cid: ChannelId = .unique
         let messageId: MessageId = .unique
         let attachmentId: AttachmentId = .init(cid: cid, messageId: messageId, index: 0)
@@ -2065,7 +2024,7 @@ final class MessageUpdater_Tests: XCTestCase {
 
         // Try to restart uploading and catch the error.
         let error = try waitFor {
-            messageUpdater.restartFailedAttachmentUploading(with: attachmentId, completion: $0)
+            messageUpdater.restartAttachmentUploading(with: attachmentId, completion: $0)
         }
 
         // Assert database error is propagated.
@@ -2083,16 +2042,15 @@ final class MessageUpdater_Tests: XCTestCase {
         try database.createMessage(id: messageId, cid: cid)
         // Create attachment in database in `.uploadingFailed` state.
         try database.writeSynchronously {
-            let attachmentDTO = try $0.createNewAttachment(
+            try $0.createNewAttachment(
                 attachment: .mockFile,
                 id: attachmentId
             )
-            attachmentDTO.localState = .uploadingFailed
         }
 
         // Try to restart uploading and catch the error.
         let error = try waitFor {
-            messageUpdater.restartFailedAttachmentUploading(with: attachmentId, completion: $0)
+            messageUpdater.restartAttachmentUploading(with: attachmentId, completion: $0)
         }
 
         // Assert successful result is propagated.

--- a/Tests/StreamChatUITests/ChatMessage_Tests.swift
+++ b/Tests/StreamChatUITests/ChatMessage_Tests.swift
@@ -101,38 +101,6 @@ final class ChatMessage_Tests: XCTestCase {
         XCTAssertFalse(deletedMessage.isInteractionEnabled)
     }
 
-    func test_isInteractionEnabled_whenMessageWithoutLocalState_returnsTrue() {
-        let nonDeletedNonEphemeralMessageWithoutLocalState: ChatMessage = .mock(
-            id: .unique,
-            cid: .unique,
-            text: .unique,
-            author: .mock(id: .unique),
-            localState: nil
-        )
-
-        XCTAssertTrue(nonDeletedNonEphemeralMessageWithoutLocalState.isInteractionEnabled)
-    }
-
-    func test_isInteractionEnabled_whenMessageWithFailedLocalState_returnsTrue() {
-        let failedLocalStates: [LocalMessageState] = [
-            .deletingFailed,
-            .sendingFailed,
-            .syncingFailed
-        ]
-
-        for localState in failedLocalStates {
-            let nonDeletedNonEphemeralMessageWithFailedLocalState: ChatMessage = .mock(
-                id: .unique,
-                cid: .unique,
-                text: .unique,
-                author: .mock(id: .unique),
-                localState: localState
-            )
-
-            XCTAssertTrue(nonDeletedNonEphemeralMessageWithFailedLocalState.isInteractionEnabled)
-        }
-    }
-
     func test_isInteractionEnabled_whenMessageHasError_returnsFalse() {
         let message: ChatMessage = .mock(
             id: .unique,


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/691

### 🎯 Goal

Allow editing pending messages. Currently, while a message is being sent, it is not possible to edit it or cancel it. 

### 🧪 Manual Testing Notes

#### Precondition
Throttle the network so that messages take more time to be sent

#### Steps
1. Send a message with and without attachments
2. While it is being sent, long press the message
3. Edit the text or attachments or delete it
4. Stop throttling the network
5. The message should be sent with the most updated data

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)