### PR TITLE
Do not run cron checks on releases

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -5,10 +5,6 @@ on:
     # Runs "At 03:00 every night"
     - cron: '0 3 * * *'
 
-  pull_request:
-    branches:
-      - 'main'
-
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - '**'
-      - '!main'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
### 📝 Summary

- Cron checks take too much time during the release process (even longer if there is a queue), and so this PR shuts them down
- Cron checks are anyways executed every night on `develop`, and can be run on `release` PR manually via  `workflow_dispatch` if required
- Smoke checks are turned back on