### PR TITLE
Do not show composer link preview with multiple attachment types

### DIFF
--- a/Tests/StreamChatUITests/SnapshotTests/Composer/ComposerVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/Composer/ComposerVC_Tests.swift
@@ -791,6 +791,50 @@ final class ComposerVC_Tests: XCTestCase {
         }
     }
 
+    func test_didChangeLinks_whenMultipleAttachmentTypes_thenDismissLinkPreview() {
+        let composerVC = SpyComposerVC()
+        composerVC.components.isComposerLinkPreviewEnabled = true
+        let mock = ChatChannelController_Mock.mock(client: .mock())
+        mock.channel_mock = .mockNonDMChannel(config: .mock(urlEnrichmentEnabled: true))
+        composerVC.channelController = mock
+        composerVC.content = .initial()
+        composerVC.content.attachments = [.mockAudio, .mockFile]
+
+        composerVC.didChangeLinks([.init(url: .localYodaImage, range: .init(location: 0, length: 10))])
+
+        XCTAssertEqual(composerVC.dismissLinkPreviewCallCount, 1)
+    }
+
+    func test_updateContent_whenMultipleAttachmentTypes_whenSkipEnrichUrlIsFalse_thenDismissLinkPreview() {
+        let composerVC = SpyComposerVC()
+        composerVC.components.isComposerLinkPreviewEnabled = true
+        let mock = ChatChannelController_Mock.mock(client: .mock())
+        mock.channel_mock = .mockNonDMChannel(config: .mock(urlEnrichmentEnabled: true))
+        composerVC.channelController = mock
+        composerVC.content = .initial()
+        composerVC.content.attachments = [.mockAudio, .mockFile]
+        composerVC.content.skipEnrichUrl = false
+
+        composerVC.updateContent()
+
+        XCTAssertEqual(composerVC.dismissLinkPreviewCallCount, 1)
+    }
+
+    func test_updateContent_whenMultipleAttachmentTypes_whenSkipEnrichUrlIsTrue_thenDoNotCallDismissLinkPreview() {
+        let composerVC = SpyComposerVC()
+        composerVC.components.isComposerLinkPreviewEnabled = true
+        let mock = ChatChannelController_Mock.mock(client: .mock())
+        mock.channel_mock = .mockNonDMChannel(config: .mock(urlEnrichmentEnabled: true))
+        composerVC.channelController = mock
+        composerVC.content = .initial()
+        composerVC.content.attachments = [.mockAudio, .mockFile]
+        composerVC.content.skipEnrichUrl = true
+
+        composerVC.updateContent()
+
+        XCTAssertEqual(composerVC.dismissLinkPreviewCallCount, 0)
+    }
+
     // MARK: - audioPlayer
     
     func test_audioPlayer_voiceRecordingAndAttachmentsVCGetTheSameInstance() {


### PR DESCRIPTION
### 🔗 Issue Links
Related to https://github.com/GetStream/stream-chat-swift/pull/2984

### 🎯 Goal
Follow-up task from https://github.com/GetStream/stream-chat-swift/pull/2984 to fix the composer link preview showing for multiple types of attachments. Whenever an attachment is inserted, we should discard the composer link preview.

### 🧪 Manual Testing Notes
**Case 1**
1. Type a link in the composer
2. The link preview should show
3. Insert an image
4. The link preview should be dismissed

**Case 2**
1. Insert an image in the composer
2. Type a link in the composer
3. The link preview should not show

**Case 3**
1. Edit a message that contains a link and an image
2. Should not show the link preview in the composer

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
