### PR TITLE
[ChatStateLayer] StreamCollection as opaque base collection wrapper

### DIFF
--- a/Sources/StreamChat/StateLayer/ChatState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChatState+Observer.swift
@@ -38,7 +38,7 @@ extension ChatState {
         
         struct Handlers {
             let channelDidChange: (ChatChannel) async -> Void
-            let messagesDidChange: ([ChatMessage]) async -> Void
+            let messagesDidChange: (StreamCollection<ChatMessage>) async -> Void
             let typingUsersDidChange: (Set<ChatUser>) async -> Void
         }
         
@@ -47,7 +47,8 @@ extension ChatState {
             channelObserver.onFieldChange(\.currentlyTypingUsers, do: { change in Task { await handlers.typingUsersDidChange(change.item) } })
             messagesObserver.onDidChange = { [weak messagesObserver] _ in
                 guard let items = messagesObserver?.items else { return }
-                Task { await handlers.messagesDidChange(Array(items)) }
+                let collection = StreamCollection(items)
+                Task { await handlers.messagesDidChange(collection) }
             }
             
             // TODO: Implement member list

--- a/Sources/StreamChat/StateLayer/ChatState.swift
+++ b/Sources/StreamChat/StateLayer/ChatState.swift
@@ -42,7 +42,7 @@ public final class ChatState: ObservableObject {
     /// Messages are ordered by timestamp and``messageOrder`` (In case of ``MessageOrdering.bottomToTop`` the list is sorted in ascending order).
     ///
     /// Use load messages in ``Chat`` for loading more messages.
-    @Published public private(set) var messages: [ChatMessage] = []
+    @Published public private(set) var messages = StreamCollection<ChatMessage>([])
     
     /// A Boolean value that returns whether the oldest messages have all been loaded or not.
     public var hasLoadedAllPreviousMessages: Bool {

--- a/Sources/StreamChat/StateLayer/MessageState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/MessageState+Observer.swift
@@ -36,7 +36,7 @@ extension MessageState {
         struct Handlers {
             let messageDidChange: (ChatMessage) async -> Void
             let reactionsDidChange: ([ChatMessageReaction]) async -> Void
-            let repliesDidChange: ([ChatMessage]) async -> Void
+            let repliesDidChange: (StreamCollection<ChatMessage>) async -> Void
         }
         
         func start(with handlers: Handlers) {
@@ -47,7 +47,8 @@ extension MessageState {
             })
             repliesObserver.onDidChange = { [weak repliesObserver] _ in
                 guard let items = repliesObserver?.items else { return }
-                Task { await handlers.repliesDidChange(Array(items)) }
+                let collection = StreamCollection(items)
+                Task { await handlers.repliesDidChange(collection) }
             }
             
             do {

--- a/Sources/StreamChat/StateLayer/MessageState.swift
+++ b/Sources/StreamChat/StateLayer/MessageState.swift
@@ -49,7 +49,7 @@ public final class MessageState: ObservableObject {
     // MARK: - Replies
     
     /// An array of loaded replies sorted by ``MessageOrdering``.
-    @Published public private(set) var replies = [ChatMessage]()
+    @Published public private(set) var replies = StreamCollection<ChatMessage>([])
     
     /// A Boolean value that returns whether the oldest replies have all been loaded or not.
     public var hasLoadedAllPreviousReplies: Bool {

--- a/Sources/StreamChat/Utils/StreamCollection.swift
+++ b/Sources/StreamChat/Utils/StreamCollection.swift
@@ -1,0 +1,41 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A collection wrapping the base collection which allows base collections of different types.
+///
+/// - Note: The type of the base collection can change in the future.
+public struct StreamCollection<Element>: RandomAccessCollection {
+    public typealias Index = Int
+
+    private let _endIndex: () -> Index
+    private let _position: (Index) -> Element
+    private let _startIndex: () -> Index
+
+    /// Creates an instance of the collection using the base collection as the data source.
+    init<BaseCollection>(_ baseCollection: BaseCollection) where BaseCollection: RandomAccessCollection, BaseCollection.Element == Element, BaseCollection.Index == Index {
+        _endIndex = { baseCollection.endIndex }
+        _position = { baseCollection[$0] }
+        _startIndex = { baseCollection.startIndex }
+    }
+
+    /// The position of the first element in a non-empty collection.
+    public var startIndex: Index { _startIndex() }
+    
+    /// The collection's “past the end” position—that is, the position one greater than the last valid subscript argument.
+    public var endIndex: Index { _endIndex() }
+    
+    /// Accesses the element at the specified position.
+    public subscript(position: Index) -> Element {
+        _position(position)
+    }
+}
+
+extension StreamCollection: CustomStringConvertible {
+    public var description: String {
+        let contents = map { String(describing: $0) }.joined(separator: ", ")
+        return "\(Self.self)(\(contents))"
+    }
+}

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -912,7 +912,7 @@ extension ChannelUpdater {
         try await update(channelQuery: channelQuery.withPagination(pagination), isInRecoveryMode: false)
     }
     
-    func loadMessages(before messageId: MessageId?, limit: Int?, channelQuery: ChannelQuery, loaded: [ChatMessage]) async throws {
+    func loadMessages(before messageId: MessageId?, limit: Int?, channelQuery: ChannelQuery, loaded: StreamCollection<ChatMessage>) async throws {
         guard !paginationState.isLoadingPreviousMessages else { return }
         guard !paginationState.hasLoadedAllPreviousMessages else { return }
         let lastLocalMessageId: () -> MessageId? = { loaded.last { !$0.isLocalOnly }?.id }
@@ -924,7 +924,7 @@ extension ChannelUpdater {
         try await update(channelQuery: channelQuery.withPagination(pagination), isInRecoveryMode: false)
     }
 
-    func loadMessages(after messageId: MessageId?, limit: Int?, channelQuery: ChannelQuery, loaded: [ChatMessage]) async throws {
+    func loadMessages(after messageId: MessageId?, limit: Int?, channelQuery: ChannelQuery, loaded: StreamCollection<ChatMessage>) async throws {
         guard !paginationState.isLoadingNextMessages else { return }
         guard !(paginationState.hasLoadedAllNextMessages || loaded.isEmpty) else { return }
         guard let messageId = messageId ?? paginationState.newestFetchedMessage?.id ?? loaded.first?.id else {
@@ -935,7 +935,7 @@ extension ChannelUpdater {
         try await update(channelQuery: channelQuery.withPagination(pagination), isInRecoveryMode: false)
     }
         
-    func loadMessages(around messageId: MessageId, limit: Int?, channelQuery: ChannelQuery, loaded: [ChatMessage]) async throws {
+    func loadMessages(around messageId: MessageId, limit: Int?, channelQuery: ChannelQuery, loaded: StreamCollection<ChatMessage>) async throws {
         guard !paginationState.isLoadingMiddleMessages else { return }
         let limit = limit ?? channelQuery.pagination?.pageSize ?? .messagesPageSize
         let pagination = MessagesPagination(pageSize: limit, parameter: .around(messageId))

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -256,6 +256,8 @@
 		4F8E531D2B833D6C008C0F9F /* ChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E531B2B833D6C008C0F9F /* ChatState.swift */; };
 		4FD2BE502B99F68300FFC6F2 /* ReadStateSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */; };
 		4FD2BE512B99F68300FFC6F2 /* ReadStateSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */; };
+		4FD2BE532B9AEE3500FFC6F2 /* StreamCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */; };
+		4FD2BE542B9AEE3500FFC6F2 /* StreamCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */; };
 		4FF2A80D2B8E011000941A64 /* ChatState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF2A80C2B8E011000941A64 /* ChatState+Observer.swift */; };
 		4FF2A80E2B8E011000941A64 /* ChatState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF2A80C2B8E011000941A64 /* ChatState+Observer.swift */; };
 		6428DD5526201DCC0065DA1D /* BannerShowingConnectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */; };
@@ -2897,6 +2899,7 @@
 		4F8E530A2B7CEBFB008C0F9F /* ChatClient+Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatClient+Chat.swift"; sourceTree = "<group>"; };
 		4F8E531B2B833D6C008C0F9F /* ChatState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatState.swift; sourceTree = "<group>"; };
 		4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadStateSender.swift; sourceTree = "<group>"; };
+		4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCollection.swift; sourceTree = "<group>"; };
 		4FF2A80C2B8E011000941A64 /* ChatState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatState+Observer.swift"; sourceTree = "<group>"; };
 		6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerShowingConnectionDelegate.swift; sourceTree = "<group>"; };
 		647F66D4261E22C200111B19 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
@@ -5093,6 +5096,7 @@
 				792FCB4824A3BF38000290C7 /* OptionSet+Extensions.swift */,
 				DA4AA3B92502731900FAAF6E /* Publisher+Extensions.swift */,
 				DAFAD6A024DC476A0043ED06 /* Result+Extensions.swift */,
+				4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */,
 				797A756524814EF8003CF16D /* SystemEnvironment.swift */,
 				CFA41B6527DA724400427602 /* SystemEnvironment+XStreamClient.swift */,
 				C14A46522845043300EF498E /* ThreadSafeWeakCollection.swift */,
@@ -10857,6 +10861,7 @@
 				79877A0B2498E4BC00015F8B /* Member.swift in Sources */,
 				84ABB015269F0A84003A4585 /* EventsController+Combine.swift in Sources */,
 				F670B50F24FE6EA900003B1A /* MessageEditor.swift in Sources */,
+				4FD2BE532B9AEE3500FFC6F2 /* StreamCollection.swift in Sources */,
 				7991D83D24F7E93900D21BA3 /* ChannelListController+SwiftUI.swift in Sources */,
 				225D7FE225D191400094E555 /* ChatMessageImageAttachment.swift in Sources */,
 				8A0D64A724E57A520017A3C0 /* GuestUserTokenRequestPayload.swift in Sources */,
@@ -11461,6 +11466,7 @@
 				C121E855274544AE00023E4C /* AttachmentEndpoints.swift in Sources */,
 				C121E856274544AE00023E4C /* ChatRemoteNotificationHandler.swift in Sources */,
 				C121E857274544AE00023E4C /* Worker.swift in Sources */,
+				4FD2BE542B9AEE3500FFC6F2 /* StreamCollection.swift in Sources */,
 				C121E858274544AE00023E4C /* CurrentUserUpdater.swift in Sources */,
 				C121E859274544AE00023E4C /* ChannelListUpdater.swift in Sources */,
 				C121E85A274544AE00023E4C /* ChannelUpdater.swift in Sources */,


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Add `StreamCollection` which allows dynamically to change the internal base collection (to different types).

### 🛠 Implementation

The new state layer uses `LazyCachedMapCollection` as the backing storage for items fetched from the database. Later, we would like to change it to a native Swift array. `StreamCollection` acts as the middle layer until this has happened allowing to change the base collection without requiring to make breaking changes to the public API layer. Ideally, the custom collection type is removed with one API breaking change, but this depends on when the new data flow lands.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
