### PR TITLE
Fix demo app storyboard warnings about button configuration and dynam…

### DIFF
--- a/DemoApp/Resources/Base.lproj/Main.storyboard
+++ b/DemoApp/Resources/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="3Sb-ov-lIw">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="3Sb-ov-lIw">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -22,27 +22,27 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Stream_logo" translatesAutoresizingMaskIntoConstraints="NO" id="vQd-FK-4Dy">
-                                <rect key="frame" x="167" y="122" width="80" height="40"/>
+                                <rect key="frame" x="167" y="126" width="80" height="40"/>
                             </imageView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="b2C-Ge-Ivw">
-                                <rect key="frame" x="0.0" y="290.5" width="414" height="571.5"/>
+                                <rect key="frame" x="0.0" y="300.5" width="414" height="561.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="UserCredentialsCell" id="aZA-7S-O7h" customClass="UserCredentialsCell" customModule="ChatSample" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="62.5"/>
+                                        <rect key="frame" x="0.0" y="50" width="414" height="65"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="aZA-7S-O7h" id="e3W-Zp-DRN">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="62.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="65"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="og9-Be-Hok">
-                                                    <rect key="frame" x="0.0" y="11" width="414" height="40.5"/>
+                                                    <rect key="frame" x="0.0" y="11" width="414" height="43"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jtp-gT-CcS">
-                                                            <rect key="frame" x="0.0" y="0.0" width="40" height="40.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="40" height="43"/>
                                                             <subviews>
                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Xf9-Cw-O8x" customClass="AvatarView" customModule="ChatSample" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="0.5" width="40" height="40"/>
+                                                                    <rect key="frame" x="0.0" y="1.5" width="40" height="40"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="40" id="Nk5-EA-aij"/>
                                                                         <constraint firstAttribute="width" secondItem="Xf9-Cw-O8x" secondAttribute="height" multiplier="1:1" id="TOs-dm-5w1"/>
@@ -51,16 +51,16 @@
                                                             </subviews>
                                                         </stackView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" distribution="fillEqually" spacingType="standard" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5Na-mZ-acb">
-                                                            <rect key="frame" x="48" y="0.0" width="334" height="40.5"/>
+                                                            <rect key="frame" x="48" y="0.0" width="334" height="43"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9sR-xp-Lkl">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="334" height="19"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="334" height="21"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="inZ-kw-esQ">
-                                                                    <rect key="frame" x="0.0" y="22" width="334" height="18.5"/>
+                                                                    <rect key="frame" x="0.0" y="22.5" width="334" height="20.5"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                     <color key="textColor" systemColor="systemGrayColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -68,7 +68,7 @@
                                                             </subviews>
                                                         </stackView>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="right" horizontalHuggingPriority="1000" verticalHuggingPriority="251" image="Icon_arrow_right" translatesAutoresizingMaskIntoConstraints="NO" id="cXw-Us-Bnd">
-                                                            <rect key="frame" x="390" y="0.0" width="24" height="40.5"/>
+                                                            <rect key="frame" x="390" y="0.0" width="24" height="43"/>
                                                         </imageView>
                                                     </subviews>
                                                 </stackView>
@@ -90,24 +90,24 @@
                                 </prototypes>
                             </tableView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="Ud7-Cg-f9Z">
-                                <rect key="frame" x="73.5" y="185" width="267.5" height="97.5"/>
+                                <rect key="frame" x="57.5" y="189" width="299.5" height="103.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to Stream Chat" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EGr-7A-pnW">
-                                        <rect key="frame" x="0.0" y="0.0" width="267.5" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="299.5" height="33.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Vrt-UC-aTs">
-                                        <rect key="frame" x="77.5" y="41" width="112" height="31"/>
-                                        <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="filled" title="Configuration"/>
+                                        <rect key="frame" x="102.5" y="44.5" width="94" height="30"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="Configuration"/>
                                         <connections>
                                             <action selector="didTapConfigurationButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AG4-Ue-m1B"/>
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select a user to try the iOS SDK:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5rj-sf-KOK">
-                                        <rect key="frame" x="42" y="83" width="183.5" height="14.5"/>
+                                        <rect key="frame" x="39" y="85.5" width="221.5" height="18"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -130,6 +130,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="u60-gi-N8s"/>
                     <connections>
+                        <outlet property="configurationButton" destination="Vrt-UC-aTs" id="Bs0-vq-N3R"/>
                         <outlet property="tableView" destination="b2C-Ge-Ivw" id="5sp-Sf-IDQ"/>
                         <segue destination="yjx-9T-97B" kind="presentation" identifier="show_advanced_options" id="lV5-dW-IzB"/>
                     </connections>
@@ -143,11 +144,11 @@
             <objects>
                 <viewController id="yjx-9T-97B" customClass="AdvancedOptionsViewController" customModule="ChatSample" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" id="LM0-SF-FGq">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="886"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="8QA-pW-MTy">
