### PR TITLE
Reconfigure cells in the channel list when handling StagedChangeset.elementUpdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix link flickering when opening a channel [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
 - Fix link flickering when quoting a message with a link [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
 - Fix channel item actions gesture overriding native swipe go-back gesture [#3000](https://github.com/GetStream/stream-chat-swift/pull/3000)
+- Fix flashing channel list avatars and improve channel list update performance [#2996](https://github.com/GetStream/stream-chat-swift/pull/2996)
 
 # [4.47.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.47.1)
 _January 24, 2024_

--- a/Scripts/updateDependency.sh
+++ b/Scripts/updateDependency.sh
@@ -67,3 +67,8 @@ do
 done
 
 rm -rf $dependency_directory
+
+if [[ $dependency_directory == *"DifferenceKit"* ]]; then
+    # We currently use customized UIKit extensions in Utils/DifferenceKit+Stream.swift
+    rm $output_directory/Extensions/UIKitExtension.swift
+fi

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -245,7 +245,7 @@ open class ChatChannelListVC: _ViewController,
         let previousChannels = channels
         let newChannels = Array(controller.channels)
         let stagedChangeset = StagedChangeset(source: previousChannels, target: newChannels)
-        collectionView.reload(using: stagedChangeset) { [weak self] newChannels in
+        collectionView.reload(using: stagedChangeset, reconfigure: { _ in true }) { [weak self] newChannels in
             self?.channels = newChannels
         }
     }

--- a/Sources/StreamChatUI/ChatChannelList/Search/ChatMessageSearchVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/Search/ChatMessageSearchVC.swift
@@ -49,7 +49,7 @@ open class ChatMessageSearchVC: ChatChannelListSearchVC, ChatMessageSearchContro
         let previousMessages = messages
         let newMessages = Array(messageSearchController.messages)
         let stagedChangeset = StagedChangeset(source: previousMessages, target: newMessages)
-        collectionView.reload(using: stagedChangeset) { [weak self] newMessages in
+        collectionView.reload(using: stagedChangeset, reconfigure: { _ in true }) { [weak self] newMessages in
             self?.messages = newMessages
         }
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
@@ -22,7 +22,8 @@ extension ChatMessageListView {
         CATransaction.setCompletionBlock(completion)
         reload(
             using: changeset,
-            with: animation()
+            with: animation(),
+            reconfigure: { _ in false }
         ) { [weak self] newMessages in
             self?.onNewDataSource?(newMessages)
         }

--- a/Sources/StreamChatUI/Utils/Extensions/DifferenceKit+Stream.swift
+++ b/Sources/StreamChatUI/Utils/Extensions/DifferenceKit+Stream.swift
@@ -1,5 +1,15 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
 #if os(iOS) || os(tvOS)
 import UIKit
+
+//
+// These are customized reload functions from DiffereceKit which use reconfigureItems and reconfigureRows.
+// We can remove this file when DifferenceKit switches to reconfigure instead of reload.
+// Reconfiguring gives a noticable performance boost since cells are not recreated.
+//
 
 extension UITableView {
     /// Applies multiple animated updates in stages using `StagedChangeset`.
@@ -11,6 +21,7 @@ extension UITableView {
     /// - Parameters:
     ///   - stagedChangeset: A staged set of changes.
     ///   - animation: An option to animate the updates.
+    ///   - reconfigure: A closure that takes an index path as its argument and if it returns `true`, cells are reconfigured, otherwise cells are reloaded
     ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
@@ -18,9 +29,10 @@ extension UITableView {
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         with animation: @autoclosure () -> RowAnimation,
+        reconfigure: (IndexPath) -> Bool,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         setData: (C) -> Void
-        ) {
+    ) {
         reload(
             using: stagedChangeset,
             deleteSectionsAnimation: animation(),
@@ -29,11 +41,12 @@ extension UITableView {
             deleteRowsAnimation: animation(),
             insertRowsAnimation: animation(),
             reloadRowsAnimation: animation(),
+            reconfigure: reconfigure,
             interrupt: interrupt,
             setData: setData
         )
     }
-
+    
     /// Applies multiple animated updates in stages using `StagedChangeset`.
     ///
     /// - Note: There are combination of changes that crash when applied simultaneously in `performBatchUpdates`.
@@ -48,6 +61,7 @@ extension UITableView {
     ///   - deleteRowsAnimation: An option to animate the row deletion.
     ///   - insertRowsAnimation: An option to animate the row insertion.
     ///   - reloadRowsAnimation: An option to animate the row reload.
+    ///   - reconfigure: A closure that takes an index path as its argument and if it returns `true`, cells are reconfigured, otherwise cells are reloaded
     ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
@@ -60,63 +74,74 @@ extension UITableView {
         deleteRowsAnimation: @autoclosure () -> RowAnimation,
         insertRowsAnimation: @autoclosure () -> RowAnimation,
         reloadRowsAnimation: @autoclosure () -> RowAnimation,
+        reconfigure: (IndexPath) -> Bool = { _ in false },
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         setData: (C) -> Void
-        ) {
+    ) {
         if case .none = window, let data = stagedChangeset.last?.data {
             setData(data)
             return reloadData()
         }
-
+        
         for changeset in stagedChangeset {
             if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
                 setData(data)
                 return reloadData()
             }
-
+            
             _performBatchUpdates {
                 setData(changeset.data)
-
+                
                 if !changeset.sectionDeleted.isEmpty {
                     deleteSections(IndexSet(changeset.sectionDeleted), with: deleteSectionsAnimation())
                 }
-
+                
                 if !changeset.sectionInserted.isEmpty {
                     insertSections(IndexSet(changeset.sectionInserted), with: insertSectionsAnimation())
                 }
-
+                
                 if !changeset.sectionUpdated.isEmpty {
                     reloadSections(IndexSet(changeset.sectionUpdated), with: reloadSectionsAnimation())
                 }
-
+                
                 for (source, target) in changeset.sectionMoved {
                     moveSection(source, toSection: target)
                 }
-
+                
                 if !changeset.elementDeleted.isEmpty {
                     deleteRows(at: changeset.elementDeleted.map { IndexPath(row: $0.element, section: $0.section) }, with: deleteRowsAnimation())
                 }
-
+                
                 if !changeset.elementInserted.isEmpty {
                     insertRows(at: changeset.elementInserted.map { IndexPath(row: $0.element, section: $0.section) }, with: insertRowsAnimation())
                 }
-
+                
                 if !changeset.elementUpdated.isEmpty {
-                    reloadRows(at: changeset.elementUpdated.map { IndexPath(row: $0.element, section: $0.section) }, with: reloadRowsAnimation())
+                    var indexPaths = changeset.elementUpdated.map { IndexPath(row: $0.element, section: $0.section) }
+                    if #available(iOS 15.0, *) {
+                        let partitioned = indexPaths.partitionReconfigurable(by: reconfigure)
+                        if !partitioned.reconfiguredIndexPaths.isEmpty {
+                            reconfigureRows(at: partitioned.reconfiguredIndexPaths)
+                        }
+                        if !partitioned.reloadedIndexPaths.isEmpty {
+                            reloadRows(at: partitioned.reloadedIndexPaths, with: reloadRowsAnimation())
+                        }
+                    } else {
+                        reloadRows(at: indexPaths, with: reloadRowsAnimation())
+                    }
                 }
-
+                
                 for (source, target) in changeset.elementMoved {
                     moveRow(at: IndexPath(row: source.element, section: source.section), to: IndexPath(row: target.element, section: target.section))
                 }
             }
         }
     }
-
+    
     private func _performBatchUpdates(_ updates: () -> Void) {
         if #available(iOS 11.0, tvOS 11.0, *) {
             performBatchUpdates(updates)
-        }
-        else {
+        } else {
             beginUpdates()
             updates()
             endUpdates()
@@ -133,57 +158,71 @@ extension UICollectionView {
     ///
     /// - Parameters:
     ///   - stagedChangeset: A staged set of changes.
+    ///   - reconfigure: A closure that takes an index path as its argument and if it returns `true`, cells are reconfigured, otherwise cells are reloaded
     ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UICollectionView.
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
+        reconfigure: (IndexPath) -> Bool,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         setData: (C) -> Void
-        ) {
+    ) {
         if case .none = window, let data = stagedChangeset.last?.data {
             setData(data)
             return reloadData()
         }
-
+        
         for changeset in stagedChangeset {
             if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
                 setData(data)
                 return reloadData()
             }
-
+            
             performBatchUpdates({
                 setData(changeset.data)
-
+                
                 if !changeset.sectionDeleted.isEmpty {
                     deleteSections(IndexSet(changeset.sectionDeleted))
                 }
-
+                
                 if !changeset.sectionInserted.isEmpty {
                     insertSections(IndexSet(changeset.sectionInserted))
                 }
-
+                
                 if !changeset.sectionUpdated.isEmpty {
                     reloadSections(IndexSet(changeset.sectionUpdated))
                 }
-
+                
                 for (source, target) in changeset.sectionMoved {
                     moveSection(source, toSection: target)
                 }
-
+                
                 if !changeset.elementDeleted.isEmpty {
                     deleteItems(at: changeset.elementDeleted.map { IndexPath(item: $0.element, section: $0.section) })
                 }
-
+                
                 if !changeset.elementInserted.isEmpty {
                     insertItems(at: changeset.elementInserted.map { IndexPath(item: $0.element, section: $0.section) })
                 }
-
+                
                 if !changeset.elementUpdated.isEmpty {
-                    reloadItems(at: changeset.elementUpdated.map { IndexPath(item: $0.element, section: $0.section) })
+                    var indexPaths = changeset.elementUpdated.map { IndexPath(row: $0.element, section: $0.section) }
+                    
+                    if #available(iOS 15.0, *) {
+                        let partitioned = indexPaths.partitionReconfigurable(by: reconfigure)
+                        if !partitioned.reconfiguredIndexPaths.isEmpty {
+                            reconfigureItems(at: partitioned.reconfiguredIndexPaths)
+                        }
+                        if !partitioned.reloadedIndexPaths.isEmpty {
+                            reloadItems(at: partitioned.reloadedIndexPaths)
+                        }
+                    } else {
+                        reloadItems(at: indexPaths)
+                    }
                 }
-
+                
                 for (source, target) in changeset.elementMoved {
                     moveItem(at: IndexPath(item: source.element, section: source.section), to: IndexPath(item: target.element, section: target.section))
                 }
@@ -191,4 +230,12 @@ extension UICollectionView {
         }
     }
 }
+
+private extension Array where Element == IndexPath {
+    mutating func partitionReconfigurable(by reconfigurable: (Element) -> Bool) -> (reloadedIndexPaths: [Element], reconfiguredIndexPaths: [Element]) {
+        let reconfigureFirstIndex = partition(by: reconfigurable)
+        return (Array(self[..<reconfigureFirstIndex]), Array(self[reconfigureFirstIndex...]))
+    }
+}
+
 #endif

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -240,6 +240,9 @@
 		43F4750C26F4E4FF0009487D /* ChatMessageReactionItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F4750B26F4E4FF0009487D /* ChatMessageReactionItemView.swift */; };
 		43F4750E26FB247C0009487D /* ChatReactionPickerReactionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F4750D26FB247C0009487D /* ChatReactionPickerReactionsView.swift */; };
 		4A4E184728D06F260062378D /* Documentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = 4A4E184528D06CA30062378D /* Documentation.docc */; };
+		4F05ECB82B6CCA4900641820 /* DifferenceKit+Stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F05ECB72B6CCA4900641820 /* DifferenceKit+Stream.swift */; };
+		4F05ECB92B6CCA4900641820 /* DifferenceKit+Stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F05ECB72B6CCA4900641820 /* DifferenceKit+Stream.swift */; };
+		4F12DC8C2B70DE82009E48CC /* DifferenceKit+Stream_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F12DC8A2B70DE4C009E48CC /* DifferenceKit+Stream_Tests.swift */; };
 		6428DD5526201DCC0065DA1D /* BannerShowingConnectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */; };
 		647F66D5261E22C200111B19 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F66D4261E22C200111B19 /* BannerView.swift */; };
 		648EC576261EF9D400B8F05F /* DemoAppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648EC575261EF9D400B8F05F /* DemoAppCoordinator.swift */; };
