### PR TITLE
Expose `UserListQuery.search(term:)` and `UserListQuery.user(withID:)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### ✅ Added
+- Expose `UserListQuery.search(term:)` and `UserListQuery.user(withID:)` [#2959](https://github.com/GetStream/stream-chat-swift/pull/2959)
+
 ## StreamChatUI
 ### ✅ Added
 - Better support for custom mixed attachments rendering [#2947](https://github.com/GetStream/stream-chat-swift/pull/2947)

--- a/Sources/StreamChat/Query/UserListQuery.swift
+++ b/Sources/StreamChat/Query/UserListQuery.swift
@@ -114,7 +114,7 @@ public struct UserListQuery: Encodable {
     }
 }
 
-extension UserListQuery {
+public extension UserListQuery {
     /// Builds `UserListQuery` for a user with the provided `userId`
     /// - Parameter userId: The user identifier
     /// - Returns: `UserListQuery` for a specific user


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Expose `UserListQuery.search(term:)` and `UserListQuery.user(withID:)`. This helper factory methods are useful to easily create and reuse these queries. They were internal, probably by mistake. 

### 🧪 Manual Testing Notes
N/A

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)