### PR TITLE
[ChatStateLayer] UserList and UserListState

### DIFF
--- a/Sources/StreamChat/Controllers/UserListController/UserListController.swift
+++ b/Sources/StreamChat/Controllers/UserListController/UserListController.swift
@@ -107,9 +107,9 @@ public class ChatUserListController: DataController, DelegateCallable, DataStore
     override public func synchronize(_ completion: ((_ error: Error?) -> Void)? = nil) {
         startUserListObserverIfNeeded()
 
-        worker.update(userListQuery: query) { error in
-            self.state = error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: error))
-            self.callback { completion?(error) }
+        worker.update(userListQuery: query) { result in
+            self.state = result.error == nil ? .remoteDataFetched : .remoteDataFetchFailed(ClientError(with: result.error))
+            self.callback { completion?(result.error) }
         }
     }
 
@@ -147,8 +147,8 @@ public extension ChatUserListController {
     ) {
         var updatedQuery = query
         updatedQuery.pagination = Pagination(pageSize: limit, offset: users.count)
-        worker.update(userListQuery: updatedQuery) { error in
-            self.callback { completion?(error) }
+        worker.update(userListQuery: updatedQuery) { result in
+            self.callback { completion?(result.error) }
         }
     }
 }

--- a/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
+++ b/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
@@ -23,7 +23,7 @@ extension ChatClient {
 extension ChatClient {
     /// Creates an instance of ``ChannelList`` which represents an array of channels matching to the specified ``ChannelListQuery``.
     ///
-    /// Matching channels are stored in ``ChannelListState.channels``. Use pagination methods in ``ChannelList`` for loading more matching channels to the observable state.
+    /// Loaded channels are stored in ``ChannelListState.channels``. Use pagination methods in ``ChannelList`` for loading more matching channels to the observable state.
     /// Refer to [querying channels in Stream documentation](https://getstream.io/chat/docs/ios-swift/query_channels/?language=swift) for additional details.
     ///
     /// - Note: Only channels that the user can read are returned, therefore, make sure that the query uses a filter that includes such logic. It is recommended to include a members filter which includes the currently logged in user (e.g. `.containMembers(userIds: ["thierry"])`).
@@ -37,6 +37,26 @@ extension ChatClient {
     public func makeChannelList(with query: ChannelListQuery, dynamicFilter: ((ChatChannel) -> Bool)? = nil) async throws -> ChannelList {
         let channels = try await channelListUpdater.update(channelListQuery: query)
         return ChannelList(channels: channels, query: query, dynamicFilter: dynamicFilter, channelListUpdater: channelListUpdater, client: self)
+    }
+}
+
+// MARK: - Factory Methods for Creating User Lists
+
+@available(iOS 13.0, *)
+extension ChatClient {
+    /// Creates an instance of ``UserList`` which represents an array of users matching to the specified ``UserListQuery``.
+    ///
+    /// Loaded users are stored in ``UserListState.users``. Use pagination methods in ``UserList`` for loading more matching users to the observable state.
+    /// Refer to [querying users in Stream documentation](https://getstream.io/chat/docs/ios-swift/query_users/?language=swift) for additional details.
+    ///
+    /// - Parameter query: The query specifies which users are part of the list and how users are sorted.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An instance of ``UserList`` which represents actions and the current state of the list.
+    public func makeUserList(with query: UserListQuery) async throws -> UserList {
+        let userListUpdater = UserListUpdater(database: databaseContainer, apiClient: apiClient)
+        let users = try await userListUpdater.update(userListQuery: query)
+        return UserList(users: users, query: query, userListUpdater: userListUpdater, client: self)
     }
 }
 

--- a/Sources/StreamChat/StateLayer/UserList.swift
+++ b/Sources/StreamChat/StateLayer/UserList.swift
@@ -1,0 +1,64 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An object which represents a list of `ChatUser`.
+@available(iOS 13.0, *)
+public struct UserList {
+    private let userListUpdater: UserListUpdater
+    
+    /// The query specifying and filtering the list of users.
+    public let query: UserListQuery
+    
+    init(users: [ChatUser], query: UserListQuery, userListUpdater: UserListUpdater, client: ChatClient, environment: Environment = .init()) {
+        self.query = query
+        self.userListUpdater = userListUpdater
+        state = environment.stateBuilder(
+            users,
+            query,
+            client.databaseContainer
+        )
+    }
+    
+    /// An observable object representing the current state of the users list.
+    public let state: UserListState
+    
+    // MARK: - User List Pagination
+    
+    /// Loads users for the specified pagination parameters and updates ``UserListState.users``.
+    ///
+    /// - Parameters:
+    ///   - pagination: The pagination configuration which includes a limit and an offset or a cursor.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of users for the pagination.
+    @discardableResult public func loadUsers(with pagination: Pagination) async throws -> [ChatUser] {
+        try await userListUpdater.loadUsers(query, pagination: pagination)
+    }
+    
+    /// Loads more users and updates ``UserListState.users``.
+    ///
+    /// - Parameters
+    ///   - limit: The limit for the page size. The default limit is 30.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of loaded channels.
+    @discardableResult public func loadNextUsers(with limit: Int? = nil) async throws -> [ChatUser] {
+        let limit = (limit ?? query.pagination?.pageSize) ?? Int.usersPageSize
+        let offset = state.users.count
+        return try await userListUpdater.loadNextUsers(query, limit: limit, offset: offset)
+    }
+}
+
+@available(iOS 13.0, *)
+extension UserList {
+    struct Environment {
+        var stateBuilder: (
+            _ users: [ChatUser],
+            _ query: UserListQuery,
+            _ database: DatabaseContainer
+        ) -> UserListState = UserListState.init
+    }
+}

--- a/Sources/StreamChat/StateLayer/UserListState.swift
+++ b/Sources/StreamChat/StateLayer/UserListState.swift
@@ -1,0 +1,65 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Represents a list of users matching to the specified query.
+@available(iOS 13.0, *)
+public final class UserListState: ObservableObject {
+    private let observer: Observer
+    
+    init(users: [ChatUser], query: UserListQuery, database: DatabaseContainer) {
+        observer = Observer(query: query, database: database)
+        self.users = StreamCollection(users)
+        observer.start(
+            with: .init(usersDidChange: { [weak self] change in await self?.setValue(change, for: \.users) })
+        )
+    }
+    
+    /// An array of users for the specified ``UserListQuery``.
+    @Published public private(set) var users = StreamCollection<ChatUser>([])
+    
+    // MARK: - Mutating the State
+    
+    @MainActor private func setValue<Value>(_ value: Value, for keyPath: ReferenceWritableKeyPath<UserListState, Value>) {
+        self[keyPath: keyPath] = value
+    }
+}
+
+// MARK: - Observing the Local State
+
+@available(iOS 13.0, *)
+extension UserListState {
+    struct Observer {
+        private let query: UserListQuery
+        private let usersObserver: BackgroundListDatabaseObserver<ChatUser, UserDTO>
+        
+        init(query: UserListQuery, database: DatabaseContainer) {
+            self.query = query
+            usersObserver = BackgroundListDatabaseObserver(
+                context: database.backgroundReadOnlyContext,
+                fetchRequest: UserDTO.userListFetchRequest(query: query),
+                itemCreator: { try $0.asModel() },
+                sorting: []
+            )
+        }
+        
+        struct Handlers {
+            let usersDidChange: (StreamCollection<ChatUser>) async -> Void
+        }
+        
+        func start(with handlers: Handlers) {
+            usersObserver.onDidChange = { [weak usersObserver] _ in
+                guard let items = usersObserver?.items else { return }
+                let collection = StreamCollection(items)
+                Task { await handlers.usersDidChange(collection) }
+            }
+            do {
+                try usersObserver.startObserving()
+            } catch {
+                log.error("Failed to start the user list observer for query: \(query)")
+            }
+        }
+    }
+}

--- a/Sources/StreamChat/Workers/Background/NewUserQueryUpdater.swift
+++ b/Sources/StreamChat/Workers/Background/NewUserQueryUpdater.swift
@@ -89,8 +89,8 @@ final class NewUserQueryUpdater: Worker {
 
                 // Send `update(userListQuery:` requests so corresponding queries will be linked to the user
                 updatedQueries?.forEach {
-                    self?.userListUpdater.update(userListQuery: $0) { error in
-                        if let error = error {
+                    self?.userListUpdater.update(userListQuery: $0) { result in
+                        if let error = result.error {
                             log.error("Internal error. Failed to update UserListQueries for the new user: \(error)")
                         }
                     }

--- a/Sources/StreamChat/Workers/UserListUpdater.swift
+++ b/Sources/StreamChat/Workers/UserListUpdater.swift
@@ -13,28 +13,32 @@ class UserListUpdater: Worker {
     ///   - policy: The update policy for the resulting user set. See `UpdatePolicy`
     ///   - completion: Called when the API call is finished. Called with `Error` if the remote update fails.
     ///
-    func update(userListQuery: UserListQuery, policy: UpdatePolicy = .merge, completion: ((Error?) -> Void)? = nil) {
+    func update(userListQuery: UserListQuery, policy: UpdatePolicy = .merge, completion: ((Result<[ChatUser], Error>) -> Void)? = nil) {
         fetch(userListQuery: userListQuery) { [weak self] (result: Result<UserListPayload, Error>) in
             switch result {
             case let .success(userListPayload):
+                var users = [ChatUser]()
                 self?.database.write { session in
                     if case .replace = policy {
                         let dto = try session.saveQuery(query: userListQuery)
                         dto?.users.removeAll()
                     }
 
-                    session.saveUsers(payload: userListPayload, query: userListQuery)
+                    let dtos = session.saveUsers(payload: userListPayload, query: userListQuery)
+                    if completion != nil {
+                        users = try dtos.map { try $0.asModel() }
+                    }
                 } completion: { error in
                     if let error = error {
                         log.error("Failed to save `UserListPayload` to the database. Error: \(error)")
-                        completion?(error)
+                        completion?(.failure(error))
                     } else {
-                        completion?(nil)
+                        completion?(.success(users))
                     }
                 }
 
             case let .failure(error):
-                completion?(error)
+                completion?(.failure(error))
             }
         }
     }
@@ -62,4 +66,31 @@ enum UpdatePolicy {
     case merge
     /// The resulting user set of the query will replace the existing user set.
     case replace
+}
+
+@available(iOS 13.0.0, *)
+extension UserListUpdater {
+    func update(userListQuery: UserListQuery, policy: UpdatePolicy = .merge) async throws -> [ChatUser] {
+        try await withCheckedThrowingContinuation { continuation in
+            update(userListQuery: userListQuery) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+    
+    func loadUsers(_ userListQuery: UserListQuery, pagination: Pagination) async throws -> [ChatUser] {
+        try await update(userListQuery: userListQuery.withPagination(pagination), policy: .merge)
+    }
+    
+    func loadNextUsers(_ userListQuery: UserListQuery, limit: Int, offset: Int) async throws -> [ChatUser] {
+        try await loadUsers(userListQuery, pagination: Pagination(pageSize: limit, offset: offset))
+    }
+}
+
+private extension UserListQuery {
+    func withPagination(_ pagination: Pagination) -> Self {
+        var query = self
+        query.pagination = pagination
+        return query
+    }
 }

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -260,6 +260,10 @@
 		4F8E53172B7F58C1008C0F9F /* ChatClient+Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E530A2B7CEBFB008C0F9F /* ChatClient+Factory.swift */; };
 		4F8E531C2B833D6C008C0F9F /* ChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E531B2B833D6C008C0F9F /* ChatState.swift */; };
 		4F8E531D2B833D6C008C0F9F /* ChatState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E531B2B833D6C008C0F9F /* ChatState.swift */; };
+		4F97F2672BA83146001C4D66 /* UserList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F2662BA83146001C4D66 /* UserList.swift */; };
+		4F97F2682BA83146001C4D66 /* UserList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F2662BA83146001C4D66 /* UserList.swift */; };
+		4F97F26A2BA83150001C4D66 /* UserListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F2692BA83150001C4D66 /* UserListState.swift */; };
+		4F97F26B2BA83150001C4D66 /* UserListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F2692BA83150001C4D66 /* UserListState.swift */; };
 		4FD2BE502B99F68300FFC6F2 /* ReadStateSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */; };
 		4FD2BE512B99F68300FFC6F2 /* ReadStateSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */; };
 		4FD2BE532B9AEE3500FFC6F2 /* StreamCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */; };
