### PR TITLE
Do not check token expiration client side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `NewMessagePendingEvent.message` with empty `cid` [#2997](https://github.com/GetStream/stream-chat-swift/pull/2997)
 - Fix attachments being sent with local URL paths [#3008](https://github.com/GetStream/stream-chat-swift/pull/3008)
 - Fix rare crash in `AttachmentDTO.id` when accessed outside of CoreData's context [#3008](https://github.com/GetStream/stream-chat-swift/pull/3008)
+### 🔄 Changed
+- Do not check token expiration client-side, only server-side [#3014](https://github.com/GetStream/stream-chat-swift/pull/3014)
 
 ## StreamChatUI
 ### ✅ Added

--- a/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
+++ b/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
@@ -565,7 +565,7 @@ class AppConfigViewController: UITableViewController {
             textField.keyboardType = .numberPad
         }
 
-        alert.addAction(.init(title: "OK", style: .default, handler: { _ in
+        alert.addAction(.init(title: "Enable", style: .default, handler: { _ in
             guard let appSecret = alert.textFields?[0].text else { return }
             guard let duration = alert.textFields?[1].text else { return }
             self.demoAppConfig.tokenRefreshDetails = .init(

--- a/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
+++ b/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
@@ -12,14 +12,22 @@ struct DemoAppConfig {
     var isHardDeleteEnabled: Bool
     /// A Boolean value to define if Atlantis will be started to proxy HTTP and WebSocket calls.
     var isAtlantisEnabled: Bool
-    /// A Boolean value to define if we should mimic token refresh scenarios.
-    var isTokenRefreshEnabled: Bool
     /// A Boolean value to define if an additional message debugger action will be added.
     var isMessageDebuggerEnabled: Bool
     /// A Boolean value to define if channel pinning example is enabled.
     var isChannelPinningEnabled: Bool
     /// A Boolean value to define if custom location attachments are enabled.
     var isLocationAttachmentsEnabled: Bool
+    /// Set this value to define if we should mimic token refresh scenarios.
+    var tokenRefreshDetails: TokenRefreshDetails?
+
+    /// The details to generate expirable tokens in the demo app.
+    struct TokenRefreshDetails {
+        // The app secret from the dashboard.
+        let appSecret: String
+        // The duration in seconds until the token is expired.
+        let duration: TimeInterval
+    }
 }
 
 class AppConfig {
@@ -33,10 +41,10 @@ class AppConfig {
         demoAppConfig = DemoAppConfig(
             isHardDeleteEnabled: false,
             isAtlantisEnabled: false,
-            isTokenRefreshEnabled: false,
             isMessageDebuggerEnabled: false,
             isChannelPinningEnabled: false,
-            isLocationAttachmentsEnabled: false
+            isLocationAttachmentsEnabled: false,
+            tokenRefreshDetails: nil
         )
 
         StreamRuntimeCheck._isBackgroundMappingEnabled = true
@@ -45,7 +53,6 @@ class AppConfig {
             demoAppConfig.isAtlantisEnabled = true
             demoAppConfig.isMessageDebuggerEnabled = true
             demoAppConfig.isLocationAttachmentsEnabled = true
-            demoAppConfig.isTokenRefreshEnabled = true
             demoAppConfig.isLocationAttachmentsEnabled = true
             demoAppConfig.isHardDeleteEnabled = true
             StreamRuntimeCheck.assertionsEnabled = true
@@ -154,6 +161,7 @@ class AppConfigViewController: UITableViewController {
         case isChannelPinningEnabled
         case isLocationAttachmentsEnabled
         case isBackgroundMappingEnabled
+        case tokenRefreshDetails
     }
 
     enum ComponentsConfigOption: String, CaseIterable {
@@ -238,7 +246,7 @@ class AppConfigViewController: UITableViewController {
         guard let cell = tableView.cellForRow(at: indexPath) else { return }
 
         switch options[indexPath.section] {
-        case .info, .demoApp:
+        case .info:
             break
         case let .components(options):
             didSelectComponentsOptionsCell(cell, at: indexPath, options: options)
@@ -246,6 +254,8 @@ class AppConfigViewController: UITableViewController {
             didSelectChatClientOptionsCell(cell, at: indexPath, options: options)
         case let .user(options):
             didSelectUserOptionsCell(cell, at: indexPath, options: options)
+        case let .demoApp(options):
+            didSelectDemoAppOptionsCell(cell, at: indexPath, options: options)
         }
     }
 
@@ -295,6 +305,13 @@ class AppConfigViewController: UITableViewController {
             cell.accessoryView = makeSwitchButton(StreamRuntimeCheck._isBackgroundMappingEnabled) { newValue in
                 StreamRuntimeCheck._isBackgroundMappingEnabled = newValue
             }
+        case .tokenRefreshDetails:
+            if let tokenRefreshDuration = demoAppConfig.tokenRefreshDetails?.duration {
+                cell.detailTextLabel?.text = "Duration: \(tokenRefreshDuration)s"
+            } else {
+                cell.detailTextLabel?.text = "Disabled"
+            }
+            cell.accessoryType = .none
         }
     }
 
@@ -452,6 +469,20 @@ class AppConfigViewController: UITableViewController {
         }
     }
 
+    private func didSelectDemoAppOptionsCell(
+        _ cell: UITableViewCell,
+        at indexPath: IndexPath,
+        options: [DemoAppConfigOption]
+    ) {
+        let option = options[indexPath.row]
+        switch option {
+        case .tokenRefreshDetails:
+            showTokenDetailsAlert()
+        default:
+            break
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeSwitchButton(_ initialValue: Bool, _ didChangeValue: @escaping (Bool) -> Void) -> SwitchButton {
@@ -515,5 +546,38 @@ class AppConfigViewController: UITableViewController {
         }
 
         navigationController?.pushViewController(selectorViewController, animated: true)
+    }
+
+    private func showTokenDetailsAlert() {
+        let alert = UIAlertController(
+            title: "Token Refreshing",
+            message: "Input the app secret from Stream's Dashboard and the desired duration.",
+            preferredStyle: .alert
+        )
+
+        alert.addTextField { textField in
+            textField.placeholder = "App Secret"
+            textField.autocapitalizationType = .none
+            textField.autocorrectionType = .no
+        }
+        alert.addTextField { textField in
+            textField.placeholder = "Duration (Seconds)"
+            textField.keyboardType = .numberPad
+        }
+
+        alert.addAction(.init(title: "OK", style: .default, handler: { _ in
+            guard let appSecret = alert.textFields?[0].text else { return }
+            guard let duration = alert.textFields?[1].text else { return }
+            self.demoAppConfig.tokenRefreshDetails = .init(
+                appSecret: appSecret,
+                duration: TimeInterval(duration)!
+            )
+        }))
+
+        alert.addAction(.init(title: "Disable", style: .destructive, handler: { _ in
+            self.demoAppConfig.tokenRefreshDetails = nil
+        }))
+
+        present(alert, animated: true, completion: nil)
     }
 }

--- a/DemoApp/Shared/StreamChatWrapper.swift
+++ b/DemoApp/Shared/StreamChatWrapper.swift
@@ -54,17 +54,23 @@ extension StreamChatWrapper {
                 language: UserConfig.shared.language,
                 extraData: userCredentials.userInfo.extraData
             )
-            guard AppConfig.shared.demoAppConfig.isTokenRefreshEnabled else {
+
+            if let tokenRefreshDetails = AppConfig.shared.demoAppConfig.tokenRefreshDetails {
                 client?.connectUser(
                     userInfo: userInfo,
-                    token: userCredentials.token,
+                    tokenProvider: refreshingTokenProvider(
+                        initialToken: userCredentials.token,
+                        appSecret: tokenRefreshDetails.appSecret,
+                        tokenDuration: tokenRefreshDetails.duration
+                    ),
                     completion: completion
                 )
                 return
             }
+
             client?.connectUser(
                 userInfo: userInfo,
-                tokenProvider: refreshingTokenProvider(initialToken: userCredentials.token, tokenDurationInMinutes: 60),
+                token: userCredentials.token,
                 completion: completion
             )
         case let .guest(userId):

--- a/DemoApp/Shared/Token+Development.swift
+++ b/DemoApp/Shared/Token+Development.swift
@@ -2,42 +2,36 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
+import CryptoKit
 import Foundation
 import StreamChat
 
 extension StreamChatWrapper {
-    func refreshingTokenProvider(initialToken: Token, tokenDurationInMinutes: Double) -> TokenProvider {
+    func refreshingTokenProvider(
+        initialToken: Token,
+        appSecret: String,
+        tokenDuration: TimeInterval
+    ) -> TokenProvider {
         { completion in
             // Simulate API call delay
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 let token: Token
-                #if GENERATE_JWT
-                let timeInterval = TimeInterval(tokenDurationInMinutes * 60)
                 let generatedToken = _generateUserToken(
                     secret: appSecret,
                     userID: initialToken.userId,
-                    expirationDate: Date().addingTimeInterval(timeInterval)
+                    expirationDate: Date().addingTimeInterval(tokenDuration)
                 )
                 if generatedToken == nil {
-                    log.warning("Unable to generate token. Falling back to initialToken")
+                    print("Demo App Token Refreshing: Unable to generate token.")
+                } else {
+                    print("Demo App Token Refreshing: New token generated.")
                 }
                 token = generatedToken ?? initialToken
-                #else
-                token = initialToken
-                #endif
                 completion(.success(token))
             }
         }
     }
 }
-
-#if GENERATE_JWT
-
-import CryptoKit
-import Foundation
-import StreamChat
-
-let appSecret = ""
 
 extension Data {
     func urlSafeBase64EncodedString() -> String {
@@ -78,5 +72,3 @@ func _generateUserToken(secret: String, userID: String, expirationDate: Date) ->
     let token = [headerBase64String, payloadBase64String, signatureBase64String].joined(separator: ".")
     return try? Token(rawValue: token)
 }
-
-#endif

--- a/DemoApp/Shared/Token+Development.swift
+++ b/DemoApp/Shared/Token+Development.swift
@@ -15,19 +15,24 @@ extension StreamChatWrapper {
         { completion in
             // Simulate API call delay
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                let token: Token
-                let generatedToken = _generateUserToken(
-                    secret: appSecret,
-                    userID: initialToken.userId,
-                    expirationDate: Date().addingTimeInterval(tokenDuration)
-                )
+                var generatedToken: Token?
+                
+                if #available(iOS 13.0, *) {
+                    generatedToken = _generateUserToken(
+                        secret: appSecret,
+                        userID: initialToken.userId,
+                        expirationDate: Date().addingTimeInterval(tokenDuration)
+                    )
+                }
+
                 if generatedToken == nil {
                     print("Demo App Token Refreshing: Unable to generate token.")
                 } else {
                     print("Demo App Token Refreshing: New token generated.")
                 }
-                token = generatedToken ?? initialToken
-                completion(.success(token))
+
+                let newToken = generatedToken ?? initialToken
+                completion(.success(newToken))
             }
         }
     }
@@ -54,6 +59,7 @@ struct JWTPayload: Encodable {
 
 // DO NOT USE THIS FOR REAL APPS! This function is only here to make it easier to
 // have expired token renewal while using the standalone demo application
+@available(iOS 13.0, *)
 func _generateUserToken(secret: String, userID: String, expirationDate: Date) -> Token? {
     guard !secret.isEmpty else { return nil }
     let privateKey = SymmetricKey(data: secret.data(using: .utf8)!)

--- a/Sources/StreamChat/Config/Token.swift
+++ b/Sources/StreamChat/Config/Token.swift
@@ -10,6 +10,12 @@ public struct Token: Decodable, Equatable, ExpressibleByStringLiteral {
     public let userId: UserId
     public let expiration: Date?
 
+    @available(
+        *,
+        deprecated,
+        
+        message: "It is not a good practice to check expiration client side since the user can change the device's time."
+    )
     public var isExpired: Bool {
         expiration.map { $0 < Date() } ?? false
     }

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -338,6 +338,7 @@ class AuthenticationRepository {
         }
 
         let onTokenReceived: (Token) -> Void = { [weak self, weak connectionRepository] token in
+            self?.isGettingToken = false
             self?.prepareEnvironment(userInfo: userInfo, newToken: token)
             // We manually change the `connectionStatus` for passive client
             // to `disconnected` when environment was prepared correctly

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -363,13 +363,11 @@ class AuthenticationRepository {
         log.debug("Requesting a new token", subsystems: .authentication)
         tokenProvider { [weak self] result in
             switch result {
-            case let .success(newToken) where !newToken.isExpired:
+            case let .success(newToken):
                 onTokenReceived(newToken)
                 self?.tokenQueue.sync(flags: .barrier) {
                     self?._tokenExpirationRetryStrategy.resetConsecutiveFailures()
                 }
-            case .success:
-                retryFetchIfPossible(nil)
             case let .failure(error):
                 log.info("Failed fetching token with error: \(error)")
                 retryFetchIfPossible(error)

--- a/Sources/StreamChat/Repositories/ConnectionRepository.swift
+++ b/Sources/StreamChat/Repositories/ConnectionRepository.swift
@@ -141,8 +141,7 @@ class ConnectionRepository {
             shouldNotifyConnectionIdWaiters = true
             connectionId = id
 
-        case let .disconnecting(source) where source.serverError?.isInvalidTokenError == true,
-             let .disconnected(source) where source.serverError?.isInvalidTokenError == true:
+        case let .disconnected(source) where source.serverError?.isInvalidTokenError == true:
             onInvalidToken()
             shouldNotifyConnectionIdWaiters = false
             connectionId = nil


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/719

### 🎯 Goal

Do not check token expiration client side. This is a bad practice since the user can change the device's time. 

### 📝 Summary
- Stops checking expiration client side
- Fixes duplicated refresh tokens
- Fixes token refreshing not working when done server-side
- Adds the possibility to set refresh tokens in the Demo App

### 🛠 Implementation
The main reason why server side refresh token was not working properly it was because `isGettingToken = false` should be set on `tokenReceived` as well, and not only when the waiting completion blocks are executed. The refresh token wouldn't be executed because `isGettingToken` was `true`, so it would ignore the refresh.

### 🧪 Manual Testing Notes
1. Open Demo App Configuration
2. Tap on "tokenRefreshDetails"
3. Input the app secret from the dashboard and the desired duration
4. Connect a user
5. The app should work normally. The console log will output this whenever a token is refreshed:
    `> Demo App Token Refreshing: New token generated.`

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
