### PR TITLE
Make login/logout more stable with BG Mapping enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix not possible to resend messages with failed attachments [#2966](https://github.com/GetStream/stream-chat-swift/pull/2966)
 - Fix not mentioning users if they are not fetched in the local device [#2967](https://github.com/GetStream/stream-chat-swift/pull/2967)
+- Make login/logout more stable with BG Mapping enabled [#2971](https://github.com/GetStream/stream-chat-swift/pull/2971)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
@@ -152,6 +152,11 @@ class BackgroundDatabaseObserver<Item, DTO: NSManagedObject> {
                 return
             }
 
+            guard !self.isDeletingDatabase else {
+                done(.continue)
+                return
+            }
+
             self.frc.managedObjectContext.perform {
                 self.processItems(changes) {
                     done(.continue)


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
It makes the login/logout flow more stable when BG Mapping is enabled. 

### 📝 Summary
After a lot of testing, I was not able to reproduce a crash anymore when logging in and logging out with BG Mapping enabled. 

### 🛠 Implementation
Whenever we start deleting the DB, we now set a `isDeletingDatabase`. The problem is that this was not being applied to the correct place, or at least, it was missing a crucial place.

### 🧪 Manual Testing Notes
Login/Logout multiple times

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)