@@ -2917,6 +2921,8 @@
 		4F8E53052B7CD01D008C0F9F /* Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chat.swift; sourceTree = "<group>"; };
 		4F8E530A2B7CEBFB008C0F9F /* ChatClient+Factory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatClient+Factory.swift"; sourceTree = "<group>"; };
 		4F8E531B2B833D6C008C0F9F /* ChatState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatState.swift; sourceTree = "<group>"; };
+		4F97F2662BA83146001C4D66 /* UserList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserList.swift; sourceTree = "<group>"; };
+		4F97F2692BA83150001C4D66 /* UserListState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListState.swift; sourceTree = "<group>"; };
 		4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadStateSender.swift; sourceTree = "<group>"; };
 		4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCollection.swift; sourceTree = "<group>"; };
 		4FD2BE552B9AF8A300FFC6F2 /* ChannelList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelList.swift; sourceTree = "<group>"; };
@@ -4845,6 +4851,8 @@
 				4F427F6B2BA2F53200D92238 /* CurrentUserState+Observer.swift */,
 				4F73F3972B91BD3000563CD9 /* MessageState.swift */,
 				4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */,
+				4F97F2662BA83146001C4D66 /* UserList.swift */,
+				4F97F2692BA83150001C4D66 /* UserListState.swift */,
 			);
 			path = StateLayer;
 			sourceTree = "<group>";
