### PR TITLE
Skipping channel updates did not work when displaying message list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix native swipe-back gesture overridden by swipe-to-reply [#3029](https://github.com/GetStream/stream-chat-swift/pull/3029)
 - Fix `CGBitmapContextInfoCreate` console log warning when creating merged channel avatars [#3018](https://github.com/GetStream/stream-chat-swift/pull/3018)
 - Slight performance improvement in the message list by caching `NSRegularExpression` in `MarkdownFormatter` [#3020](https://github.com/GetStream/stream-chat-swift/pull/3020)
+- Slight performance improvement in the message list by skipping channel list updates when it is not visible [#3021](https://github.com/GetStream/stream-chat-swift/pull/3021)
 
 # [4.48.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.48.1)
 _February 09, 2024_

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -83,6 +83,7 @@ open class ChatChannelListVC: _ViewController,
     /// is impacting the message list performance as well, so we skip channel list
     /// updates when the channel list is not visible in the window.
     private(set) var skippedRendering = false
+    private(set) var skipChannelUpdates = true
 
     /// A component responsible to handle when to load new channels.
     private lazy var viewPaginationHandler: ViewPaginationHandling = {
@@ -162,11 +163,19 @@ open class ChatChannelListVC: _ViewController,
 
     override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
+        skipChannelUpdates = false
+        
         if skippedRendering {
-            reloadChannels()
+            UIView.performWithoutAnimation {
+                reloadChannels()
+            }
             skippedRendering = false
         }
+    }
+    
+    override open func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        skipChannelUpdates = true
     }
 
     open func collectionView(
@@ -395,8 +404,7 @@ open class ChatChannelListVC: _ViewController,
         _ controller: ChatChannelListController,
         didChangeChannels changes: [ListChange<ChatChannel>]
     ) {
-        let isViewNotVisible = viewIfLoaded?.window == nil
-        if isViewNotVisible {
+        if skipChannelUpdates {
             skippedRendering = true
             return
         }

--- a/Tests/StreamChatUITests/SnapshotTests/ChatChannelList/ChatChannelListVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/ChatChannelList/ChatChannelListVC_Tests.swift
@@ -307,6 +307,7 @@ final class ChatChannelListVC_Tests: XCTestCase {
         mockedChannelListController.channels_mock = [.mock(cid: .unique)]
         channelListVC.emptyView.isHidden = false
 
+        channelListVC.viewWillAppear(false)
         channelListVC.controller(mockedChannelListController, didChangeChannels: [])
 
         XCTAssertEqual(channelListVC.emptyView.isHidden, true)
@@ -320,6 +321,7 @@ final class ChatChannelListVC_Tests: XCTestCase {
         mockedChannelListController.channels_mock = []
         channelListVC.emptyView.isHidden = true
 
+        channelListVC.viewWillAppear(false)
         channelListVC.controller(mockedChannelListController, didChangeChannels: [])
 
         XCTAssertEqual(channelListVC.emptyView.isHidden, false)
@@ -332,13 +334,15 @@ final class ChatChannelListVC_Tests: XCTestCase {
         mockedChannelListController.channels_mock = [.mock(cid: .unique), .mock(cid: .unique)]
         channelListVC.controller(mockedChannelListController, didChangeChannels: [])
         XCTAssertEqual(channelListVC.skippedRendering, true)
-
+        XCTAssertEqual(channelListVC.skipChannelUpdates, true)
+        
         channelListVC.viewWillAppear(false)
 
         XCTAssertEqual(channelListVC.skippedRendering, false)
+        XCTAssertEqual(channelListVC.skipChannelUpdates, false)
         XCTAssertEqual(channelListVC.reloadChannelsCallCount, 1)
     }
-
+    
     func test_swipeableViewActionViews() {
         mockedChannelListController.channels_mock = [.mock(cid: .unique, ownCapabilities: [.deleteChannel])]
         let channelListVC = ChatChannelListVC()


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [ios-issues-tracking/42](https://github.com/GetStream/ios-issues-tracking/issues/42)

Related [ios-issues-tracking/669](https://github.com/GetStream/ios-issues-tracking/issues/669)

### 🎯 Goal

Fix channel list update skip logic when we are displaying messages instead

### 📝 Summary

Track channel list's visibility with `viewWillAppear` and `viewWillDisappear`

### 🛠 Implementation

We have a logic in place which tries to skip channel updates when user is in the message list instead. Since we use navigation controller, then after pushing the message list to the stack, channel list stays in the view hierarchy. Therefore, we can't check if channel list's window is nil. Instead, we should track it with `viewWillAppear` and `viewWillDisappear`.

Did some extra testing:
- UINavigationController: skipping happens
- UISplitViewController: skipping does not happen (e.g. channel list and message list side by side)
- UITabViewController: skipping happens

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
