### PR TITLE
Fix controllers having empty data when state changed to `.remoteDataFetched` with background mapping enabled

### DIFF
--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -156,8 +156,8 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
 
     /// Database observers.
     /// Will be `nil` when observing channel with backend generated `id` is not yet created.
-    private var channelObserver: EntityDatabaseObserverWrapper<ChatChannel, ChannelDTO>?
-    private var messagesObserver: ListDatabaseObserverWrapper<ChatMessage, MessageDTO>?
+    internal var channelObserver: EntityDatabaseObserverWrapper<ChatChannel, ChannelDTO>?
+    internal var messagesObserver: ListDatabaseObserverWrapper<ChatMessage, MessageDTO>?
 
     private var eventObservers: [EventObserver] = []
     private let environment: Environment

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1518,6 +1518,7 @@ private extension ChatChannelController {
                     log.debug("didUpdateMessages: \(changes.map(\.debugDescription))")
 
                     $0.channelController(self, didUpdateMessages: changes)
+                    $0.controller(self, didChangeState: self.state)
                 }
             }
             return observer

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -89,6 +89,7 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
                 }
                 log.debug("didChangeChannels: \(changes.map(\.debugDescription))")
                 $0.controller(self, didChangeChannels: changes)
+                $0.controller(self, didChangeState: state)
             }
         }
 

--- a/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.swift
@@ -56,7 +56,7 @@ public class ChatChannelWatcherListController: DataController, DelegateCallable,
     }
 
     /// The observer used to observe the changes in the database.
-    private lazy var watchersObserver: ListDatabaseObserverWrapper<ChatUser, UserDTO> = createWatchersObserver()
+    internal lazy var watchersObserver: ListDatabaseObserverWrapper<ChatUser, UserDTO> = createWatchersObserver()
 
     /// The worker used to fetch the remote data and communicate with servers.
     private lazy var updater: ChannelUpdater = self.environment.channelUpdaterBuilder(

--- a/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.swift
@@ -113,6 +113,7 @@ public class ChatChannelWatcherListController: DataController, DelegateCallable,
                     return
                 }
                 $0.channelWatcherListController(self, didChangeWatchers: changes)
+                $0.controller(self, didChangeState: state)
             }
         }
 