@@ -1386,8 +1389,6 @@
 		ADCB577A28A42D7700B81AE8 /* Algorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCB576A28A42D7700B81AE8 /* Algorithm.swift */; };
 		ADCB577B28A42D7700B81AE8 /* AppKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCB576C28A42D7700B81AE8 /* AppKitExtension.swift */; };
 		ADCB577C28A42D7700B81AE8 /* AppKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCB576C28A42D7700B81AE8 /* AppKitExtension.swift */; };
-		ADCB577D28A42D7700B81AE8 /* UIKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCB576D28A42D7700B81AE8 /* UIKitExtension.swift */; };
-		ADCB577E28A42D7700B81AE8 /* UIKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCB576D28A42D7700B81AE8 /* UIKitExtension.swift */; };
 		ADCB577F28A42D7700B81AE8 /* ContentIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCB576E28A42D7700B81AE8 /* ContentIdentifiable.swift */; };
 		ADCB578028A42D7700B81AE8 /* ContentIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCB576E28A42D7700B81AE8 /* ContentIdentifiable.swift */; };
 		ADCB578128A42D7700B81AE8 /* AnyDifferentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCB576F28A42D7700B81AE8 /* AnyDifferentiable.swift */; };
@@ -2865,6 +2866,8 @@
 		43F4750D26FB247C0009487D /* ChatReactionPickerReactionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatReactionPickerReactionsView.swift; sourceTree = "<group>"; };
 		4A4E184528D06CA30062378D /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
 		4A51230029D3170C005CEA9B /* docusaurus */ = {isa = PBXFileReference; lastKnownFileType = folder; path = docusaurus; sourceTree = "<group>"; };
