### PR TITLE
Remove connectionIDWaiters property with internal synchronization sin…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### 🐞 Fixed
+- Fix a possible threading issue in `ConnectionRepository` [#2985](https://github.com/GetStream/stream-chat-swift/pull/2985)
+
 ### 🔄 Changed
 
 # [4.47.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.47.1)

--- a/Tests/StreamChatTests/Repositories/ConnectionRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/ConnectionRepository_Tests.swift
@@ -471,15 +471,16 @@ final class ConnectionRepository_Tests: XCTestCase {
     }
 
     func test_connectionId_doesNotDeadlock() {
-        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+        let iterations = 100
+        let expectations = (0..<iterations).map { XCTestExpectation(description: "\($0)") }
+        DispatchQueue.concurrentPerform(iterations: 100) { index in
             repository.provideConnectionId(timeout: 0) { _ in
-                self.repository.connectionIdWaiters.forEach { _ in }
+                expectations[index].fulfill()
             }
         }
-
-        DispatchQueue.concurrentPerform(iterations: 100) { _ in
-            repository.connectionIdWaiters.forEach { _ in }
-        }
+        // Trigger another complete for making sure that _connectionIdWaiters were correctly cleaned up as part of provideConnectionId (expectation is not fulfilled twice)
+        repository.completeConnectionIdWaiters(connectionId: "newId")
+        wait(for: expectations, timeout: defaultTimeout)
     }
 
     // MARK: Complete ConnectionId Waiters


### PR DESCRIPTION
…ce it can cause threading issues when reading and mutating the dictionary

### 🔗 Issue Links

Resolves [GetStream/ios-issues-tracking/709](https://github.com/GetStream/ios-issues-tracking/issues/709)

Related [GetStream/stream-chat-swift/2568](https://github.com/GetStream/stream-chat-swift/issues/2568)

### 🎯 Goal

Clean up unused code and remove a way of causing threading issues with mutating `_connectionIdWaiters` through the separate property

### 📝 Summary

Removing a way for accidentally creating a timing issue which can cause hard to find issues.

### 🛠 Implementation

We have had issues in the past where we create a property which wraps another property with a dispatch queue. If the value is, for example, dictionary, then code like `connectionIdWaiters["key"] = value` causes timing issues since the subscript first triggers the getter on the queue, then modifies the value, and then uses the setter on the queue again. If someone else reads or writes between that get and set cycle, we start dropping changes to the dictionary (e.g. thread B reads the state before thread A called set with a new key, thread B happily commits its updates and thread A's change gets lost). 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
