### PR TITLE
Replace usages of `split` with `components` for Channel ID initializers

### DIFF
--- a/Sources/StreamChat/Models/ChannelId.swift
+++ b/Sources/StreamChat/Models/ChannelId.swift
@@ -10,6 +10,7 @@ import Foundation
 ///
 public struct ChannelId: Hashable, CustomStringConvertible {
     private static let separator: Character = ":"
+    private static let separatorCharSet = CharacterSet(charactersIn: String(separator))
 
     public let rawValue: String
 
@@ -24,7 +25,7 @@ public struct ChannelId: Hashable, CustomStringConvertible {
     }
 
     public init(cid: String) throws {
-        let channelPair = cid.split(separator: ChannelId.separator)
+        let channelPair = cid.components(separatedBy: Self.separatorCharSet)
 
         guard
             channelPair.count == 2,
@@ -43,13 +44,13 @@ public struct ChannelId: Hashable, CustomStringConvertible {
 public extension ChannelId {
     /// The type of the channel the id belongs to.
     var type: ChannelType {
-        let channelPair = rawValue.split(separator: ChannelId.separator)
+        let channelPair = rawValue.components(separatedBy: Self.separatorCharSet)
         return ChannelType(rawValue: String(channelPair[0]))
     }
 
     /// The id of the channel without the encoded type information.
     var id: String {
-        let channelPair = rawValue.split(separator: ChannelId.separator)
+        let channelPair = rawValue.components(separatedBy: Self.separatorCharSet)
         return String(channelPair[1])
     }
 }

--- a/Tests/StreamChatTests/Models/ChannelId_Tests.swift
+++ b/Tests/StreamChatTests/Models/ChannelId_Tests.swift
@@ -14,6 +14,13 @@ final class ChannelId_Tests: XCTestCase {
         XCTAssertEqual(channelId.id, "123")
     }
 
+    func test_channelId_malformed_init_with_type() {
+        let channelId = ChannelId(type: .messaging, id: "")
+        XCTAssertEqual(channelId.rawValue, "messaging:")
+        XCTAssertEqual(channelId.type, ChannelType.messaging)
+        XCTAssertEqual(channelId.id, "")
+    }
+
     func test_invalidChannelId() {
         // Channel with invalid character
         XCTAssertThrowsError(try ChannelId(cid: "*"))


### PR DESCRIPTION
### 🎯 Goal

This makes the `id` computer property on `ChannelId` safer by using `components(separatedBy:)` rather than `split(separator:)`.

### 📝 Summary

We're seeing a case where we're accidentally passing an empty string into `ChannelId(type:id:)`. Because `id` on `ChannelId` blindly does a `split` (ie. the `rawValue` is `messaging:`, we get an index out of bounds exceptions and the app crashes.

This PR uses `components(separatedBy:)` to ensure we have two parts coming back.

> [!NOTE]
> I think `ChannelId(type:id:)` should also throw if `id` is empty, but that seems like a much bigger (and breaking) change so will leave that to you all

### 🎨 Showcase

Tested via `test_channelId_malformed_init_with_type`

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

<img src="https://media1.giphy.com/media/L1kmEnKq8eQyA/giphy.gif"/>