### PR TITLE
Images in merged avatars change their location when opening channel list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChatUI
 ### 🐞 Fixed
 - Fix composer link preview overridden by previous enrichment [#3025](https://github.com/GetStream/stream-chat-swift/pull/3025)
+- Fix merged avatars changing sub-image locations when opening channel list [#3013](https://github.com/GetStream/stream-chat-swift/pull/3013)
 
 # [4.48.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.48.1)
 _February 09, 2024_

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 		4F05ECB82B6CCA4900641820 /* DifferenceKit+Stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F05ECB72B6CCA4900641820 /* DifferenceKit+Stream.swift */; };
 		4F05ECB92B6CCA4900641820 /* DifferenceKit+Stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F05ECB72B6CCA4900641820 /* DifferenceKit+Stream.swift */; };
 		4F12DC8C2B70DE82009E48CC /* DifferenceKit+Stream_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F12DC8A2B70DE4C009E48CC /* DifferenceKit+Stream_Tests.swift */; };
+		4F12DC922B73801D009E48CC /* NukeImageLoader_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F12DC912B73801D009E48CC /* NukeImageLoader_Tests.swift */; };
 		6428DD5526201DCC0065DA1D /* BannerShowingConnectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */; };
 		647F66D5261E22C200111B19 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F66D4261E22C200111B19 /* BannerView.swift */; };
 		648EC576261EF9D400B8F05F /* DemoAppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648EC575261EF9D400B8F05F /* DemoAppCoordinator.swift */; };
@@ -2868,6 +2869,7 @@
 		4A51230029D3170C005CEA9B /* docusaurus */ = {isa = PBXFileReference; lastKnownFileType = folder; path = docusaurus; sourceTree = "<group>"; };
 		4F05ECB72B6CCA4900641820 /* DifferenceKit+Stream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DifferenceKit+Stream.swift"; sourceTree = "<group>"; };
 		4F12DC8A2B70DE4C009E48CC /* DifferenceKit+Stream_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DifferenceKit+Stream_Tests.swift"; sourceTree = "<group>"; };
+		4F12DC912B73801D009E48CC /* NukeImageLoader_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NukeImageLoader_Tests.swift; sourceTree = "<group>"; };
 		6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerShowingConnectionDelegate.swift; sourceTree = "<group>"; };
 		647F66D4261E22C200111B19 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
 		648EC575261EF9D400B8F05F /* DemoAppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppCoordinator.swift; sourceTree = "<group>"; };
@@ -7226,6 +7228,7 @@
 		A3960E0427DA5512003AB2B0 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				AD4CDD80296498B10057BC8A /* ViewPaginationHandling */,
 				BDDD1EAB2632E32000BA007B /* AppearanceProvider_Tests.swift */,
 				C1320E07276B2E0800A06B35 /* Array+SafeSubscript_Tests.swift */,
 				E73262D725ED6432008CB152 /* ChatChannelNamer_Tests.swift */,
@@ -7238,11 +7241,11 @@
 				AD4C15552A55874700A32955 /* ImageLoading_Tests.swift */,
 				AD7BBFCD2901B1AE004E8B76 /* ImageResultsMapper_Tests.swift */,
 				ADD2A99528FF227800A83305 /* ImageSizeCalculator_Tests.swift */,
+				4F12DC912B73801D009E48CC /* NukeImageLoader_Tests.swift */,
 				BD40C1F4265FA80D004392CE /* StreamImageCDN_Tests.swift */,
 				ACDB5412269C6F2A007CD465 /* String+Extensions_Tests.swift */,
 				ADAA9F402B2240300078C3D4 /* TextViewMentionedUsersHandler_Tests.swift */,
 				7865705725FB6DF300974045 /* UIViewController+Extensions_Tests.swift */,
-				AD4CDD80296498B10057BC8A /* ViewPaginationHandling */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -10139,6 +10142,7 @@
 				406CC6152A127552000780F7 /* VoiceRecordingAttachmentViewInjector_Tests.swift in Sources */,
 				A3D9D69727EDE87C00725066 /* ImageLoader_Mock.swift in Sources */,
 				4F12DC8C2B70DE82009E48CC /* DifferenceKit+Stream_Tests.swift in Sources */,
+				4F12DC922B73801D009E48CC /* NukeImageLoader_Tests.swift in Sources */,
 				64B75B002631700500A466D1 /* ChatMessage_Tests.swift in Sources */,
 				ADAA377125E43C3700C31528 /* ChatSuggestionsVC_Tests.swift in Sources */,
 				E73262E025ED64AB008CB152 /* ChatChannelNamer_Tests.swift in Sources */,

