### PR TITLE
Fix native swipe-back gesture overridden by swipe to reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix composer link preview overridden by previous enrichment [#3025](https://github.com/GetStream/stream-chat-swift/pull/3025)
 - Fix merged avatars changing sub-image locations when opening channel list [#3013](https://github.com/GetStream/stream-chat-swift/pull/3013)
-- Fix native swipe-back gesture overridden by swipe to reply [#3029](https://github.com/GetStream/stream-chat-swift/pull/3029)
+- Fix native swipe-back gesture overridden by swipe-to-reply [#3029](https://github.com/GetStream/stream-chat-swift/pull/3029)
 
 # [4.48.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.48.1)
 _February 09, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix composer link preview overridden by previous enrichment [#3025](https://github.com/GetStream/stream-chat-swift/pull/3025)
 - Fix merged avatars changing sub-image locations when opening channel list [#3013](https://github.com/GetStream/stream-chat-swift/pull/3013)
+- Fix native swipe-back gesture overridden by swipe to reply [#3029](https://github.com/GetStream/stream-chat-swift/pull/3029)
 
 # [4.48.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.48.1)
 _February 09, 2024_

--- a/DemoApp/StreamChat/Components/DemoChatChannelVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelVC.swift
@@ -6,7 +6,7 @@ import Foundation
 import StreamChatUI
 import UIKit
 
-final class DemoChatChannelVC: ChatChannelVC {
+final class DemoChatChannelVC: ChatChannelVC, UIGestureRecognizerDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -17,6 +17,16 @@ final class DemoChatChannelVC: ChatChannelVC {
             action: #selector(debugTap)
         )
         navigationItem.rightBarButtonItems?.append(debugButton)
+
+        // Custom back button to make sure swipe back gesture is not overridden.
+        let customBackButton = UIBarButtonItem(
+            title: "Back",
+            style: .plain,
+            target: self,
+            action: #selector(goBack)
+        )
+        navigationItem.leftBarButtonItems = [customBackButton]
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
 
     @objc private func debugTap() {
@@ -33,5 +43,9 @@ final class DemoChatChannelVC: ChatChannelVC {
         }
 
         channelListVC.demoRouter?.didTapMoreButton(for: cid)
+    }
+
+    @objc private func goBack() {
+        dismiss(animated: true)
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -441,7 +441,7 @@ open class ChatMessageListVC: _ViewController,
     }
 
     /// Handles the pan gesture recognizer not conflicting with the message list vertical scrolling.
-    public func gestureRecognizerShouldBegin(_ gesture: UIGestureRecognizer) -> Bool {
+    open func gestureRecognizerShouldBegin(_ gesture: UIGestureRecognizer) -> Bool {
         guard let panGestureRecognizer = gesture as? UIPanGestureRecognizer else {
             return true
         }
@@ -454,6 +454,11 @@ open class ChatMessageListVC: _ViewController,
 
         let translation = panGestureRecognizer.translation(in: cell)
         return abs(translation.x) > abs(translation.y)
+    }
+
+    open func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        // Do not override the native swipe-back gesture to dismiss the controller.
+        otherGestureRecognizer == navigationController?.interactivePopGestureRecognizer
     }
 
     /// The message cell was select and should show the available message actions.


### PR DESCRIPTION
### 🔗 Issue Links

Relates to https://github.com/GetStream/stream-chat-swift/pull/3010

### 🎯 Goal

Fix native swipe-back gesture overridden by swipe to reply.

### 🛠 Implementation
We use the `shouldRequireFailureOf` delegate method to check if the gesture should be overriden or not. If the active gesture is the one from swipe back, then we do not trigger the swipe-to-reply.

This issue was a problem with custom back buttons. So a custom back button was added to the Demo App to make sure we can test this.

### 🧪 Manual Testing Notes
1. Open a channel
2. Swipe back to go to the channel list
3. Open the channel again
4. Swipe to reply a message on the left
5. Both 2. and 3. should work

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)