### PR TITLE
Remove a space from the first comment line

### DIFF
--- a/StreamChat.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/StreamChat.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>FILEHEADER</key>
-	<string> 
+	<string>
 // Copyright © ___YEAR___ Stream.io Inc. All rights reserved.
 //</string>
 </dict>


### PR DESCRIPTION
### 🎯 Goal

The new file header template has a trailing space which SwiftLint is not happy about

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