-                                <rect key="frame" x="0.0" y="60" width="414" height="160"/>
+                                <rect key="frame" x="0.0" y="16" width="414" height="160"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Chat API Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Jye-aX-OTy">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="34"/>
@@ -172,7 +173,7 @@
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NAL-Cp-UKn" customClass="MainButton" customModule="ChatSample" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="252" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="208" width="414" height="44"/>
                                 <color key="backgroundColor" name="AccentColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="JRh-ZO-YhQ"/>
@@ -207,7 +208,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="3Sb-ov-lIw" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ktR-xo-jHV">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -228,7 +229,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="bfN-Fc-dZz">
-                                <rect key="frame" x="16" y="60" width="382" height="56"/>
+                                <rect key="frame" x="16" y="64" width="382" height="56"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TO:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Au-Y4-xwF">
                                         <rect key="frame" x="0.0" y="0.0" width="19" height="56"/>
@@ -266,7 +267,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="67"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.3" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="zHO-Qg-7VF">
-                                                <rect key="frame" x="0.0" y="1.5" width="40" height="64.5"/>
+                                                <rect key="frame" x="0.0" y="1" width="40" height="66"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="40" id="PeU-HZ-pfQ"/>
                                                 </constraints>
@@ -302,7 +303,7 @@
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="UserCredentialsCell" rowHeight="72" id="fPJ-ch-riB" customClass="UserCredentialsCell" customModule="ChatSample" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="44.5" width="414" height="72"/>
+                                                <rect key="frame" x="0.0" y="50" width="414" height="72"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fPJ-ch-riB" id="A5U-q9-6qd">
                                                     <rect key="frame" x="0.0" y="0.0" width="414" height="72"/>
@@ -321,13 +322,13 @@
                                                                     <rect key="frame" x="58" y="0.0" width="324" height="50"/>
                                                                     <subviews>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f5O-TL-XcV">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="324" height="23.5"/>
+                                                                            <rect key="frame" x="0.0" y="0.0" width="324" height="24.5"/>
                                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                                             <nil key="textColor"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7PS-Dc-6d7">
-                                                                            <rect key="frame" x="0.0" y="26.5" width="324" height="23.5"/>
+                                                                            <rect key="frame" x="0.0" y="26" width="324" height="24"/>
                                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                             <color key="textColor" systemColor="systemGrayColor"/>
                                                                             <nil key="highlightedColor"/>
@@ -363,7 +364,7 @@
                                 <rect key="frame" x="0.0" y="367" width="295.5" height="162.5"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="magnifyingglass" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="QJY-eK-8rq">
-                                        <rect key="frame" x="58" y="52.5" width="140" height="138.5"/>
+                                        <rect key="frame" x="58" y="56.5" width="140" height="138.5"/>
                                         <color key="tintColor" systemColor="tertiaryLabelColor"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="140" id="6LF-rz-iND"/>
@@ -371,7 +372,7 @@
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No user matches these keywords..." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sqo-ta-rZH">
-                                        <rect key="frame" x="16" y="208" width="224" height="17"/>
+                                        <rect key="frame" x="16" y="212" width="224" height="17"/>
                                         <fontDescription key="fontDescription" type="system" weight="light" pointSize="14"/>
                                         <color key="textColor" systemColor="secondaryLabelColor"/>
                                         <nil key="highlightedColor"/>
@@ -437,7 +438,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <searchBar contentMode="redraw" searchBarStyle="minimal" placeholder="Search" translatesAutoresizingMaskIntoConstraints="NO" id="z40-B9-qFo">
-                                <rect key="frame" x="0.0" y="52" width="414" height="51"/>
+                                <rect key="frame" x="0.0" y="56" width="414" height="47"/>
                                 <offsetWrapper key="searchTextPositionAdjustment" horizontal="8" vertical="0.0"/>
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
@@ -461,10 +462,10 @@
                                                 </collectionViewFlowLayout>
                                                 <cells>
                                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="GroupUserCell" id="Mgv-Ml-5Ew" customClass="GroupUserCell" customModule="ChatSample" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="-14" width="128" height="128"/>
+                                                        <rect key="frame" x="0.0" y="5" width="64" height="90.5"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="LI1-gx-p7l">
-                                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="64" height="90.5"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <subviews>
                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Hfs-oZ-VPu" customClass="AvatarView" customModule="ChatSample" customModuleProvider="target">
@@ -475,13 +476,13 @@
                                                                     </constraints>
                                                                 </imageView>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LkB-9t-RLq">
-                                                                    <rect key="frame" x="0.0" y="70" width="64" height="17"/>
-                                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
+                                                                    <rect key="frame" x="0.0" y="70" width="64" height="20.5"/>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Iut-cT-KXn">
-                                                                    <rect key="frame" x="-56" y="0.0" width="240" height="128"/>
+                                                                    <rect key="frame" x="46" y="6" width="12" height="12"/>
                                                                     <color key="backgroundColor" systemColor="labelColor"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="12" id="9Nt-pA-ZHT"/>
@@ -489,7 +490,7 @@
                                                                     </constraints>
                                                                 </view>
                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="xmark.circle.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="d1Y-X1-M2b" customClass="AvatarView" customModule="ChatSample" customModuleProvider="target">
