### PR TITLE
[ChatStateLayer] Unread message and last read message

### DIFF
--- a/Sources/StreamChat/Extensions/Collection+Extensions.swift
+++ b/Sources/StreamChat/Extensions/Collection+Extensions.swift
@@ -1,0 +1,14 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension Collection {
+    /// Returns an element if the index is valid.
+    ///
+    /// - Note: Checks if the index is part of indices.
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Sources/StreamChat/StateLayer/ChatState+Internal.swift
+++ b/Sources/StreamChat/StateLayer/ChatState+Internal.swift
@@ -15,11 +15,17 @@ extension ChatState {
         
         static func firstUnreadMessage(in state: ChatState, userId: UserId) -> MessageId? {
             guard let channel = state.channel else { return nil }
-            let lookup = UnreadMessageLookup(userId: userId, readStates: channel.reads, messageOrder: state.messageOrder, messages: state.messages, hasLoadedAllPreviousMessages: state.hasLoadedAllPreviousMessages)
-            return lookup.firstUnreadMessage
+            let lookup = UnreadMessageLookup(
+                userId: userId,
+                readStates: channel.reads,
+                messageOrder: state.messageOrder,
+                messages: state.messages,
+                hasLoadedAllPreviousMessages: state.hasLoadedAllPreviousMessages
+            )
+            return lookup.firstUnreadMessageId
         }
         
-        private var firstUnreadMessage: MessageId? {
+        private var firstUnreadMessageId: MessageId? {
             guard let readInfo = readStates.first(where: { $0.user.id == userId }) else {
                 // Read state is unavailable
                 return hasLoadedAllPreviousMessages ? oldestRegularMessageId : nil
@@ -29,12 +35,12 @@ extension ChatState {
                 // Everything is unread if read state is there but there is no lastReadMessageId
                 return hasLoadedAllPreviousMessages ? oldestRegularMessageId : nil
             }
-            if let lastReadIndex = indexOfMessage(lastReadMessageId) {
+            if let lastReadIndex = indexOfMessageId(lastReadMessageId) {
                 if isMostRecent(at: lastReadIndex) {
                     // Everything has been read
                     return nil
                 } else {
-                    return lookupUnreadMessage(after: lastReadIndex)
+                    return lookupUnreadMessageId(after: lastReadIndex)
                 }
             } else {
                 // Can't reach the last read message (if all have been loaded then the channel might have been truncated or hidden, in that case, use the oldest message)
@@ -42,7 +48,7 @@ extension ChatState {
             }
         }
         
-        private func lookupUnreadMessage(after excludedSearchIndex: Int) -> MessageId? {
+        private func lookupUnreadMessageId(after excludedSearchIndex: Int) -> MessageId? {
             let searchRange: ReversedCollection<Range<Int>> = {
                 if messageOrder.isAscending {
                     return (messages.endIndex..<excludedSearchIndex).reversed()
@@ -58,7 +64,7 @@ extension ChatState {
             return nil
         }
         
-        private func indexOfMessage(_ messageId: MessageId) -> Int? {
+        private func indexOfMessageId(_ messageId: MessageId) -> Int? {
             messages.firstIndex(where: { $0.id == messageId })
         }
         

--- a/Sources/StreamChat/StateLayer/ChatState+Internal.swift
+++ b/Sources/StreamChat/StateLayer/ChatState+Internal.swift
@@ -1,0 +1,92 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+@available(iOS 13.0, *)
+extension ChatState {
+    struct UnreadMessageLookup {
+        let userId: UserId
+        let readStates: [ChatChannelRead]
+        let messageOrder: MessageOrdering
+        let messages: StreamCollection<ChatMessage>
+        let hasLoadedAllPreviousMessages: Bool
+        
+        static func firstUnreadMessage(in state: ChatState, userId: UserId) -> MessageId? {
+            guard let channel = state.channel else { return nil }
+            let lookup = UnreadMessageLookup(userId: userId, readStates: channel.reads, messageOrder: state.messageOrder, messages: state.messages, hasLoadedAllPreviousMessages: state.hasLoadedAllPreviousMessages)
+            return lookup.firstUnreadMessage
+        }
+        
+        private var firstUnreadMessage: MessageId? {
+            guard let readInfo = readStates.first(where: { $0.user.id == userId }) else {
+                // Read state is unavailable
+                return hasLoadedAllPreviousMessages ? oldestRegularMessageId : nil
+            }
+            guard readInfo.unreadMessagesCount > 0 else { return nil }
+            guard let lastReadMessageId = readInfo.lastReadMessageId else {
+                // Everything is unread if read state is there but there is no lastReadMessageId
+                return hasLoadedAllPreviousMessages ? oldestRegularMessageId : nil
+            }
+            if let lastReadIndex = indexOfMessage(lastReadMessageId) {
+                if isMostRecent(at: lastReadIndex) {
+                    // Everything has been read
+                    return nil
+                } else {
+                    return lookupUnreadMessage(after: lastReadIndex)
+                }
+            } else {
+                // Can't reach the last read message (if all have been loaded then the channel might have been truncated or hidden, in that case, use the oldest message)
+                return hasLoadedAllPreviousMessages ? oldestRegularMessageId : nil
+            }
+        }
+        
+        private func lookupUnreadMessage(after excludedSearchIndex: Int) -> MessageId? {
+            let searchRange: ReversedCollection<Range<Int>> = {
+                if messageOrder.isAscending {
+                    return (messages.endIndex..<excludedSearchIndex).reversed()
+                } else {
+                    return (messages.startIndex..<excludedSearchIndex).reversed()
+                }
+            }()
+            for index in searchRange {
+                if let message = messages[safe: index], message.deletedAt == nil, message.author.id != userId {
+                    return message.id
+                }
+            }
+            return nil
+        }
+        
+        private func indexOfMessage(_ messageId: MessageId) -> Int? {
+            messages.firstIndex(where: { $0.id == messageId })
+        }
+        
+        private func isMostRecent(at index: Int) -> Bool {
+            if messageOrder.isAscending {
+                return messages.index(before: messages.endIndex) == index
+            } else {
+                return messages.startIndex == index
+            }
+        }
+        
+        private var oldestRegularMessageId: MessageId? {
+            if messageOrder.isAscending {
+                return messages.first(where: \.isRegular)?.id
+            } else {
+                return messages.last(where: \.isRegular)?.id
+            }
+        }
+    }
+}
+
+private extension ChatMessage {
+    var isRegular: Bool {
+        switch type {
+        case .regular, .reply:
+            return true
+        case .deleted, .ephemeral, .error, .system:
+            return false
+        }
+    }
+}

--- a/Sources/StreamChat/StateLayer/ChatState+Observer.swift
+++ b/Sources/StreamChat/StateLayer/ChatState+Observer.swift
@@ -72,7 +72,7 @@ extension ChatState {
     }
 }
 
-private extension MessageOrdering {
+extension MessageOrdering {
     var isAscending: Bool {
         switch self {
         case .topToBottom:

--- a/Sources/StreamChat/StateLayer/ChatState.swift
+++ b/Sources/StreamChat/StateLayer/ChatState.swift
@@ -81,7 +81,7 @@ public final class ChatState: ObservableObject {
     // MARK: - Message Reading
     
     /// The id of the message which the current user last read.
-    public var lastReadMessage: MessageId? {
+    public var lastReadMessageId: MessageId? {
         guard let channel else { return nil }
         guard let userId = authenticationRepository.currentUserId else { return nil }
         return channel.lastReadMessageId(userId: userId)
@@ -95,7 +95,7 @@ public final class ChatState: ObservableObject {
     /// * Read state's ``ChatChannelRead.lastReadMessageId`` is nil: oldest message if all the messages have been paginated, otherwise nil
     /// * Last read message is unreachable (e.g. channel was truncated): oldest message if all the messages have been paginated, otherwise nil
     /// * Next message after the last read message id not from the current user
-    public var firstUnreadMessage: MessageId? {
+    public var firstUnreadMessageId: MessageId? {
         guard let userId = authenticationRepository.currentUserId else { return nil }
         return UnreadMessageLookup.firstUnreadMessage(in: self, userId: userId)
     }

--- a/Sources/StreamChat/StateLayer/ChatState.swift
+++ b/Sources/StreamChat/StateLayer/ChatState.swift
@@ -7,12 +7,14 @@ import Foundation
 /// Represents a ``ChatChannel`` and its state.
 @available(iOS 13.0, *)
 public final class ChatState: ObservableObject {
+    private let authenticationRepository: AuthenticationRepository
     private let cid: ChannelId
     private var channelObserver: EntityDatabaseObserverWrapper<ChatChannel, ChannelDTO>?
     private let paginationState: MessagesPaginationState
     private let observer: Observer
     
-    init(cid: ChannelId, channelQuery: ChannelQuery, messageOrder: MessageOrdering, database: DatabaseContainer, eventNotificationCenter: EventNotificationCenter, paginationState: MessagesPaginationState) {
+    init(cid: ChannelId, channelQuery: ChannelQuery, messageOrder: MessageOrdering, authenticationRepository: AuthenticationRepository, database: DatabaseContainer, eventNotificationCenter: EventNotificationCenter, paginationState: MessagesPaginationState) {
+        self.authenticationRepository = authenticationRepository
         self.cid = cid
         self.messageOrder = messageOrder
         self.paginationState = paginationState
@@ -74,6 +76,28 @@ public final class ChatState: ObservableObject {
     /// A Boolean value that returns whether the channel is currently loading previous (old) messages.
     public var isLoadingPreviousMessages: Bool {
         paginationState.isLoadingPreviousMessages
+    }
+    
+    // MARK: - Message Reading
+    
+    /// The id of the message which the current user last read.
+    public var lastReadMessage: MessageId? {
+        guard let channel else { return nil }
+        guard let userId = authenticationRepository.currentUserId else { return nil }
+        return channel.lastReadMessageId(userId: userId)
+    }
+    
+    /// The id of the first unread message.
+    ///
+    /// The returned message id follows requirements:
+    /// * Read state is unavailable: oldest message if all the messages have been paginated, otherwise nil
+    /// * Unread message count is zero: nil
+    /// * Read state's ``ChatChannelRead.lastReadMessageId`` is nil: oldest message if all the messages have been paginated, otherwise nil
+    /// * Last read message is unreachable (e.g. channel was truncated): oldest message if all the messages have been paginated, otherwise nil
+    /// * Next message after the last read message id not from the current user
+    public var firstUnreadMessage: MessageId? {
+        guard let userId = authenticationRepository.currentUserId else { return nil }
+        return UnreadMessageLookup.firstUnreadMessage(in: self, userId: userId)
     }
 
     // MARK: - Throttling and Slow Mode

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -260,6 +260,10 @@
 		4FD2BE542B9AEE3500FFC6F2 /* StreamCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */; };
 		4FF2A80D2B8E011000941A64 /* ChatState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF2A80C2B8E011000941A64 /* ChatState+Observer.swift */; };
 		4FF2A80E2B8E011000941A64 /* ChatState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF2A80C2B8E011000941A64 /* ChatState+Observer.swift */; };
+		4FFB5EA02BA0507900F0454F /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB5E9F2BA0507900F0454F /* Collection+Extensions.swift */; };
+		4FFB5EA12BA0507900F0454F /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB5E9F2BA0507900F0454F /* Collection+Extensions.swift */; };
+		4FFB5EA32BA0524600F0454F /* ChatState+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB5EA22BA0524600F0454F /* ChatState+Internal.swift */; };
+		4FFB5EA42BA0524600F0454F /* ChatState+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB5EA22BA0524600F0454F /* ChatState+Internal.swift */; };
 		6428DD5526201DCC0065DA1D /* BannerShowingConnectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */; };
 		647F66D5261E22C200111B19 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F66D4261E22C200111B19 /* BannerView.swift */; };
 		648EC576261EF9D400B8F05F /* DemoAppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648EC575261EF9D400B8F05F /* DemoAppCoordinator.swift */; };
@@ -2901,6 +2905,8 @@
 		4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadStateSender.swift; sourceTree = "<group>"; };
 		4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCollection.swift; sourceTree = "<group>"; };
 		4FF2A80C2B8E011000941A64 /* ChatState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatState+Observer.swift"; sourceTree = "<group>"; };
+		4FFB5E9F2BA0507900F0454F /* Collection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extensions.swift"; sourceTree = "<group>"; };
+		4FFB5EA22BA0524600F0454F /* ChatState+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatState+Internal.swift"; sourceTree = "<group>"; };
 		6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerShowingConnectionDelegate.swift; sourceTree = "<group>"; };
 		647F66D4261E22C200111B19 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
 		648EC575261EF9D400B8F05F /* DemoAppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppCoordinator.swift; sourceTree = "<group>"; };
@@ -4811,6 +4817,7 @@
 				4F8E53052B7CD01D008C0F9F /* Chat.swift */,
 				4F8E530A2B7CEBFB008C0F9F /* ChatClient+Chat.swift */,
 				4F8E531B2B833D6C008C0F9F /* ChatState.swift */,
+				4FFB5EA22BA0524600F0454F /* ChatState+Internal.swift */,
 				4FF2A80C2B8E011000941A64 /* ChatState+Observer.swift */,
 				4F73F3972B91BD3000563CD9 /* MessageState.swift */,
 				4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */,
@@ -6991,6 +6998,7 @@
 		A36C39F3286067F90004EB7E /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				4FFB5E9F2BA0507900F0454F /* Collection+Extensions.swift */,
 				A36C39F42860680A0004EB7E /* URL+EnrichedURL.swift */,
 			);
 			path = Extensions;
@@ -10747,6 +10755,7 @@
 				88BEBCD32536FD7600D9E8B7 /* MemberListController+Combine.swift in Sources */,
 				888E8C36252B2AAF00195E03 /* UserController+SwiftUI.swift in Sources */,
 				C143789027BC03EE00E23965 /* EndpointPath.swift in Sources */,
+				4FFB5EA32BA0524600F0454F /* ChatState+Internal.swift in Sources */,
 				C10C7552299D1D67008C8F78 /* ChannelRepository.swift in Sources */,
 				790A4C45252DD4F1001F4A23 /* DevicePayloads.swift in Sources */,
 				C1FC2F902742579D0062530F /* NativeEngine.swift in Sources */,
@@ -10872,6 +10881,7 @@
 				79896D5C2506593E00BA8F1C /* ChannelReadDTO.swift in Sources */,
 				8819DFD52525F49D00FD1A50 /* UserController.swift in Sources */,
 				40789D3C29F6AD9C0018C2BB /* Debouncer.swift in Sources */,
+				4FFB5EA02BA0507900F0454F /* Collection+Extensions.swift in Sources */,
 				F6CCA24D251235F7004C1859 /* UserTypingStateUpdaterMiddleware.swift in Sources */,
 				4FD2BE502B99F68300FFC6F2 /* ReadStateSender.swift in Sources */,
 				8A618E4524D19D510003D83C /* WebSocketPingController.swift in Sources */,
@@ -11490,6 +11500,7 @@
 				C121E867274544AE00023E4C /* NewUserQueryUpdater.swift in Sources */,
 				C121E868274544AF00023E4C /* MessageEditor.swift in Sources */,
 				AD78F9F028EC719200BC0FCE /* ChannelTruncateRequestPayload.swift in Sources */,
+				4FFB5EA12BA0507900F0454F /* Collection+Extensions.swift in Sources */,
 				C121E869274544AF00023E4C /* ConnectionRecoveryHandler.swift in Sources */,
 				C121E86B274544AF00023E4C /* AttachmentQueueUploader.swift in Sources */,
 				4042968A29FACA6A0089126D /* AudioValuePercentageNormaliser.swift in Sources */,
@@ -11681,6 +11692,7 @@
 				C121E8EF274544B200023E4C /* MainQueue+Synchronous.swift in Sources */,
 				C121E8F0274544B200023E4C /* Dictionary+Extensions.swift in Sources */,
 				C121E8F1274544B200023E4C /* MultipartFormData.swift in Sources */,
+				4FFB5EA42BA0524600F0454F /* ChatState+Internal.swift in Sources */,
 				C121E8F2274544B200023E4C /* SystemEnvironment+Version.swift in Sources */,
 				AD78F9EF28EC718D00BC0FCE /* EventBatcher.swift in Sources */,
 				4F8E53162B7F58BE008C0F9F /* Chat.swift in Sources */,


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Unread message and last read message lookup for ChatState

### 📝 Summary

* Add `ChatState.lastReadMessage`
* Add `ChatState.firstUnreadMessage`

### 🛠 Implementation

* Follows the rather complicated logic in [ChatChannelController](https://github.com/GetStream/stream-chat-swift/blob/develop/Sources/StreamChat/Controllers/ChannelController/ChannelController.swift#L1231)
* Added logic for taking account the message order

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
