### PR TITLE
Fix `ChatMessageListVC` swipe-to-reply pan gesture recognizer overriding native swipe go-back gesture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Add `Components.default.isComposerLinkPreviewEnabled` flag to enable composer link previews [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
 - Add support for showing link previews in the composer [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
-- Fix issue where an interactive pop gesture from a navigation controller would not work from the channel list [#3000](https://github.com/GetStream/stream-chat-swift/pull/3000)
 ### 🐞 Fixed
 - Fix link flickering when opening a channel [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
 - Fix link flickering when quoting a message with a link [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
+- Fix channel item actions gesture overriding native swipe go-back gesture [#3000](https://github.com/GetStream/stream-chat-swift/pull/3000)
 
 # [4.47.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.47.1)
 _January 24, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Add `Components.default.isComposerLinkPreviewEnabled` flag to enable composer link previews [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
 - Add support for showing link previews in the composer [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
+- Fix issue where an interactive pop gesture from a navigation controller would not work from the channel list [#3000](https://github.com/GetStream/stream-chat-swift/pull/3000)
 ### 🐞 Fixed
 - Fix link flickering when opening a channel [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
 - Fix link flickering when quoting a message with a link [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix link flickering when opening a channel [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
 - Fix link flickering when quoting a message with a link [#2984](https://github.com/GetStream/stream-chat-swift/pull/2984)
 - Fix channel item actions gesture overriding native swipe go-back gesture [#3000](https://github.com/GetStream/stream-chat-swift/pull/3000)
+- Fix `ChatMessageListVC` swipe-to-reply pan gesture recognizer overriding native swipe go-back gesture [#3010](https://github.com/GetStream/stream-chat-swift/pull/3010)
 
 # [4.47.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.47.1)
 _January 24, 2024_

--- a/Sources/StreamChatUI/ChatChannelList/SwipeableView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/SwipeableView.swift
@@ -157,13 +157,16 @@ open class SwipeableView: _View, ComponentsProvider, UIGestureRecognizerDelegate
             return false
         }
 
-        // Additionally, if the horizontal swipe is left-to-right and action items
-        // are not expanded, we'll deny this recognizer, so that it doesn't steal
-        // the gesture from another recognizer, such as a UINavigationController's
-        // interactivePopGestureRecognizer
-        if !isOpen, translation.x > 0 {
+        // Additionally, if the gesture recognizer started from the left edge of the screen,
+        // ignore this recognizer so that it doesn't steal the gesture from UINavigationController's
+        // interactivePopGestureRecognizer.
+        let edgeThreshold: CGFloat = 30
+        let location = recognizer.location(in: self)
+        if location.x < edgeThreshold {
             return false
         }
+
+
         return true
     }
 

--- a/Sources/StreamChatUI/ChatChannelList/SwipeableView.swift
+++ b/Sources/StreamChatUI/ChatChannelList/SwipeableView.swift
@@ -142,7 +142,7 @@ open class SwipeableView: _View, ComponentsProvider, UIGestureRecognizerDelegate
         }
     }
 
-    override public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+    override open func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         guard let recognizer = gestureRecognizer as? UIPanGestureRecognizer else {
             return super.gestureRecognizerShouldBegin(gestureRecognizer)
         }
@@ -153,11 +153,21 @@ open class SwipeableView: _View, ComponentsProvider, UIGestureRecognizerDelegate
         //
         // *This practically means on panning the cell we don't accidentally scroll the list
         let translation = recognizer.translation(in: self)
+        if abs(translation.x) <= abs(translation.y) {
+            return false
+        }
 
-        return abs(translation.x) > abs(translation.y)
+        // Additionally, if the horizontal swipe is left-to-right and action items
+        // are not expanded, we'll deny this recognizer, so that it doesn't steal
+        // the gesture from another recognizer, such as a UINavigationController's
+        // interactivePopGestureRecognizer
+        if !isOpen, translation.x > 0 {
+            return false
+        }
+        return true
     }
 
-    public func gestureRecognizer(
+    open func gestureRecognizer(
         _ gestureRecognizer: UIGestureRecognizer,
         shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {
@@ -169,7 +179,7 @@ open class SwipeableView: _View, ComponentsProvider, UIGestureRecognizerDelegate
         true
     }
 
-    public func gestureRecognizer(
+    open func gestureRecognizer(
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -186,9 +186,11 @@ open class ChatMessageListVC: _ViewController,
         tapOnList.delegate = self
         listView.addGestureRecognizer(tapOnList)
 
-        let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
-        panGestureRecognizer.delegate = self
-        listView.addGestureRecognizer(panGestureRecognizer)
+        if components.messageSwipeToReplyEnabled {
+            let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+            panGestureRecognizer.delegate = self
+            listView.addGestureRecognizer(panGestureRecognizer)
+        }
 
         scrollToBottomButton.addTarget(self, action: #selector(didTapScrollToBottomButton), for: .touchUpInside)
         jumpToUnreadMessagesButton.addTarget(self, action: #selector(didTapJumpToUnreadButton))


### PR DESCRIPTION
### 🔗 Issue Links

N/A

### 🎯 Goal

Similar to https://github.com/GetStream/stream-chat-swift/pull/3000, the `ChatMessageListVC` is disabling the native swipe to go back functionality.

### 📝 Summary

The `ChatMessageListVC` uses a pan gesture recognizer for its swipe-to-reply functionality, but this pan gesture recognizer disables the navigation controller's interactive pop functionality.

### 🛠 Implementation

This PR prevents the pan gesture recognizer from being added to its view if `components.messageSwipeToReplyEnabled` is turned off. An alternative implementation would have made the pan gesture recognizer a stored property on the VC and still added it to the view, so that clients could control it's `enabled` property.

We've implemented a workaround for the time being, which is to subclass ChatMessageListVC and implement `UIGestureRecognizerDelegate`'s `shouldRequireFailureOf` function, so that the pan gesture recognizer waits for the native interactive pop gesture to fail.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

