### PR TITLE
Fix token provider retrying after calling disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+## StreamChat
+### 🐞 Fixed
+- Fix token provider retrying after calling disconnect [#3052](https://github.com/GetStream/stream-chat-swift/pull/3052)
+- Fix connect user never completing when disconnecting after token provider fails [#3052](https://github.com/GetStream/stream-chat-swift/pull/3052)
 
 # [4.49.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.49.0)
 _February 27, 2024_

--- a/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
+++ b/DemoApp/Screens/AppConfigViewController/AppConfigViewController.swift
@@ -23,10 +23,14 @@ struct DemoAppConfig {
 
     /// The details to generate expirable tokens in the demo app.
     struct TokenRefreshDetails {
-        // The app secret from the dashboard.
+        /// The app secret from the dashboard.
         let appSecret: String
-        // The duration in seconds until the token is expired.
+        /// The duration in seconds until the token is expired.
         let duration: TimeInterval
+        /// In order to test token refresh fails, we can set a value of how
+        /// many token refresh will succeed before it starts failing.
+        /// By default it is 0. Which means it will always succeed.
+        let numberOfSuccessfulRefreshesBeforeFailing: Int
     }
 }
 
@@ -564,18 +568,33 @@ class AppConfigViewController: UITableViewController {
             textField.placeholder = "App Secret"
             textField.autocapitalizationType = .none
             textField.autocorrectionType = .no
+            if let appSecret = self.demoAppConfig.tokenRefreshDetails?.appSecret {
+                textField.text = appSecret
+            }
         }
         alert.addTextField { textField in
             textField.placeholder = "Duration (Seconds)"
             textField.keyboardType = .numberPad
+            if let duration = self.demoAppConfig.tokenRefreshDetails?.duration {
+                textField.text = "\(duration)"
+            }
+        }
+        alert.addTextField { textField in
+            textField.placeholder = "Number of Refreshes Before Failing"
+            textField.keyboardType = .numberPad
+            if let numberOfRefreshes = self.demoAppConfig.tokenRefreshDetails?.numberOfSuccessfulRefreshesBeforeFailing {
+                textField.text = "\(numberOfRefreshes)"
+            }
         }
 
         alert.addAction(.init(title: "Enable", style: .default, handler: { _ in
             guard let appSecret = alert.textFields?[0].text else { return }
             guard let duration = alert.textFields?[1].text else { return }
+            guard let successfulRetries = alert.textFields?[2].text else { return }
             self.demoAppConfig.tokenRefreshDetails = .init(
                 appSecret: appSecret,
-                duration: TimeInterval(duration)!
+                duration: TimeInterval(duration) ?? 60,
+                numberOfSuccessfulRefreshesBeforeFailing: Int(successfulRetries) ?? 0
             )
         }))
 

--- a/DemoApp/Shared/StreamChatWrapper.swift
+++ b/DemoApp/Shared/StreamChatWrapper.swift
@@ -87,6 +87,9 @@ extension StreamChatWrapper {
         // Setup Stream Chat
         setUpChat()
 
+        // Reset number of refresh tokens
+        numberOfRefreshTokens = 0
+
         // We connect from a background thread to make sure it works without issues/crashes.
         // This is for testing purposes only. As a customer you can connect directly without dispatching to any queue.
         DispatchQueue.global().async {

--- a/DemoApp/Shared/StreamChatWrapper.swift
+++ b/DemoApp/Shared/StreamChatWrapper.swift
@@ -115,8 +115,6 @@ extension StreamChatWrapper {
         }
 
         client.logout(completion: completion)
-
-        self.client = nil
     }
 }
 

--- a/DemoApp/Shared/StreamChatWrapper.swift
+++ b/DemoApp/Shared/StreamChatWrapper.swift
@@ -10,6 +10,10 @@ import UserNotifications
 final class StreamChatWrapper {
     static let shared = StreamChatWrapper()
 
+    /// How many times the token has been refreshed. This is mostly used
+    /// to fake token refresh fails.
+    var numberOfRefreshTokens = 0
+
     // This closure is called once the SDK is ready to register for remote push notifications
     var onRemotePushRegistration: (() -> Void)?
 
@@ -60,8 +64,7 @@ extension StreamChatWrapper {
                     userInfo: userInfo,
                     tokenProvider: refreshingTokenProvider(
                         initialToken: userCredentials.token,
-                        appSecret: tokenRefreshDetails.appSecret,
-                        tokenDuration: tokenRefreshDetails.duration
+                        refreshDetails: tokenRefreshDetails
                     ),
                     completion: completion
                 )

--- a/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
+++ b/DemoApp/StreamChat/Components/DemoChatChannelListRouter.swift
@@ -15,6 +15,7 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
 
     var channelPresentingStyle: ChannelPresentingStyle = .push
     var onLogout: (() -> Void)?
+    var onDisconnect: (() -> Void)?
 
     lazy var streamModalTransitioningDelegate = StreamModalTransitioningDelegate()
 
@@ -36,6 +37,9 @@ final class DemoChatChannelListRouter: ChatChannelListRouter {
             }),
             .init(title: "Logout", style: .destructive, handler: { [weak self] _ in
                 self?.onLogout?()
+            }),
+            .init(title: "Disconnect", style: .destructive, handler: { [weak self] _ in
+                self?.onDisconnect?()
             })
         ])
     }

