### PR TITLE
[ChatStateLayer] Channel list query reset in SyncRepository

### DIFF
--- a/Sources/StreamChat/ChatClient+Environment.swift
+++ b/Sources/StreamChat/ChatClient+Environment.swift
@@ -127,7 +127,8 @@ extension ChatClient {
             _ offlineRequestsRepository: OfflineRequestsRepository,
             _ eventNotificationCenter: EventNotificationCenter,
             _ database: DatabaseContainer,
-            _ apiClient: APIClient
+            _ apiClient: APIClient,
+            _ channelListUpater: ChannelListUpdater
         ) -> SyncRepository = {
             SyncRepository(
                 config: $0,
@@ -136,7 +137,8 @@ extension ChatClient {
                 offlineRequestsRepository: $3,
                 eventNotificationCenter: $4,
                 database: $5,
-                apiClient: $6
+                apiClient: $6,
+                channelListUpdater: $7
             )
         }
 

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -156,6 +156,10 @@ public class ChatClient {
             apiClient,
             config.queuedActionsMaxHoursThreshold
         )
+        let channelListUpdater = environment.channelListUpdaterBuilder(
+            databaseContainer,
+            apiClient
+        )
         let syncRepository = environment.syncRepositoryBuilder(
             config,
             activeChannelControllers,
@@ -163,7 +167,8 @@ public class ChatClient {
             offlineRequestsRepository,
             eventNotificationCenter,
             databaseContainer,
-            apiClient
+            apiClient,
+            channelListUpdater
         )
         let webSocketClient = factory.makeWebSocketClient(
             requestEncoder: webSocketEncoder,
@@ -185,6 +190,7 @@ public class ChatClient {
             environment.timerType
         )
 
+        self.channelListUpdater = channelListUpdater
         self.databaseContainer = databaseContainer
         self.apiClient = apiClient
         self.webSocketClient = webSocketClient
@@ -197,10 +203,6 @@ public class ChatClient {
         extensionLifecycle = environment.extensionLifecycleBuilder(config.applicationGroupIdentifier)
         callRepository = environment.callRepositoryBuilder(apiClient)
         channelRepository = environment.channelRepositoryBuilder(
-            databaseContainer,
-            apiClient
-        )
-        channelListUpdater = environment.channelListUpdaterBuilder(
             databaseContainer,
             apiClient
         )

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -138,8 +138,7 @@ class SyncRepository {
             }
         operations.append(contentsOf: refetchChannelListQueryOperations)
         let channelListRegistry = ChannelListRegistry()
-        let notification = Notification(name: SyncRepository.syncRepositoryChannelListQueryRegistrationNotification, object: channelListRegistry)
-        NotificationCenter.default.post(notification)
+        NotificationCenter.default.post(Notification(name: .syncRepositoryChannelListQueryRegistration, object: channelListRegistry))
         operations.append(contentsOf: channelListRegistry.registeredChannelListQueries.map { query in
             RefetchChannelListQueryOperation(query: query, channelListUpdater: channelListUpdater, context: context)
         })
@@ -364,7 +363,9 @@ extension SyncRepository {
             }
         }
     }
-    
-    /// A notification which contains ChannelListRegistry as the notification's object.
-    static let syncRepositoryChannelListQueryRegistrationNotification = Notification.Name("syncRepositoryChannelListQueryRegistrationNotification")
+}
+
+extension Notification.Name {
+    /// A notification which contains ``ChannelListRegistry`` as the notification's object.
+    static let syncRepositoryChannelListQueryRegistration = Notification.Name("io.getstream.StreamChat.channelListQueryRegistration")
 }

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -350,20 +350,18 @@ private extension Date {
 extension SyncRepository {
     final class ChannelListRegistry {
         private var channelListQueries = [ChannelListQuery]()
-        private let lock = NSLock()
+        private let queue = DispatchQueue(label: "io.getstream.sync-repository.channel-list-registry")
         
         var registeredChannelListQueries: [ChannelListQuery] {
-            let queries: [ChannelListQuery]
-            lock.lock()
-            queries = channelListQueries
-            lock.unlock()
-            return queries
+            queue.sync {
+                channelListQueries
+            }
         }
         
         func register(query: ChannelListQuery) {
-            lock.lock()
-            channelListQueries.append(query)
-            lock.unlock()
+            queue.sync {
+                channelListQueries.append(query)
+            }
         }
     }
     

--- a/Sources/StreamChat/Repositories/SyncRepository.swift
+++ b/Sources/StreamChat/Repositories/SyncRepository.swift
@@ -35,6 +35,7 @@ class SyncRepository {
     private let config: ChatClientConfig
     private let database: DatabaseContainer
     private let apiClient: APIClient
+    private let channelListUpdater: ChannelListUpdater
     let activeChannelControllers: ThreadSafeWeakCollection<ChatChannelController>
     let activeChannelListControllers: ThreadSafeWeakCollection<ChatChannelListController>
     let offlineRequestsRepository: OfflineRequestsRepository
@@ -54,12 +55,14 @@ class SyncRepository {
         offlineRequestsRepository: OfflineRequestsRepository,
         eventNotificationCenter: EventNotificationCenter,
         database: DatabaseContainer,
-        apiClient: APIClient
+        apiClient: APIClient,
+        channelListUpdater: ChannelListUpdater
     ) {
         self.config = config
         self.activeChannelControllers = activeChannelControllers
         self.activeChannelListControllers = activeChannelListControllers
         self.offlineRequestsRepository = offlineRequestsRepository
+        self.channelListUpdater = channelListUpdater
         self.eventNotificationCenter = eventNotificationCenter
         self.database = database
         self.apiClient = apiClient
@@ -134,6 +137,12 @@ class SyncRepository {
                 )
             }
         operations.append(contentsOf: refetchChannelListQueryOperations)
+        let channelListRegistry = ChannelListRegistry()
+        let notification = Notification(name: SyncRepository.syncRepositoryChannelListQueryRegistrationNotification, object: channelListRegistry)
+        NotificationCenter.default.post(notification)
+        operations.append(contentsOf: channelListRegistry.registeredChannelListQueries.map { query in
+            RefetchChannelListQueryOperation(query: query, channelListUpdater: channelListUpdater, context: context)
+        })
 
         // 4. Clean up unwanted channels
         operations.append(DeleteUnwantedChannelsOperation(database: database, context: context))
@@ -336,4 +345,28 @@ private extension Date {
     var numberOfDaysUntilNow: Int {
         Calendar.current.dateComponents([.day], from: self, to: Date()).day ?? 0
     }
+}
+
+extension SyncRepository {
+    final class ChannelListRegistry {
+        private var channelListQueries = [ChannelListQuery]()
+        private let lock = NSLock()
+        
+        var registeredChannelListQueries: [ChannelListQuery] {
+            let queries: [ChannelListQuery]
+            lock.lock()
+            queries = channelListQueries
+            lock.unlock()
+            return queries
+        }
+        
+        func register(query: ChannelListQuery) {
+            lock.lock()
+            channelListQueries.append(query)
+            lock.unlock()
+        }
+    }
+    
+    /// A notification which contains ChannelListRegistry as the notification's object.
+    static let syncRepositoryChannelListQueryRegistrationNotification = Notification.Name("syncRepositoryChannelListQueryRegistrationNotification")
 }

--- a/Sources/StreamChat/StateLayer/ChannelList.swift
+++ b/Sources/StreamChat/StateLayer/ChannelList.swift
@@ -24,7 +24,6 @@ public struct ChannelList {
         self.state = state
         
         // These are currently not implemented compared to ChannelListController:
-        #warning("Implement query reset (e.g. SyncRepository)")
         #warning("Implement linking and unlinking based on EventController callbacks")
     }
     

--- a/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
@@ -2,13 +2,15 @@
 // Copyright © 2024 Stream.io Inc. All rights reserved.
 //
 
+import Combine
 import Foundation
 
 @available(iOS 13.0, *)
 extension ChannelListState {
-    struct Observer {
+    final class Observer {
         private let channelListObserver: BackgroundListDatabaseObserver<ChatChannel, ChannelDTO>
         private let query: ChannelListQuery
+        private var syncRepositoryCancellable: AnyCancellable?
         
         init(query: ChannelListQuery, chatClientConfig: ChatClientConfig, database: DatabaseContainer) {
             self.query = query
@@ -31,6 +33,11 @@ extension ChannelListState {
         }
         
         func start(with handlers: Handlers) {
+            syncRepositoryCancellable = NotificationCenter.default
+                .publisher(for: SyncRepository.syncRepositoryChannelListQueryRegistrationNotification)
+                .compactMap { $0.object as? SyncRepository.ChannelListRegistry }
+                .sink(receiveValue: { [query] registry in registry.register(query: query) })
+            
             channelListObserver.onDidChange = { [weak channelListObserver] _ in
                 guard let items = channelListObserver?.items else { return }
                 let collection = StreamCollection(items)

--- a/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChannelListState+Observer.swift
@@ -34,7 +34,7 @@ extension ChannelListState {
         
         func start(with handlers: Handlers) {
             syncRepositoryCancellable = NotificationCenter.default
-                .publisher(for: SyncRepository.syncRepositoryChannelListQueryRegistrationNotification)
+                .publisher(for: .syncRepositoryChannelListQueryRegistration)
                 .compactMap { $0.object as? SyncRepository.ChannelListRegistry }
                 .sink(receiveValue: { [query] registry in registry.register(query: query) })
             


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer-channel-list-query*

### 🎯 Goal

Refetch channel list queries when syncing is triggered for the new chat state layer.

### 📝 Summary

SyncRepository is keeping track of active ChannelListController objects (see [#1](https://github.com/GetStream/stream-chat-swift/blob/develop/Sources/StreamChat/ChatClient.swift#L45), [#2](https://github.com/GetStream/stream-chat-swift/blob/develop/Sources/StreamChat/Repositories/SyncRepository.swift#L129), [#3](https://github.com/GetStream/stream-chat-swift/blob/develop/Sources/StreamChat/Repositories/SyncOperations.swift#L103)). New ChannelList and ChannelListState objects should support the same functionality (resetting ends up fetching channels for the query and updating CoreData store).

This PR proposes to do this differently in a less coupled fashion for the new state layer. 

### 🛠 Implementation

Proposal is to use a notification, which contains an object. If ChannelState observers the notification and adds the query to the shared object, then we could skip having references to ChannelList/ChannelListState types in SyncRepository.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
