### PR TITLE
[ChatStateLayer] Add global user flagging and muting support

### DIFF
--- a/Sources/StreamChat/Workers/UserUpdater.swift
+++ b/Sources/StreamChat/Workers/UserUpdater.swift
@@ -105,3 +105,38 @@ extension ClientError {
         }
     }
 }
+
+@available(iOS 13.0, *)
+extension UserUpdater {
+    func muteUser(_ userId: UserId) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            muteUser(userId) { error in
+                continuation.resume(with: error)
+            }
+        }
+    }
+    
+    func unmuteUser(_ userId: UserId) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            unmuteUser(userId) { error in
+                continuation.resume(with: error)
+            }
+        }
+    }
+    
+    func flag(_ userId: UserId) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            flagUser(true, with: userId) { error in
+                continuation.resume(with: error)
+            }
+        }
+    }
+    
+    func unflag(_ userId: UserId) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            flagUser(false, with: userId) { error in
+                continuation.resume(with: error)
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer-current-user*

### 🎯 Goal

`ChatUserController` provides ways for muting and flagging users in all the channels. Add these functions to the `ConnectedUser` type.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)