--- a/Sources/StreamChat/Controllers/DataController.swift
+++ b/Sources/StreamChat/Controllers/DataController.swift
@@ -24,7 +24,9 @@ public class DataController: Controller {
     public internal(set) var state: State = .initialized {
         didSet {
             callback {
-                self.stateMulticastDelegate.invoke { $0.controller(self, didChangeState: self.state) }
+                if self.state != .remoteDataFetched {
+                    self.stateMulticastDelegate.invoke { $0.controller(self, didChangeState: self.state) }
+                }
             }
         }
     }

--- a/Sources/StreamChat/Controllers/DatabaseObserver/EntityDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/EntityDatabaseObserver.swift
@@ -76,8 +76,8 @@ extension EntityChange {
 }
 
 class EntityDatabaseObserverWrapper<Item, DTO: NSManagedObject> {
-    private var foreground: EntityDatabaseObserver<Item, DTO>?
-    private var background: BackgroundEntityDatabaseObserver<Item, DTO>?
+    internal var foreground: EntityDatabaseObserver<Item, DTO>?
+    internal var background: BackgroundEntityDatabaseObserver<Item, DTO>?
     let isBackground: Bool
 
     var item: Item? {
@@ -161,7 +161,7 @@ class EntityDatabaseObserver<Item, DTO: NSManagedObject> {
 
     /// Called with the aggregated changes after the internal `NSFetchResultsController` calls `controllerDidChangeContent`
     /// on its delegate.
-    private var listeners: [(EntityChange<Item>) -> Void] = []
+    internal var listeners: [(EntityChange<Item>) -> Void] = []
 
     /// Acts like the `NSFetchedResultsController`'s delegate and aggregates the reported changes into easily consumable form.
     private(set) lazy var changeAggregator = ListChangeAggregator<DTO, Item>(itemCreator: itemCreator)
@@ -304,7 +304,7 @@ class BackgroundEntityDatabaseObserver<Item, DTO: NSManagedObject>: BackgroundDa
 
     /// Called with the aggregated changes after the internal `NSFetchResultsController` calls `controllerDidChangeContent`
     /// on its delegate.
-    private var listeners: [(EntityChange<Item>) -> Void] = []
+    internal var listeners: [(EntityChange<Item>) -> Void] = []
 
     /// Creates a new `BackgroundEntityDatabaseObserver`.
     ///

--- a/Sources/StreamChat/Controllers/MemberController/MemberController.swift
+++ b/Sources/StreamChat/Controllers/MemberController/MemberController.swift
@@ -66,7 +66,7 @@ public class ChatChannelMemberController: DataController, DelegateCallable, Data
     private lazy var memberListUpdater = createMemberListUpdater()
 
     /// The observer used to track the user changes in the database.
-    private lazy var memberObserver = createMemberObserver()
+    internal lazy var memberObserver = createMemberObserver()
         .onChange { [weak self] change in
             self?.delegateCallback { [weak self] in
                 guard let self = self else {
@@ -75,6 +75,7 @@ public class ChatChannelMemberController: DataController, DelegateCallable, Data
                 }
 
                 $0.memberController(self, didUpdateMember: change)
+                $0.controller(self, didChangeState: state)
             }
         }
 

--- a/Sources/StreamChat/Controllers/MemberListController/MemberListController.swift
+++ b/Sources/StreamChat/Controllers/MemberListController/MemberListController.swift
@@ -113,6 +113,7 @@ public class ChatChannelMemberListController: DataController, DelegateCallable, 
                 }
 
                 $0.memberListController(self, didChangeMembers: changes)
+                $0.controller(self, didChangeState: state)
             }
         }
 

--- a/Sources/StreamChat/Controllers/MemberListController/MemberListController.swift
+++ b/Sources/StreamChat/Controllers/MemberListController/MemberListController.swift
@@ -34,10 +34,10 @@ public class ChatChannelMemberListController: DataController, DelegateCallable, 
     }
 
     /// The worker used to fetch the remote data and communicate with servers.
-    private lazy var memberListUpdater = createMemberListUpdater()
+    internal lazy var memberListUpdater = createMemberListUpdater()
 
     /// The observer used to observe the changes in the database.
-    private lazy var memberListObserver = createMemberListObserver()
+    internal lazy var memberListObserver = createMemberListObserver()
 
     /// The type-erased delegate.
     var multicastDelegate: MulticastDelegate<ChatChannelMemberListControllerDelegate> = .init() {

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -165,7 +165,7 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
     }
 
     /// The observer used to listen to message updates
-    private lazy var messageObserver = createMessageObserver()
+    internal lazy var messageObserver = createMessageObserver()
         .onChange { [weak self] change in
             self?.delegateCallback { [weak self] in
                 guard let self = self else {
@@ -179,7 +179,7 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
 
     /// The observer used to listen replies updates.
     /// It will be reset on `listOrdering` changes.
-    private var repliesObserver: ListDatabaseObserverWrapper<ChatMessage, MessageDTO>?
+    internal var repliesObserver: ListDatabaseObserverWrapper<ChatMessage, MessageDTO>?
 
     /// The worker used to fetch the remote data and communicate with servers.
     private let messageUpdater: MessageUpdater

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -785,6 +785,7 @@ private extension ChatMessageController {
                 }
                 log.debug("didChangeReplies: \(changes.map(\.debugDescription))")
                 $0.messageController(self, didChangeReplies: changes)
+                $0.controller(self, didChangeState: state)
             }
         }
 

--- a/Sources/StreamChat/Controllers/SearchControllers/MessageSearchController/MessageSearchController.swift
+++ b/Sources/StreamChat/Controllers/SearchControllers/MessageSearchController/MessageSearchController.swift
@@ -104,6 +104,7 @@ public class ChatMessageSearchController: DataController, DelegateCallable, Data
                     return
                 }
                 $0.controller(self, didChangeMessages: changes)
+                $0.controller(self, didChangeState: state)
             }
         }
 

