### PR TITLE
[ChatStateLayer] Local message lookup in chat

### DIFF
--- a/Sources/StreamChat/Database/DataStore.swift
+++ b/Sources/StreamChat/Database/DataStore.swift
@@ -22,6 +22,10 @@ public struct DataStore {
     init(client: ChatClient) {
         database = client.databaseContainer
     }
+    
+    init(database: DatabaseContainer) {
+        self.database = database
+    }
 
     /// Loads a user model with a matching `id` from the **local data store**.
     ///

--- a/Sources/StreamChat/StateLayer/ChatState.swift
+++ b/Sources/StreamChat/StateLayer/ChatState.swift
@@ -10,12 +10,14 @@ public final class ChatState: ObservableObject {
     private let authenticationRepository: AuthenticationRepository
     private let cid: ChannelId
     private var channelObserver: EntityDatabaseObserverWrapper<ChatChannel, ChannelDTO>?
+    private let dataStore: DataStore
     private let paginationState: MessagesPaginationState
     private let observer: Observer
     
     init(cid: ChannelId, channelQuery: ChannelQuery, messageOrder: MessageOrdering, authenticationRepository: AuthenticationRepository, database: DatabaseContainer, eventNotificationCenter: EventNotificationCenter, paginationState: MessagesPaginationState) {
         self.authenticationRepository = authenticationRepository
         self.cid = cid
+        dataStore = DataStore(database: database)
         self.messageOrder = messageOrder
         self.paginationState = paginationState
         observer = Observer(cid: cid, channelQuery: channelQuery, messageOrder: messageOrder, database: database, eventNotificationCenter: eventNotificationCenter)
@@ -46,6 +48,17 @@ public final class ChatState: ObservableObject {
     ///
     /// Use load messages in ``Chat`` for loading more messages.
     @Published public private(set) var messages = StreamCollection<ChatMessage>([])
+    
+    /// Access a message available locally by its id.
+    ///
+    /// - Note: This method does a local lookup of the message.
+    ///
+    /// - Parameter messageId: The id of the message available locally.
+    ///
+    /// - Returns: An instance of the locally available chat message
+    public func message(for messageId: MessageId) -> ChatMessage? {
+        dataStore.message(id: messageId)
+    }
     
     /// A Boolean value that returns whether the oldest messages have all been loaded or not.
     public var hasLoadedAllPreviousMessages: Bool {

--- a/Sources/StreamChat/StateLayer/ChatState.swift
+++ b/Sources/StreamChat/StateLayer/ChatState.swift
@@ -49,15 +49,18 @@ public final class ChatState: ObservableObject {
     /// Use load messages in ``Chat`` for loading more messages.
     @Published public private(set) var messages = StreamCollection<ChatMessage>([])
     
-    /// Access a message available locally by its id.
+    /// Access a message which is available locally by its id.
     ///
-    /// - Note: This method does a local lookup of the message.
+    /// - Note: This method does a local lookup of the message and returns a message present in ``ChatState.messages``.
     ///
-    /// - Parameter messageId: The id of the message available locally.
+    /// - Parameter messageId: The id of the message which is available locally.
     ///
     /// - Returns: An instance of the locally available chat message
-    public func message(for messageId: MessageId) -> ChatMessage? {
-        dataStore.message(id: messageId)
+    public func localMessage(for messageId: MessageId) -> ChatMessage? {
+        if let message = dataStore.message(id: messageId), message.cid == cid {
+            return message
+        }
+        return nil
     }
     
     /// A Boolean value that returns whether the oldest messages have all been loaded or not.


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

### 📝 Summary

Controllers conform to `DataStoreProvider` which requires that controller has `ChatClient` getter. New state layer does not capture `ChatClient` instances. Some of our UI code need these quick lookup methods the `DataStore` type defines.

Since the `DataStore` type itself if tied to `DatabaseContainer` and we are considering the possibility of not using CD as the only data source then it feels like it is better if the new layer does not expose `DataStore` directly. Maybe we just want to use in-memory array as a data source, then using this type makes it more complicated (I would need to inject data to it).

Therefore, proposing to just adding lookup methods on the new state layer level where needed.  

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
