### PR TITLE
Update xcode version for cron checks

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   build-test-app-and-frameworks:
     name: Build Test App and Frameworks
-    runs-on: macos-14
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4.1.1
     - uses: ./.github/actions/ruby-cache
@@ -25,6 +25,8 @@ jobs:
     - name: Build
       run: bundle exec fastlane build_test_app_and_frameworks
       timeout-minutes: 60
+      env:
+        XCODE_VERSION: "14.3.1"
     - uses: actions/upload-artifact@v3
       if: success()
       with:


### PR DESCRIPTION
The app could not be installed on older iOS devices if it was build on the latest Xcode/macOS