### PR TITLE
[ChatStateLayer] UserSearch and UserSearchState

### DIFF
--- a/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
+++ b/Sources/StreamChat/StateLayer/ChatClient+Factory.swift
@@ -294,3 +294,17 @@ extension ChatClient {
         MessageSearch(client: self)
     }
 }
+
+// MARK: - Factory Methods for Searching User
+
+@available(iOS 13.0, *)
+extension ChatClient {
+    /// Creates an instance of ``UserSearch`` which represents an array of users matching to the specified ``UserListQuery``.
+    ///
+    /// Use ``UserSearch`` as a data source for user search UIs.
+    ///
+    /// - Returns: An instance of ``UserSearch`` which represents search actions and the search state.
+    public func makeUserSearch() -> UserSearch {
+        UserSearch(client: self)
+    }
+}

--- a/Sources/StreamChat/StateLayer/UserSearch.swift
+++ b/Sources/StreamChat/StateLayer/UserSearch.swift
@@ -1,0 +1,84 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An object which represents a list of `ChatUser` for the specified search query.
+@available(iOS 13.0, *)
+public struct UserSearch {
+    private let userListUpdater: UserListUpdater
+    
+    init(client: ChatClient, environment: Environment = .init()) {
+        userListUpdater = environment.userListUpdaterBuilder(
+            client.databaseContainer,
+            client.apiClient
+        )
+        state = UserSearchState()
+    }
+    
+    /// An observable object representing the current state of the search.
+    public let state: UserSearchState
+    
+    /// Searches for users with the specified search term and updates ``UserSearchState.users``.
+    ///
+    /// - Parameter term: The search term for searching users.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of users for the search term.
+    @discardableResult public func search(term: String) async throws -> [ChatUser] {
+        try await search(query: .search(term: term))
+    }
+    
+    /// Searches for users with the specified query and updates ``UserSearchState.users``.
+    ///
+    /// - Parameters:
+    ///   - query: The user list query used for searching.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of users for the query.
+    @discardableResult public func search(query: UserListQuery) async throws -> [ChatUser] {
+        let limit = query.pagination?.pageSize ?? .usersPageSize
+        let pagination = Pagination(pageSize: limit, offset: 0)
+        return try await search(query: query, pagination: pagination)
+    }
+    
+    /// Searches for more users with the specified query and updates ``UserSearchState.users``.
+    ///
+    /// - Parameters
+    ///   - limit: The limit for the page size. The default limit is 30.
+    ///
+    /// - Throws: An error while communicating with the Stream API.
+    /// - Returns: An array of loaded channels.
+    @discardableResult public func loadNextUsers(limit: Int? = nil) async throws -> [ChatUser] {
+        guard let query = await state.value(forKeyPath: \.query) else { throw ClientError("Call search() before calling for next page") }
+        let limit = (limit ?? query.pagination?.pageSize) ?? .usersPageSize
+        let offset = await state.value(forKeyPath: \.users.count)
+        let pagination = Pagination(pageSize: limit, offset: offset)
+        return try await search(query: query, pagination: pagination)
+    }
+    
+    // MARK: - Private
+    
+    private func search(query: UserListQuery, pagination: Pagination) async throws -> [ChatUser] {
+        let task = Task {
+            let users = try await userListUpdater.fetch(userListQuery: query, pagination: pagination)
+            try Task.checkCancellation()
+            return users
+        }
+        await state.setActiveTask(task, query: query)
+        let users = try await task.value
+        await state.setUsers(users, for: query, pagination: pagination)
+        return users
+    }
+}
+
+@available(iOS 13.0, *)
+extension UserSearch {
+    struct Environment {
+        var userListUpdaterBuilder: (
+            _ database: DatabaseContainer,
+            _ apiClient: APIClient
+        ) -> UserListUpdater = UserListUpdater.init
+    }
+}

