### PR TITLE
Do not mark message as failed when server returns duplicated message error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### ✅ Added
 - Add new `ChatMessage.textUpdatedAt` for when the message text is edited [#3059](https://github.com/GetStream/stream-chat-swift/pull/3059)
+- Expose `ClientError.errorPayload` to easily check for server error details [#3061](https://github.com/GetStream/stream-chat-swift/pull/3061)
 ### 🐞 Fixed
 - Fix token provider retrying after calling disconnect [#3052](https://github.com/GetStream/stream-chat-swift/pull/3052)
 - Fix connect user never completing when disconnecting after token provider fails [#3052](https://github.com/GetStream/stream-chat-swift/pull/3052)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix current user cache not deleted on logout causing unread count issues after switching users [#3055](https://github.com/GetStream/stream-chat-swift/pull/3055)
 - Fix rare crash in `startObserver()` on logout when converting DTO to model in `itemCreator` [#3053](https://github.com/GetStream/stream-chat-swift/pull/3053)
 - Fix invalid token triggering token refresh in an infinite loop [#3056](https://github.com/GetStream/stream-chat-swift/pull/3056)
+- Do not mark a message as failed when the server returns duplicated message error [#3061](https://github.com/GetStream/stream-chat-swift/pull/3061)
 
 ## StreamChatUI
 ### ✅ Added

--- a/Sources/StreamChat/Database/DTOs/MessageDTO.swift
+++ b/Sources/StreamChat/Database/DTOs/MessageDTO.swift
@@ -1083,6 +1083,17 @@ extension MessageDTO {
             extraData: decodedExtraData
         )
     }
+
+    /// The message has been successfully sent to the server.
+    func markMessageAsSent() {
+        locallyCreatedAt = nil
+        localMessageState = nil
+    }
+
+    /// The message failed to be sent to the server.
+    func markMessageAsFailed() {
+        localMessageState = .sendingFailed
+    }
 }
 
 private extension ChatMessage {

--- a/Sources/StreamChat/Errors/ClientError.swift
+++ b/Sources/StreamChat/Errors/ClientError.swift
@@ -19,7 +19,10 @@ public class ClientError: Error, CustomStringConvertible {
     /// An underlying error.
     public let underlyingError: Error?
 
-    var errorDescription: String? { underlyingError.map(String.init(describing:)) }
+    public var errorDescription: String? { underlyingError.map(String.init(describing:)) }
+
+    /// The error payload if the underlying error comes from a server error.
+    public var errorPayload: ErrorPayload? { underlyingError as? ErrorPayload }
 
     /// Retrieve the localized description for this error.
     public var localizedDescription: String { message ?? errorDescription ?? "" }

--- a/Sources/StreamChat/Errors/ErrorPayload.swift
+++ b/Sources/StreamChat/Errors/ErrorPayload.swift
@@ -24,7 +24,7 @@ public struct ErrorPayload: LocalizedError, Codable, CustomDebugStringConvertibl
     }
 
     public var debugDescription: String {
-        "ServerErrorPayload(code: \(code), message: \"\(message)\", statusCode: \(statusCode)))."
+        "\(String(describing: Self.self))(code: \(code), message: \"\(message)\", statusCode: \(statusCode)))."
     }
 }
 

--- a/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
@@ -114,7 +114,7 @@ final class MessageRepositoryTests: XCTestCase {
 
         wait(for: [apiClient.request_expectation], timeout: defaultTimeout)
 
-        let error = ClientError(with: ErrorPayload(code: 4, message: "DuplicatedMessage", statusCode: 400))
+        let error = ClientError(with: ErrorPayload(code: 4, message: "Message X already exists.", statusCode: 400))
         (apiClient.request_completion as? (Result<MessagePayload.Boxed, Error>) -> Void)?(.failure(error))
 
         wait(for: [expectation], timeout: defaultTimeout)

--- a/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
+++ b/Tests/StreamChatTests/Repositories/MessageRepository_Tests.swift
@@ -102,6 +102,37 @@ final class MessageRepositoryTests: XCTestCase {
         }
     }
 
+    func test_sendMessage_APIFailure_whenDuplicatedMessage_shouldNotMarkMessageAsFailed() throws {
+        let id = MessageId.unique
+        try createMessage(id: id, localState: .pendingSend)
+        let expectation = self.expectation(description: "Send Message completes")
+        var result: Result<ChatMessage, MessageRepositoryError>?
+        repository.sendMessage(with: id) {
+            result = $0
+            expectation.fulfill()
+        }
+
+        wait(for: [apiClient.request_expectation], timeout: defaultTimeout)
+
+        let error = ClientError(with: ErrorPayload(code: 4, message: "DuplicatedMessage", statusCode: 400))
+        (apiClient.request_completion as? (Result<MessagePayload.Boxed, Error>) -> Void)?(.failure(error))
+
+        wait(for: [expectation], timeout: defaultTimeout)
+
+        var currentMessageState: LocalMessageState?
+        try database.writeSynchronously { session in
+            currentMessageState = session.message(id: id)?.localMessageState
+        }
+
+        XCTAssertNil(currentMessageState)
+        switch result?.error {
+        case .failedToSendMessage:
+            break
+        default:
+            XCTFail()
+        }
+    }
+
     func test_sendMessage_APISuccess() throws {
         let id = MessageId.unique
         try createMessage(id: id, localState: .pendingSend)


### PR DESCRIPTION
### 🔗 Issue Links
Resolves https://github.com/GetStream/ios-issues-tracking/issues/754

### 🎯 Goal

Do not mark message as failed when server returns duplicated message error. This would cause an unrecoverable state, where the message would always be in failed state, even tho the message already exists on the server.

### 🧪 Manual Testing Notes
1. Setup Proxyman
2. Use Map Local to override sending a message:
```
Wildcard: `https://chat.stream-io-api.com/channels/messaging/*/message*`
Response:
HTTP/1.1 400 Bad Request
....
{"code":4,"message":"SendMessage failed with error: \"a message with ID b742eacb-be19-4cf5-91e2-0debd6ce72da already exists\"","StatusCode":400,"duration":"0.00ms","more_info":"https://getstream.io/chat/docs/api_errors_response","details":[]}
```
3. Send a message
4. It should not display the error icon 
5. Switch the error to something like too many mentioned_users:
```
{"code":4,"message":"SendMessage failed with error: \"message.mentioned_users must contain at maximum 25 items\"","exception_fields":{"message.mentioned_users":"message.mentioned_users must contain at maximum 25 items"},"StatusCode":400,"duration":"0.00ms","more_info":"https://getstream.io/chat/docs/api_errors_response","details":[]}
```
6. The message should fail

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
