### PR TITLE
Cache regular expression used for markdown which increases performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix merged avatars changing sub-image locations when opening channel list [#3013](https://github.com/GetStream/stream-chat-swift/pull/3013)
 - Fix native swipe-back gesture overridden by swipe-to-reply [#3029](https://github.com/GetStream/stream-chat-swift/pull/3029)
 - Fix `CGBitmapContextInfoCreate` console log warning when creating merged channel avatars [#3018](https://github.com/GetStream/stream-chat-swift/pull/3018)
+- Slight performance improvement in the message list by caching `NSRegularExpression` in `MarkdownFormatter` [#3020](https://github.com/GetStream/stream-chat-swift/pull/3020)
 
 # [4.48.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.48.1)
 _February 09, 2024_

--- a/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
+++ b/Sources/StreamChatUI/Appearance+Formatters/MarkdownFormatter.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import StreamChat
 import UIKit
 
 public protocol MarkdownFormatter {
@@ -27,11 +28,16 @@ open class DefaultMarkdownFormatter: MarkdownFormatter {
     private let markdownRegexPattern: String =
         "((?:\\`(.*?)\\`)|(?:\\*{1,2}(.*?)\\*{1,2})|(?:\\~{2}(.*?)\\~{2})|(?:\\_{1,2}(.*?)\\_{1,2})|^(>){1}|(#){1,6}|(=){3,10}|(-){1,3}|(\\d{1,3}\\.)|(?:\\[(.*?)\\])(?:\\((.*?)\\))|(?:\\[(.*?)\\])(?:\\[(.*?)\\])|(\\]\\:))+"
 
-    open func containsMarkdown(_ string: String) -> Bool {
+    private lazy var regex: NSRegularExpression? = {
         guard let regex = try? NSRegularExpression(pattern: markdownRegexPattern, options: .anchorsMatchLines) else {
-            return false
+            log.error("Failed to create markdown regular expression")
+            return nil
         }
-
+        return regex
+    }()
+    
+    open func containsMarkdown(_ string: String) -> Bool {
+        guard let regex = regex else { return false }
         return regex.numberOfMatches(in: string, range: .init(location: 0, length: string.utf16.count)) > 0
     }
 


### PR DESCRIPTION
### 🔗 Issue Links

Related: [ios-issues-tracking/669](https://github.com/GetStream/ios-issues-tracking/issues/669)

### 🎯 Goal

Better performance by caching regular expression

### 🛠 Implementation

Time profiler shows that recreating NSRegularExpression gets expensive. I was seeing ~0.6% of main thread time spent on just creating the NSRegularExpression again and again.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