--- a/Sources/StreamChat/Controllers/UserController/UserController.swift
+++ b/Sources/StreamChat/Controllers/UserController/UserController.swift
@@ -49,7 +49,7 @@ public class ChatUserController: DataController, DelegateCallable, DataStoreProv
     private lazy var userUpdater = createUserUpdater()
 
     /// The observer used to track the user changes in the database.
-    private lazy var userObserver = createUserObserver()
+    internal lazy var userObserver = createUserObserver()
         .onChange { [weak self] change in
             self?.delegateCallback { [weak self] in
                 guard let self = self else {
@@ -57,6 +57,7 @@ public class ChatUserController: DataController, DelegateCallable, DataStoreProv
                     return
                 }
                 $0.userController(self, didUpdateUser: change)
+                $0.controller(self, didChangeState: state)
             }
         }
 

--- a/Sources/StreamChat/Controllers/UserListController/UserListController.swift
+++ b/Sources/StreamChat/Controllers/UserListController/UserListController.swift
@@ -72,6 +72,7 @@ public class ChatUserListController: DataController, DelegateCallable, DataStore
                 }
 
                 $0.controller(self, didChangeUsers: changes)
+                $0.controller(self, didChangeState: state)
             }
         }
 

--- a/TestTools/StreamChatTestTools/SpyPattern/QueueAware/DataController_Delegate.swift
+++ b/TestTools/StreamChatTestTools/SpyPattern/QueueAware/DataController_Delegate.swift
@@ -2,15 +2,20 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
+import XCTest
 import Foundation
 @testable import StreamChat
 
 // A concrete `DataControllerDelegate` implementation allowing capturing the delegate calls
 final class DataController_Delegate: QueueAwareDelegate, DataControllerStateDelegate {
     var state: DataController.State = .initialized
+    var didChangeStateCallCount = 0
+    var didChangeStateExp = XCTestExpectation(description: "didChangeState called")
 
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
         self.state = state
+        didChangeStateCallCount += 1
+        didChangeStateExp.fulfill()
         validateQueue()
     }
 }

--- a/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelController/ChannelController_Tests.swift
@@ -1401,6 +1401,8 @@ final class ChannelController_Tests: XCTestCase {
 
         // Simulate network call response
         env.channelUpdater?.update_completion?(.success(dummyPayload(with: .unique)))
+        // State change is only notified when observer is called with data changes.
+        controller.messagesObserver?.onDidChange?([])
 
         // Assert delegate is notified about state changes
         AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)

--- a/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelListController/ChannelListController_Tests.swift
@@ -695,6 +695,8 @@ final class ChannelListController_Tests: XCTestCase {
 
         // Simulate network call response
         env.channelListUpdater?.update_completion?(.success([]))
+        // State change is only notified when observer is called with data changes.
+        controller.channelListObserver.onDidChange?([])
 
         // Assert delegate is notified about state changes
         AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)

--- a/Tests/StreamChatTests/Controllers/ChannelWatcherListController/ChatChannelWatcherListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/ChannelWatcherListController/ChatChannelWatcherListController_Tests.swift
@@ -266,6 +266,8 @@ final class ChatChannelWatcherListController_Tests: XCTestCase {
 
         // Simulate network call response
         env.watcherListUpdater!.channelWatchers_completion!(nil)
+        // State change is only notified when observer is called with data changes.
+        controller.watchersObserver.onDidChange?([])
 
         // Assert delegate is notified about state changes
         AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)

--- a/Tests/StreamChatTests/Controllers/MemberController/MemberController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MemberController/MemberController_Tests.swift
@@ -266,6 +266,9 @@ final class MemberController_Tests: XCTestCase {
 
         // Simulate network call response
         env.memberListUpdater!.load_completion!(nil)
+        // State change is only notified when observer is called with data changes.
+        controller.memberObserver.onChange { _ in }
+        controller.memberObserver.foreground?.listeners.first?(.update(.dummy))
 
         // Assert delegate is notified about state changes
         AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)

