### PR TITLE
[DemoApp] Do not translate deleted messages

### DIFF
--- a/DemoApp/StreamChat/Components/DemoChatMessageContentView.swift
+++ b/DemoApp/StreamChat/Components/DemoChatMessageContentView.swift
@@ -32,6 +32,7 @@ final class DemoChatMessageContentView: ChatMessageContentView {
         /// If automatic translation is added, do not show manual translation
         /// (Demo App only feature to test LLC manual translation)
         if layoutOptions?.contains(.translation) == false,
+           content?.isDeleted == false,
            let translations = content?.translations,
            let turkishTranslation = translations[.turkish] {
             textView?.text = turkishTranslation


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://github.com/GetStream/stream-chat-swift/issues/2983

### 🎯 Goal

Do not translate deleted messages in the DemoApp

### 🧪 Manual Testing Notes

1. Open a channel
2. Send a message
3. Translate it to Turkish
4. Soft-delete the translated message
- Message text is updated to "Message deleted"
- Message cell is disabled

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExc3QxemttajhxeXRicjZtcWNmbTdvMGZ6eHM0aHVjaXI5ZDZhZ253aiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/6qdKZFhT0VBm0/giphy.gif)
