### PR TITLE
Fix invalid token triggering token refresh in an infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix token provider retrying after calling disconnect [#3052](https://github.com/GetStream/stream-chat-swift/pull/3052)
 - Fix connect user never completing when disconnecting after token provider fails [#3052](https://github.com/GetStream/stream-chat-swift/pull/3052)
 - Fix current user cache not deleted on logout causing unread count issues after switching users [#3055](https://github.com/GetStream/stream-chat-swift/pull/3055)
+- Fix invalid token calling token refresh in an infinite loop [#3056](https://github.com/GetStream/stream-chat-swift/pull/3056)
 
 # [4.49.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.49.0)
 _February 27, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix token provider retrying after calling disconnect [#3052](https://github.com/GetStream/stream-chat-swift/pull/3052)
 - Fix connect user never completing when disconnecting after token provider fails [#3052](https://github.com/GetStream/stream-chat-swift/pull/3052)
 - Fix current user cache not deleted on logout causing unread count issues after switching users [#3055](https://github.com/GetStream/stream-chat-swift/pull/3055)
-- Fix invalid token calling token refresh in an infinite loop [#3056](https://github.com/GetStream/stream-chat-swift/pull/3056)
+- Fix invalid token triggering token refresh in an infinite loop [#3056](https://github.com/GetStream/stream-chat-swift/pull/3056)
 
 # [4.49.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.49.0)
 _February 27, 2024_

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -451,9 +451,12 @@ extension ChatClient: AuthenticationRepositoryDelegate {
 
 extension ChatClient: ConnectionStateDelegate {
     func webSocketClient(_ client: WebSocketClient, didUpdateConnectionState state: WebSocketConnectionState) {
-        connectionRepository.handleConnectionUpdate(state: state, onInvalidToken: { [weak self] in
-            self?.refreshToken(completion: nil)
-        })
+        connectionRepository.handleConnectionUpdate(
+            state: state,
+            onExpiredToken: { [weak self] in
+                self?.refreshToken(completion: nil)
+            }
+        )
         connectionRecoveryHandler?.webSocketClient(client, didUpdateConnectionState: state)
     }
 }

--- a/Sources/StreamChat/Errors/ErrorPayload.swift
+++ b/Sources/StreamChat/Errors/ErrorPayload.swift
@@ -29,7 +29,7 @@ public struct ErrorPayload: LocalizedError, Codable, CustomDebugStringConvertibl
 }
 
 /// https://getstream.io/chat/docs/ios-swift/api_errors_response/
-private enum StreamErrorCode {
+enum StreamErrorCode {
     /// Usually returned when trying to perform an API call without a token.
     static let accessKeyInvalid = 2
     static let expiredToken = 40

--- a/Sources/StreamChat/Repositories/ConnectionRepository.swift
+++ b/Sources/StreamChat/Repositories/ConnectionRepository.swift
@@ -128,7 +128,7 @@ class ConnectionRepository {
 
     func handleConnectionUpdate(
         state: WebSocketConnectionState,
-        onInvalidToken: () -> Void
+        onExpiredToken: () -> Void
     ) {
         connectionStatus = .init(webSocketConnectionState: state)
 
@@ -140,9 +140,10 @@ class ConnectionRepository {
         case let .connected(connectionId: id):
             shouldNotifyConnectionIdWaiters = true
             connectionId = id
-
         case let .disconnected(source) where source.serverError?.isInvalidTokenError == true:
-            onInvalidToken()
+            if source.serverError?.isExpiredTokenError == true {
+                onExpiredToken()
+            }
             shouldNotifyConnectionIdWaiters = false
             connectionId = nil
         case .disconnected:

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/ConnectionRepository_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/ConnectionRepository_Mock.swift
@@ -15,7 +15,7 @@ final class ConnectionRepository_Mock: ConnectionRepository, Spy {
         static let updateWebSocketEndpointUserId = "updateWebSocketEndpoint(with:)"
         static let completeConnectionIdWaiters = "completeConnectionIdWaiters(connectionId:)"
         static let provideConnectionId = "provideConnectionId(timeout:completion:)"
-        static let handleConnectionUpdate = "handleConnectionUpdate(state:onInvalidToken:)"
+        static let handleConnectionUpdate = "handleConnectionUpdate(state:onExpiredToken:)"
     }
 
     var recordedFunctions: [String] = []
@@ -28,7 +28,7 @@ final class ConnectionRepository_Mock: ConnectionRepository, Spy {
     var updateWebSocketEndpointUserInfo: UserInfo?
     var completeWaitersConnectionId: ConnectionId?
     var connectionUpdateState: WebSocketConnectionState?
-    var simulateInvalidTokenOnConnectionUpdate = false
+    var simulateExpiredTokenOnConnectionUpdate = false
 
     convenience init() {
         self.init(isClientInActiveMode: true,
@@ -100,11 +100,11 @@ final class ConnectionRepository_Mock: ConnectionRepository, Spy {
         record()
     }
 
-    override func handleConnectionUpdate(state: WebSocketConnectionState, onInvalidToken: () -> Void) {
+    override func handleConnectionUpdate(state: WebSocketConnectionState, onExpiredToken: () -> Void) {
         record()
         connectionUpdateState = state
-        if simulateInvalidTokenOnConnectionUpdate {
-            onInvalidToken()
+        if simulateExpiredTokenOnConnectionUpdate {
+            onExpiredToken()
         }
     }
 
@@ -117,7 +117,7 @@ final class ConnectionRepository_Mock: ConnectionRepository, Spy {
 
         disconnectResult = nil
         disconnectSource = nil
-        simulateInvalidTokenOnConnectionUpdate = false
+        simulateExpiredTokenOnConnectionUpdate = false
         connectionUpdateState = nil
         completeWaitersConnectionId = nil
         updateWebSocketEndpointToken = nil

--- a/Tests/StreamChatTests/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/ChatClient_Tests.swift
@@ -758,14 +758,14 @@ final class ChatClient_Tests: XCTestCase {
         XCTAssertNotCall(AuthenticationRepository_Mock.Signature.refreshToken, on: authenticationRepository)
     }
 
-    func test_webSocketClientStateUpdate_calls_connectionRepository_invalidToken() throws {
+    func test_webSocketClientStateUpdate_calls_connectionRepository_expiredToken() throws {
         let client = ChatClient(config: inMemoryStorageConfig, environment: testEnv.environment)
         let webSocketClient = try XCTUnwrap(client.webSocketClient)
         let connectionRepository = try XCTUnwrap(client.connectionRepository as? ConnectionRepository_Mock)
         let authenticationRepository = try XCTUnwrap(client.authenticationRepository as? AuthenticationRepository_Mock)
 
         let state = WebSocketConnectionState.disconnected(source: .systemInitiated)
-        connectionRepository.simulateInvalidTokenOnConnectionUpdate = true
+        connectionRepository.simulateExpiredTokenOnConnectionUpdate = true
         client.webSocketClient(webSocketClient, didUpdateConnectionState: state)
 
         XCTAssertCall(ConnectionRepository_Mock.Signature.handleConnectionUpdate, on: connectionRepository)


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/739
Related to https://github.com/GetStream/stream-chat-swift/issues/3032

### 🎯 Goal
Fix invalid token calling token refresh in an infinite loop

### 🛠 Implementation

We were incorrectly triggering a token refresh whenever we received an invalid token. The token refresh should only be triggered when the token is expired. If a token is invalid, it is because of a programming error, so if we retry it, it will be in an infinite loop:
1. Get Token
2. Signature is Invalid
3. Refresh Token
4. Signature is Invalid
5. Go to 3.

With this change, if a token is invalid, we simply stop retrying, and a manual retry should be done. 

### 🧪 Manual Testing Notes
1. Open Demo App Configuration
2. Tap on tokenRefreshDetails
3. Add an invalid secret to the token
4. Open the app
5. The channel list fetch should fail, and you should not see a loop of "Token refreshing" in the console log.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)