+		4F05ECB72B6CCA4900641820 /* DifferenceKit+Stream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DifferenceKit+Stream.swift"; sourceTree = "<group>"; };
+		4F12DC8A2B70DE4C009E48CC /* DifferenceKit+Stream_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DifferenceKit+Stream_Tests.swift"; sourceTree = "<group>"; };
 		6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerShowingConnectionDelegate.swift; sourceTree = "<group>"; };
 		647F66D4261E22C200111B19 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
 		648EC575261EF9D400B8F05F /* DemoAppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppCoordinator.swift; sourceTree = "<group>"; };
@@ -3881,7 +3884,6 @@
 		ADCB576928A42D7700B81AE8 /* ArraySection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArraySection.swift; sourceTree = "<group>"; };
 		ADCB576A28A42D7700B81AE8 /* Algorithm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Algorithm.swift; sourceTree = "<group>"; };
 		ADCB576C28A42D7700B81AE8 /* AppKitExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppKitExtension.swift; sourceTree = "<group>"; };
-		ADCB576D28A42D7700B81AE8 /* UIKitExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKitExtension.swift; sourceTree = "<group>"; };
 		ADCB576E28A42D7700B81AE8 /* ContentIdentifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentIdentifiable.swift; sourceTree = "<group>"; };
 		ADCB576F28A42D7700B81AE8 /* AnyDifferentiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyDifferentiable.swift; sourceTree = "<group>"; };
 		ADCB577028A42D7700B81AE8 /* StagedChangeset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StagedChangeset.swift; sourceTree = "<group>"; };
@@ -7224,21 +7226,22 @@
 		A3960E0427DA5512003AB2B0 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				ADAA9F402B2240300078C3D4 /* TextViewMentionedUsersHandler_Tests.swift */,
