### PR TITLE
Make reconfigure closure optional when reloading with staged changesets

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListView+DiffKit.swift
@@ -22,8 +22,7 @@ extension ChatMessageListView {
         CATransaction.setCompletionBlock(completion)
         reload(
             using: changeset,
-            with: animation(),
-            reconfigure: { _ in false }
+            with: animation()
         ) { [weak self] newMessages in
             self?.onNewDataSource?(newMessages)
         }

--- a/Sources/StreamChatUI/Utils/Extensions/DifferenceKit+Stream.swift
+++ b/Sources/StreamChatUI/Utils/Extensions/DifferenceKit+Stream.swift
@@ -29,7 +29,7 @@ extension UITableView {
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         with animation: @autoclosure () -> RowAnimation,
-        reconfigure: (IndexPath) -> Bool,
+        reconfigure: ((IndexPath) -> Bool)? = nil,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         setData: (C) -> Void
     ) {
@@ -74,7 +74,7 @@ extension UITableView {
         deleteRowsAnimation: @autoclosure () -> RowAnimation,
         insertRowsAnimation: @autoclosure () -> RowAnimation,
         reloadRowsAnimation: @autoclosure () -> RowAnimation,
-        reconfigure: (IndexPath) -> Bool = { _ in false },
+        reconfigure: ((IndexPath) -> Bool)? = nil,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         setData: (C) -> Void
     ) {
@@ -118,7 +118,7 @@ extension UITableView {
                 
                 if !changeset.elementUpdated.isEmpty {
                     var indexPaths = changeset.elementUpdated.map { IndexPath(row: $0.element, section: $0.section) }
-                    if #available(iOS 15.0, *) {
+                    if #available(iOS 15.0, *), let reconfigure {
                         let partitioned = indexPaths.partitionReconfigurable(by: reconfigure)
                         if !partitioned.reconfiguredIndexPaths.isEmpty {
                             reconfigureRows(at: partitioned.reconfiguredIndexPaths)
@@ -165,7 +165,7 @@ extension UICollectionView {
     ///              The collection should be set to data-source of UICollectionView.
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
-        reconfigure: (IndexPath) -> Bool,
+        reconfigure: ((IndexPath) -> Bool)? = nil,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         setData: (C) -> Void
     ) {
@@ -210,7 +210,7 @@ extension UICollectionView {
                 if !changeset.elementUpdated.isEmpty {
                     var indexPaths = changeset.elementUpdated.map { IndexPath(row: $0.element, section: $0.section) }
                     
-                    if #available(iOS 15.0, *) {
+                    if #available(iOS 15.0, *), let reconfigure {
                         let partitioned = indexPaths.partitionReconfigurable(by: reconfigure)
                         if !partitioned.reconfiguredIndexPaths.isEmpty {
                             reconfigureItems(at: partitioned.reconfiguredIndexPaths)


### PR DESCRIPTION
### 🔗 Issue Links

Related to [PR:2996](https://github.com/GetStream/stream-chat-swift/pull/2996)

### 🎯 Goal

Make call sites nicer when we actually do not want to use reconfigure support (example: message list). Also optional closure allows skipping the partition call if we want to skip reconfigure.
This is a cleanup to the existing PR.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
