### PR TITLE
[ChatStateLayer] ChannelList and ChannelListState

### DIFF
--- a/Sources/StreamChat/ChatClient+Environment.swift
+++ b/Sources/StreamChat/ChatClient+Environment.swift
@@ -152,6 +152,13 @@ extension ChatClient {
         ) -> ChannelRepository = {
             ChannelRepository(database: $0, apiClient: $1)
         }
+        
+        var channelListUpdaterBuilder: (
+            _ database: DatabaseContainer,
+            _ apiClient: APIClient
+        ) -> ChannelListUpdater = {
+            ChannelListUpdater(database: $0, apiClient: $1)
+        }
 
         var messageRepositoryBuilder: (
             _ database: DatabaseContainer,

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -74,6 +74,8 @@ public class ChatClient {
     let callRepository: CallRepository
 
     let channelRepository: ChannelRepository
+    
+    let channelListUpdater: ChannelListUpdater
 
     func makeMessagesPaginationStateHandler() -> MessagesPaginationStateHandling {
         MessagesPaginationStateHandler()
@@ -195,6 +197,10 @@ public class ChatClient {
         extensionLifecycle = environment.extensionLifecycleBuilder(config.applicationGroupIdentifier)
         callRepository = environment.callRepositoryBuilder(apiClient)
         channelRepository = environment.channelRepositoryBuilder(
+            databaseContainer,
+            apiClient
+        )
+        channelListUpdater = environment.channelListUpdaterBuilder(
             databaseContainer,
             apiClient
         )

--- a/Sources/StreamChat/StateLayer/ChannelList.swift
+++ b/Sources/StreamChat/StateLayer/ChannelList.swift
@@ -42,9 +42,7 @@ public struct ChannelList {
     /// - Returns: An array of channels for the pagination.
     @discardableResult public func loadChannels(with pagination: Pagination) async throws -> [ChatChannel] {
         guard pagination.pageSize > 0 else { return [] }
-        let channels = try await channelListUpdater.loadChannels(query: query, pagination: pagination)
-        await state.setLoadedAllChannels(channels.count < pagination.pageSize)
-        return channels
+        return try await channelListUpdater.loadChannels(query: query, pagination: pagination)
     }
     
     /// Loads more channels and updates ``ChatListState.channels``.
@@ -57,9 +55,7 @@ public struct ChannelList {
     @discardableResult public func loadNextChannels(with limit: Int? = nil) async throws -> [ChatChannel] {
         let limit = limit ?? query.pagination.pageSize
         let count = await state.value(forKeyPath: \.channels.count)
-        let channels = try await channelListUpdater.loadNextChannels(query: query, limit: limit, loadedChannelsCount: count)
-        await state.setLoadedAllChannels(channels.count < limit)
-        return channels
+        return try await channelListUpdater.loadNextChannels(query: query, limit: limit, loadedChannelsCount: count)
     }
 }
 

--- a/Sources/StreamChat/StateLayer/ChannelList.swift
+++ b/Sources/StreamChat/StateLayer/ChannelList.swift
@@ -1,0 +1,76 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An object which represents a list of `ChatChannel`.
+@available(iOS 13.0, *)
+public struct ChannelList {
+    /// The query specifying and filtering the list of channels.
+    public let query: ChannelListQuery
+    
+    private let channelListUpdater: ChannelListUpdater
+    
+    init(channels: [ChatChannel], query: ChannelListQuery, dynamicFilter: ((ChatChannel) -> Bool)?, channelListUpdater: ChannelListUpdater, client: ChatClient, environment: Environment = .init()) {
+        self.channelListUpdater = channelListUpdater
+        self.query = query
+        let state = environment.stateBuilder(
+            channels,
+            query,
+            client.config,
+            client.databaseContainer
+        )
+        self.state = state
+        
+        // These are currently not implemented compared to ChannelListController:
+        #warning("Implement query reset (e.g. SyncRepository)")
+        #warning("Implement linking and unlinking based on EventController callbacks")
+    }
+    
+    /// An observable object representing the current state of the channel list.
+    public let state: ChannelListState
+    
+    // MARK: - Channel List Pagination
+    
+    /// Loads channels for the specified pagination parameters and updates ``ChatListState.channels``.
+    ///
+    /// - Parameters:
+    ///   - pagination: The pagination configuration which includes limit and cursor.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of channels for the pagination.
+    @discardableResult public func loadChannels(with pagination: Pagination) async throws -> [ChatChannel] {
+        guard pagination.pageSize > 0 else { return [] }
+        let channels = try await channelListUpdater.loadChannels(query: query, pagination: pagination)
+        await state.setLoadedAllChannels(channels.count < pagination.pageSize)
+        return channels
+    }
+    
+    /// Loads more channels and updates ``ChatListState.channels``.
+    ///
+    /// - Parameters
+    ///   - limit: The limit for the page size. The default limit is 20.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of loaded channels.
+    @discardableResult public func loadNextChannels(with limit: Int? = nil) async throws -> [ChatChannel] {
+        let limit = limit ?? query.pagination.pageSize
+        let count = await state.value(forKeyPath: \.channels.count)
+        let channels = try await channelListUpdater.loadNextChannels(query: query, limit: limit, loadedChannelsCount: count)
+        await state.setLoadedAllChannels(channels.count < limit)
+        return channels
+    }
+}
+
+@available(iOS 13.0, *)
+extension ChannelList {
+    struct Environment {
+        var stateBuilder: (
+            _ channels: [ChatChannel],
+            _ query: ChannelListQuery,
+            _ clientConfig: ChatClientConfig,
+            _ database: DatabaseContainer
+        ) -> ChannelListState = ChannelListState.init
+    }
+}

--- a/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
@@ -1,0 +1,47 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+@available(iOS 13.0, *)
+extension ChannelListState {
+    struct Observer {
+        private let channelListObserver: BackgroundListDatabaseObserver<ChatChannel, ChannelDTO>
+        private let query: ChannelListQuery
+        
+        init(query: ChannelListQuery, chatClientConfig: ChatClientConfig, database: DatabaseContainer) {
+            self.query = query
+            // Note that for channel list we sort outside of NSFetchRequest because ChannelListQuery defines its own sorting (see runtimeSorting)
+            channelListObserver = BackgroundListDatabaseObserver(
+                context: database.backgroundReadOnlyContext,
+                fetchRequest: ChannelDTO.channelListFetchRequest(
+                    query: query,
+                    chatClientConfig: chatClientConfig
+                ),
+                itemCreator: {
+                    try $0.asModel() as ChatChannel
+                },
+                sorting: query.sort.runtimeSorting
+            )
+        }
+        
+        struct Handlers {
+            let channelsDidChange: (StreamCollection<ChatChannel>) async -> Void
+        }
+        
+        func start(with handlers: Handlers) {
+            channelListObserver.onDidChange = { [weak channelListObserver] _ in
+                guard let items = channelListObserver?.items else { return }
+                let collection = StreamCollection(items)
+                Task { await handlers.channelsDidChange(collection) }
+            }
+            
+            do {
+                try channelListObserver.startObserving()
+            } catch {
+                log.error("Failed to start the channel list observer for query: \(query)")
+            }
+        }
+    }
+}

--- a/Sources/StreamChat/StateLayer/ChannelListState.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState.swift
@@ -1,0 +1,45 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Represents a list of channels matching to the specified query.
+@available(iOS 13.0, *)
+public final class ChannelListState: ObservableObject {
+    private let observer: Observer
+    private let clientConfig: ChatClientConfig
+    let query: ChannelListQuery
+    
+    init(channels: [ChatChannel], query: ChannelListQuery, clientConfig: ChatClientConfig, database: DatabaseContainer) {
+        self.channels = StreamCollection<ChatChannel>(channels)
+        self.clientConfig = clientConfig
+        hasLoadedAllChannels = channels.count < query.pagination.pageSize
+        observer = Observer(query: query, chatClientConfig: clientConfig, database: database)
+        self.query = query
+        
+        observer.start(
+            with: .init(channelsDidChange: { [weak self] channels in await self?.setValue(channels, for: \.channels) })
+        )
+    }
+    
+    /// An array of channels for the specified ``ChannelListQuery``.
+    @Published public private(set) var channels = StreamCollection<ChatChannel>([])
+    
+    /// True, if all the channels were loaded with paginated loading.
+    @Published public private(set) var hasLoadedAllChannels = false
+    
+    // MARK: - Mutating the State
+    
+    @MainActor func value<Value>(forKeyPath keyPath: KeyPath<ChannelListState, Value>) -> Value {
+        self[keyPath: keyPath]
+    }
+    
+    @MainActor func setValue<Value>(_ value: Value, for keyPath: ReferenceWritableKeyPath<ChannelListState, Value>) {
+        self[keyPath: keyPath] = value
+    }
+    
+    @MainActor func setLoadedAllChannels(_ value: Bool) {
+        setValue(value, for: \.hasLoadedAllChannels)
+    }
+}

--- a/Sources/StreamChat/StateLayer/ChannelListState.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState.swift
@@ -14,7 +14,6 @@ public final class ChannelListState: ObservableObject {
     init(channels: [ChatChannel], query: ChannelListQuery, clientConfig: ChatClientConfig, database: DatabaseContainer) {
         self.channels = StreamCollection<ChatChannel>(channels)
         self.clientConfig = clientConfig
-        hasLoadedAllChannels = channels.count < query.pagination.pageSize
         observer = Observer(query: query, chatClientConfig: clientConfig, database: database)
         self.query = query
         
@@ -26,9 +25,6 @@ public final class ChannelListState: ObservableObject {
     /// An array of channels for the specified ``ChannelListQuery``.
     @Published public private(set) var channels = StreamCollection<ChatChannel>([])
     
-    /// True, if all the channels were loaded with paginated loading.
-    @Published public private(set) var hasLoadedAllChannels = false
-    
     // MARK: - Mutating the State
     
     @MainActor func value<Value>(forKeyPath keyPath: KeyPath<ChannelListState, Value>) -> Value {
@@ -37,9 +33,5 @@ public final class ChannelListState: ObservableObject {
     
     @MainActor func setValue<Value>(_ value: Value, for keyPath: ReferenceWritableKeyPath<ChannelListState, Value>) {
         self[keyPath: keyPath] = value
-    }
-    
-    @MainActor func setLoadedAllChannels(_ value: Bool) {
-        setValue(value, for: \.hasLoadedAllChannels)
     }
 }

--- a/Sources/StreamChat/Utils/StreamCollection.swift
+++ b/Sources/StreamChat/Utils/StreamCollection.swift
@@ -15,7 +15,7 @@ public struct StreamCollection<Element>: RandomAccessCollection {
     private let _startIndex: () -> Index
 
     /// Creates an instance of the collection using the base collection as the data source.
-    init<BaseCollection>(_ baseCollection: BaseCollection) where BaseCollection: RandomAccessCollection, BaseCollection.Element == Element, BaseCollection.Index == Index {
+    public init<BaseCollection>(_ baseCollection: BaseCollection) where BaseCollection: RandomAccessCollection, BaseCollection.Element == Element, BaseCollection.Index == Index {
         _endIndex = { baseCollection.endIndex }
         _position = { baseCollection[$0] }
         _startIndex = { baseCollection.startIndex }

--- a/Sources/StreamChat/Workers/ChannelListUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater.swift
@@ -209,3 +209,57 @@ private extension ChannelListUpdater {
         }
     }
 }
+
+@available(iOS 13.0, *)
+extension ChannelListUpdater {
+    func link(channel: ChatChannel, with query: ChannelListQuery) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            link(channel: channel, with: query) { error in
+                continuation.resume(with: error)
+            }
+        }
+    }
+
+    func startWatchingChannels(withIds ids: [ChannelId]) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            startWatchingChannels(withIds: ids) { error in
+                continuation.resume(with: error)
+            }
+        }
+    }
+
+    func unlink(channel: ChatChannel, with query: ChannelListQuery) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            unlink(channel: channel, with: query) { error in
+                continuation.resume(with: error)
+            }
+        }
+    }
+
+    func update(channelListQuery: ChannelListQuery) async throws -> [ChatChannel] {
+        try await withCheckedThrowingContinuation { continuation in
+            update(channelListQuery: channelListQuery) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+    
+    // MARK: -
+    
+    func loadChannels(query: ChannelListQuery, pagination: Pagination) async throws -> [ChatChannel] {
+        try await update(channelListQuery: query.withPagination(pagination))
+    }
+    
+    func loadNextChannels(query: ChannelListQuery, limit: Int, loadedChannelsCount: Int) async throws -> [ChatChannel] {
+        let pagination = Pagination(pageSize: limit, offset: loadedChannelsCount)
+        return try await update(channelListQuery: query.withPagination(pagination))
+    }
+}
+
+private extension ChannelListQuery {
+    func withPagination(_ pagination: Pagination) -> Self {
+        var query = self
+        query.pagination = pagination
+        return query
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -249,15 +249,21 @@
 		4F73F39E2B91C7BF00563CD9 /* MessageState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */; };
 		4F73F39F2B91C7BF00563CD9 /* MessageState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */; };
 		4F8E53062B7CD01D008C0F9F /* Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E53052B7CD01D008C0F9F /* Chat.swift */; };
-		4F8E530B2B7CEBFB008C0F9F /* ChatClient+Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E530A2B7CEBFB008C0F9F /* ChatClient+Chat.swift */; };
+		4F8E530B2B7CEBFB008C0F9F /* ChatClient+Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E530A2B7CEBFB008C0F9F /* ChatClient+Factory.swift */; };
 		4F8E53162B7F58BE008C0F9F /* Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E53052B7CD01D008C0F9F /* Chat.swift */; };
-		4F8E53172B7F58C1008C0F9F /* ChatClient+Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E530A2B7CEBFB008C0F9F /* ChatClient+Chat.swift */; };
+		4F8E53172B7F58C1008C0F9F /* ChatClient+Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E530A2B7CEBFB008C0F9F /* ChatClient+Factory.swift */; };
 		4F8E531C2B833D6C008C0F9F /* ChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E531B2B833D6C008C0F9F /* ChatState.swift */; };
 		4F8E531D2B833D6C008C0F9F /* ChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E531B2B833D6C008C0F9F /* ChatState.swift */; };
 		4FD2BE502B99F68300FFC6F2 /* ReadStateSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */; };
 		4FD2BE512B99F68300FFC6F2 /* ReadStateSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */; };
 		4FD2BE532B9AEE3500FFC6F2 /* StreamCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */; };
 		4FD2BE542B9AEE3500FFC6F2 /* StreamCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */; };
