### PR TITLE
[ChatStateLayer] Loading watchers for a channel

### DIFF
--- a/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.swift
+++ b/Sources/StreamChat/Controllers/ChannelWatcherListController/ChatChannelWatcherListController.swift
@@ -92,7 +92,8 @@ public class ChatChannelWatcherListController: DataController, DelegateCallable,
             return
         }
 
-        updater.channelWatchers(query: query) { error in
+        updater.channelWatchers(query: query) { result in
+            let error = result.error
             self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
             self.callback { completion?(error) }
         }
@@ -181,9 +182,9 @@ public extension ChatChannelWatcherListController {
     func loadNextWatchers(limit: Int = .channelWatchersPageSize, completion: ((Error?) -> Void)? = nil) {
         var updatedQuery = query
         updatedQuery.pagination = .init(pageSize: limit, offset: watchers.count)
-        updater.channelWatchers(query: updatedQuery) { error in
+        updater.channelWatchers(query: updatedQuery) { result in
             self.query = updatedQuery
-            self.callback { completion?(error) }
+            self.callback { completion?(result.error) }
         }
     }
 }

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -870,9 +870,7 @@ public final class Chat {
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of watchers for the pagination.
     @discardableResult public func loadWatchers(with pagination: Pagination) async throws -> [ChatUser] {
-        let watchers = try await channelUpdater.channelWatchers(for: .init(cid: cid, pagination: pagination))
-        await state.setLoadedAllWatchers(watchers.count < pagination.pageSize)
-        return watchers
+        try await channelUpdater.channelWatchers(for: .init(cid: cid, pagination: pagination))
     }
 
     /// Loads more watchers and updates ``ChatState.watchers``.

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -282,7 +282,7 @@ public final class Chat {
     ///
     /// - Parameters:
     ///   - message: The parent message id which has replies.
-    ///   - pagination: The pagination configuration which includes limit and cursor.
+    ///   - pagination: The pagination configuration which includes a limit and a cursor.
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of messages for the pagination.
@@ -459,7 +459,7 @@ public final class Chat {
     ///
     /// - Parameters:
     ///   - messageId: The id of the message to load reactions.
-    ///   - pagination: The pagination configuration which includes limit and offset or cursor.
+    ///   - pagination: The pagination configuration which includes a limit and an offset or a cursor.
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of reactions for given limit and offset.
@@ -495,7 +495,7 @@ public final class Chat {
     ///
     /// - Parameters:
     ///   - messageId: The parent message id which has replies.
-    ///   - pagination: The pagination configuration which includes limit and cursor.
+    ///   - pagination: The pagination configuration which includes a limit and a cursor.
     ///
     /// - Throws: An error while communicating with the Stream API.
     /// - Returns: An array of messages for the pagination.
@@ -858,6 +858,34 @@ public final class Chat {
     /// - Throws: An error while communicating with the Stream API.
     public func stopWatching() async throws {
         try await channelUpdater.stopWatching(cid: cid)
+    }
+    
+    // MARK: -
+    
+    /// Loads watchers for the specified pagination parameters and updates ``ChatState.watchers``.
+    ///
+    /// - Parameters:
+    ///   - pagination: The pagination configuration which includes a limit and a cursor or an offset.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of watchers for the pagination.
+    @discardableResult public func loadWatchers(with pagination: Pagination) async throws -> [ChatUser] {
+        let watchers = try await channelUpdater.channelWatchers(for: .init(cid: cid, pagination: pagination))
+        await state.setLoadedAllWatchers(watchers.count < pagination.pageSize)
+        return watchers
+    }
+
+    /// Loads more watchers and updates ``ChatState.watchers``.
+    ///
+    /// - Parameters:
+    ///   - limit: The limit for the page size. The default limit is 30.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of loaded watchers.
+    @discardableResult public func loadNextWatchers(with limit: Int? = nil) async throws -> [ChatUser] {
+        let count = await state.value(forKeyPath: \.watchers.count)
+        let pagination = Pagination(pageSize: limit ?? .channelWatchersPageSize, offset: count)
+        return try await loadWatchers(with: pagination)
     }
 }
 

--- a/Sources/StreamChat/StateLayer/ChatState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChatState+Observer.swift
@@ -11,6 +11,7 @@ extension ChatState {
         private let channelObserver: BackgroundEntityDatabaseObserver<ChatChannel, ChannelDTO>
         private let eventNotificationCenter: EventNotificationCenter
         private let messagesObserver: BackgroundListDatabaseObserver<ChatMessage, MessageDTO>
+        private let watchersObserver: BackgroundListDatabaseObserver<ChatUser, UserDTO>
         private var webSocketEventObservers = [EventObserver]()
         
         init(cid: ChannelId, channelQuery: ChannelQuery, database: DatabaseContainer, eventNotificationCenter: EventNotificationCenter) {
@@ -33,6 +34,12 @@ extension ChatState {
                 itemCreator: { try $0.asModel() as ChatMessage },
                 sorting: []
             )
+            watchersObserver = BackgroundListDatabaseObserver(
+                context: context,
+                fetchRequest: UserDTO.watcherFetchRequest(cid: cid),
+                itemCreator: { try $0.asModel() as ChatUser },
+                sorting: []
+            )
             self.eventNotificationCenter = eventNotificationCenter
         }
         
@@ -40,6 +47,7 @@ extension ChatState {
             let channelDidChange: (ChatChannel) async -> Void
             let messagesDidChange: (StreamCollection<ChatMessage>) async -> Void
             let typingUsersDidChange: (Set<ChatUser>) async -> Void
+            let watchersDidChange: (StreamCollection<ChatUser>) async -> Void
         }
         
         func start(with handlers: Handlers) {
@@ -49,6 +57,11 @@ extension ChatState {
                 guard let items = messagesObserver?.items else { return }
                 let collection = StreamCollection(items)
                 Task { await handlers.messagesDidChange(collection) }
+            }
+            watchersObserver.onDidChange = { [weak watchersObserver] _ in
+                guard let items = watchersObserver?.items else { return }
+                let collection = StreamCollection(items)
+                Task { await handlers.watchersDidChange(collection) }
             }
             
             // TODO: Implement member list
@@ -61,12 +74,17 @@ extension ChatState {
             do {
                 try channelObserver.startObserving()
             } catch {
-                log.error("Failed to start the channel observer")
+                log.error("Failed to start the channel observer for cid: \(cid)")
             }
             do {
                 try messagesObserver.startObserving()
             } catch {
-                log.error("Failed to start the messages observer")
+                log.error("Failed to start the messages observer for cid: \(cid)")
+            }
+            do {
+                try watchersObserver.startObserving()
+            } catch {
+                log.error("Failed to start the watchers observer for cid: \(cid)")
             }
         }
     }

--- a/Sources/StreamChat/StateLayer/ChatState.swift
+++ b/Sources/StreamChat/StateLayer/ChatState.swift
@@ -22,7 +22,8 @@ public final class ChatState: ObservableObject {
             with: .init(
                 channelDidChange: { [weak self] in await self?.setValue($0, for: \.channel) },
                 messagesDidChange: { [weak self] in await self?.setValue($0, for: \.messages) },
-                typingUsersDidChange: { [weak self] in await self?.setValue($0, for: \.typingUsers) }
+                typingUsersDidChange: { [weak self] in await self?.setValue($0, for: \.typingUsers) },
+                watchersDidChange: { [weak self] in await self?.setValue($0, for: \.watchers) }
             )
         )
     }
@@ -96,6 +97,18 @@ public final class ChatState: ObservableObject {
     /// A list of users who are currently typing.
     @Published public private(set) var typingUsers = Set<ChatUser>()
     
+    // MARK: - Watchers
+    
+    /// An array of users who are currently watching the channel.
+    ///
+    /// Use load watchers method in ``Chat`` for populating this array.
+    @Published public private(set) var watchers = StreamCollection<ChatUser>([])
+    
+    /// True, if all the watchers were loaded with paginated loading.
+    ///
+    /// The value is set to true when the pagination request returns less than the pagination page size.
+    @Published public private(set) var hasLoadedAllWatchers = false
+    
     // MARK: - Mutating the State
     
     // Force main actor when accessing the state.
@@ -106,5 +119,9 @@ public final class ChatState: ObservableObject {
     // Force mutations on main actor since ChatState is meant to be used by UI.
     @MainActor func setValue<Value>(_ value: Value, for keyPath: ReferenceWritableKeyPath<ChatState, Value>) {
         self[keyPath: keyPath] = value
+    }
+    
+    @MainActor func setLoadedAllWatchers(_ flag: Bool) {
+        hasLoadedAllWatchers = flag
     }
 }

--- a/Sources/StreamChat/StateLayer/ChatState.swift
+++ b/Sources/StreamChat/StateLayer/ChatState.swift
@@ -104,11 +104,6 @@ public final class ChatState: ObservableObject {
     /// Use load watchers method in ``Chat`` for populating this array.
     @Published public private(set) var watchers = StreamCollection<ChatUser>([])
     
-    /// True, if all the watchers were loaded with paginated loading.
-    ///
-    /// The value is set to true when the pagination request returns less than the pagination page size.
-    @Published public private(set) var hasLoadedAllWatchers = false
-    
     // MARK: - Mutating the State
     
     // Force main actor when accessing the state.
@@ -119,9 +114,5 @@ public final class ChatState: ObservableObject {
     // Force mutations on main actor since ChatState is meant to be used by UI.
     @MainActor func setValue<Value>(_ value: Value, for keyPath: ReferenceWritableKeyPath<ChatState, Value>) {
         self[keyPath: keyPath] = value
-    }
-    
-    @MainActor func setLoadedAllWatchers(_ flag: Bool) {
-        hasLoadedAllWatchers = flag
     }
 }

--- a/Sources/StreamChat/Workers/ChannelUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelUpdater.swift
@@ -553,7 +553,7 @@ class ChannelUpdater: Worker {
     /// - Parameters:
     ///   - query: Query object for watchers. See `ChannelWatcherListQuery`
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
-    func channelWatchers(query: ChannelWatcherListQuery, completion: ((Error?) -> Void)? = nil) {
+    func channelWatchers(query: ChannelWatcherListQuery, completion: ((Result<ChannelPayload, Error>) -> Void)? = nil) {
         apiClient.request(endpoint: .channelWatchers(query: query)) { (result: Result<ChannelPayload, Error>) in
             do {
                 let payload = try result.get()
@@ -569,10 +569,14 @@ class ChannelUpdater: Worker {
                     // we should save the payload as it's the latest state of the channel
                     try session.saveChannel(payload: payload)
                 } completion: { error in
-                    completion?(error)
+                    if let error {
+                        completion?(.failure(error))
+                    } else {
+                        completion?(result)
+                    }
                 }
             } catch {
-                completion?(error)
+                completion?(.failure(error))
             }
         }
     }
@@ -717,6 +721,18 @@ extension ChannelUpdater {
             addMembers(currentUserId: currentUserId, cid: cid, userIds: userIds, message: message, hideHistory: hideHistory) { error in
                 continuation.resume(with: error)
             }
+        }
+    }
+    
+    func channelWatchers(for query: ChannelWatcherListQuery) async throws -> [ChatUser] {
+        let payload = try await withCheckedThrowingContinuation { continuation in
+            channelWatchers(query: query) { result in
+                continuation.resume(with: result)
+            }
+        }
+        guard let ids = payload.watchers?.map(\.id) else { return [] }
+        return try await database.backgroundRead { context in
+            try ids.compactMap { try UserDTO.load(id: $0, context: context)?.asModel() }
         }
     }
     


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Support loading watchers for channels.

### 📝 Summary

* Add `Chat.loadWatchers(with:)` (argument is `Pagination`, aligns with other platforms what support general pagination method)
* Add `Chat.loadNextWatchers(with:)` (convenience which uses pagination with an offset)
* Add `ChatState.watchers`
* Add `ChatState.hasLoadedAllWatchers` (`ChatChannelWatcherListController` does not have it but added it so that out pagination implementations have similar interfaces)

### 🛠 Implementation

Follows along what we have in `ChatChannelWatcherListController` (pagination + watchers). 

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)