### PR TITLE
Added internal config for switching the WS implementation

### DIFF
--- a/Sources/StreamChat/Config/StreamRuntimeCheck.swift
+++ b/Sources/StreamChat/Config/StreamRuntimeCheck.swift
@@ -33,4 +33,9 @@ public enum StreamRuntimeCheck {
 
         return currentDepth <= _backgroundMappingRelationshipsMaxDepth
     }
+    
+    /// For *internal use* only
+    ///
+    ///  Enables using our legacy web socket connection.
+    public static var _useLegacyWebSocketConnection = false
 }

--- a/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
+++ b/Sources/StreamChat/WebSocketClient/WebSocketClient.swift
@@ -164,7 +164,7 @@ extension WebSocketClient {
         var createPingController: CreatePingController = WebSocketPingController.init
 
         var createEngine: CreateEngine = {
-            if #available(iOS 13, *) {
+            if #available(iOS 13, *), !StreamRuntimeCheck._useLegacyWebSocketConnection {
                 return URLSessionWebSocketEngine(request: $0, sessionConfiguration: $1, callbackQueue: $2)
             } else {
                 return StarscreamWebSocketProvider(request: $0, sessionConfiguration: $1, callbackQueue: $2)


### PR DESCRIPTION
### 🎯 Goal

Provide a way to use stars scream instead of the url session WS.

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
