### PR TITLE
[V2] Fix controllers having empty data when state changed to .remoteDataFetched with background mapping enabled

### DIFF
--- a/DemoApp/Screens/Create Chat/CreateChatViewController.swift
+++ b/DemoApp/Screens/Create Chat/CreateChatViewController.swift
@@ -281,10 +281,10 @@ extension CreateChatViewController: ChatUserSearchControllerDelegate {
     }
 
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
-        if case .remoteDataFetched = state {
+        if case let .remoteDataFetched(isEmpty) = state {
             print("\(users.count) users found")
             users = searchController.userArray
-            update(for: users.isEmpty ? .noUsers : .searching)
+            update(for: isEmpty ? .noUsers : .searching)
         }
     }
 }

--- a/DemoApp/Screens/Create Chat/CreateGroupViewController.swift
+++ b/DemoApp/Screens/Create Chat/CreateGroupViewController.swift
@@ -148,10 +148,10 @@ extension CreateGroupViewController: ChatUserSearchControllerDelegate {
     }
 
     func controller(_ controller: DataController, didChangeState state: DataController.State) {
-        if case .remoteDataFetched = state {
+        if case let .remoteDataFetched(isEmpty) = state {
             print("\(users.count) users found")
             loadingIndicator.stopAnimating()
-            noMatchView.isHidden = !users.isEmpty
+            noMatchView.isHidden = !isEmpty
         }
     }
 }

--- a/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListVC.swift
@@ -159,7 +159,8 @@ final class DemoChatChannelListVC: ChatChannelListVC, EventsControllerDelegate {
     override func controller(_ controller: DataController, didChangeState state: DataController.State) {
         super.controller(controller, didChangeState: state)
 
-        if highlightSelectedChannel && (state == .remoteDataFetched || state == .localDataFetched) && selectedChannel == nil {
+        // TODO: This is actually a breaking change
+        if highlightSelectedChannel && (state.isRemoteDataFetched || state == .localDataFetched) && selectedChannel == nil {
             guard let channel = self.controller.channels.first else { return }
 
             router.showChannel(for: channel.cid)

--- a/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
+++ b/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift
@@ -1010,7 +1010,7 @@ public class ChatChannelController: DataController, DelegateCallable, DataStoreP
             return
         }
         updater.startWatching(cid: cid, isInRecoveryMode: isInRecoveryMode) { error in
-            self.state = error.map { .remoteDataFetchFailed(ClientError(with: $0)) } ?? .remoteDataFetched
+            self.state = error.map { .remoteDataFetchFailed(ClientError(with: $0)) } ?? .remoteDataFetched(isEmpty: false)
             self.callback {
                 completion?(error)
             }
@@ -1340,8 +1340,8 @@ private extension ChatChannelController {
             onChannelCreated: channelCreatedCallback,
             completion: { result in
                 switch result {
-                case .success:
-                    self.state = .remoteDataFetched
+                case let .success(channel):
+                    self.state = .remoteDataFetched(isEmpty: channel.messages.isEmpty)
                     self.callback { completion?(nil) }
                 case let .failure(error):
                     self.state = .remoteDataFetchFailed(ClientError(with: error))

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -225,7 +225,7 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
         ) { [weak self] result in
             switch result {
             case let .success(channels):
-                self?.state = .remoteDataFetched
+                self?.state = .remoteDataFetched(isEmpty: channels.isEmpty)
                 self?.hasLoadedAllPreviousChannels = channels.count < limit
                 self?.callback { completion?(nil) }
             case let .failure(error):

--- a/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
+++ b/Sources/StreamChat/Controllers/CurrentUserController/CurrentUserController.swift
@@ -115,7 +115,7 @@ public class CurrentChatUserController: DataController, DelegateCallable, DataSt
                 error = ClientError.ConnectionNotSuccessful()
             }
 
-            self?.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(error!)
+            self?.state = error == nil ? .remoteDataFetched(isEmpty: false) : .remoteDataFetchFailed(error!)
             self?.callback { completion?(error) }
         }
     }

--- a/Sources/StreamChat/Controllers/DataController.swift
+++ b/Sources/StreamChat/Controllers/DataController.swift
@@ -15,9 +15,18 @@ public class DataController: Controller {
         /// The controller failed to fetch local data.
         case localDataFetchFailed(ClientError)
         /// The controller fetched remote data.
-        case remoteDataFetched
+        case remoteDataFetched(isEmpty: Bool)
         /// The controller failed to fetch remote data.
         case remoteDataFetchFailed(ClientError)
+
+        public var isRemoteDataFetched: Bool {
+            switch self {
+            case .remoteDataFetched:
+                return true
+            default:
+                return false
+            }
+        }
     }
 
     /// The current state of the controller.

--- a/Sources/StreamChat/Controllers/MemberController/MemberController.swift
+++ b/Sources/StreamChat/Controllers/MemberController/MemberController.swift
@@ -106,9 +106,14 @@ public class ChatChannelMemberController: DataController, DelegateCallable, Data
             return
         }
 
-        memberListUpdater.load(.channelMember(userId: userId, cid: cid)) { error in
-            self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
-            self.callback { completion?(error) }
+        memberListUpdater.load(.channelMember(userId: userId, cid: cid)) { result in
+            switch result {
+            case let .success(members):
+                self.state = .remoteDataFetched(isEmpty: members.isEmpty)
+            case let .failure(error):
+                self.state = .remoteDataFetchFailed(ClientError(with: error))
+            }
+            self.callback { completion?(result.error) }
         }
     }
 

--- a/Sources/StreamChat/Controllers/MessageController/MessageController.swift
+++ b/Sources/StreamChat/Controllers/MessageController/MessageController.swift
@@ -212,7 +212,7 @@ public class ChatMessageController: DataController, DelegateCallable, DataStoreP
 
         messageUpdater.getMessage(cid: cid, messageId: messageId) { result in
             let error = result.error
-            self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
+            self.state = error == nil ? .remoteDataFetched(isEmpty: false) : .remoteDataFetchFailed(ClientError(with: error))
             self.callback { completion?(error) }
         }
     }

--- a/Sources/StreamChat/Controllers/SearchControllers/MessageSearchController/MessageSearchController.swift
+++ b/Sources/StreamChat/Controllers/SearchControllers/MessageSearchController/MessageSearchController.swift
@@ -205,9 +205,13 @@ public class ChatMessageSearchController: DataController, DelegateCallable, Data
                 self.updateNextPageCursor(with: payload)
             }
 
-            let error = result.error
-            self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
-            self.callback { completion?(error) }
+            switch result {
+            case let .success(payload):
+                self.state = .remoteDataFetched(isEmpty: payload.results.isEmpty)
+            case let .failure(error):
+                self.state = .remoteDataFetchFailed(ClientError(with: error))
+            }
+            self.callback { completion?(result.error) }
         }
     }
 