@@ -10581,6 +10589,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4F97F2672BA83146001C4D66 /* UserList.swift in Sources */,
 				DA8407032524F7E6005A0F62 /* UserListUpdater.swift in Sources */,
 				4F8E53062B7CD01D008C0F9F /* Chat.swift in Sources */,
 				DAE566E724FFD22300E39431 /* ChannelController+SwiftUI.swift in Sources */,
@@ -10865,6 +10874,7 @@
 				84A43CAF26A9A25000302763 /* UnknownChannelEvent.swift in Sources */,
 				C1B0B38327BFC08900C8207D /* EndpointPath+OfflineRequest.swift in Sources */,
 				C1EFF3F3285E459C0057B91B /* IdentifiableModel.swift in Sources */,
+				4F97F26A2BA83150001C4D66 /* UserListState.swift in Sources */,
 				DAFAD6A124DC476A0043ED06 /* Result+Extensions.swift in Sources */,
 				C1FC2F982742579D0062530F /* TCPTransport.swift in Sources */,
 				AD17CDF927E4DB2700E0D092 /* PushProvider.swift in Sources */,
@@ -11418,6 +11428,7 @@
 				C121E816274544AD00023E4C /* EventType.swift in Sources */,
 				AD70DC3A2ADEC3C400CFC3B7 /* MessageModerationDetailsDTO.swift in Sources */,
 				C121E817274544AD00023E4C /* Event.swift in Sources */,
