### PR TITLE
[ChatStateLayer] Channel member pagination and MemberListState

### DIFF
--- a/Sources/StreamChat/ChatClient+Environment.swift
+++ b/Sources/StreamChat/ChatClient+Environment.swift
@@ -161,6 +161,16 @@ extension ChatClient {
         ) -> ChannelListUpdater = {
             ChannelListUpdater(database: $0, apiClient: $1)
         }
+        
+        var memberUpdaterBuilder: (
+            _ database: DatabaseContainer,
+            _ apiClient: APIClient
+        ) -> ChannelMemberUpdater = ChannelMemberUpdater.init
+        
+        var memberListUpdaterBuilder: (
+            _ database: DatabaseContainer,
+            _ apiClient: APIClient
+        ) -> ChannelMemberListUpdater = ChannelMemberListUpdater.init
 
         var messageRepositoryBuilder: (
             _ database: DatabaseContainer,

--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -76,6 +76,10 @@ public class ChatClient {
     let channelRepository: ChannelRepository
     
     let channelListUpdater: ChannelListUpdater
+    
+    let memberUpdater: ChannelMemberUpdater
+    
+    let memberListUpdater: ChannelMemberListUpdater
 
     func makeMessagesPaginationStateHandler() -> MessagesPaginationStateHandling {
         MessagesPaginationStateHandler()
@@ -203,6 +207,14 @@ public class ChatClient {
         extensionLifecycle = environment.extensionLifecycleBuilder(config.applicationGroupIdentifier)
         callRepository = environment.callRepositoryBuilder(apiClient)
         channelRepository = environment.channelRepositoryBuilder(
+            databaseContainer,
+            apiClient
+        )
+        memberUpdater = environment.memberUpdaterBuilder(
+            databaseContainer,
+            apiClient
+        )
+        memberListUpdater = environment.memberListUpdaterBuilder(
             databaseContainer,
             apiClient
         )

--- a/Sources/StreamChat/StateLayer/Chat.swift
+++ b/Sources/StreamChat/StateLayer/Chat.swift
@@ -186,6 +186,40 @@ public final class Chat {
         return MemberState(member: member, cid: cid, database: databaseContainer)
     }
     
+    // MARK: - Member List
+    
+    /// Loads an array of members for the specified query.
+    ///
+    /// - Parameters:
+    ///   - filter: The filter to use for fetching channel members.
+    ///   - sort: An array of sorting parameters.
+    ///   - pagination: The pagination configuration which includes a limit and an offset or a cursor.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of paginated channel members for the query.
+    public func loadMembers(with filter: Filter<MemberListFilterScope>, sort: [Sorting<ChannelMemberListSortingKey>] = [], pagination: Pagination) async throws -> [ChatChannelMember] {
+        var query = ChannelMemberListQuery(cid: cid, filter: filter, sort: sort)
+        query.pagination = pagination
+        return try await memberListUpdater.load(query)
+    }
+    
+    /// Returns an observable member list state for the specified query.
+    ///
+    /// Calling ``Chat.loadMembers(with:sort:pagination:)`` automatically updates ``MemberListState.members`` for the same query.
+    ///
+    /// - Parameters:
+    ///   - filter: The filter to use for fetching channel members.
+    ///   - sort: An array of sorting parameters.
+    ///   - pagination: The pagination configuration which includes a limit and an offset or a cursor.
+    ///
+    /// - Returns: An instance of `MemberListState` which conforms to the `ObservableObject`.
+    public func makeMemberListState(for filter: Filter<MemberListFilterScope>, sort: [Sorting<ChannelMemberListSortingKey>] = [], pagination: Pagination) async throws -> MemberListState {
+        var query = ChannelMemberListQuery(cid: cid, filter: filter, sort: sort)
+        query.pagination = pagination
+        let members = try await memberListUpdater.load(query)
+        return MemberListState(members: members, query: query, database: databaseContainer)
+    }
+    
     // MARK: - Messages
     
     /// Deletes the specified message.

--- a/Sources/StreamChat/StateLayer/MemberListState.swift
+++ b/Sources/StreamChat/StateLayer/MemberListState.swift
@@ -1,0 +1,64 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Represents a list of channel members matching to the specified query.
+@available(iOS 13.0, *)
+public final class MemberListState: ObservableObject {
+    private let observer: Observer
+    
+    init(members: [ChatChannelMember], query: ChannelMemberListQuery, database: DatabaseContainer) {
+        self.members = StreamCollection(members)
+        observer = Observer(query: query, database: database)
+        observer.start(
+            with: .init(membersDidChange: { [weak self] members in await self?.setValue(members, for: \.members)
+            })
+        )
+    }
+    
+    /// An array of members for the specified ``ChannelMemberListQuery``.
+    @Published public private(set) var members = StreamCollection<ChatChannelMember>([])
+    
+    // MARK: - Mutating the State
+    
+    @MainActor func setValue<Value>(_ value: Value, for keyPath: ReferenceWritableKeyPath<MemberListState, Value>) {
+        self[keyPath: keyPath] = value
+    }
+}
+
+// MARK: - Observing the Local State
+
+@available(iOS 13.0, *)
+extension MemberListState {
+    struct Observer {
+        private let memberListObserver: BackgroundListDatabaseObserver<ChatChannelMember, MemberDTO>
+        
+        init(query: ChannelMemberListQuery, database: DatabaseContainer) {
+            memberListObserver = BackgroundListDatabaseObserver(
+                context: database.backgroundReadOnlyContext,
+                fetchRequest: MemberDTO.members(matching: query),
+                itemCreator: { try $0.asModel() as ChatChannelMember },
+                sorting: []
+            )
+        }
+        
+        struct Handlers {
+            let membersDidChange: (StreamCollection<ChatChannelMember>) async -> Void
+        }
+        
+        func start(with handlers: Handlers) {
+            memberListObserver.onDidChange = { [weak memberListObserver] _ in
+                guard let items = memberListObserver?.items else { return }
+                let collection = StreamCollection(items)
+                Task { await handlers.membersDidChange(collection) }
+            }
+            do {
+                try memberListObserver.startObserving()
+            } catch {
+                log.error("Failed to start the member list observer with error \(error)")
+            }
+        }
+    }
+}

--- a/Sources/StreamChat/StateLayer/MemberState.swift
+++ b/Sources/StreamChat/StateLayer/MemberState.swift
@@ -1,0 +1,73 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An observable object for the specified channel member.
+///
+/// - Note: All the properties of the represented ``ChatChannelMember`` can be accessed directly on the ``MemberState`` object (e.g. `state.name` returns ``ChatChannelMember.name``).
+@available(iOS 13.0, *)
+@dynamicMemberLookup
+public final class MemberState: ObservableObject {
+    private let observer: Observer
+    
+    init(member: ChatChannelMember, cid: ChannelId, database: DatabaseContainer) {
+        self.member = member
+        observer = Observer(userId: member.id, cid: cid, database: database)
+        observer.start(
+            with: .init(
+                memberDidChange: { [weak self] change in await self?.setValue(change, for: \.member) }
+            )
+        )
+    }
+    
+    /// The represented channel member.
+    ///
+    /// - Note: This property is automatically updated when properties of the member change.
+    @Published public private(set) var member: ChatChannelMember
+    
+    // MARK: - Accessing the Member's Data
+    
+    /// Accesses the represented ``ChatChannelMember`` data.
+    public subscript<T>(dynamicMember keyPath: KeyPath<ChatChannelMember, T>) -> T {
+        member[keyPath: keyPath]
+    }
+    
+    // MARK: - Mutating the State
+    
+    @MainActor func setValue<Value>(_ value: Value, for keyPath: ReferenceWritableKeyPath<MemberState, Value>) {
+        self[keyPath: keyPath] = value
+    }
+}
+
+// MARK: - Observing the Local State
+
+@available(iOS 13.0, *)
+extension MemberState {
+    struct Observer {
+        private let memberObserver: BackgroundEntityDatabaseObserver<ChatChannelMember, MemberDTO>
+        private let userId: UserId
+        
+        init(userId: UserId, cid: ChannelId, database: DatabaseContainer) {
+            memberObserver = BackgroundEntityDatabaseObserver(
+                context: database.backgroundReadOnlyContext,
+                fetchRequest: MemberDTO.member(userId, in: cid),
+                itemCreator: { try $0.asModel() as ChatChannelMember }
+            )
+            self.userId = userId
+        }
+        
+        struct Handlers {
+            let memberDidChange: (ChatChannelMember) async -> Void
+        }
+        
+        func start(with handlers: Handlers) {
+            do {
+                try memberObserver.startObserving()
+            } catch {
+                log.error("Failed to start the member observer for member: \(userId)")
+            }
+        }
+    }
+}

--- a/Sources/StreamChat/Workers/ChannelMemberUpdater.swift
+++ b/Sources/StreamChat/Workers/ChannelMemberUpdater.swift
@@ -44,3 +44,22 @@ class ChannelMemberUpdater: Worker {
         }
     }
 }
+
+@available(iOS 13.0, *)
+extension ChannelMemberUpdater {
+    func banMember(_ userId: UserId, in cid: ChannelId, shadow: Bool, for timeoutInMinutes: Int?, reason: String?) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            banMember(userId, in: cid, shadow: shadow, for: timeoutInMinutes, reason: reason) { error in
+                continuation.resume(with: error)
+            }
+        }
+    }
+    
+    func unbanMember(_ userId: UserId, in cid: ChannelId) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            unbanMember(userId, in: cid) { error in
+                continuation.resume(with: error)
+            }
+        }
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -270,6 +270,8 @@
 		4FFB5EA12BA0507900F0454F /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB5E9F2BA0507900F0454F /* Collection+Extensions.swift */; };
 		4FFB5EA32BA0524600F0454F /* ChatState+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB5EA22BA0524600F0454F /* ChatState+Internal.swift */; };
 		4FFB5EA42BA0524600F0454F /* ChatState+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB5EA22BA0524600F0454F /* ChatState+Internal.swift */; };