--- a/Sources/StreamChat/Controllers/SearchControllers/UserSearchController/UserSearchController.swift
+++ b/Sources/StreamChat/Controllers/SearchControllers/UserSearchController/UserSearchController.swift
@@ -139,7 +139,7 @@ private extension ChatUserSearchController {
                     if let listChanges = listChanges, let users = self?.userList(after: listChanges) {
                         self?._users = users
                     }
-                    self?.state = .remoteDataFetched
+                    self?.state = .remoteDataFetched(isEmpty: self?._users.isEmpty == true)
 
                     self?.callback {
                         self?.multicastDelegate.invoke {

--- a/Sources/StreamChat/Controllers/UserController/UserController.swift
+++ b/Sources/StreamChat/Controllers/UserController/UserController.swift
@@ -99,7 +99,7 @@ public class ChatUserController: DataController, DelegateCallable, DataStoreProv
         }
 
         userUpdater.loadUser(userId) { error in
-            self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
+            self.state = error == nil ? .remoteDataFetched(isEmpty: false) : .remoteDataFetchFailed(ClientError(with: error))
             self.callback { completion?(error) }
         }
     }

--- a/Sources/StreamChat/Workers/Background/NewUserQueryUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/NewUserQueryUpdater.swift
@@ -89,8 +89,8 @@ final class NewUserQueryUpdater: Worker {
 
                 // Send `update(userListQuery:` requests so corresponding queries will be linked to the user
                 updatedQueries?.forEach {
-                    self?.userListUpdater.update(userListQuery: $0) { error in
-                        if let error = error {
+                    self?.userListUpdater.update(userListQuery: $0) { result in
+                        if let error = result.error {
                             log.error("Internal error. Failed to update UserListQueries for the new user: \(error)")
                         }
                     }

--- a/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/ChatChannelListVC.swift
@@ -438,9 +438,9 @@ open class ChatChannelListVC: _ViewController,
             switch newState {
             case .initialized, .localDataFetched:
                 isLoading = controller.channels.isEmpty
-            case .remoteDataFetched:
+            case let .remoteDataFetched(isEmpty):
                 isLoading = false
-                shouldHideEmptyView = !controller.channels.isEmpty
+                shouldHideEmptyView = !isEmpty
             case .localDataFetchFailed, .remoteDataFetchFailed:
                 shouldHideEmptyView = emptyView.isHidden
                 isLoading = false

--- a/Sources/StreamChatUI/ChatChannelList/Search/ChatChannelListSearchVC.swift
+++ b/Sources/StreamChatUI/ChatChannelList/Search/ChatChannelListSearchVC.swift
@@ -108,10 +108,10 @@ open class ChatChannelListSearchVC: ChatChannelListVC, UISearchResultsUpdating {
             } else {
                 loadingIndicator.stopAnimating()
             }
-        case .remoteDataFetched:
+        case let .remoteDataFetched(isEmpty):
             loadingIndicator.stopAnimating()
             emptyView.subtitleLabel.text = L10n.ChannelList.Search.Empty.subtitle("\"\(currentSearchText)\"")
-            emptyView.isHidden = !hasEmptyResults
+            emptyView.isHidden = !isEmpty
         default:
             loadingIndicator.stopAnimating()
         }


### PR DESCRIPTION
### 🔗 Issue Links
TODO

### 🎯 Goal

Alternative of https://github.com/GetStream/stream-chat-swift/pull/3039

### 📝 Summary

TODO

### 🛠 Implementation

TODO

### 🧪 Manual Testing Notes

**Scenario 1**
1. Logout
2. Login (Test both with Background Mapping enabled and disabled)
3. The first load of the Channel List should not show an empty view

**Scenario 2**
1. Logout
2. Login (Test both with Background Mapping enabled and disabled)
3. Search a message "Hey"
4. Results should show

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)