### PR TITLE
Add `ChatClient.loadAppSettings` and `ChatClient.appSettings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## StreamChat
 ### ✅ Added
 - Add mute expiration support when muting a channel [#3083](https://github.com/GetStream/stream-chat-swift/pull/3083)
+- Add `ChatClient.loadAppSettings` and `ChatClient.appSettings` [#3091](https://github.com/GetStream/stream-chat-swift/pull/3091)
+- Load the app settings when connecting the user [#3091](https://github.com/GetStream/stream-chat-swift/pull/3091)
 
 # [4.50.0](https://github.com/GetStream/stream-chat-swift/releases/tag/4.50.0)
 _March 11, 2024_

--- a/Sources/StreamChat/APIClient/Endpoints/AppEndpoints.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/AppEndpoints.swift
@@ -1,0 +1,17 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+extension Endpoint {
+    static func appSettings() -> Endpoint<AppSettingsPayload> {
+        .init(
+            path: .appSettings,
+            method: .get,
+            queryItems: nil,
+            requiresConnectionId: false,
+            body: nil
+        )
+    }
+}

--- a/Sources/StreamChat/APIClient/Endpoints/EndpointPath+OfflineRequest.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/EndpointPath+OfflineRequest.swift
@@ -13,7 +13,7 @@ extension EndpointPath {
              .deleteChannel, .channelUpdate, .muteChannel, .showChannel, .truncateChannel, .markChannelRead, .markChannelUnread,
              .markAllChannelsRead, .channelEvent, .stopWatchingChannel, .pinnedMessages, .uploadAttachment, .message,
              .replies, .reactions, .messageAction, .banMember, .flagUser, .flagMessage, .muteUser, .translateMessage,
-             .callToken, .createCall, .deleteFile, .deleteImage, .og:
+             .callToken, .createCall, .deleteFile, .deleteImage, .og, .appSettings:
             return false
         }
     }

--- a/Sources/StreamChat/APIClient/Endpoints/EndpointPath.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/EndpointPath.swift
@@ -52,6 +52,8 @@ enum EndpointPath: Codable {
     case deleteFile(String)
     case deleteImage(String)
 
+    case appSettings
+
     var value: String {
         switch self {
         case .connect: return "connect"
@@ -98,6 +100,7 @@ enum EndpointPath: Codable {
         case let .createCall(queryString): return "channels/\(queryString)/call"
         case let .deleteFile(channelId): return "channels/\(channelId)/file"
         case let .deleteImage(channelId): return "channels/\(channelId)/image"
+        case .appSettings: return "app"
         }
     }
 

--- a/Sources/StreamChat/APIClient/Endpoints/Payloads/AppSettingsPayload.swift
+++ b/Sources/StreamChat/APIClient/Endpoints/Payloads/AppSettingsPayload.swift
@@ -1,0 +1,52 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The payload of the /GET app request.
+struct AppSettingsPayload: Decodable {
+    let app: AppPayload
+
+    struct AppPayload: Decodable {
+        let name: String
+        let fileUploadConfig: UploadConfigPayload
+        let imageUploadConfig: UploadConfigPayload
+        let autoTranslationEnabled: Bool
+        let asyncUrlEnrichEnabled: Bool
+    }
+    
+    struct UploadConfigPayload: Decodable {
+        let allowedFileExtensions: [String]
+        let blockedFileExtensions: [String]
+        let allowedMimeTypes: [String]
+        let blockedMimeTypes: [String]
+    }
+}
+
+// MARK: - Codable
+
+extension AppSettingsPayload {
+    enum CodingKeys: CodingKey {
+        case app
+    }
+}
+
+extension AppSettingsPayload.AppPayload {
+    enum CodingKeys: String, CodingKey {
+        case name
+        case fileUploadConfig = "file_upload_config"
+        case imageUploadConfig = "image_upload_config"
+        case autoTranslationEnabled = "auto_translation_enabled"
+        case asyncUrlEnrichEnabled = "async_url_enrich_enabled"
+    }
+}
+
+extension AppSettingsPayload.UploadConfigPayload {
+    enum CodingKeys: String, CodingKey {
+        case allowedFileExtensions = "allowed_file_extensions"
+        case blockedFileExtensions = "blocked_file_extensions"
+        case allowedMimeTypes = "allowed_mime_types"
+        case blockedMimeTypes = "blocked_mime_types"
+    }
+}

--- a/Sources/StreamChat/Models/AppSettings.swift
+++ b/Sources/StreamChat/Models/AppSettings.swift
@@ -1,0 +1,55 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A type representing the app settings.
+public struct AppSettings {
+    /// The name of the app.
+    public let name: String
+    /// The the file uploading configuration.
+    public let fileUploadConfig: UploadConfig
+    /// The the image uploading configuration.
+    public let imageUploadConfig: UploadConfig
+    /// A boolean value determining if auto translation is enabled.
+    public let autoTranslationEnabled: Bool
+    /// A boolean value determining if async url enrichment is enabled.
+    public let asyncUrlEnrichEnabled: Bool
+
+    public struct UploadConfig {
+        /// The allowed file extensions.
+        public var allowedFileExtensions: [String]
+        /// The blocked file extensions.
+        public var blockedFileExtensions: [String]
+        /// The allowed mime types.
+        public var allowedMimeTypes: [String]
+        /// The blocked mime types.
+        public var blockedMimeTypes: [String]
+    }
+}
+
+// MARK: - Payload -> Model
+
+extension AppSettingsPayload {
+    func asModel() -> AppSettings {
+        .init(
+            name: app.name,
+            fileUploadConfig: app.fileUploadConfig.asModel(),
+            imageUploadConfig: app.imageUploadConfig.asModel(),
+            autoTranslationEnabled: app.autoTranslationEnabled,
+            asyncUrlEnrichEnabled: app.asyncUrlEnrichEnabled
+        )
+    }
+}
+
+extension AppSettingsPayload.UploadConfigPayload {
+    func asModel() -> AppSettings.UploadConfig {
+        .init(
+            allowedFileExtensions: allowedFileExtensions,
+            blockedFileExtensions: blockedFileExtensions,
+            allowedMimeTypes: allowedMimeTypes,
+            blockedMimeTypes: blockedMimeTypes
+        )
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -1335,6 +1335,12 @@
 		AD87D0BD263C7C09008B466C /* CircularCloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD87D0BC263C7C09008B466C /* CircularCloseButton.swift */; };
 		AD8B72752908016400921C31 /* ImageDownloadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8B72742908016400921C31 /* ImageDownloadRequest.swift */; };
 		AD8B72762908016400921C31 /* ImageDownloadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8B72742908016400921C31 /* ImageDownloadRequest.swift */; };
+		AD8C7C5D2BA3BE1E00260715 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8C7C5C2BA3BE1E00260715 /* AppSettings.swift */; };
+		AD8C7C5E2BA3BE1E00260715 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8C7C5C2BA3BE1E00260715 /* AppSettings.swift */; };
+		AD8C7C612BA3DF2800260715 /* AppSettings.json in Sources */ = {isa = PBXBuildFile; fileRef = AD8C7C5F2BA3DF2800260715 /* AppSettings.json */; };
+		AD8C7C632BA464E600260715 /* AppSettingsPayload_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8C7C622BA464E600260715 /* AppSettingsPayload_Tests.swift */; };
+		AD8C7C642BA4682E00260715 /* AppSettings.json in Resources */ = {isa = PBXBuildFile; fileRef = AD8C7C5F2BA3DF2800260715 /* AppSettings.json */; };
+		AD8C7C662BA46A4A00260715 /* AppEndpoints_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8C7C652BA46A4A00260715 /* AppEndpoints_Tests.swift */; };
 		AD8D1809268F7290004E3A5C /* TypingSuggester.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8D1808268F7290004E3A5C /* TypingSuggester.swift */; };
 		AD8D180B268F8ED4004E3A5C /* SlackComposerVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8D180A268F8ED4004E3A5C /* SlackComposerVC.swift */; };
 		AD8FEE582AA8E1A100273F88 /* ChatClient+Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8FEE572AA8E1A100273F88 /* ChatClient+Environment.swift */; };
@@ -1446,6 +1452,10 @@
 		ADEE888D289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEE888C289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift */; };
 		ADEE888E289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEE888C289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift */; };
 		ADEED08127F202C100A42B52 /* yoda_with_long_file_name.txt in Resources */ = {isa = PBXBuildFile; fileRef = ADEED08027F202C100A42B52 /* yoda_with_long_file_name.txt */; };
+		ADF2BBE82B9B61E30069D467 /* AppEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF2BBE72B9B61E30069D467 /* AppEndpoints.swift */; };
+		ADF2BBE92B9B61E30069D467 /* AppEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF2BBE72B9B61E30069D467 /* AppEndpoints.swift */; };
+		ADF2BBEB2B9B622B0069D467 /* AppSettingsPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF2BBEA2B9B622B0069D467 /* AppSettingsPayload.swift */; };
+		ADF2BBEC2B9B622B0069D467 /* AppSettingsPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF2BBEA2B9B622B0069D467 /* AppSettingsPayload.swift */; };
 		ADF34F8A25CDC58900AD637C /* ConnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF34F6A25CD6A1D00AD637C /* ConnectionController.swift */; };
 		ADF34F9E25CDD8E600AD637C /* ConnectionController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF34F9D25CDD8E600AD637C /* ConnectionController+SwiftUI.swift */; };
 		ADF34FA625CDD8F600AD637C /* ConnectionController+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF34FA525CDD8F600AD637C /* ConnectionController+Combine.swift */; };
@@ -3853,6 +3863,10 @@
 		AD87D0AA263C7A7E008B466C /* ShrinkInputButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShrinkInputButton.swift; sourceTree = "<group>"; };
 		AD87D0BC263C7C09008B466C /* CircularCloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularCloseButton.swift; sourceTree = "<group>"; };
 		AD8B72742908016400921C31 /* ImageDownloadRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloadRequest.swift; sourceTree = "<group>"; };
+		AD8C7C5C2BA3BE1E00260715 /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
+		AD8C7C5F2BA3DF2800260715 /* AppSettings.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = AppSettings.json; sourceTree = "<group>"; };
+		AD8C7C622BA464E600260715 /* AppSettingsPayload_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsPayload_Tests.swift; sourceTree = "<group>"; };
+		AD8C7C652BA46A4A00260715 /* AppEndpoints_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEndpoints_Tests.swift; sourceTree = "<group>"; };
 		AD8D1808268F7290004E3A5C /* TypingSuggester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingSuggester.swift; sourceTree = "<group>"; };
 		AD8D180A268F8ED4004E3A5C /* SlackComposerVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlackComposerVC.swift; sourceTree = "<group>"; };
 		AD8FEE572AA8E1A100273F88 /* ChatClient+Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatClient+Environment.swift"; sourceTree = "<group>"; };
@@ -3931,6 +3945,8 @@
 		ADEE651C29BF715300186129 /* ChatMessageListVCDelegate_Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageListVCDelegate_Mock.swift; sourceTree = "<group>"; };
 		ADEE888C289C3CC0007DF3F8 /* ChatMessageListView+DiffKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatMessageListView+DiffKit.swift"; sourceTree = "<group>"; };
 		ADEED08027F202C100A42B52 /* yoda_with_long_file_name.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = yoda_with_long_file_name.txt; sourceTree = "<group>"; };
+		ADF2BBE72B9B61E30069D467 /* AppEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEndpoints.swift; sourceTree = "<group>"; };
+		ADF2BBEA2B9B622B0069D467 /* AppSettingsPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsPayload.swift; sourceTree = "<group>"; };
 		ADF34F6A25CD6A1D00AD637C /* ConnectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionController.swift; sourceTree = "<group>"; };
 		ADF34F9D25CDD8E600AD637C /* ConnectionController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionController+SwiftUI.swift"; sourceTree = "<group>"; };
 		ADF34FA525CDD8F600AD637C /* ConnectionController+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionController+Combine.swift"; sourceTree = "<group>"; };
@@ -5169,6 +5185,7 @@
 		79682C4724BF37550071578E /* Payloads */ = {
 			isa = PBXGroup;
 			children = (
+				ADF2BBEA2B9B622B0069D467 /* AppSettingsPayload.swift */,
 				43D3F0F52841052600B74921 /* CallPayloads.swift */,
 				DA9985ED24E175AA000E9885 /* ChannelCodingKeys.swift */,
 				DAFAD6A224DD8E1A0043ED06 /* ChannelEditDetailPayload.swift */,
@@ -5239,6 +5256,7 @@
 				DA84070825250528005A0F62 /* UserEndpoints.swift */,
 				F65D9090250A5989000B8CEB /* WebSocketConnectEndpoint.swift */,
 				84355D872AB2FCAC00FD5838 /* FilesEndpoints.swift */,
+				ADF2BBE72B9B61E30069D467 /* AppEndpoints.swift */,
 				79682C4724BF37550071578E /* Payloads */,
 				DAEAF4B624DADA990015FB28 /* Requests */,
 			);
@@ -5308,6 +5326,7 @@
 		799C9430247D2FB9001F1104 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				AD8C7C5C2BA3BE1E00260715 /* AppSettings.swift */,
 				8A62706D24BF45360040BFD6 /* BanEnabling.swift */,
 				43D3F0FE28410B4800B74921 /* Call.swift */,
 				79877A062498E4BC00015F8B /* Channel.swift */,
@@ -6408,6 +6427,7 @@
 		A364D09327D0BF330029857A /* Endpoints */ = {
 			isa = PBXGroup;
 			children = (
+				AD8C7C652BA46A4A00260715 /* AppEndpoints_Tests.swift */,
 				88381E8625825A240047A6A3 /* AttachmentEndpoints_Tests.swift */,
 				AC82033928C60B100002EFDD /* CallEndpoints_Tests.swift */,
 				DAEAF4B724DC026C0015FB28 /* ChannelEndpoints_Tests.swift */,
@@ -6431,6 +6451,7 @@
 		A364D09427D0BF3A0029857A /* Payloads */ = {
 			isa = PBXGroup;
 			children = (
+				AD8C7C622BA464E600260715 /* AppSettingsPayload_Tests.swift */,
 				DA7229E224E140260074503A /* ChannelEditDetailPayload_Tests.swift */,
 				8A0D64AA24E57BF20017A3C0 /* ChannelListPayload_Tests.swift */,
 				C122B8802A02645200D27F41 /* ChannelReadPayload_Tests.swift */,
@@ -7475,6 +7496,7 @@
 			isa = PBXGroup;
 			children = (
 				798779F72498E47700015F8B /* Channel.json */,
+				AD8C7C5F2BA3DF2800260715 /* AppSettings.json */,
 				792C87892853B25500B68630 /* BigChannelListPayload.json */,
 				AD2C94DB29CB8CC40096DCA1 /* PartiallyFailingChannelListPayload.json */,
 				AD2C94DE29CB93C40096DCA1 /* FailingChannelListPayload.json */,
@@ -9584,6 +9606,7 @@
 				A311B41A27E8B9B900CFCF6D /* UserStopTypingThread.json in Resources */,
 				A344077B27D753530044F150 /* yoda.txt in Resources */,
 				A311B41B27E8B9BE00CFCF6D /* FlagMessagePayload+NoExtraData.json in Resources */,
+				AD8C7C642BA4682E00260715 /* AppSettings.json in Resources */,
 				A311B40627E8B9AD00CFCF6D /* NotificationMarkAllRead.json in Resources */,
 				A311B3E327E8B98C00CFCF6D /* MessageReactionPayload.json in Resources */,
 				A311B41127E8B9B900CFCF6D /* UserUnbanned.json in Resources */,
@@ -10585,6 +10608,7 @@
 				84355D882AB2FCAC00FD5838 /* FilesEndpoints.swift in Sources */,
 				7964F3B9249A314D002A09EC /* BaseLogDestination.swift in Sources */,
 				C1FC2F942742579D0062530F /* Security.swift in Sources */,
+				ADF2BBE82B9B61E30069D467 /* AppEndpoints.swift in Sources */,
 				AD52A21C2804851600D0157E /* CommandDTO.swift in Sources */,
 				792AF91624D812440010097B /* EntityDatabaseObserver.swift in Sources */,
 				C1FC2F9D2742579D0062530F /* FoundationHTTPHandler.swift in Sources */,
@@ -10750,6 +10774,7 @@
 				43D3F0FC28410A0200B74921 /* CreateCallRequestBody.swift in Sources */,
 				79877A0D2498E4BC00015F8B /* CurrentUser.swift in Sources */,
 				4042967D29FAC9DA0089126D /* AudioAnalysisContext.swift in Sources */,
+				AD8C7C5D2BA3BE1E00260715 /* AppSettings.swift in Sources */,
 				AD8FEE5B2AA8E1E400273F88 /* ChatClientFactory.swift in Sources */,
 				88D85D9A252F168B00AE1030 /* MemberController+Combine.swift in Sources */,
 				792A4F462480107A00EAF71D /* ChannelQuery.swift in Sources */,
@@ -10837,6 +10862,7 @@
 				ADE40043291B1A510000C98B /* AttachmentUploader.swift in Sources */,
 				8836FFBB2540741D009FDF73 /* FlagUserPayload.swift in Sources */,
 				C1FC2F9F2742579D0062530F /* WebSocket.swift in Sources */,
+				ADF2BBEB2B9B622B0069D467 /* AppSettingsPayload.swift in Sources */,
 				C173538E27D9F804008AC412 /* KeyedDecodingContainer+Array.swift in Sources */,
 				84AA4E3626F264610056A684 /* EventDTOConverterMiddleware.swift in Sources */,
 				ADF34FA625CDD8F600AD637C /* ConnectionController+Combine.swift in Sources */,
@@ -10935,6 +10961,7 @@
 				84D5BC59277B188E00A65C75 /* PinnedMessagesPagination_Tests.swift in Sources */,
 				A36C39F828606B5D0004EB7E /* URL_EnrichedURL_Tests.swift in Sources */,
 				888E8C51252B4BAB00195E03 /* ChannelMemberBanRequestPayload_Tests.swift in Sources */,
+				AD8C7C662BA46A4A00260715 /* AppEndpoints_Tests.swift in Sources */,
 				791D3D9026776BE400E3A0F9 /* ChannelMemberListSortingKey_Tests.swift in Sources */,
 				A382131E2805C8AC0068D30E /* TestsEnvironmentSetup.swift in Sources */,
 				A34ECB4C27F5CA5E00A804C1 /* ReactionEvents_IntegrationTests.swift in Sources */,
@@ -11043,6 +11070,7 @@
 				843C53AB269370A900C7D8EA /* ImageAttachmentPayload_Tests.swift in Sources */,
 				792FCB4D24A3D56D000290C7 /* DatabaseSession_Tests.swift in Sources */,
 				A34ECB5227F5CB9B00A804C1 /* ListChange_Tests.swift in Sources */,
+				AD8C7C632BA464E600260715 /* AppSettingsPayload_Tests.swift in Sources */,
 				430156F226B4523A0006E7EA /* WebSocketConnectPayload_Tests.swift in Sources */,
 				84A1D2F626AB357900014712 /* UnknownChannelEvent_Tests.swift in Sources */,
 				40FC028D29BE981B00E2A1CD /* AttachmentFileType_Tests.swift in Sources */,
@@ -11306,6 +11334,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				40789D1C29F6AC500018C2BB /* AudioPlaybackState.swift in Sources */,
+				AD8C7C612BA3DF2800260715 /* AppSettings.json in Sources */,
 				C121E804274544AC00023E4C /* ChatClient.swift in Sources */,
 				C121E805274544AC00023E4C /* Deprecations.swift in Sources */,
 				C121E806274544AC00023E4C /* Token.swift in Sources */,
@@ -11367,6 +11396,7 @@
 				C121E82F274544AD00023E4C /* RequestDecoder.swift in Sources */,
 				C121E830274544AD00023E4C /* HTTPHeader.swift in Sources */,
 				40789D1429F6AC500018C2BB /* AudioPlaybackContext.swift in Sources */,
+				AD8C7C5E2BA3BE1E00260715 /* AppSettings.swift in Sources */,
 				C121E831274544AD00023E4C /* FlagMessagePayload.swift in Sources */,
 				C121E832274544AD00023E4C /* ChannelMemberListPayload.swift in Sources */,
 				C121E833274544AD00023E4C /* UserListPayload.swift in Sources */,
@@ -11479,6 +11509,7 @@
 				C121E881274544AF00023E4C /* AttachmentTypes.swift in Sources */,
 				C121E882274544AF00023E4C /* ChatMessageLinkAttachment.swift in Sources */,
 				C18F5B532840BD2C00527915 /* DBDate.swift in Sources */,
+				ADF2BBE92B9B61E30069D467 /* AppEndpoints.swift in Sources */,
 				C121E883274544AF00023E4C /* ChatMessageGiphyAttachment.swift in Sources */,
 				CFE616BC28348AC800AE2ABF /* StreamTimer.swift in Sources */,
 				AD0F7F1A2B613EDC00914C4C /* TextLinkDetector.swift in Sources */,
@@ -11545,6 +11576,7 @@
 				C174E0F7284DFA5A0040B936 /* IdentifiablePayload.swift in Sources */,
 				C121E8B4274544B000023E4C /* CurrentUserController+SwiftUI.swift in Sources */,
 				40789D1E29F6AC500018C2BB /* AudioPlayingDelegate.swift in Sources */,
+				ADF2BBEC2B9B622B0069D467 /* AppSettingsPayload.swift in Sources */,
 				C121E8B5274544B000023E4C /* CurrentUserController+Combine.swift in Sources */,
 				C121E8B6274544B000023E4C /* ConnectionController.swift in Sources */,
 				C121E8B7274544B000023E4C /* ConnectionController+SwiftUI.swift in Sources */,

--- a/TestTools/StreamChatTestTools/Fixtures/JSONs/AppSettings.json
+++ b/TestTools/StreamChatTestTools/Fixtures/JSONs/AppSettings.json
@@ -1,0 +1,38 @@
+{
+    "app":{
+        "name":"Stream SDK - iOS",
+        "file_upload_config":{
+            "allowed_file_extensions":[
+                "jpg", "png"
+            ],
+            "blocked_file_extensions":[
+                "webp"
+            ],
+            "allowed_mime_types":[
+                "image/jpg", "image/png"
+            ],
+            "blocked_mime_types":[
+                "image/webp"
+            ]
+        },
+        "image_upload_config":{
+            "allowed_file_extensions":[
+                "mp3", "wav"
+            ],
+            "blocked_file_extensions":[
+                "mp4"
+            ],
+            "allowed_mime_types":[
+                "audio/mp3", "audio/wav"
+            ],
+            "blocked_mime_types":[
+                "audio/mp4"
+            ]
+        },
+        "video_provider":"",
+        "auto_translation_enabled":true,
+        "async_url_enrich_enabled":false
+    },
+    "duration":"0.99ms"
+}
+

--- a/Tests/StreamChatTests/APIClient/Endpoints/AppEndpoints_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/AppEndpoints_Tests.swift
@@ -1,0 +1,18 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatTestTools
+import XCTest
+
+final class AppEndpoints_Tests: XCTestCase {
+    func test_appSettings() throws {
+        let endpoint = AnyEndpoint(Endpoint<AppSettingsPayload>.appSettings())
+        XCTAssertEqual(endpoint.method, .get)
+        XCTAssertEqual(endpoint.path.value, "app")
+        XCTAssertEqual(endpoint.queryItems, nil)
+        XCTAssertEqual(endpoint.requiresConnectionId, false)
+        XCTAssertEqual(endpoint.body, nil)
+    }
+}

--- a/Tests/StreamChatTests/APIClient/Endpoints/Payloads/AppSettingsPayload_Tests.swift
+++ b/Tests/StreamChatTests/APIClient/Endpoints/Payloads/AppSettingsPayload_Tests.swift
@@ -1,0 +1,25 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+import XCTest
+
+final class AppSettingsPayload_Tests: XCTestCase {
+    func testDecoding() throws {
+        let url = XCTestCase.mockData(fromJSONFile: "AppSettings")
+        let payload = try JSONDecoder.default.decode(AppSettingsPayload.self, from: url)
+
+        XCTAssertEqual(payload.app.name, "Stream SDK - iOS")
+        XCTAssertEqual(payload.app.autoTranslationEnabled, true)
+        XCTAssertEqual(payload.app.asyncUrlEnrichEnabled, false)
+        XCTAssertEqual(payload.app.fileUploadConfig.allowedFileExtensions, ["jpg", "png"])
+        XCTAssertEqual(payload.app.fileUploadConfig.blockedFileExtensions, ["webp"])
+        XCTAssertEqual(payload.app.fileUploadConfig.allowedMimeTypes, ["image/jpg", "image/png"])
+        XCTAssertEqual(payload.app.fileUploadConfig.blockedMimeTypes, ["image/webp"])
+        XCTAssertEqual(payload.app.imageUploadConfig.allowedFileExtensions, ["mp3", "wav"])
+        XCTAssertEqual(payload.app.imageUploadConfig.blockedFileExtensions, ["mp4"])
+        XCTAssertEqual(payload.app.imageUploadConfig.allowedMimeTypes, ["audio/mp3", "audio/wav"])
+        XCTAssertEqual(payload.app.imageUploadConfig.blockedMimeTypes, ["audio/mp4"])
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links
Relates to https://github.com/GetStream/ios-issues-tracking/issues/757

### 🎯 Goal
Add a way to fetch the app settings. When connecting the user, it loads the app settings.

### 📝 Summary
The app settings are useful to get file upload configurations, and we were missing it in the iOS SDK. This work is also going to be useful for implementing the new size limit in https://github.com/GetStream/ios-issues-tracking/issues/757.

### 🛠 Implementation
Besides making the app settings request available to be called manually, we also load them whenever the user is connected, so that file upload limitations are available as soon as the user is connected.

It would be simpler if the backend just retrieved the app settings on the `connectUser` response since this would simplify the integration a lot. If the app settings call fails, we won't have the app settings available. We could add a retry mechanism for this call, but we agreed with Android team and the rest of the SDKs to simplify this for now, since even if the appSettings request failed, the server will always protect against these checks.

### 🧪 Manual Testing Notes
1. Open Proxyman
2. Verify that the app settings request is called when connecting the user.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)