+		4FD2BE562B9AF8A300FFC6F2 /* ChannelList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE552B9AF8A300FFC6F2 /* ChannelList.swift */; };
+		4FD2BE572B9AF8A300FFC6F2 /* ChannelList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE552B9AF8A300FFC6F2 /* ChannelList.swift */; };
+		4FD2BE592B9AF8B600FFC6F2 /* ChannelListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE582B9AF8B600FFC6F2 /* ChannelListState.swift */; };
+		4FD2BE5A2B9AF8B600FFC6F2 /* ChannelListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE582B9AF8B600FFC6F2 /* ChannelListState.swift */; };
+		4FD2BE5C2B9AF8C300FFC6F2 /* ChannelListState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE5B2B9AF8C300FFC6F2 /* ChannelListState+Observer.swift */; };
+		4FD2BE5D2B9AF8C300FFC6F2 /* ChannelListState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE5B2B9AF8C300FFC6F2 /* ChannelListState+Observer.swift */; };
 		4FF2A80D2B8E011000941A64 /* ChatState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF2A80C2B8E011000941A64 /* ChatState+Observer.swift */; };
 		4FF2A80E2B8E011000941A64 /* ChatState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF2A80C2B8E011000941A64 /* ChatState+Observer.swift */; };
 		6428DD5526201DCC0065DA1D /* BannerShowingConnectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */; };
