### PR TITLE
[ChatStateLayer] Use fetch request for channel list contains channel check

### DIFF
--- a/Sources/StreamChat/Workers/ChannelListUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelListUpdater.swift
@@ -172,7 +172,7 @@ class ChannelListUpdater: Worker {
     }
 }
 
-private extension DatabaseSession {
+extension DatabaseSession {
     func getChannelWithQuery(cid: ChannelId, query: ChannelListQuery) -> (ChannelDTO, ChannelListQueryDTO)? {
         guard let queryDTO = channelListQuery(filterHash: query.filter.filterHash) else {
             log.debug("Channel list query has not yet created \(query)")


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Use fetch request for checking the changed channel is part of the channel list query

### 📝 Summary

Fetch request avoids looping over the collection which is currently a `LazyCachedMapCollection` and looping would trigger loading each of the channel which can be expensive and wasteful.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
