### PR TITLE
Fix CGBitmapContextInfoCreate warnings in console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix composer link preview overridden by previous enrichment [#3025](https://github.com/GetStream/stream-chat-swift/pull/3025)
 - Fix merged avatars changing sub-image locations when opening channel list [#3013](https://github.com/GetStream/stream-chat-swift/pull/3013)
 - Fix native swipe-back gesture overridden by swipe-to-reply [#3029](https://github.com/GetStream/stream-chat-swift/pull/3029)
+- Fix `CGBitmapContextInfoCreate` console log warning when creating merged channel avatars [#3018](https://github.com/GetStream/stream-chat-swift/pull/3018)
 
 # [4.48.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.48.1)
 _February 09, 2024_

--- a/Sources/StreamChatUI/Utils/ImageLoading/ImageResultsMapper.swift
+++ b/Sources/StreamChatUI/Utils/ImageLoading/ImageResultsMapper.swift
@@ -18,22 +18,25 @@ struct ImageResultsMapper {
     /// - Returns: Returns an array of UIImages without errors.
     func mapErrors(with placeholderImages: [UIImage]) -> [UIImage] {
         var placeholderImages = placeholderImages
-        var finalImages: [UIImage] = []
-
-        for result in results {
+        return mapErrors {
+            guard !placeholderImages.isEmpty else { return nil }
+            return placeholderImages.removeFirst()
+        }
+    }
+    
+    /// Replace errors with placeholder images.
+    ///
+    /// - Parameter provider: The placeholder image provider. Returning nil will skip the result with a failure.
+    ///
+    /// - Returns: Returns an array of UIImages without errors.
+    func mapErrors(with provider: () -> UIImage?) -> [UIImage] {
+        results.compactMap { result in
             switch result {
             case let .success(image):
-                finalImages.append(image)
+                return image
             case .failure:
-                guard !placeholderImages.isEmpty else {
-                    continue
-                }
-
-                let placeholder = placeholderImages.removeFirst()
-                finalImages.append(placeholder)
+                return provider()
             }
         }
-
-        return finalImages
     }
 }

--- a/Tests/StreamChatUITests/Mocks/ImageLoader_Mock.swift
+++ b/Tests/StreamChatUITests/Mocks/ImageLoader_Mock.swift
@@ -23,7 +23,12 @@ final class ImageLoader_Mock: ImageLoading {
         with request: ImageDownloadRequest,
         completion: @escaping ((Result<UIImage, Error>) -> Void)
     ) -> Cancellable? {
-        let image = UIImage(data: try! Data(contentsOf: request.url))!
+        var image = UIImage(data: try! Data(contentsOf: request.url))!
+        
+        if let resize = request.options.resize {
+            let cgSize = CGSize(width: resize.width, height: resize.height)
+            image = NukeImageProcessor().scale(image: image, to: cgSize)
+        }
         completion(.success(image))
         return nil
     }
@@ -32,9 +37,14 @@ final class ImageLoader_Mock: ImageLoading {
         with requests: [ImageDownloadRequest],
         completion: @escaping (([Result<UIImage, Error>]) -> Void)
     ) {
-        let results = requests.map(\.url).map {
-            Result<UIImage, Error>.success(UIImage(data: try! Data(contentsOf: $0))!)
-        }
+        let results = requests
+            .map { request in
+                let image = UIImage(data: try! Data(contentsOf: request.url))!
+                guard let resize = request.options.resize else { return image }
+                let cgSize = CGSize(width: resize.width, height: resize.height)
+                return NukeImageProcessor().scale(image: image, to: cgSize)
+            }
+            .map { Result<UIImage, Error>.success($0) }
         completion(results)
     }
 }

--- a/Tests/StreamChatUITests/Utils/ImageResultsMapper_Tests.swift
+++ b/Tests/StreamChatUITests/Utils/ImageResultsMapper_Tests.swift
@@ -128,4 +128,24 @@ final class ImageResultsMapper_Tests: XCTestCase {
             fakePlaceholderImage4
         ])
     }
+    
+    func test_mapErrorsWithPlaceholders_when2ErrorsBut1Placeholder_then1FailingResultIsDropped() {
+        let results: [Result<UIImage, Error>] = [
+            .success(TestImages.chewbacca.image),
+            .failure(MockError()),
+            .failure(MockError()),
+            .success(TestImages.yoda.image)
+        ]
+
+        let mapper = ImageResultsMapper(results: results)
+        let images = mapper.mapErrors(with: [
+            fakePlaceholderImage1
+        ])
+
+        XCTAssertEqual(images, [
+            TestImages.chewbacca.image,
+            fakePlaceholderImage1,
+            TestImages.yoda.image
+        ])
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [ios-issues-tracking/725](https://github.com/GetStream/ios-issues-tracking/issues/725)

### 🎯 Goal

Fix CGBitmapContextInfoCreate warnings in console log when opening the channel list

### 📝 Summary

- CGBitmapContextInfoCreate warning does not appear

### 🛠 Implementation

CGBitmapContextInfoCreate warning appeared in console when creating merged/avatar collages for channel list. The warning was triggered when already resized image was passed again to the Nuke's image resizer. Seems to be an issue with creating a CGContext the Nuke uses for the same image which came from the same CGContext (e.g. double resize). Only triggered for images which have wide gamut/extended color space. Seems like it is something to do with bitmapInfo and color space mismatch (extended color spaces should use float data for the image store which is also an option part of CGBitmapInfo). Since we can't change Nuke, the fix is to avoid double resize call (which does not make sense anyway). 

`CGBitmapContextInfoCreate: CGColorSpace which uses extended range requires floating point or CIF10 bitmap context`

### 🎨 Showcase

Screenshots comparing the same channel list. We expect no visual changes.

| Before | After |
| ------ | ----- |
| ![before](https://github.com/GetStream/stream-chat-swift/assets/1469907/ea5fab51-01b0-4436-b111-dfb71db3b48c) |  ![after](https://github.com/GetStream/stream-chat-swift/assets/1469907/7dc2cdc1-bb8e-4dfa-9ab1-32875a57a268) |

### 🧪 Manual Testing Notes

1. Log in with a test account, channel list must have channels with merged avatars
2. Observe Xcode's console, no warning about bitmap context should be logged

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
