### PR TITLE
Add `message.edited` local key to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add new `Components.isMessageEditedLabelEnabled` [#3059](https://github.com/GetStream/stream-chat-swift/pull/3059)
 - Add "Edited" label when a message is edited [#3059](https://github.com/GetStream/stream-chat-swift/pull/3059)
    - Note: For now, only when the text changes it is marked as edited.
+ - Add `message.edited` localization key [#3059](https://github.com/GetStream/stream-chat-swift/pull/3059)
 
 # [4.49.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.49.0)
 _February 27, 2024_


### PR DESCRIPTION
### 🔗 Issue Links

None

### 🎯 Goal

Forgot to add the new localisation key to the changelog. 

TODO: We need to add a danger warning in these cases. 