-                                                                    <rect key="frame" x="8" y="9" width="104" height="40"/>
+                                                                    <rect key="frame" x="40" y="0.5" width="24" height="23"/>
                                                                     <color key="tintColor" systemColor="systemBackgroundColor"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="24" id="8Lh-Mu-Dgy"/>
@@ -540,20 +541,20 @@
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchUserCell" id="pn0-12-DRx" customClass="SearchUserCell" customModule="ChatSample" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="44.5" width="414" height="62.5"/>
+                                                <rect key="frame" x="0.0" y="50" width="414" height="65"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pn0-12-DRx" id="vN2-tu-tg7">
-                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="62.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="65"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="89v-OL-xTg">
-                                                            <rect key="frame" x="0.0" y="11" width="414" height="40.5"/>
+                                                            <rect key="frame" x="0.0" y="11" width="414" height="43"/>
                                                             <subviews>
                                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="4yC-T0-RPx">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="40" height="40.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="40" height="43"/>
                                                                     <subviews>
                                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="krv-MI-Hsw" customClass="AvatarView" customModule="ChatSample" customModuleProvider="target">
-                                                                            <rect key="frame" x="0.0" y="0.5" width="40" height="40"/>
+                                                                            <rect key="frame" x="0.0" y="1.5" width="40" height="40"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="width" secondItem="krv-MI-Hsw" secondAttribute="height" multiplier="1:1" id="JQW-7X-mwh"/>
                                                                                 <constraint firstAttribute="width" constant="40" id="Rdu-Mp-zgK"/>
@@ -562,16 +563,16 @@
                                                                     </subviews>
                                                                 </stackView>
                                                                 <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" distribution="fillEqually" spacingType="standard" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z45-Uy-CDj">
-                                                                    <rect key="frame" x="48" y="0.0" width="334" height="40.5"/>
+                                                                    <rect key="frame" x="48" y="0.0" width="334" height="43"/>
                                                                     <subviews>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="paJ-Wo-GrD">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="334" height="19"/>
+                                                                            <rect key="frame" x="0.0" y="0.0" width="334" height="21"/>
                                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                                             <nil key="textColor"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gaD-71-t1Z">
-                                                                            <rect key="frame" x="0.0" y="22" width="334" height="18.5"/>
+                                                                            <rect key="frame" x="0.0" y="22.5" width="334" height="20.5"/>
                                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                             <color key="textColor" systemColor="systemGrayColor"/>
                                                                             <nil key="highlightedColor"/>
@@ -579,7 +580,7 @@
                                                                     </subviews>
                                                                 </stackView>
                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="right" horizontalHuggingPriority="1000" verticalHuggingPriority="251" image="Icon_arrow_right" translatesAutoresizingMaskIntoConstraints="NO" id="ZKN-4j-CKV">
-                                                                    <rect key="frame" x="390" y="0.0" width="24" height="40.5"/>
+                                                                    <rect key="frame" x="390" y="0.0" width="24" height="43"/>
                                                                 </imageView>
                                                             </subviews>
                                                         </stackView>
@@ -670,10 +671,10 @@
     <resources>
         <image name="Icon_arrow_right" width="24" height="24"/>
         <image name="Stream_logo" width="80" height="40"/>
-        <image name="magnifyingglass" catalog="system" width="128" height="115"/>
-        <image name="person" catalog="system" width="128" height="117"/>
-        <image name="person.3" catalog="system" width="128" height="62"/>
-        <image name="xmark.circle.fill" catalog="system" width="128" height="121"/>
+        <image name="magnifyingglass" catalog="system" width="128" height="117"/>
+        <image name="person" catalog="system" width="128" height="121"/>
+        <image name="person.3" catalog="system" width="128" height="66"/>
+        <image name="xmark.circle.fill" catalog="system" width="128" height="123"/>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
@@ -690,7 +691,7 @@
             <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="tertiaryLabelColor">
-            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29803921568627451" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="tertiarySystemGroupedBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/DemoApp/Screens/LoginViewController/LoginViewController.swift
+++ b/DemoApp/Screens/LoginViewController/LoginViewController.swift
@@ -7,6 +7,7 @@ import StreamChat
 import UIKit
 
 class LoginViewController: UIViewController {
+    @IBOutlet var configurationButton: UIButton!
     @IBOutlet var tableView: UITableView!
     var onUserSelection: ((DemoUserType) -> Void)!
 
@@ -19,6 +20,9 @@ class LoginViewController: UIViewController {
 
         // An old trick to force the table view to hide empty lines
         tableView.tableFooterView = UIView()
+        if #available(iOS 15.0, *) {
+            configurationButton.configuration = .filled()
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
### 🎯 Goal

No warnings in the demo app storyboard

### 📝 Summary

- Set button configuration to filled in the code which is iOS 15 but our deployment target is iOS 14
- Set text style to headline instead of system bold 14 (dynamic type warning, label is slightly bigger now)

### 🎨 Showcase
<img width="413" alt="warning" src="https://github.com/GetStream/stream-chat-swift/assets/1469907/1ca7dc23-55e3-40da-a75b-9a303f11fb04">

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