--- a/Tests/StreamChatUITests/Utils/NukeImageLoader_Tests.swift
+++ b/Tests/StreamChatUITests/Utils/NukeImageLoader_Tests.swift
@@ -1,0 +1,114 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import StreamChatTestTools
+@testable import StreamChatUI
+import XCTest
+
+final class NukeImageLoader_Tests: XCTestCase {
+    private var requests: [ImageDownloadRequest]!
+    private var imageLoader: MockNukeImageLoader!
+    private var imagePipeline: MockPipeline!
+    
+    override func setUpWithError() throws {
+        imagePipeline = MockPipeline()
+        imageLoader = MockNukeImageLoader(mockPipeline: imagePipeline)
+        requests = (0..<5)
+            .compactMap { URL(string: "https://www.example.com/\($0)") }
+            .map { ImageDownloadRequest(url: $0, options: .init()) }
+    }
+    
+    override func tearDownWithError() throws {
+        imageLoader = nil
+        imagePipeline = nil
+        requests = nil
+    }
+
+    func test_downloadMultipleImages_whenPipelineReturnsResultsInTheSameOrder_thenCompletionResultsAreInTheSameOrderAsPassedInRequests() throws {
+        let expectation = XCTestExpectation()
+        imageLoader.downloadMultipleImages(with: requests) { results in
+            let ids = results.map(MockPipeline.pipelineLoadingCompletionIndex(for:))
+            XCTAssertEqual(ids, [1, 2, 3, 4, 5])
+            expectation.fulfill()
+        }
+        imagePipeline.dispatchPipelineCompletions(order: .same)
+        wait(for: [expectation], timeout: defaultTimeout)
+    }
+    
+    func test_downloadMultipleImages_whenPipelineReturnsResultsInReverseOrder_thenCompletionResultsAreInTheSameOrderAsPassedInRequests() throws {
+        let expectation = XCTestExpectation()
+        imageLoader.downloadMultipleImages(with: requests) { results in
+            let ids = results.map(MockPipeline.pipelineLoadingCompletionIndex(for:))
+            XCTAssertEqual(ids, [1, 2, 3, 4, 5])
+            expectation.fulfill()
+        }
+        imagePipeline.dispatchPipelineCompletions(order: .reversed)
+        wait(for: [expectation], timeout: defaultTimeout)
+    }
+    
+    func test_downloadMultipleImages_whenPipelineReturnsResultsInShuffledOrder_thenCompletionResultsAreInTheSameOrderAsPassedInRequests() throws {
+        let expectation = XCTestExpectation()
+        imageLoader.downloadMultipleImages(with: requests) { results in
+            let ids = results.map(MockPipeline.pipelineLoadingCompletionIndex(for:))
+            XCTAssertEqual(ids, [1, 2, 3, 4, 5])
+            expectation.fulfill()
+        }
+        imagePipeline.dispatchPipelineCompletions(order: .shuffled)
+        wait(for: [expectation], timeout: defaultTimeout)
+    }
+}
+
+extension NukeImageLoader_Tests {
+    final class MockPipeline: NukeImagePipelineLoading {
+        enum Order {
+            case same, reversed, shuffled
+        }
+        
+        private var counter: Int = 0
+        private var scheduledRequests = [(loadOrderId: Int, request: ImageRequest, completion: (Result<UIImage, Error>) -> Void)]()
+        
+        func dispatchPipelineCompletions(order: Order) {
+            let requests = {
+                switch order {
+                case .same: return scheduledRequests
+                case .reversed: return scheduledRequests.reversed()
+                case .shuffled:
+                    let first = scheduledRequests.filter { !$0.loadOrderId.isMultiple(of: 2) }
+                    let second = scheduledRequests.filter { $0.loadOrderId.isMultiple(of: 2) }
+                    return first + second
+                }
+            }()
+            for request in requests {
+                request.completion(.success(Self.responseImage(for: request.loadOrderId)))
+            }
+        }
+        
+        static func responseImage(for loadOrderId: Int) -> UIImage {
+            UIGraphicsImageRenderer(size: CGSize(width: loadOrderId, height: loadOrderId)).image { _ in }
+        }
+        
+        static func pipelineLoadingCompletionIndex(for result: Result<UIImage, Error>) -> Int {
+            guard let image = try? result.get() else { return -1 }
+            return Int(image.size.width)
+        }
+        
+        func loadImage(with request: ImageRequest, completion: @escaping (Result<UIImage, Swift.Error>) -> Void) -> ImageTask {
+            counter += 1
+            scheduledRequests.append((counter, request, completion))
+            return ImageTask(taskId: Int64(counter), request: request, isDataTask: false)
+        }
+    }
+    
+    final class MockNukeImageLoader: NukeImageLoader {
+        let mockPipeline: MockPipeline
+        
+        init(mockPipeline: MockPipeline) {
+            self.mockPipeline = mockPipeline
+        }
+        
+        override var imagePipeline: NukeImagePipelineLoading {
+            mockPipeline
+        }
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Related to [ios-issues-tracking/669](https://github.com/GetStream/ios-issues-tracking/issues/669)

### 🎯 Goal

Removed the flickering when opening channel list and merged avatars are loaded.

### 📝 Summary

- Remove the non-determinism in the NukeImageLoader

### 🛠 Implementation

NukeImageLoader sends multiple image loading requests to Nuke. It collects an array of results but the array is not sorted and depends on which request finished first. We currently just converted results into an array of images and proceeded with creating the merged avatars (individual images are also cached). When channel list updates cells, then the avatar generation is triggered again but this time, the order is different, because we already have images cached (in that case request order == response order). This change will make sure that returned images are always ordered by initiated requests order.

### 🎨 Showcase

| Before | After |
| ------ | ----- |
| ![](https://github.com/GetStream/stream-chat-swift/assets/1469907/37817237-279f-4522-a220-cdfd3ce1aa86)   |  ![](https://github.com/GetStream/stream-chat-swift/assets/1469907/0400d505-f577-4259-bd19-53dd2632df00)  |

### 🧪 Manual Testing Notes

1. Login with account, I used R2-D2 and observe merged avatars when channel list appears

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)