--- a/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
+++ b/DemoApp/StreamChat/StreamChatWrapper+DemoApp.swift
@@ -13,11 +13,6 @@ extension StreamChatWrapper {
             Components.default.mixedAttachmentInjector.register(.location, with: LocationAttachmentViewInjector.self)
         }
 
-        guard client == nil else {
-            log.error("Client was already instantiated")
-            return
-        }
-
         // Set the log level
         LogConfig.level = .warning
         LogConfig.formatters = [
@@ -25,7 +20,9 @@ extension StreamChatWrapper {
         ]
 
         // Create Client
-        client = ChatClient(config: config)
+        if client == nil {
+            client = ChatClient(config: config)
+        }
         client?.registerAttachment(LocationAttachmentPayload.self)
 
         // L10N

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -341,6 +341,7 @@ public class ChatClient {
             completion()
         }
         authenticationRepository.clearTokenProvider()
+        authenticationRepository.cancelTimers()
     }
 
     /// Disconnects the chat client form the chat servers and removes all the local data related.

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -51,7 +51,7 @@ class AuthenticationRepository {
     private var _tokenProviderTimer: TimerControl?
     private var _connectionProviderTimer: TimerControl?
 
-    private var isGettingToken: Bool {
+    private(set) var isGettingToken: Bool {
         get { tokenQueue.sync { _isGettingToken } }
         set { tokenQueue.async(flags: .barrier) { self._isGettingToken = newValue }}
     }
@@ -198,6 +198,7 @@ class AuthenticationRepository {
 
     func clearTokenProvider() {
         tokenProvider = nil
+        isGettingToken = false
     }
 
     func cancelTimers() {

--- a/Sources/StreamChat/Repositories/AuthenticationRepository.swift
+++ b/Sources/StreamChat/Repositories/AuthenticationRepository.swift
@@ -44,11 +44,12 @@ class AuthenticationRepository {
     private var _consecutiveRefreshFailures: Int = 0
     private var _currentUserId: UserId?
     private var _currentToken: Token?
-    /// Retry timing strategy for refreshing an expired token
     private var _tokenExpirationRetryStrategy: RetryStrategy
     private var _tokenProvider: TokenProvider?
     private var _tokenRequestCompletions: [(Error?) -> Void] = []
     private var _tokenWaiters: [String: (Result<Token, Error>) -> Void] = [:]
+    private var _tokenProviderTimer: TimerControl?
+    private var _connectionProviderTimer: TimerControl?
 
     private var isGettingToken: Bool {
         get { tokenQueue.sync { _isGettingToken } }
@@ -76,7 +77,21 @@ class AuthenticationRepository {
         get { tokenQueue.sync { _tokenProvider } }
         set { tokenQueue.async(flags: .barrier) { self._tokenProvider = newValue }}
     }
+
+    private var tokenProviderTimer: TimerControl? {
+        get { tokenQueue.sync { _tokenProviderTimer } }
+        set { tokenQueue.async(flags: .barrier) {
+            self._tokenProviderTimer = newValue
+        }}
+    }
     
+    private var connectionProviderTimer: TimerControl? {
+        get { tokenQueue.sync { _connectionProviderTimer } }
+        set { tokenQueue.async(flags: .barrier) {
+            self._connectionProviderTimer = newValue
+        }}
+    }
+
     weak var delegate: AuthenticationRepositoryDelegate?
 
     private let apiClient: APIClient
@@ -185,6 +200,11 @@ class AuthenticationRepository {
         tokenProvider = nil
     }
 
+    func cancelTimers() {
+        connectionProviderTimer?.cancel()
+        tokenProviderTimer?.cancel()
+    }
+
     func logOutUser() {
         log.debug("Logging out user", subsystems: .authentication)
         clearTokenProvider()
@@ -244,7 +264,7 @@ class AuthenticationRepository {
         }
 
         let globalQueue = DispatchQueue.global()
-        timerType.schedule(timeInterval: timeout, queue: globalQueue) { [weak self] in
+        connectionProviderTimer = timerType.schedule(timeInterval: timeout, queue: globalQueue) { [weak self] in
             guard let self = self else { return }
             // Not the nicest, but we need to ensure the read and write below are treated as an atomic operation,
             // in a queue that is concurrent, whilst the completion needs to be called outside of the barrier'ed operation.
@@ -294,7 +314,7 @@ class AuthenticationRepository {
         let interval = tokenQueue.sync(flags: .barrier) {
             _tokenExpirationRetryStrategy.getDelayAfterTheFailure()
         }
-        timerType.schedule(
+        tokenProviderTimer = timerType.schedule(
             timeInterval: interval,
             queue: .main
         ) { [weak self] in

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1356,6 +1356,7 @@
 		ADA5A0F9276790C100E1C465 /* ChatMessageListDateSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA5A0F7276790C100E1C465 /* ChatMessageListDateSeparatorView.swift */; };
 		ADA8EBE928CFD52F00DB9B03 /* TextViewUserMentionsHandler_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA8EBE828CFD52F00DB9B03 /* TextViewUserMentionsHandler_Mock.swift */; };
 		ADA8EBEB28CFD82C00DB9B03 /* ChatMessageContentViewDelegate_Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA8EBEA28CFD82C00DB9B03 /* ChatMessageContentViewDelegate_Mock.swift */; };
+		ADAA10EC2B90D58B007AB03F /* FakeTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADAA10EA2B90D589007AB03F /* FakeTimer.swift */; };
 		ADAA377125E43C3700C31528 /* ChatSuggestionsVC_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADD5A9E725DE8AF6006DC88A /* ChatSuggestionsVC_Tests.swift */; };
 		ADAA9F412B2240300078C3D4 /* TextViewMentionedUsersHandler_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADAA9F402B2240300078C3D4 /* TextViewMentionedUsersHandler_Tests.swift */; };
 		ADAC47AA275A7C960027B672 /* ChatMessageContentView_Documentation_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADAC47A9275A7C960027B672 /* ChatMessageContentView_Documentation_Tests.swift */; };
@@ -3864,6 +3865,7 @@
 		ADA5A0F7276790C100E1C465 /* ChatMessageListDateSeparatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListDateSeparatorView.swift; sourceTree = "<group>"; };
 		ADA8EBE828CFD52F00DB9B03 /* TextViewUserMentionsHandler_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewUserMentionsHandler_Mock.swift; sourceTree = "<group>"; };
 		ADA8EBEA28CFD82C00DB9B03 /* ChatMessageContentViewDelegate_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageContentViewDelegate_Mock.swift; sourceTree = "<group>"; };
+		ADAA10EA2B90D589007AB03F /* FakeTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeTimer.swift; sourceTree = "<group>"; };
 		ADAA9F402B2240300078C3D4 /* TextViewMentionedUsersHandler_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewMentionedUsersHandler_Tests.swift; sourceTree = "<group>"; };
 		ADAC47A9275A7C960027B672 /* ChatMessageContentView_Documentation_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageContentView_Documentation_Tests.swift; sourceTree = "<group>"; };
 		ADB22F7A25F1626200853C92 /* OnlineIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnlineIndicatorView.swift; sourceTree = "<group>"; };
@@ -6127,6 +6129,7 @@
 				A3C3BC8127E8AB1E00224761 /* SpyPattern */,
 				A3C7BA7A27E3785500BBF4FA /* TestData */,
 				A3D15D8227E9D4B5006B34D7 /* VirtualTime */,
+				ADAA10E92B90D554007AB03F /* FakeTimer */,
 				8263464A2B0BACC600122D0E /* Difference */,
 			);
 			path = StreamChatTestTools;
@@ -8030,6 +8033,14 @@
 				A30DEC98260B47DE0066E8CE /* TitleContainerView.swift */,
 			);
 			path = TitleContainerView;
+			sourceTree = "<group>";
+		};
+		ADAA10E92B90D554007AB03F /* FakeTimer */ = {
+			isa = PBXGroup;
+			children = (
+				ADAA10EA2B90D589007AB03F /* FakeTimer.swift */,
+			);
+			path = FakeTimer;
 			sourceTree = "<group>";
 		};
 		ADB22F7925F1626200853C92 /* ChatPresenceAvatarView */ = {
@@ -10307,6 +10318,7 @@
 				A3C3BC3327E87F2900224761 /* OfflineRequestsRepository_Mock.swift in Sources */,
 				A344078027D753530044F150 /* ChatChannelMember_Mock.swift in Sources */,
 				C1C5345A29AFDDAE006F9AF4 /* ChannelRepository_Mock.swift in Sources */,
+				ADAA10EC2B90D58B007AB03F /* FakeTimer.swift in Sources */,
 				82F714A32B077FDE00442A74 /* XCTestCase+StressTest.swift in Sources */,
 				A3C3BC1B27E87EFE00224761 /* ChatClient_Mock.swift in Sources */,
 				A3C3BC6727E8AA0A00224761 /* ChatMessage+Unique.swift in Sources */,

--- a/TestTools/StreamChatTestTools/FakeTimer/FakeTimer.swift
+++ b/TestTools/StreamChatTestTools/FakeTimer/FakeTimer.swift
@@ -1,0 +1,39 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamChat
+
+class FakeTimer: StreamChat.Timer {
+    static var mockTimer: TimerControl?
+    static var mockRepeatingTimer: RepeatingTimerControl?
+
+    static func schedule(timeInterval: TimeInterval, queue: DispatchQueue, onFire: @escaping () -> Void) -> StreamChat.TimerControl {
+        return mockTimer!
+    }
+
+    static func scheduleRepeating(timeInterval: TimeInterval, queue: DispatchQueue, onFire: @escaping () -> Void) -> StreamChat.RepeatingTimerControl {
+        mockRepeatingTimer!
+    }
+}
+
+class MockTimer: TimerControl {
+    var cancelCallCount = 0
+    func cancel() {
+        cancelCallCount += 1
+    }
+}
+
+class MockRepeatingTimer: RepeatingTimerControl {
+    var resumeCallCount = 0
+    var suspendCallCount = 0
+
+    func resume() {
+        resumeCallCount += 1
+    }
+
+    func suspend() {
+        suspendCallCount += 1
+    }
+}

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/AuthenticationRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Repositories/AuthenticationRepository_Mock.swift
@@ -94,6 +94,11 @@ class AuthenticationRepository_Mock: AuthenticationRepository, Spy {
         record()
     }
 
+    var cancelTimersCallCount: Int = 0
+    override func cancelTimers() {
+        cancelTimersCallCount += 1
+    }
+
     override func completeTokenWaiters(token: Token?) {
         record()
         completeWaitersToken = token

--- a/Tests/StreamChatTests/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/ChatClient_Tests.swift
@@ -328,7 +328,7 @@ final class ChatClient_Tests: XCTestCase {
         XCTAssertEqual(client.activeChannelControllers.count, 0)
         XCTAssertEqual(client.activeChannelListControllers.count, 0)
     }
-    
+
     func test_apiClient_usesInjectedURLSessionConfiguration() {
         // configure a URLSessionConfiguration with a URLProtocol class
         var urlSessionConfiguration = URLSessionConfiguration.default
@@ -645,7 +645,7 @@ final class ChatClient_Tests: XCTestCase {
 
     // MARK: - Disconnect
 
-    func test_disconnect_shouldCallConnectionRepository_andClearTokenProvider() throws {
+    func test_disconnect_shouldCallConnectionRepository_andClearTokenProvider_andCancelTimers() throws {
         let client = ChatClient(config: inMemoryStorageConfig, environment: testEnv.environment)
         let authenticationRepository = try XCTUnwrap(client.authenticationRepository as? AuthenticationRepository_Mock)
         let connectionRepository = try XCTUnwrap(client.connectionRepository as? ConnectionRepository_Mock)
@@ -659,6 +659,7 @@ final class ChatClient_Tests: XCTestCase {
 
         XCTAssertCall(ConnectionRepository_Mock.Signature.disconnect, on: connectionRepository)
         XCTAssertCall(AuthenticationRepository_Mock.Signature.clearTokenProvider, on: authenticationRepository)
+        XCTAssertEqual(client.mockAuthenticationRepository.cancelTimersCallCount, 1)
     }
 
     func test_logout_shouldDisconnect_logOut_andRemoveAllData() throws {

--- a/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
@@ -799,13 +799,12 @@ final class AuthenticationRepository_Tests: XCTestCase {
     }
 
     func test_clearTokenProvider_thenIsGettingTokenFalse() {
-        let userInfo = UserInfo(id: "123")
         repository.connectUser(
             userInfo: .init(id: .newUniqueId),
             tokenProvider: { _ in },
             completion: { _ in }
         )
-        XCTAssertTrue(repository.isGettingToken)
+        AssertAsync.willBeTrue(repository.isGettingToken)
 
         repository.clearTokenProvider()
 

--- a/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
@@ -798,6 +798,20 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertNotNil(repository.currentUserId)
     }
 
+    func test_clearTokenProvider_thenIsGettingTokenFalse() {
+        let userInfo = UserInfo(id: "123")
+        repository.connectUser(
+            userInfo: .init(id: .newUniqueId),
+            tokenProvider: { _ in },
+            completion: { _ in }
+        )
+        XCTAssertTrue(repository.isGettingToken)
+
+        repository.clearTokenProvider()
+
+        XCTAssertFalse(repository.isGettingToken)
+    }
+
     // MARK: Log out
 
     func test_logOut_clearsUserData() {

--- a/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/AuthenticationRepository_Tests.swift
@@ -1026,6 +1026,32 @@ final class AuthenticationRepository_Tests: XCTestCase {
         XCTAssertEqual(state, .newToken)
     }
 
+    // MARK: Cancel Timers
+
+    func test_cancelTimers() {
+        let mockTimer = MockTimer()
+        FakeTimer.mockTimer = mockTimer
+        let repository = AuthenticationRepository(
+            apiClient: apiClient,
+            databaseContainer: database,
+            connectionRepository: connectionRepository,
+            tokenExpirationRetryStrategy: retryStrategy,
+            timerType: FakeTimer.self
+        )
+
+        repository.provideToken(completion: { _ in })
+        repository.connectUser(
+            userInfo: .init(id: .newUniqueId),
+            tokenProvider: { _ in },
+            completion: { _ in }
+        )
+
+        repository.cancelTimers()
+        // should cancel the connection provider timer and the
+        // the token provider timer
+        XCTAssertEqual(mockTimer.cancelCallCount, 2)
+    }
+
     // MARK: Helpers
 
     private func testPrepareEnvironmentAfterConnect(


### PR DESCRIPTION
### 🔗 Issue Links
Related to https://github.com/GetStream/stream-chat-swift/issues/3030
Resolves https://github.com/GetStream/ios-issues-tracking/issues/740

### 🎯 Goal

Fix token provider keeps retrying after calling disconnect.

### 📝 Summary
- Changes the ChatClient to a singleton in the Demo App
- Add a way to disconnect the user in the Demo App, and not only logout
- Add a way to fake token refresh failures
     - The token refresh details now accept a number of refreshes before it starts failing, so that we can fake token refresh failures.
- Fixes token provider retrying after calling disconnect
- Fixes connect user never completing when disconnecting in a middle of a retry

### 🛠 Implementation
The reason this was happening was because whenever we disconnected, we didn't cancel the timers of the `AuthenticationRepository` so they kept running. 

### 🧪 Manual Testing Notes

1. Open Demo App Configuration
2. Edit tokenRefreshDetails
3. Add the App Secret
4. Set the duration, ex: 10
5. Set the number of refreshes, ex: 1
6. Login with ex: Leia Organa
7. You should see `Demo App Token Refreshing: New token generated` twice in the console app. (The first connect, and 1 retry)
8. After observing `Demo App Token Refreshing: Token refresh failed.`
9. Logout or Disconnect
10. No more logging of `Demo App Token Refreshing` should be happening
11. Connect the user again
12. It should show the Channel List

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)