--- a/Sources/StreamChat/StateLayer/UserSearchState.swift
+++ b/Sources/StreamChat/StateLayer/UserSearchState.swift
@@ -1,0 +1,47 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Represents a list of user search results.
+@available(iOS 13.0, *)
+public final class UserSearchState: ObservableObject {
+    /// The search query the results corresponds to.
+    @Published public private(set) var query: UserListQuery?
+    
+    /// An array of search results for the specified query and pagination state.
+    @Published public private(set) var users = StreamCollection<ChatUser>([])
+    
+    // MARK: - Private
+    
+    private var activeTask: Task<[ChatUser], Error>?
+}
+
+// MARK: - Mutating the State on the Main Actor
+
+@available(iOS 13.0, *)
+extension UserSearchState {
+    @MainActor func value<Value>(forKeyPath keyPath: KeyPath<UserSearchState, Value>) -> Value {
+        self[keyPath: keyPath]
+    }
+        
+    @MainActor func setActiveTask(_ task: Task<[ChatUser], Error>, query: UserListQuery) {
+        if let activeTask {
+            activeTask.cancel()
+        }
+        activeTask = task
+        self.query = query
+    }
+    
+    @MainActor func setUsers(_ newUsers: [ChatUser], for query: UserListQuery, pagination: Pagination) {
+        // When the query changes we set the pagination to 0, otherwise we are loading more results for the same query
+        if pagination.offset == 0 {
+            users = StreamCollection(newUsers)
+        } else {
+            var result = Array(users[..<pagination.offset])
+            result.append(contentsOf: newUsers)
+            users = StreamCollection(result)
+        }
+    }
+}

--- a/StreamChat.xcodeproj/project.pbxproj
+++ b/StreamChat.xcodeproj/project.pbxproj
@@ -274,6 +274,10 @@
 		4F97F2782BA87E30001C4D66 /* MessageSearchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F2762BA87E30001C4D66 /* MessageSearchState.swift */; };
 		4F97F27A2BA88936001C4D66 /* MessageSearchState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F2792BA88936001C4D66 /* MessageSearchState+Observer.swift */; };
 		4F97F27B2BA88936001C4D66 /* MessageSearchState+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F2792BA88936001C4D66 /* MessageSearchState+Observer.swift */; };
+		4F97F26D2BA858E9001C4D66 /* UserSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F26C2BA858E9001C4D66 /* UserSearch.swift */; };
+		4F97F26E2BA858E9001C4D66 /* UserSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F26C2BA858E9001C4D66 /* UserSearch.swift */; };
+		4F97F2702BA86491001C4D66 /* UserSearchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F26F2BA86491001C4D66 /* UserSearchState.swift */; };
+		4F97F2712BA86491001C4D66 /* UserSearchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F97F26F2BA86491001C4D66 /* UserSearchState.swift */; };
 		4FD2BE502B99F68300FFC6F2 /* ReadStateSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */; };
 		4FD2BE512B99F68300FFC6F2 /* ReadStateSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */; };
 		4FD2BE532B9AEE3500FFC6F2 /* StreamCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */; };
@@ -2938,6 +2942,8 @@
 		4F97F2732BA87C41001C4D66 /* MessageSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSearch.swift; sourceTree = "<group>"; };
 		4F97F2762BA87E30001C4D66 /* MessageSearchState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSearchState.swift; sourceTree = "<group>"; };
 		4F97F2792BA88936001C4D66 /* MessageSearchState+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessageSearchState+Observer.swift"; sourceTree = "<group>"; };
+		4F97F26C2BA858E9001C4D66 /* UserSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSearch.swift; sourceTree = "<group>"; };
+		4F97F26F2BA86491001C4D66 /* UserSearchState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSearchState.swift; sourceTree = "<group>"; };
 		4FD2BE4F2B99F68300FFC6F2 /* ReadStateSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadStateSender.swift; sourceTree = "<group>"; };
 		4FD2BE522B9AEE3500FFC6F2 /* StreamCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCollection.swift; sourceTree = "<group>"; };
 		4FD2BE552B9AF8A300FFC6F2 /* ChannelList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelList.swift; sourceTree = "<group>"; };
@@ -4874,6 +4880,8 @@
 				4F73F39D2B91C7BF00563CD9 /* MessageState+Observer.swift */,
 				4F97F2662BA83146001C4D66 /* UserList.swift */,
 				4F97F2692BA83150001C4D66 /* UserListState.swift */,