--- a/Tests/StreamChatTests/Controllers/MemberListController/MemberListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MemberListController/MemberListController_Tests.swift
@@ -269,6 +269,8 @@ final class MemberListController_Tests: XCTestCase {
 
         // Simulate network call response
         env.memberListUpdater!.load_completion!(nil)
+        // State change is only notified when observer is called with data changes.
+        controller.memberListObserver.onDidChange?([])
 
         // Assert delegate is notified about state changes
         AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)

--- a/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/MessageController/MessageController_Tests.swift
@@ -713,6 +713,8 @@ final class MessageController_Tests: XCTestCase {
 
         // Simulate network call response
         env.messageUpdater.getMessage_completion?(.success(ChatMessage.unique))
+        // State change is only notified when observer is called with data changes.
+        controller.repliesObserver?.onDidChange?([])
 
         // Assert delegate is notified about state changes
         AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)

--- a/Tests/StreamChatTests/Controllers/SearchControllers/UserController/UserController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/SearchControllers/UserController/UserController_Tests.swift
@@ -313,6 +313,9 @@ final class UserController_Tests: XCTestCase {
 
         // Simulate network call response
         env.userUpdater!.loadUser_completion!(nil)
+        // State change is only notified when observer is called with data changes.
+        controller.userObserver.onChange { _ in }
+        controller.userObserver.foreground?.listeners.first?(.update(.mock(id: .anonymous)))
 
         // Assert delegate is notified about state changes
         AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)

--- a/Tests/StreamChatTests/Controllers/SearchControllers/UserListController/UserListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/SearchControllers/UserListController/UserListController_Tests.swift
@@ -241,6 +241,8 @@ final class UserListController_Tests: XCTestCase {
 
         // Simulate network call response
         env.userListUpdater?.update_completion?(nil)
+        // State change is only notified when observer is called with data changes.
+        controller.userListObserver.onDidChange?([])
 
         // Assert delegate is notified about state changes
         AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)

--- a/Tests/StreamChatTests/DataController_Tests.swift
+++ b/Tests/StreamChatTests/DataController_Tests.swift
@@ -28,6 +28,26 @@ final class DataController_Tests: XCTestCase {
         AssertAsync.willBeEqual(delegate.state, .localDataFetched)
     }
 
+    func test_delegateMethodIsNotCalled_whenStateIsRemoteDataFetched() {
+        // GIVEN
+        let controller = DataController()
+        let delegateQueueId = UUID()
+        let delegate = DataController_Delegate(expectedQueueId: delegateQueueId)
+        delegate.didChangeStateExp.isInverted = true
+        controller.stateMulticastDelegate.add(additionalDelegate: delegate)
+        controller.callbackQueue = DispatchQueue.testQueue(withId: delegateQueueId)
+
+        // Check if state is `initialized` initially.
+        XCTAssertEqual(delegate.state, .initialized)
+
+        // WHEN
+        controller.state = .remoteDataFetched
+
+        // THEN
+        wait(for: [delegate.didChangeStateExp], timeout: defaultTimeout)
+        XCTAssertEqual(delegate.didChangeStateCallCount, 0)
+    }
+
     func test_canBeRecoveredTrueWhenStateIs_remoteDataFetched() {
         let controller = DataController()
         controller.state = .remoteDataFetched


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/675

### 🎯 Goal
- Fix search showing empty data with background mapping enabled
- Fix channel list showing empty data for a split second with background mapping enabled

### 🛠 Implementation

#### Problem
The root cause of Search not working correctly with background mapping is that when we call `state = .remoteDataFetched` after the HTTP Request, at this time, the `viewContext` does not know about the changes because of background mapping. So, the `controller.messages` has empty data when the delegate event `didChangeState` is called. 

#### Solution
The only solution I found without changing the codebase too much is to change how we report the `.remoteDataFetched` state. Now, we will only report this state when the `FRC` reports changes, so that when `didChangeState` is called, we have all the data available.

### 🧪 Manual Testing Notes
**Scenario 1**
1. Logout
2. Login (Test both with Background Mapping enabled and disabled)
3. The first load of the Channel List should not show an empty view

**Scenario 2**
1. Logout
2. Login (Test both with Background Mapping enabled and disabled)
3. Search a message "Hey"
4. Results should show

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)