### PR TITLE
Fix controllers having empty data when state changed to .remoteDataFetched with background mapping enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### ✅ Added
 - Add parallel attachment uploading [#3034](https://github.com/GetStream/stream-chat-swift/pull/3034)
+### 🐞 Fixed
+- Fix controllers having empty data when state changed to `.remoteDataFetched` with background mapping enabled [#3042](https://github.com/GetStream/stream-chat-swift/pull/3042)
+- Fix showing empty search results with background mapping enabled [#3042](https://github.com/GetStream/stream-chat-swift/pull/3042)
 
 ## StreamChatUI
 ### 🐞 Fixed

--- a/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelListController/ChannelListController.swift
@@ -225,7 +225,9 @@ public class ChatChannelListController: DataController, DelegateCallable, DataSt
         ) { [weak self] result in
             switch result {
             case let .success(channels):
-                self?.state = .remoteDataFetched
+                self?.channelListObserver.refreshItems { [weak self] in
+                    self?.state = .remoteDataFetched
+                }
                 self?.hasLoadedAllPreviousChannels = channels.count < limit
                 self?.callback { completion?(nil) }
             case let .failure(error):

--- a/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundDatabaseObserver.swift
@@ -143,16 +143,18 @@ class BackgroundDatabaseObserver<Item, DTO: NSManagedObject> {
 
     /// This method will add a new operation to the `processingQueue`, where operations are executed one-by-one.
     /// The operation added to the queue will start the process of getting new results for the observer.
-    private func updateItems(changes: [ListChange<Item>]?) {
+    func updateItems(changes: [ListChange<Item>]?, completion: (() -> Void)? = nil) {
         let operation = AsyncOperation { [weak self] _, done in
             guard let self = self else {
                 done(.continue)
+                completion?()
                 return
             }
 
             self.frc.managedObjectContext.perform {
                 self.processItems(changes) {
                     done(.continue)
+                    completion?()
                 }
             }
         }

--- a/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundListDatabaseObserver.swift
+++ b/Sources/StreamChat/Controllers/DatabaseObserver/BackgroundListDatabaseObserver.swift
@@ -21,6 +21,17 @@ class ListDatabaseObserverWrapper<Item, DTO: NSManagedObject> {
         }
     }
 
+    /// This function is only useful with background mapping enabled.
+    /// Since DB updates now happen in a background thread, sometimes we need to
+    /// wait for the updates to do some action, so this function is useful for that.
+    func refreshItems(completion: @escaping () -> Void) {
+        if let background = background {
+            background.updateItems(changes: nil, completion: completion)
+        } else {
+            completion()
+        }
+    }
+
     /// Called with the aggregated changes after the internal `NSFetchResultsController` calls `controllerWillChangeContent`
     /// on its delegate.
     var onWillChange: (() -> Void)? {

--- a/Sources/StreamChat/Controllers/SearchControllers/MessageSearchController/MessageSearchController.swift
+++ b/Sources/StreamChat/Controllers/SearchControllers/MessageSearchController/MessageSearchController.swift
@@ -206,8 +206,10 @@ public class ChatMessageSearchController: DataController, DelegateCallable, Data
             }
 
             let error = result.error
-            self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
             self.callback { completion?(error) }
+            self.messagesObserver?.refreshItems { [weak self] in
+                self?.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
+            }
         }
     }
 


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/675
Resolves https://github.com/GetStream/ios-issues-tracking/issues/626

### 🎯 Goal
- Fix search showing empty data with background mapping enabled
- Fix channel list showing empty data for a split second with background mapping enabled

### 🛠 Implementation

#### Problem
The root cause of Search not working correctly with background mapping is that when we call `state = .remoteDataFetched` after the HTTP Request, at this time, the items from the background observer are not yet populated. They are only populated when the FRC Notifies of changes, which because it is in a background thread, is an async process.  So, the `controller.messages` has empty data when the delegate event `didChangeState` is called. 

#### Solution
After trying multiple solutions, I think this one is the one which requires the least changes and has less impact on the customer's app. The solution involves in adding a function to the background observer to "force" refreshing the items of the observer and provide a completion block to notify when they are updated. This way, we can call this refresh function and only call `didChangeState` event when the items are updated. 

### 🧪 Manual Testing Notes
**Scenario 1**
1. Logout
2. Login (Test both with Background Mapping enabled and disabled)
3. The first load of the Channel List should not show an empty view

**Scenario 2**
1. Logout
2. Login (Test both with Background Mapping enabled and disabled)
3. Search a message "Hey"
4. Results should show

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)