### PR TITLE
Do not check token expiration in token provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix threading issues in `ConnectionRepository` [#2985](https://github.com/GetStream/stream-chat-swift/pull/2985), [#2987](https://github.com/GetStream/stream-chat-swift/pull/2987)
 - Fix threading issues in `AuthenticationRepository` [#2986](https://github.com/GetStream/stream-chat-swift/pull/2986)
 - Fix `NewMessagePendingEvent.message` with empty `cid` [#2997](https://github.com/GetStream/stream-chat-swift/pull/2997)
+### 🔄 Changed
+- Do not check token expiration in token provider [#2998](https://github.com/GetStream/stream-chat-swift/pull/2998)
 
 ## StreamChatUI
 ### ✅ Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix threading issues in `AuthenticationRepository` [#2986](https://github.com/GetStream/stream-chat-swift/pull/2986)
 - Fix `NewMessagePendingEvent.message` with empty `cid` [#2997](https://github.com/GetStream/stream-chat-swift/pull/2997)
 ### 🔄 Changed
-- Do not check token expiration in token provider [#2998](https://github.com/GetStream/stream-chat-swift/pull/2998)
+- Do not check token expiration client side [#2998](https://github.com/GetStream/stream-chat-swift/pull/2998)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/Config/Token.swift
+++ b/Sources/StreamChat/Config/Token.swift
@@ -10,6 +10,12 @@ public struct Token: Decodable, Equatable, ExpressibleByStringLiteral {
     public let userId: UserId
     public let expiration: Date?
 
+    @available(
+        *,
+        deprecated,
+        
+        message: "It is not a good practice to check expiration client side since the user can change the device's time."
+    )
     public var isExpired: Bool {
         expiration.map { $0 < Date() } ?? false
     }

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -363,13 +363,11 @@ class AuthenticationRepository {
         log.debug("Requesting a new token", subsystems: .authentication)
         tokenProvider { [weak self] result in
             switch result {
-            case let .success(newToken) where !newToken.isExpired:
+            case let .success(newToken):
                 onTokenReceived(newToken)
                 self?.tokenQueue.sync(flags: .barrier) {
                     self?._tokenExpirationRetryStrategy.resetConsecutiveFailures()
                 }
-            case .success:
-                retryFetchIfPossible(nil)
             case let .failure(error):
                 log.info("Failed fetching token with error: \(error)")
                 retryFetchIfPossible(error)

--- a/Sources/StreamChat/Repositories/ConnectionRepository.swift
+++ b/Sources/StreamChat/Repositories/ConnectionRepository.swift
@@ -140,9 +140,11 @@ class ConnectionRepository {
         case let .connected(connectionId: id):
             shouldNotifyConnectionIdWaiters = true
             connectionId = id
-
         case let .disconnecting(source) where source.serverError?.isInvalidTokenError == true,
-             let .disconnected(source) where source.serverError?.isInvalidTokenError == true:
+             let .disconnecting(source) where source.serverError?.isExpiredTokenError == true:
+            fallthrough
+        case let .disconnected(source) where source.serverError?.isExpiredTokenError == true,
+             let .disconnected(source) where source.serverError?.isExpiredTokenError == true:
             onInvalidToken()
             shouldNotifyConnectionIdWaiters = false
             connectionId = nil

--- a/Sources/StreamChat/Repositories/ConnectionRepository.swift
+++ b/Sources/StreamChat/Repositories/ConnectionRepository.swift
@@ -141,9 +141,8 @@ class ConnectionRepository {
             shouldNotifyConnectionIdWaiters = true
             connectionId = id
         case let .disconnecting(source) where source.serverError?.isInvalidTokenError == true,
-             let .disconnecting(source) where source.serverError?.isExpiredTokenError == true:
-            fallthrough
-        case let .disconnected(source) where source.serverError?.isExpiredTokenError == true,
+             let .disconnecting(source) where source.serverError?.isExpiredTokenError == true,
+             let .disconnected(source) where source.serverError?.isInvalidTokenError == true,
              let .disconnected(source) where source.serverError?.isExpiredTokenError == true:
             onInvalidToken()
             shouldNotifyConnectionIdWaiters = false


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
Do not check token expiration in the SDK since it is a bad practice. The user can abuse this by changing the device's time.

### 🧪 Manual Testing Notes
N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)