### PR TITLE
Clean up text view data detector types in the message cell

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/ChatMessageContentView.swift
@@ -799,7 +799,6 @@ open class ChatMessageContentView: _View, ThemeProvider, UITextViewDelegate {
                 .withoutAutoresizingMaskConstraints
                 .withAccessibilityIdentifier(identifier: "textView")
             textView?.isEditable = false
-            textView?.dataDetectorTypes = .link
             textView?.isScrollEnabled = false
             textView?.backgroundColor = .clear
             textView?.adjustsFontForContentSizeCategory = true


### PR DESCRIPTION
### 🔗 Issue Links

Related to [PR 2984](https://github.com/GetStream/stream-chat-swift/pull/2984)

### 📝 Summary

Clean up data detector types because since [PR 2984](https://github.com/GetStream/stream-chat-swift/pull/2984) we detect links manually in the text view.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