+				4F97F2682BA83146001C4D66 /* UserList.swift in Sources */,
 				C121E818274544AD00023E4C /* EventPayload.swift in Sources */,
 				C121E819274544AD00023E4C /* EventDecoder.swift in Sources */,
 				C121E81A274544AD00023E4C /* ConnectionEvents.swift in Sources */,
@@ -11498,6 +11509,7 @@
 				C121E84E274544AE00023E4C /* ChannelEndpoints.swift in Sources */,
 				C121E84F274544AE00023E4C /* UserEndpoints.swift in Sources */,
 				C121E850274544AE00023E4C /* SyncEndpoint.swift in Sources */,
+				4F97F26B2BA83150001C4D66 /* UserListState.swift in Sources */,
 				84D5BC70277B61A000A65C75 /* PinnedMessagesSortingKey.swift in Sources */,
 				C121E851274544AE00023E4C /* MessageEndpoints.swift in Sources */,
 				C121E852274544AE00023E4C /* ModerationEndpoints.swift in Sources */,

--- a/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/UserListUpdater_Mock.swift
+++ b/TestTools/StreamChatTestTools/Mocks/StreamChat/Workers/UserListUpdater_Mock.swift
@@ -9,7 +9,7 @@ import XCTest
 final class UserListUpdater_Mock: UserListUpdater {
     @Atomic var update_queries: [UserListQuery] = []
     @Atomic var update_policy: UpdatePolicy?
-    @Atomic var update_completion: ((Error?) -> Void)?
+    @Atomic var update_completion: ((Result<[ChatUser], Error>) -> Void)?
 
     @Atomic var fetch_queries: [UserListQuery] = []
     @Atomic var fetch_completion: ((Result<UserListPayload, Error>) -> Void)?
@@ -26,7 +26,7 @@ final class UserListUpdater_Mock: UserListUpdater {
     override func update(
         userListQuery: UserListQuery,
         policy: UpdatePolicy = .merge,
-        completion: ((Error?) -> Void)? = nil
+        completion: ((Result<[ChatUser], Error>) -> Void)? = nil
     ) {
         _update_queries.mutate { $0.append(userListQuery) }
         update_policy = policy

--- a/Tests/StreamChatTests/Controllers/SearchControllers/UserListController/UserListController_Tests.swift
+++ b/Tests/StreamChatTests/Controllers/SearchControllers/UserListController/UserListController_Tests.swift
@@ -63,7 +63,7 @@ final class UserListController_Tests: XCTestCase {
         controller.synchronize()
 
         // Simulate successfull network call.
-        env.userListUpdater?.update_completion?(nil)
+        env.userListUpdater?.update_completion?(.success([]))
 
         // Check if state changed after successful network call.
         XCTAssertEqual(controller.state, .remoteDataFetched)
@@ -89,7 +89,7 @@ final class UserListController_Tests: XCTestCase {
 
         // Simulate failed network call.
         let error = TestError()
-        env.userListUpdater?.update_completion?(error)
+        env.userListUpdater?.update_completion?(.failure(error))
 
         // Check if state changed after failed network call.
         XCTAssertEqual(controller.state, .remoteDataFetchFailed(ClientError(with: error)))
@@ -136,7 +136,7 @@ final class UserListController_Tests: XCTestCase {
         }
 
         // Simulate successful network call.
-        env.userListUpdater?.update_completion?(nil)
+        env.userListUpdater?.update_completion?(.success([]))
 
         // Assert the existing user is loaded
         XCTAssertEqual(controller.users.map(\.id), [userId])
@@ -167,7 +167,7 @@ final class UserListController_Tests: XCTestCase {
         XCTAssertFalse(completionCalled)
 
         // Simulate successful update
-        env.userListUpdater!.update_completion?(nil)
+        env.userListUpdater!.update_completion?(.success([]))
         // Release reference of completion so we can deallocate stuff
         env.userListUpdater!.update_completion = nil
 
@@ -189,7 +189,7 @@ final class UserListController_Tests: XCTestCase {
 
         // Simulate failed update
         let testError = TestError()
-        env.userListUpdater!.update_completion?(testError)
+        env.userListUpdater!.update_completion?(.failure(testError))
 
         // Completion should be called with the error
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)
@@ -240,7 +240,7 @@ final class UserListController_Tests: XCTestCase {
         controller.synchronize()
 
         // Simulate network call response
-        env.userListUpdater?.update_completion?(nil)
+        env.userListUpdater?.update_completion?(.success([]))
 
         // Assert delegate is notified about state changes
         AssertAsync.willBeEqual(delegate.state, .remoteDataFetched)
@@ -293,7 +293,7 @@ final class UserListController_Tests: XCTestCase {
         controller = nil
 
         // Simulate successful update
-        env!.userListUpdater?.update_completion?(nil)
+        env!.userListUpdater?.update_completion?(.success([]))
         // Release reference of completion so we can deallocate stuff
         env.userListUpdater!.update_completion = nil
 
@@ -313,7 +313,7 @@ final class UserListController_Tests: XCTestCase {
 
         // Simulate failed udpate
         let testError = TestError()
-        env.userListUpdater!.update_completion?(testError)
+        env.userListUpdater!.update_completion?(.failure(testError))
 
         // Completion should be called with the error
         AssertAsync.willBeEqual(completionCalledError as? TestError, testError)

--- a/Tests/StreamChatTests/Workers/UserListUpdater_Tests.swift
+++ b/Tests/StreamChatTests/Workers/UserListUpdater_Tests.swift
@@ -56,8 +56,8 @@ final class UserListUpdater_Tests: XCTestCase {
         // Simulate `update` call
         let query = UserListQuery(filter: .equal(.id, to: "Luke"))
         let completionCalled = expectation(description: "completion called")
-        listUpdater.update(userListQuery: query, completion: { error in
-            XCTAssertNil(error)
+        listUpdater.update(userListQuery: query, completion: { result in
+            XCTAssertNil(result.error)
             completionCalled.fulfill()
         })
 
@@ -79,7 +79,7 @@ final class UserListUpdater_Tests: XCTestCase {
         // Simulate `update` call
         let query = UserListQuery(filter: .equal(.id, to: "Luke"))
         var completionCalledError: Error?
-        listUpdater.update(userListQuery: query, completion: { completionCalledError = $0 })
+        listUpdater.update(userListQuery: query, completion: { completionCalledError = $0.error })
 
         // Simualte API response with failure
         let error = TestError()


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Add `UserList` and `UserListState` for representing `ChatUserListController` functionality in the new state layer

### 📝 Summary

- Add `UserList`
- Add `UserListState`
- Add `ChatClient.makeUserList()`

### 🛠 Implementation

Follows the same flow as we have for channel lists.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
