### PR TITLE
Add parallel attachment uploading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+## StreamChat
+### ✅ Added
+- Add parallel attachment uploading [#3034](https://github.com/GetStream/stream-chat-swift/pull/3034)
+
 ## StreamChatUI
 ### 🐞 Fixed
 - Fix composer link preview overridden by previous enrichment [#3025](https://github.com/GetStream/stream-chat-swift/pull/3025)

--- a/DemoApp/StreamChat/Components/DemoChatChannelVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelVC.swift
@@ -46,6 +46,6 @@ final class DemoChatChannelVC: ChatChannelVC, UIGestureRecognizerDelegate {
     }
 
     @objc private func goBack() {
-        dismiss(animated: true)
+        navigationController?.popViewController(animated: true)
     }
 }

--- a/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/Spy/APIClient_Spy.swift
@@ -34,6 +34,7 @@ final class APIClient_Spy: APIClient, Spy {
     @Atomic var uploadFile_attachment: AnyChatMessageAttachment?
     @Atomic var uploadFile_progress: ((Double) -> Void)?
     @Atomic var uploadFile_completion: ((Result<UploadedAttachment, Error>) -> Void)?
+    @Atomic var uploadFile_callCount = 0
 
     @Atomic var init_sessionConfiguration: URLSessionConfiguration
     @Atomic var init_requestEncoder: RequestEncoder
@@ -143,9 +144,11 @@ final class APIClient_Spy: APIClient, Spy {
         progress: ((Double) -> Void)?,
         completion: @escaping (Result<UploadedAttachment, Error>) -> Void
     ) {
+
         uploadFile_attachment = attachment
         uploadFile_progress = progress
         uploadFile_completion = completion
+        uploadFile_callCount += 1
         uploadRequest_expectation.fulfill()
     }
 

--- a/Tests/StreamChatTests/Workers/Background/AttachmentQueueUploader_Tests.swift
+++ b/Tests/StreamChatTests/Workers/Background/AttachmentQueueUploader_Tests.swift
@@ -601,6 +601,44 @@ final class AttachmentQueueUploader_Tests: XCTestCase {
             "messaging:dummy-fake-0.txt"
         )
     }
+
+    func test_uploadAttachmentsInParallel() throws {
+        let cid: ChannelId = .unique
+        let messageId: MessageId = .unique
+
+        // Create channel in the database.
+        try database.createChannel(cid: cid, withMessages: false)
+        // Create message in the database.
+        try database.createMessage(id: messageId, cid: cid, localState: .pendingSend)
+
+        let attachmentPayloads: [AnyAttachmentPayload] = [
+            .mockFile,
+            .mockImage,
+            .mockVideo,
+            .mockAudio,
+            .mockVoiceRecording
+        ]
+
+        for (index, envelope) in attachmentPayloads.enumerated() {
+            let attachmentId = AttachmentId(cid: cid, messageId: messageId, index: index)
+            // Seed attachment in `.pendingUpload` state to the database.
+            try database.writeSynchronously { session in
+                try session.createNewAttachment(attachment: envelope, id: attachmentId)
+            }
+
+            // Load attachment from the database.
+            let attachment = try XCTUnwrap(database.viewContext.attachment(id: attachmentId))
+
+            // Assert attachment is in `.pendingUpload` state.
+            XCTAssertEqual(attachment.localState, .pendingUpload)
+        }
+
+        // Attachments start all uploading at the same time.
+        AssertAsync.willBeEqual(
+            apiClient.uploadFile_callCount,
+            attachmentPayloads.count
+        )
+    }
 }
 
 private extension URL {


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/701

### 🎯 Goal
Adds parallel attachment uploading

### 📝 Summary
- Fix back button in Demo App's message list
- Add parallel attachment uploading

### 🛠 Implementation
Before, we were uploading the next attachment only when the current attachment finished uploading. This is not needed at all. We can start all uploads at the same time. 

### 🎨 Showcase

https://github.com/GetStream/stream-chat-swift/assets/12814114/fad1dc36-20ff-4627-a83f-94c5e62dddd8

### 🧪 Manual Testing Notes
**Scenario 1**
1. Open a channel
2. Add a message with multiple attachments
3. All attachments should start uploading at the same time

**Scenario 2**
1. Open a channel
2. Add a message with multiple attachments
3. Add another message with multiple attachments
4. Both messages's attachments should uploading at the same time

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)