@@ -2896,10 +2902,13 @@
 		4F73F3972B91BD3000563CD9 /* MessageState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageState.swift; sourceTree = "<group>"; };
 		4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessageState+Observer.swift"; sourceTree = "<group>"; };
 		4F8E53052B7CD01D008C0F9F /* Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chat.swift; sourceTree = "<group>"; };
-		4F8E530A2B7CEBFB008C0F9F /* ChatClient+Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatClient+Chat.swift"; sourceTree = "<group>"; };
+		4F8E530A2B7CEBFB008C0F9F /* ChatClient+Factory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatClient+Factory.swift"; sourceTree = "<group>"; };
 		4F8E531B2B833D6C008C0F9F /* ChatState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatState.swift; sourceTree = "<group>"; };
 		4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadStateSender.swift; sourceTree = "<group>"; };
 		4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCollection.swift; sourceTree = "<group>"; };
+		4FD2BE552B9AF8A300FFC6F2 /* ChannelList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelList.swift; sourceTree = "<group>"; };
+		4FD2BE582B9AF8B600FFC6F2 /* ChannelListState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListState.swift; sourceTree = "<group>"; };
+		4FD2BE5B2B9AF8C300FFC6F2 /* ChannelListState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelListState+Observer.swift"; sourceTree = "<group>"; };
 		4FF2A80C2B8E011000941A64 /* ChatState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatState+Observer.swift"; sourceTree = "<group>"; };
 		6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerShowingConnectionDelegate.swift; sourceTree = "<group>"; };
 		647F66D4261E22C200111B19 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
@@ -4808,8 +4817,11 @@
 		4F8E53042B7CCFA7008C0F9F /* StateLayer */ = {
 			isa = PBXGroup;
 			children = (
+				4FD2BE552B9AF8A300FFC6F2 /* ChannelList.swift */,
+				4FD2BE582B9AF8B600FFC6F2 /* ChannelListState.swift */,
+				4FD2BE5B2B9AF8C300FFC6F2 /* ChannelListState+Observer.swift */,
+				4F8E530A2B7CEBFB008C0F9F /* ChatClient+Factory.swift */,
 				4F8E53052B7CD01D008C0F9F /* Chat.swift */,
-				4F8E530A2B7CEBFB008C0F9F /* ChatClient+Chat.swift */,
 				4F8E531B2B833D6C008C0F9F /* ChatState.swift */,
 				4FF2A80C2B8E011000941A64 /* ChatState+Observer.swift */,
 				4F73F3972B91BD3000563CD9 /* MessageState.swift */,
@@ -10562,6 +10574,7 @@
 				C1FC2F972742579D0062530F /* Compression.swift in Sources */,
 				C1B49B3D2822A7AD00F4E89E /* StreamRuntimeCheck.swift in Sources */,
 				40789D1529F6AC500018C2BB /* AudioPlaybackRate.swift in Sources */,
+				4FD2BE592B9AF8B600FFC6F2 /* ChannelListState.swift in Sources */,
 				C1B0B38627BFE8AB00C8207D /* MessageRepository.swift in Sources */,
 				847E946E269C687300E31D0C /* EventsController.swift in Sources */,
 				79DDF80E249CB920002F4412 /* RequestDecoder.swift in Sources */,
@@ -10704,6 +10717,7 @@
 				40C20EB229F69E1D00702EEE /* ChatMessageVoiceRecordingAttachment.swift in Sources */,
 				F8933D2125FFAB400054BBFF /* APIPathConvertible.swift in Sources */,
 				795296FC258264A100435B2E /* UserSearchController.swift in Sources */,
+				4FD2BE5C2B9AF8C300FFC6F2 /* ChannelListState+Observer.swift in Sources */,
 				840B4FCF26A9E53100D5EFAB /* CustomEventRequestBody.swift in Sources */,
 				79CD959224F9380B00E87377 /* MulticastDelegate.swift in Sources */,
 				7964F3BC249A5E60002A09EC /* RequestEncoder.swift in Sources */,
@@ -10822,7 +10836,7 @@
 				79280F3F2484E3BA00CDEB89 /* ClientError.swift in Sources */,
 				C174E0F6284DFA5A0040B936 /* IdentifiablePayload.swift in Sources */,
 				884C61222594A449008B70DC /* AttachmentActionRequestBody.swift in Sources */,
-				4F8E530B2B7CEBFB008C0F9F /* ChatClient+Chat.swift in Sources */,
+				4F8E530B2B7CEBFB008C0F9F /* ChatClient+Factory.swift in Sources */,
 				40789D1929F6AC500018C2BB /* AudioPlayerObserving.swift in Sources */,
 				84A43CAF26A9A25000302763 /* UnknownChannelEvent.swift in Sources */,
 				C1B0B38327BFC08900C8207D /* EndpointPath+OfflineRequest.swift in Sources */,
@@ -10899,6 +10913,7 @@
 				8899BC53254318CC003CB98B /* MessageReaction.swift in Sources */,
 				8A0175F02501174000570345 /* TypingEventsSender.swift in Sources */,
 				E7DD8EC125E4083B0059A322 /* OptionalDecodable.swift in Sources */,
+				4FD2BE562B9AF8A300FFC6F2 /* ChannelList.swift in Sources */,
 				F6FF1DAA24FD23D300151735 /* MessageEndpoints.swift in Sources */,
 				DA8407002524F778005A0F62 /* UserListController.swift in Sources */,
 				799C943E247D2FB9001F1104 /* ChatMessage.swift in Sources */,
@@ -11388,6 +11403,7 @@
 				AD6A248B280DA890003BA1E4 /* PushDevice.swift in Sources */,
 				C14A46542845043300EF498E /* ThreadSafeWeakCollection.swift in Sources */,
 				C121E81E274544AD00023E4C /* MessageEvents.swift in Sources */,
+				4FD2BE5A2B9AF8B600FFC6F2 /* ChannelListState.swift in Sources */,
 				C1B49B412822C01C00F4E89E /* NSManagedObject+Validation.swift in Sources */,
 				C121E81F274544AD00023E4C /* MemberEvents.swift in Sources */,
 				C121E820274544AD00023E4C /* ReactionEvents.swift in Sources */,
@@ -11404,7 +11420,7 @@
 				C121E827274544AD00023E4C /* WebSocketPingController.swift in Sources */,
 				C121E828274544AD00023E4C /* RetryStrategy.swift in Sources */,
 				C121E829274544AD00023E4C /* WebSocketConnectPayload.swift in Sources */,
-				4F8E53172B7F58C1008C0F9F /* ChatClient+Chat.swift in Sources */,
+				4F8E53172B7F58C1008C0F9F /* ChatClient+Factory.swift in Sources */,
 				C121E82A274544AD00023E4C /* ConnectionStatus.swift in Sources */,
 				C121E82B274544AD00023E4C /* APIPathConvertible.swift in Sources */,
 				AD8FEE5C2AA8E1E400273F88 /* ChatClientFactory.swift in Sources */,
@@ -11486,6 +11502,7 @@
 				C121E864274544AE00023E4C /* EventObserver.swift in Sources */,
 				C121E865274544AE00023E4C /* MemberEventObserver.swift in Sources */,
 				43D3F10028410B4800B74921 /* Call.swift in Sources */,
+				4FD2BE5D2B9AF8C300FFC6F2 /* ChannelListState+Observer.swift in Sources */,
 				C121E866274544AE00023E4C /* MessageSender.swift in Sources */,
 				C121E867274544AE00023E4C /* NewUserQueryUpdater.swift in Sources */,
 				C121E868274544AF00023E4C /* MessageEditor.swift in Sources */,
@@ -11590,6 +11607,7 @@
 				4F8E531D2B833D6C008C0F9F /* ChatState.swift in Sources */,
 				C121E8AC274544B000023E4C /* ChatChannelWatcherListController+SwiftUI.swift in Sources */,
 				C121E8AD274544B000023E4C /* ChannelController.swift in Sources */,
+				4FD2BE572B9AF8A300FFC6F2 /* ChannelList.swift in Sources */,
 				C1E8AD58278C8A6F0041B775 /* SyncRepository.swift in Sources */,
 				C121E8AE274544B000023E4C /* ChannelController+SwiftUI.swift in Sources */,
 				C121E8AF274544B000023E4C /* ChannelController+Combine.swift in Sources */,


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Add ChannelList and ChannelListState for actions and state when loading lists of channels with `ChannelListQuery`

### 📝 Summary

* Adds actions and observable state support
* Does not include channel linking (will be a separate follow-up PR)
* Does not include tracking logic with SyncRepository (I have some ideas around it, will be a separate follow-up PR)

### 🛠 Implementation

ChannelListUpdater makes the queries. ChatClient provides the factory method for creating the ChannelList objects. ChannelListState holds the state. 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
