### PR TITLE
Support completion handlers when reloading views

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
@@ -9,25 +9,23 @@ extension ChatMessageListView {
     internal func reloadMessages(
         previousSnapshot: [ChatMessage],
         newSnapshot: [ChatMessage],
-        with animation: @autoclosure () -> RowAnimation,
         completion: (() -> Void)? = nil
     ) {
         let changeset = StagedChangeset(
             source: previousSnapshot,
             target: newSnapshot
         )
-        // This is need because DiffKit doesn't provide a completion block for when the reload is finished.
-        // The CATransaction notifies when animations are finished executing between begin() and commit().
-        CATransaction.begin()
-        CATransaction.setCompletionBlock(completion)
-        reload(
-            using: changeset,
-            with: animation(),
-            reconfigure: { _ in false }
-        ) { [weak self] newMessages in
-            self?.onNewDataSource?(newMessages)
+        UIView.performWithoutAnimation {
+            reload(
+                using: changeset,
+                with: .fade,
+                reconfigure: { _ in false },
+                setData: { [weak self] newMessages in
+                    self?.onNewDataSource?(newMessages)
+                },
+                completion: { _ in completion?() }
+            )
         }
-        CATransaction.commit()
     }
 }
 

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView.swift
@@ -216,17 +216,14 @@ open class ChatMessageListView: UITableView, Customizable, ComponentsProvider {
             !self.skippedMessages.contains($0.id)
         }
         adjustContentInsetToPositionMessagesAtTheTop()
-        UIView.performWithoutAnimation {
-            reloadMessages(
-                previousSnapshot: previousMessagesSnapshot,
-                newSnapshot: newMessagesWithoutSkipped,
-                with: .fade,
-                completion: { [weak self] in
-                    completion?()
-                    self?.adjustContentInsetToPositionMessagesAtTheTop()
-                }
-            )
-        }
+        reloadMessages(
+            previousSnapshot: previousMessagesSnapshot,
+            newSnapshot: newMessagesWithoutSkipped,
+            completion: { [weak self] in
+                completion?()
+                self?.adjustContentInsetToPositionMessagesAtTheTop()
+            }
+        )
     }
 
     /// Reset the skipped messages and reload the message list

--- a/Sources/StreamChatUI/Utils/Extensions/DifferenceKit+Stream.swift
+++ b/Sources/StreamChatUI/Utils/Extensions/DifferenceKit+Stream.swift
@@ -26,12 +26,14 @@ extension UITableView {
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UITableView.
+    ///   - completion: A completion handler block to execute when all of the operations finish. This block takes a single Boolean parameter that contains the value true if all of the related animations completed successfully or false if they were interrupted.
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         with animation: @autoclosure () -> RowAnimation,
         reconfigure: (IndexPath) -> Bool,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
-        setData: (C) -> Void
+        setData: (C) -> Void,
+        completion: ((Bool) -> Void)? = nil
     ) {
         reload(
             using: stagedChangeset,
@@ -43,7 +45,8 @@ extension UITableView {
             reloadRowsAnimation: animation(),
             reconfigure: reconfigure,
             interrupt: interrupt,
-            setData: setData
+            setData: setData,
+            completion: completion
         )
     }
     
@@ -66,6 +69,7 @@ extension UITableView {
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UITableView.
+    ///   - completion: A completion handler block to execute when all of the operations finish. This block takes a single Boolean parameter that contains the value true if all of the related animations completed successfully or false if they were interrupted.
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         deleteSectionsAnimation: @autoclosure () -> RowAnimation,
@@ -76,20 +80,25 @@ extension UITableView {
         reloadRowsAnimation: @autoclosure () -> RowAnimation,
         reconfigure: (IndexPath) -> Bool = { _ in false },
         interrupt: ((Changeset<C>) -> Bool)? = nil,
-        setData: (C) -> Void
+        setData: (C) -> Void,
+        completion: ((Bool) -> Void)? = nil
     ) {
         if case .none = window, let data = stagedChangeset.last?.data {
             setData(data)
-            return reloadData()
+            reloadData()
+            completion?(true)
+            return
         }
         
         for changeset in stagedChangeset {
             if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
                 setData(data)
-                return reloadData()
+                reloadData()
+                completion?(true)
+                return
             }
             
-            _performBatchUpdates {
+            performBatchUpdates({
                 setData(changeset.data)
                 
                 if !changeset.sectionDeleted.isEmpty {
@@ -134,17 +143,7 @@ extension UITableView {
                 for (source, target) in changeset.elementMoved {
                     moveRow(at: IndexPath(row: source.element, section: source.section), to: IndexPath(row: target.element, section: target.section))
                 }
-            }
-        }
-    }
-    
-    private func _performBatchUpdates(_ updates: () -> Void) {
-        if #available(iOS 11.0, tvOS 11.0, *) {
-            performBatchUpdates(updates)
-        } else {
-            beginUpdates()
-            updates()
-            endUpdates()
+            }, completion: completion)
         }
     }
 }
@@ -163,21 +162,27 @@ extension UICollectionView {
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UICollectionView.
+    ///   - completion: A completion handler block to execute when all of the operations finish. This block takes a single Boolean parameter that contains the value true if all of the related animations completed successfully or false if they were interrupted.
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         reconfigure: (IndexPath) -> Bool,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
-        setData: (C) -> Void
+        setData: (C) -> Void,
+        completion: ((Bool) -> Void)? = nil
     ) {
         if case .none = window, let data = stagedChangeset.last?.data {
             setData(data)
-            return reloadData()
+            reloadData()
+            completion?(true)
+            return
         }
         
         for changeset in stagedChangeset {
             if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
                 setData(data)
-                return reloadData()
+                reloadData()
+                completion?(true)
+                return
             }
             
             performBatchUpdates({
@@ -226,7 +231,7 @@ extension UICollectionView {
                 for (source, target) in changeset.elementMoved {
                     moveItem(at: IndexPath(item: source.element, section: source.section), to: IndexPath(item: target.element, section: target.section))
                 }
-            })
+            }, completion: completion)
         }
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [ios-issues-tracking/722](https://github.com/GetStream/ios-issues-tracking/issues/722)

### 🎯 Goal

Cleanup completion handler workaround in message list

### 📝 Summary

I noticed that we have a workaround for completion blocks when reloading using staged changesets. Since we currently have custom DifferenceKit extension, we can add support for it.

### 🛠 Implementation

Add completion handler to difference kit extension. This is a cleanup, no expected functional changes.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
