### PR TITLE
Demo app build warning about version mismatch

### DIFF
--- a/DemoShare/Info.plist
+++ b/DemoShare/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>


### PR DESCRIPTION
### 📝 Summary

Fixes `warning: The CFBundleShortVersionString of an app extension ('1.0.0') must match that of its containing parent app ('1.0').` when building the demo app