### PR TITLE
Fix channel item actions gesture overriding native swipe go-back gesture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Add `Components.default.isComposerLinkPreviewEnabled` flag to enable composer link previews [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
 - Add support for showing link previews in the composer [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
-- Fix issue where an interactive pop gesture from a navigation controller would not work from the channel list [#3000](https://github.com/GetStream/stream-chat-swift/pull/3000)
 ### 🐞 Fixed
 - Fix link flickering when opening a channel [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
 - Fix link flickering when quoting a message with a link [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
+- Fix channel item actions gesture overriding native swipe go-back gesture [#3000](https://github.com/GetStream/stream-chat-swift/pull/3000)
 
 # [4.47.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.47.1)
 _January 24, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Add `Components.default.isComposerLinkPreviewEnabled` flag to enable composer link previews [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
 - Add support for showing link previews in the composer [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
+- Fix issue where an interactive pop gesture from a navigation controller would not work from the channel list [#3000](https://github.com/GetStream/stream-chat-swift/pull/3000)
 ### 🐞 Fixed
 - Fix link flickering when opening a channel [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
 - Fix link flickering when quoting a message with a link [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)

--- a/Sources/StreamChatUI/ChatChannelList/SwipeableView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/SwipeableView.swift
@@ -157,13 +157,16 @@ open class SwipeableView: _View, ComponentsProvider, UIGestureRecognizerDelegate
             return false
         }
 
-        // Additionally, if the horizontal swipe is left-to-right and action items
-        // are not expanded, we'll deny this recognizer, so that it doesn't steal
-        // the gesture from another recognizer, such as a UINavigationController's
-        // interactivePopGestureRecognizer
-        if !isOpen, translation.x > 0 {
+        // Additionally, if the gesture recognizer started from the left edge of the screen,
+        // ignore this recognizer so that it doesn't steal the gesture from UINavigationController's
+        // interactivePopGestureRecognizer.
+        let edgeThreshold: CGFloat = 30
+        let location = recognizer.location(in: self)
+        if location.x < edgeThreshold {
             return false
         }
+
+
         return true
     }
 

--- a/Sources/StreamChatUI/ChatChannelList/SwipeableView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/SwipeableView.swift
@@ -142,7 +142,7 @@ open class SwipeableView: _View, ComponentsProvider, UIGestureRecognizerDelegate
         }
     }
 
-    override public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+    override open func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         guard let recognizer = gestureRecognizer as? UIPanGestureRecognizer else {
             return super.gestureRecognizerShouldBegin(gestureRecognizer)
         }
@@ -153,11 +153,21 @@ open class SwipeableView: _View, ComponentsProvider, UIGestureRecognizerDelegate
         //
         // *This practically means on panning the cell we don't accidentally scroll the list
         let translation = recognizer.translation(in: self)
+        if abs(translation.x) <= abs(translation.y) {
+            return false
+        }
 
-        return abs(translation.x) > abs(translation.y)
+        // Additionally, if the horizontal swipe is left-to-right and action items
+        // are not expanded, we'll deny this recognizer, so that it doesn't steal
+        // the gesture from another recognizer, such as a UINavigationController's
+        // interactivePopGestureRecognizer
+        if !isOpen, translation.x > 0 {
+            return false
+        }
+        return true
     }
 
-    public func gestureRecognizer(
+    open func gestureRecognizer(
         _ gestureRecognizer: UIGestureRecognizer,
         shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {
@@ -169,7 +179,7 @@ open class SwipeableView: _View, ComponentsProvider, UIGestureRecognizerDelegate
         true
     }
 
-    public func gestureRecognizer(
+    open func gestureRecognizer(
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/ios-issues-tracking/issues/645

### 🎯 Goal

When showing the ChannelListVC in a UINavigationController's stack, I noticed the swipe-to-go-back interaction wasn't working correctly. Upon investigation, I found the SwipeableView steals the gesture recognition from the navigation controller's interactivePoopGestureRecognizer

### 📝 Summary

I've changed this view to ignore horizontal swipe gesture's when the action items are not expanded (i.e. view is not "open") _and_ the gesture is left-to-right. This SDK doesn't currently support action items on the left side, so this change should be safe.

### 🛠 Implementation

- I've also made the delegate functions open. Making them public doesn't make sense because panGestureRecognizer is public and subclass or client of this view can override the delegate themselves.
- An alternative to this solution is to leave the delegate functions open and require subclassing to get this behavior, but I believe this behavior should be the default.
- I believe this logic is valid even for right to left languages, but might want to check me on that.

### 🧪 Manual Testing Notes
1. Swipe left the channel item
2. The actions should appear at the right
3. Try closing the actions by swiping to the right, close to the left edge, like you would navigate back
4. It should not move the channel list item view

(In the Demo App right now we don't have a way to swipe back, so this is the best way to test it.)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