+				4F97F26C2BA858E9001C4D66 /* UserSearch.swift */,
+				4F97F26F2BA86491001C4D66 /* UserSearchState.swift */,
 			);
 			path = StateLayer;
 			sourceTree = "<group>";
@@ -10659,6 +10667,7 @@
 				C1FC2FA12742579D0062530F /* Engine.swift in Sources */,
 				22692C9725D1841E007C41D0 /* ChatMessageFileAttachment.swift in Sources */,
 				DA8407062524F84F005A0F62 /* UserListQuery.swift in Sources */,
+				4F97F2702BA86491001C4D66 /* UserSearchState.swift in Sources */,
 				DBF17AE825D48865004517B3 /* BackgroundTaskScheduler.swift in Sources */,
 				79280F4F2485308100CDEB89 /* DataController.swift in Sources */,
 				ADC40C3426E294EB005B616C /* MessageSearchController+Combine.swift in Sources */,
@@ -10819,6 +10828,7 @@
 				C1FC2F902742579D0062530F /* NativeEngine.swift in Sources */,
 				792A4F39247FFACB00EAF71D /* WebSocketEngine.swift in Sources */,
 				C1FC2F922742579D0062530F /* Server.swift in Sources */,
+				4F97F26D2BA858E9001C4D66 /* UserSearch.swift in Sources */,
 				79280F422484F4EC00CDEB89 /* Event.swift in Sources */,
 				C1FC2F932742579D0062530F /* Framer.swift in Sources */,
 				C14D27B62869EEE40063F6F2 /* Array+CompactMapLoggingError.swift in Sources */,
@@ -11615,6 +11625,7 @@
 				C121E87F274544AF00023E4C /* ChannelMuteDTO.swift in Sources */,
 				C121E880274544AF00023E4C /* AttachmentId.swift in Sources */,
 				40789D4C29F6C87B0018C2BB /* AudioRecordingState_Tests.swift in Sources */,
+				4F97F26E2BA858E9001C4D66 /* UserSearch.swift in Sources */,
 				C121E881274544AF00023E4C /* AttachmentTypes.swift in Sources */,
 				C121E882274544AF00023E4C /* ChatMessageLinkAttachment.swift in Sources */,
 				C18F5B532840BD2C00527915 /* DBDate.swift in Sources */,
@@ -11754,6 +11765,7 @@
 				40789D3D29F6AD9C0018C2BB /* Debouncer.swift in Sources */,
 				C121E8E5274544B200023E4C /* Timers.swift in Sources */,
 				C121E8E6274544B200023E4C /* SystemEnvironment.swift in Sources */,
+				4F97F2712BA86491001C4D66 /* UserSearchState.swift in Sources */,
 				43D3F0F72841052600B74921 /* CallPayloads.swift in Sources */,
 				C121E8E7274544B200023E4C /* Bundle+Extensions.swift in Sources */,
 				C121E8E8274544B200023E4C /* OptionSet+Extensions.swift in Sources */,


### PR DESCRIPTION
### 🔗 Issue Links

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

*Merges to feature/chat-state-layer*

### 🎯 Goal

Adds `UserSearchController` functionality to the new chat state layer.

### 📝 Summary

- Add `UserSearch` and `UserSearchState` for representing the functionality in `ChatUserSearchController`

### 🛠 Implementation

`ChatUserSearchController` does not really need CoreData support and it currently uses the store only for converting `UserPayload` > `ChatUser` (`UserPayload` is saved to CD as `UserDTO` and the DTO is converted to `ChatUser`). There is also complexity around `UserDTO` and `UserListQueryDTO`. Since we do not really need any CoreData storage here, there are no CoreDataLazy in `ChatUser`, it is possible map the `UserPayload` to `ChatUser` with one exception (`isFlaggedByCurrentUser`), I am proposing to skip CoreData in the `UserSearch`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)