+		4FFB5EA62BA0993000F0454F /* MemberState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB5EA52BA0993000F0454F /* MemberState.swift */; };
+		4FFB5EA72BA0993000F0454F /* MemberState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFB5EA52BA0993000F0454F /* MemberState.swift */; };
 		6428DD5526201DCC0065DA1D /* BannerShowingConnectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */; };
 		647F66D5261E22C200111B19 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F66D4261E22C200111B19 /* BannerView.swift */; };
 		648EC576261EF9D400B8F05F /* DemoAppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648EC575261EF9D400B8F05F /* DemoAppCoordinator.swift */; };
@@ -2916,6 +2918,7 @@
 		4FF2A80C2B8E011000941A64 /* ChatState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatState+Observer.swift"; sourceTree = "<group>"; };
 		4FFB5E9F2BA0507900F0454F /* Collection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extensions.swift"; sourceTree = "<group>"; };
 		4FFB5EA22BA0524600F0454F /* ChatState+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatState+Internal.swift"; sourceTree = "<group>"; };
+		4FFB5EA52BA0993000F0454F /* MemberState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberState.swift; sourceTree = "<group>"; };
 		6428DD5426201DCC0065DA1D /* BannerShowingConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerShowingConnectionDelegate.swift; sourceTree = "<group>"; };
 		647F66D4261E22C200111B19 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
 		648EC575261EF9D400B8F05F /* DemoAppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppCoordinator.swift; sourceTree = "<group>"; };
@@ -4831,6 +4834,7 @@
 				4F8E531B2B833D6C008C0F9F /* ChatState.swift */,
 				4FFB5EA22BA0524600F0454F /* ChatState+Internal.swift */,
 				4FF2A80C2B8E011000941A64 /* ChatState+Observer.swift */,
