### PR TITLE
[CI] Fix E2E cron check on iOS 17

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -359,7 +359,7 @@ lane :test_e2e_mock do |options|
     derived_data_path: derived_data_path,
     cloned_source_packages_path: source_packages_path,
     clean: is_localhost,
-    test_without_building: options[:test_without_building],
+    test_without_building: options[:cron] && options[:device].include?('(17.2)') ? nil : options[:test_without_building],
     xcargs: buildcache_xcargs,
     devices: options[:device],
     prelaunch_simulator: is_ci,


### PR DESCRIPTION
### 📝 Summary

- In cron checks, we build the app for e2e tests on all iOS versions on macOS 13 (otherwise it breaks older iOS versions). For some reason, this breaks the tests on iOS 17. This change just requires the lane to build the app again for iOS 17 in cron checks.