### PR TITLE
Fix DemoApp's login-logout flow crashing in StreamDevelopers scheme

### DIFF
--- a/DemoApp/Shared/StreamChatWrapper.swift
+++ b/DemoApp/Shared/StreamChatWrapper.swift
@@ -117,10 +117,10 @@ extension StreamChatWrapper {
                 if let error = error {
                     log.warning("removing the device failed with an error \(error)")
                 }
+
+                client.logout(completion: completion)
             }
         }
-
-        client.logout(completion: completion)
     }
 }
 

--- a/DemoApp/Shared/StreamChatWrapper.swift
+++ b/DemoApp/Shared/StreamChatWrapper.swift
@@ -90,18 +90,14 @@ extension StreamChatWrapper {
         // Reset number of refresh tokens
         numberOfRefreshTokens = 0
 
-        // We connect from a background thread to make sure it works without issues/crashes.
-        // This is for testing purposes only. As a customer you can connect directly without dispatching to any queue.
-        DispatchQueue.global().async {
-            self.connect(user: user) { [weak self] error in
-                if let error = error {
-                    log.warning(error.localizedDescription)
-                } else {
-                    self?.onRemotePushRegistration?()
-                }
-                DispatchQueue.main.async {
-                    completion(error)
-                }
+        connect(user: user) { [weak self] error in
+            if let error = error {
+                log.warning(error.localizedDescription)
+            } else {
+                self?.onRemotePushRegistration?()
+            }
+            DispatchQueue.main.async {
+                completion(error)
             }
         }
     }


### PR DESCRIPTION
### 🔗 Issue Links
None

### 🎯 Goal
The goal is to fix the login logout flow in the DemoApp with the singleton approach. There were 2 issues:

1. We were logging out at the same time we removed the device. This would make the request for the removal of the device fail because the current user would not be available anymore. It would also cause a race condition, and we would have 2 current users at the same time, triggering an assertion in the StreamDevelopers scheme. 
2. When logging in to the user, we were connecting the user in a background thread, this would cause the channel list to be open before erasing the previous user, which would trigger an assertion in the StreamDevelopers scheme as well since we would also have 2 current users at the same time.

With this flow fixed, we also show customers how login/logout should be implemented. 

### 🧪 Manual Testing Notes
Scenario 1
1. Open DemoApp-StreamDevelopers app.
2. Login/Logout
4. Should not crash.

Scenario 2
1. Open DemoApp-StreamDevelopers app.
2. Login
3. Disconnect
5. Login with a different user
6. Should not crash.