+				4FFB5EA52BA0993000F0454F /* MemberState.swift */,
 				4F73F3972B91BD3000563CD9 /* MessageState.swift */,
 				4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */,
 			);
@@ -10612,6 +10616,7 @@
 				79983C8126663436000995F6 /* ChatMessageVideoAttachment.swift in Sources */,
 				79877A0A2498E4BC00015F8B /* Device.swift in Sources */,
 				DABC6AC8254707CB00A8FC78 /* AttachmentDTO.swift in Sources */,
+				4FFB5EA62BA0993000F0454F /* MemberState.swift in Sources */,
 				40789D1329F6AC500018C2BB /* AudioPlaybackContext.swift in Sources */,
 				C1FC2FA12742579D0062530F /* Engine.swift in Sources */,
 				22692C9725D1841E007C41D0 /* ChatMessageFileAttachment.swift in Sources */,
@@ -11592,6 +11597,7 @@
 				C121E897274544B000023E4C /* User+SwiftUI.swift in Sources */,
 				C121E898274544B000023E4C /* MessageReaction.swift in Sources */,
 				C121E899274544B000023E4C /* MessageReactionType.swift in Sources */,
+				4FFB5EA72BA0993000F0454F /* MemberState.swift in Sources */,
 				C121E89A274544B000023E4C /* MuteDetails.swift in Sources */,
 				C121E89B274544B000023E4C /* Controller.swift in Sources */,
 				404296DE2A0114900089126D /* StreamAudioQueuePlayer_Tests.swift in Sources */,

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -254,6 +254,8 @@
 		4F8E53172B7F58C1008C0F9F /* ChatClient+Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E530A2B7CEBFB008C0F9F /* ChatClient+Factory.swift */; };
 		4F8E531C2B833D6C008C0F9F /* ChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E531B2B833D6C008C0F9F /* ChatState.swift */; };
 		4F8E531D2B833D6C008C0F9F /* ChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E531B2B833D6C008C0F9F /* ChatState.swift */; };
