### PR TITLE
Fix race condition when dismissing the gallery causing the UI to be blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `CGBitmapContextInfoCreate` console log warning when creating merged channel avatars [#3018](https://github.com/GetStream/stream-chat-swift/pull/3018)
 - Slight performance improvement in the message list by caching `NSRegularExpression` in `MarkdownFormatter` [#3020](https://github.com/GetStream/stream-chat-swift/pull/3020)
 - Slight performance improvement in the message list by skipping channel list updates when it is not visible [#3021](https://github.com/GetStream/stream-chat-swift/pull/3021)
+- Fix race condition when dismissing the gallery which blocked the UI [#3037](https://github.com/GetStream/stream-chat-swift/pull/3037)
 
 # [4.48.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.48.1)
 _February 09, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `CGBitmapContextInfoCreate` console log warning when creating merged channel avatars [#3018](https://github.com/GetStream/stream-chat-swift/pull/3018)
 - Slight performance improvement in the message list by caching `NSRegularExpression` in `MarkdownFormatter` [#3020](https://github.com/GetStream/stream-chat-swift/pull/3020)
 - Slight performance improvement in the message list by skipping channel list updates when it is not visible [#3021](https://github.com/GetStream/stream-chat-swift/pull/3021)
-- Fix race condition when dismissing the gallery which blocked the UI [#3037](https://github.com/GetStream/stream-chat-swift/pull/3037)
+- Fix race condition when dismissing the gallery causing the UI to be blocked [#3037](https://github.com/GetStream/stream-chat-swift/pull/3037)
 
 # [4.48.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.48.1)
 _February 09, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `CGBitmapContextInfoCreate` console log warning when creating merged channel avatars [#3018](https://github.com/GetStream/stream-chat-swift/pull/3018)
 - Slight performance improvement in the message list by caching `NSRegularExpression` in `MarkdownFormatter` [#3020](https://github.com/GetStream/stream-chat-swift/pull/3020)
 - Slight performance improvement in the message list by skipping channel list updates when it is not visible [#3021](https://github.com/GetStream/stream-chat-swift/pull/3021)
-- Fix race condition when dismissing the gallery causing the UI to be blocked [#3037](https://github.com/GetStream/stream-chat-swift/pull/3037)
+- Fix rare race condition when dismissing the gallery causing the UI to be blocked [#3037](https://github.com/GetStream/stream-chat-swift/pull/3037)
 
 # [4.48.1](https://github.com/GetStream/stream-chat-swift/releases/tag/4.48.1)
 _February 09, 2024_

--- a/Sources/StreamChatUI/Gallery/ZoomDismissalInteractionController.swift
+++ b/Sources/StreamChatUI/Gallery/ZoomDismissalInteractionController.swift
@@ -63,8 +63,11 @@ open class ZoomDismissalInteractionController: NSObject, UIViewControllerInterac
                     transitionImageView.removeFromSuperview()
                     animator.transitionImageView = nil
 
-                    transitionContext.cancelInteractiveTransition()
-                    transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+                    // We should only cancel the transition if it was not cancelled already.
+                    if !transitionContext.transitionWasCancelled {
+                        transitionContext.cancelInteractiveTransition()
+                        transitionContext.completeTransition(false)
+                    }
                 }
             )
         } else {


### PR DESCRIPTION
### 🔗 Issue Links
Will fix https://github.com/GetStream/stream-chat-swift/issues/2975

### 🎯 Goal
Fix UI getting blocked after swiping up the gallery view.

### 🛠 Implementation
The issue is that a cancellation and a regular dismissal were happening at the same time, causing a race condition. A cancel was getting called twice, and with `completeTransition(true)`, causing the transition to finish when it should not.

### 🧪 Manual Testing Notes
1. Open a channel
2. Open a image attachment
3. Swipe up multiple times very fast until the gallery is dismissed
4. The UI should not be blocked

### ☑️ Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)