### PR TITLE
Fix local only messages not editable

### DIFF
--- a/Sources/StreamChat/APIClient/APIClient.swift
+++ b/Sources/StreamChat/APIClient/APIClient.swift
@@ -80,6 +80,7 @@ class APIClient {
     /// - Parameters:
     ///   - endpoint: The `Endpoint` used to create the network request.
     ///   - completion: Called when the networking request is finished.
+    @discardableResult
     func request<Response: Decodable>(
         endpoint: Endpoint<Response>,
         completion: @escaping (Result<Response, Error>) -> Void

--- a/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/ChannelEndpoints.swift
@@ -130,7 +130,8 @@ extension Endpoint {
             method: .post,
             queryItems: nil,
             requiresConnectionId: false,
-            body: body
+            body: body,
+            cancellableId: messagePayload.id
         )
     }
 

--- a/Sources/StreamChat/APIClient/Endpoints/Endpoint.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Endpoint.swift
@@ -11,6 +11,7 @@ struct Endpoint<ResponseType: Decodable>: Codable {
     let requiresConnectionId: Bool
     let requiresToken: Bool
     let body: Encodable?
+    let cancellableId: String? // If the request is cancellable
 
     init(
         path: EndpointPath,
@@ -18,7 +19,8 @@ struct Endpoint<ResponseType: Decodable>: Codable {
         queryItems: Encodable? = nil,
         requiresConnectionId: Bool = false,
         requiresToken: Bool = true,
-        body: Encodable? = nil
+        body: Encodable? = nil,
+        cancellableId: String? = nil
     ) {
         self.path = path
         self.method = method
@@ -26,6 +28,7 @@ struct Endpoint<ResponseType: Decodable>: Codable {
         self.requiresConnectionId = requiresConnectionId
         self.requiresToken = requiresToken
         self.body = body
+        self.cancellableId = cancellableId
     }
 
     // MARK: - Codable
@@ -47,6 +50,7 @@ struct Endpoint<ResponseType: Decodable>: Codable {
         requiresConnectionId = try container.decode(Bool.self, forKey: .requiresConnectionId)
         requiresToken = try container.decode(Bool.self, forKey: .requiresToken)
         body = try container.decodeIfPresent(Data.self, forKey: .body)
+        cancellableId = nil
     }
 
     func encode(to encoder: Encoder) throws {

--- a/Sources/StreamChat/Repositories/MessageRepository.swift
+++ b/Sources/StreamChat/Repositories/MessageRepository.swift
@@ -16,6 +16,8 @@ class MessageRepository {
     let database: DatabaseContainer
     let apiClient: APIClient
 
+    var messageSendingOperations: [MessageId: Cancellable] = [:]
+
     init(database: DatabaseContainer, apiClient: APIClient) {
         self.database = database
         self.apiClient = apiClient
@@ -69,7 +71,8 @@ class MessageRepository {
                     skipPush: skipPush,
                     skipEnrichUrl: skipEnrichUrl
                 )
-                self?.apiClient.request(endpoint: endpoint) {
+
+                self?.messageSendingOperations[messageId] = self?.apiClient.request(endpoint: endpoint) {
                     switch $0 {
                     case let .success(payload):
                         self?.saveSuccessfullySentMessage(cid: cid, message: payload.message) { result in
@@ -84,6 +87,8 @@ class MessageRepository {
                     case let .failure(error):
                         self?.handleSendingMessageError(error, messageId: messageId, completion: completion)
                     }
+
+                    self?.messageSendingOperations[messageId] = nil
                 }
             })
         }

--- a/Sources/StreamChat/Utils/InternetConnection/Error+InternetNotAvailable.swift
+++ b/Sources/StreamChat/Utils/InternetConnection/Error+InternetNotAvailable.swift
@@ -33,6 +33,10 @@ extension Error {
         return false
     }
 
+    var isMessageAlreadyExists: Bool {
+        ((self as? ClientError)?.underlyingError as? ErrorPayload)?.code == 4
+    }
+
     var isRateLimitError: Bool {
         if let error = (self as? ClientError)?.underlyingError as? ErrorPayload,
            error.statusCode == 429 {

--- a/Sources/StreamChat/Utils/Operations/AsyncOperation.swift
+++ b/Sources/StreamChat/Utils/Operations/AsyncOperation.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-class AsyncOperation: BaseOperation {
+class AsyncOperation: BaseOperation, Cancellable {
     enum Output {
         case retry
         case `continue`

--- a/Sources/StreamChat/Workers/Background/MessageSender.swift
+++ b/Sources/StreamChat/Workers/Background/MessageSender.swift
@@ -163,7 +163,8 @@ private class MessageSendingQueue {
                     switch error {
                     case .messageDoesNotExist,
                          .messageNotPendingSend,
-                         .messageDoesNotHaveValidChannel:
+                         .messageDoesNotHaveValidChannel,
+                         .messageAlreadyExists:
                         let event = NewMessageErrorEvent(messageId: request.messageId, error: error)
                         self?.eventsNotificationCenter.process(event)
                     case let .failedToSendMessage(error):

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -155,6 +155,12 @@ class MessageUpdater: Worker {
             }
 
             if messageDTO.isLocalOnly {
+                if let messageSendingRequest = self.apiClient.cancellableRequests[messageId] {
+                    messageSendingRequest.cancel()
+                }
+                if let messageSendingOperation = self.repository.messageSendingOperations[messageId] {
+                    messageSendingOperation.cancel()
+                }
                 try updateMessage(localState: .pendingSend)
                 return
             }

--- a/Sources/StreamChat/Workers/MessageUpdater.swift
+++ b/Sources/StreamChat/Workers/MessageUpdater.swift
@@ -154,14 +154,14 @@ class MessageUpdater: Worker {
                 return
             }
 
-            if messageDTO.isLocalOnly {
+            if messageDTO.localMessageState == .pendingSend || messageDTO.localMessageState == .sending {
                 if let messageSendingRequest = self.apiClient.cancellableRequests[messageId] {
                     messageSendingRequest.cancel()
                 }
                 if let messageSendingOperation = self.repository.messageSendingOperations[messageId] {
                     messageSendingOperation.cancel()
                 }
-                try updateMessage(localState: .pendingSend)
+                try updateMessage(localState: .pendingSync)
                 return
             }
 


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
It looks like this [PR](https://github.com/GetStream/stream-chat-swift/pull/2958) did not fix every case. So this PR solves it.

Now, we simply check if the message is local only, or it was already sent to the server. If it is local only, we enqueue it for being sent. If it is already available on the server, we enqueue it to be edited. This is applied to editing, pinning and unpinning a message.

### 🧪 Manual Testing Notes

#### Precondition
Throttle the network so that messages take more time to be sent

#### Steps
1. Send a message with and without attachments
2. While it is being sent, long press the message
3. Edit the text or attachments or delete it
4. Stop throttling the network
5. The message should be sent with the most updated data

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