+		4F94B0E02BA1C4220045216B /* MemberListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F94B0DF2BA1C4220045216B /* MemberListState.swift */; };
+		4F94B0E12BA1C4220045216B /* MemberListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F94B0DF2BA1C4220045216B /* MemberListState.swift */; };
 		4FD2BE502B99F68300FFC6F2 /* ReadStateSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */; };
 		4FD2BE512B99F68300FFC6F2 /* ReadStateSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */; };
 		4FD2BE532B9AEE3500FFC6F2 /* StreamCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */; };
@@ -2910,6 +2912,7 @@
 		4F8E53052B7CD01D008C0F9F /* Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chat.swift; sourceTree = "<group>"; };
 		4F8E530A2B7CEBFB008C0F9F /* ChatClient+Factory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatClient+Factory.swift"; sourceTree = "<group>"; };
 		4F8E531B2B833D6C008C0F9F /* ChatState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatState.swift; sourceTree = "<group>"; };
+		4F94B0DF2BA1C4220045216B /* MemberListState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberListState.swift; sourceTree = "<group>"; };
 		4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadStateSender.swift; sourceTree = "<group>"; };
 		4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCollection.swift; sourceTree = "<group>"; };
 		4FD2BE552B9AF8A300FFC6F2 /* ChannelList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelList.swift; sourceTree = "<group>"; };
@@ -4834,6 +4837,7 @@
 				4F8E531B2B833D6C008C0F9F /* ChatState.swift */,
 				4FFB5EA22BA0524600F0454F /* ChatState+Internal.swift */,
 				4FF2A80C2B8E011000941A64 /* ChatState+Observer.swift */,
+				4F94B0DF2BA1C4220045216B /* MemberListState.swift */,
 				4FFB5EA52BA0993000F0454F /* MemberState.swift */,
 				4F73F3972B91BD3000563CD9 /* MessageState.swift */,
 				4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */,
@@ -10602,6 +10606,7 @@
 				7978FBBF26E1667C002CA2DF /* MessageSearchController.swift in Sources */,
 				DAF1BED1250660F8003CEDC0 /* MessageController+SwiftUI.swift in Sources */,
 				AD70DC3C2ADEF09C00CFC3B7 /* MessageModerationDetails.swift in Sources */,
+				4F94B0E02BA1C4220045216B /* MemberListState.swift in Sources */,
 				796CBC2B25F7CDAC003299B0 /* UserChannelBanEventsMiddleware.swift in Sources */,
 				8AC9CBD624C73689006E236C /* NotificationEvents.swift in Sources */,
 				F6FF1DA824FD232C00151735 /* MessageUpdater.swift in Sources */,
@@ -11512,6 +11517,7 @@
 				4042969029FBCE1D0089126D /* AudioSamplesExtractor_Tests.swift in Sources */,
 				C121E861274544AE00023E4C /* ChannelMemberUpdater.swift in Sources */,
 				AD70DC3D2ADEF09C00CFC3B7 /* MessageModerationDetails.swift in Sources */,
+				4F94B0E12BA1C4220045216B /* MemberListState.swift in Sources */,
 				C121E862274544AE00023E4C /* ConnectionRepository.swift in Sources */,
 				C121E863274544AE00023E4C /* EventSender.swift in Sources */,
 				C121E864274544AE00023E4C /* EventObserver.swift in Sources */,


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Add functionality in `ChatChannelMemberListController` to the new state layer

### 📝 Summary

* Add `Chat.loadMembers` for querying channel members
* Add `MemberListState` for observing channel members

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
