### PR TITLE
Fix `NewMessagePendingEvent.message` with empty `cid`

### DIFF
--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -593,6 +593,7 @@ extension NSManagedObjectContext: MessageDatabaseSession {
             try pin(message: message, pinning: pinning)
         }
 
+        message.cid = cid.rawValue
         message.type = parentMessageId == nil ? MessageType.regular.rawValue : MessageType.reply.rawValue
         message.text = text
         message.command = command

--- a/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/ChannelUpdater_Tests.swift
@@ -592,6 +592,9 @@ final class ChannelUpdater_Tests: XCTestCase {
             }
         }
 
+        // Make sure when creating a new message, the cid is locally available.
+        XCTAssertNotNil(newMessage.cid)
+
         func id(for envelope: AnyAttachmentPayload) -> AttachmentId {
             .init(cid: cid, messageId: newMessage.id, index: attachmentEnvelopes.firstIndex(of: envelope)!)
         }


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal

Fix `NewMessagePendingEvent.message` with empty `cid`.

### 🛠 Implementation
When creating the message with `ChannelUpdater`, we were not setting the `cid` of the message. So we would report the NewMessagePendingEvent without the cid. 

### 🧪 Manual Testing Notes
N/A

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)