### PR TITLE
Fix composer link preview overridden by previous enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChatUI
+### 🐞 Fixed
+- Fix overriding of actual current composer link preview [#3025](https://github.com/GetStream/stream-chat-swift/pull/3025)
 
 # [4.48.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.48.1)
 _February 09, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## StreamChatUI
 ### 🐞 Fixed
-- Fix overriding of actual current composer link preview [#3025](https://github.com/GetStream/stream-chat-swift/pull/3025)
+- Fix composer link preview overridden by previous enrichment [#3025](https://github.com/GetStream/stream-chat-swift/pull/3025)
 
 # [4.48.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.48.1)
 _February 09, 2024_

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -1005,19 +1005,22 @@ open class ComposerVC: _ViewController,
 
         enrichUrlDebouncer.execute { [weak self] in
             self?.channelController?.enrichUrl(link.url) { [weak self] result in
+                let enrichedUrlText = link.url.absoluteString
+                let currentLinks = self?.composerView.inputMessageView.textView.links ?? []
+                guard let currentUrlText = currentLinks.first?.url.absoluteString else {
+                    return
+                }
+
+                // Only show/dismiss enrichment if the current url is still the one
+                // that should be shown. Since we currently do not support
+                // cancelling previous requests, this is the current optimal solution.
+                guard enrichedUrlText == currentUrlText else {
+                    return
+                }
+
                 switch result {
                 case let .success(linkPayload):
-                    let enrichedUrlText = linkPayload.originalURL.absoluteString
-                    let currentLinks = self?.composerView.inputMessageView.textView.links ?? []
-                    guard let currentUrlText = currentLinks.first?.url.absoluteString else {
-                        return
-                    }
-                    // Only show enrichment if the current url is still the one
-                    // that should be shown. Since we currently do not support
-                    // cancelling previous requests, this is the current optimal solution.
-                    if enrichedUrlText == currentUrlText {
-                        self?.showLinkPreview(for: linkPayload)
-                    }
+                    self?.showLinkPreview(for: linkPayload)
                 case .failure:
                     self?.dismissLinkPreview()
                 }

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -289,7 +289,7 @@ open class ComposerVC: _ViewController,
 
     open var cooldownTracker: CooldownTracker = CooldownTracker(timer: ScheduledStreamTimer(interval: 1))
 
-    public var enrichUrlDebouncer = Debouncer(0.3, queue: .main)
+    public var enrichUrlDebouncer = Debouncer(0.4, queue: .main)
 
     lazy var linkDetector = TextLinkDetector()
 

--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -1007,7 +1007,17 @@ open class ComposerVC: _ViewController,
             self?.channelController?.enrichUrl(link.url) { [weak self] result in
                 switch result {
                 case let .success(linkPayload):
-                    self?.showLinkPreview(for: linkPayload)
+                    let enrichedUrlText = linkPayload.originalURL.absoluteString
+                    let currentLinks = self?.composerView.inputMessageView.textView.links ?? []
+                    guard let currentUrlText = currentLinks.first?.url.absoluteString else {
+                        return
+                    }
+                    // Only show enrichment if the current url is still the one
+                    // that should be shown. Since we currently do not support
+                    // cancelling previous requests, this is the current optimal solution.
+                    if enrichedUrlText == currentUrlText {
+                        self?.showLinkPreview(for: linkPayload)
+                    }
                 case .failure:
                     self?.dismissLinkPreview()
                 }

--- a/Tests/StreamChatUITests/SnapshotTests/Composer/ComposerVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/Composer/ComposerVC_Tests.swift
@@ -733,6 +733,37 @@ final class ComposerVC_Tests: XCTestCase {
         }
     }
 
+    func test_didChangeLinks_whenEnrichSuccess_whenUrlDoesNotEqualToCurrentInput_thenDoNotCallShowPreview() {
+        let composerVC = SpyComposerVC()
+        composerVC.components.isComposerLinkPreviewEnabled = true
+        let mock = ChatChannelController_Mock.mock(client: .mock())
+        mock.channel_mock = .mockNonDMChannel(config: .mock(urlEnrichmentEnabled: true))
+        let mockAPIClient = mock.client.mockAPIClient
+        composerVC.channelController = mock
+        composerVC.enrichUrlDebouncer = .init(0, queue: .main)
+        composerVC.content = .initial()
+        composerVC.content.text = """
+        Some link: https://github.com/GetStream/stream-chat-swiftui
+        Another one: www.google.com
+        """
+        composerVC.updateContent()
+
+        let url = URL(string: "https://github.com/GetStream/stream-chat-swift")!
+        mockAPIClient.test_mockResponseResult(.success(LinkAttachmentPayload(
+            originalURL: url
+        )))
+
+        composerVC.didChangeLinks([
+            .init(url: url, originalText: "https://github.com/GetStream/stream-chat-swift", range: .init(location: 0, length: 0)),
+            .init(url: URL(string: "http://www.google.com")!, originalText: "www.google.com", range: .init(location: 0, length: 0))
+        ])
+
+        AssertAsync {
+            Assert.willBeEqual(composerVC.showLinkPreviewCallCount, 0)
+            Assert.willBeEqual(composerVC.dismissLinkPreviewCallCount, 0)
+        }
+    }
+
     func test_didChangeLinks_whenEnrichFails_thenDismissLinkPreview() {
         let composerVC = SpyComposerVC()
         composerVC.components.isComposerLinkPreviewEnabled = true

--- a/Tests/StreamChatUITests/SnapshotTests/Composer/ComposerVC_Tests.swift
+++ b/Tests/StreamChatUITests/SnapshotTests/Composer/ComposerVC_Tests.swift
@@ -792,7 +792,7 @@ final class ComposerVC_Tests: XCTestCase {
         }
     }
 
-    func test_didChangeLinks_whenUrlDoesNotEqualToCurrentInput_thenDoNotCallDismissPreview() {
+    func test_didChangeLinks_whenEnrichFails_whenUrlDoesNotEqualToCurrentInput_thenDoNotCallDismissPreview() {
         let composerVC = SpyComposerVC()
         composerVC.components.isComposerLinkPreviewEnabled = true
         let mock = ChatChannelController_Mock.mock(client: .mock())


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal

Fix composer link preview overriding actual current link preview

### 📝 Summary

- Increases the debouncer to 0.4s to be more aligned with how usually requests take to complete
- Fix composer link preview overriding actual current link preview

### 🛠 Implementation

The proper way to do this is to cancel the previous request whenever we send a new request to enrich the url. The problem is that right now we do not have support for cancellable requests in our SDK, mostly because of tech debt issues. So right now, the best way to improve this is when we show the link preview we need to make sure that url is still the one in the composer input.

### 🧪 Manual Testing Notes

**Link preview should not show after sending the message**
1. Type a valid link in the composer
2. Very quickly after typing it, send the message
3. After the message was sent, it should not show the link preview

**Valid old link preview should not override current link preview**
1. Type a link in the composer
2. Very quickly type a new one
3. Only the new one should be shown

**Incorrect old link preview should not override current link preview**
1. Type an invalid link in the composer
2. Very quickly type a new valid one
3. Only the new one should be shown (The preview should not be dismissed)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