-				40A941542B443212006D6965 /* DefaultAudioPlaybackRateFormatter_Tests.swift */,
-				40A941552B443212006D6965 /* DefaultAudioRecordingNameFormatter_Tests.swift */,
-				AD4C15552A55874700A32955 /* ImageLoading_Tests.swift */,
 				BDDD1EAB2632E32000BA007B /* AppearanceProvider_Tests.swift */,
 				C1320E07276B2E0800A06B35 /* Array+SafeSubscript_Tests.swift */,
 				E73262D725ED6432008CB152 /* ChatChannelNamer_Tests.swift */,
 				795296C02582494000435B2E /* ComponentsProvider_Tests.swift */,
 				ACA3C98426CA23F300EB8B07 /* DateUtils_Tests.swift */,
+				40A941542B443212006D6965 /* DefaultAudioPlaybackRateFormatter_Tests.swift */,
+				40A941552B443212006D6965 /* DefaultAudioRecordingNameFormatter_Tests.swift */,
+				CF24AAB2284A5659005AD3B8 /* DefaultMarkdownFormatter_Tests.swift */,
+				4F12DC8A2B70DE4C009E48CC /* DifferenceKit+Stream_Tests.swift */,
+				AD4C15552A55874700A32955 /* ImageLoading_Tests.swift */,
+				AD7BBFCD2901B1AE004E8B76 /* ImageResultsMapper_Tests.swift */,
+				ADD2A99528FF227800A83305 /* ImageSizeCalculator_Tests.swift */,
 				BD40C1F4265FA80D004392CE /* StreamImageCDN_Tests.swift */,
 				ACDB5412269C6F2A007CD465 /* String+Extensions_Tests.swift */,
+				ADAA9F402B2240300078C3D4 /* TextViewMentionedUsersHandler_Tests.swift */,
 				7865705725FB6DF300974045 /* UIViewController+Extensions_Tests.swift */,
-				CF24AAB2284A5659005AD3B8 /* DefaultMarkdownFormatter_Tests.swift */,
-				ADD2A99528FF227800A83305 /* ImageSizeCalculator_Tests.swift */,
-				AD7BBFCD2901B1AE004E8B76 /* ImageResultsMapper_Tests.swift */,
 				AD4CDD80296498B10057BC8A /* ViewPaginationHandling */,
 			);
 			path = Utils;
@@ -7581,8 +7584,8 @@
 		A3D9D68A27EDE53600725066 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				A3D9D68B27EDE54900725066 /* UIView+SimulateViewAddedToHierarchy.swift */,
 				C12297D52AC57F7C00C5FF04 /* ChatMessage+Equatable_Tests.swift */,
+				A3D9D68B27EDE54900725066 /* UIView+SimulateViewAddedToHierarchy.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -7975,16 +7978,17 @@
 		AD95FD0F28F9B72200DBDF41 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */,
 				88EF29FE2571288600B06EF1 /* Array+Extensions.swift */,
-				E386432C2857299E00DB3FBE /* Reusable+Extensions.swift */,
+				C171041D2768C34E008FB3F2 /* Array+SafeSubscript.swift */,
 				224FF6962562F5AE00725DD1 /* Bundle+Extensions.swift */,
 				883051732630366E0069D731 /* CACornerMask+Extensions.swift */,
 				E70120152583EBC90036DACD /* CALayer+Extensions.swift */,
 				F64DFA8B26282F8B00F7F6F9 /* CGPoint+Extensions.swift */,
 				F6E5E3462627A372007FA51F /* CGRect+Extensions.swift */,
 				79CCB66D259CBC4F0082F172 /* ChatChannelNamer.swift */,
+				4F05ECB72B6CCA4900641820 /* DifferenceKit+Stream.swift */,
 				88D88F85257F9AA700AFE2A2 /* NSLayoutConstraint+Extensions.swift */,
+				E386432C2857299E00DB3FBE /* Reusable+Extensions.swift */,
 				2241167F258A91280034184D /* String+Extensions.swift */,
 				224FF6902562F58F00725DD1 /* UIColor+Extensions.swift */,
 				228190EA256733420048D7C6 /* UIFont+Extensions.swift */,
@@ -8091,7 +8095,6 @@
 			isa = PBXGroup;
 			children = (
 				ADCB576C28A42D7700B81AE8 /* AppKitExtension.swift */,
-				ADCB576D28A42D7700B81AE8 /* UIKitExtension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -9860,6 +9863,7 @@
 				C1FC2F8527416E150062530F /* DataCache.swift in Sources */,
 				40824D0E2A1270CB003B61FD /* ChatMessageVoiceRecordingAttachmentListView.swift in Sources */,
 				88D66E762599DF1400CFC102 /* ChatMessageReactionAppearance.swift in Sources */,
+				4F05ECB82B6CCA4900641820 /* DifferenceKit+Stream.swift in Sources */,
 				C1FC2F8D27416E1F0062530F /* NSImageView+SwiftyGif.swift in Sources */,
 				F80BCA0A263011F500F2107B /* ImageAttachmentGalleryCell.swift in Sources */,
 				843F0BC326775CDB00B342CB /* Cache.swift in Sources */,
@@ -10000,7 +10004,6 @@
 				AD8D1809268F7290004E3A5C /* TypingSuggester.swift in Sources */,
 				F880DEA32628528B0025AD64 /* GalleryVC.swift in Sources */,
 				ADCB577728A42D7700B81AE8 /* ArraySection.swift in Sources */,
-				ADCB577D28A42D7700B81AE8 /* UIKitExtension.swift in Sources */,
 				C1FC2F8727416E150062530F /* OperationTask.swift in Sources */,
 				78C8473825FA0EF000A5D1D0 /* ChatChannelUnreadCountView+SwiftUI.swift in Sources */,
 				ACCA772A26C40C96007AE2ED /* ImageLoading.swift in Sources */,
@@ -10135,6 +10138,7 @@
 				8893FEF9265F890700DD62BE /* ChatMessageBubbleView_Tests.swift in Sources */,
 				406CC6152A127552000780F7 /* VoiceRecordingAttachmentViewInjector_Tests.swift in Sources */,
 				A3D9D69727EDE87C00725066 /* ImageLoader_Mock.swift in Sources */,
+				4F12DC8C2B70DE82009E48CC /* DifferenceKit+Stream_Tests.swift in Sources */,
 				64B75B002631700500A466D1 /* ChatMessage_Tests.swift in Sources */,
 				ADAA377125E43C3700C31528 /* ChatSuggestionsVC_Tests.swift in Sources */,
 				E73262E025ED64AB008CB152 /* ChatChannelNamer_Tests.swift in Sources */,
@@ -11683,6 +11687,7 @@
 				C121EB912746A1E800023E4C /* ChatMentionSuggestionView.swift in Sources */,
 				C121EB922746A1E800023E4C /* ChatMentionSuggestionCollectionViewCell.swift in Sources */,
 				C121EB932746A1E800023E4C /* ChatCommandSuggestionView.swift in Sources */,
+				4F05ECB92B6CCA4900641820 /* DifferenceKit+Stream.swift in Sources */,
 				C121EB942746A1E800023E4C /* ChatCommandSuggestionCollectionViewCell.swift in Sources */,
 				40824D4A2A1271EF003B61FD /* PlayPauseButton_Tests.swift in Sources */,
 				C12297D42AC57A3200C5FF04 /* Throttler.swift in Sources */,
@@ -11925,7 +11930,6 @@
 				C121EC312746A1ED00023E4C /* Operation.swift in Sources */,
 				C121EC322746A1ED00023E4C /* ImageRequestKeys.swift in Sources */,
 				C121EC332746A1ED00023E4C /* LinkedList.swift in Sources */,
-				ADCB577E28A42D7700B81AE8 /* UIKitExtension.swift in Sources */,
 				C121EC342746A1ED00023E4C /* UIImageView+SwiftyGif.swift in Sources */,
 				C121EC352746A1ED00023E4C /* NSImage+SwiftyGif.swift in Sources */,
 				C121EC362746A1ED00023E4C /* UIImage+SwiftyGif.swift in Sources */,

--- a/Tests/StreamChatUITests/Utils/DifferenceKit+Stream_Tests.swift
+++ b/Tests/StreamChatUITests/Utils/DifferenceKit+Stream_Tests.swift
@@ -1,0 +1,131 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatUI
+import XCTest
+
+final class DifferenceKit_Stream_Tests: XCTestCase {
+    fileprivate func makeCollectionView() -> MockCollectionView {
+        let window = UIWindow(frame: .zero)
+        let collectionView = MockCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        window.addSubview(collectionView)
+        return collectionView
+    }
+    
+    fileprivate func makeTableView() -> MockTableView {
+        let window = UIWindow(frame: .zero)
+        let tableView = MockTableView(frame: .zero)
+        window.addSubview(tableView)
+        return tableView
+    }
+    
+    func generateUpdatedElementsStagedChangeset(count: Int) -> StagedChangeset<[Int]> {
+        let paths = (0..<count).map { ElementPath(element: $0, section: 0) }
+        let changeset = Changeset(data: [0], elementUpdated: paths)
+        return StagedChangeset(arrayLiteral: changeset)
+    }
+    
+    // MARK: - UICollectionView
+    
+    func test_collectionViewReconfigureItems_isCalledAlongWithReload() throws {
+        let collectionView = makeCollectionView()
+        collectionView.reload(
+            using: generateUpdatedElementsStagedChangeset(count: 10),
+            reconfigure: { $0.item.isMultiple(of: 2) },
+            setData: { _ in }
+        )
+        XCTAssertEqual(collectionView.reconfiguredIndexes.sorted(), [0, 2, 4, 6, 8])
+        XCTAssertEqual(collectionView.reloadedIndexes.sorted(), [1, 3, 5, 7, 9])
+    }
+    
+    func test_collectionViewReconfigureItems_isOnlyCalled() throws {
+        let collectionView = makeCollectionView()
+        collectionView.reload(
+            using: generateUpdatedElementsStagedChangeset(count: 5),
+            reconfigure: { _ in true },
+            setData: { _ in }
+        )
+        XCTAssertEqual(collectionView.reconfiguredIndexes.sorted(), [0, 1, 2, 3, 4])
+        XCTAssertEqual(collectionView.reloadedIndexes.sorted(), [])
+    }
+    
+    func test_collectionViewReloadItems_isOnlyCalled() throws {
+        let collectionView = makeCollectionView()
+        collectionView.reload(
+            using: generateUpdatedElementsStagedChangeset(count: 3),
+            reconfigure: { _ in false },
+            setData: { _ in }
+        )
+        XCTAssertEqual(collectionView.reconfiguredIndexes.sorted(), [])
+        XCTAssertEqual(collectionView.reloadedIndexes.sorted(), [0, 1, 2])
+    }
+    
+    // MARK: - UITableView
+    
+    func test_tableViewReconfigureRows_isCalledAlongWithReload() throws {
+        let tableView = makeTableView()
+        tableView.reload(
+            using: generateUpdatedElementsStagedChangeset(count: 10),
+            with: .automatic,
+            reconfigure: { $0.item.isMultiple(of: 2) },
+            setData: { _ in }
+        )
+        XCTAssertEqual(tableView.reconfiguredIndexes.sorted(), [0, 2, 4, 6, 8])
+        XCTAssertEqual(tableView.reloadedIndexes.sorted(), [1, 3, 5, 7, 9])
+    }
+    
+    func test_tableViewReconfigureRows_isOnlyCalled() throws {
+        let tableView = makeTableView()
+        tableView.reload(
+            using: generateUpdatedElementsStagedChangeset(count: 5),
+            with: .automatic,
+            reconfigure: { _ in true },
+            setData: { _ in }
+        )
+        XCTAssertEqual(tableView.reconfiguredIndexes.sorted(), [0, 1, 2, 3, 4])
+        XCTAssertEqual(tableView.reloadedIndexes.sorted(), [])
+    }
+    
+    func test_tableViewReloadRows_isOnlyCalled() throws {
+        let tableView = makeTableView()
+        tableView.reload(
+            using: generateUpdatedElementsStagedChangeset(count: 3),
+            with: .automatic,
+            reconfigure: { _ in false },
+            setData: { _ in }
+        )
+        XCTAssertEqual(tableView.reconfiguredIndexes.sorted(), [])
+        XCTAssertEqual(tableView.reloadedIndexes.sorted(), [0, 1, 2])
+    }
+}
+
+extension String: Differentiable {}
+
+private extension DifferenceKit_Stream_Tests {
+    final class MockCollectionView: UICollectionView {
+        private(set) var reconfiguredIndexes = [Int]()
+        private(set) var reloadedIndexes = [Int]()
+        
+        override func reloadItems(at indexPaths: [IndexPath]) {
+            reloadedIndexes.append(contentsOf: indexPaths.map(\.item))
+        }
+        
+        override func reconfigureItems(at indexPaths: [IndexPath]) {
+            reconfiguredIndexes.append(contentsOf: indexPaths.map(\.item))
+        }
+    }
+    
+    final class MockTableView: UITableView {
+        private(set) var reconfiguredIndexes = [Int]()
+        private(set) var reloadedIndexes = [Int]()
+        
+        override func reloadRows(at indexPaths: [IndexPath], with animation: UITableView.RowAnimation) {
+            reloadedIndexes.append(contentsOf: indexPaths.map(\.item))
+        }
+        
+        override func reconfigureRows(at indexPaths: [IndexPath]) {
+            reconfiguredIndexes.append(contentsOf: indexPaths.map(\.item))
+        }
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [ios-issues-tracking/716](https://github.com/GetStream/ios-issues-tracking/issues/716)

### 🎯 Goal

Increase list performance and reduce UI glitches

### 📝 Summary

- Avatars flash when opening the channel list

### 🛠 Implementation

Avatars flash in the channel list when we apply `StagedChangeset.elementUpdated` changes. I observed that we call`reload(using:interrupt:setData:)` (applying data changes to the view) on the channel view 5 times after opening it (demo app) where one of the reload call contains 20 (in my case) `elementUpdated` changes. These, currently trigger cell reloads which cause the UI glitch (avatars flashing) and also reduces the performance since all the cells need to be created (it was the 4th reload call)

The proposed fix is to use Apple provided `UICollectionView.reconfigureItems(at:)` and `UITableView.reconfigureRows(at:)`. Since the channel list is a collection view and we only use a single cell type, then we can turn on cell reusing there. Message list is a table view and has more sophisticated reuse identifier handling, so currently do not use reconfiguring there (needs a separate PR since it is more complex).

I also did some micro-measurements with time profiler and iPhone 12 Pro Max.

#### Precondition
R2-D2 account is logged in.

#### Steps

1. Build the app for profiling
2. Launch the app on a device with time profiler running
3. Wait a little bit when things settle down and check what was the overall main thread usage without diving into details.

#### Results

5 consecutive runs (with 3 warmup runs before)

| Run | reloadItems (ms)  | reconfigureItems (ms) |
| --- | ------------- | ------------- |
| 1 | 484  | 381  |
| 2 | 479  | 398  |
| 3 | 499  | 387  |
| 4 | 491  | 386  |
| 5 | 494  | 393  |
| Avg | 489  | 389 |

Around 20% less CPU time on the main thread.

### 🎨 Showcase

| Before | After |
| ------ | ----- |
| ![](https://github.com/GetStream/stream-chat-swift/assets/1469907/8958a9ea-afef-465e-9d70-aaf0f536f6a5) | ![](https://github.com/GetStream/stream-chat-swift/assets/1469907/16e9c32b-79e0-472f-97f2-e1a95e752f37) |

### 🧪 Manual Testing Notes

We need to make sure that reconfiguring items does not have any side-effects. We might have relied to the fact that cells are reloaded.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaDQzdDg0b3o3djV0djg3dGNueHZ0MHh0Y2hxaTJvbjF2c2tnd2Z4aSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1wXeZxGTdF8Uka5k4C/giphy.gif)
